### PR TITLE
Mitigate unsoundness in `InternalState`

### DIFF
--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -23,11 +23,12 @@ use crate::{
     },
     exec::Interpreter,
 };
+use gc::{Finalize, Trace};
 use rustc_hash::FxHashMap;
 use std::time::SystemTime;
 
 /// This is the internal console object state.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Trace, Finalize)]
 pub struct ConsoleState {
     count_map: FxHashMap<String, u32>,
     timer_map: FxHashMap<String, u128>,

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -39,10 +39,14 @@ pub enum ConstructorKind {
 /// Defines how this references are interpreted within the formal parameters and code body of the function.
 ///
 /// Arrow functions don't define a `this` and thus are lexical, `function`s do define a this and thus are NonLexical
-#[derive(Trace, Finalize, Debug, Clone)]
+#[derive(Finalize, Copy, Debug, Clone)]
 pub enum ThisMode {
     Lexical,
     NonLexical,
+}
+
+unsafe impl Trace for ThisMode {
+    unsafe_empty_trace!();
 }
 
 /// FunctionBody is specific to this interpreter, it will either be Rust code or JavaScript code (AST Node)

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -9,10 +9,6 @@
 //! [spec]: https://tc39.es/ecma262/#sec-regexp-constructor
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
-use gc::{unsafe_empty_trace, Finalize, Gc, Trace};
-use regex::Regex;
-use std::ops::Deref;
-
 use crate::{
     builtins::{
         object::{InternalState, Object, ObjectInternalMethods, ObjectKind, PROTOTYPE},
@@ -21,6 +17,9 @@ use crate::{
     },
     exec::Interpreter,
 };
+use gc::{unsafe_empty_trace, Finalize, Trace};
+use regex::Regex;
+use std::ops::Deref;
 
 #[cfg(test)]
 mod tests;

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -9,9 +9,9 @@
 //! [spec]: https://tc39.es/ecma262/#sec-regexp-constructor
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
-use std::ops::Deref;
-
+use gc::{unsafe_empty_trace, Finalize, Gc, Trace};
 use regex::Regex;
+use std::ops::Deref;
 
 use crate::{
     builtins::{
@@ -26,7 +26,7 @@ use crate::{
 mod tests;
 
 /// The internal representation on a `RegExp` object.
-#[derive(Debug)]
+#[derive(Debug, Finalize)]
 struct RegExp {
     /// Regex matcher.
     matcher: Regex,
@@ -54,6 +54,12 @@ struct RegExp {
 
     /// Flag 'u' - Unicode.
     unicode: bool,
+}
+
+// FIXME: Maybe `Regex` could at some point implement `Trace`, and we need to take that into
+// account.
+unsafe impl Trace for RegExp {
+    unsafe_empty_trace!();
 }
 
 impl InternalState for RegExp {}

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -488,18 +488,14 @@ impl ValueData {
     /// This will panic if this value doesn't have an internal state or if the internal state doesn't
     /// have the concrete type `S`.
     pub fn with_internal_state_ref<S: InternalState, R, F: FnOnce(&S) -> R>(&self, f: F) -> R {
-        // fn get_type<T>(_: &T) {
-        //     dbg!(type_name::<T>());
-        // }
-
-        dbg!(std::any::type_name::<S>());
-
         if let Self::Object(ref obj) = *self {
             let o = obj.borrow();
-            dbg!(&o.state);
-            let state = o.state.as_ref().expect("no state").downcast_ref();
-            dbg!(&state);
-            let state = state.expect("wrong state type");
+            let state = o
+                .state
+                .as_ref()
+                .expect("no state")
+                .downcast_ref()
+                .expect("wrong state type");
             f(state)
         } else {
             panic!("not an object");

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -487,18 +487,19 @@ impl ValueData {
     ///
     /// This will panic if this value doesn't have an internal state or if the internal state doesn't
     /// have the concrete type `S`.
-    pub fn with_internal_state_ref<S: Any + InternalState, R, F: FnOnce(&S) -> R>(
-        &self,
-        f: F,
-    ) -> R {
+    pub fn with_internal_state_ref<S: InternalState, R, F: FnOnce(&S) -> R>(&self, f: F) -> R {
+        // fn get_type<T>(_: &T) {
+        //     dbg!(type_name::<T>());
+        // }
+
+        dbg!(std::any::type_name::<S>());
+
         if let Self::Object(ref obj) = *self {
             let o = obj.borrow();
-            let state = o
-                .state
-                .as_ref()
-                .expect("no state")
-                .downcast_ref()
-                .expect("wrong state type");
+            dbg!(&o.state);
+            let state = o.state.as_ref().expect("no state").downcast_ref();
+            dbg!(&state);
+            let state = state.expect("wrong state type");
             f(state)
         } else {
             panic!("not an object");


### PR DESCRIPTION
This comes from https://github.com/boa-dev/boa/issues/363#issuecomment-626170196. It turns out that implementing an empty trace was not safe if the contained type was not `Trace`.

I'm still having issues, though, since we cannot downcast a non `Any` type. Adding `Any` to the `InternalState` trait bounds doesn't help either. Any idea on how to fix this, @HalidOdat or @jasonwilliams ?

This still has the issue that `Regex` does not implement `Trace`, and in the future it could, which would make it unsound again. In any case, I think this is a good compromise for now. In the future we will probably need to change the `Regex` for a different thing, in any case, since it doesn't implement everything in the JavaScript regular expressions.