### PR TITLE
Fix function object constructable/callable

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -1031,7 +1031,7 @@ impl Array {
         make_builtin_fn(Self::slice, "slice", &prototype, 2);
         make_builtin_fn(Self::some, "some", &prototype, 2);
 
-        let array = make_constructor_fn(Self::make_array, global, prototype);
+        let array = make_constructor_fn("Array", 1, Self::make_array, global, prototype, true);
 
         // Static Methods
         make_builtin_fn(Self::is_array, "isArray", &array, 1);

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -96,14 +96,14 @@ impl BigInt {
         ))
     }
 
-    // /// `BigInt.prototype.valueOf()`
-    // ///
-    // /// The `valueOf()` method returns the wrapped primitive value of a Number object.
-    // ///
-    // /// More information:
-    // ///  - [ECMAScript reference][spec]
-    // ///  - [MDN documentation][mdn]
-    // ///
+    /// `BigInt.prototype.valueOf()`
+    ///
+    /// The `valueOf()` method returns the wrapped primitive value of a Number object.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf
     pub(crate) fn value_of(
@@ -124,7 +124,7 @@ impl BigInt {
         make_builtin_fn(Self::to_string, "toString", &prototype, 1);
         make_builtin_fn(Self::value_of, "valueOf", &prototype, 0);
 
-        make_constructor_fn(Self::make_bigint, global, prototype)
+        make_constructor_fn("BigInt", 1, Self::make_bigint, global, prototype, false)
     }
 
     /// Initialise the `BigInt` object on the global object.

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -115,7 +115,14 @@ impl Boolean {
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
         make_builtin_fn(Self::value_of, "valueOf", &prototype, 0);
 
-        make_constructor_fn(Self::construct_boolean, global, prototype)
+        make_constructor_fn(
+            "Boolean",
+            1,
+            Self::construct_boolean,
+            global,
+            prototype,
+            true,
+        )
     }
 
     /// Initialise the `Boolean` object on the global object.

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -72,9 +72,10 @@ impl Error {
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
         prototype.set_field("message", Value::from(""));
-        prototype.set_field("name", Value::from("Error"));
+
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
-        make_constructor_fn(Self::make_error, global, prototype)
+
+        make_constructor_fn("Error", 1, Self::make_error, global, prototype, true)
     }
 
     /// Initialise the global object with the `Error` object.

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -63,9 +63,10 @@ impl RangeError {
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
         prototype.set_field("message", Value::from(""));
-        prototype.set_field("name", Value::from("RangeError"));
+
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
-        make_constructor_fn(Self::make_error, global, prototype)
+
+        make_constructor_fn("RangeError", 1, Self::make_error, global, prototype, true)
     }
 
     /// Runs a `new RangeError(message)`.

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -1,4 +1,4 @@
-//! Builtins live here, such as Object, String, Math etc
+//! Builtins live here, such as Object, String, Math, etc.
 
 pub mod array;
 pub mod bigint;

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -89,21 +89,6 @@ impl Number {
         Ok(data)
     }
 
-    /// `Number()` function.
-    ///
-    /// More Information https://tc39.es/ecma262/#sec-number-constructor-number-value
-    pub(crate) fn call_number(
-        _this: &mut Value,
-        args: &[Value],
-        _ctx: &mut Interpreter,
-    ) -> ResultValue {
-        let data = match args.get(0) {
-            Some(ref value) => Self::to_number(value),
-            None => Self::to_number(&Value::from(0)),
-        };
-        Ok(data)
-    }
-
     /// `Number.prototype.toExponential( [fractionDigits] )`
     ///
     /// The `toExponential()` method returns a string representing the Number object in exponential notation.
@@ -417,7 +402,7 @@ impl Number {
         make_builtin_fn(Self::to_string, "toString", &prototype, 1);
         make_builtin_fn(Self::value_of, "valueOf", &prototype, 0);
 
-        make_constructor_fn(Self::make_number, global, prototype)
+        make_constructor_fn("Number", 1, Self::make_number, global, prototype, true)
     }
 
     /// Initialise the `Number` object on the global object.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -471,7 +471,10 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iscallable
     pub fn is_callable(&self) -> bool {
-        self.func.is_some()
+        match self.func {
+            Some(ref function) => function.is_callable(),
+            None => false,
+        }
     }
 
     /// It determines if Object is a function object with a [[Construct]] internal method.
@@ -480,8 +483,11 @@ impl Object {
     /// - [EcmaScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isconstructor
-    pub fn is_constructor(&self) -> bool {
-        self.func.is_some()
+    pub fn is_constructable(&self) -> bool {
+        match self.func {
+            Some(ref function) => function.is_constructable(),
+            None => false,
+        }
     }
 }
 
@@ -614,7 +620,7 @@ pub fn create(global: &Value) -> Value {
     make_builtin_fn(has_own_property, "hasOwnProperty", &prototype, 0);
     make_builtin_fn(to_string, "toString", &prototype, 0);
 
-    let object = make_constructor_fn(make_object, global, prototype);
+    let object = make_constructor_fn("Object", 1, make_object, global, prototype, true);
 
     object.set_field("length", Value::from(1));
     make_builtin_fn(set_prototype_of, "setPrototypeOf", &object, 2);

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -485,7 +485,7 @@ impl RegExp {
         make_builtin_fn(Self::get_sticky, "sticky", &prototype, 0);
         make_builtin_fn(Self::get_unicode, "unicode", &prototype, 0);
 
-        make_constructor_fn(Self::make_regexp, global, prototype)
+        make_constructor_fn("RegExp", 1, Self::make_regexp, global, prototype, true)
     }
 
     /// Initialise the `RegExp` object on the global object.

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1071,7 +1071,7 @@ impl String {
         make_builtin_fn(Self::match_all, "matchAll", &prototype, 1);
         make_builtin_fn(Self::replace, "replace", &prototype, 2);
 
-        make_constructor_fn(Self::make_string, global, prototype)
+        make_constructor_fn("String", 1, Self::make_string, global, prototype, true)
     }
 
     /// Initialise the `String` object on the global object.

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -92,8 +92,9 @@ pub fn to_string(this: &mut Value, _: &[Value], _: &mut Interpreter) -> ResultVa
 pub fn create(global: &Value) -> Value {
     // Create prototype object
     let prototype = Value::new_object(Some(global));
+
     make_builtin_fn(to_string, "toString", &prototype, 0);
-    make_constructor_fn(call_symbol, global, prototype)
+    make_constructor_fn("Symbol", 1, call_symbol, global, prototype, false)
 }
 
 /// Initialise the `Symbol` object on the global object.

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -217,7 +217,7 @@ impl ValueData {
         match *self {
             Self::Object(ref o) => {
                 let borrowed_obj = o.borrow();
-                borrowed_obj.is_callable() || borrowed_obj.is_constructor()
+                borrowed_obj.is_callable() || borrowed_obj.is_constructable()
             }
             _ => false,
         }

--- a/boa/src/exec/declaration/mod.rs
+++ b/boa/src/exec/declaration/mod.rs
@@ -18,6 +18,8 @@ impl Executable for FunctionDecl {
             self.parameters().to_vec(),
             self.body().to_vec(),
             ThisMode::NonLexical,
+            true,
+            true,
         );
 
         // Set the name and assign it in the current environment
@@ -43,6 +45,8 @@ impl Executable for FunctionExpr {
             self.parameters().to_vec(),
             self.body().to_vec(),
             ThisMode::NonLexical,
+            true,
+            true,
         );
 
         if let Some(name) = self.name() {
@@ -125,6 +129,8 @@ impl Executable for ArrowFunctionDecl {
             self.params().to_vec(),
             self.body().to_vec(),
             ThisMode::Lexical,
+            false,
+            true,
         ))
     }
 }

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -58,7 +58,14 @@ impl Interpreter {
     }
 
     /// Utility to create a function Value for Function Declarations, Arrow Functions or Function Expressions
-    pub(crate) fn create_function<P, B>(&mut self, params: P, body: B, this_mode: ThisMode) -> Value
+    pub(crate) fn create_function<P, B>(
+        &mut self,
+        params: P,
+        body: B,
+        this_mode: ThisMode,
+        constructable: bool,
+        callable: bool,
+    ) -> Value
     where
         P: Into<Box<[FormalParameter]>>,
         B: Into<StatementList>,
@@ -69,7 +76,7 @@ impl Interpreter {
             .get_global_object()
             .expect("Could not get the global object")
             .get_field("Function")
-            .get_field("Prototype");
+            .get_field(PROTOTYPE);
 
         // Every new function has a prototype property pre-made
         let global_val = &self
@@ -81,11 +88,13 @@ impl Interpreter {
 
         let params = params.into();
         let params_len = params.len();
-        let func = FunctionObject::create_ordinary(
+        let func = FunctionObject::new(
             params,
-            self.realm.environment.get_current_environment().clone(),
+            Some(self.realm.environment.get_current_environment().clone()),
             FunctionBody::Ordinary(body.into()),
             this_mode,
+            constructable,
+            callable,
         );
 
         let mut new_func = Object::function();

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -7,7 +7,7 @@
 use crate::{
     builtins::{
         self,
-        function::NativeFunctionData,
+        function::{Function, NativeFunctionData},
         value::{Value, ValueData},
     },
     environment::{
@@ -60,10 +60,7 @@ impl Realm {
 
     /// Utility to add a function to the global object
     pub fn register_global_func(self, func_name: &str, func: NativeFunctionData) -> Self {
-        let func = crate::builtins::function::Function::create_builtin(
-            vec![],
-            crate::builtins::function::FunctionBody::BuiltIn(func),
-        );
+        let func = Function::builtin(Vec::new(), func);
         self.global_obj
             .set_field(Value::from(func_name), ValueData::from_func(func));
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

<!---
This Pull Request fixes/closes #{issue_num}.
--->

It changes the following:
 - Removed unnesecary `FunctionKind` and cleanup
 - Added `name` property to global objects. example: BigInt.name === "BigInt"
 - Added `length` property to global objects. example: Boolean.length === 1
 - Made arrow functions only callable.
 - Fixes function objects constructability and callability.

Not all function objects are constructable or callable for example:
|        Type        | constructable 				|  callable |
| ------------------ | ---------------------------- |-----------|
| Arrow Functions    |    false  				    |   true    |
| Function Decl/Expr |    true   				    |   true    |
| Classes            |    true       				|   false   |
| Builtins           | false (unless explicit true) |   true    |

More informations see: <https://stackoverflow.com/a/40922715>
