### PR TITLE
Fixed parsing if statement without else block preceded by a newline

### DIFF
--- a/boa/src/syntax/parser/statement/if_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/if_stm/mod.rs
@@ -57,15 +57,15 @@ impl TokenParser for IfStatement {
         let then_stm =
             Statement::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?;
 
-        let else_stm = match cursor.next() {
-            Some(else_tok) if else_tok.kind == TokenKind::Keyword(Keyword::Else) => Some(
-                Statement::new(self.allow_yield, self.allow_await, self.allow_return)
-                    .parse(cursor)?,
-            ),
-            _ => {
-                cursor.back();
-                None
+        let else_stm = match cursor.peek(0) {
+            Some(else_tok) if else_tok.kind == TokenKind::Keyword(Keyword::Else) => {
+                cursor.next();
+                Some(
+                    Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+                        .parse(cursor)?,
+                )
             }
+            _ => None,
         };
 
         Ok(Node::if_node::<_, _, Node, _>(cond, then_stm, else_stm))

--- a/boa/src/syntax/parser/statement/if_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/if_stm/tests.rs
@@ -1,1 +1,31 @@
+use crate::syntax::{
+    ast::{
+        node::{Block, Node},
+        Const,
+    },
+    parser::tests::check_parser,
+};
 
+#[test]
+fn if_without_else_block() {
+    check_parser(
+        "if (true) {}",
+        vec![Node::if_node::<_, _, Node, _>(
+            Const::from(true),
+            Block::from(Vec::new()),
+            None,
+        )],
+    );
+}
+
+#[test]
+fn if_without_else_block_with_trailing_newline() {
+    check_parser(
+        "if (true) {}\n",
+        vec![Node::if_node::<_, _, Node, _>(
+            Const::from(true),
+            Block::from(Vec::new()),
+            None,
+        )],
+    );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

<!---
This Pull Request fixes/closes #{issue_num}.
--->

It changes the following:
 - Fixes parsing error caused by if statement without else block preceded by a newline

This example on master will give a parsing error:
```js
if (x) {} // <--- newline here

```
It produces this error:
```
Parsing Error: unexpected token '}' at line 1, col 11
```