### PR TITLE
Update links on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ Currently, it has support for some of the language.
 
 ## Live Demo (WASM)
 
-<https://jasonwilliams.github.io/boa/>
+<https://boa-dev.github.io/boa/>
 
 You can get more verbose errors when running from the command line
 
 ## Development documentation
 
-You can check the internal development docs at <https://jasonwilliams.github.io/boa/doc>
+You can check the internal development docs at <https://boa-dev.github.io/boa/doc>
 
 ## Benchmarks
 
-<https://jasonwilliams.github.io/boa/dev/bench/>
+<https://boa-dev.github.io/boa/dev/bench/>
 
 ## Contributing
 


### PR DESCRIPTION
Since the repo migrated from <https://jasonwilliams.github.io/boa/> to <https://boa-dev.github.io/boa/>, the links on the README.md got deprecated.

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:
 - Links on README.md
