### PR TITLE
Execution benchmarks now only take execution into account

### DIFF
--- a/boa/benches/README.md
+++ b/boa/benches/README.md
@@ -1,0 +1,11 @@
+# Boa Benchmarks.
+
+We divide the benchmarks in 3 sections:
+ - Execution benchmarks
+ - Lexing benchmarks
+ - Parsing benchmarks
+
+The idea is to check the performance of Boa in different scenarios and dividing the Boa execution
+process in its different parts.
+
+Note that lexing benchmarks will soon disappear.


### PR DESCRIPTION
This Pull Request tries to change the execution benchmarks in order to only benchmark the actual execution. This should give us much more interesting information on the actual execution.

To be determined:
 - Should we rename the benchmarks in order to not show a huge drop on execution time in the benchmarks web page?
 - Should we maintain old benchmarks of Realm + exec too and just duplicate the benchmarks?

I can also add benchmarks for #427, #429 and #430 if you'd like.
