### PR TITLE
Update to use a newer version of codecov github action

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1.0.7
 
   test_on_windows:
     name: Test Suite on Windows


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

Relates to issue #378.

It changes the following:
- Updated codecov action version specified to 1.0.7 (latest version) to try and see if this fixes the problem with tokenless codecov not working.
