### PR TITLE
Has own property should call get own property

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -608,8 +608,7 @@ pub fn has_own_property(this: &mut Value, args: &[Value], ctx: &mut Interpreter)
     } else {
         Some(ctx.to_string(args.get(0).expect("Cannot get object"))?)
     };
-    let own_property =
-        this
+    let own_property = this
         .as_object()
         .as_deref()
         .expect("Cannot get THIS object")

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -614,7 +614,11 @@ pub fn has_own_property(this: &mut Value, args: &[Value], ctx: &mut Interpreter)
         .as_deref()
         .expect("Cannot get THIS object")
         .get_own_property(&Value::string(&prop.expect("cannot get prop")));
-    own_property.value.as_ref().map_or_else(|| Ok(Value::from(false)), |val| Ok(!Value::from(val.is_undefined())))
+    if own_property.is_none() {
+        Ok(Value::from(false))
+    } else {
+        Ok(Value::from(true))
+    }
 }
 
 /// Create a new `Object` object.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -36,6 +36,9 @@ pub use internal_state::{InternalState, InternalStateCell};
 pub mod internal_methods_trait;
 mod internal_state;
 
+#[cfg(test)]
+mod tests;
+
 /// Static `prototype`, usually set on constructors as a key to point to their respective prototype object.
 pub static PROTOTYPE: &str = "prototype";
 
@@ -605,12 +608,13 @@ pub fn has_own_property(this: &mut Value, args: &[Value], ctx: &mut Interpreter)
     } else {
         Some(ctx.to_string(args.get(0).expect("Cannot get object"))?)
     };
-    Ok(Value::from(
-        prop.is_some()
-            && this
-                .get_property(&prop.expect("Cannot get object"))
-                .is_some(),
-    ))
+    let own_property =
+        this
+        .as_object()
+        .as_deref()
+        .expect("Cannot get THIS object")
+        .get_own_property(&Value::string(&prop.expect("cannot get prop")));
+    own_property.value.as_ref().map_or_else(|| Ok(Value::from(false)), |val| Ok(!Value::from(val.is_undefined())))
 }
 
 /// Create a new `Object` object.

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -10,7 +10,13 @@ fn object_has_own_property() {
 
     eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "x.hasOwnProperty('someProp')"), "true");
-    assert_eq!(forward(&mut engine, "x.hasOwnProperty('undefinedProp')"), "true");
+    assert_eq!(
+        forward(&mut engine, "x.hasOwnProperty('undefinedProp')"),
+        "true"
+    );
     assert_eq!(forward(&mut engine, "x.hasOwnProperty('nullProp')"), "true");
-    assert_eq!(forward(&mut engine, "x.hasOwnProperty('hasOwnProperty')"), "false");
+    assert_eq!(
+        forward(&mut engine, "x.hasOwnProperty('hasOwnProperty')"),
+        "false"
+    );
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -1,0 +1,14 @@
+use crate::{exec::Interpreter, forward, realm::Realm};
+
+#[test]
+fn object_has_own_property() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let init = r#"
+        let x = { someProp: 1 };
+    "#;
+
+    eprintln!("{}", forward(&mut engine, init));
+    assert_eq!(forward(&mut engine, "x.hasOwnProperty('someProp')"), "true");
+    assert_eq!(forward(&mut engine, "x.hasOwnProperty('hasOwnProperty')"), "false");
+}

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -5,10 +5,12 @@ fn object_has_own_property() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
     let init = r#"
-        let x = { someProp: 1 };
+        let x = { someProp: 1, undefinedProp: undefined, nullProp: null };
     "#;
 
     eprintln!("{}", forward(&mut engine, init));
     assert_eq!(forward(&mut engine, "x.hasOwnProperty('someProp')"), "true");
+    assert_eq!(forward(&mut engine, "x.hasOwnProperty('undefinedProp')"), "true");
+    assert_eq!(forward(&mut engine, "x.hasOwnProperty('nullProp')"), "true");
     assert_eq!(forward(&mut engine, "x.hasOwnProperty('hasOwnProperty')"), "false");
 }


### PR DESCRIPTION
This Pull Request fixes/closes #443

It changes the following:
 - HasOwnProperty now uses GetOwnProperty instead of GetProperty
