### PR TITLE
Add proto object to from json

### DIFF
--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -107,7 +107,8 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
     };
     let replacer = match args.get(1) {
         Some(replacer) if replacer.is_object() => replacer,
-        _ => return Ok(Value::from(object.to_json().to_string())),
+        // TODO: handle the error case
+        _ => return Ok(Value::from(object.to_json(ctx).unwrap().to_string())),
     };
 
     let replacer_as_object = replacer
@@ -133,7 +134,10 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
                         )?),
                     );
                 }
-                Ok(Value::from(object_to_return.to_json().to_string()))
+                // TODO: Handle the error case
+                Ok(Value::from(
+                    object_to_return.to_json(ctx).unwrap().to_string(),
+                ))
             })
             .ok_or_else(Value::undefined)?
     } else if replacer_as_object.kind == ObjectKind::Array {
@@ -149,7 +153,8 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
         for field in fields {
             if let Some(value) = object
                 .get_property(&ctx.to_string(&field)?)
-                .map(|prop| prop.value.as_ref().map(|v| v.to_json()))
+                // TODO: handle the error case
+                .map(|prop| prop.value.as_ref().map(|v| v.to_json(ctx).unwrap()))
                 .flatten()
             {
                 obj_to_return.insert(field.to_string(), value);
@@ -157,7 +162,8 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
         }
         Ok(Value::from(JSONValue::Object(obj_to_return).to_string()))
     } else {
-        Ok(Value::from(object.to_json().to_string()))
+        // TODO: handle the error case
+        Ok(Value::from(object.to_json(ctx).unwrap().to_string()))
     }
 }
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -17,9 +17,10 @@ use crate::builtins::{
     function::make_builtin_fn,
     object::ObjectKind,
     property::Property,
-    value::{ResultValue, Value},
+    value::{ResultValue, Value, ValueData},
 };
 use crate::{exec::Interpreter, BoaProfiler};
+use gc::Gc;
 use serde_json::{self, Value as JSONValue};
 
 #[cfg(test)]
@@ -42,7 +43,7 @@ pub fn parse(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> ResultValu
         &ctx.to_string(args.get(0).expect("cannot get argument for JSON.parse"))?,
     ) {
         Ok(json) => {
-            let j = Value::from(json);
+            let j = Value(Gc::new(ValueData::from_json(json)));
             match args.get(1) {
                 Some(reviver) if reviver.is_function() => {
                     let mut holder = Value::new_object(None);

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -19,7 +19,8 @@ use crate::builtins::{
     property::Property,
     value::{ResultValue, Value, ValueData},
 };
-use crate::{exec::Interpreter, BoaProfiler};
+use crate::exec::Interpreter;
+use crate::profiler::BoaProfiler;
 use gc::Gc;
 use serde_json::{self, Value as JSONValue};
 
@@ -43,7 +44,7 @@ pub fn parse(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> ResultValu
         &ctx.to_string(args.get(0).expect("cannot get argument for JSON.parse"))?,
     ) {
         Ok(json) => {
-            let j = Value(Gc::new(ValueData::from_json(json)));
+            let j = Value(Gc::new(ValueData::from_json(json, ctx)));
             match args.get(1) {
                 Some(reviver) if reviver.is_function() => {
                     let mut holder = Value::new_object(None);

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -19,8 +19,7 @@ use crate::builtins::{
     property::Property,
     value::{ResultValue, Value},
 };
-use crate::exec::Interpreter;
-use crate::profiler::BoaProfiler;
+use crate::{exec::Interpreter, BoaProfiler};
 use serde_json::{self, Value as JSONValue};
 
 #[cfg(test)]

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -17,11 +17,10 @@ use crate::builtins::{
     function::make_builtin_fn,
     object::ObjectKind,
     property::Property,
-    value::{ResultValue, Value, ValueData},
+    value::{ResultValue, Value},
 };
 use crate::exec::Interpreter;
 use crate::profiler::BoaProfiler;
-use gc::Gc;
 use serde_json::{self, Value as JSONValue};
 
 #[cfg(test)]
@@ -44,7 +43,7 @@ pub fn parse(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> ResultValu
         &ctx.to_string(args.get(0).expect("cannot get argument for JSON.parse"))?,
     ) {
         Ok(json) => {
-            let j = Value(Gc::new(ValueData::from_json(json, ctx)));
+            let j = Value::from_json(json, ctx);
             match args.get(1) {
                 Some(reviver) if reviver.is_function() => {
                     let mut holder = Value::new_object(None);

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -107,8 +107,7 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
     };
     let replacer = match args.get(1) {
         Some(replacer) if replacer.is_object() => replacer,
-        // TODO: handle the error case
-        _ => return Ok(Value::from(object.to_json(ctx).unwrap().to_string())),
+        _ => return Ok(Value::from(object.to_json(ctx)?.to_string())),
     };
 
     let replacer_as_object = replacer
@@ -134,9 +133,8 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
                         )?),
                     );
                 }
-                // TODO: Handle the error case
                 Ok(Value::from(
-                    object_to_return.to_json(ctx).unwrap().to_string(),
+                    object_to_return.to_json(ctx)?.to_string(),
                 ))
             })
             .ok_or_else(Value::undefined)?
@@ -153,17 +151,16 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
         for field in fields {
             if let Some(value) = object
                 .get_property(&ctx.to_string(&field)?)
-                // TODO: handle the error case
-                .map(|prop| prop.value.as_ref().map(|v| v.to_json(ctx).unwrap()))
+                .map(|prop| prop.value.as_ref().map(|v| v.to_json(ctx)))
                 .flatten()
+                .transpose()?
             {
                 obj_to_return.insert(field.to_string(), value);
             }
         }
         Ok(Value::from(JSONValue::Object(obj_to_return).to_string()))
     } else {
-        // TODO: handle the error case
-        Ok(Value::from(object.to_json(ctx).unwrap().to_string()))
+        Ok(Value::from(object.to_json(ctx)?.to_string()))
     }
 }
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -133,9 +133,7 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
                         )?),
                     );
                 }
-                Ok(Value::from(
-                    object_to_return.to_json(ctx)?.to_string(),
-                ))
+                Ok(Value::from(object_to_return.to_json(ctx)?.to_string()))
             })
             .ok_or_else(Value::undefined)?
     } else if replacer_as_object.kind == ObjectKind::Array {

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -149,8 +149,7 @@ pub fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> Result
         for field in fields {
             if let Some(value) = object
                 .get_property(&ctx.to_string(&field)?)
-                .map(|prop| prop.value.as_ref().map(|v| v.to_json(ctx)))
-                .flatten()
+                .and_then(|prop| prop.value.as_ref().map(|v| v.to_json(ctx)))
                 .transpose()?
             {
                 obj_to_return.insert(field.to_string(), value);

--- a/boa/src/builtins/value/conversions.rs
+++ b/boa/src/builtins/value/conversions.rs
@@ -170,12 +170,6 @@ impl TryFrom<&Value> for Object {
     }
 }
 
-impl From<JSONValue> for Value {
-    fn from(value: JSONValue) -> Self {
-        Self(Gc::new(ValueData::from_json(value)))
-    }
-}
-
 impl From<&Value> for JSONValue {
     fn from(value: &Value) -> Self {
         value.to_json()

--- a/boa/src/builtins/value/conversions.rs
+++ b/boa/src/builtins/value/conversions.rs
@@ -170,12 +170,6 @@ impl TryFrom<&Value> for Object {
     }
 }
 
-impl From<&Value> for JSONValue {
-    fn from(value: &Value) -> Self {
-        value.to_json()
-    }
-}
-
 impl From<()> for Value {
     fn from(_: ()) -> Self {
         Value::null()

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -685,7 +685,7 @@ impl ValueData {
                     new_obj.properties.insert(
                         idx.to_string(),
                         Property::default()
-                            .value(Value::from(json.clone()))
+                            .value(Value(Gc::new(ValueData::from_json(json.clone()))))
                             .writable(true)
                             .configurable(true),
                     );
@@ -702,7 +702,7 @@ impl ValueData {
                     new_obj.properties.insert(
                         key.clone(),
                         Property::default()
-                            .value(Value::from(json.clone()))
+                            .value(Value(Gc::new(ValueData::from_json(json.clone()))))
                             .writable(true)
                             .configurable(true),
                     );

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -202,6 +202,52 @@ impl Value {
             JSONValue::Null => Self::null(),
         }
     }
+
+    /// Conversts the `Value` to `JSON`.
+    pub fn to_json(&self) -> JSONValue {
+        match *self.data() {
+            ValueData::Null => JSONValue::Null,
+            ValueData::Boolean(b) => JSONValue::Bool(b),
+            ValueData::Object(ref obj) => {
+                if obj.borrow().kind == ObjectKind::Array {
+                    let mut arr: Vec<JSONValue> = Vec::new();
+                    obj.borrow().properties.keys().for_each(|k| {
+                        if k != "length" {
+                            let value = self.get_field(k.to_string());
+                            if value.is_undefined() || value.is_function() {
+                                arr.push(JSONValue::Null);
+                            } else {
+                                arr.push(self.get_field(k.to_string()).to_json());
+                            }
+                        }
+                    });
+                    JSONValue::Array(arr)
+                } else {
+                    let mut new_obj = Map::new();
+                    obj.borrow().properties.keys().for_each(|k| {
+                        let key = k.clone();
+                        let value = self.get_field(k.to_string());
+                        if !value.is_undefined() && !value.is_function() {
+                            new_obj.insert(key, value.to_json());
+                        }
+                    });
+                    JSONValue::Object(new_obj)
+                }
+            }
+            ValueData::String(ref str) => JSONValue::String(str.clone()),
+            ValueData::Rational(num) => JSONValue::Number(
+                JSONNumber::from_f64(num).expect("Could not convert to JSONNumber"),
+            ),
+            ValueData::Integer(val) => JSONValue::Number(JSONNumber::from(val)),
+            ValueData::BigInt(_) => {
+                // TODO: throw TypeError
+                panic!("TypeError: \"BigInt value can't be serialized in JSON\"");
+            }
+            ValueData::Symbol(_) | ValueData::Undefined => {
+                unreachable!("Symbols and Undefined JSON Values depend on parent type");
+            }
+        }
+    }
 }
 
 impl Deref for Value {
@@ -722,52 +768,6 @@ impl ValueData {
         // Set length to parameters
         new_func_val.set_field("length", Value::from(length));
         new_func_val
-    }
-
-    /// Conversts the `Value` to `JSON`.
-    pub fn to_json(&self) -> JSONValue {
-        match *self {
-            Self::Null => JSONValue::Null,
-            Self::Boolean(b) => JSONValue::Bool(b),
-            Self::Object(ref obj) => {
-                if obj.borrow().kind == ObjectKind::Array {
-                    let mut arr: Vec<JSONValue> = Vec::new();
-                    obj.borrow().properties.keys().for_each(|k| {
-                        if k != "length" {
-                            let value = self.get_field(k.to_string());
-                            if value.is_undefined() || value.is_function() {
-                                arr.push(JSONValue::Null);
-                            } else {
-                                arr.push(self.get_field(k.to_string()).to_json());
-                            }
-                        }
-                    });
-                    JSONValue::Array(arr)
-                } else {
-                    let mut new_obj = Map::new();
-                    obj.borrow().properties.keys().for_each(|k| {
-                        let key = k.clone();
-                        let value = self.get_field(k.to_string());
-                        if !value.is_undefined() && !value.is_function() {
-                            new_obj.insert(key, value.to_json());
-                        }
-                    });
-                    JSONValue::Object(new_obj)
-                }
-            }
-            Self::String(ref str) => JSONValue::String(str.clone()),
-            Self::Rational(num) => JSONValue::Number(
-                JSONNumber::from_f64(num).expect("Could not convert to JSONNumber"),
-            ),
-            Self::Integer(val) => JSONValue::Number(JSONNumber::from(val)),
-            Self::BigInt(_) => {
-                // TODO: throw TypeError
-                panic!("TypeError: \"BigInt value can't be serialized in JSON\"");
-            }
-            Self::Symbol(_) | Self::Undefined => {
-                unreachable!("Symbols and Undefined JSON Values depend on parent type");
-            }
-        }
     }
 
     /// Get the type of the value

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -233,11 +233,7 @@ impl Value {
             }
             ValueData::String(ref str) => Ok(JSONValue::String(str.clone())),
             ValueData::Rational(num) => {
-                if let Some(number) = JSONNumber::from_f64(num) {
-                    Ok(JSONValue::Number(number))
-                } else {
-                    Ok(JSONValue::Null)
-                }
+                JSONNumber::from_f64(num).map(JsonValue::Number).unwrap_or(JSONValue::Null)
             }
             ValueData::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
             ValueData::BigInt(_) => Err(interpreter

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -208,30 +208,28 @@ impl Value {
             ValueData::Object(ref obj) => {
                 if obj.borrow().kind == ObjectKind::Array {
                     let mut arr: Vec<JSONValue> = Vec::new();
-                    obj.borrow().properties.keys().for_each(|k| {
+                    for k in obj.borrow().properties.keys() {
                         if k != "length" {
                             let value = self.get_field(k.to_string());
                             if value.is_undefined() || value.is_function() {
                                 arr.push(JSONValue::Null);
                             } else {
                                 arr.push(
-                                    // TODO: Handle the errors
-                                    self.get_field(k.to_string()).to_json(interpreter).unwrap(),
+                                    self.get_field(k.to_string()).to_json(interpreter)?
                                 );
                             }
                         }
-                    });
+                    }
                     Ok(JSONValue::Array(arr))
                 } else {
                     let mut new_obj = Map::new();
-                    obj.borrow().properties.keys().for_each(|k| {
+                    for k in obj.borrow().properties.keys() {
                         let key = k.clone();
                         let value = self.get_field(k.to_string());
                         if !value.is_undefined() && !value.is_function() {
-                            // TODO: Handle the errors
-                            new_obj.insert(key, value.to_json(interpreter).unwrap());
+                            new_obj.insert(key, value.to_json(interpreter)?);
                         }
-                    });
+                    }
                     Ok(JSONValue::Object(new_obj))
                 }
             }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -215,6 +215,7 @@ impl Value {
                                 arr.push(JSONValue::Null);
                             } else {
                                 arr.push(
+                                    // TODO: Handle the errors
                                     self.get_field(k.to_string()).to_json(interpreter).unwrap(),
                                 );
                             }
@@ -239,11 +240,10 @@ impl Value {
                 JSONNumber::from_f64(num).expect("Could not convert to JSONNumber"),
             )),
             ValueData::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
-            ValueData::BigInt(_) => {
-                Err(interpreter.throw_type_error("BigInt value can't be serialized in JSON")?)
-            }
+            ValueData::BigInt(_) => Err(interpreter
+                .throw_type_error("BigInt value can't be serialized in JSON")
+                .expect_err("throw_type_error should always return an error")),
             ValueData::Symbol(_) | ValueData::Undefined => {
-                // TODO: What should this return?
                 unreachable!("Symbols and Undefined JSON Values depend on parent type");
             }
         }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -15,6 +15,7 @@ use crate::builtins::{
 };
 use crate::BoaProfiler;
 
+use crate::exec::Interpreter;
 use gc::{Finalize, Gc, GcCell, GcCellRef, Trace};
 use serde_json::{map::Map, Number as JSONNumber, Value as JSONValue};
 use std::{
@@ -672,7 +673,7 @@ impl ValueData {
     }
 
     /// Convert from a JSON value to a JS value
-    pub fn from_json(json: JSONValue) -> Self {
+    pub fn from_json(json: JSONValue, interpreter: &mut Interpreter) -> Self {
         match json {
             JSONValue::Number(v) => {
                 Self::Rational(v.as_f64().expect("Could not convert value to f64"))
@@ -685,7 +686,10 @@ impl ValueData {
                     new_obj.properties.insert(
                         idx.to_string(),
                         Property::default()
-                            .value(Value(Gc::new(ValueData::from_json(json.clone()))))
+                            .value(Value(Gc::new(ValueData::from_json(
+                                json.clone(),
+                                interpreter,
+                            ))))
                             .writable(true)
                             .configurable(true),
                     );
@@ -702,7 +706,10 @@ impl ValueData {
                     new_obj.properties.insert(
                         key.clone(),
                         Property::default()
-                            .value(Value(Gc::new(ValueData::from_json(json.clone()))))
+                            .value(Value(Gc::new(ValueData::from_json(
+                                json.clone(),
+                                interpreter,
+                            ))))
                             .writable(true)
                             .configurable(true),
                     );

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -232,9 +232,9 @@ impl Value {
                 }
             }
             ValueData::String(ref str) => Ok(JSONValue::String(str.clone())),
-            ValueData::Rational(num) => {
-                JSONNumber::from_f64(num).map(JsonValue::Number).unwrap_or(JSONValue::Null)
-            }
+            ValueData::Rational(num) => Ok(JSONNumber::from_f64(num)
+                .map(JSONValue::Number)
+                .unwrap_or(JSONValue::Null)),
             ValueData::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
             ValueData::BigInt(_) => Err(interpreter
                 .throw_type_error("BigInt value can't be serialized in JSON")

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -161,27 +161,28 @@ impl Value {
             JSONValue::Bool(v) => Self::boolean(v),
             JSONValue::Array(vs) => {
                 let mut new_obj = Object::default();
-                for (idx, json) in vs.iter().enumerate() {
+                let length = vs.len();
+                for (idx, json) in vs.into_iter().enumerate() {
                     new_obj.properties.insert(
                         idx.to_string(),
                         Property::default()
-                            .value(Self::from_json(json.clone(), interpreter))
+                            .value(Self::from_json(json, interpreter))
                             .writable(true)
                             .configurable(true),
                     );
                 }
                 new_obj.properties.insert(
                     "length".to_string(),
-                    Property::default().value(Self::from(vs.len())),
+                    Property::default().value(Self::from(length)),
                 );
                 Self::object(new_obj)
             }
             JSONValue::Object(obj) => {
                 let new_obj = Value::new_object(Some(&interpreter.realm.global_obj));
-                for (key, json) in obj.iter() {
-                    let value = Self::from_json(json.clone(), interpreter);
+                for (key, json) in obj.into_iter() {
+                    let value = Self::from_json(json, interpreter);
                     new_obj.set_property(
-                        key.clone(),
+                        key,
                         Property::default()
                             .value(value)
                             .writable(true)

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -21,6 +21,7 @@ use serde_json::{map::Map, Number as JSONNumber, Value as JSONValue};
 use std::{
     any::Any,
     collections::HashSet,
+    convert::TryFrom,
     f64::NAN,
     fmt::{self, Display},
     ops::{Add, BitAnd, BitOr, BitXor, Deref, DerefMut, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
@@ -155,7 +156,11 @@ impl Value {
     pub fn from_json(json: JSONValue, interpreter: &mut Interpreter) -> Self {
         match json {
             JSONValue::Number(v) => {
-                Self::rational(v.as_f64().expect("Could not convert value to f64"))
+                if let Some(Ok(integer_32)) = v.as_i64().map(i32::try_from) {
+                    Self::integer(integer_32)
+                } else {
+                    Self::rational(v.as_f64().expect("Could not convert value to f64"))
+                }
             }
             JSONValue::String(v) => Self::string(v),
             JSONValue::Bool(v) => Self::boolean(v),

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -214,9 +214,7 @@ impl Value {
                             if value.is_undefined() || value.is_function() {
                                 arr.push(JSONValue::Null);
                             } else {
-                                arr.push(
-                                    self.get_field(k.to_string()).to_json(interpreter)?
-                                );
+                                arr.push(self.get_field(k.to_string()).to_json(interpreter)?);
                             }
                         }
                     }
@@ -240,7 +238,7 @@ impl Value {
                 } else {
                     Ok(JSONValue::Null)
                 }
-            },
+            }
             ValueData::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
             ValueData::BigInt(_) => Err(interpreter
                 .throw_type_error("BigInt value can't be serialized in JSON")

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -177,18 +177,10 @@ impl Value {
                 Self::object(new_obj)
             }
             JSONValue::Object(obj) => {
-                let mut new_obj = Object::default();
+                let new_obj = Value::new_object(Some(&interpreter.realm.global_obj));
                 for (key, json) in obj.iter() {
                     let value = Self::from_json(json.clone(), interpreter);
-                    if value.is_object() {
-                        let proto = interpreter
-                            .realm
-                            .global_obj
-                            .get_field("Object")
-                            .get_field(PROTOTYPE);
-                        value.set_internal_slot(INSTANCE_PROTOTYPE, proto);
-                    }
-                    new_obj.properties.insert(
+                    new_obj.set_property(
                         key.clone(),
                         Property::default()
                             .value(value)
@@ -196,8 +188,7 @@ impl Value {
                             .configurable(true),
                     );
                 }
-
-                Self::object(new_obj)
+                new_obj
             }
             JSONValue::Null => Self::null(),
         }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -234,9 +234,13 @@ impl Value {
                 }
             }
             ValueData::String(ref str) => Ok(JSONValue::String(str.clone())),
-            ValueData::Rational(num) => Ok(JSONValue::Number(
-                JSONNumber::from_f64(num).expect("Could not convert to JSONNumber"),
-            )),
+            ValueData::Rational(num) => {
+                if let Some(number) = JSONNumber::from_f64(num) {
+                    Ok(JSONValue::Number(number))
+                } else {
+                    Ok(JSONValue::Null)
+                }
+            },
             ValueData::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
             ValueData::BigInt(_) => Err(interpreter
                 .throw_type_error("BigInt value can't be serialized in JSON")


### PR DESCRIPTION
This Pull Request addresses objects created from JSON parse #452.

It changes the following:
 - Removes `impl From<JSONValue> for Value { ... }` conversion.
 - Removes `ValueData::from_json` and `ValueData::to_json`
 - Adds `Value::from_json` and `Value::to_json`
 - Adds the object prototype to object created from JSON objects in `Value::from_json()`

It does not yet address Booleans, Arrays, Strings, Numbers or Null.