### PR TITLE
[Property accessor - executor] fix bracket accessing on non-objects types

### DIFF
--- a/boa/src/exec/field/mod.rs
+++ b/boa/src/exec/field/mod.rs
@@ -19,7 +19,12 @@ impl Executable for GetConstField {
 
 impl Executable for GetField {
     fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
-        let obj = self.obj().run(interpreter)?;
+        let mut obj = self.obj().run(interpreter)?;
+        if obj.get_type() != "object" || obj.get_type() != "symbol" {
+            obj = interpreter
+                .to_object(&obj)
+                .expect("failed to convert to object");
+        }
         let field = self.field().run(interpreter)?;
 
         Ok(obj.get_field(field.to_string()))

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -1,6 +1,44 @@
 use crate::{builtins::Value, exec, exec::Interpreter, forward, realm::Realm};
 
 #[test]
+fn property_accessor_member_expression_dot_notation_on_string_literal() {
+    let scenario = r#"
+        typeof 'asd'.matchAll;
+        "#;
+
+    assert_eq!(&exec(scenario), "function");
+}
+
+#[test]
+fn property_accessor_member_expression_bracket_notation_on_string_literal() {
+    let scenario = r#"
+        typeof 'asd'['matchAll'];
+        "#;
+
+    assert_eq!(&exec(scenario), "function");
+}
+
+#[test]
+fn property_accessor_member_expression_dot_notation_on_function() {
+    let scenario = r#"
+        function asd () {};
+        asd.name;
+        "#;
+
+    assert_eq!(&exec(scenario), "asd");
+}
+
+#[test]
+fn property_accessor_member_expression_bracket_notation_on_function() {
+    let scenario = r#"
+        function asd () {};
+        asd['name'];
+        "#;
+
+    assert_eq!(&exec(scenario), "asd");
+}
+
+#[test]
 fn empty_let_decl_undefined() {
     let scenario = r#"
         let a;


### PR DESCRIPTION
Closes #210 
I've added 4 tests, to test accessing properties on functions and strings with both bracket and dot notation.