### PR TITLE
create boolean objects with prototype

### DIFF
--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -19,7 +19,7 @@ fn json_sanity() {
     assert_eq!(
         forward(
             &mut engine,
-            r#"JSON.stringify({aaa: 'bbb'}) == '{"aaa":"bbb"}'"#
+            r#"JSON.stringify({aaa: 'bbb', ccc: true}) == '{"aaa":"bbb","ccc":true}'"#
         ),
         "true"
     );
@@ -251,20 +251,33 @@ fn json_parse_sets_prototypes() {
     let mut engine = Interpreter::new(realm);
     let init = r#"
         const jsonString = "{
-            \"ob\":{\"ject\":1}
+            \"ob\":{\"ject\":1},
+            \"booleanTrue\": true
         }";
         const jsonObj = JSON.parse(jsonString);
     "#;
     eprintln!("{}", forward(&mut engine, init));
     let object = forward_val(&mut engine, r#"jsonObj.ob"#).unwrap();
     let object_prototype = object.get_internal_slot(INSTANCE_PROTOTYPE);
+    let boolean_true_prototype = forward_val(&mut engine, r#"jsonObj.booleanTrue"#)
+        .unwrap()
+        .get_internal_slot(INSTANCE_PROTOTYPE);
     let global_object_prototype = engine
         .realm
         .global_obj
         .get_field("Object")
         .get_field(PROTOTYPE);
+    let global_boolean_prototype = engine
+        .realm
+        .global_obj
+        .get_field("Boolean")
+        .get_field(PROTOTYPE);
     assert_eq!(
         same_value(&object_prototype, &global_object_prototype, true),
+        true
+    );
+    assert_eq!(
+        same_value(&boolean_true_prototype, &global_boolean_prototype, true),
         true
     );
 }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -163,7 +163,17 @@ impl Value {
                 }
             }
             JSONValue::String(v) => Self::string(v),
-            JSONValue::Bool(v) => Self::boolean(v),
+            JSONValue::Bool(v) => {
+                let boolean_prototype = interpreter
+                    .realm
+                    .global_obj
+                    .get_field("Boolean")
+                    .get_field(PROTOTYPE);
+                let boolean_value =
+                    Self::new_object_from_prototype(boolean_prototype, ObjectKind::Boolean);
+                boolean_value.set_internal_slot("BooleanData", Self::boolean(v));
+                boolean_value
+            }
             JSONValue::Array(vs) => {
                 let mut new_obj = Object::default();
                 let length = vs.len();


### PR DESCRIPTION
This Pull Request address boolean values for #452 .

It changes the following:
 - Adds the prototype to boolean values created in `Value::from_json`
