### PR TITLE
add array prototype to arrays built in from_json

### DIFF
--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -251,20 +251,34 @@ fn json_parse_sets_prototypes() {
     let mut engine = Interpreter::new(realm);
     let init = r#"
         const jsonString = "{
-            \"ob\":{\"ject\":1}
+            \"ob\":{\"ject\":1},
+            \"arr\": [0,1]
         }";
         const jsonObj = JSON.parse(jsonString);
     "#;
     eprintln!("{}", forward(&mut engine, init));
-    let object = forward_val(&mut engine, r#"jsonObj.ob"#).unwrap();
-    let object_prototype = object.get_internal_slot(INSTANCE_PROTOTYPE);
+    let object_prototype = forward_val(&mut engine, r#"jsonObj.ob"#)
+        .unwrap()
+        .get_internal_slot(INSTANCE_PROTOTYPE);
+    let array_prototype = forward_val(&mut engine, r#"jsonObj.arr"#)
+        .unwrap()
+        .get_internal_slot(INSTANCE_PROTOTYPE);
     let global_object_prototype = engine
         .realm
         .global_obj
         .get_field("Object")
         .get_field(PROTOTYPE);
+    let global_array_prototype = engine
+        .realm
+        .global_obj
+        .get_field("Array")
+        .get_field(PROTOTYPE);
     assert_eq!(
         same_value(&object_prototype, &global_object_prototype, true),
+        true
+    );
+    assert_eq!(
+        same_value(&array_prototype, &global_array_prototype, true),
         true
     );
 }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -165,10 +165,16 @@ impl Value {
             JSONValue::String(v) => Self::string(v),
             JSONValue::Bool(v) => Self::boolean(v),
             JSONValue::Array(vs) => {
-                let mut new_obj = Object::default();
+                let global_array_prototype = interpreter
+                    .realm
+                    .global_obj
+                    .get_field("Array")
+                    .get_field(PROTOTYPE);
+                let new_obj =
+                    Value::new_object_from_prototype(global_array_prototype, ObjectKind::Array);
                 let length = vs.len();
                 for (idx, json) in vs.into_iter().enumerate() {
-                    new_obj.properties.insert(
+                    new_obj.set_property(
                         idx.to_string(),
                         Property::default()
                             .value(Self::from_json(json, interpreter))
@@ -176,11 +182,11 @@ impl Value {
                             .configurable(true),
                     );
                 }
-                new_obj.properties.insert(
+                new_obj.set_property(
                     "length".to_string(),
                     Property::default().value(Self::from(length)),
                 );
-                Self::object(new_obj)
+                new_obj
             }
             JSONValue::Object(obj) => {
                 let new_obj = Value::new_object(Some(&interpreter.realm.global_obj));


### PR DESCRIPTION
This Pull Request fixes/closes #452.

It changes the following:
 - Adds the array prototype to arrays created in `Value::from_json`
