### PR TITLE
Small optimisation in some types that can be `Copy`

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -40,10 +40,14 @@ pub enum ConstructorKind {
 /// Defines how this references are interpreted within the formal parameters and code body of the function.
 ///
 /// Arrow functions don't define a `this` and thus are lexical, `function`s do define a this and thus are NonLexical
-#[derive(Trace, Finalize, Debug, Clone)]
+#[derive(Copy, Finalize, Debug, Clone)]
 pub enum ThisMode {
     Lexical,
     NonLexical,
+}
+
+unsafe impl Trace for ThisMode {
+    unsafe_empty_trace!();
 }
 
 /// FunctionBody is specific to this interpreter, it will either be Rust code or JavaScript code (AST Node)

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -16,12 +16,12 @@ use crate::{
         lexical_environment::{Environment, EnvironmentType},
     },
 };
-use gc::{Finalize, Trace};
+use gc::{unsafe_empty_trace, Finalize, Trace};
 use rustc_hash::FxHashMap;
 
 /// Different binding status for `this`.
 /// Usually set on a function environment record
-#[derive(Trace, Finalize, Debug, Clone)]
+#[derive(Copy, Finalize, Debug, Clone)]
 pub enum BindingStatus {
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.
     Lexical,
@@ -29,6 +29,10 @@ pub enum BindingStatus {
     Initialized,
     /// If uninitialized the function environment record has not been bouned with a `this` value
     Uninitialized,
+}
+
+unsafe impl Trace for BindingStatus {
+    unsafe_empty_trace!();
 }
 
 /// <https://tc39.es/ecma262/#table-16>

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -41,7 +41,7 @@ pub use self::{
     try_node::{Catch, Finally, Try},
 };
 use super::Const;
-use gc::{Finalize, Trace};
+use gc::{unsafe_empty_trace, Finalize, Trace};
 use std::{
     cmp::Ordering,
     fmt::{self, Display},
@@ -428,7 +428,7 @@ impl PropertyDefinition {
 /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Trace, Finalize)]
+#[derive(Clone, Debug, PartialEq, Copy, Finalize)]
 pub enum MethodDefinitionKind {
     /// The `get` syntax binds an object property to a function that will be called when that property is looked up.
     ///
@@ -471,4 +471,8 @@ pub enum MethodDefinitionKind {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#Method_definition_syntax
     Ordinary,
     // TODO: support other method definition kinds, like `Generator`.
+}
+
+unsafe impl Trace for MethodDefinitionKind {
+    unsafe_empty_trace!();
 }


### PR DESCRIPTION
This PR adds some `Copy` implementation to some enumerations that can be stored in the stack by adding an empty trace implementation to them. This could improve execution times a bit.