### PR TITLE
Fixed global objects initialization order

### DIFF
--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -33,39 +33,44 @@ pub(crate) use self::{
     regexp::RegExp,
     string::String,
     symbol::Symbol,
-    value::{ResultValue, Value},
+    value::{ResultValue, Value, ValueData},
 };
 
 /// Initializes builtin objects and functions
 #[inline]
 pub fn init(global: &Value) {
-    let globals = vec![
+    let globals = [
         // The `Function` global must be initialized before other types.
-        function::init(global),
-        Array::init(global),
-        BigInt::init(global),
-        Boolean::init(global),
-        Json::init(global),
-        Math::init(global),
-        Number::init(global),
-        object::init(global),
-        RegExp::init(global),
-        String::init(global),
-        Symbol::init(global),
-        console::init(global),
+        function::init,
+        object::init,
+        Array::init,
+        BigInt::init,
+        Boolean::init,
+        Json::init,
+        Math::init,
+        Number::init,
+        RegExp::init,
+        String::init,
+        Symbol::init,
+        console::init,
         // Global error types.
-        Error::init(global),
-        RangeError::init(global),
-        ReferenceError::init(global),
-        TypeError::init(global),
+        Error::init,
+        RangeError::init,
+        ReferenceError::init,
+        TypeError::init,
         // Global properties.
-        NaN::init(global),
-        Infinity::init(global),
-        GlobalThis::init(global),
+        NaN::init,
+        Infinity::init,
+        GlobalThis::init,
     ];
 
-    let mut global_object = global.as_object_mut().expect("global object");
-    for (name, value) in globals {
-        global_object.insert_field(name, value);
+    match global.data() {
+        ValueData::Object(ref global_object) => {
+            for init in &globals {
+                let (name, value) = init(global);
+                global_object.borrow_mut().insert_field(name, value);
+            }
+        }
+        _ => unreachable!("expect global object"),
     }
 }


### PR DESCRIPTION
It changes the following:
 - Fix the order of builtins (`Object` should be initialized before `Array`)
 - Removed `vec![]` from builtins

This unblocks #434 