### PR TITLE
434 json parse enumerability

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -994,7 +994,7 @@ impl Array {
     /// Create a new `Array` object.
     pub(crate) fn create(global: &Value) -> Value {
         // Create prototype
-        let prototype = Value::new_object(None);
+        let prototype = Value::new_object(Some(global));
         let length = Property::default().value(Value::from(0));
 
         prototype.set_property("length", length);

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -299,7 +299,7 @@ fn json_fields_should_be_enumerable() {
         r#"
         var b = JSON.parse('[0, 1]');
         b.propertyIsEnumerable('0');
-        "#
+        "#,
     );
     let expected = forward(&mut engine, r#"true"#);
 

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -287,14 +287,22 @@ fn json_parse_sets_prototypes() {
 fn json_fields_should_be_enumerable() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
-    let actual = forward(
+    let actual_object = forward(
         &mut engine,
         r#"
         var a = JSON.parse('{"x":0}');
         a.propertyIsEnumerable('x');
     "#,
     );
+    let actual_array_index = forward(
+        &mut engine,
+        r#"
+        var b = JSON.parse('[0, 1]');
+        b.propertyIsEnumerable('0');
+        "#
+    );
     let expected = forward(&mut engine, r#"true"#);
 
-    assert_eq!(actual, expected);
+    assert_eq!(actual_object, expected);
+    assert_eq!(actual_array_index, expected);
 }

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -282,3 +282,19 @@ fn json_parse_sets_prototypes() {
         true
     );
 }
+
+#[test]
+fn json_fields_should_be_enumerable() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let actual = forward(
+        &mut engine,
+        r#"
+        var a = JSON.parse('{"x":0}');
+        a.propertyIsEnumerable('x');
+    "#,
+    );
+    let expected = forward(&mut engine, r#"true"#);
+
+    assert_eq!(actual, expected);
+}

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -486,14 +486,13 @@ pub fn property_is_enumerable(
     let property_key = ctx.to_property_key(&mut key.clone())?;
     let own_property = ctx.to_object(this).map(|obj| {
         obj.as_object()
-           .as_deref()
-           .expect("Unable to deref object")
-           .get_own_property(&property_key)
+            .as_deref()
+            .expect("Unable to deref object")
+            .get_own_property(&property_key)
     });
-    own_property.map_or(
-        Ok(Value::from(false)),
-        |own_prop| Ok(Value::from(own_prop.enumerable.unwrap_or(false)))
-    )
+    own_property.map_or(Ok(Value::from(false)), |own_prop| {
+        Ok(Value::from(own_prop.enumerable.unwrap_or(false)))
+    })
 }
 
 /// Create a new `Object` object.
@@ -501,7 +500,12 @@ pub fn create(global: &Value) -> Value {
     let prototype = Value::new_object(None);
 
     make_builtin_fn(has_own_property, "hasOwnProperty", &prototype, 0);
-    make_builtin_fn(property_is_enumerable, "propertyIsEnumerable", &prototype, 0);
+    make_builtin_fn(
+        property_is_enumerable,
+        "propertyIsEnumerable",
+        &prototype,
+        0,
+    );
     make_builtin_fn(to_string, "toString", &prototype, 0);
 
     let object = make_constructor_fn("Object", 1, make_object, global, prototype, true);

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -490,7 +490,6 @@ pub fn property_is_enumerable(
             .expect("got an error here")
             .get_own_property(&property_key)
     });
-    println!("calling here");
     let unwrapped_own_prop = own_property.expect("bummer");
     if unwrapped_own_prop.is_none() {
         Ok(Value::from(false))

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -478,24 +478,22 @@ pub fn property_is_enumerable(
     ctx: &mut Interpreter,
 ) -> ResultValue {
     let key = if args.is_empty() {
-        None
+        return Ok(Value::from(false));
     } else {
-        Some(args.get(0).expect("Cannot get object"))
+        args.get(0).expect("Cannot get key")
     };
 
-    let property_key = ctx.to_property_key(&mut key.unwrap().clone())?;
+    let property_key = ctx.to_property_key(&mut key.clone())?;
     let own_property = ctx.to_object(this).map(|obj| {
         obj.as_object()
-            .as_deref()
-            .expect("got an error here")
-            .get_own_property(&property_key)
+           .as_deref()
+           .expect("Unable to deref object")
+           .get_own_property(&property_key)
     });
-    let unwrapped_own_prop = own_property.expect("bummer");
-    if unwrapped_own_prop.is_none() {
-        Ok(Value::from(false))
-    } else {
-        Ok(Value::from(unwrapped_own_prop.enumerable.unwrap()))
-    }
+    own_property.map_or(
+        Ok(Value::from(false)),
+        |own_prop| Ok(Value::from(own_prop.enumerable.unwrap_or(false)))
+    )
 }
 
 /// Create a new `Object` object.

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -20,3 +20,21 @@ fn object_has_own_property() {
         "false"
     );
 }
+
+#[test]
+fn object_property_is_enumerable() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let init = r#"
+        let x = { enumerableProp: 'yes' };
+    "#;
+    eprintln!("{}", forward(&mut engine, init));
+    assert_eq!(
+        forward(&mut engine, r#"x.propertyIsEnumerable('enumerableProp')"#),
+        "true"
+    );
+    assert_eq!(
+        forward(&mut engine, r#"x.propertyIsEnumerable('hasOwnProperty')"#),
+        "false"
+    );
+}

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -37,4 +37,12 @@ fn object_property_is_enumerable() {
         forward(&mut engine, r#"x.propertyIsEnumerable('hasOwnProperty')"#),
         "false"
     );
+    assert_eq!(
+        forward(&mut engine, r#"x.propertyIsEnumerable('not_here')"#),
+        "false",
+    );
+    assert_eq!(
+        forward(&mut engine, r#"x.propertyIsEnumerable()"#),
+        "false",
+    )
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -41,8 +41,5 @@ fn object_property_is_enumerable() {
         forward(&mut engine, r#"x.propertyIsEnumerable('not_here')"#),
         "false",
     );
-    assert_eq!(
-        forward(&mut engine, r#"x.propertyIsEnumerable()"#),
-        "false",
-    )
+    assert_eq!(forward(&mut engine, r#"x.propertyIsEnumerable()"#), "false",)
 }

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -214,7 +214,7 @@ impl Value {
                             .value(value)
                             .writable(true)
                             .configurable(true)
-                            .enumerable(true)
+                            .enumerable(true),
                     );
                 }
                 new_obj

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -194,7 +194,8 @@ impl Value {
                         Property::default()
                             .value(Self::from_json(json, interpreter))
                             .writable(true)
-                            .configurable(true),
+                            .configurable(true)
+                            .enumerable(true),
                     );
                 }
                 new_obj.set_property(
@@ -212,7 +213,8 @@ impl Value {
                         Property::default()
                             .value(value)
                             .writable(true)
-                            .configurable(true),
+                            .configurable(true)
+                            .enumerable(true)
                     );
                 }
                 new_obj


### PR DESCRIPTION
This Pull Request fixes/closes #434

It changes the following:
 - Adds `propertyIsEnumerable` function to Object Prototype
 - Uses `propertyIsEnumerable` to test that values coming out of `JSON.parse(...)` are enumerable
