### PR TITLE
Fixed function call with unspecified arguments

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -192,21 +192,20 @@ impl Function {
                     let local_env = new_function_environment(
                         function,
                         None,
-                        Some(self.environment.as_ref().unwrap().clone()),
+                        self.environment.as_ref().cloned(),
                         BindingStatus::Uninitialized,
                     );
 
                     // Add argument bindings to the function environment
-                    for i in 0..self.params.len() {
-                        let param = self.params.get(i).expect("Could not get param");
+                    for (i, param) in self.params.iter().enumerate() {
                         // Rest Parameters
                         if param.is_rest_param() {
                             self.add_rest_param(param, i, args_list, interpreter, &local_env);
                             break;
                         }
 
-                        let value = args_list.get(i).expect("Could not get value");
-                        self.add_arguments_to_environment(param, value.clone(), &local_env);
+                        let value = args_list.get(i).cloned().unwrap_or_else(Value::undefined);
+                        self.add_arguments_to_environment(param, value, &local_env);
                     }
 
                     // Add arguments object
@@ -253,7 +252,7 @@ impl Function {
                     let local_env = new_function_environment(
                         function,
                         Some(this.clone()),
-                        Some(self.environment.as_ref().unwrap().clone()),
+                        self.environment.as_ref().cloned(),
                         BindingStatus::Initialized,
                     );
 
@@ -265,8 +264,8 @@ impl Function {
                             break;
                         }
 
-                        let value = args_list.get(i).expect("Could not get value");
-                        self.add_arguments_to_environment(param, value.clone(), &local_env);
+                        let value = args_list.get(i).cloned().unwrap_or_else(Value::undefined);
+                        self.add_arguments_to_environment(param, value, &local_env);
                     }
 
                     // Add arguments object

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -477,16 +477,14 @@ pub fn property_is_enumerable(
     args: &[Value],
     ctx: &mut Interpreter,
 ) -> ResultValue {
-    let key = if args.is_empty() {
-        return Ok(Value::from(false));
-    } else {
-        args.get(0).expect("Cannot get key")
+    let key = match args.get(0) {
+        None => return Ok(Value::from(false)),
+        Some(key) => key,
     };
 
     let property_key = ctx.to_property_key(&mut key.clone())?;
     let own_property = ctx.to_object(this).map(|obj| {
         obj.as_object()
-            .as_deref()
             .expect("Unable to deref object")
             .get_own_property(&property_key)
     });

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -912,3 +912,18 @@ fn to_string() {
     assert_eq!(engine.to_string(&Value::rational(55.0)).unwrap(), "55");
     assert_eq!(engine.to_string(&Value::string("hello")).unwrap(), "hello");
 }
+
+#[test]
+fn calling_function_with_unspecified_arguments() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let scenario = r#"
+        function test(a, b) {
+            return b;
+        }
+
+        test(10)
+    "#;
+
+    assert_eq!(forward(&mut engine, scenario), "undefined");
+}


### PR DESCRIPTION
This pull request fixes #505 

It changes the following:
 - Fixed calling a function with less amount of arguments than the function declaration parameters.

This is blocked until #501 lands