### PR TITLE
JSON.stringify(undefined) should return undefined

### DIFF
--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -108,7 +108,9 @@ impl Json {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
     pub(crate) fn stringify(_: &mut Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
         let object = match args.get(0) {
-            Some(obj) if obj.is_symbol() || obj.is_function() => return Ok(Value::undefined()),
+            Some(obj) if obj.is_symbol() || obj.is_function() || obj.is_undefined() => {
+                return Ok(Value::undefined())
+            }
             None => return Ok(Value::undefined()),
             Some(obj) => obj,
         };

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -191,11 +191,13 @@ fn json_stringify_return_undefined() {
     let actual_no_args = forward(&mut engine, r#"JSON.stringify()"#);
     let actual_function = forward(&mut engine, r#"JSON.stringify(() => {})"#);
     let actual_symbol = forward(&mut engine, r#"JSON.stringify(Symbol())"#);
+    let actual_undefined = forward(&mut engine, r#"JSON.stringify(undefined)"#);
     let expected = forward(&mut engine, r#"undefined"#);
 
     assert_eq!(actual_no_args, expected);
     assert_eq!(actual_function, expected);
     assert_eq!(actual_symbol, expected);
+    assert_eq!(actual_undefined, expected);
 }
 
 #[test]

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -184,20 +184,46 @@ fn json_stringify_function_replacer_propogate_error() {
 }
 
 #[test]
-fn json_stringify_return_undefined() {
+fn json_stringify_function() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let actual_function = forward(&mut engine, r#"JSON.stringify(() => {})"#);
+    let expected = forward(&mut engine, r#"undefined"#);
+
+    assert_eq!(actual_function, expected);
+}
+
+#[test]
+fn json_stringify_undefined() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let actual_undefined = forward(&mut engine, r#"JSON.stringify(undefined)"#);
+    let expected = forward(&mut engine, r#"undefined"#);
+
+    assert_eq!(actual_undefined, expected);
+}
+
+#[test]
+fn json_stringify_symbol() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let actual_symbol = forward(&mut engine, r#"JSON.stringify(Symbol())"#);
+    let expected = forward(&mut engine, r#"undefined"#);
+
+    assert_eq!(actual_symbol, expected);
+}
+
+#[test]
+fn json_stringify_no_args() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
 
     let actual_no_args = forward(&mut engine, r#"JSON.stringify()"#);
-    let actual_function = forward(&mut engine, r#"JSON.stringify(() => {})"#);
-    let actual_symbol = forward(&mut engine, r#"JSON.stringify(Symbol())"#);
-    let actual_undefined = forward(&mut engine, r#"JSON.stringify(undefined)"#);
     let expected = forward(&mut engine, r#"undefined"#);
 
     assert_eq!(actual_no_args, expected);
-    assert_eq!(actual_function, expected);
-    assert_eq!(actual_symbol, expected);
-    assert_eq!(actual_undefined, expected);
 }
 
 #[test]


### PR DESCRIPTION
This Pull Request fixes/closes #509

It changes the following:
 - `JSON.stringify(undefined);` now returns undefined according to [spec](https://tc39.es/ecma262/#sec-json.stringify)