### PR TITLE
TypeError when to_object is passed null or undefined

### DIFF
--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -424,7 +424,7 @@ impl Interpreter {
     /// https://tc39.es/ecma262/#sec-toobject
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_object(&mut self, value: &Value) -> ResultValue {
-    match value {
+        match value {
             Value::Undefined | Value::Null => {
                 self.throw_type_error("cannot convert 'null' or 'undefined' to object")
             }

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -414,7 +414,7 @@ impl Interpreter {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_object(&mut self, value: &Value) -> ResultValue {
         match value.data() {
-            ValueData::Undefined | ValueData::Null => Err(Value::undefined()),
+            ValueData::Undefined | ValueData::Null => self.throw_type_error("cannot convert 'null' or 'undefined' to object"),
             ValueData::Boolean(boolean) => {
                 let proto = self
                     .realm

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -424,7 +424,7 @@ impl Interpreter {
     /// https://tc39.es/ecma262/#sec-toobject
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_object(&mut self, value: &Value) -> ResultValue {
-    match value.data() {
+    match value {
             Value::Undefined | Value::Null => {
                 self.throw_type_error("cannot convert 'null' or 'undefined' to object")
             }

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -414,7 +414,9 @@ impl Interpreter {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_object(&mut self, value: &Value) -> ResultValue {
         match value.data() {
-            ValueData::Undefined | ValueData::Null => self.throw_type_error("cannot convert 'null' or 'undefined' to object"),
+            ValueData::Undefined | ValueData::Null => {
+                self.throw_type_error("cannot convert 'null' or 'undefined' to object")
+            }
             ValueData::Boolean(boolean) => {
                 let proto = self
                     .realm

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -932,13 +932,10 @@ fn calling_function_with_unspecified_arguments() {
 fn to_object() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
-    
+
     assert!(engine
         .to_object(&Value::undefined())
         .unwrap_err()
         .is_object());
-    assert!(engine
-        .to_object(&Value::null())
-        .unwrap_err()
-        .is_object());
+    assert!(engine.to_object(&Value::null()).unwrap_err().is_object());
 }

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -927,3 +927,12 @@ fn calling_function_with_unspecified_arguments() {
 
     assert_eq!(forward(&mut engine, scenario), "undefined");
 }
+
+#[test]
+fn to_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    
+    assert!(engine.to_object(&Value::undefined()).unwrap_err().is_object());
+    assert!(engine.to_object(&Value::null()).unwrap_err().is_object());
+}

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -933,6 +933,12 @@ fn to_object() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
     
-    assert!(engine.to_object(&Value::undefined()).unwrap_err().is_object());
-    assert!(engine.to_object(&Value::null()).unwrap_err().is_object());
+    assert!(engine
+        .to_object(&Value::undefined())
+        .unwrap_err()
+        .is_object());
+    assert!(engine
+        .to_object(&Value::null())
+        .unwrap_err()
+        .is_object());
 }


### PR DESCRIPTION
This Pull Request fixes/closes #483.

It changes the following:
 - Changed the `to_object` implementation to throw a `TypeError` when passed an `undefined` or `null` value.

Best,
