### PR TITLE
update pass through math methods

### DIFF
--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -64,7 +64,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     pub(crate) fn acosh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).acosh()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).acosh())
+            .into())
     }
 
     /// Get the arcsine of a number.
@@ -88,7 +91,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
     pub(crate) fn asinh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).asinh()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).asinh())
+            .into())
     }
 
     /// Get the arctangent of a number.
@@ -112,7 +118,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
     pub(crate) fn atanh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).atanh()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).atanh())
+            .into())
     }
 
     /// Get the arctangent of a numbers.
@@ -201,7 +210,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.floor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
     pub(crate) fn floor(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).floor()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).floor())
+            .into())
     }
 
     /// Get the natural logarithm of a number.
@@ -343,7 +355,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     pub(crate) fn round(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).round()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).round())
+            .into())
     }
 
     /// Get the sign of a number.
@@ -429,7 +444,10 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
     pub(crate) fn trunc(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).trunc()).into())
+        Ok(args
+            .get(0)
+            .map_or(f64::NAN, |x| f64::from(x).trunc())
+            .into())
     }
 
     /// Create a new `Math` object

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -40,11 +40,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.abs
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
     pub(crate) fn abs(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).abs()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).abs()).into())
     }
 
     /// Get the arccos of a number.
@@ -56,11 +52,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
     pub(crate) fn acos(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).acos()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).acos()).into())
     }
 
     /// Get the hyperbolic arccos of a number.
@@ -72,11 +64,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
     pub(crate) fn acosh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).acosh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).acosh()).into())
     }
 
     /// Get the arcsine of a number.
@@ -88,11 +76,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.asin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
     pub(crate) fn asin(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).asin()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).asin()).into())
     }
 
     /// Get the hyperbolic arcsine of a number.
@@ -104,11 +88,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
     pub(crate) fn asinh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).asinh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).asinh()).into())
     }
 
     /// Get the arctangent of a number.
@@ -120,11 +100,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan
     pub(crate) fn atan(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).atan()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).atan()).into())
     }
 
     /// Get the hyperbolic arctangent of a number.
@@ -136,11 +112,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
     pub(crate) fn atanh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).atanh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).atanh()).into())
     }
 
     /// Get the arctangent of a numbers.
@@ -169,11 +141,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.cbrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
     pub(crate) fn cbrt(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).cbrt()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).cbrt()).into())
     }
 
     /// Get lowest integer above a number.
@@ -185,11 +153,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.ceil
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
     pub(crate) fn ceil(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).ceil()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).ceil()).into())
     }
 
     /// Get the cosine of a number.
@@ -201,11 +165,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.cos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
     pub(crate) fn cos(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).cos()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).cos()).into())
     }
 
     /// Get the hyperbolic cosine of a number.
@@ -217,11 +177,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.cosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
     pub(crate) fn cosh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).cosh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).cosh()).into())
     }
 
     /// Get the power to raise the natural logarithm to get the number.
@@ -233,11 +189,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.exp
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
     pub(crate) fn exp(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).exp()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).exp()).into())
     }
 
     /// Get the highest integer below a number.
@@ -249,11 +201,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.floor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
     pub(crate) fn floor(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).floor()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).floor()).into())
     }
 
     /// Get the natural logarithm of a number.
@@ -395,11 +343,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     pub(crate) fn round(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).round()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).round()).into())
     }
 
     /// Get the sign of a number.
@@ -433,11 +377,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.sin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
     pub(crate) fn sin(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).sin()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).sin()).into())
     }
 
     /// Get the hyperbolic sine of a number.
@@ -449,11 +389,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.sinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh
     pub(crate) fn sinh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).sinh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).sinh()).into())
     }
 
     /// Get the square root of a number.
@@ -465,19 +401,11 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.sqrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt
     pub(crate) fn sqrt(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).sqrt()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).sqrt()).into())
     }
     /// Get the tangent of a number
     pub(crate) fn tan(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).tan()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).tan()).into())
     }
 
     /// Get the hyperbolic tangent of a number.
@@ -489,11 +417,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.tanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh
     pub(crate) fn tanh(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).tanh()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).tanh()).into())
     }
 
     /// Get the integer part of a number.
@@ -505,11 +429,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
     pub(crate) fn trunc(_: &mut Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        Ok(Value::from(if args.is_empty() {
-            f64::NAN
-        } else {
-            f64::from(args.get(0).expect("Could not get argument")).trunc()
-        }))
+        Ok(args.get(0).map_or(f64::NAN, |x| f64::from(x).trunc()).into())
     }
 
     /// Create a new `Math` object


### PR DESCRIPTION
This Pull Request addresses all of the Math methods that simply call the Rust f64 equivalents #514 

It changes the following:
 - It refactors the following methods to use a `map_or` instead of if statements.
    - `Math::abs`
    - `Math::acos`
    - `Math::acosh`
    - `Math::asin`
    - `Math::asinh`
    - `Math::atan`
    - `Math::atanh`
    - `Math::cbrt`
    - `Math::ceil`
    - `Math::cos`
    - `Math::cosh`
    - `Math::exp`
    - `Math::floor`
    - `Math::round`
    - `Math::sin`
    - `Math::sinh`
    - `Math::sqrt`
    - `Math::tan`
    - `Math::tanh`
    - `Math::trunc`

