### PR TITLE
Fix all `Value` operations and add unsigned shift right

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -514,8 +514,8 @@ impl Array {
         while i < len {
             let element = this.get_field(i.to_string());
             let arguments = [element, Value::from(i), this.clone()];
-            let result = interpreter.call(callback, &this_arg, &arguments)?.is_true();
-            if !result {
+            let result = interpreter.call(callback, &this_arg, &arguments)?;
+            if !result.to_boolean() {
                 return Ok(Value::from(false));
             }
             len = min(max_len, i32::from(&this.get_field("length")));
@@ -695,7 +695,7 @@ impl Array {
             let element = this.get_field(i.to_string());
             let arguments = [element.clone(), Value::from(i), this.clone()];
             let result = interpreter.call(callback, &this_arg, &arguments)?;
-            if result.is_true() {
+            if result.to_boolean() {
                 return Ok(element);
             }
         }
@@ -737,7 +737,7 @@ impl Array {
 
             let result = interpreter.call(predicate_arg, &this_arg, &arguments)?;
 
-            if result.is_true() {
+            if result.to_boolean() {
                 return Ok(Value::rational(f64::from(i)));
             }
         }
@@ -902,7 +902,7 @@ impl Array {
                     .call(&callback, &this_val, &args)
                     .unwrap_or_else(|_| Value::undefined());
 
-                if callback_result.is_true() {
+                if callback_result.to_boolean() {
                     Some(element)
                 } else {
                     None
@@ -946,8 +946,8 @@ impl Array {
         while i < len {
             let element = this.get_field(i.to_string());
             let arguments = [element, Value::from(i), this.clone()];
-            let result = interpreter.call(callback, &this_arg, &arguments)?.is_true();
-            if result {
+            let result = interpreter.call(callback, &this_arg, &arguments)?;
+            if result.to_boolean() {
                 return Ok(Value::from(true));
             }
             // the length of the array must be updated because the callback can mutate it.

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -50,10 +50,10 @@ fn constructor_gives_true_instance() {
     assert_eq!(true_bool.is_object(), true);
 
     // Values should all be truthy
-    assert_eq!(true_val.is_true(), true);
-    assert_eq!(true_num.is_true(), true);
-    assert_eq!(true_string.is_true(), true);
-    assert_eq!(true_bool.is_true(), true);
+    assert_eq!(true_val.to_boolean(), true);
+    assert_eq!(true_num.to_boolean(), true);
+    assert_eq!(true_string.to_boolean(), true);
+    assert_eq!(true_bool.to_boolean(), true);
 }
 
 #[test]

--- a/boa/src/builtins/number/conversions.rs
+++ b/boa/src/builtins/number/conversions.rs
@@ -25,6 +25,7 @@ impl Number {
         }
     }
 
+    #[inline]
     pub(crate) fn significand(self) -> u64 {
         let d64 = self.0.to_bits();
         let significand = d64 & Self::SIGNIFICAND_MASK;
@@ -78,5 +79,13 @@ impl Number {
         };
 
         (self.sign() * (bits as i64)) as i32
+    }
+
+    /// Converts a 64-bit floating point number to an `u32` according to the [`ToUint32`][ToUint32] algorithm.
+    ///
+    /// [ToInt32]: https://tc39.es/ecma262/#sec-touint32
+    #[inline]
+    pub(crate) fn to_uint32(self) -> u32 {
+        self.to_int32() as u32
     }
 }

--- a/boa/src/builtins/number/conversions.rs
+++ b/boa/src/builtins/number/conversions.rs
@@ -1,0 +1,82 @@
+use super::Number;
+
+impl Number {
+    const SIGN_MASK: u64 = 0x8000000000000000;
+    const EXPONENT_MASK: u64 = 0x7FF0000000000000;
+    const SIGNIFICAND_MASK: u64 = 0x000FFFFFFFFFFFFF;
+    const HIDDEN_BIT: u64 = 0x0010000000000000;
+    const PHYSICAL_SIGNIFICAND_SIZE: i32 = 52; // Excludes the hidden bit.
+    const SIGNIFICAND_SIZE: i32 = 53;
+
+    const EXPONENT_BIAS: i32 = 0x3FF + Self::PHYSICAL_SIGNIFICAND_SIZE;
+    const DENORMAL_EXPONENT: i32 = -Self::EXPONENT_BIAS + 1;
+
+    #[inline]
+    pub(crate) fn is_denormal(self) -> bool {
+        (self.0.to_bits() & Self::EXPONENT_MASK) == 0
+    }
+
+    #[inline]
+    pub(crate) fn sign(self) -> i64 {
+        if (self.0.to_bits() & Self::SIGN_MASK) == 0 {
+            1
+        } else {
+            -1
+        }
+    }
+
+    pub(crate) fn significand(self) -> u64 {
+        let d64 = self.0.to_bits();
+        let significand = d64 & Self::SIGNIFICAND_MASK;
+
+        if !self.is_denormal() {
+            significand + Self::HIDDEN_BIT
+        } else {
+            significand
+        }
+    }
+
+    #[inline]
+    pub(crate) fn exponent(self) -> i32 {
+        if self.is_denormal() {
+            return Self::DENORMAL_EXPONENT;
+        }
+
+        let d64 = self.0.to_bits();
+        let biased_e = ((d64 & Self::EXPONENT_MASK) >> Self::PHYSICAL_SIGNIFICAND_SIZE) as i32;
+
+        biased_e - Self::EXPONENT_BIAS
+    }
+
+    /// Converts a 64-bit floating point number to an `i32` according to the [`ToInt32`][ToInt32] algorithm.
+    ///
+    /// [ToInt32]: https://tc39.es/ecma262/#sec-toint32
+    #[inline]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn to_int32(self) -> i32 {
+        if self.0.is_finite() && self.0 <= f64::from(i32::MAX) && self.0 >= f64::from(i32::MIN) {
+            let i = self.0 as i32;
+            if f64::from(i) == self.0 {
+                return i;
+            }
+        }
+
+        // let exponent = ((bits >> 52) & 0x7ff);
+        let exponent = self.exponent();
+        let bits = if exponent < 0 {
+            if exponent <= -Self::SIGNIFICAND_SIZE {
+                return 0;
+            }
+
+            self.significand() >> -exponent
+        } else {
+            if exponent > 31 {
+                return 0;
+            }
+
+            (self.significand() << exponent) & 0xFFFFFFFF
+        };
+
+        (self.sign() * (bits as i64)) as i32
+    }
+}

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -26,6 +26,8 @@ use num_traits::float::FloatCore;
 
 mod conversions;
 
+pub(crate) use conversions::{f64_to_int32, f64_to_uint32};
+
 #[cfg(test)]
 mod tests;
 
@@ -33,7 +35,7 @@ const BUF_SIZE: usize = 2200;
 
 /// `Number` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Number(f64);
+pub(crate) struct Number;
 
 /// Maximum number of arguments expected to the builtin parseInt() function.
 const PARSE_INT_MAX_ARG_COUNT: usize = 2;
@@ -93,12 +95,6 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.min_value
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
     pub(crate) const MIN_VALUE: f64 = f64::MIN;
-
-    /// Create a new number.
-    #[inline]
-    pub(crate) fn new(value: f64) -> Self {
-        Self(value)
-    }
 
     /// This function returns a `Result` of the number `Value`.
     ///

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -13,9 +13,6 @@
 //! [spec]: https://tc39.es/ecma262/#sec-number-object
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-#[cfg(test)]
-mod tests;
-
 use super::{
     function::{make_builtin_fn, make_constructor_fn},
     object::ObjectData,
@@ -27,11 +24,16 @@ use crate::{
 };
 use num_traits::float::FloatCore;
 
+mod conversions;
+
+#[cfg(test)]
+mod tests;
+
 const BUF_SIZE: usize = 2200;
 
 /// `Number` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Number;
+pub(crate) struct Number(f64);
 
 /// Maximum number of arguments expected to the builtin parseInt() function.
 const PARSE_INT_MAX_ARG_COUNT: usize = 2;
@@ -47,10 +49,56 @@ impl Number {
     pub(crate) const LENGTH: usize = 1;
 
     /// The `Number.MAX_SAFE_INTEGER` constant represents the maximum safe integer in JavaScript (`2^53 - 1`).
+    ///
+    /// /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-number.max_safe_integer
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
     pub(crate) const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991_f64;
 
     /// The `Number.MIN_SAFE_INTEGER` constant represents the minimum safe integer in JavaScript (`-(253 - 1)`).
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-number.min_safe_integer
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_SAFE_INTEGER
     pub(crate) const MIN_SAFE_INTEGER: f64 = -9_007_199_254_740_991_f64;
+
+    /// The `Number.MAX_VALUE` property represents the maximum numeric value representable in JavaScript.
+    ///
+    /// The `MAX_VALUE` property has a value of approximately `1.79E+308`, or `2^1024`.
+    /// Values larger than `MAX_VALUE` are represented as `Infinity`.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-number.max_value
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_VALUE
+    pub(crate) const MAX_VALUE: f64 = f64::MAX;
+
+    /// The `Number.MIN_VALUE` property represents the smallest positive numeric value representable in JavaScript.
+    ///
+    /// The `MIN_VALUE` property is the number closest to `0`, not the most negative number, that JavaScript can represent.
+    /// It has a value of approximately `5e-324`. Values smaller than `MIN_VALUE` ("underflow values") are converted to `0`.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-number.min_value
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
+    pub(crate) const MIN_VALUE: f64 = f64::MIN;
+
+    /// Create a new number.
+    #[inline]
+    pub(crate) fn new(value: f64) -> Self {
+        Self(value)
+    }
 
     /// This function returns a `Result` of the number `Value`.
     ///
@@ -59,7 +107,6 @@ impl Number {
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisnumbervalue
     fn this_number_value(value: &Value, ctx: &mut Interpreter) -> Result<f64, Value> {
@@ -547,8 +594,8 @@ impl Number {
             properties.insert_field("EPSILON", Value::from(f64::EPSILON));
             properties.insert_field("MAX_SAFE_INTEGER", Value::from(Self::MAX_SAFE_INTEGER));
             properties.insert_field("MIN_SAFE_INTEGER", Value::from(Self::MIN_SAFE_INTEGER));
-            properties.insert_field("MAX_VALUE", Value::from(f64::MAX));
-            properties.insert_field("MIN_VALUE", Value::from(f64::MIN));
+            properties.insert_field("MAX_VALUE", Value::from(Self::MAX_VALUE));
+            properties.insert_field("MIN_VALUE", Value::from(Self::MIN_VALUE));
             properties.insert_field("NEGATIVE_INFINITY", Value::from(f64::NEG_INFINITY));
             properties.insert_field("POSITIVE_INFINITY", Value::from(f64::INFINITY));
             properties.insert_field("NaN", Value::from(f64::NAN));

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -46,6 +46,12 @@ impl Number {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 1;
 
+    /// The `Number.MAX_SAFE_INTEGER` constant represents the maximum safe integer in JavaScript (`2^53 - 1`).
+    pub(crate) const MAX_SAFE_INTEGER: f64 = 9_007_199_254_740_991_f64;
+
+    /// The `Number.MIN_SAFE_INTEGER` constant represents the minimum safe integer in JavaScript (`-(253 - 1)`).
+    pub(crate) const MIN_SAFE_INTEGER: f64 = -9_007_199_254_740_991_f64;
+
     /// This function returns a `Result` of the number `Value`.
     ///
     /// If the `Value` is a `Number` primitive of `Number` object the number is returned.
@@ -539,8 +545,8 @@ impl Number {
         {
             let mut properties = number.as_object_mut().expect("'Number' object");
             properties.insert_field("EPSILON", Value::from(f64::EPSILON));
-            properties.insert_field("MAX_SAFE_INTEGER", Value::from(9_007_199_254_740_991_f64));
-            properties.insert_field("MIN_SAFE_INTEGER", Value::from(-9_007_199_254_740_991_f64));
+            properties.insert_field("MAX_SAFE_INTEGER", Value::from(Self::MAX_SAFE_INTEGER));
+            properties.insert_field("MIN_SAFE_INTEGER", Value::from(Self::MIN_SAFE_INTEGER));
             properties.insert_field("MAX_VALUE", Value::from(f64::MAX));
             properties.insert_field("MIN_VALUE", Value::from(f64::MIN));
             properties.insert_field("NEGATIVE_INFINITY", Value::from(f64::NEG_INFINITY));

--- a/boa/src/builtins/value/conversions.rs
+++ b/boa/src/builtins/value/conversions.rs
@@ -120,7 +120,7 @@ impl From<bool> for Value {
 
 impl From<&Value> for bool {
     fn from(value: &Value) -> Self {
-        value.is_true()
+        value.to_boolean()
     }
 }
 

--- a/boa/src/builtins/value/display.rs
+++ b/boa/src/builtins/value/display.rs
@@ -131,7 +131,7 @@ pub(crate) fn display_obj(v: &Value, print_internals: bool) -> String {
     ) -> String {
         if let Value::Object(ref v) = *data {
             // The in-memory address of the current object
-            let addr = address_of(v.borrow().deref());
+            let addr = address_of(v.as_ref());
 
             // We need not continue if this object has already been
             // printed up the current chain

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -413,21 +413,6 @@ impl Value {
         }
     }
 
-    /// Returns true if the value is true.
-    ///
-    /// [toBoolean](https://tc39.es/ecma262/#sec-toboolean)
-    pub fn is_true(&self) -> bool {
-        match *self {
-            Self::Object(_) => true,
-            Self::String(ref s) if !s.is_empty() => true,
-            Self::Rational(n) if n != 0.0 && !n.is_nan() => true,
-            Self::Integer(n) if n != 0 => true,
-            Self::Boolean(v) => v,
-            Self::BigInt(ref n) if *n.as_inner() != 0 => true,
-            _ => false,
-        }
-    }
-
     /// Converts the value into a 64-bit floating point number
     pub fn to_number(&self) -> f64 {
         match *self {
@@ -473,7 +458,12 @@ impl Value {
         }
     }
 
-    /// Creates a new boolean value from the input
+    /// Converts the value to a `bool` type.
+    ///
+    /// More information:
+    ///  - [ECMAScript][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-toboolean
     pub fn to_boolean(&self) -> bool {
         match *self {
             Self::Undefined | Self::Null => false,

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -28,7 +28,6 @@ use std::{
     convert::TryFrom,
     f64::NAN,
     fmt::{self, Display},
-    ops::{Add, BitAnd, BitOr, BitXor, Deref, Div, Mul, Neg, Not, Rem, Shl, Shr, Sub},
     str::FromStr,
 };
 
@@ -157,14 +156,6 @@ impl Value {
     #[inline]
     pub(crate) fn symbol(symbol: Symbol) -> Self {
         Self::Symbol(RcSymbol::from(symbol))
-    }
-
-    /// Helper function to convert the `Value` to a number and compute its power.
-    pub fn as_num_to_power(&self, other: Self) -> Self {
-        match (self, other) {
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::bigint(a.as_inner().clone().pow(b)),
-            (a, b) => Self::rational(a.to_number().powf(b.to_number())),
-        }
     }
 
     /// Returns a new empty object
@@ -703,7 +694,7 @@ impl Value {
     #[inline]
     pub fn set_data(&self, data: ObjectData) {
         if let Self::Object(ref obj) = *self {
-            (*obj.deref().borrow_mut()).data = data;
+            obj.borrow_mut().data = data;
         }
     }
 

--- a/boa/src/builtins/value/operations.rs
+++ b/boa/src/builtins/value/operations.rs
@@ -1,9 +1,9 @@
 use super::*;
 
-impl Add for Value {
-    type Output = Self;
-    fn add(self, other: Self) -> Self {
-        match (self, other) {
+impl Value {
+    #[inline]
+    pub fn add(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::String(ref s), ref o) => {
                 Self::string(format!("{}{}", s.clone(), &o.to_string()))
             }
@@ -12,121 +12,116 @@ impl Add for Value {
             }
             (ref s, Self::String(ref o)) => Self::string(format!("{}{}", s.to_string(), o)),
             (ref s, ref o) => Self::rational(s.to_number() + o.to_number()),
-        }
+        })
     }
-}
-impl Sub for Value {
-    type Output = Self;
-    fn sub(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn sub(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() - b.as_inner().clone())
             }
             (a, b) => Self::rational(a.to_number() - b.to_number()),
-        }
+        })
     }
-}
-impl Mul for Value {
-    type Output = Self;
-    fn mul(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn mul(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() * b.as_inner().clone())
             }
             (a, b) => Self::rational(a.to_number() * b.to_number()),
-        }
+        })
     }
-}
-impl Div for Value {
-    type Output = Self;
-    fn div(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn div(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() / b.as_inner().clone())
             }
             (a, b) => Self::rational(a.to_number() / b.to_number()),
-        }
+        })
     }
-}
-impl Rem for Value {
-    type Output = Self;
-    fn rem(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn rem(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() % b.as_inner().clone())
             }
             (a, b) => Self::rational(a.to_number() % b.to_number()),
-        }
+        })
     }
-}
-impl BitAnd for Value {
-    type Output = Self;
-    fn bitand(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn pow(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::bigint(a.as_inner().clone().pow(b)),
+            (a, b) => Self::rational(a.to_number().powf(b.to_number())),
+        })
+    }
+
+    #[inline]
+    pub fn bitand(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() & b.as_inner().clone())
             }
-            (a, b) => Self::integer(a.to_integer() & b.to_integer()),
-        }
+            (a, b) => Self::rational(a.to_integer() & b.to_integer()),
+        })
     }
-}
-impl BitOr for Value {
-    type Output = Self;
-    fn bitor(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn bitor(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() | b.as_inner().clone())
             }
             (a, b) => Self::integer(a.to_integer() | b.to_integer()),
-        }
+        })
     }
-}
-impl BitXor for Value {
-    type Output = Self;
-    fn bitxor(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
-                Self::bigint(a.as_inner().clone() ^ b.as_inner().clone())
-            }
-            (a, b) => Self::integer(a.to_integer() ^ b.to_integer()),
-        }
-    }
-}
 
-impl Shl for Value {
-    type Output = Self;
-    fn shl(self, other: Self) -> Self {
-        match (self, other) {
+    #[inline]
+    pub fn bitxor(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
+                Self::bigint(a.as_inner().clone() | b.as_inner().clone())
+            }
+            (a, b) => Self::integer(a.to_integer() | b.to_integer()),
+        })
+    }
+
+    #[inline]
+    pub fn shl(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() << b.as_inner().clone())
             }
             (a, b) => Self::integer(a.to_integer() << b.to_integer()),
-        }
+        })
     }
-}
-impl Shr for Value {
-    type Output = Self;
-    fn shr(self, other: Self) -> Self {
-        match (self, other) {
+
+    #[inline]
+    pub fn shr(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
+        Ok(match (self, other) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() >> b.as_inner().clone())
             }
             (a, b) => Self::integer(a.to_integer() >> b.to_integer()),
-        }
+        })
     }
-}
-impl Not for Value {
-    type Output = Self;
-    fn not(self) -> Self {
-        Self::boolean(!self.to_boolean())
+
+    #[inline]
+    pub fn ushr(&self, other: &Self, interpreter: &mut Interpreter) -> ResultValue {
+        // FIXME: Unsigned shift right
+        self.shr(other, interpreter)
     }
-}
 
-impl Neg for Value {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        match self {
+    #[inline]
+    pub fn neg(&self, _: &mut Interpreter) -> ResultValue {
+        Ok(match *self {
             Self::Object(_) | Self::Symbol(_) | Self::Undefined => Self::rational(NAN),
             Self::String(ref str) => Self::rational(match f64::from_str(str) {
                 Ok(num) => -num,
@@ -137,6 +132,11 @@ impl Neg for Value {
             Self::Boolean(true) => Self::integer(1),
             Self::Boolean(false) | Self::Null => Self::integer(0),
             Self::BigInt(ref num) => Self::bigint(-num.as_inner().clone()),
-        }
+        })
+    }
+
+    #[inline]
+    pub fn not(&self, _: &mut Interpreter) -> ResultValue {
+        Ok(Self::boolean(!self.to_boolean()))
     }
 }

--- a/boa/src/builtins/value/operations.rs
+++ b/boa/src/builtins/value/operations.rs
@@ -118,7 +118,7 @@ impl Shr for Value {
 impl Not for Value {
     type Output = Self;
     fn not(self) -> Self {
-        Self::boolean(!self.is_true())
+        Self::boolean(!self.to_boolean())
     }
 }
 

--- a/boa/src/builtins/value/operations.rs
+++ b/boa/src/builtins/value/operations.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::builtins::number::Number;
 
 impl Value {
     #[inline]
@@ -64,52 +65,91 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitand(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
-        Ok(match (self, other) {
+    pub fn bitand(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+        Ok(match (ctx.to_numeric(self)?, ctx.to_numeric(other)?) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() & b.as_inner().clone())
             }
-            (a, b) => Self::rational(a.to_integer() & b.to_integer()),
+            (Self::Rational(a), Self::Rational(b)) => {
+                Self::integer(Number::new(a).to_int32() & Number::new(b).to_int32())
+            }
+            (_, _) => {
+                return ctx.throw_type_error(
+                    "cannot mix BigInt and other types, use explicit conversions",
+                );
+            }
         })
     }
 
     #[inline]
-    pub fn bitor(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
-        Ok(match (self, other) {
+    pub fn bitor(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+        Ok(match (ctx.to_numeric(self)?, ctx.to_numeric(other)?) {
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() | b.as_inner().clone())
             }
-            (a, b) => Self::integer(a.to_integer() | b.to_integer()),
-        })
-    }
-
-    #[inline]
-    pub fn bitxor(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
-        Ok(match (self, other) {
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
-                Self::bigint(a.as_inner().clone() | b.as_inner().clone())
+            (Self::Rational(a), Self::Rational(b)) => {
+                Self::integer(Number::new(a).to_int32() | Number::new(b).to_int32())
             }
-            (a, b) => Self::integer(a.to_integer() | b.to_integer()),
+            (_, _) => {
+                return ctx.throw_type_error(
+                    "cannot mix BigInt and other types, use explicit conversions",
+                );
+            }
         })
     }
 
     #[inline]
-    pub fn shl(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
-        Ok(match (self, other) {
+    pub fn bitxor(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+        Ok(match (ctx.to_numeric(self)?, ctx.to_numeric(other)?) {
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
+                Self::bigint(a.as_inner().clone() ^ b.as_inner().clone())
+            }
+            (Self::Rational(a), Self::Rational(b)) => {
+                Self::integer(Number::new(a).to_int32() ^ Number::new(b).to_int32())
+            }
+            (_, _) => {
+                return ctx.throw_type_error(
+                    "cannot mix BigInt and other types, use explicit conversions",
+                );
+            }
+        })
+    }
+
+    #[inline]
+    pub fn shl(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+        Ok(match (ctx.to_numeric(self)?, ctx.to_numeric(other)?) {
+            (Self::Rational(a), Self::Rational(b)) => Self::integer(
+                Number::new(a)
+                    .to_int32()
+                    .wrapping_shl(Number::new(b).to_uint32()),
+            ),
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() << b.as_inner().clone())
             }
-            (a, b) => Self::integer(a.to_integer() << b.to_integer()),
+            (_, _) => {
+                return ctx.throw_type_error(
+                    "cannot mix BigInt and other types, use explicit conversions",
+                );
+            }
         })
     }
 
     #[inline]
-    pub fn shr(&self, other: &Self, _: &mut Interpreter) -> ResultValue {
-        Ok(match (self, other) {
+    pub fn shr(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+        Ok(match (ctx.to_numeric(self)?, ctx.to_numeric(other)?) {
+            (Self::Rational(a), Self::Rational(b)) => Self::integer(
+                Number::new(a)
+                    .to_int32()
+                    .wrapping_shr(Number::new(b).to_uint32()),
+            ),
             (Self::BigInt(ref a), Self::BigInt(ref b)) => {
                 Self::bigint(a.as_inner().clone() >> b.as_inner().clone())
             }
-            (a, b) => Self::integer(a.to_integer() >> b.to_integer()),
+            (_, _) => {
+                return ctx.throw_type_error(
+                    "cannot mix BigInt and other types, use explicit conversions",
+                );
+            }
         })
     }
 

--- a/boa/src/builtins/value/operations.rs
+++ b/boa/src/builtins/value/operations.rs
@@ -161,8 +161,9 @@ impl Value {
                     .to_uint32()
                     .wrapping_shr(Number::new(b).to_uint32()),
             ),
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
-                Self::bigint(a.as_inner().clone() >> b.as_inner().clone())
+            (Self::BigInt(_), Self::BigInt(_)) => {
+                return ctx
+                    .throw_type_error("BigInts have no unsigned right shift, use >> instead");
             }
             (_, _) => {
                 return ctx.throw_type_error(

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -5,13 +5,13 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 #[test]
-fn check_is_object() {
+fn is_object() {
     let val = Value::new_object(None);
     assert_eq!(val.is_object(), true);
 }
 
 #[test]
-fn check_string_to_value() {
+fn string_to_value() {
     let s = String::from("Hello");
     let v = Value::from(s);
     assert_eq!(v.is_string(), true);
@@ -19,14 +19,14 @@ fn check_string_to_value() {
 }
 
 #[test]
-fn check_undefined() {
+fn undefined() {
     let u = Value::Undefined;
     assert_eq!(u.get_type(), Type::Undefined);
     assert_eq!(u.to_string(), "undefined");
 }
 
 #[test]
-fn check_get_set_field() {
+fn get_set_field() {
     let obj = Value::new_object(None);
     // Create string and convert it to a Value
     let s = Value::from("bar");
@@ -35,14 +35,14 @@ fn check_get_set_field() {
 }
 
 #[test]
-fn check_integer_is_true() {
+fn integer_is_true() {
     assert_eq!(Value::from(1).to_boolean(), true);
     assert_eq!(Value::from(0).to_boolean(), false);
     assert_eq!(Value::from(-1).to_boolean(), true);
 }
 
 #[test]
-fn check_number_is_true() {
+fn number_is_true() {
     assert_eq!(Value::from(1.0).to_boolean(), true);
     assert_eq!(Value::from(0.1).to_boolean(), true);
     assert_eq!(Value::from(0.0).to_boolean(), false);
@@ -212,4 +212,114 @@ fn get_types() {
         forward_val(&mut engine, "Symbol()").unwrap().get_type(),
         Type::Symbol
     );
+}
+
+#[test]
+fn add_number_and_number() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "1 + 2").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, 3);
+}
+
+#[test]
+fn add_number_and_string() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "1 + \" + 2 = 3\"").unwrap();
+    let value = engine.to_string(&value).unwrap();
+    assert_eq!(value, "1 + 2 = 3");
+}
+
+#[test]
+fn add_string_and_string() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "\"Hello\" + \", world\"").unwrap();
+    let value = engine.to_string(&value).unwrap();
+    assert_eq!(value, "Hello, world");
+}
+
+#[test]
+fn add_number_object_and_number() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "new Number(10) + 6").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, 16);
+}
+
+#[test]
+fn add_number_object_and_string_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "new Number(10) + new String(\"0\")").unwrap();
+    let value = engine.to_string(&value).unwrap();
+    assert_eq!(value, "100");
+}
+
+#[test]
+fn sub_number_and_number() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "1 - 999").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, -998);
+}
+
+#[test]
+fn sub_number_object_and_number_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "new Number(1) - new Number(999)").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, -998);
+}
+
+#[test]
+fn sub_string_and_number_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "'Hello' - new Number(999)").unwrap();
+    let value = engine.to_number(&value).unwrap();
+    assert!(value.is_nan());
+}
+
+#[test]
+fn bitand_integer_and_integer() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "0xFFFF & 0xFF").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, 255);
+}
+
+#[test]
+fn bitand_integer_and_rational() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "0xFFFF & 255.5").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, 255);
+}
+
+#[test]
+fn bitand_rational_and_rational() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "255.772 & 255.5").unwrap();
+    let value = engine.to_int32(&value).unwrap();
+    assert_eq!(value, 255);
 }

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -36,19 +36,19 @@ fn check_get_set_field() {
 
 #[test]
 fn check_integer_is_true() {
-    assert_eq!(Value::from(1).is_true(), true);
-    assert_eq!(Value::from(0).is_true(), false);
-    assert_eq!(Value::from(-1).is_true(), true);
+    assert_eq!(Value::from(1).to_boolean(), true);
+    assert_eq!(Value::from(0).to_boolean(), false);
+    assert_eq!(Value::from(-1).to_boolean(), true);
 }
 
 #[test]
 fn check_number_is_true() {
-    assert_eq!(Value::from(1.0).is_true(), true);
-    assert_eq!(Value::from(0.1).is_true(), true);
-    assert_eq!(Value::from(0.0).is_true(), false);
-    assert_eq!(Value::from(-0.0).is_true(), false);
-    assert_eq!(Value::from(-1.0).is_true(), true);
-    assert_eq!(Value::from(NAN).is_true(), false);
+    assert_eq!(Value::from(1.0).to_boolean(), true);
+    assert_eq!(Value::from(0.1).to_boolean(), true);
+    assert_eq!(Value::from(0.0).to_boolean(), false);
+    assert_eq!(Value::from(-0.0).to_boolean(), false);
+    assert_eq!(Value::from(-1.0).to_boolean(), true);
+    assert_eq!(Value::from(NAN).to_boolean(), false);
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness

--- a/boa/src/exec/conditional/mod.rs
+++ b/boa/src/exec/conditional/mod.rs
@@ -7,7 +7,7 @@ use std::borrow::Borrow;
 
 impl Executable for If {
     fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
-        Ok(if self.cond().run(interpreter)?.borrow().is_true() {
+        Ok(if self.cond().run(interpreter)?.borrow().to_boolean() {
             self.body().run(interpreter)?
         } else if let Some(ref else_e) = self.else_node() {
             else_e.run(interpreter)?

--- a/boa/src/exec/iteration/mod.rs
+++ b/boa/src/exec/iteration/mod.rs
@@ -29,7 +29,7 @@ impl Executable for ForLoop {
 
         while self
             .condition()
-            .map(|cond| cond.run(interpreter).map(|v| v.is_true()))
+            .map(|cond| cond.run(interpreter).map(|v| v.to_boolean()))
             .transpose()?
             .unwrap_or(true)
         {
@@ -66,7 +66,7 @@ impl Executable for ForLoop {
 impl Executable for WhileLoop {
     fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
         let mut result = Value::undefined();
-        while self.cond().run(interpreter)?.borrow().is_true() {
+        while self.cond().run(interpreter)?.borrow().to_boolean() {
             result = self.expr().run(interpreter)?;
             match interpreter.get_current_state() {
                 InterpreterState::Break(_label) => {
@@ -107,7 +107,7 @@ impl Executable for DoWhileLoop {
             }
         }
 
-        while self.cond().run(interpreter)?.borrow().is_true() {
+        while self.cond().run(interpreter)?.borrow().to_boolean() {
             result = self.body().run(interpreter)?;
             match interpreter.get_current_state() {
                 InterpreterState::Break(_label) => {

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -231,29 +231,38 @@ impl Interpreter {
 
         let integer_index = self.to_integer(value)?;
 
-        if integer_index < 0 {
+        if integer_index < 0.0 {
             return Err(self.construct_range_error("Integer index must be >= 0"));
         }
 
-        if integer_index > 2i64.pow(53) - 1 {
+        if integer_index > Number::MAX_SAFE_INTEGER {
             return Err(self.construct_range_error("Integer index must be less than 2**(53) - 1"));
         }
 
         Ok(integer_index as usize)
     }
 
-    /// Converts a value to an integral 64 bit signed integer.
+    /// Converts a value to an integral Number value.
     ///
     /// See: https://tc39.es/ecma262/#sec-tointeger
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_integer(&mut self, value: &Value) -> Result<i64, Value> {
+    pub fn to_integer(&mut self, value: &Value) -> Result<f64, Value> {
+        // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(value)?;
 
-        if number.is_nan() {
-            return Ok(0);
+        // 2. If number is +∞ or -∞, return number.
+        if !number.is_finite() {
+            // 3. If number is NaN, +0, or -0, return +0.
+            if number.is_nan() {
+                return Ok(0.0);
+            }
+            return Ok(number);
         }
 
-        Ok(number as i64)
+        // 4. Let integer be the Number value that is the same sign as number and whose magnitude is floor(abs(number)).
+        // 5. If integer is -0, return +0.
+        // 6. Return integer.
+        Ok(number.trunc() + 0.0) // We add 0.0 to convert -0.0 to +0.0
     }
 
     /// Converts a value to an integral 32 bit signed integer.
@@ -261,12 +270,17 @@ impl Interpreter {
     /// See: https://tc39.es/ecma262/#sec-toint32
     #[allow(clippy::wrong_self_convention)]
     pub fn to_int32(&mut self, value: &Value) -> Result<i32, Value> {
+        // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(value)?;
 
-        if number.is_nan() || number.is_infinite() || Number::equal(number, -0.0) {
+        // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
+        if !number.is_finite() {
             return Ok(0);
         }
 
+        // 1. Let int be the Number value that is the same sign as number and whose magnitude is floor(abs(number)).
+        // 2. Let int32bit be int modulo 2^32.
+        // 3. Return int32bit.
         Ok(number as i32)
     }
 
@@ -277,7 +291,7 @@ impl Interpreter {
     pub fn to_uint32(&mut self, value: &Value) -> Result<u32, Value> {
         let number = self.to_number(value)?;
 
-        if number.is_nan() || number.is_infinite() || Number::equal(number, -0.0) {
+        if !number.is_finite() {
             return Ok(0);
         }
 
@@ -289,14 +303,16 @@ impl Interpreter {
     /// See: https://tc39.es/ecma262/#sec-tolength
     #[allow(clippy::wrong_self_convention)]
     pub fn to_length(&mut self, value: &Value) -> Result<usize, Value> {
+        // 1. Let len be ? ToInteger(argument).
         let len = self.to_integer(value)?;
-        if len < 0 {
+
+        // 2. If len ≤ +0, return +0.
+        if len < 0.0 {
             return Ok(0);
         }
-        let len = len as usize;
 
-        let max = 2usize.pow(53) - 1;
-        Ok(len.min(max))
+        // 3. Return min(len, 2^53 - 1).
+        Ok(len.min(Number::MAX_SAFE_INTEGER) as usize)
     }
 
     /// Converts a value to a double precision floating point.

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -256,6 +256,49 @@ impl Interpreter {
         Ok(number as i64)
     }
 
+    /// Converts a value to an integral 32 bit signed integer.
+    ///
+    /// See: https://tc39.es/ecma262/#sec-toint32
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_int32(&mut self, value: &Value) -> Result<i32, Value> {
+        let number = self.to_number(value)?;
+
+        if number.is_nan() || number.is_infinite() || Number::equal(number, -0.0) {
+            return Ok(0);
+        }
+
+        Ok(number as i32)
+    }
+
+    /// Converts a value to an integral 32 bit unsigned integer.
+    ///
+    /// See: https://tc39.es/ecma262/#sec-toint32
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_uint32(&mut self, value: &Value) -> Result<u32, Value> {
+        let number = self.to_number(value)?;
+
+        if number.is_nan() || number.is_infinite() || Number::equal(number, -0.0) {
+            return Ok(0);
+        }
+
+        Ok(number as u32)
+    }
+
+    /// Converts argument to an integer suitable for use as the length of an array-like object.
+    ///
+    /// See: https://tc39.es/ecma262/#sec-tolength
+    #[allow(clippy::wrong_self_convention)]
+    pub fn to_length(&mut self, value: &Value) -> Result<usize, Value> {
+        let len = self.to_integer(value)?;
+        if len < 0 {
+            return Ok(0);
+        }
+        let len = len as usize;
+
+        let max = 2usize.pow(53) - 1;
+        Ok(len.min(max))
+    }
+
     /// Converts a value to a double precision floating point.
     ///
     /// See: https://tc39.es/ecma262/#sec-tonumber

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -274,14 +274,10 @@ impl Interpreter {
         let number = self.to_number(value)?;
 
         // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-        if !number.is_finite() {
-            return Ok(0);
-        }
-
-        // 1. Let int be the Number value that is the same sign as number and whose magnitude is floor(abs(number)).
-        // 2. Let int32bit be int modulo 2^32.
-        // 3. Return int32bit.
-        Ok(number as i32)
+        // 3. Let int be the Number value that is the same sign as number and whose magnitude is floor(abs(number)).
+        // 4. Let int32bit be int modulo 2^32.
+        // 5. Return int32bit.
+        Ok(Number::new(number).to_int32())
     }
 
     /// Converts a value to an integral 32 bit unsigned integer.

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -24,6 +24,7 @@ mod try_node;
 use crate::{
     builtins::{
         function::{Function as FunctionObject, FunctionBody, ThisMode},
+        number::{f64_to_int32, f64_to_uint32},
         object::{Object, ObjectData, INSTANCE_PROTOTYPE, PROTOTYPE},
         property::Property,
         value::{RcBigInt, RcString, ResultValue, Type, Value},
@@ -276,7 +277,7 @@ impl Interpreter {
         }
         let number = self.to_number(value)?;
 
-        Ok(Number::new(number).to_int32())
+        Ok(f64_to_int32(number))
     }
 
     /// Converts a value to an integral 32 bit unsigned integer.
@@ -290,7 +291,7 @@ impl Interpreter {
         }
         let number = self.to_number(value)?;
 
-        Ok(Number::new(number).to_uint32())
+        Ok(f64_to_uint32(number))
     }
 
     /// Converts argument to an integer suitable for use as the length of an array-like object.

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -270,13 +270,12 @@ impl Interpreter {
     /// See: https://tc39.es/ecma262/#sec-toint32
     #[allow(clippy::wrong_self_convention)]
     pub fn to_int32(&mut self, value: &Value) -> Result<i32, Value> {
-        // 1. Let number be ? ToNumber(argument).
+        // This is the fast path, if the value is Integer we can just return it.
+        if let Value::Integer(number) = *value {
+            return Ok(number);
+        }
         let number = self.to_number(value)?;
 
-        // 2. If number is NaN, +0, -0, +∞, or -∞, return +0.
-        // 3. Let int be the Number value that is the same sign as number and whose magnitude is floor(abs(number)).
-        // 4. Let int32bit be int modulo 2^32.
-        // 5. Return int32bit.
         Ok(Number::new(number).to_int32())
     }
 
@@ -285,13 +284,13 @@ impl Interpreter {
     /// See: https://tc39.es/ecma262/#sec-toint32
     #[allow(clippy::wrong_self_convention)]
     pub fn to_uint32(&mut self, value: &Value) -> Result<u32, Value> {
+        // This is the fast path, if the value is Integer we can just return it.
+        if let Value::Integer(number) = *value {
+            return Ok(number as u32);
+        }
         let number = self.to_number(value)?;
 
-        if !number.is_finite() {
-            return Ok(0);
-        }
-
-        Ok(number as u32)
+        Ok(Number::new(number).to_uint32())
     }
 
     /// Converts argument to an integer suitable for use as the length of an array-like object.

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -1,4 +1,10 @@
-use crate::{builtins::Value, exec, exec::Interpreter, forward, realm::Realm};
+use crate::{
+    builtins::{Number, Value},
+    exec,
+    exec::Interpreter,
+    forward,
+    realm::Realm,
+};
 
 #[test]
 fn function_declaration_returns_undefined() {
@@ -895,10 +901,63 @@ fn to_integer() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
 
-    assert_eq!(engine.to_integer(&Value::number(f64::NAN)).unwrap(), 0);
-    assert_eq!(engine.to_integer(&Value::number(0.0f64)).unwrap(), 0);
-    assert_eq!(engine.to_integer(&Value::number(20.9)).unwrap(), 20);
-    assert_eq!(engine.to_integer(&Value::number(-20.9)).unwrap(), -20);
+    assert!(Number::equal(
+        engine.to_integer(&Value::number(f64::NAN)).unwrap(),
+        0.0
+    ));
+    assert!(Number::equal(
+        engine
+            .to_integer(&Value::number(f64::NEG_INFINITY))
+            .unwrap(),
+        f64::NEG_INFINITY
+    ));
+    assert!(Number::equal(
+        engine.to_integer(&Value::number(f64::INFINITY)).unwrap(),
+        f64::INFINITY
+    ));
+    assert!(Number::equal(
+        engine.to_integer(&Value::number(0.0)).unwrap(),
+        0.0
+    ));
+    let number = engine.to_integer(&Value::number(-0.0)).unwrap();
+    assert!(!number.is_sign_negative());
+    assert!(Number::equal(number, 0.0));
+    assert!(Number::equal(
+        engine.to_integer(&Value::number(20.9)).unwrap(),
+        20.0
+    ));
+    assert!(Number::equal(
+        engine.to_integer(&Value::number(-20.9)).unwrap(),
+        -20.0
+    ));
+}
+
+#[test]
+fn to_length() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    assert_eq!(engine.to_length(&Value::number(f64::NAN)).unwrap(), 0);
+    assert_eq!(
+        engine.to_length(&Value::number(f64::NEG_INFINITY)).unwrap(),
+        0
+    );
+    assert_eq!(
+        engine.to_length(&Value::number(f64::INFINITY)).unwrap(),
+        Number::MAX_SAFE_INTEGER as usize
+    );
+    assert_eq!(engine.to_length(&Value::number(0.0)).unwrap(), 0);
+    assert_eq!(engine.to_length(&Value::number(-0.0)).unwrap(), 0);
+    assert_eq!(engine.to_length(&Value::number(20.9)).unwrap(), 20);
+    assert_eq!(engine.to_length(&Value::number(-20.9)).unwrap(), 0);
+    assert_eq!(
+        engine.to_length(&Value::number(100000000000.0)).unwrap(),
+        100000000000
+    );
+    assert_eq!(
+        engine.to_length(&Value::number(4010101101.0)).unwrap(),
+        4010101101
+    );
 }
 
 #[test]

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -961,6 +961,120 @@ fn to_length() {
 }
 
 #[test]
+fn to_int32() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    macro_rules! check_to_int32 {
+        ($from:expr => $to:expr) => {
+            assert_eq!(engine.to_int32(&Value::number($from)).unwrap(), $to);
+        };
+    };
+
+    check_to_int32!(f64::NAN => 0);
+    check_to_int32!(f64::NEG_INFINITY => 0);
+    check_to_int32!(f64::INFINITY => 0);
+    check_to_int32!(0 => 0);
+    check_to_int32!(-0.0 => 0);
+
+    check_to_int32!(20.9 => 20);
+    check_to_int32!(-20.9 => -20);
+
+    check_to_int32!(Number::MIN_VALUE => 0);
+    check_to_int32!(-Number::MIN_VALUE => 0);
+    check_to_int32!(0.1 => 0);
+    check_to_int32!(-0.1 => 0);
+    check_to_int32!(1 => 1);
+    check_to_int32!(1.1 => 1);
+    check_to_int32!(-1 => -1);
+    check_to_int32!(0.6 => 0);
+    check_to_int32!(1.6 => 1);
+    check_to_int32!(-0.6 => 0);
+    check_to_int32!(-1.6 => -1);
+
+    check_to_int32!(2147483647.0 => 2147483647);
+    check_to_int32!(2147483648.0 => -2147483648);
+    check_to_int32!(2147483649.0 => -2147483647);
+
+    check_to_int32!(4294967295.0 => -1);
+    check_to_int32!(4294967296.0 => 0);
+    check_to_int32!(4294967297.0 => 1);
+
+    check_to_int32!(-2147483647.0 => -2147483647);
+    check_to_int32!(-2147483648.0 => -2147483648);
+    check_to_int32!(-2147483649.0 => 2147483647);
+
+    check_to_int32!(-4294967295.0 => 1);
+    check_to_int32!(-4294967296.0 => 0);
+    check_to_int32!(-4294967297.0 => -1);
+
+    check_to_int32!(2147483648.25 => -2147483648);
+    check_to_int32!(2147483648.5 => -2147483648);
+    check_to_int32!(2147483648.75 => -2147483648);
+    check_to_int32!(4294967295.25 => -1);
+    check_to_int32!(4294967295.5 => -1);
+    check_to_int32!(4294967295.75 => -1);
+    check_to_int32!(3000000000.25 => -1294967296);
+    check_to_int32!(3000000000.5 => -1294967296);
+    check_to_int32!(3000000000.75 => -1294967296);
+
+    check_to_int32!(-2147483648.25 => -2147483648);
+    check_to_int32!(-2147483648.5 => -2147483648);
+    check_to_int32!(-2147483648.75 => -2147483648);
+    check_to_int32!(-4294967295.25 => 1);
+    check_to_int32!(-4294967295.5 => 1);
+    check_to_int32!(-4294967295.75 => 1);
+    check_to_int32!(-3000000000.25 => 1294967296);
+    check_to_int32!(-3000000000.5 => 1294967296);
+    check_to_int32!(-3000000000.75 => 1294967296);
+
+    let base = 2f64.powf(64.0);
+    check_to_int32!(base + 0.0 => 0);
+    check_to_int32!(base + 1117.0 => 0);
+    check_to_int32!(base + 2234.0 => 4096);
+    check_to_int32!(base + 3351.0 => 4096);
+    check_to_int32!(base + 4468.0 => 4096);
+    check_to_int32!(base + 5585.0 => 4096);
+    check_to_int32!(base + 6702.0 => 8192);
+    check_to_int32!(base + 7819.0 => 8192);
+    check_to_int32!(base + 8936.0 => 8192);
+    check_to_int32!(base + 10053.0 => 8192);
+    check_to_int32!(base + 11170.0 => 12288);
+    check_to_int32!(base + 12287.0 => 12288);
+    check_to_int32!(base + 13404.0 => 12288);
+    check_to_int32!(base + 14521.0 => 16384);
+    check_to_int32!(base + 15638.0 => 16384);
+    check_to_int32!(base + 16755.0 => 16384);
+    check_to_int32!(base + 17872.0 => 16384);
+    check_to_int32!(base + 18989.0 => 20480);
+    check_to_int32!(base + 20106.0 => 20480);
+    check_to_int32!(base + 21223.0 => 20480);
+    check_to_int32!(base + 22340.0 => 20480);
+    check_to_int32!(base + 23457.0 => 24576);
+    check_to_int32!(base + 24574.0 => 24576);
+    check_to_int32!(base + 25691.0 => 24576);
+    check_to_int32!(base + 26808.0 => 28672);
+    check_to_int32!(base + 27925.0 => 28672);
+    check_to_int32!(base + 29042.0 => 28672);
+    check_to_int32!(base + 30159.0 => 28672);
+    check_to_int32!(base + 31276.0 => 32768);
+
+    // bignum is (2^53 - 1) * 2^31 - highest number with bit 31 set.
+    let bignum = 2f64.powf(84.0) - 2f64.powf(31.0);
+    check_to_int32!(bignum => -2147483648);
+    check_to_int32!(-bignum => -2147483648);
+    check_to_int32!(2.0 * bignum => 0);
+    check_to_int32!(-(2.0 * bignum) => 0);
+    check_to_int32!(bignum - 2f64.powf(31.0) => 0);
+    check_to_int32!(-(bignum - 2f64.powf(31.0)) => 0);
+
+    // max_fraction is largest number below 1.
+    let max_fraction = 1.0 - 2f64.powf(-53.0);
+    check_to_int32!(max_fraction => 0);
+    check_to_int32!(-max_fraction => 0);
+}
+
+#[test]
 fn to_string() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);


### PR DESCRIPTION
**What is the problem with the current implementation of `Value`s operations?**
The problem is that they are not spec compliant for objects, for example `ToNumber` (`to_number`) for objects it is supposed to call `to_primitive` and because it does not the code `new Number(6) + 3` is broken and does not give the expected output `9`. Also because `to_number` is called by `Value`s operators, this means that the `Value` operations can throw exceptions and it requires context and should return a `ResultValue`.

It changes the following:
 - Removed `Value::is_true()` (this is a duplicate of `to_boolean`)
 - Added `to_int32`, `to_uint32` and `to_length` to `Interpreter`
 - Made `to_integer` spec compliant
 - Made `Value` operators => functions (these functions take in an `Interpreter`, and can throw in certain cases, see example) 
 - Made all `Value` operations spec compliant.
 - Added fast paths for all `Value` operations

The below code is fixed with this PR:
```js
Number.prototype.valueOf = null;
Number.prototype.toString = null;

new Number(5) + 5 // this should throw, because it calls `to_primitive`
```

I'm not sure if I should move `to_boolean` to `Interpreter`, because it's the only one that can't throw and does not need context