### PR TITLE
fix json.stringify symbol handling

### DIFF
--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -54,8 +54,6 @@ fn json_stringify_remove_function_values_from_objects() {
 }
 
 #[test]
-#[ignore]
-// there is a bug for setting a symbol as a field's value
 fn json_stringify_remove_symbols_from_objects() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);
@@ -152,7 +150,6 @@ fn json_stringify_array_converts_function_to_null() {
 }
 
 #[test]
-#[ignore]
 fn json_stringify_array_converts_symbol_to_null() {
     let realm = Realm::create();
     let mut engine = Interpreter::new(realm);

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -260,7 +260,7 @@ impl Value {
                     for k in obj.borrow().properties().keys() {
                         if k != "length" {
                             let value = self.get_field(k.to_string());
-                            if value.is_undefined() || value.is_function() {
+                            if value.is_undefined() || value.is_function() || value.is_symbol() {
                                 arr.push(JSONValue::Null);
                             } else {
                                 arr.push(self.get_field(k.to_string()).to_json(interpreter)?);
@@ -273,7 +273,7 @@ impl Value {
                     for k in obj.borrow().properties().keys() {
                         let key = k.clone();
                         let value = self.get_field(k.to_string());
-                        if !value.is_undefined() && !value.is_function() {
+                        if !value.is_undefined() && !value.is_function() && !value.is_symbol() {
                             new_obj.insert(key.to_string(), value.to_json(interpreter)?);
                         }
                     }


### PR DESCRIPTION
This Pull Request fixes/closes #405

See NOTE 5 in the [spec](https://tc39.es/ecma262/#sec-json.stringify).

It changes the following:
 - Addresses Symbol handling in `JSON.stringify(...)`
   - Converts `Symbol()`s to `null` when in an array.
   - Does not add fields whose value is `Symbol()` to objects.
