### PR TITLE
Feature `SyntaxError`

### DIFF
--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -20,17 +20,19 @@ use crate::{
     profiler::BoaProfiler,
 };
 
-// mod eval;
 pub(crate) mod range;
 pub(crate) mod reference;
 pub(crate) mod syntax;
 pub(crate) mod r#type;
-// mod uri;
+// pub(crate) mod eval;
+// pub(crate) mod uri;
 
 pub(crate) use self::r#type::TypeError;
 pub(crate) use self::range::RangeError;
 pub(crate) use self::reference::ReferenceError;
 pub(crate) use self::syntax::SyntaxError;
+// pub(crate) use self::eval::EvalError;
+// pub(crate) use self::uri::UriError;
 
 /// Built-in `Error` object.
 #[derive(Debug, Clone, Copy)]
@@ -72,7 +74,7 @@ impl Error {
         Ok(Value::from(format!("{}: {}", name, message)))
     }
 
-    /// Create a new `SyntaxError` object.
+    /// Create a new `Error` object.
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
         prototype.set_field("message", Value::from(""));

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -44,17 +44,11 @@ impl Error {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        if !args.is_empty() {
-            this.set_field(
-                "message",
-                Value::from(
-                    args.get(0)
-                        .expect("failed getting error message")
-                        .to_string(),
-                ),
-            );
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+        if let Some(message) = args.get(0) {
+            this.set_field("message", ctx.to_string(message)?);
         }
+
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -63,7 +63,8 @@ impl RangeError {
     /// Create a new `RangeError` object.
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
-        prototype.set_field("message", Value::from(""));
+        prototype.set_field("name", Self::NAME);
+        prototype.set_field("message", "");
 
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
 

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -32,17 +32,11 @@ impl RangeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        if !args.is_empty() {
-            this.set_field(
-                "message",
-                Value::from(
-                    args.get(0)
-                        .expect("failed getting error message")
-                        .to_string(),
-                ),
-            );
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+        if let Some(message) = args.get(0) {
+            this.set_field("message", ctx.to_string(message)?);
         }
+
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -31,17 +31,11 @@ impl ReferenceError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        if !args.is_empty() {
-            this.set_field(
-                "message",
-                Value::from(
-                    args.get(0)
-                        .expect("failed getting error message")
-                        .to_string(),
-                ),
-            );
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+        if let Some(message) = args.get(0) {
+            this.set_field("message", ctx.to_string(message)?);
         }
+
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -62,7 +62,8 @@ impl ReferenceError {
     /// Create a new `ReferenceError` object.
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
-        prototype.set_field("message", Value::from(""));
+        prototype.set_field("name", Self::NAME);
+        prototype.set_field("message", "");
 
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
 

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -38,6 +38,7 @@ impl SyntaxError {
         if let Some(message) = args.get(0) {
             this.set_field("message", ctx.to_string(message)?);
         }
+
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -21,7 +21,6 @@ use crate::{
     exec::Interpreter,
     profiler::BoaProfiler,
 };
-
 /// JavaScript `SyntaxError` impleentation.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SyntaxError;
@@ -62,7 +61,7 @@ impl SyntaxError {
         Ok(format!("{}: {}", name, message).into())
     }
 
-    /// Create a new `RangeError` object.
+    /// Create a new `SyntaxError` object.
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
         prototype.set_field("name", Self::NAME);

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -38,16 +38,9 @@ impl TypeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
-        if !args.is_empty() {
-            this.set_field(
-                "message",
-                Value::from(
-                    args.get(0)
-                        .expect("failed getting error message")
-                        .to_string(),
-                ),
-            );
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+        if let Some(message) = args.get(0) {
+            this.set_field("message", ctx.to_string(message)?);
         }
 
         // This value is used by console.log and other routines to match Object type

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -69,7 +69,8 @@ impl TypeError {
     /// Create a new `RangeError` object.
     pub(crate) fn create(global: &Value) -> Value {
         let prototype = Value::new_object(Some(global));
-        prototype.set_field("message", Value::from(""));
+        prototype.set_field("name", Self::NAME);
+        prototype.set_field("message", "");
 
         make_builtin_fn(Self::to_string, "toString", &prototype, 0);
 

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -24,7 +24,7 @@ pub(crate) use self::{
     array::Array,
     bigint::BigInt,
     boolean::Boolean,
-    error::{Error, RangeError, ReferenceError, TypeError},
+    error::{Error, RangeError, ReferenceError, SyntaxError, TypeError},
     global_this::GlobalThis,
     infinity::Infinity,
     json::Json,
@@ -60,6 +60,7 @@ pub fn init(global: &Value) {
         RangeError::init,
         ReferenceError::init,
         TypeError::init,
+        SyntaxError::init,
         // Global properties.
         NaN::init,
         Infinity::init,

--- a/boa/src/exec/exception.rs
+++ b/boa/src/exec/exception.rs
@@ -72,4 +72,25 @@ impl Interpreter {
     {
         Err(self.construct_reference_error(message))
     }
+
+    /// Constructs a `SyntaxError` with the specified message.
+    pub fn construct_syntax_error<M>(&mut self, message: M) -> Value
+    where
+        M: Into<String>,
+    {
+        New::from(Call::new(
+            Identifier::from("SyntaxError"),
+            vec![Const::from(message.into()).into()],
+        ))
+        .run(self)
+        .expect_err("SyntaxError should always throw")
+    }
+
+    /// Throws a `SyntaxError` with the specified message.
+    pub fn throw_syntax_error<M>(&mut self, message: M) -> ResultValue
+    where
+        M: Into<String>,
+    {
+        Err(self.construct_syntax_error(message))
+    }
 }


### PR DESCRIPTION
It changes the following:
 - Implement `SyntaxError` object
 - Add `.construct_syntax_error()` and `.throw_syntax_error()`
 - Made error objects construction use `to_string()` (spec compliant and some cleanup)
 - Fix missing `name` field in `prototype` of error objects
