### PR TITLE
Cleanup and added test for `String.prototype.concat`

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -184,8 +184,6 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.concat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat
     pub(crate) fn concat(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
-        // First we get it the actual string a private field stored on the object only the engine has access to.
-        // Then we convert it into a Rust String by wrapping it in from_value
         let object = ctx.require_object_coercible(this)?;
         let mut string = ctx.to_string(object)?.to_string();
 

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -71,11 +71,25 @@ fn concat() {
         "#;
     eprintln!("{}", forward(&mut engine, init));
 
-    // Todo: fix this
-    let _a = forward(&mut engine, "hello.concat(world, nice)");
-    let _b = forward(&mut engine, "hello + world + nice");
-    // assert_eq!(a, String::from("Hello, world! Have a nice day."));
-    // assert_eq!(b, String::from("Hello, world! Have a nice day."));
+    let a = forward(&mut engine, "hello.concat(world, nice)");
+    assert_eq!(a, "Hello, world! Have a nice day.");
+
+    let b = forward(&mut engine, "hello + world + nice");
+    assert_eq!(b, "Hello, world! Have a nice day.");
+}
+
+#[test]
+fn generic_concat() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let init = r#"
+        Number.prototype.concat = String.prototype.concat;
+        let number = new Number(100);
+        "#;
+    eprintln!("{}", forward(&mut engine, init));
+
+    let a = forward(&mut engine, "number.concat(' - 50', ' = 50')");
+    assert_eq!(a, "100 - 50 = 50");
 }
 
 #[allow(clippy::result_unwrap_used)]


### PR DESCRIPTION


It changes the following:
 - Uncomented one of the `concat` test case (the other one is fixed by #520)
 - Added a test case for a generic `concat` method (as described in spec) 
 - Removed deprecated comment.
