### PR TITLE
Fixed stack overflow bug

### DIFF
--- a/boa/src/exec/call/mod.rs
+++ b/boa/src/exec/call/mod.rs
@@ -11,10 +11,8 @@ impl Executable for Call {
         let (this, func) = match self.expr() {
             Node::GetConstField(ref get_const_field) => {
                 let mut obj = get_const_field.obj().run(interpreter)?;
-                if obj.get_type() != Type::Object || obj.get_type() != Type::Symbol {
-                    obj = interpreter
-                        .to_object(&obj)
-                        .expect("failed to convert to object");
+                if obj.get_type() != Type::Object {
+                    obj = interpreter.to_object(&obj)?;
                 }
                 (obj.clone(), obj.get_field(get_const_field.field()))
             }

--- a/boa/src/exec/field/mod.rs
+++ b/boa/src/exec/field/mod.rs
@@ -7,10 +7,9 @@ use crate::{
 impl Executable for GetConstField {
     fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
         let mut obj = self.obj().run(interpreter)?;
-        if obj.get_type() != Type::Object || obj.get_type() != Type::Symbol {
+        if obj.get_type() != Type::Object {
             obj = interpreter.to_object(&obj)?;
         }
-
         Ok(obj.get_field(self.field()))
     }
 }
@@ -18,7 +17,7 @@ impl Executable for GetConstField {
 impl Executable for GetField {
     fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
         let mut obj = self.obj().run(interpreter)?;
-        if obj.get_type() != Type::Object || obj.get_type() != Type::Symbol {
+        if obj.get_type() != Type::Object {
             obj = interpreter.to_object(&obj)?;
         }
         let field = self.field().run(interpreter)?;

--- a/tester/src/main.rs
+++ b/tester/src/main.rs
@@ -87,31 +87,17 @@ fn read_suite(path: &Path) -> io::Result<TestSuite> {
         st.to_string_lossy().ends_with("_FIXTURE")
             // TODO: see if we can fix this.
             || st.to_string_lossy() == "line-terminator-normalisation-CR"
-            // TODO: see if we can fix the stack overflows.
-            || st.to_string_lossy() == "this-val-tostring-err"
-            || st.to_string_lossy() == "this-not-callable"
-            || st.to_string_lossy() == "S15.3.4.2_A10"
-            || st.to_string_lossy() == "S15.3.4.2_A11"
-            || st.to_string_lossy() == "S15.3.4.2_A9"
-            || st.to_string_lossy() == "proxy-non-callable-throws"
-            || st.to_string_lossy() == "S15.3.4.2_A12"
-            || st.to_string_lossy() == "S15.3.4.2_A13"
-            || st.to_string_lossy() == "S15.3.4.2_A14"
-            || st.to_string_lossy() == "15.3.4.5.1-4-1"
-            || st.to_string_lossy() == "15.3.4.5.2-4-14"
-            || st.to_string_lossy() == "15.3.4.5-2-12"
-            || st.to_string_lossy() == "15.3.4.5.1-4-13"
-            || st.to_string_lossy() == "15.3.4.5.2-4-12"
-            || st.to_string_lossy() == "15.3.4.5.2-4-9"
-            || st.to_string_lossy() == "instance-name-chained"
-            || st.to_string_lossy() == "15.3.4.5.1-4-3"
-            || st.to_string_lossy() == "15.3.4.5.1-4-5" 
-            || st.to_string_lossy() == "15.3.4.5.1-4-10"
-            || st.to_string_lossy() == "15.3.4.5-2-15"
-            || st.to_string_lossy() == "15.3.4.5.2-4-4"
-            || st.to_string_lossy() == "15.3.4.5.2-4-10"
-            || st.to_string_lossy() == "S15.3.4.5_A14"
-            || st.to_string_lossy() == "15.3.4.5.1-4-9"
+            // This does not break the tester but it does iterate from 0 to u32::MAX,
+            // because of incorect implementation of `Array.prototype.indexOf`.
+            // TODO: Fix it do iterate on the elements in the array **in insertion order**, not from
+            // 0 to u32::MAX untill it reaches the element.
+            || st.to_string_lossy() == "15.4.4.14-5-12"
+            // Another one of these `Array.prototype.indexOf`, but now with `NaN`.
+            || st.to_string_lossy() == "15.4.4.14-5-14"
+            // Another one of these `Array.prototype.indexOf`, but now with `-Infinity`.
+            || st.to_string_lossy() == "15.4.4.14-5-13"
+            // More `Array.prototype.indexOf` with large second argument.
+            || st.to_string_lossy() == "15.4.4.14-5-13"
     };
 
     // TODO: iterate in parallel


### PR DESCRIPTION
Fixed the stack overflow bug :D

This is the example code that caused it:
```js
let x;
x.y(); // this will overflow
```

 - Removed check for `Symbol`  when it should only check for `Object` in GetField/Const , this was from when we did not have symbol primitives (pre-#419 ) (this is another bug).
 - Removed the ignore cases for these tests since the either pass or fail, not overflow.
 - Added some tests to ignore `Array.prototype.indexOf` they don't stop the tester but they "freeze" it (iterate from 0 to a very large number like `u32::MAX`).

Now it reaches a **lot** more, but still gets stuck by `indexOf` in some tests.
