### PR TITLE
Fixed `String.prototype.replace` stack overflow when function throws

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -497,7 +497,7 @@ impl String {
                     // Push the whole string being examined
                     results.push(Value::from(primitive_val.to_string()));
 
-                    let result = ctx.call(&replace_object, this, &results).unwrap();
+                    let result = ctx.call(&replace_object, this, &results)?;
 
                     ctx.to_string(&result)?.to_string()
                 }

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -14,8 +14,7 @@ fill-string-empty
 // Stack overflow (seemingly in JSON.stringify with circular references):
 value-array-circular
 value-object-circular
-// Other stack overflows:
-S15.5.4.11_A12
+// other
 var-env-var-init-global-new
 var-env-func-init-global-update-configurable
 var-env-var-init-global-exstng


### PR DESCRIPTION
This fixes the buffer overflow caused by replace when the second argument function throws.

It changes the following:
 - Removed test that overflows from ignore list.
