### PR TITLE
Made `boa_cli` bin default binary when calling `cargo run`

### DIFF
--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["command-line-utilities"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
+default-run = "boa"
 
 [dependencies]
 Boa = { path = "../boa", features = ["serde"] }


### PR DESCRIPTION
This PR make boa binary the default when calling `cargo run`, so we don't have to do `cargo run --bin boa`