### PR TITLE
Better error formatting and cli color

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -97,6 +106,7 @@ name = "boa_cli"
 version = "0.9.0"
 dependencies = [
  "Boa",
+ "ansi_term 0.12.1",
  "jemallocator",
  "rustyline",
  "serde_json",
@@ -162,7 +172,7 @@ version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,15 +41,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,7 +97,7 @@ name = "boa_cli"
 version = "0.9.0"
 dependencies = [
  "Boa",
- "ansi_term 0.12.1",
+ "colored",
  "jemallocator",
  "rustyline",
  "serde_json",
@@ -172,7 +163,7 @@ version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -188,6 +179,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]

--- a/boa/src/builtins/value/display.rs
+++ b/boa/src/builtins/value/display.rs
@@ -175,6 +175,14 @@ pub(crate) fn display_obj(v: &Value, print_internals: bool) -> String {
     // in-memory address in this set
     let mut encounters = HashSet::new();
 
+    if let Value::Object(object) = v {
+        if object.borrow().is_error() {
+            let name = v.get_field("name");
+            let message = v.get_field("message");
+            return format!("{}: {}", name, message);
+        }
+    }
+
     fn display_obj_internal(
         data: &Value,
         encounters: &mut HashSet<usize>,

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -15,7 +15,7 @@ Boa = { path = "../boa", features = ["serde"] }
 rustyline = "6.2.0"
 structopt = "0.3.15"
 serde_json = "1.0.56"
-ansi_term = "0.12.1"
+colored = "2.0.0"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.3.2"

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -15,6 +15,7 @@ Boa = { path = "../boa", features = ["serde"] }
 rustyline = "6.2.0"
 structopt = "0.3.15"
 serde_json = "1.0.56"
+ansi_term = "0.12.1"
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.3.2"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -25,13 +25,13 @@
     clippy::as_conversions
 )]
 
-use ansi_term::{Colour as Color, Style};
 use boa::{
     exec::Interpreter,
     forward_val,
     realm::Realm,
     syntax::ast::{node::StatementList, token::Token},
 };
+use colored::*;
 use rustyline::{config::Config, error::ReadlineError, EditMode, Editor};
 use std::{fs::read_to_string, path::PathBuf};
 use structopt::{clap::arg_enum, StructOpt};
@@ -209,11 +209,7 @@ pub fn main() -> Result<(), std::io::Error> {
         let mut editor = Editor::<()>::with_config(config);
         let _ = editor.load_history(CLI_HISTORY);
 
-        let readline = Style::default()
-            .bold()
-            .fg(Color::Cyan)
-            .paint("> ")
-            .to_string();
+        let readline = "> ".cyan().bold().to_string();
 
         loop {
             match editor.readline(&readline) {
@@ -230,11 +226,7 @@ pub fn main() -> Result<(), std::io::Error> {
                     } else {
                         match forward_val(&mut engine, line.trim_end()) {
                             Ok(v) => println!("{}", v),
-                            Err(v) => eprintln!(
-                                "{}: {}",
-                                Color::Red.paint("Uncaught"),
-                                Color::Red.paint(&v.to_string())
-                            ),
+                            Err(v) => eprintln!("{}: {}", "Uncaught".red(), v.to_string().red()),
                         }
                     }
                 }

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -25,6 +25,7 @@
     clippy::as_conversions
 )]
 
+use ansi_term::{Colour as Color, Style};
 use boa::{
     exec::Interpreter,
     forward_val,
@@ -208,8 +209,14 @@ pub fn main() -> Result<(), std::io::Error> {
         let mut editor = Editor::<()>::with_config(config);
         let _ = editor.load_history(CLI_HISTORY);
 
+        let readline = Style::default()
+            .bold()
+            .fg(Color::Cyan)
+            .paint("> ")
+            .to_string();
+
         loop {
-            match editor.readline("> ") {
+            match editor.readline(&readline) {
                 Ok(line) if line == ".exit" => break,
                 Err(ReadlineError::Interrupted) | Err(ReadlineError::Eof) => break,
 
@@ -223,7 +230,11 @@ pub fn main() -> Result<(), std::io::Error> {
                     } else {
                         match forward_val(&mut engine, line.trim_end()) {
                             Ok(v) => println!("{}", v),
-                            Err(v) => eprintln!("{}", v),
+                            Err(v) => eprintln!(
+                                "{}: {}",
+                                Color::Red.paint("Uncaught"),
+                                Color::Red.paint(&v.to_string())
+                            ),
                         }
                     }
                 }


### PR DESCRIPTION
This Pull Request fixes/closes #507 .

It changes the following:
 - Better error formatting `errorName: message`, example `TypeError: 'this' is not an object`
 - Made readline (`"> "`) bold cyan color
 - uncaught errors: `Uncaught: errorMessage` in red in cli

Example:
![Screenshot_2020-07-22_04-59-11](https://user-images.githubusercontent.com/8566042/88129366-3a514300-cbd8-11ea-9f48-6e08f48037f6.png)
