### PR TITLE
Implement Well-Known Symbols

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -1115,7 +1115,7 @@ impl Array {
     /// Initialise the `Array` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -1114,7 +1114,7 @@ impl Array {
 
     /// Initialise the `Array` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -1114,7 +1114,8 @@ impl Array {
 
     /// Initialise the `Array` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -201,7 +201,7 @@ impl BigInt {
     /// Initialise the `BigInt` object on the global object.
     #[inline]
     pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -200,7 +200,8 @@ impl BigInt {
 
     /// Initialise the `BigInt` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -200,7 +200,7 @@ impl BigInt {
 
     /// Initialise the `BigInt` object on the global object.
     #[inline]
-    pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -98,7 +98,7 @@ impl Boolean {
 
     /// Initialise the `Boolean` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -99,7 +99,7 @@ impl Boolean {
     /// Initialise the `Boolean` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create Prototype

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -98,7 +98,8 @@ impl Boolean {
 
     /// Initialise the `Boolean` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create Prototype

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -489,7 +489,8 @@ impl Console {
 
     /// Initialise the `console` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let console = Value::new_object(Some(global));

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -490,7 +490,7 @@ impl Console {
     /// Initialise the `console` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let console = Value::new_object(Some(global));

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -489,7 +489,7 @@ impl Console {
 
     /// Initialise the `console` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -76,7 +76,7 @@ impl Error {
 
     /// Initialise the global object with the `Error` object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -77,7 +77,7 @@ impl Error {
     /// Initialise the global object with the `Error` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -76,7 +76,8 @@ impl Error {
 
     /// Initialise the global object with the `Error` object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -63,7 +63,7 @@ impl RangeError {
     /// Initialise the global object with the `RangeError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -62,7 +62,7 @@ impl RangeError {
 
     /// Initialise the global object with the `RangeError` object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -62,7 +62,8 @@ impl RangeError {
 
     /// Initialise the global object with the `RangeError` object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -60,7 +60,8 @@ impl ReferenceError {
     }
 
     /// Initialise the global object with the `ReferenceError` object.
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -61,7 +61,7 @@ impl ReferenceError {
 
     /// Initialise the global object with the `ReferenceError` object.
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -60,7 +60,7 @@ impl ReferenceError {
     }
 
     /// Initialise the global object with the `ReferenceError` object.
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -65,7 +65,7 @@ impl SyntaxError {
     /// Initialise the global object with the `SyntaxError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -64,7 +64,8 @@ impl SyntaxError {
 
     /// Initialise the global object with the `SyntaxError` object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -64,7 +64,7 @@ impl SyntaxError {
 
     /// Initialise the global object with the `SyntaxError` object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -68,7 +68,7 @@ impl TypeError {
 
     /// Initialise the global object with the `RangeError` object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -69,7 +69,7 @@ impl TypeError {
     /// Initialise the global object with the `RangeError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -68,7 +68,8 @@ impl TypeError {
 
     /// Initialise the global object with the `RangeError` object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -533,7 +533,7 @@ where
 
 /// Initialise the `Function` object on the global object.
 #[inline]
-pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
     let global = &interpreter.realm.global_obj;
     let _timer = BoaProfiler::global().start_event("function", "init");
     let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -533,7 +533,8 @@ where
 
 /// Initialise the `Function` object on the global object.
 #[inline]
-pub fn init(global: &Value) -> (&str, Value) {
+pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    let global = &interpreter.realm.global_obj;
     let _timer = BoaProfiler::global().start_event("function", "init");
     let prototype = Value::new_object(Some(global));
 

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -534,7 +534,7 @@ where
 /// Initialise the `Function` object on the global object.
 #[inline]
 pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-    let global = &interpreter.realm.global_obj;
+    let global = interpreter.global();
     let _timer = BoaProfiler::global().start_event("function", "init");
     let prototype = Value::new_object(Some(global));
 

--- a/boa/src/builtins/global_this/mod.rs
+++ b/boa/src/builtins/global_this/mod.rs
@@ -10,7 +10,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-globalthis
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 
-use crate::{builtins::value::Value, BoaProfiler};
+use crate::{builtins::value::Value, BoaProfiler, Interpreter};
 
 #[cfg(test)]
 mod tests;
@@ -24,7 +24,8 @@ impl GlobalThis {
 
     /// Initialize the `globalThis` property on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, global.clone())

--- a/boa/src/builtins/global_this/mod.rs
+++ b/boa/src/builtins/global_this/mod.rs
@@ -24,7 +24,7 @@ impl GlobalThis {
 
     /// Initialize the `globalThis` property on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/global_this/mod.rs
+++ b/boa/src/builtins/global_this/mod.rs
@@ -25,7 +25,7 @@ impl GlobalThis {
     /// Initialize the `globalThis` property on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, global.clone())

--- a/boa/src/builtins/infinity/mod.rs
+++ b/boa/src/builtins/infinity/mod.rs
@@ -24,7 +24,7 @@ impl Infinity {
 
     /// Initialize the `Infinity` property on the global object.
     #[inline]
-    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&'static str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::from(f64::INFINITY))

--- a/boa/src/builtins/infinity/mod.rs
+++ b/boa/src/builtins/infinity/mod.rs
@@ -12,7 +12,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{builtins::value::Value, BoaProfiler};
+use crate::{builtins::value::Value, BoaProfiler, Interpreter};
 
 /// JavaScript global `Infinity` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -24,7 +24,7 @@ impl Infinity {
 
     /// Initialize the `Infinity` property on the global object.
     #[inline]
-    pub(crate) fn init(_: &Value) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::from(f64::INFINITY))

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -172,7 +172,7 @@ impl Json {
 
     /// Initialise the `JSON` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
         let json = Value::new_object(Some(global));

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -172,7 +172,8 @@ impl Json {
 
     /// Initialise the `JSON` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
         let json = Value::new_object(Some(global));
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -173,7 +173,7 @@ impl Json {
     /// Initialise the `JSON` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
         let json = Value::new_object(Some(global));
 

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -285,7 +285,7 @@ impl Map {
 
     /// Initialise the `Map` object on the global object.
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -284,7 +284,8 @@ impl Map {
     }
 
     /// Initialise the `Map` object on the global object.
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -284,7 +284,7 @@ impl Map {
     }
 
     /// Initialise the `Map` object on the global object.
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -698,7 +698,7 @@ impl Math {
     /// Initialise the `Math` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Self::create(global))

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -697,7 +697,7 @@ impl Math {
 
     /// Initialise the `Math` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -697,7 +697,8 @@ impl Math {
 
     /// Initialise the `Math` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Self::create(global))

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -40,10 +40,11 @@ pub(crate) use self::{
     undefined::Undefined,
     value::{ResultValue, Value},
 };
+use crate::Interpreter;
 
 /// Initializes builtin objects and functions
 #[inline]
-pub fn init(global: &Value) {
+pub fn init(interpreter: &mut Interpreter) {
     let globals = [
         // The `Function` global must be initialized before other types.
         function::init,
@@ -72,13 +73,15 @@ pub fn init(global: &Value) {
         Undefined::init,
     ];
 
-    match global {
-        Value::Object(ref global_object) => {
-            for init in &globals {
-                let (name, value) = init(global);
+    for init in &globals {
+        let (name, value) = init(interpreter);
+        let name = name.to_string();
+        let global = &interpreter.realm.global_obj;
+        match global {
+            Value::Object(ref global_object) => {
                 global_object.borrow_mut().insert_field(name, value);
             }
+            _ => unreachable!("expect global object"),
         }
-        _ => unreachable!("expect global object"),
     }
 }

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -75,7 +75,6 @@ pub fn init(interpreter: &mut Interpreter) {
 
     for init in &globals {
         let (name, value) = init(interpreter);
-        let name = name.to_string();
         let global = &interpreter.realm.global_obj;
         match global {
             Value::Object(ref global_object) => {

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -75,7 +75,7 @@ pub fn init(interpreter: &mut Interpreter) {
 
     for init in &globals {
         let (name, value) = init(interpreter);
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         match global {
             Value::Object(ref global_object) => {
                 global_object.borrow_mut().insert_field(name, value);

--- a/boa/src/builtins/nan/mod.rs
+++ b/boa/src/builtins/nan/mod.rs
@@ -13,7 +13,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{builtins::value::Value, BoaProfiler};
+use crate::{builtins::value::Value, BoaProfiler, Interpreter};
 
 /// JavaScript global `NaN` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -25,7 +25,7 @@ impl NaN {
 
     /// Initialize the `NaN` property on the global object.
     #[inline]
-    pub(crate) fn init(_: &Value) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::from(f64::NAN))

--- a/boa/src/builtins/nan/mod.rs
+++ b/boa/src/builtins/nan/mod.rs
@@ -25,7 +25,7 @@ impl NaN {
 
     /// Initialize the `NaN` property on the global object.
     #[inline]
-    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&'static str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::from(f64::NAN))

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -727,7 +727,8 @@ impl Number {
 
     /// Initialise the `Number` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -727,7 +727,7 @@ impl Number {
 
     /// Initialise the `Number` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -728,7 +728,7 @@ impl Number {
     /// Initialise the `Number` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let prototype = Value::new_object(Some(global));

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -578,7 +578,7 @@ pub fn property_is_enumerable(this: &Value, args: &[Value], ctx: &mut Interprete
 /// Initialise the `Object` object on the global object.
 #[inline]
 pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-    let global = &interpreter.realm.global_obj;
+    let global = interpreter.global();
     let _timer = BoaProfiler::global().start_event("object", "init");
 
     let prototype = Value::new_object(None);

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -577,7 +577,8 @@ pub fn property_is_enumerable(this: &Value, args: &[Value], ctx: &mut Interprete
 
 /// Initialise the `Object` object on the global object.
 #[inline]
-pub fn init(global: &Value) -> (&str, Value) {
+pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    let global = &interpreter.realm.global_obj;
     let _timer = BoaProfiler::global().start_event("object", "init");
 
     let prototype = Value::new_object(None);

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -577,7 +577,7 @@ pub fn property_is_enumerable(this: &Value, args: &[Value], ctx: &mut Interprete
 
 /// Initialise the `Object` object on the global object.
 #[inline]
-pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
     let global = &interpreter.realm.global_obj;
     let _timer = BoaProfiler::global().start_event("object", "init");
 

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -492,7 +492,8 @@ impl RegExp {
 
     /// Initialise the `RegExp` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Self::create(global))

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -492,7 +492,7 @@ impl RegExp {
 
     /// Initialise the `RegExp` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -493,7 +493,7 @@ impl RegExp {
     /// Initialise the `RegExp` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Self::create(global))

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1023,7 +1023,7 @@ impl String {
 
     /// Initialise the `String` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1023,7 +1023,8 @@ impl String {
 
     /// Initialise the `String` object on the global object.
     #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create `String` `prototype`

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1024,7 +1024,7 @@ impl String {
     /// Initialise the `String` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create `String` `prototype`

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -101,6 +101,8 @@ impl Symbol {
     /// Initialise the `Symbol` object on the global object.
     #[inline]
     pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
+        // Define the Well-Known Symbols
+        // https://tc39.es/ecma262/#sec-well-known-symbols
         let symbol_async_iterator = Symbol(
             Some("Symbol.asyncIterator".into()),
             interpreter.generate_hash(),

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -100,7 +100,40 @@ impl Symbol {
 
     /// Initialise the `Symbol` object on the global object.
     #[inline]
-    pub fn init(global: &Value) -> (&str, Value) {
+    pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+        let symbol_async_iterator = Symbol(
+            Some("Symbol.asyncIterator".into()),
+            interpreter.generate_hash(),
+        );
+        let symbol_has_instance = Symbol(
+            Some("Symbol.hasInstance".into()),
+            interpreter.generate_hash(),
+        );
+        let symbol_is_concat_spreadable = Symbol(
+            Some("Symbol.isConcatSpreadable".into()),
+            interpreter.generate_hash(),
+        );
+        let symbol_iterator = Symbol(Some("Symbol.iterator".into()), interpreter.generate_hash());
+        let symbol_match = Symbol(Some("Symbol.match".into()), interpreter.generate_hash());
+        let symbol_match_all = Symbol(Some("Symbol.matchAll".into()), interpreter.generate_hash());
+        let symbol_replace = Symbol(Some("Symbol.replace".into()), interpreter.generate_hash());
+        let symbol_search = Symbol(Some("Symbol.search".into()), interpreter.generate_hash());
+        let symbol_species = Symbol(Some("Symbol.species".into()), interpreter.generate_hash());
+        let symbol_split = Symbol(Some("Symbol.split".into()), interpreter.generate_hash());
+        let symbol_to_primitive = Symbol(
+            Some("Symbol.toPrimitive".into()),
+            interpreter.generate_hash(),
+        );
+        let symbol_to_string_tag = Symbol(
+            Some("Symbol.toStringTag".into()),
+            interpreter.generate_hash(),
+        );
+        let symbol_unscopables = Symbol(
+            Some("Symbol.unscopables".into()),
+            interpreter.generate_hash(),
+        );
+
+        let global = &interpreter.realm.global_obj;
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype object
@@ -117,6 +150,23 @@ impl Symbol {
             false,
             true,
         );
+
+        symbol_object.set_field("asyncIterator", Value::symbol(symbol_async_iterator));
+        symbol_object.set_field("hasInstance", Value::symbol(symbol_has_instance));
+        symbol_object.set_field(
+            "isConcatSpreadable",
+            Value::symbol(symbol_is_concat_spreadable),
+        );
+        symbol_object.set_field("iterator", Value::symbol(symbol_iterator));
+        symbol_object.set_field("match", Value::symbol(symbol_match));
+        symbol_object.set_field("matchAll", Value::symbol(symbol_match_all));
+        symbol_object.set_field("replace", Value::symbol(symbol_replace));
+        symbol_object.set_field("search", Value::symbol(symbol_search));
+        symbol_object.set_field("species", Value::symbol(symbol_species));
+        symbol_object.set_field("split", Value::symbol(symbol_split));
+        symbol_object.set_field("toPrimitive", Value::symbol(symbol_to_primitive));
+        symbol_object.set_field("toStringTag", Value::symbol(symbol_to_string_tag));
+        symbol_object.set_field("unscopables", Value::symbol(symbol_unscopables));
 
         (Self::NAME, symbol_object)
     }

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -133,7 +133,7 @@ impl Symbol {
             interpreter.generate_hash(),
         );
 
-        let global = &interpreter.realm.global_obj;
+        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype object

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -100,7 +100,7 @@ impl Symbol {
 
     /// Initialise the `Symbol` object on the global object.
     #[inline]
-    pub fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let symbol_async_iterator = Symbol(
             Some("Symbol.asyncIterator".into()),
             interpreter.generate_hash(),

--- a/boa/src/builtins/undefined/mod.rs
+++ b/boa/src/builtins/undefined/mod.rs
@@ -24,7 +24,7 @@ impl Undefined {
 
     /// Initialize the `undefined` property on the global object.
     #[inline]
-    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&'static str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::undefined())

--- a/boa/src/builtins/undefined/mod.rs
+++ b/boa/src/builtins/undefined/mod.rs
@@ -12,7 +12,7 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{builtins::value::Value, BoaProfiler};
+use crate::{builtins::value::Value, BoaProfiler, Interpreter};
 
 /// JavaScript global `undefined` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -24,7 +24,7 @@ impl Undefined {
 
     /// Initialize the `undefined` property on the global object.
     #[inline]
-    pub(crate) fn init(_: &Value) -> (&str, Value) {
+    pub(crate) fn init(_interpreter: &mut Interpreter) -> (&str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::undefined())

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -214,7 +214,7 @@ impl Value {
                 new_obj
             }
             JSONValue::Object(obj) => {
-                let new_obj = Value::new_object(Some(&interpreter.realm.global_obj));
+                let new_obj = Value::new_object(Some(interpreter.global()));
                 for (key, json) in obj.into_iter() {
                     let value = Self::from_json(json, interpreter);
                     new_obj.set_property(

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -23,6 +23,7 @@ mod throw;
 mod try_node;
 
 use crate::{
+    builtins,
     builtins::{
         function::{Function as FunctionObject, FunctionBody, ThisMode},
         number::{f64_to_int32, f64_to_uint32},
@@ -79,12 +80,25 @@ pub struct Interpreter {
 impl Interpreter {
     /// Creates a new interpreter.
     pub fn new(realm: Realm) -> Self {
-        Self {
+        let mut interpreter = Self {
             state: InterpreterState::Executing,
             realm,
             symbol_count: 0,
             console: Console::default(),
-        }
+        };
+
+        // Add new builtIns to Interpreter Realm
+        // At a later date this can be removed from here and called explicitly, but for now we almost always want these default builtins
+        interpreter.create_intrinsics();
+
+        interpreter
+    }
+
+    /// Sets up the default global objects within Global
+    fn create_intrinsics(&mut self) {
+        let _timer = BoaProfiler::global().start_event("create_intrinsics", "interpreter");
+        // Create intrinsics, add global objects here
+        builtins::init(self);
     }
 
     /// Retrieves the `Realm` of this executor.

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -113,6 +113,7 @@ impl Interpreter {
         &mut self.realm
     }
 
+    /// Retrieves the global object of the `Realm` of this executor.
     #[inline]
     pub(crate) fn global(&self) -> &Value {
         &self.realm.global_obj

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -113,6 +113,11 @@ impl Interpreter {
         &mut self.realm
     }
 
+    #[inline]
+    pub(crate) fn global(&self) -> &Value {
+        &self.realm.global_obj
+    }
+
     /// Generates a new `Symbol` internal hash.
     ///
     /// This currently is an incremented value.

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -6,7 +6,6 @@
 
 use crate::{
     builtins::{
-        self,
         function::{Function, NativeFunctionData},
         value::Value,
     },
@@ -40,25 +39,11 @@ impl Realm {
         // We need to clone the global here because its referenced from separate places (only pointer is cloned)
         let global_env = new_global_environment(global.clone(), global.clone());
 
-        let new_realm = Self {
+        Self {
             global_obj: global.clone(),
             global_env,
             environment: LexicalEnvironment::new(global),
-        };
-
-        // Add new builtIns to Realm
-        // At a later date this can be removed from here and called explicity, but for now we almost always want these default builtins
-        new_realm.create_instrinsics();
-
-        new_realm
-    }
-
-    // Sets up the default global objects within Global
-    fn create_instrinsics(&self) {
-        let _timer = BoaProfiler::global().start_event("create_instrinsics", "realm");
-        let global = &self.global_obj;
-        // Create intrinsics, add global objects here
-        builtins::init(global);
+        }
     }
 
     /// Utility to add a function to the global object


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request closes #585.

It changes the following:
 - Moves create_intrinsics from Realm to Interpreter
 - Changes the signature of the `init` function from `pub(crate) fn init(global: &Value) -> (&str, Value)` to `pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value)`, allowing the init functions to reference the interpreter
 - Add the Well-Known Symbols to the Symbol object
