### PR TITLE
Implement the comma operator

### DIFF
--- a/boa/src/exec/operator/mod.rs
+++ b/boa/src/exec/operator/mod.rs
@@ -142,7 +142,7 @@ impl Executable for BinOp {
             op::BinOp::Comma => {
                 self.lhs().run(interpreter)?;
                 Ok(self.rhs().run(interpreter)?)
-            },
+            }
         }
     }
 }

--- a/boa/src/exec/operator/mod.rs
+++ b/boa/src/exec/operator/mod.rs
@@ -139,6 +139,10 @@ impl Executable for BinOp {
                 }
                 _ => Ok(Value::undefined()),
             },
+            op::BinOp::Comma => {
+                self.lhs().run(interpreter)?;
+                Ok(self.rhs().run(interpreter)?)
+            },
         }
     }
 }

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -1163,3 +1163,22 @@ fn not_a_function() {
     "#;
     assert_eq!(forward(&mut engine, scenario), "TypeError: not a function");
 }
+
+#[test]
+fn comma_operator() {
+    let scenario = r#"
+        var a, b;
+        b = 10;
+        a = (b++, b);
+        a
+    "#;
+    assert_eq!(&exec(scenario), "11");
+
+    let scenario = r#"
+        var a, b;
+        b = 10;
+        a = (b += 5, b /= 3, b - 3);
+        a
+    "#;
+    assert_eq!(&exec(scenario), "2");
+}

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -705,6 +705,9 @@ pub enum BinOp {
     ///
     /// see: [`AssignOp`](enum.AssignOp.html).
     Assign(AssignOp),
+
+    /// Comma operation.
+    Comma,
 }
 
 impl From<NumOp> for BinOp {
@@ -748,6 +751,7 @@ impl Display for BinOp {
                 Self::Comp(ref op) => op.to_string(),
                 Self::Log(ref op) => op.to_string(),
                 Self::Assign(ref op) => op.to_string(),
+                Self::Comma => ",".to_string(),
             }
         )
     }

--- a/boa/src/syntax/ast/punctuator.rs
+++ b/boa/src/syntax/ast/punctuator.rs
@@ -167,6 +167,7 @@ impl Punctuator {
             Self::LeftSh => Some(BinOp::Bit(BitOp::Shl)),
             Self::RightSh => Some(BinOp::Bit(BitOp::Shr)),
             Self::URightSh => Some(BinOp::Bit(BitOp::UShr)),
+            Self::Comma => Some(BinOp::Comma),
             _ => None,
         }
     }

--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -116,7 +116,7 @@ impl TokenParser for AssignmentExpression {
                 TokenKind::Punctuator(Punctuator::Assign) => {
                     lhs = Assign::new(lhs, self.parse(cursor)?).into();
                 }
-                TokenKind::Punctuator(p) if p.as_binop().is_some() => {
+                TokenKind::Punctuator(p) if p.as_binop().is_some() && p != Punctuator::Comma => {
                     let expr = self.parse(cursor)?;
                     let binop = p.as_binop().expect("binop disappeared");
                     lhs = BinOp::new(binop, lhs, expr).into();


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #569 .

It changes the following:
 - Adds the comma operator
 - Changes assignment operator parsing so that the comma operator is not parsed as part of the assignment (explained below)
 - Adds tests

Examples:
```js
var a, b;
b = 10;
a = (b++, b);

// a is now 11, b is now 11
```

```js
var a, b;
b = 10;
a = (b += 5, b - 1);

// a is now 14, b is now 15
```

```js
var a, b;
b = 10;
a = (b += 5, b *= 2, b - 1);

// a is now 29, b is now 30
```

The reason why assignment operator parsing is changed is because otherwise, for cases like the second example, the parser continues to parse the tokens after the comma operator as part of the assignment. For the second example, this would cause the `b` to be assigned the value of `5, b - 1` (which is `b - 1`). So I made a minor change to the assignment operator parsing so that it stops parsing when it reaches a comma operator.