### PR TITLE
`RegExp` specialization

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -19,7 +19,7 @@ use crate::{
         map::ordered_map::OrderedMap,
         property::Property,
         value::{RcBigInt, RcString, RcSymbol, ResultValue, Value},
-        BigInt,
+        BigInt, RegExp,
     },
     exec::Interpreter,
     BoaProfiler,
@@ -71,6 +71,7 @@ pub struct Object {
 pub enum ObjectData {
     Array,
     Map(OrderedMap<Value, Value>),
+    RegExp(RegExp),
     BigInt(RcBigInt),
     Boolean(bool),
     Function(Function),
@@ -87,8 +88,9 @@ impl Display for ObjectData {
             f,
             "{}",
             match self {
-                Self::Function(_) => "Function",
                 Self::Array => "Array",
+                Self::Function(_) => "Function",
+                Self::RegExp(_) => "RegExp",
                 Self::Map(_) => "Map",
                 Self::String(_) => "String",
                 Self::Symbol(_) => "Symbol",
@@ -377,6 +379,20 @@ impl Object {
     pub fn as_bigint(&self) -> Option<&BigInt> {
         match self.data {
             ObjectData::BigInt(ref bigint) => Some(bigint),
+            _ => None,
+        }
+    }
+
+    /// Checks if it a `BigInt` object.
+    #[inline]
+    pub fn is_regexp(&self) -> bool {
+        matches!(self.data, ObjectData::RegExp(_))
+    }
+
+    #[inline]
+    pub fn as_regexp(&self) -> Option<&RegExp> {
+        match self.data {
+            ObjectData::RegExp(ref regexp) => Some(regexp),
             _ => None,
         }
     }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -383,7 +383,7 @@ impl Object {
         }
     }
 
-    /// Checks if it a `BigInt` object.
+    /// Checks if it a `RegExp` object.
     #[inline]
     pub fn is_regexp(&self) -> bool {
         matches!(self.data, ObjectData::RegExp(_))

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -474,8 +474,11 @@ impl RegExp {
         Ok(result)
     }
 
-    /// Create a new `RegExp` object.
-    pub(crate) fn create(global: &Value) -> Value {
+    /// Initialise the `RegExp` object on the global object.
+    #[inline]
+    pub(crate) fn init(global: &Value) -> (&str, Value) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
         // Create prototype
         let prototype = Value::new_object(Some(global));
         prototype
@@ -497,7 +500,7 @@ impl RegExp {
         // make_builtin_fn(Self::get_sticky, "sticky", &prototype, 0);
         // make_builtin_fn(Self::get_unicode, "unicode", &prototype, 0);
 
-        make_constructor_fn(
+        let regexp = make_constructor_fn(
             Self::NAME,
             Self::LENGTH,
             Self::make_regexp,
@@ -505,14 +508,8 @@ impl RegExp {
             prototype,
             true,
             true,
-        )
-    }
+        );
 
-    /// Initialise the `RegExp` object on the global object.
-    #[inline]
-    pub(crate) fn init(global: &Value) -> (&str, Value) {
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        (Self::NAME, Self::create(global))
+        (Self::NAME, regexp)
     }
 }

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -476,7 +476,7 @@ impl RegExp {
 
     /// Initialise the `RegExp` object on the global object.
     #[inline]
-    pub(crate) fn init(interpreter: &mut Interpreter) -> (&str, Value) {
+    pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
         let global = interpreter.global();
 

--- a/boa/src/builtins/regexp/tests.rs
+++ b/boa/src/builtins/regexp/tests.rs
@@ -1,4 +1,3 @@
-use super::*;
 use crate::{exec::Interpreter, forward, realm::Realm};
 
 #[test]
@@ -15,13 +14,6 @@ fn constructors() {
     assert_eq!(forward(&mut engine, "constructed.test('1.0')"), "true");
     assert_eq!(forward(&mut engine, "literal.test('1.0')"), "true");
     assert_eq!(forward(&mut engine, "ctor_literal.test('1.0')"), "true");
-}
-
-#[test]
-fn check_regexp_constructor_is_function() {
-    let global = Value::new_object(None);
-    let regexp_constructor = RegExp::create(&global);
-    assert_eq!(regexp_constructor.is_function(), true);
 }
 
 // TODO: uncomment this test when property getters are supported

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -415,14 +415,9 @@ impl String {
             Value::Object(ref obj) => {
                 let obj = obj.borrow();
 
-                if obj.internal_slots().get("RegExpMatcher").is_some() {
+                if let Some(regexp) = obj.as_regexp() {
                     // first argument is another `RegExp` object, so copy its pattern and flags
-                    if let Some(body) = obj.internal_slots().get("OriginalSource") {
-                        return body
-                            .as_string()
-                            .expect("OriginalSource should be a string")
-                            .into();
-                    }
+                    return regexp.original_source.clone();
                 }
                 "undefined".to_string()
             }


### PR DESCRIPTION
It changes the following:
 - Removed Dependency of Internal State
 - Removed Dependency of Internal slots
 - Merged create into init (like all the other objects)
 - Specialized `RegExp` object
 - Removed wrong methods that should be getters (but we don't support getter so I disabled them for now)

BTW: This is not to make the methods spec compliant, this PR only focus on removing the dependency (I tried not to change the old behaviour). Making the methods spec compliant should be done in a separate PR.