### PR TITLE
Fixed `String.prototype.indexOf()` bug, when the search string is empty

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -556,6 +556,10 @@ impl String {
             .transpose()?
             .map_or(0, |position| position.max(0.0).min(length as f64) as usize);
 
+        if search_string.is_empty() {
+            return Ok(start.min(length).into());
+        }
+
         if start < length {
             if let Some(position) = string.find(search_string.as_str()) {
                 return Ok(string[..position].chars().count().into());

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -497,3 +497,15 @@ fn generic_index_of() {
     assert_eq!(forward(&mut engine, "(10).indexOf(0)"), "1");
     assert_eq!(forward(&mut engine, "(10).indexOf('0')"), "1");
 }
+
+#[test]
+fn index_of_empty_search_string() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    assert_eq!(forward(&mut engine, "''.indexOf('')"), "0");
+    assert_eq!(forward(&mut engine, "''.indexOf('', 10)"), "0");
+    assert_eq!(forward(&mut engine, "'ABC'.indexOf('', 1)"), "1");
+    assert_eq!(forward(&mut engine, "'ABC'.indexOf('', 2)"), "2");
+    assert_eq!(forward(&mut engine, "'ABC'.indexOf('', 10)"), "3");
+}


### PR DESCRIPTION
It changes the following:
 - Fixed `String.prototype.indexOf()` bug, when the search string is empty
 - Added test.
