### PR TITLE
Fix internal object methods

### DIFF
--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -185,6 +185,8 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
     pub fn get_own_property(&self, key: &PropertyKey) -> Option<Property> {
         match self.data {
+            // String exotic objects
+            // See: https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p
             ObjectData::String(ref string) => {
                 let descriptor = self.ordinary_get_own_property(key);
                 if descriptor.is_some() {
@@ -194,6 +196,32 @@ impl Object {
             }
             _ => self.ordinary_get_own_property(key),
         }
+    }
+
+    /// Determine the object that provides inherited properties for this ordinary object.
+    /// A `null` value indicates that there are no inherited properties.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
+    #[inline]
+    pub fn ordinary_get_prototype_of(&self) -> Value {
+        self.prototype.clone()
+    }
+
+    /// Determine the object that provides inherited properties for this object.
+    /// A `null` value indicates that there are no inherited properties.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#table-5
+    #[inline]
+    pub fn get_prototype_of(&self) -> Value {
+        self.ordinary_get_prototype_of()
     }
 
     /// [[Get]]
@@ -401,18 +429,6 @@ impl Object {
         }
         self.prototype = val;
         true
-    }
-
-    /// Returns either the prototype or null
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
-    #[inline]
-    pub fn get_prototype_of(&self) -> Value {
-        self.prototype.clone()
     }
 
     /// Helper function for property insertion.

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -91,20 +91,35 @@ impl Object {
         self.ordinary_has_property(key)
     }
 
-    /// Delete property.
-    pub fn delete(&mut self, key: &PropertyKey) -> bool {
-        let desc = if let Some(desc) = self.get_own_property(key) {
-            desc
-        } else {
-            return true;
-        };
-
-        if desc.configurable_or(false) {
-            self.remove_property(&key.to_string());
-            return true;
+    /// Remove the own property from this ordinary object.
+    /// Return `false` if the property was not deleted and is still present.
+    /// Return `true` if the property was deleted or is not present.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
+    fn ordinary_delete(&mut self, key: &PropertyKey) -> bool {
+        if let Some(descriptor) = self.get_own_property(key) {
+            if descriptor.configurable_or(false) {
+                self.remove_property(&key.to_string());
+                return true;
+            }
         }
 
         false
+    }
+
+    /// Remove the own property from this object.
+    /// Return `false` if the property was not deleted and is still present.
+    /// Return `true` if the property was deleted or is not present.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#table-5
+    pub fn delete(&mut self, key: &PropertyKey) -> bool {
+        self.ordinary_delete(key)
     }
 
     /// [[Get]]

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -35,6 +35,29 @@ impl Object {
         self.ordinary_is_extensible()
     }
 
+    /// Prevent further extensions to ordinary object.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
+    #[inline]
+    fn ordinary_prevent_extensions(&self) -> bool {
+        self.extensible = false;
+        true
+    }
+
+    /// Prevent further extensions to object.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#table-5
+    #[inline]
+    pub fn prevent_extensions(&self) -> bool {
+        self.ordinary_is_extensible()
+    }
+
     /// Check if object has property.
     ///
     /// More information:

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -42,7 +42,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
     #[inline]
-    fn ordinary_prevent_extensions(&self) -> bool {
+    fn ordinary_prevent_extensions(&mut self) -> bool {
         self.extensible = false;
         true
     }
@@ -56,8 +56,8 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#table-5
     #[inline]
-    pub fn prevent_extensions(&self) -> bool {
-        self.ordinary_is_extensible()
+    pub fn prevent_extensions(&mut self) -> bool {
+        self.ordinary_prevent_extensions()
     }
 
     /// Check if object has property.
@@ -81,18 +81,6 @@ impl Object {
             return false;
         }
 
-        true
-    }
-
-    /// Disable extensibility.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-    #[inline]
-    pub fn prevent_extensions(&mut self) -> bool {
-        self.extensible = false;
         true
     }
 

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -13,6 +13,28 @@ use crate::builtins::{
 use crate::BoaProfiler;
 
 impl Object {
+    /// Check if the ordinary object is extensible.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
+    #[inline]
+    fn ordinary_is_extensible(&self) -> bool {
+        self.extensible
+    }
+
+    /// Check if the object is extensible.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#table-5
+    #[inline]
+    pub fn is_extensible(&self) -> bool {
+        self.ordinary_is_extensible()
+    }
+
     /// Check if object has property.
     ///
     /// More information:
@@ -35,17 +57,6 @@ impl Object {
         }
 
         true
-    }
-
-    /// Check if it is extensible.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-    #[inline]
-    pub fn is_extensible(&self) -> bool {
-        self.extensible
     }
 
     /// Disable extensibility.

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -24,7 +24,7 @@ impl Object {
         self.extensible
     }
 
-    /// Check if the object is extensible.
+    /// Determine whether it is permitted to add additional properties to this object.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -47,7 +47,9 @@ impl Object {
         true
     }
 
-    /// Prevent further extensions to object.
+    /// Control whether new properties may be added to this object.
+    /// Returns `true` if the operation was successful or `false`
+    /// if the operation was unsuccessful.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]

--- a/boa/src/builtins/object/internal_methods.rs
+++ b/boa/src/builtins/object/internal_methods.rs
@@ -60,13 +60,14 @@ impl Object {
         self.ordinary_prevent_extensions()
     }
 
-    /// Check if object has property.
+    /// Return a bool value indicating whether this ordinay object already has either an own
+    /// or inherited property with the specified key.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
-    pub fn has_property(&self, key: &PropertyKey) -> bool {
+    /// [spec]: https://tc39.es/ecma262/#table-5
+    fn ordinary_has_property(&self, key: &PropertyKey) -> bool {
         if self.get_own_property(key).is_some() {
             return true;
         }
@@ -77,6 +78,17 @@ impl Object {
         } else {
             false
         }
+    }
+
+    /// Return a bool value indicating whether this ordinay object already has either an own
+    /// or inherited property with the specified key.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
+    pub fn has_property(&self, key: &PropertyKey) -> bool {
+        self.ordinary_has_property(key)
     }
 
     /// Delete property.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -561,16 +561,16 @@ pub fn property_is_enumerable(this: &Value, args: &[Value], ctx: &mut Interprete
         Some(key) => key,
     };
 
-    let property_key = ctx.to_property_key(key)?;
-    let own_property = ctx.to_object(this).map(|obj| {
-        obj.as_object()
-            .expect("Unable to deref object")
-            .get_own_property(&property_key)
-    });
+    let key = ctx.to_property_key(key)?;
+    let property = ctx
+        .to_object(this)?
+        .as_object()
+        .expect("Unable to deref object")
+        .get_own_property(&key);
 
-    Ok(own_property.map_or(Value::from(false), |own_prop| {
-        Value::from(own_prop.enumerable_or(false))
-    }))
+    Ok(property
+        .map_or(false, |own_prop| own_prop.enumerable_or(false))
+        .into())
 }
 
 /// Initialise the `Object` object on the global object.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -569,7 +569,7 @@ pub fn property_is_enumerable(this: &Value, args: &[Value], ctx: &mut Interprete
         .get_own_property(&key);
 
     Ok(property
-        .map_or(false, |own_prop| own_prop.enumerable_or(false))
+        .map_or(false, |own_prop| own_prop.enumerable())
         .into())
 }
 

--- a/boa/src/builtins/property/attribute/mod.rs
+++ b/boa/src/builtins/property/attribute/mod.rs
@@ -82,9 +82,10 @@ impl Attribute {
     }
 
     /// Gets the `writable` flag.
+    ///
+    /// If `writable` is not present, `false` is returned.
     #[inline]
     pub fn writable(self) -> bool {
-        debug_assert!(self.has_writable());
         self.contains(Self::WRITABLE)
     }
 
@@ -105,9 +106,10 @@ impl Attribute {
     }
 
     /// Gets the `enumerable` flag.
+    ///
+    /// If `enumerable` is not present, `false` is returned.
     #[inline]
     pub fn enumerable(self) -> bool {
-        debug_assert!(self.has_enumerable());
         self.contains(Self::ENUMERABLE)
     }
 
@@ -128,9 +130,10 @@ impl Attribute {
     }
 
     /// Gets the `configurable` flag.
+    ///
+    /// If `configurable` is not present, `false` is returned.
     #[inline]
     pub fn configurable(self) -> bool {
-        debug_assert!(self.has_configurable());
         self.contains(Self::CONFIGURABLE)
     }
 }

--- a/boa/src/builtins/property/attribute/tests.rs
+++ b/boa/src/builtins/property/attribute/tests.rs
@@ -41,6 +41,7 @@ fn enumerable_configurable() {
     let attribute = Attribute::ENUMERABLE | Attribute::CONFIGURABLE;
 
     assert!(!attribute.has_writable());
+    assert!(!attribute.writable());
 
     assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
@@ -65,8 +66,11 @@ fn default() {
     let attribute = Attribute::default();
 
     assert!(attribute.has_writable());
+    assert!(!attribute.writable());
     assert!(attribute.has_enumerable());
+    assert!(!attribute.enumerable());
     assert!(attribute.has_configurable());
+    assert!(!attribute.enumerable());
 }
 
 #[test]
@@ -76,8 +80,11 @@ fn clear() {
     attribute.clear();
 
     assert!(!attribute.has_writable());
+    assert!(!attribute.writable());
     assert!(!attribute.has_enumerable());
+    assert!(!attribute.enumerable());
     assert!(!attribute.has_configurable());
+    assert!(!attribute.enumerable());
 
     assert!(attribute.is_empty());
 }

--- a/boa/src/builtins/property/mod.rs
+++ b/boa/src/builtins/property/mod.rs
@@ -88,7 +88,9 @@ impl Property {
         }
     }
 
-    /// Get the
+    /// Gets the `enumerable` flag.
+    ///
+    /// If `configurable` is not present, `false` is returned.
     #[inline]
     pub fn configurable(&self) -> bool {
         self.attribute.configurable()
@@ -99,43 +101,30 @@ impl Property {
         self.attribute.set_configurable(configurable)
     }
 
-    #[inline]
-    pub fn configurable_or(&self, value: bool) -> bool {
-        if self.attribute.has_configurable() {
-            self.attribute.configurable()
-        } else {
-            value
-        }
-    }
-
-    /// Set enumerable
+    /// Gets the `enumerable` flag.
+    ///
+    /// If `enumerable` is not present, `false` is returned.
     #[inline]
     pub fn enumerable(&self) -> bool {
         self.attribute.enumerable()
     }
 
     #[inline]
-    pub fn enumerable_or(&self, value: bool) -> bool {
-        if self.attribute.has_enumerable() {
-            self.attribute.enumerable()
-        } else {
-            value
-        }
+    pub fn set_enumerable(&mut self, enumerable: bool) {
+        self.attribute.set_enumerable(enumerable)
     }
 
-    /// Set writable
+    /// Gets the `writable` flag.
+    ///
+    /// If `writable` is not present, `false` is returned.
     #[inline]
     pub fn writable(&self) -> bool {
         self.attribute.writable()
     }
 
     #[inline]
-    pub fn writable_or(&self, value: bool) -> bool {
-        if self.attribute.has_writable() {
-            self.attribute.writable()
-        } else {
-            value
-        }
+    pub fn set_writable(&mut self, writable: bool) {
+        self.attribute.set_writable(writable)
     }
 
     /// Set value

--- a/boa/src/builtins/property/mod.rs
+++ b/boa/src/builtins/property/mod.rs
@@ -292,6 +292,23 @@ pub enum PropertyKey {
     Symbol(RcSymbol),
 }
 
+impl PropertyKey {
+    pub fn is_string(&self) -> bool {
+        matches!(self, Self::String(_))
+    }
+
+    pub fn is_symbol(&self) -> bool {
+        matches!(self, Self::Symbol(_))
+    }
+
+    pub fn to_index(&self) -> Option<usize> {
+        match self {
+            Self::String(ref string) => string.parse().ok(),
+            Self::Symbol(_) => None,
+        }
+    }
+}
+
 impl From<RcString> for PropertyKey {
     #[inline]
     fn from(string: RcString) -> PropertyKey {

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -520,37 +520,14 @@ impl Value {
     /// TODO: this function should use the get Value if its set
     pub fn get_field<F>(&self, field: F) -> Self
     where
-        F: Into<Value>,
+        F: Into<PropertyKey>,
     {
         let _timer = BoaProfiler::global().start_event("Value::get_field", "value");
-        match field.into() {
-            // Our field will either be a String or a Symbol
-            Self::String(ref s) => {
-                match self.get_property(s) {
-                    Some(prop) => {
-                        // If the Property has [[Get]] set to a function, we should run that and return the Value
-                        let prop_getter = match prop.get {
-                            Some(_) => None,
-                            None => None,
-                        };
-
-                        // If the getter is populated, use that. If not use [[Value]] instead
-                        if let Some(val) = prop_getter {
-                            val
-                        } else {
-                            let val = prop
-                                .value
-                                .as_ref()
-                                .expect("Could not get property as reference");
-                            val.clone()
-                        }
-                    }
-                    None => Value::undefined(),
-                }
-            }
-            Self::Symbol(_) => unimplemented!(),
-            _ => Value::undefined(),
+        if let Some(object) = self.as_object() {
+            return object.get(&field.into());
         }
+
+        Value::undefined()
     }
 
     /// Check whether an object has an internal state set.

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -73,7 +73,7 @@ impl GlobalEnvironmentRecord {
         let global_object = &mut self.object_record.bindings;
         let existing_prop = global_object.get_property(&name);
         if let Some(prop) = existing_prop {
-            if prop.value.is_none() || prop.configurable_or(false) {
+            if prop.value.is_none() || prop.configurable() {
                 let mut property =
                     Property::data_descriptor(value, Attribute::WRITABLE | Attribute::ENUMERABLE);
                 property.set_configurable(deletion);


### PR DESCRIPTION
This PR closes #591 , #557, #602 

- Ordinary internal methods:
  - [ ] [OrdinarySet][ordinary-set]
  - [ ] [OrdinaryGet][ordinary-get]
  - [x] [OrdinaryDelete][ordinary-delete]
  - [ ] [OrdinaryToPrimitive][ordinary-to-primitive]
  - [ ] [OrdinaryHasInstance][ordinary-has-instance]
  - [x] [OrdinaryHasProperty][ordinary-has-property]
  - [x] [OrdinaryIsExtensible][ordinary-is-extensible]
  - [x] [OrdinaryPreventExtensions][ordinary-prevent-extensions]
  - [x] [OrdinaryGetPrototypeOf][ordinary-get-prototype-of]
  - [x] [OrdinarySetPrototypeOf][ordinary-set-prototype-of]
  - [x] [OrdinaryGetOwnProperty][ordinary-get-own-property]
  - [x] [OrdinaryDefineOwnProperty][ordinary-define-own-property]
- ...

<!-- Ordinary internal methods -->
[ordinary-set]: https://tc39.es/ecma262/#sec-ordinaryset
[ordinary-get]: https://tc39.es/ecma262/#sec-ordinaryget
[ordinary-delete]: https://tc39.es/ecma262/#sec-ordinarydelete
[ordinary-to-primitive]: https://tc39.es/ecma262/#sec-ordinarytoprimitive
[ordinary-has-instance]: https://tc39.es/ecma262/#sec-ordinaryhasinstance
[ordinary-has-property]: https://tc39.es/ecma262/#sec-ordinaryhasproperty
[ordinary-is-extensible]: https://tc39.es/ecma262/#sec-ordinaryisextensible
[ordinary-prevent-extensions]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
[ordinary-get-prototype-of]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
[ordinary-set-prototype-of]: https://tc39.es/ecma262/#sec-ordinarysetprototypeof
[ordinary-get-own-property]: https://tc39.es/ecma262/#sec-ordinarygetownproperty
[ordinary-define-own-property]: https://tc39.es/ecma262/#sec-ordinarydefineownproperty