### PR TITLE
Index `PropertyKey`, `Object` iterators and symbol support

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -413,8 +413,7 @@ impl Array {
 
         if len == 0 {
             this.set_field("length", 0);
-            // Since length is 0, this will be an Undefined value
-            return Ok(this.get_field(0));
+            return Ok(Value::undefined());
         }
 
         let first: Value = this.get_field(0);

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -14,8 +14,8 @@
 use crate::{
     builtins::{
         object::{Object, ObjectData, PROTOTYPE},
-        property::{Attribute, Property, PropertyKey},
-        value::{RcString, Value},
+        property::{Attribute, Property},
+        value::Value,
         Array,
     },
     environment::lexical_environment::Environment,
@@ -180,7 +180,7 @@ pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
     );
     // Define length as a property
-    obj.define_own_property(&PropertyKey::from(RcString::from("length")), length);
+    obj.define_own_property("length", length);
     let mut index: usize = 0;
     while index < len {
         let val = arguments_list.get(index).expect("Could not get argument");
@@ -189,8 +189,7 @@ pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
             Attribute::WRITABLE | Attribute::ENUMERABLE | Attribute::CONFIGURABLE,
         );
 
-        obj.properties_mut()
-            .insert(RcString::from(index.to_string()), prop);
+        obj.insert_property(index, prop);
         index += 1;
     }
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -13,9 +13,15 @@
 //! [json]: https://www.json.org/json-en.html
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
 
-use crate::builtins::property::{Property, PropertyKey};
-use crate::builtins::{function::make_builtin_fn, value::Value};
-use crate::{exec::Interpreter, BoaProfiler, Result};
+use crate::{
+    builtins::{
+        function::make_builtin_fn,
+        property::{Property, PropertyKey},
+        value::Value,
+    },
+    exec::Interpreter,
+    BoaProfiler, Result,
+};
 use serde_json::{self, Value as JSONValue};
 
 #[cfg(test)]
@@ -54,7 +60,7 @@ impl Json {
                     Some(reviver) if reviver.is_function() => {
                         let mut holder = Value::new_object(None);
                         holder.set_field("", j);
-                        Self::walk(reviver, ctx, &mut holder, &"".into())
+                        Self::walk(reviver, ctx, &mut holder, &PropertyKey::from(""))
                     }
                     _ => Ok(j),
                 }

--- a/boa/src/builtins/object/iter.rs
+++ b/boa/src/builtins/object/iter.rs
@@ -1,0 +1,422 @@
+use super::*;
+use std::collections::hash_map;
+use std::iter::FusedIterator;
+
+impl Object {
+    /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(PropertyKey, &'a Property)`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn iter(&self) -> Iter<'_> {
+        Iter {
+            indexed_properties: self.indexed_properties.iter(),
+            string_properties: self.properties.iter(),
+            symbol_properties: self.symbol_properties.iter(),
+        }
+    }
+
+    /// An iterator visiting all keys in arbitrary order. The iterator element type is `PropertyKey`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn keys(&self) -> Keys<'_> {
+        Keys(self.iter())
+    }
+
+    /// An iterator visiting all values in arbitrary order. The iterator element type is `&'a Property`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn values(&self) -> Values<'_> {
+        Values(self.iter())
+    }
+
+    /// An iterator visiting all symbol key-value pairs in arbitrary order. The iterator element type is `(&'a RcSymbol, &'a Property)`.
+    ///
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn symbol_properties(&self) -> SymbolProperties<'_> {
+        SymbolProperties(self.symbol_properties.iter())
+    }
+
+    /// An iterator visiting all symbol keys in arbitrary order. The iterator element type is `&'a RcSymbol`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn symbol_property_keys(&self) -> SymbolPropertyKeys<'_> {
+        SymbolPropertyKeys(self.symbol_properties.keys())
+    }
+
+    /// An iterator visiting all symbol values in arbitrary order. The iterator element type is `&'a Property`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn symbol_property_values(&self) -> SymbolPropertyValues<'_> {
+        SymbolPropertyValues(self.symbol_properties.values())
+    }
+
+    /// An iterator visiting all indexed key-value pairs in arbitrary order. The iterator element type is `(&'a u32, &'a Property)`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn index_properties(&self) -> IndexProperties<'_> {
+        IndexProperties(self.indexed_properties.iter())
+    }
+
+    /// An iterator visiting all index keys in arbitrary order. The iterator element type is `&'a u32`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn index_property_keys(&self) -> IndexPropertyKeys<'_> {
+        IndexPropertyKeys(self.indexed_properties.keys())
+    }
+
+    /// An iterator visiting all index values in arbitrary order. The iterator element type is `&'a Property`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn index_property_values(&self) -> IndexPropertyValues<'_> {
+        IndexPropertyValues(self.indexed_properties.values())
+    }
+
+    /// An iterator visiting all string key-value pairs in arbitrary order. The iterator element type is `(&'a RcString, &'a Property)`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn string_properties(&self) -> StringProperties<'_> {
+        StringProperties(self.properties.iter())
+    }
+
+    /// An iterator visiting all string keys in arbitrary order. The iterator element type is `&'a RcString`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn string_property_keys(&self) -> StringPropertyKeys<'_> {
+        StringPropertyKeys(self.properties.keys())
+    }
+
+    /// An iterator visiting all string values in arbitrary order. The iterator element type is `&'a Property`.
+    ///
+    /// This iterator does not recurse down the prototype chain.
+    #[inline]
+    pub fn string_property_values(&self) -> StringPropertyValues<'_> {
+        StringPropertyValues(self.properties.values())
+    }
+}
+
+/// An iterator over the property entries of an `Object`
+#[derive(Debug, Clone)]
+pub struct Iter<'a> {
+    indexed_properties: hash_map::Iter<'a, u32, Property>,
+    string_properties: hash_map::Iter<'a, RcString, Property>,
+    symbol_properties: hash_map::Iter<'a, RcSymbol, Property>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = (PropertyKey, &'a Property);
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((key, value)) = self.indexed_properties.next() {
+            Some(((*key).into(), value))
+        } else if let Some((key, value)) = self.string_properties.next() {
+            Some((key.clone().into(), value))
+        } else {
+            let (key, value) = self.symbol_properties.next()?;
+            Some((key.clone().into(), value))
+        }
+    }
+}
+
+impl ExactSizeIterator for Iter<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.indexed_properties.len() + self.string_properties.len() + self.symbol_properties.len()
+    }
+}
+
+impl FusedIterator for Iter<'_> {}
+
+/// An iterator over the keys (`PropertyKey`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct Keys<'a>(Iter<'a>);
+
+impl<'a> Iterator for Keys<'a> {
+    type Item = PropertyKey;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (key, _) = self.0.next()?;
+        Some(key)
+    }
+}
+
+impl ExactSizeIterator for Keys<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for Keys<'_> {}
+
+/// An iterator over the values (`Property`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct Values<'a>(Iter<'a>);
+
+impl<'a> Iterator for Values<'a> {
+    type Item = &'a Property;
+    fn next(&mut self) -> Option<Self::Item> {
+        let (_, value) = self.0.next()?;
+        Some(value)
+    }
+}
+
+impl ExactSizeIterator for Values<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for Values<'_> {}
+
+/// An iterator over the `Symbol` property entries of an `Object`
+#[derive(Debug, Clone)]
+pub struct SymbolProperties<'a>(hash_map::Iter<'a, RcSymbol, Property>);
+
+impl<'a> Iterator for SymbolProperties<'a> {
+    type Item = (&'a RcSymbol, &'a Property);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for SymbolProperties<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for SymbolProperties<'_> {}
+
+/// An iterator over the keys (`RcSymbol`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct SymbolPropertyKeys<'a>(hash_map::Keys<'a, RcSymbol, Property>);
+
+impl<'a> Iterator for SymbolPropertyKeys<'a> {
+    type Item = &'a RcSymbol;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for SymbolPropertyKeys<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for SymbolPropertyKeys<'_> {}
+
+/// An iterator over the `Symbol` values (`Property`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct SymbolPropertyValues<'a>(hash_map::Values<'a, RcSymbol, Property>);
+
+impl<'a> Iterator for SymbolPropertyValues<'a> {
+    type Item = &'a Property;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for SymbolPropertyValues<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for SymbolPropertyValues<'_> {}
+
+/// An iterator over the indexed property entries of an `Object`
+#[derive(Debug, Clone)]
+pub struct IndexProperties<'a>(hash_map::Iter<'a, u32, Property>);
+
+impl<'a> Iterator for IndexProperties<'a> {
+    type Item = (&'a u32, &'a Property);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for IndexProperties<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for IndexProperties<'_> {}
+
+/// An iterator over the index keys (`u32`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct IndexPropertyKeys<'a>(hash_map::Keys<'a, u32, Property>);
+
+impl<'a> Iterator for IndexPropertyKeys<'a> {
+    type Item = &'a u32;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for IndexPropertyKeys<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for IndexPropertyKeys<'_> {}
+
+/// An iterator over the index values (`Property`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct IndexPropertyValues<'a>(hash_map::Values<'a, u32, Property>);
+
+impl<'a> Iterator for IndexPropertyValues<'a> {
+    type Item = &'a Property;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for IndexPropertyValues<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for IndexPropertyValues<'_> {}
+
+/// An iterator over the `String` property entries of an `Object`
+#[derive(Debug, Clone)]
+pub struct StringProperties<'a>(hash_map::Iter<'a, RcString, Property>);
+
+impl<'a> Iterator for StringProperties<'a> {
+    type Item = (&'a RcString, &'a Property);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for StringProperties<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for StringProperties<'_> {}
+
+/// An iterator over the string keys (`RcString`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct StringPropertyKeys<'a>(hash_map::Keys<'a, RcString, Property>);
+
+impl<'a> Iterator for StringPropertyKeys<'a> {
+    type Item = &'a RcString;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for StringPropertyKeys<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for StringPropertyKeys<'_> {}
+
+/// An iterator over the string values (`Property`) of an `Object`.
+#[derive(Debug, Clone)]
+pub struct StringPropertyValues<'a>(hash_map::Values<'a, RcString, Property>);
+
+impl<'a> Iterator for StringPropertyValues<'a> {
+    type Item = &'a Property;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl ExactSizeIterator for StringPropertyValues<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl FusedIterator for StringPropertyValues<'_> {}

--- a/boa/src/builtins/object/iter.rs
+++ b/boa/src/builtins/object/iter.rs
@@ -1,6 +1,5 @@
-use super::*;
-use std::collections::hash_map;
-use std::iter::FusedIterator;
+use super::{Object, Property, PropertyKey, RcString, RcSymbol};
+use std::{collections::hash_map, iter::FusedIterator};
 
 impl Object {
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator element type is `(PropertyKey, &'a Property)`.
@@ -10,7 +9,7 @@ impl Object {
     pub fn iter(&self) -> Iter<'_> {
         Iter {
             indexed_properties: self.indexed_properties.iter(),
-            string_properties: self.properties.iter(),
+            string_properties: self.string_properties.iter(),
             symbol_properties: self.symbol_properties.iter(),
         }
     }
@@ -85,7 +84,7 @@ impl Object {
     /// This iterator does not recurse down the prototype chain.
     #[inline]
     pub fn string_properties(&self) -> StringProperties<'_> {
-        StringProperties(self.properties.iter())
+        StringProperties(self.string_properties.iter())
     }
 
     /// An iterator visiting all string keys in arbitrary order. The iterator element type is `&'a RcString`.
@@ -93,7 +92,7 @@ impl Object {
     /// This iterator does not recurse down the prototype chain.
     #[inline]
     pub fn string_property_keys(&self) -> StringPropertyKeys<'_> {
-        StringPropertyKeys(self.properties.keys())
+        StringPropertyKeys(self.string_properties.keys())
     }
 
     /// An iterator visiting all string values in arbitrary order. The iterator element type is `&'a Property`.
@@ -101,7 +100,7 @@ impl Object {
     /// This iterator does not recurse down the prototype chain.
     #[inline]
     pub fn string_property_values(&self) -> StringPropertyValues<'_> {
-        StringPropertyValues(self.properties.values())
+        StringPropertyValues(self.string_properties.values())
     }
 }
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -52,7 +52,7 @@ pub struct Object {
     pub data: ObjectData,
     indexed_properties: FxHashMap<u32, Property>,
     /// Properties
-    pub(crate) properties: FxHashMap<RcString, Property>,
+    string_properties: FxHashMap<RcString, Property>,
     /// Symbol Properties
     symbol_properties: FxHashMap<RcSymbol, Property>,
     /// Instance prototype `__proto__`.
@@ -110,7 +110,7 @@ impl Default for Object {
         Self {
             data: ObjectData::Ordinary,
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype: Value::null(),
             extensible: true,
@@ -131,7 +131,7 @@ impl Object {
         Self {
             data: ObjectData::Function(function),
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype,
             extensible: true,
@@ -156,7 +156,7 @@ impl Object {
         Self {
             data: ObjectData::Boolean(value),
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype: Value::null(),
             extensible: true,
@@ -168,7 +168,7 @@ impl Object {
         Self {
             data: ObjectData::Number(value),
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype: Value::null(),
             extensible: true,
@@ -183,7 +183,7 @@ impl Object {
         Self {
             data: ObjectData::String(value.into()),
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype: Value::null(),
             extensible: true,
@@ -195,7 +195,7 @@ impl Object {
         Self {
             data: ObjectData::BigInt(value),
             indexed_properties: FxHashMap::default(),
-            properties: FxHashMap::default(),
+            string_properties: FxHashMap::default(),
             symbol_properties: FxHashMap::default(),
             prototype: Value::null(),
             extensible: true,

--- a/boa/src/builtins/property/mod.rs
+++ b/boa/src/builtins/property/mod.rs
@@ -356,17 +356,6 @@ impl fmt::Display for PropertyKey {
     }
 }
 
-// impl From<&PropertyKey> for RcString {
-//     #[inline]
-//     fn from(property_key: &PropertyKey) -> RcString {
-//         match property_key {
-//             PropertyKey::String(ref string) => string.clone(),
-//             PropertyKey::Symbol(ref symbol) => symbol.to_string().into(),
-//             PropertyKey::
-//         }
-//     }
-// }
-
 impl From<&PropertyKey> for Value {
     #[inline]
     fn from(property_key: &PropertyKey) -> Value {

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -20,14 +20,26 @@ mod tests;
 
 use super::function::{make_builtin_fn, make_constructor_fn};
 use crate::{
-    builtins::value::{RcString, RcSymbol, Value},
+    builtins::{
+        property::{Attribute, Property},
+        value::{RcString, RcSymbol, Value},
+    },
     exec::Interpreter,
     BoaProfiler, Result,
 };
 use gc::{Finalize, Trace};
 
 #[derive(Debug, Finalize, Trace, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Symbol(Option<RcString>, u32);
+pub struct Symbol {
+    hash: u32,
+    description: Option<RcString>,
+}
+
+impl Symbol {
+    pub(crate) fn new(hash: u32, description: Option<RcString>) -> Self {
+        Self { hash, description }
+    }
+}
 
 impl Symbol {
     /// The name of the object.
@@ -38,12 +50,12 @@ impl Symbol {
 
     /// Returns the `Symbol`s description.
     pub fn description(&self) -> Option<&str> {
-        self.0.as_deref()
+        self.description.as_deref()
     }
 
     /// Returns the `Symbol`s hash.
     pub fn hash(&self) -> u32 {
-        self.1
+        self.hash
     }
 
     fn this_symbol_value(value: &Value, ctx: &mut Interpreter) -> Result<RcSymbol> {
@@ -78,7 +90,7 @@ impl Symbol {
             _ => None,
         };
 
-        Ok(Value::symbol(Symbol(description, ctx.generate_hash())))
+        Ok(ctx.construct_symbol(description).into())
     }
 
     /// `Symbol.prototype.toString()`
@@ -103,37 +115,21 @@ impl Symbol {
     pub fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
         // Define the Well-Known Symbols
         // https://tc39.es/ecma262/#sec-well-known-symbols
-        let symbol_async_iterator = Symbol(
-            Some("Symbol.asyncIterator".into()),
-            interpreter.generate_hash(),
-        );
-        let symbol_has_instance = Symbol(
-            Some("Symbol.hasInstance".into()),
-            interpreter.generate_hash(),
-        );
-        let symbol_is_concat_spreadable = Symbol(
-            Some("Symbol.isConcatSpreadable".into()),
-            interpreter.generate_hash(),
-        );
-        let symbol_iterator = Symbol(Some("Symbol.iterator".into()), interpreter.generate_hash());
-        let symbol_match = Symbol(Some("Symbol.match".into()), interpreter.generate_hash());
-        let symbol_match_all = Symbol(Some("Symbol.matchAll".into()), interpreter.generate_hash());
-        let symbol_replace = Symbol(Some("Symbol.replace".into()), interpreter.generate_hash());
-        let symbol_search = Symbol(Some("Symbol.search".into()), interpreter.generate_hash());
-        let symbol_species = Symbol(Some("Symbol.species".into()), interpreter.generate_hash());
-        let symbol_split = Symbol(Some("Symbol.split".into()), interpreter.generate_hash());
-        let symbol_to_primitive = Symbol(
-            Some("Symbol.toPrimitive".into()),
-            interpreter.generate_hash(),
-        );
-        let symbol_to_string_tag = Symbol(
-            Some("Symbol.toStringTag".into()),
-            interpreter.generate_hash(),
-        );
-        let symbol_unscopables = Symbol(
-            Some("Symbol.unscopables".into()),
-            interpreter.generate_hash(),
-        );
+        let symbol_async_iterator =
+            interpreter.construct_symbol(Some("Symbol.asyncIterator".into()));
+        let symbol_has_instance = interpreter.construct_symbol(Some("Symbol.hasInstance".into()));
+        let symbol_is_concat_spreadable =
+            interpreter.construct_symbol(Some("Symbol.isConcatSpreadable".into()));
+        let symbol_iterator = interpreter.construct_symbol(Some("Symbol.iterator".into()));
+        let symbol_match = interpreter.construct_symbol(Some("Symbol.match".into()));
+        let symbol_match_all = interpreter.construct_symbol(Some("Symbol.matchAll".into()));
+        let symbol_replace = interpreter.construct_symbol(Some("Symbol.replace".into()));
+        let symbol_search = interpreter.construct_symbol(Some("Symbol.search".into()));
+        let symbol_species = interpreter.construct_symbol(Some("Symbol.species".into()));
+        let symbol_split = interpreter.construct_symbol(Some("Symbol.split".into()));
+        let symbol_to_primitive = interpreter.construct_symbol(Some("Symbol.toPrimitive".into()));
+        let symbol_to_string_tag = interpreter.construct_symbol(Some("Symbol.toStringTag".into()));
+        let symbol_unscopables = interpreter.construct_symbol(Some("Symbol.unscopables".into()));
 
         let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
@@ -153,22 +149,62 @@ impl Symbol {
             true,
         );
 
-        symbol_object.set_field("asyncIterator", Value::symbol(symbol_async_iterator));
-        symbol_object.set_field("hasInstance", Value::symbol(symbol_has_instance));
-        symbol_object.set_field(
-            "isConcatSpreadable",
-            Value::symbol(symbol_is_concat_spreadable),
-        );
-        symbol_object.set_field("iterator", Value::symbol(symbol_iterator));
-        symbol_object.set_field("match", Value::symbol(symbol_match));
-        symbol_object.set_field("matchAll", Value::symbol(symbol_match_all));
-        symbol_object.set_field("replace", Value::symbol(symbol_replace));
-        symbol_object.set_field("search", Value::symbol(symbol_search));
-        symbol_object.set_field("species", Value::symbol(symbol_species));
-        symbol_object.set_field("split", Value::symbol(symbol_split));
-        symbol_object.set_field("toPrimitive", Value::symbol(symbol_to_primitive));
-        symbol_object.set_field("toStringTag", Value::symbol(symbol_to_string_tag));
-        symbol_object.set_field("unscopables", Value::symbol(symbol_unscopables));
+        {
+            let mut symbol_object = symbol_object.as_object_mut().unwrap();
+            let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+            symbol_object.insert_property(
+                "asyncIterator",
+                Property::data_descriptor(symbol_async_iterator.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "hasInstance",
+                Property::data_descriptor(symbol_has_instance.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "isConcatSpreadable",
+                Property::data_descriptor(symbol_is_concat_spreadable.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "iterator",
+                Property::data_descriptor(symbol_iterator.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "match",
+                Property::data_descriptor(symbol_match.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "matchAll",
+                Property::data_descriptor(symbol_match_all.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "replace",
+                Property::data_descriptor(symbol_replace.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "search",
+                Property::data_descriptor(symbol_search.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "species",
+                Property::data_descriptor(symbol_species.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "split",
+                Property::data_descriptor(symbol_split.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "toPrimitive",
+                Property::data_descriptor(symbol_to_primitive.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "toStringTag",
+                Property::data_descriptor(symbol_to_string_tag.into(), attribute),
+            );
+            symbol_object.insert_property(
+                "unscopables",
+                Property::data_descriptor(symbol_unscopables.into(), attribute),
+            );
+        }
 
         (Self::NAME, symbol_object)
     }

--- a/boa/src/builtins/symbol/tests.rs
+++ b/boa/src/builtins/symbol/tests.rs
@@ -23,3 +23,20 @@ fn print_symbol_expect_description() {
     let sym = forward_val(&mut engine, "sym.toString()").unwrap();
     assert_eq!(sym.display().to_string(), "\"Symbol(Hello)\"");
 }
+
+#[test]
+fn symbol_access() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let init = r#"
+        var x = {};
+        var sym1 = Symbol("Hello");
+        var sym2 = Symbol("Hello");
+        x[sym1] = 10;
+        x[sym2] = 20;
+        "#;
+    forward_val(&mut engine, init).unwrap();
+    assert_eq!(forward(&mut engine, "x[sym1]"), "10");
+    assert_eq!(forward(&mut engine, "x[sym2]"), "20");
+    assert_eq!(forward(&mut engine, "x['Symbol(Hello)']"), "undefined");
+}

--- a/boa/src/builtins/value/conversions.rs
+++ b/boa/src/builtins/value/conversions.rs
@@ -127,10 +127,7 @@ where
     fn from(value: &[T]) -> Self {
         let mut array = Object::default();
         for (i, item) in value.iter().enumerate() {
-            array.properties_mut().insert(
-                RcString::from(i.to_string()),
-                Property::default().value(item.clone().into()),
-            );
+            array.insert_property(i, Property::default().value(item.clone().into()));
         }
         Self::from(array)
     }
@@ -143,10 +140,7 @@ where
     fn from(value: Vec<T>) -> Self {
         let mut array = Object::default();
         for (i, item) in value.into_iter().enumerate() {
-            array.properties_mut().insert(
-                RcString::from(i.to_string()),
-                Property::default().value(item.into()),
-            );
+            array.insert_property(i, Property::default().value(item.into()));
         }
         Value::from(array)
     }

--- a/boa/src/builtins/value/display.rs
+++ b/boa/src/builtins/value/display.rs
@@ -67,7 +67,7 @@ macro_rules! print_obj_value {
     (impl $field:ident, $v:expr, $f:expr) => {
         $v
             .borrow()
-            .$field()
+            .$field
             .iter()
             .map($f)
             .collect::<Vec<String>>()
@@ -94,7 +94,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 ObjectData::Array => {
                     let len = v
                         .borrow()
-                        .properties()
+                        .properties
                         .get("length")
                         .expect("Could not get Array's length property")
                         .value
@@ -114,9 +114,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                 // which are part of the Array
                                 log_string_from(
                                     &v.borrow()
-                                        .properties()
-                                        .get(i.to_string().as_str())
-                                        .unwrap()
+                                        .get_own_property(&i.into())
                                         .value
                                         .clone()
                                         .expect("Could not borrow value"),
@@ -135,7 +133,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 ObjectData::Map(ref map) => {
                     let size = v
                         .borrow()
-                        .properties()
+                        .properties
                         .get("size")
                         .unwrap()
                         .value

--- a/boa/src/builtins/value/display.rs
+++ b/boa/src/builtins/value/display.rs
@@ -47,7 +47,7 @@ macro_rules! print_obj_value {
         }
     };
     (props of $obj:expr, $display_fn:ident, $indent:expr, $encounters:expr, $print_internals:expr) => {
-        print_obj_value!(impl properties, $obj, |(key, val)| {
+        print_obj_value!(impl $obj, |(key, val)| {
             let v = &val
                 .value
                 .as_ref()
@@ -64,10 +64,9 @@ macro_rules! print_obj_value {
 
     // A private overload of the macro
     // DO NOT use directly
-    (impl $field:ident, $v:expr, $f:expr) => {
+    (impl $v:expr, $f:expr) => {
         $v
             .borrow()
-            .$field
             .iter()
             .map($f)
             .collect::<Vec<String>>()
@@ -94,9 +93,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 ObjectData::Array => {
                     let len = v
                         .borrow()
-                        .properties
-                        .get("length")
-                        .expect("Could not get Array's length property")
+                        .get_own_property(&PropertyKey::from("length"))
                         .value
                         .clone()
                         .expect("Could not borrow value")
@@ -133,9 +130,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 ObjectData::Map(ref map) => {
                     let size = v
                         .borrow()
-                        .properties
-                        .get("size")
-                        .unwrap()
+                        .get_own_property(&PropertyKey::from("size"))
                         .value
                         .clone()
                         .expect("Could not borrow value")

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -493,9 +493,9 @@ impl Value {
     /// Resolve the property in the object and get its value, or undefined if this is not an object or the field doesn't exist
     /// get_field recieves a Property from get_prop(). It should then return the [[Get]] result value if that's set, otherwise fall back to [[Value]]
     /// TODO: this function should use the get Value if its set
-    pub fn get_field<Key>(&self, key: Key) -> Self
+    pub fn get_field<K>(&self, key: K) -> Self
     where
-        Key: Into<PropertyKey>,
+        K: Into<PropertyKey>,
     {
         let _timer = BoaProfiler::global().start_event("Value::get_field", "value");
         let key = key.into();
@@ -524,9 +524,9 @@ impl Value {
 
     /// Check to see if the Value has the field, mainly used by environment records.
     #[inline]
-    pub fn has_field<Key>(&self, key: Key) -> bool
+    pub fn has_field<K>(&self, key: K) -> bool
     where
-        Key: Into<PropertyKey>,
+        K: Into<PropertyKey>,
     {
         let _timer = BoaProfiler::global().start_event("Value::has_field", "value");
         self.as_object()
@@ -536,16 +536,16 @@ impl Value {
 
     /// Set the field in the value
     #[inline]
-    pub fn set_field<F, V>(&self, field: F, value: V) -> Value
+    pub fn set_field<K, V>(&self, key: K, value: V) -> Value
     where
-        F: Into<PropertyKey>,
+        K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        let field = field.into();
+        let key = key.into();
         let value = value.into();
         let _timer = BoaProfiler::global().start_event("Value::set_field", "value");
         if let Self::Object(ref obj) = *self {
-            if let PropertyKey::Index(index) = field {
+            if let PropertyKey::Index(index) = key {
                 if obj.borrow().is_array() {
                     let len = self.get_field("length").as_number().unwrap() as u32;
                     if len < index + 1 {
@@ -553,7 +553,7 @@ impl Value {
                     }
                 }
             }
-            obj.borrow_mut().set(field, value.clone());
+            obj.borrow_mut().set(key, value.clone());
         }
         value
     }
@@ -567,9 +567,9 @@ impl Value {
     }
 
     /// Set the property in the value.
-    pub fn set_property<Key>(&self, key: Key, property: Property) -> Property
+    pub fn set_property<K>(&self, key: K, property: Property) -> Property
     where
-        Key: Into<PropertyKey>,
+        K: Into<PropertyKey>,
     {
         if let Some(mut object) = self.as_object_mut() {
             object.insert_property(key.into(), property.clone());

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -56,7 +56,7 @@ impl GlobalEnvironmentRecord {
     pub fn create_global_var_binding(&mut self, name: String, deletion: bool) {
         let obj_rec = &mut self.object_record;
         let global_object = &obj_rec.bindings;
-        let has_property = global_object.has_field(&name);
+        let has_property = global_object.has_field(name.as_str());
         let extensible = global_object.is_extensible();
         if !has_property && extensible {
             obj_rec.create_mutable_binding(name.clone(), deletion);
@@ -71,7 +71,7 @@ impl GlobalEnvironmentRecord {
 
     pub fn create_global_function_binding(&mut self, name: &str, value: Value, deletion: bool) {
         let global_object = &mut self.object_record.bindings;
-        let existing_prop = global_object.get_property(&name);
+        let existing_prop = global_object.get_property(name);
         if let Some(prop) = existing_prop {
             if prop.value.is_none() || prop.configurable_or(false) {
                 let mut property =

--- a/boa/src/exec/call/mod.rs
+++ b/boa/src/exec/call/mod.rs
@@ -19,8 +19,10 @@ impl Executable for Call {
             Node::GetField(ref get_field) => {
                 let obj = get_field.obj().run(interpreter)?;
                 let field = get_field.field().run(interpreter)?;
-                // FIXME: This should not call `.display()`
-                (obj.clone(), obj.get_field(field.display().to_string()))
+                (
+                    obj.clone(),
+                    obj.get_field(field.to_property_key(interpreter)?),
+                )
             }
             _ => (
                 interpreter.realm().global_obj.clone(),

--- a/boa/src/exec/field/mod.rs
+++ b/boa/src/exec/field/mod.rs
@@ -24,6 +24,6 @@ impl Executable for GetField {
         }
         let field = self.field().run(interpreter)?;
 
-        Ok(obj.get_field(field.to_string(interpreter)?))
+        Ok(obj.get_field(field.to_property_key(interpreter)?))
     }
 }

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -28,8 +28,8 @@ use crate::{
         function::{Function, FunctionFlags, NativeFunction},
         object::{GcObject, Object, ObjectData, PROTOTYPE},
         property::PropertyKey,
-        value::{PreferredType, Type, Value},
-        Console,
+        value::{PreferredType, RcString, RcSymbol, Type, Value},
+        Console, Symbol,
     },
     realm::Realm,
     syntax::ast::{
@@ -169,9 +169,9 @@ impl Interpreter {
             Function::BuiltIn(body.into(), FunctionFlags::CALLABLE),
             function_prototype,
         );
-        function.set(&PROTOTYPE.into(), proto);
-        function.set(&"length".into(), length.into());
-        function.set(&"name".into(), name.into());
+        function.set(PROTOTYPE.into(), proto);
+        function.set("length".into(), length.into());
+        function.set("name".into(), name.into());
 
         Ok(GcObject::new(function))
     }
@@ -357,6 +357,19 @@ impl Interpreter {
     /// A helper function for getting a mutable reference to the `console` object.
     pub(crate) fn console_mut(&mut self) -> &mut Console {
         &mut self.console
+    }
+
+    /// Construct a new `Symbol` with an optional description.
+    #[inline]
+    pub fn construct_symbol(&mut self, description: Option<RcString>) -> RcSymbol {
+        RcSymbol::from(Symbol::new(self.generate_hash(), description))
+    }
+
+    /// Construct an empty object.
+    #[inline]
+    pub fn construct_object(&self) -> GcObject {
+        let object_prototype = self.global().get_field("Object").get_field(PROTOTYPE);
+        GcObject::new(Object::create(object_prototype))
     }
 }
 

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -622,7 +622,7 @@ fn unary_delete() {
         const c = delete a.c + '';
         a.b + c
     "#;
-    assert_eq!(&exec(delete_not_existing_prop), "\"5false\"");
+    assert_eq!(&exec(delete_not_existing_prop), "\"5true\"");
 
     let delete_field = r#"
         const a = { b: 5 };


### PR DESCRIPTION
It changes the following:
 - Added `iter` method to object to iterate over all (indexed, string and symbol) keys (`PropertyKey`) and value (`Property`)
 - Added `keys` method to object to iterate over all (indexed, string and symbol) keys (`PropertyKey`)
 - Added `values` method to object to iterate through all the (indexed, string and symbol) values (`Property`).
 - Added `symbol_properties` method to object to iterate over symbol keys (`RcSymbol`) and value (`Property`)
 - Added `symbol_property_keys` method to object to iterate over symbol keys (`RcSymbol`)
 - Added `symbol_property_values` method to object to iterate over symbol values (`Property`)
 - Added `index_properties` method to object to iterate over index keys (`u32`) and value (`Property`)
 - Added `index_property_keys` method to object to iterate over index keys (`u32`)
 - Added `index_property_values` method to object to iterate over index values (`Property`)
 - Added `string_properties` method to object to iterate over string keys (`RcString`) and value (`Property`)
 - Added `string_property_keys` method to object to iterate over string keys (`RcString`)
 - Added `string_property_values` method to object to iterate over string values (`Property`)
 - Removed `properties`, `properties_mut`, `symbol_properties` and `symbol_properties_mut`.
 - Added `Symbol` indexing support.
 - Added `.construct_symbol()` for creating symbols
 - Added `.construct_object()` for creating object with the prototype set.
 - Added `PropertyKey::Index(u32)` This is done for a couple of reasons:
   - To store indexed indexes (u32 size numbers) as `u32` and not as `RcString`s (memory optimization)
   - To not convert back and forth from index to index string
   - To make index comparisons fast (compare two `u32` instead of `RcString`s)
   - when we are getting an index for example array we don't have to do `.get_field(i.to_string())` instead we should do `.get_field(i)`
 - Added `indexed_properties` Hash map with key `u32` this is because an array index is from `0` to `2^32 - 1` (`u32::MAX`).
	- This is done for a some reasons:
      - We can make this a `IndexMap` and when we need to iterate through all the elements (in order) we can do so without iteration through `0` to `length` (this is what caused the test runner to freeze in #567 with `indexOf` with sparse elements). should make iteration very fast. 
      - we can easily iterate through all the elements without converting to `RcString`. 
  - Made `Object` `symbol_properties` contain key `RcSymbol` instead of just hash:
    - If we want do display the symbol we need to have the symbol.
    - If we want to get the `Symbol` `description` we need the symbol:
      - Example `Symbol.toPrimitive.description`