### PR TITLE
Fix infinite recursion for Debug::fmt

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -48,7 +48,7 @@ pub static PROTOTYPE: &str = "prototype";
 // pub static INSTANCE_PROTOTYPE: &str = "__proto__";
 
 /// The internal representation of an JavaScript object.
-#[derive(Debug, Trace, Finalize, Clone)]
+#[derive(Trace, Finalize, Clone)]
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
@@ -62,6 +62,18 @@ pub struct Object {
     state: Option<InternalStateCell>,
     /// Whether it can have new properties added to it.
     extensible: bool,
+}
+
+impl Debug for Object {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Object")
+            .field("data", &self.data)
+            .field("properties", &self.properties)
+            .field("symbol_properties", &self.symbol_properties)
+            .field("state", &self.state)
+            .field("extensible", &self.extensible)
+            .finish()
+    }
 }
 
 /// Defines the different types of objects.

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -411,6 +411,18 @@ fn display_negative_zero_object() {
 }
 
 #[test]
+fn debug_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let value = forward_val(&mut engine, "new Array([new Date()])").unwrap();
+
+    // We don't care about the contents of the debug display (it is *debug* after all).
+    // In the commit that this test was added, this would cause a stack overflow, so
+    // executing Debug::fmt is the assertion.
+    let _ = format!("{:?}", value);
+}
+
+#[test]
 #[ignore] // TODO: Once objects are printed in a simpler way this test can be simplified and used
 fn display_object() {
     let realm = Realm::create();


### PR DESCRIPTION
This Pull Request fixes/closes #608.

It changes the following:
 - Adds a test for stack overflow
 - Removes prototype from the `Debug::fmt` for `Object`
