### PR TITLE
Remove `Value::as_num_to_power()`

### DIFF
--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -155,14 +155,6 @@ impl Value {
         Self::Symbol(RcSymbol::from(symbol))
     }
 
-    /// Helper function to convert the `Value` to a number and compute its power.
-    pub fn as_num_to_power(&self, other: Self) -> Self {
-        match (self, other) {
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::bigint(a.as_inner().clone().pow(b)),
-            (a, b) => Self::rational(a.to_number().powf(b.to_number())),
-        }
-    }
-
     /// Returns a new empty object
     pub fn new_object(global: Option<&Value>) -> Self {
         let _timer = BoaProfiler::global().start_event("new_object", "value");

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -359,6 +359,44 @@ fn bitand_rational_and_rational() {
 }
 
 #[test]
+fn pow_number_and_number() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "3 ** 3").unwrap();
+    let value = engine.to_number(&value).unwrap();
+    assert_eq!(value, 27.0);
+}
+
+#[test]
+fn pow_number_and_string() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(&mut engine, "3 ** 'Hello'").unwrap();
+    let value = engine.to_number(&value).unwrap();
+    assert!(value.is_nan());
+}
+
+#[test]
+fn assign_pow_number_and_string() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+
+    let value = forward_val(
+        &mut engine,
+        r"
+        let a = 3;
+        a **= 'Hello'
+        a
+    ",
+    )
+    .unwrap();
+    let value = engine.to_number(&value).unwrap();
+    assert!(value.is_nan());
+}
+
+#[test]
 fn display_string() {
     let s = String::from("Hello");
     let v = Value::from(s);


### PR DESCRIPTION
It changes the following:
 - Removed `Value::as_num_to_power()` this is not spec complaint and `Value::pow()` should be used instead.
 - Added pow operator tests
