### PR TITLE
Fix Stack Overflow for `Debug::fmt`

### DIFF
--- a/boa/src/builtins/object/gcobject.rs
+++ b/boa/src/builtins/object/gcobject.rs
@@ -102,7 +102,8 @@ impl Drop for RecursionLimiter {
 
 impl RecursionLimiter {
     thread_local! {
-        pub static VISITED: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+        /// The list of pointers to `GcObject` that have been visited during the current `Debug::fmt` graph.
+        static VISITED: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
     }
 
     /// Determines if the specified `GcObject` has been visited, and returns a struct that will free it when dropped.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -48,7 +48,7 @@ pub static PROTOTYPE: &str = "prototype";
 // pub static INSTANCE_PROTOTYPE: &str = "__proto__";
 
 /// The internal representation of an JavaScript object.
-#[derive(Trace, Finalize, Clone)]
+#[derive(Debug, Trace, Finalize, Clone)]
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
@@ -62,18 +62,6 @@ pub struct Object {
     state: Option<InternalStateCell>,
     /// Whether it can have new properties added to it.
     extensible: bool,
-}
-
-impl Debug for Object {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Object")
-            .field("data", &self.data)
-            .field("properties", &self.properties)
-            .field("symbol_properties", &self.symbol_properties)
-            .field("state", &self.state)
-            .field("extensible", &self.extensible)
-            .finish()
-    }
 }
 
 /// Defines the different types of objects.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -48,7 +48,7 @@ pub static PROTOTYPE: &str = "prototype";
 // pub static INSTANCE_PROTOTYPE: &str = "__proto__";
 
 /// The internal representation of an JavaScript object.
-#[derive(Debug, Trace, Finalize, Clone)]
+#[derive(Trace, Finalize, Clone)]
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
@@ -62,6 +62,18 @@ pub struct Object {
     state: Option<InternalStateCell>,
     /// Whether it can have new properties added to it.
     extensible: bool,
+}
+
+impl Debug for Object {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Object")
+            .field("data", &self.data)
+            .field("properties", &self.properties)
+            .field("symbol_properties", &self.symbol_properties)
+            .field("state", &self.state)
+            .field("extensible", &self.extensible)
+            .finish()
+    }
 }
 
 /// Defines the different types of objects.

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -455,10 +455,12 @@ fn debug_object() {
     let mut engine = Interpreter::new(realm);
     let value = forward_val(&mut engine, "new Array([new Date()])").unwrap();
 
-    // We don't care about the contents of the debug display (it is *debug* after all).
-    // In the commit that this test was added, this would cause a stack overflow, so
-    // executing Debug::fmt is the assertion.
-    let _ = format!("{:?}", value);
+    // We don't care about the contents of the debug display (it is *debug* after all). In the commit that this test was
+    // added, this would cause a stack overflow, so executing Debug::fmt is the assertion.
+    //
+    // However, we want to make sure that no data is being left in the internal hashset, so executing this twice should
+    // result in the same output.
+    assert_eq!(format!("{:?}", value), format!("{:?}", value));
 }
 
 #[test]

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -450,6 +450,18 @@ fn display_negative_zero_object() {
 }
 
 #[test]
+fn debug_object() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let value = forward_val(&mut engine, "new Array([new Date()])").unwrap();
+
+    // We don't care about the contents of the debug display (it is *debug* after all).
+    // In the commit that this test was added, this would cause a stack overflow, so
+    // executing Debug::fmt is the assertion.
+    let _ = format!("{:?}", value);
+}
+
+#[test]
 #[ignore] // TODO: Once objects are printed in a simpler way this test can be simplified and used
 fn display_object() {
     let realm = Realm::create();


### PR DESCRIPTION
This Pull Request fixes/closes #608.

It changes the following:
 - Adds RecursionLimiter. This tracks the `GcObject` pointers that have been visited during a `Debug::fmt` call.
 - Adds a test for the stack overflow.

The same object cannot appear twice in the output, by design. JS object graphs tend the be huge, and comprehending a massive data dump is nearly impossible. If the same object appears twice, even if not recursive, it is always elided. The following graph:

```js
let a = {};
a.c = a;
let b = {
 d: a, e: a
};
debug(b);
```

Would print:
```js
{
  d: {
    c: ... // Recursion protected
  },
  e: ... // Will never appear twice
}
```
