### PR TITLE
Feature `boa::Result<T>`

### DIFF
--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -14,12 +14,9 @@ mod tests;
 
 use super::function::{make_builtin_fn, make_constructor_fn};
 use crate::{
-    builtins::{
-        object::ObjectData,
-        value::{ResultValue, Value},
-    },
+    builtins::{object::ObjectData, value::Value},
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 /// Boolean implementation.
@@ -39,7 +36,7 @@ impl Boolean {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisbooleanvalue
-    fn this_boolean_value(value: &Value, ctx: &mut Interpreter) -> Result<bool, Value> {
+    fn this_boolean_value(value: &Value, ctx: &mut Interpreter) -> Result<bool> {
         match value {
             Value::Boolean(boolean) => return Ok(*boolean),
             Value::Object(ref object) => {
@@ -61,7 +58,7 @@ impl Boolean {
         this: &Value,
         args: &[Value],
         _: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         // Get the argument, if any
         let data = args.get(0).map(|x| x.to_boolean()).unwrap_or(false);
         this.set_data(ObjectData::Boolean(data));
@@ -78,7 +75,7 @@ impl Boolean {
     /// [spec]: https://tc39.es/ecma262/#sec-boolean-object
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let boolean = Self::this_boolean_value(this, ctx)?;
         Ok(Value::from(boolean.to_string()))
     }
@@ -92,7 +89,7 @@ impl Boolean {
     /// [spec]: https://tc39.es/ecma262/#sec-boolean.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
     #[inline]
-    pub(crate) fn value_of(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn value_of(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(Value::from(Self::this_boolean_value(this, ctx)?))
     }
 

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -19,10 +19,10 @@ mod tests;
 use crate::{
     builtins::{
         function::make_builtin_fn,
-        value::{display_obj, RcString, ResultValue, Value},
+        value::{display_obj, RcString, Value},
     },
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use rustc_hash::FxHashMap;
 use std::time::SystemTime;
@@ -59,8 +59,9 @@ pub(crate) fn logger(msg: LogMessage, console_state: &Console) {
 }
 
 /// This represents the `console` formatter.
-pub fn formatter(data: &[Value], ctx: &mut Interpreter) -> Result<String, Value> {
+pub fn formatter(data: &[Value], ctx: &mut Interpreter) -> Result<String> {
     let target = data.get(0).cloned().unwrap_or_default().to_string(ctx)?;
+
     match data.len() {
         0 => Ok(String::new()),
         1 => Ok(target.to_string()),
@@ -153,7 +154,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#assert
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert
-    pub(crate) fn assert(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn assert(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let assertion = get_arg_at_index::<bool>(args, 0).unwrap_or_default();
 
         if !assertion {
@@ -184,7 +185,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/clear
-    pub(crate) fn clear(_: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn clear(_: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         ctx.console_mut().groups.clear();
         Ok(Value::undefined())
     }
@@ -199,7 +200,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#debug
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/debug
-    pub(crate) fn debug(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn debug(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         logger(LogMessage::Log(formatter(args, ctx)?), ctx.console());
         Ok(Value::undefined())
     }
@@ -214,7 +215,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#error
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/error
-    pub(crate) fn error(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn error(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         logger(LogMessage::Error(formatter(args, ctx)?), ctx.console());
         Ok(Value::undefined())
     }
@@ -229,7 +230,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#info
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/info
-    pub(crate) fn info(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn info(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         logger(LogMessage::Info(formatter(args, ctx)?), ctx.console());
         Ok(Value::undefined())
     }
@@ -244,7 +245,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/log
-    pub(crate) fn log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         logger(LogMessage::Log(formatter(args, ctx)?), ctx.console());
         Ok(Value::undefined())
     }
@@ -259,7 +260,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#trace
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/trace
-    pub(crate) fn trace(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn trace(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if !args.is_empty() {
             logger(LogMessage::Log(formatter(args, ctx)?), ctx.console());
 
@@ -283,7 +284,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#warn
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/warn
-    pub(crate) fn warn(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn warn(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         logger(LogMessage::Warn(formatter(args, ctx)?), ctx.console());
         Ok(Value::undefined())
     }
@@ -298,7 +299,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#count
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/count
-    pub(crate) fn count(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn count(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let label = match args.get(0) {
             Some(value) => value.to_string(ctx)?,
             None => "default".into(),
@@ -322,7 +323,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#countreset
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/countReset
-    pub(crate) fn count_reset(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn count_reset(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let label = match args.get(0) {
             Some(value) => value.to_string(ctx)?,
             None => "default".into(),
@@ -356,7 +357,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#time
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/time
-    pub(crate) fn time(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn time(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let label = match args.get(0) {
             Some(value) => value.to_string(ctx)?,
             None => "default".into(),
@@ -385,7 +386,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#timelog
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/timeLog
-    pub(crate) fn time_log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn time_log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let label = match args.get(0) {
             Some(value) => value.to_string(ctx)?,
             None => "default".into(),
@@ -418,7 +419,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#timeend
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/timeEnd
-    pub(crate) fn time_end(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn time_end(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let label = match args.get(0) {
             Some(value) => value.to_string(ctx)?,
             None => "default".into(),
@@ -450,7 +451,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#group
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/group
-    pub(crate) fn group(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn group(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let group_label = formatter(args, ctx)?;
 
         logger(
@@ -472,7 +473,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#groupend
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/groupEnd
-    pub(crate) fn group_end(_: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn group_end(_: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         ctx.console_mut().groups.pop();
 
         Ok(Value::undefined())
@@ -488,7 +489,7 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#dir
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/dir
-    pub(crate) fn dir(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn dir(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let undefined = Value::undefined();
         logger(
             LogMessage::Info(display_obj(args.get(0).unwrap_or(&undefined), true)),

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -14,10 +14,11 @@ use crate::{
     builtins::{
         function::{make_builtin_fn, make_constructor_fn},
         object::ObjectData,
-        value::{ResultValue, Value},
+        value::Value,
     },
     exec::Interpreter,
     profiler::BoaProfiler,
+    Result,
 };
 
 pub(crate) mod range;
@@ -46,7 +47,7 @@ impl Error {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -68,7 +69,7 @@ impl Error {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
         let name = this.get_field("name");
         let message = this.get_field("message");
         Ok(Value::from(format!(

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -11,13 +11,11 @@
 
 use crate::{
     builtins::{
-        function::make_builtin_fn,
-        function::make_constructor_fn,
-        object::ObjectData,
-        value::{ResultValue, Value},
+        function::make_builtin_fn, function::make_constructor_fn, object::ObjectData, value::Value,
     },
     exec::Interpreter,
     profiler::BoaProfiler,
+    Result,
 };
 
 /// JavaScript `RangeError` impleentation.
@@ -32,7 +30,7 @@ impl RangeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -54,9 +52,10 @@ impl RangeError {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let name = this.get_field("name").to_string(ctx)?;
         let message = this.get_field("message").to_string(ctx)?;
+
         Ok(Value::from(format!("{}: {}", name, message)))
     }
 

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -11,13 +11,11 @@
 
 use crate::{
     builtins::{
-        function::make_builtin_fn,
-        function::make_constructor_fn,
-        object::ObjectData,
-        value::{ResultValue, Value},
+        function::make_builtin_fn, function::make_constructor_fn, object::ObjectData, value::Value,
     },
     exec::Interpreter,
     profiler::BoaProfiler,
+    Result,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -31,7 +29,7 @@ impl ReferenceError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -53,9 +51,10 @@ impl ReferenceError {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let name = this.get_field("name").to_string(ctx)?;
         let message = this.get_field("message").to_string(ctx)?;
+
         Ok(Value::from(format!("{}: {}", name, message)))
     }
 

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -13,13 +13,11 @@
 
 use crate::{
     builtins::{
-        function::make_builtin_fn,
-        function::make_constructor_fn,
-        object::ObjectData,
-        value::{ResultValue, Value},
+        function::make_builtin_fn, function::make_constructor_fn, object::ObjectData, value::Value,
     },
     exec::Interpreter,
     profiler::BoaProfiler,
+    Result,
 };
 
 /// JavaScript `SyntaxError` impleentation.
@@ -34,7 +32,7 @@ impl SyntaxError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -56,7 +54,7 @@ impl SyntaxError {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
         let name = this.get_field("name");
         let message = this.get_field("message");
         // FIXME: This should not use `.display()`

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -17,13 +17,10 @@
 
 use crate::{
     builtins::{
-        function::make_builtin_fn,
-        function::make_constructor_fn,
-        object::ObjectData,
-        value::{ResultValue, Value},
+        function::make_builtin_fn, function::make_constructor_fn, object::ObjectData, value::Value,
     },
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 /// JavaScript `TypeError` implementation.
@@ -38,7 +35,7 @@ impl TypeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -60,9 +57,10 @@ impl TypeError {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let name = this.get_field("name").to_string(ctx)?;
         let message = this.get_field("message").to_string(ctx)?;
+
         Ok(Value::from(format!("{}: {}", name, message)))
     }
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -13,12 +13,8 @@
 //! [json]: https://www.json.org/json-en.html
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
 
-use crate::builtins::{
-    function::make_builtin_fn,
-    property::Property,
-    value::{ResultValue, Value},
-};
-use crate::{exec::Interpreter, BoaProfiler};
+use crate::builtins::{function::make_builtin_fn, property::Property, value::Value};
+use crate::{exec::Interpreter, BoaProfiler, Result};
 use serde_json::{self, Value as JSONValue};
 
 #[cfg(test)]
@@ -44,7 +40,7 @@ impl Json {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-    pub(crate) fn parse(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn parse(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         match serde_json::from_str::<JSONValue>(
             &args
                 .get(0)
@@ -72,7 +68,12 @@ impl Json {
     /// for possible transformation.
     ///
     /// [polyfill]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-    fn walk(reviver: &Value, ctx: &mut Interpreter, holder: &mut Value, key: Value) -> ResultValue {
+    fn walk(
+        reviver: &Value,
+        ctx: &mut Interpreter,
+        holder: &mut Value,
+        key: Value,
+    ) -> Result<Value> {
         let mut value = holder.get_field(key.clone());
 
         let obj = value.as_object().as_deref().cloned();
@@ -109,7 +110,7 @@ impl Json {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json.stringify
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-    pub(crate) fn stringify(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn stringify(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let object = match args.get(0) {
             Some(obj) if obj.is_symbol() || obj.is_function() || obj.is_undefined() => {
                 return Ok(Value::undefined())

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -5,10 +5,10 @@ use crate::{
     builtins::{
         object::{ObjectData, PROTOTYPE},
         property::{Attribute, Property},
-        value::{ResultValue, Value},
+        value::Value,
     },
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use ordered_map::OrderedMap;
 
@@ -44,7 +44,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
-    pub(crate) fn set(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn set(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let (key, value) = match args.len() {
             0 => (Value::Undefined, Value::Undefined),
             1 => (args[0].clone(), Value::Undefined),
@@ -77,7 +77,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.delete
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
-    pub(crate) fn delete(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn delete(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -109,7 +109,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
-    pub(crate) fn get(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn get(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -140,7 +140,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
-    pub(crate) fn clear(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn clear(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
         this.set_data(ObjectData::Map(OrderedMap::new()));
 
         Self::set_size(this, 0);
@@ -158,7 +158,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn has(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -189,7 +189,7 @@ impl Map {
         this: &Value,
         args: &[Value],
         interpreter: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         if args.is_empty() {
             return Err(Value::from("Missing argument for Map.prototype.forEach"));
         }
@@ -227,7 +227,7 @@ impl Map {
     }
 
     /// Create a new map
-    pub(crate) fn make_map(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_map(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         // Make a new Object which will internally represent the Array (mapping
         // between indices and values): this creates an Object with no prototype
 

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -12,12 +12,9 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 
 use crate::{
-    builtins::{
-        function::make_builtin_fn,
-        value::{ResultValue, Value},
-    },
+    builtins::{function::make_builtin_fn, value::Value},
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use std::f64;
 
@@ -40,7 +37,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.abs
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
-    pub(crate) fn abs(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn abs(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -57,7 +54,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
-    pub(crate) fn acos(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn acos(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -74,7 +71,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
-    pub(crate) fn acosh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn acosh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -91,7 +88,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
-    pub(crate) fn asin(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn asin(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -108,7 +105,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
-    pub(crate) fn asinh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn asinh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -125,7 +122,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan
-    pub(crate) fn atan(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn atan(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -142,7 +139,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
-    pub(crate) fn atanh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn atanh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -159,7 +156,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
-    pub(crate) fn atan2(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn atan2(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_number(ctx)).transpose()?,
             args.get(1).map(|x| x.to_number(ctx)).transpose()?,
@@ -178,7 +175,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cbrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
-    pub(crate) fn cbrt(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn cbrt(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -195,7 +192,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.ceil
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
-    pub(crate) fn ceil(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn ceil(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -212,7 +209,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.clz32
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
-    pub(crate) fn clz32(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn clz32(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_u32(ctx))
@@ -230,7 +227,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
-    pub(crate) fn cos(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn cos(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -247,7 +244,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
-    pub(crate) fn cosh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn cosh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -264,7 +261,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.exp
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
-    pub(crate) fn exp(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn exp(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -283,7 +280,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.expm1
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1
-    pub(crate) fn expm1(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn expm1(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -300,7 +297,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.floor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
-    pub(crate) fn floor(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn floor(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -317,7 +314,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.fround
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
-    pub(crate) fn fround(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn fround(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -334,7 +331,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.hypot
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
-    pub(crate) fn hypot(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn hypot(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let mut result = 0f64;
         for arg in args {
             let x = arg.to_number(ctx)?;
@@ -351,7 +348,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.imul
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-    pub(crate) fn imul(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn imul(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_u32(ctx)).transpose()?,
             args.get(1).map(|x| x.to_u32(ctx)).transpose()?,
@@ -370,7 +367,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
-    pub(crate) fn log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn log(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -387,7 +384,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log1p
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p
-    pub(crate) fn log1p(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn log1p(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -404,7 +401,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log10
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10
-    pub(crate) fn log10(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn log10(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -421,7 +418,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
-    pub(crate) fn log2(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn log2(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -438,7 +435,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.max
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max
-    pub(crate) fn max(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn max(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let mut max = f64::NEG_INFINITY;
         for arg in args {
             let num = arg.to_number(ctx)?;
@@ -455,7 +452,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.min
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min
-    pub(crate) fn min(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn min(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let mut min = f64::INFINITY;
         for arg in args {
             let num = arg.to_number(ctx)?;
@@ -472,7 +469,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.pow
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
-    pub(crate) fn pow(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn pow(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_number(ctx)).transpose()?,
             args.get(1).map(|x| x.to_number(ctx)).transpose()?,
@@ -491,7 +488,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.random
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-    pub(crate) fn random(_: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn random(_: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
         Ok(rand::random::<f64>().into())
     }
 
@@ -503,7 +500,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-    pub(crate) fn round(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn round(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -520,7 +517,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
-    pub(crate) fn sign(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn sign(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -546,7 +543,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
-    pub(crate) fn sin(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn sin(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -563,7 +560,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh
-    pub(crate) fn sinh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn sinh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -580,7 +577,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sqrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt
-    pub(crate) fn sqrt(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn sqrt(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -597,7 +594,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tan
-    pub(crate) fn tan(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn tan(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -614,7 +611,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh
-    pub(crate) fn tanh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn tanh(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))
@@ -631,7 +628,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
-    pub(crate) fn trunc(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn trunc(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(ctx))

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use self::{
     string::String,
     symbol::Symbol,
     undefined::Undefined,
-    value::{ResultValue, Value},
+    value::Value,
 };
 use crate::Interpreter;
 

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -18,11 +18,7 @@ use super::{
     object::ObjectData,
     value::AbstractRelation,
 };
-use crate::{
-    builtins::value::{ResultValue, Value},
-    exec::Interpreter,
-    BoaProfiler,
-};
+use crate::{builtins::value::Value, exec::Interpreter, BoaProfiler, Result};
 use num_traits::float::FloatCore;
 
 mod conversions;
@@ -106,7 +102,7 @@ impl Number {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisnumbervalue
-    fn this_number_value(value: &Value, ctx: &mut Interpreter) -> Result<f64, Value> {
+    fn this_number_value(value: &Value, ctx: &mut Interpreter) -> Result<f64> {
         match *value {
             Value::Integer(integer) => return Ok(f64::from(integer)),
             Value::Rational(rational) => return Ok(rational),
@@ -133,7 +129,11 @@ impl Number {
     /// `[[Construct]]` - Creates a Number instance
     ///
     /// `[[Call]]` - Creates a number primitive
-    pub(crate) fn make_number(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_number(
+        this: &Value,
+        args: &[Value],
+        ctx: &mut Interpreter,
+    ) -> Result<Value> {
         let data = match args.get(0) {
             Some(ref value) => value.to_numeric_number(ctx)?,
             None => 0.0,
@@ -158,7 +158,7 @@ impl Number {
         this: &Value,
         _args: &[Value],
         ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         let this_num = Self::this_number_value(this, ctx)?;
         let this_str_num = Self::num_to_exponential(this_num);
         Ok(Value::from(this_str_num))
@@ -175,7 +175,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tofixed
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_fixed(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_fixed(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let this_num = Self::this_number_value(this, ctx)?;
         let precision = match args.get(0) {
             Some(n) => match n.to_integer(ctx)? as i32 {
@@ -206,7 +206,7 @@ impl Number {
         this: &Value,
         _args: &[Value],
         ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         let this_num = Self::this_number_value(this, ctx)?;
         let this_str_num = format!("{}", this_num);
         Ok(Value::from(this_str_num))
@@ -223,7 +223,11 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.toexponential
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_precision(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_precision(
+        this: &Value,
+        args: &[Value],
+        ctx: &mut Interpreter,
+    ) -> Result<Value> {
         let this_num = Self::this_number_value(this, ctx)?;
         let _num_str_len = format!("{}", this_num).len();
         let _precision = match args.get(0) {
@@ -377,7 +381,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         // 1. Let x be ? thisNumberValue(this value).
         let x = Self::this_number_value(this, ctx)?;
 
@@ -432,7 +436,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf
-    pub(crate) fn value_of(this: &Value, _args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn value_of(this: &Value, _args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         Ok(Value::from(Self::this_number_value(this, ctx)?))
     }
 
@@ -450,7 +454,11 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parseint-string-radix
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-    pub(crate) fn parse_int(_this: &Value, args: &[Value], _ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn parse_int(
+        _this: &Value,
+        args: &[Value],
+        _ctx: &mut Interpreter,
+    ) -> Result<Value> {
         if let (Some(val), r) = (args.get(0), args.get(1)) {
             let mut radix = if let Some(rx) = r {
                 if let Value::Integer(i) = rx {
@@ -520,7 +528,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         _ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         if let Some(val) = args.get(0) {
             match val {
                 Value::String(s) => {
@@ -566,7 +574,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(ctx)?;
             Ok(number.is_finite().into())
@@ -593,7 +601,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(ctx)?;
             Ok(number.is_nan().into())
@@ -620,7 +628,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         _ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         Ok(Value::from(if let Some(val) = args.get(0) {
             match val {
                 Value::Integer(_) => true,
@@ -646,7 +654,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         _ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         Ok(args.get(0).map_or(false, Self::is_integer).into())
     }
 
@@ -668,7 +676,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         _ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         Ok(Value::from(if let Some(val) = args.get(0) {
             match val {
                 Value::Integer(_) => false,
@@ -698,7 +706,7 @@ impl Number {
         _this: &Value,
         args: &[Value],
         _ctx: &mut Interpreter,
-    ) -> ResultValue {
+    ) -> Result<Value> {
         Ok(Value::from(match args.get(0) {
             Some(Value::Integer(_)) => true,
             Some(Value::Rational(number)) if Self::is_float_integer(*number) => {

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -16,10 +16,10 @@ use crate::{
     builtins::{
         object::{InternalState, ObjectData},
         property::Property,
-        value::{RcString, ResultValue, Value},
+        value::{RcString, Value},
     },
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use gc::{unsafe_empty_trace, Finalize, Trace};
 
@@ -74,7 +74,7 @@ impl RegExp {
     pub(crate) const LENGTH: usize = 2;
 
     /// Create a new `RegExp`
-    pub(crate) fn make_regexp(this: &Value, args: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn make_regexp(this: &Value, args: &[Value], _: &mut Interpreter) -> Result<Value> {
         let arg = args.get(0).ok_or_else(Value::undefined)?;
         let mut regex_body = String::new();
         let mut regex_flags = String::new();
@@ -171,7 +171,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.dotAll
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
-    // fn get_dot_all(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_dot_all(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.dot_all)))
     // }
 
@@ -186,7 +186,7 @@ impl RegExp {
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.flags
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags
     // /// [flags]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2
-    // fn get_flags(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_flags(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.flags.clone())))
     // }
 
@@ -200,7 +200,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.global
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global
-    // fn get_global(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_global(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.global)))
     // }
 
@@ -214,7 +214,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
-    // fn get_ignore_case(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_ignore_case(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.ignore_case)))
     // }
 
@@ -228,7 +228,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline
-    // fn get_multiline(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_multiline(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.multiline)))
     // }
 
@@ -243,7 +243,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.source
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source
-    // fn get_source(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_source(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     Ok(this.get_internal_slot("OriginalSource"))
     // }
 
@@ -257,7 +257,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky
-    // fn get_sticky(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_sticky(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.sticky)))
     // }
 
@@ -272,7 +272,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode
-    // fn get_unicode(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    // fn get_unicode(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.unicode)))
     // }
 
@@ -288,7 +288,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.test
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
-    pub(crate) fn test(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn test(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let arg_str = args
             .get(0)
             .expect("could not get argument")
@@ -327,7 +327,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.exec
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
-    pub(crate) fn exec(this: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn exec(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let arg_str = args
             .get(0)
             .expect("could not get argument")
@@ -383,7 +383,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype-@@match
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match
-    pub(crate) fn r#match(this: &Value, arg: RcString, ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn r#match(this: &Value, arg: RcString, ctx: &mut Interpreter) -> Result<Value> {
         let (matcher, flags) = if let Some(object) = this.as_object() {
             let regex = object.as_regexp().unwrap();
             (regex.matcher.clone(), regex.flags.clone())
@@ -415,7 +415,7 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Interpreter) -> Result<Value> {
         let (body, flags) = if let Some(object) = this.as_object() {
             let regex = object.as_regexp().unwrap();
             (regex.original_source.clone(), regex.flags.clone())
@@ -436,7 +436,7 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp-prototype-matchall
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
     // TODO: it's returning an array, it should return an iterator
-    pub(crate) fn match_all(this: &Value, arg_str: String) -> ResultValue {
+    pub(crate) fn match_all(this: &Value, arg_str: String) -> Result<Value> {
         let matches = if let Some(object) = this.as_object() {
             let regex = object.as_regexp().unwrap();
             let mut matches = Vec::new();

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -20,9 +20,9 @@ mod tests;
 
 use super::function::{make_builtin_fn, make_constructor_fn};
 use crate::{
-    builtins::value::{RcString, RcSymbol, ResultValue, Value},
+    builtins::value::{RcString, RcSymbol, Value},
     exec::Interpreter,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use gc::{Finalize, Trace};
 
@@ -46,7 +46,7 @@ impl Symbol {
         self.1
     }
 
-    fn this_symbol_value(value: &Value, ctx: &mut Interpreter) -> Result<RcSymbol, Value> {
+    fn this_symbol_value(value: &Value, ctx: &mut Interpreter) -> Result<RcSymbol> {
         match value {
             Value::Symbol(ref symbol) => return Ok(symbol.clone()),
             Value::Object(ref object) => {
@@ -72,7 +72,7 @@ impl Symbol {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol-description
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
-    pub(crate) fn call(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn call(_: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let description = match args.get(0) {
             Some(ref value) if !value.is_undefined() => Some(value.to_string(ctx)?),
             _ => None,
@@ -92,7 +92,7 @@ impl Symbol {
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> ResultValue {
+    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let symbol = Self::this_symbol_value(this, ctx)?;
         let description = symbol.description().unwrap_or("");
         Ok(Value::from(format!("Symbol({})", description)))

--- a/boa/src/builtins/value/conversions.rs
+++ b/boa/src/builtins/value/conversions.rs
@@ -67,18 +67,6 @@ impl Display for TryFromCharError {
     }
 }
 
-impl TryFrom<&Value> for char {
-    type Error = TryFromCharError;
-
-    fn try_from(value: &Value) -> Result<Self, Self::Error> {
-        if let Some(c) = value.display().to_string().chars().next() {
-            Ok(c)
-        } else {
-            Err(TryFromCharError)
-        }
-    }
-}
-
 impl From<f64> for Value {
     fn from(value: f64) -> Self {
         Self::rational(value)

--- a/boa/src/builtins/value/equality.rs
+++ b/boa/src/builtins/value/equality.rs
@@ -37,7 +37,7 @@ impl Value {
     /// This method is executed when doing abstract equality comparisons with the `==` operator.
     ///  For more information, check <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
     #[allow(clippy::float_cmp)]
-    pub fn equals(&self, other: &Self, interpreter: &mut Interpreter) -> Result<bool, Value> {
+    pub fn equals(&self, other: &Self, interpreter: &mut Interpreter) -> Result<bool> {
         // 1. If Type(x) is the same as Type(y), then
         //     a. Return the result of performing Strict Equality Comparison x === y.
         if self.get_type() == other.get_type() {

--- a/boa/src/builtins/value/operations.rs
+++ b/boa/src/builtins/value/operations.rs
@@ -6,7 +6,7 @@ use crate::builtins::{
 
 impl Value {
     #[inline]
-    pub fn add(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn add(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) + f64::from(*y)),
@@ -43,7 +43,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn sub(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn sub(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) - f64::from(*y)),
@@ -71,7 +71,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn mul(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn mul(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) * f64::from(*y)),
@@ -99,7 +99,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn div(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn div(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) / f64::from(*y)),
@@ -127,7 +127,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn rem(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn rem(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x % *y),
@@ -155,7 +155,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn pow(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn pow(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x).powi(*y)),
@@ -181,7 +181,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitand(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn bitand(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x & y),
@@ -213,7 +213,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitor(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn bitor(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x | y),
@@ -245,7 +245,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitxor(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn bitxor(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x ^ y),
@@ -277,7 +277,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn shl(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn shl(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x.wrapping_shl(*y as u32)),
@@ -313,7 +313,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn shr(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn shr(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x.wrapping_shr(*y as u32)),
@@ -349,7 +349,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn ushr(&self, other: &Self, ctx: &mut Interpreter) -> ResultValue {
+    pub fn ushr(&self, other: &Self, ctx: &mut Interpreter) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => {
@@ -384,7 +384,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn neg(&self, interpreter: &mut Interpreter) -> ResultValue {
+    pub fn neg(&self, interpreter: &mut Interpreter) -> Result<Value> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::rational(NAN),
             Self::Object(_) => Self::rational(match self.to_numeric_number(interpreter) {
@@ -404,7 +404,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn not(&self, _: &mut Interpreter) -> Result<bool, Value> {
+    pub fn not(&self, _: &mut Interpreter) -> Result<bool> {
         Ok(!self.to_boolean())
     }
 
@@ -430,7 +430,7 @@ impl Value {
         other: &Self,
         left_first: bool,
         ctx: &mut Interpreter,
-    ) -> Result<AbstractRelation, Value> {
+    ) -> Result<AbstractRelation> {
         Ok(match (self, other) {
             // Fast path (for some common operations):
             (Self::Integer(x), Self::Integer(y)) => (x < y).into(),
@@ -528,7 +528,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn lt(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool, Value> {
+    pub fn lt(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool> {
         match self.abstract_relation(other, true, ctx)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -545,7 +545,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn le(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool, Value> {
+    pub fn le(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool> {
         match other.abstract_relation(self, false, ctx)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),
@@ -562,7 +562,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn gt(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool, Value> {
+    pub fn gt(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool> {
         match other.abstract_relation(self, false, ctx)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -579,7 +579,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn ge(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool, Value> {
+    pub fn ge(&self, other: &Self, ctx: &mut Interpreter) -> Result<bool> {
         match self.abstract_relation(other, true, ctx)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),

--- a/boa/src/exec/array/mod.rs
+++ b/boa/src/exec/array/mod.rs
@@ -2,13 +2,13 @@
 
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::{Array, ResultValue},
+    builtins::{Array, Value},
     syntax::ast::node::{ArrayDecl, Node},
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 impl Executable for ArrayDecl {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("ArrayDecl", "exec");
         let array = Array::new_array(interpreter)?;
         let mut elements = Vec::new();

--- a/boa/src/exec/block/mod.rs
+++ b/boa/src/exec/block/mod.rs
@@ -2,14 +2,12 @@
 
 use super::{Executable, Interpreter, InterpreterState};
 use crate::{
-    builtins::value::{ResultValue, Value},
-    environment::lexical_environment::new_declarative_environment,
-    syntax::ast::node::Block,
-    BoaProfiler,
+    builtins::value::Value, environment::lexical_environment::new_declarative_environment,
+    syntax::ast::node::Block, BoaProfiler, Result,
 };
 
 impl Executable for Block {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Block", "exec");
         {
             let env = &mut interpreter.realm_mut().environment;

--- a/boa/src/exec/break_node/mod.rs
+++ b/boa/src/exec/break_node/mod.rs
@@ -1,14 +1,11 @@
 use super::{Executable, Interpreter, InterpreterState};
-use crate::{
-    builtins::value::{ResultValue, Value},
-    syntax::ast::node::Break,
-};
+use crate::{builtins::value::Value, syntax::ast::node::Break, Result};
 
 #[cfg(test)]
 mod tests;
 
 impl Executable for Break {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         interpreter.set_current_state(InterpreterState::Break(self.label().map(String::from)));
 
         Ok(Value::undefined())

--- a/boa/src/exec/call/mod.rs
+++ b/boa/src/exec/call/mod.rs
@@ -1,12 +1,12 @@
 use super::{Executable, Interpreter, InterpreterState};
 use crate::{
-    builtins::value::{ResultValue, Type},
+    builtins::value::{Type, Value},
     syntax::ast::node::{Call, Node},
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 impl Executable for Call {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Call", "exec");
         let (this, func) = match self.expr() {
             Node::GetConstField(ref get_const_field) => {

--- a/boa/src/exec/conditional/mod.rs
+++ b/boa/src/exec/conditional/mod.rs
@@ -1,12 +1,9 @@
 use super::{Executable, Interpreter};
-use crate::{
-    builtins::{ResultValue, Value},
-    syntax::ast::node::If,
-};
+use crate::{builtins::Value, syntax::ast::node::If, Result};
 use std::borrow::Borrow;
 
 impl Executable for If {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         Ok(if self.cond().run(interpreter)?.borrow().to_boolean() {
             self.body().run(interpreter)?
         } else if let Some(ref else_e) = self.else_node() {

--- a/boa/src/exec/declaration/mod.rs
+++ b/boa/src/exec/declaration/mod.rs
@@ -2,19 +2,16 @@
 
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::{
-        function::ThisMode,
-        value::{ResultValue, Value},
-    },
+    builtins::{function::ThisMode, value::Value},
     environment::lexical_environment::VariableScope,
     syntax::ast::node::{
         ArrowFunctionDecl, ConstDeclList, FunctionDecl, FunctionExpr, LetDeclList, VarDeclList,
     },
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 impl Executable for FunctionDecl {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("FunctionDecl", "exec");
         let val = interpreter.create_function(
             self.parameters().to_vec(),
@@ -42,7 +39,7 @@ impl Executable for FunctionDecl {
 }
 
 impl Executable for FunctionExpr {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let val = interpreter.create_function(
             self.parameters().to_vec(),
             self.body().to_vec(),
@@ -60,7 +57,7 @@ impl Executable for FunctionExpr {
 }
 
 impl Executable for VarDeclList {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         for var in self.as_ref() {
             let val = match var.init() {
                 Some(v) => v.run(interpreter)?,
@@ -86,7 +83,7 @@ impl Executable for VarDeclList {
 }
 
 impl Executable for ConstDeclList {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         for decl in self.as_ref() {
             let val = decl.init().run(interpreter)?;
 
@@ -105,7 +102,7 @@ impl Executable for ConstDeclList {
 }
 
 impl Executable for LetDeclList {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         for var in self.as_ref() {
             let val = match var.init() {
                 Some(v) => v.run(interpreter)?,
@@ -126,7 +123,7 @@ impl Executable for LetDeclList {
 }
 
 impl Executable for ArrowFunctionDecl {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         Ok(interpreter.create_function(
             self.params().to_vec(),
             self.body().to_vec(),

--- a/boa/src/exec/exception.rs
+++ b/boa/src/exec/exception.rs
@@ -23,7 +23,7 @@ impl Interpreter {
     }
 
     /// Throws a `RangeError` with the specified message.
-    pub fn throw_range_error<M>(&mut self, message: M) -> ResultValue
+    pub fn throw_range_error<M>(&mut self, message: M) -> Result<Value>
     where
         M: Into<String>,
     {
@@ -45,7 +45,7 @@ impl Interpreter {
     }
 
     /// Throws a `TypeError` with the specified message.
-    pub fn throw_type_error<M>(&mut self, message: M) -> ResultValue
+    pub fn throw_type_error<M>(&mut self, message: M) -> Result<Value>
     where
         M: Into<String>,
     {
@@ -66,7 +66,7 @@ impl Interpreter {
     }
 
     /// Throws a `ReferenceError` with the specified message.
-    pub fn throw_reference_error<M>(&mut self, message: M) -> ResultValue
+    pub fn throw_reference_error<M>(&mut self, message: M) -> Result<Value>
     where
         M: Into<String>,
     {
@@ -87,7 +87,7 @@ impl Interpreter {
     }
 
     /// Throws a `SyntaxError` with the specified message.
-    pub fn throw_syntax_error<M>(&mut self, message: M) -> ResultValue
+    pub fn throw_syntax_error<M>(&mut self, message: M) -> Result<Value>
     where
         M: Into<String>,
     {

--- a/boa/src/exec/field/mod.rs
+++ b/boa/src/exec/field/mod.rs
@@ -1,11 +1,12 @@
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::value::{ResultValue, Type},
+    builtins::value::{Type, Value},
     syntax::ast::node::{GetConstField, GetField},
+    Result,
 };
 
 impl Executable for GetConstField {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let mut obj = self.obj().run(interpreter)?;
         if obj.get_type() != Type::Object {
             obj = obj.to_object(interpreter)?;
@@ -16,7 +17,7 @@ impl Executable for GetConstField {
 }
 
 impl Executable for GetField {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let mut obj = self.obj().run(interpreter)?;
         if obj.get_type() != Type::Object {
             obj = obj.to_object(interpreter)?;

--- a/boa/src/exec/identifier/mod.rs
+++ b/boa/src/exec/identifier/mod.rs
@@ -1,8 +1,8 @@
 use super::{Executable, Interpreter};
-use crate::{builtins::value::ResultValue, syntax::ast::node::identifier::Identifier};
+use crate::{builtins::value::Value, syntax::ast::node::identifier::Identifier, Result};
 
 impl Executable for Identifier {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         interpreter
             .realm()
             .environment

--- a/boa/src/exec/iteration/mod.rs
+++ b/boa/src/exec/iteration/mod.rs
@@ -2,10 +2,10 @@
 
 use super::{Executable, Interpreter, InterpreterState};
 use crate::{
-    builtins::value::{ResultValue, Value},
+    builtins::value::Value,
     environment::lexical_environment::new_declarative_environment,
     syntax::ast::node::{DoWhileLoop, ForLoop, WhileLoop},
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 use std::borrow::Borrow;
 
@@ -13,7 +13,7 @@ use std::borrow::Borrow;
 mod tests;
 
 impl Executable for ForLoop {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         // Create the block environment.
         let _timer = BoaProfiler::global().start_event("ForLoop", "exec");
         {
@@ -64,7 +64,7 @@ impl Executable for ForLoop {
 }
 
 impl Executable for WhileLoop {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let mut result = Value::undefined();
         while self.cond().run(interpreter)?.borrow().to_boolean() {
             result = self.expr().run(interpreter)?;
@@ -89,7 +89,7 @@ impl Executable for WhileLoop {
 }
 
 impl Executable for DoWhileLoop {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let mut result = self.body().run(interpreter)?;
         match interpreter.get_current_state() {
             InterpreterState::Break(_label) => {

--- a/boa/src/exec/new/mod.rs
+++ b/boa/src/exec/new/mod.rs
@@ -2,14 +2,14 @@ use super::{Executable, Interpreter};
 use crate::{
     builtins::{
         object::{ObjectData, PROTOTYPE},
-        value::{ResultValue, Value},
+        value::Value,
     },
     syntax::ast::node::New,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 impl Executable for New {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("New", "exec");
         // let (callee, args) = match call.as_ref() {
         //     Node::Call(callee, args) => (callee, args),

--- a/boa/src/exec/object/mod.rs
+++ b/boa/src/exec/object/mod.rs
@@ -2,15 +2,16 @@
 
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::value::{ResultValue, Value},
+    builtins::value::Value,
     syntax::ast::node::MethodDefinitionKind,
     syntax::ast::node::{Object, PropertyDefinition},
+    Result,
 };
 
 use std::borrow::Borrow;
 
 impl Executable for Object {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let global_val = &interpreter
             .realm()
             .environment

--- a/boa/src/exec/operator/mod.rs
+++ b/boa/src/exec/operator/mod.rs
@@ -4,17 +4,17 @@ mod tests;
 
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::value::{ResultValue, Value},
+    builtins::value::Value,
     environment::lexical_environment::VariableScope,
     syntax::ast::{
         node::{Assign, BinOp, Node, UnaryOp},
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 impl Executable for Assign {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Assign", "exec");
         let val = self.rhs().run(interpreter)?;
         match self.lhs() {
@@ -50,7 +50,7 @@ impl Executable for Assign {
 }
 
 impl Executable for BinOp {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         match self.op() {
             op::BinOp::Num(op) => {
                 let x = self.lhs().run(interpreter)?;
@@ -150,7 +150,12 @@ impl Executable for BinOp {
 
 impl BinOp {
     /// Runs the assignment operators.
-    fn run_assign(op: AssignOp, x: Value, y: Value, interpreter: &mut Interpreter) -> ResultValue {
+    fn run_assign(
+        op: AssignOp,
+        x: Value,
+        y: Value,
+        interpreter: &mut Interpreter,
+    ) -> Result<Value> {
         match op {
             AssignOp::Add => x.add(&y, interpreter),
             AssignOp::Sub => x.sub(&y, interpreter),
@@ -168,7 +173,7 @@ impl BinOp {
 }
 
 impl Executable for UnaryOp {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let x = self.target().run(interpreter)?;
 
         Ok(match self.op() {

--- a/boa/src/exec/return_smt/mod.rs
+++ b/boa/src/exec/return_smt/mod.rs
@@ -1,11 +1,8 @@
 use super::{Executable, Interpreter, InterpreterState};
-use crate::{
-    builtins::value::{ResultValue, Value},
-    syntax::ast::node::Return,
-};
+use crate::{builtins::value::Value, syntax::ast::node::Return, Result};
 
 impl Executable for Return {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let result = match self.expr() {
             Some(ref v) => v.run(interpreter),
             None => Ok(Value::undefined()),

--- a/boa/src/exec/spread/mod.rs
+++ b/boa/src/exec/spread/mod.rs
@@ -1,8 +1,8 @@
 use super::{Executable, Interpreter};
-use crate::{builtins::value::ResultValue, syntax::ast::node::Spread};
+use crate::{builtins::value::Value, syntax::ast::node::Spread, Result};
 
 impl Executable for Spread {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         // TODO: for now we can do nothing but return the value as-is
         self.val().run(interpreter)
     }

--- a/boa/src/exec/statement_list.rs
+++ b/boa/src/exec/statement_list.rs
@@ -1,14 +1,10 @@
 //! Statement list execution.
 
 use super::{Executable, Interpreter, InterpreterState};
-use crate::{
-    builtins::value::{ResultValue, Value},
-    syntax::ast::node::StatementList,
-    BoaProfiler,
-};
+use crate::{builtins::value::Value, syntax::ast::node::StatementList, BoaProfiler, Result};
 
 impl Executable for StatementList {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("StatementList", "exec");
         let mut obj = Value::null();
         interpreter.set_current_state(InterpreterState::Executing);

--- a/boa/src/exec/switch/mod.rs
+++ b/boa/src/exec/switch/mod.rs
@@ -1,14 +1,11 @@
 use super::{Executable, Interpreter, InterpreterState};
-use crate::{
-    builtins::value::{ResultValue, Value},
-    syntax::ast::node::Switch,
-};
+use crate::{builtins::value::Value, syntax::ast::node::Switch, Result};
 
 #[cfg(test)]
 mod tests;
 
 impl Executable for Switch {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let default = self.default();
         let val = self.val().run(interpreter)?;
         let mut result = Value::null();

--- a/boa/src/exec/throw/mod.rs
+++ b/boa/src/exec/throw/mod.rs
@@ -1,9 +1,9 @@
 use super::{Executable, Interpreter};
-use crate::{builtins::value::ResultValue, syntax::ast::node::Throw};
+use crate::{builtins::value::Value, syntax::ast::node::Throw, Result};
 
 impl Executable for Throw {
     #[inline]
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         Err(self.expr().run(interpreter)?)
     }
 }

--- a/boa/src/exec/try_node/mod.rs
+++ b/boa/src/exec/try_node/mod.rs
@@ -2,17 +2,17 @@
 
 use super::{Executable, Interpreter};
 use crate::{
-    builtins::value::ResultValue,
+    builtins::value::Value,
     environment::lexical_environment::{new_declarative_environment, VariableScope},
     syntax::ast::node::Try,
-    BoaProfiler,
+    BoaProfiler, Result,
 };
 
 #[cfg(test)]
 mod tests;
 
 impl Executable for Try {
-    fn run(&self, interpreter: &mut Interpreter) -> ResultValue {
+    fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Try", "exec");
         let res = self.block().run(interpreter).map_or_else(
             |err| {

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -41,15 +41,20 @@ pub mod profiler;
 pub mod realm;
 pub mod syntax;
 
-use crate::{builtins::value::ResultValue, syntax::ast::node::StatementList};
+use crate::{builtins::value::Value, syntax::ast::node::StatementList};
 pub use crate::{
     exec::{Executable, Interpreter},
     profiler::BoaProfiler,
     realm::Realm,
     syntax::{lexer::Lexer, parser::Parser},
 };
+use std::result::Result as StdResult;
 
-fn parser_expr(src: &str) -> Result<StatementList, String> {
+/// The result of a Javascript expression is represented like this so it can succeed (`Ok`) or fail (`Err`)
+#[must_use]
+pub type Result<T> = StdResult<T, Value>;
+
+fn parser_expr(src: &str) -> StdResult<StatementList, String> {
     let mut lexer = Lexer::new(src);
     lexer.lex().map_err(|e| format!("Syntax Error: {}", e))?;
     let tokens = lexer.tokens;
@@ -77,7 +82,7 @@ pub fn forward(engine: &mut Interpreter, src: &str) -> String {
 /// Similar to `forward`, except the current value is returned instad of the string
 /// If the interpreter fails parsing an error value is returned instead (error object)
 #[allow(clippy::unit_arg, clippy::drop_copy)]
-pub fn forward_val(engine: &mut Interpreter, src: &str) -> ResultValue {
+pub fn forward_val(engine: &mut Interpreter, src: &str) -> Result<Value> {
     let main_timer = BoaProfiler::global().start_event("Main", "Main");
     // Setup executor
     let result = match parser_expr(src) {


### PR DESCRIPTION
Related to #445 

This PRs removes the `ResultValue` and adds a generic type alias `Result<T>` where the `Err` is `Value`, this is common practice and is done in many places in the standard library, serde, etc (example `std::fmt::Result`, `std::io::Result`, `serde::Result`)

It changes the following:
 - Removed `ResultValue`.
 - Added type alias `type Result<T> = StdResult<T, Value>`