### PR TITLE
Rename `Value::to_*int32` to `Value::to_*32`

### DIFF
--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -215,7 +215,7 @@ impl Math {
     pub(crate) fn clz32(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
         Ok(args
             .get(0)
-            .map(|x| x.to_uint32(ctx))
+            .map(|x| x.to_u32(ctx))
             .transpose()?
             .map(u32::leading_zeros)
             .unwrap_or(32)
@@ -353,8 +353,8 @@ impl Math {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
     pub(crate) fn imul(_: &Value, args: &[Value], ctx: &mut Interpreter) -> ResultValue {
         Ok(match (
-            args.get(0).map(|x| x.to_uint32(ctx)).transpose()?,
-            args.get(1).map(|x| x.to_uint32(ctx)).transpose()?,
+            args.get(0).map(|x| x.to_u32(ctx)).transpose()?,
+            args.get(1).map(|x| x.to_u32(ctx)).transpose()?,
         ) {
             (Some(x), Some(y)) => x.wrapping_mul(y) as i32,
             (_, _) => 0,

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -888,7 +888,7 @@ impl Value {
     /// This function is equivalent to `value | 0` in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-toint32>
-    pub fn to_uint32(&self, ctx: &mut Interpreter) -> Result<u32, Value> {
+    pub fn to_u32(&self, ctx: &mut Interpreter) -> Result<u32, Value> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Value::Integer(number) = *self {
             return Ok(number as u32);
@@ -901,7 +901,7 @@ impl Value {
     /// Converts a value to an integral 32 bit signed integer.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toint32>
-    pub fn to_int32(&self, ctx: &mut Interpreter) -> Result<i32, Value> {
+    pub fn to_i32(&self, ctx: &mut Interpreter) -> Result<i32, Value> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Value::Integer(number) = *self {
             return Ok(number);

--- a/boa/src/builtins/value/tests.rs
+++ b/boa/src/builtins/value/tests.rs
@@ -254,7 +254,7 @@ fn add_number_and_number() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "1 + 2").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, 3);
 }
 
@@ -284,7 +284,7 @@ fn add_number_object_and_number() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "new Number(10) + 6").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, 16);
 }
 
@@ -304,7 +304,7 @@ fn sub_number_and_number() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "1 - 999").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, -998);
 }
 
@@ -314,7 +314,7 @@ fn sub_number_object_and_number_object() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "new Number(1) - new Number(999)").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, -998);
 }
 
@@ -334,7 +334,7 @@ fn bitand_integer_and_integer() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "0xFFFF & 0xFF").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, 255);
 }
 
@@ -344,7 +344,7 @@ fn bitand_integer_and_rational() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "0xFFFF & 255.5").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, 255);
 }
 
@@ -354,7 +354,7 @@ fn bitand_rational_and_rational() {
     let mut engine = Interpreter::new(realm);
 
     let value = forward_val(&mut engine, "255.772 & 255.5").unwrap();
-    let value = value.to_int32(&mut engine).unwrap();
+    let value = value.to_i32(&mut engine).unwrap();
     assert_eq!(value, 255);
 }
 

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -972,7 +972,7 @@ fn to_int32() {
 
     macro_rules! check_to_int32 {
         ($from:expr => $to:expr) => {
-            assert_eq!(Value::from($from).to_int32(&mut engine).unwrap(), $to);
+            assert_eq!(Value::from($from).to_i32(&mut engine).unwrap(), $to);
         };
     };
 


### PR DESCRIPTION
This PR is related to https://github.com/boa-dev/boa/issues/445#issuecomment-674524820

It changes the following:
 - Renamed `Value::to_uint32()` **=>** `Value::to_u32()`
 - Renamed `Value::to_int32()` **=>** `Value::to_i32()`
