### PR TITLE
Change default return type from null to undefined

### DIFF
--- a/boa/src/exec/block/mod.rs
+++ b/boa/src/exec/block/mod.rs
@@ -16,7 +16,9 @@ impl Executable for Block {
             )));
         }
 
-        let mut obj = Value::null();
+        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+        // The return value is uninitialized, which means it defaults to Value::Undefined
+        let mut obj = Value::default();
         for statement in self.statements() {
             obj = statement.run(interpreter)?;
 

--- a/boa/src/exec/statement_list.rs
+++ b/boa/src/exec/statement_list.rs
@@ -6,7 +6,7 @@ use crate::{builtins::value::Value, syntax::ast::node::StatementList, BoaProfile
 impl Executable for StatementList {
     fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("StatementList", "exec");
-        let mut obj = Value::null();
+        let mut obj = Value::default();
         interpreter.set_current_state(InterpreterState::Executing);
         for (i, item) in self.statements().iter().enumerate() {
             let val = item.run(interpreter)?;

--- a/boa/src/exec/statement_list.rs
+++ b/boa/src/exec/statement_list.rs
@@ -6,6 +6,9 @@ use crate::{builtins::value::Value, syntax::ast::node::StatementList, BoaProfile
 impl Executable for StatementList {
     fn run(&self, interpreter: &mut Interpreter) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("StatementList", "exec");
+
+        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+        // The return value is uninitialized, which means it defaults to Value::Undefined
         let mut obj = Value::default();
         interpreter.set_current_state(InterpreterState::Executing);
         for (i, item) in self.statements().iter().enumerate() {

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -16,6 +16,12 @@ fn function_declaration_returns_undefined() {
 }
 
 #[test]
+fn empty_function_returns_undefined() {
+    let scenario = "(function () {}) ()";
+    assert_eq!(&exec(scenario), "undefined");
+}
+
+#[test]
 fn property_accessor_member_expression_dot_notation_on_string_literal() {
     let scenario = r#"
         typeof 'asd'.matchAll;
@@ -1204,4 +1210,10 @@ fn comma_operator() {
         a
     "#;
     assert_eq!(&exec(scenario), "2");
+}
+
+#[test]
+fn test_result_of_empty_block() {
+    let scenario = "{}";
+    assert_eq!(&exec(scenario), "undefined");
 }


### PR DESCRIPTION
This PR changes the default result of `statement_list` from `null` to `undefined`.