### PR TITLE
Fix undefined constant expression evaluation

### DIFF
--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -372,6 +372,7 @@ impl Executable for Node {
             Node::Const(Const::Num(num)) => Ok(Value::rational(num)),
             Node::Const(Const::Int(num)) => Ok(Value::integer(num)),
             Node::Const(Const::BigInt(ref num)) => Ok(Value::from(num.clone())),
+            Node::Const(Const::Undefined) => Ok(Value::Undefined),
             // we can't move String from Const into value, because const is a garbage collected value
             // Which means Drop() get's called on Const, but str will be gone at that point.
             // Do Const values need to be garbage collected? We no longer need them once we've generated Values
@@ -410,7 +411,8 @@ impl Executable for Node {
             }
             Node::Try(ref try_node) => try_node.run(interpreter),
             Node::Break(ref break_node) => break_node.run(interpreter),
-            ref i => unimplemented!("{:?}", i),
+            Node::ConditionalOp(_) => unimplemented!("ConditionalOp"),
+            Node::Continue(_) => unimplemented!("Continue"),
         }
     }
 }

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -770,9 +770,7 @@ mod in_operator {
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut engine, "Foo").unwrap();
         let foo_obj = foo_val.as_object().unwrap();
-        assert!(bar_obj
-            .prototype()
-            .strict_equals(&foo_obj.get_field("prototype").unwrap()));
+        assert!(bar_obj.prototype().strict_equals(&foo_obj.get_field("prototype").unwrap()));
     }
 }
 

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -770,7 +770,9 @@ mod in_operator {
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut engine, "Foo").unwrap();
         let foo_obj = foo_val.as_object().unwrap();
-        assert!(bar_obj.prototype().strict_equals(&foo_obj.get_field("prototype").unwrap()));
+        assert!(bar_obj
+            .prototype()
+            .strict_equals(&foo_obj.get_field("prototype").unwrap()));
     }
 }
 
@@ -1219,4 +1221,16 @@ fn comma_operator() {
 fn test_result_of_empty_block() {
     let scenario = "{}";
     assert_eq!(&exec(scenario), "undefined");
+}
+
+#[test]
+fn test_undefined_constant() {
+    let scenario = "undefined";
+    assert_eq!(&exec(scenario), "undefined");
+}
+
+#[test]
+fn test_undefined_type() {
+    let scenario = "typeof undefined";
+    assert_eq!(&exec(scenario), "\"undefined\"");
 }

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -770,7 +770,9 @@ mod in_operator {
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut engine, "Foo").unwrap();
         let foo_obj = foo_val.as_object().unwrap();
-        assert!(bar_obj.prototype().strict_equals(&foo_obj.get_field("prototype").unwrap()));
+        assert!(bar_obj
+            .prototype()
+            .strict_equals(&foo_obj.get_field("prototype").unwrap()));
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #644 and #631.

It changes the following:
 - Adds support for `undefined` expr
 - Makes the `Node` match exhaustive (I have `ConditionalOp` and `Continue` as a local WIP, but they don't really belong in this PR)

