### PR TITLE
Test + fmt fix

### DIFF
--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -966,7 +966,7 @@ fn to_length() {
     assert_eq!(
         Value::number(100000000000.0)
             .to_length(&mut engine)
-            .unwrap() as u128,
+            .unwrap() as u64,
         100000000000
     );
     assert_eq!(

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -769,10 +769,9 @@ mod in_operator {
         let bar_val = forward_val(&mut engine, "bar").unwrap();
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut engine, "Foo").unwrap();
-        let foo_obj = foo_val.as_object().unwrap();
         assert!(bar_obj
             .prototype()
-            .strict_equals(&foo_obj.get_field("prototype").unwrap()));
+            .strict_equals(&foo_val.get_field("prototype")));
     }
 }
 
@@ -967,7 +966,7 @@ fn to_length() {
     assert_eq!(
         Value::number(100000000000.0)
             .to_length(&mut engine)
-            .unwrap(),
+            .unwrap() as u128,
         100000000000
     );
     assert_eq!(


### PR DESCRIPTION
The last few PR's introduced a failing test + a rust fmt issue.

Note the 'as u128' is because usize cannot fit the value 100000000000 in all environments.

This should fix both but I'm a little unsure about the test so it would be great if you could check it @HalidOdat ?