### PR TITLE
Fixes unit test for `builtins::tests::expm1`. #652

### DIFF
--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -305,7 +305,7 @@ fn expm1() {
 
     assert_eq!(a, String::from("NaN"));
     assert_eq!(b, String::from("NaN"));
-    assert_eq!(c.to_number(&mut engine).unwrap(), 1.718_281_828_459_045);
+    assert_eq!(c.to_number(&mut engine).unwrap(), 1.718_281_828_459_045_3);
     assert_eq!(d.to_number(&mut engine).unwrap(), -0.632_120_558_828_557_7);
     assert_eq!(e.to_number(&mut engine).unwrap(), 0_f64);
     assert_eq!(f.to_number(&mut engine).unwrap(), 6.389_056_098_930_65);


### PR DESCRIPTION
Adds extra digit for test cast c, so cargo test no longer fails.

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #652.

It changes the following:
 - Modifies testcase c for `expm` implementation for extra digit of precision.

