### PR TITLE
Move `require_object_coercible` to `Value`

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -199,7 +199,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.concat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat
     pub(crate) fn concat(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let object = ctx.require_object_coercible(this)?;
+        let object = this.require_object_coercible(ctx)?;
         let mut string = object.to_string(ctx)?.to_string();
 
         for arg in args {
@@ -221,7 +221,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.repeat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat
     pub(crate) fn repeat(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let object = ctx.require_object_coercible(this)?;
+        let object = this.require_object_coercible(ctx)?;
         let string = object.to_string(ctx)?;
 
         if let Some(arg) = args.get(0) {
@@ -563,7 +563,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.indexof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf
     pub(crate) fn index_of(this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let this = ctx.require_object_coercible(this)?;
+        let this = this.require_object_coercible(ctx)?;
         let string = this.to_string(ctx)?;
 
         let search_string = args
@@ -610,7 +610,7 @@ impl String {
         args: &[Value],
         ctx: &mut Interpreter,
     ) -> Result<Value> {
-        let this = ctx.require_object_coercible(this)?;
+        let this = this.require_object_coercible(ctx)?;
         let string = this.to_string(ctx)?;
 
         let search_string = args
@@ -776,7 +776,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trim
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
     pub(crate) fn trim(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let this = ctx.require_object_coercible(this)?;
+        let this = this.require_object_coercible(ctx)?;
         let string = this.to_string(ctx)?;
         Ok(Value::from(
             string.trim_matches(Self::is_trimmable_whitespace),
@@ -796,7 +796,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trimstart
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart
     pub(crate) fn trim_start(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let this = ctx.require_object_coercible(this)?;
+        let this = this.require_object_coercible(ctx)?;
         let string = this.to_string(ctx)?;
         Ok(Value::from(
             string.trim_start_matches(Self::is_trimmable_whitespace),
@@ -816,7 +816,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trimend
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd
     pub(crate) fn trim_end(this: &Value, _: &[Value], ctx: &mut Interpreter) -> Result<Value> {
-        let this = ctx.require_object_coercible(this)?;
+        let this = this.require_object_coercible(ctx)?;
         let string = this.to_string(ctx)?;
         Ok(Value::from(
             string.trim_end_matches(Self::is_trimmable_whitespace),

--- a/boa/src/builtins/value/mod.rs
+++ b/boa/src/builtins/value/mod.rs
@@ -916,6 +916,26 @@ impl Value {
         }
         primitive.to_number(ctx)
     }
+
+    /// Check if the `Value` can be converted to an `Object`
+    ///
+    /// The abstract operation `RequireObjectCoercible` takes argument argument.
+    /// It throws an error if argument is a value that cannot be converted to an Object using `ToObject`.
+    /// It is defined by [Table 15][table]
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [table]: https://tc39.es/ecma262/#table-14
+    /// [spec]: https://tc39.es/ecma262/#sec-requireobjectcoercible
+    #[inline]
+    pub fn require_object_coercible<'a>(&'a self, ctx: &mut Interpreter) -> Result<&'a Value> {
+        if self.is_null_or_undefined() {
+            Err(ctx.construct_type_error("cannot convert null or undefined to Object"))
+        } else {
+            Ok(self)
+        }
+    }
 }
 
 impl Default for Value {

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -333,26 +333,6 @@ impl Interpreter {
         &self.state
     }
 
-    /// Check if the `Value` can be converted to an `Object`
-    ///
-    /// The abstract operation `RequireObjectCoercible` takes argument argument.
-    /// It throws an error if argument is a value that cannot be converted to an Object using `ToObject`.
-    /// It is defined by [Table 15][table]
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [table]: https://tc39.es/ecma262/#table-14
-    /// [spec]: https://tc39.es/ecma262/#sec-requireobjectcoercible
-    #[inline]
-    pub fn require_object_coercible<'a>(&mut self, value: &'a Value) -> Result<&'a Value> {
-        if value.is_null_or_undefined() {
-            Err(self.construct_type_error("cannot convert null or undefined to Object"))
-        } else {
-            Ok(value)
-        }
-    }
-
     /// A helper function for getting a immutable reference to the `console` object.
     pub(crate) fn console(&self) -> &Console {
         &self.console


### PR DESCRIPTION
This is something I missed when I was moving the methods in #625 , like `to_string()` this is a value operation so it belongs in `Value` .

It changes the following:
 - Move `Interpreter::require_object_coercible` to `Value::require_object_coercible`
