### PR TITLE
Cache standard objects

### DIFF
--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -502,10 +502,9 @@ impl Console {
     /// Initialise the `console` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let console = Value::new_object(Some(global));
+        let console = interpreter.construct_object().into();
 
         make_builtin_fn(Self::assert, "assert", &console, 0, interpreter);
         make_builtin_fn(Self::clear, "clear", &console, 0, interpreter);

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -1243,10 +1243,9 @@ impl Date {
     /// Initialise the `Date` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype = interpreter.construct_object().into();
 
         make_builtin_fn(
             getter_method!(get_date),
@@ -1555,7 +1554,7 @@ impl Date {
             Self::NAME,
             Self::LENGTH,
             Self::make_date,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -82,10 +82,9 @@ impl Error {
     /// Initialise the global object with the `Error` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         prototype.set_field("name", Self::NAME);
         prototype.set_field("message", "");
 
@@ -95,7 +94,7 @@ impl Error {
             Self::NAME,
             Self::LENGTH,
             Self::make_error,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -62,10 +62,9 @@ impl RangeError {
     /// Initialise the global object with the `RangeError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         prototype.set_field("name", Self::NAME);
         prototype.set_field("message", "");
 
@@ -75,7 +74,7 @@ impl RangeError {
             Self::NAME,
             Self::LENGTH,
             Self::make_error,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -60,10 +60,9 @@ impl ReferenceError {
 
     /// Initialise the global object with the `ReferenceError` object.
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         prototype.set_field("name", Self::NAME);
         prototype.set_field("message", "");
 
@@ -73,7 +72,7 @@ impl ReferenceError {
             Self::NAME,
             Self::LENGTH,
             Self::make_error,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -64,10 +64,9 @@ impl SyntaxError {
     /// Initialise the global object with the `SyntaxError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         prototype.set_field("name", Self::NAME);
         prototype.set_field("message", "");
 
@@ -77,7 +76,7 @@ impl SyntaxError {
             Self::NAME,
             Self::LENGTH,
             Self::make_error,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -67,10 +67,9 @@ impl TypeError {
     /// Initialise the global object with the `RangeError` object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         prototype.set_field("name", Self::NAME);
         prototype.set_field("message", "");
 
@@ -80,7 +79,7 @@ impl TypeError {
             Self::NAME,
             Self::LENGTH,
             Self::make_error,
-            global,
+            interpreter,
             prototype,
             true,
             true,

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -182,9 +182,8 @@ impl Json {
     /// Initialise the `JSON` object on the global object.
     #[inline]
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-        let json = Value::new_object(Some(global));
+        let json: Value = interpreter.construct_object().into();
 
         make_builtin_fn(Self::parse, "parse", &json, 2, interpreter);
         make_builtin_fn(Self::stringify, "stringify", &json, 3, interpreter);

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -7,7 +7,7 @@ use crate::{
         property::{Attribute, Property},
         value::Value,
     },
-    exec::Interpreter,
+    exec::{Interpreter, StandardConstructor},
     BoaProfiler, Result,
 };
 use ordered_map::OrderedMap;
@@ -285,11 +285,10 @@ impl Map {
 
     /// Initialise the `Map` object on the global object.
     pub(crate) fn init(interpreter: &mut Interpreter) -> (&'static str, Value) {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
 
         make_builtin_fn(Self::set, "set", &prototype, 2, interpreter);
         make_builtin_fn(Self::delete, "delete", &prototype, 1, interpreter);
@@ -302,11 +301,14 @@ impl Map {
             Self::NAME,
             Self::LENGTH,
             Self::make_map,
-            global,
-            prototype,
+            interpreter,
+            prototype.clone(),
             true,
             false,
         );
+
+        interpreter.standard_objects.map =
+            StandardConstructor::new(map_object.unwrap_object(), prototype.unwrap_object());
 
         (Self::NAME, map_object)
     }

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -639,9 +639,8 @@ impl Math {
 
     /// Create a new `Math` object
     pub(crate) fn create(interpreter: &mut Interpreter) -> Value {
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event("math:create", "init");
-        let math = Value::new_object(Some(global));
+        let math: Value = interpreter.construct_object().into();
 
         {
             let mut properties = math.as_object_mut().unwrap();

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -142,3 +142,20 @@ fn object_property_is_enumerable() {
     );
     assert_eq!(forward(&mut engine, r#"x.propertyIsEnumerable()"#), "false",)
 }
+
+#[test]
+fn custom() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    assert_eq!(
+        forward(&mut engine, r#"Object.getPrototypeOf(Object.prototype)"#),
+        "null"
+    );
+    assert_eq!(
+        forward(
+            &mut engine,
+            r#"Object.getPrototypeOf(Function.prototype) === Object.prototype"#
+        ),
+        "true"
+    );
+}

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -20,7 +20,7 @@ use crate::{
         value::{RcString, Value},
         RegExp,
     },
-    exec::Interpreter,
+    exec::{Interpreter, StandardConstructor},
     BoaProfiler, Result,
 };
 use regex::Regex;
@@ -1034,8 +1034,7 @@ impl String {
 
         // Create `String` `prototype`
 
-        let global = interpreter.global();
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
         let length = Property::default().value(Value::from(0));
 
         prototype.set_property("length", length);
@@ -1087,11 +1086,15 @@ impl String {
             Self::NAME,
             Self::LENGTH,
             Self::make_string,
-            global,
-            prototype,
+            interpreter,
+            prototype.clone(),
             true,
             true,
         );
+
+        // Set standard object
+        interpreter.standard_objects.string =
+            StandardConstructor::new(string_object.unwrap_object(), prototype.unwrap_object());
 
         (Self::NAME, string_object)
     }

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -24,7 +24,7 @@ use crate::{
         property::{Attribute, Property},
         value::{RcString, RcSymbol, Value},
     },
-    exec::Interpreter,
+    exec::{Interpreter, StandardConstructor},
     BoaProfiler, Result,
 };
 use gc::{Finalize, Trace};
@@ -131,11 +131,10 @@ impl Symbol {
         let symbol_to_string_tag = interpreter.construct_symbol(Some("Symbol.toStringTag".into()));
         let symbol_unscopables = interpreter.construct_symbol(Some("Symbol.unscopables".into()));
 
-        let global = interpreter.global();
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype object
-        let prototype = Value::new_object(Some(global));
+        let prototype: Value = interpreter.construct_object().into();
 
         make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
 
@@ -143,8 +142,8 @@ impl Symbol {
             Self::NAME,
             Self::LENGTH,
             Self::call,
-            global,
-            prototype,
+            interpreter,
+            prototype.clone(),
             false,
             true,
         );
@@ -206,6 +205,9 @@ impl Symbol {
             );
         }
 
+        // Set standard object
+        interpreter.standard_objects.symbol =
+            StandardConstructor::new(symbol_object.unwrap_object(), prototype.unwrap_object());
         (Self::NAME, symbol_object)
     }
 }


### PR DESCRIPTION
This PR attempts to fix #613.

- Following structures have been added (as suggested by @HalidOdat):
```Rust
// Cache constructor object (function Object()), etc
struct StandardConstructor {
    pub constructor: GcObject,
    pub prototype: GcObject
}
// Cache standard objects such as constructors
struct StandardObjects {
    pub object: StandardConstructor,
    pub function: StandardConstructor,
    // And so on..
}
```
- Interpreter now has a field `standard_objects` of type `StandardObjects`.
    - This way, global lookups can be eliminated wherever `Interpreter` is in scope.
- Method `unwrap_object` has been added to fetch the `GcObject` in `Value`.

Every builtin sets its cache field (in `interpreter.standard_objects`) in their `init` functions.