### PR TITLE
Add documentation to `GcObject` methods

### DIFF
--- a/boa/src/builtins/object/gcobject.rs
+++ b/boa/src/builtins/object/gcobject.rs
@@ -24,7 +24,7 @@ use std::{
 /// A wrapper type for an immutably borrowed `Object`.
 pub type Ref<'object> = GcCellRef<'object, Object>;
 
-/// A wrapper type for an mutably borrowed `Object`.
+/// A wrapper type for a mutably borrowed `Object`.
 pub type RefMut<'object> = GcCellRefMut<'object, Object>;
 
 /// Garbage collected `Object`.

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -36,7 +36,7 @@ mod gcobject;
 mod internal_methods;
 mod iter;
 
-pub use gcobject::GcObject;
+pub use gcobject::{GcObject, Ref, RefMut};
 pub use iter::*;
 
 #[cfg(test)]


### PR DESCRIPTION
It changes the following:
 - Added documentation to `GcObject` methods
 - Added type aliases `Ref` and `RefMut` to abstract the gc.
