### PR TITLE
Added approx_eq! macro for expm1 tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ dependencies = [
  "bitflags",
  "chrono",
  "criterion",
+ "float-cmp",
  "gc",
  "indexmap",
  "jemallocator",
@@ -344,6 +345,15 @@ name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "fs_extra"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -26,6 +26,7 @@ bitflags = "1.2.1"
 indexmap = "1.4.0"
 ryu-js = "0.2.0"
 chrono = "0.4"
+float-cmp = { version = "0.8.0", features = ["std"] }
 
 # Optional Dependencies
 serde = { version = "1.0.114", features = ["derive"], optional = true }

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -26,7 +26,7 @@ bitflags = "1.2.1"
 indexmap = "1.4.0"
 ryu-js = "0.2.0"
 chrono = "0.4"
-float-cmp = { version = "0.8.0", features = ["std"] }
+float-cmp = "0.8.0"
 
 # Optional Dependencies
 serde = { version = "1.0.114", features = ["derive"], optional = true }

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -26,7 +26,6 @@ bitflags = "1.2.1"
 indexmap = "1.4.0"
 ryu-js = "0.2.0"
 chrono = "0.4"
-float-cmp = "0.8.0"
 
 # Optional Dependencies
 serde = { version = "1.0.114", features = ["derive"], optional = true }
@@ -35,6 +34,7 @@ once_cell = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 criterion = "=0.3.2"
+float-cmp = "0.8.0"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 jemallocator = "0.3.2"

--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -706,22 +706,20 @@ fn sqrt() {
     assert_eq!(c.to_number(&mut engine).unwrap(), 3_f64);
 }
 
-// TODO: Precision is always off between ci and local. We proably need a better way to compare floats anyways
+#[test]
+fn tan() {
+    let realm = Realm::create();
+    let mut engine = Interpreter::new(realm);
+    let init = r#"
+        var a = Math.tan(1.1);
+        "#;
 
-// #[test]
-// fn tan() {
-//     let realm = Realm::create();
-//     let mut engine = Interpreter::new(realm);
-//     let init = r#"
-//         var a = Math.tan(1.1);
-//         "#;
+    eprintln!("{}", forward(&mut engine, init));
 
-//     eprintln!("{}", forward(&mut engine, init));
+    let a = forward_val(&mut engine, "a").unwrap();
 
-//     let a = forward_val(&mut engine, "a").unwrap();
-
-//     assert_eq!(a.to_number(), f64::from(1.964_759_657_248_652_5));
-// }
+    assert!(float_cmp::approx_eq!(f64, a.to_number(&mut engine).unwrap(), f64::from(1.964_759_657_248_652_5)));
+}
 
 #[test]
 fn tanh() {

--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -718,7 +718,11 @@ fn tan() {
 
     let a = forward_val(&mut engine, "a").unwrap();
 
-    assert!(float_cmp::approx_eq!(f64, a.to_number(&mut engine).unwrap(), f64::from(1.964_759_657_248_652_5)));
+    assert!(float_cmp::approx_eq!(
+        f64,
+        a.to_number(&mut engine).unwrap(),
+        f64::from(1.964_759_657_248_652_5)
+    ));
 }
 
 #[test]

--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -305,10 +305,26 @@ fn expm1() {
 
     assert_eq!(a, String::from("NaN"));
     assert_eq!(b, String::from("NaN"));
-    assert_eq!(c.to_number(&mut engine).unwrap(), 1.718_281_828_459_045);
-    assert_eq!(d.to_number(&mut engine).unwrap(), -0.632_120_558_828_557_7);
-    assert_eq!(e.to_number(&mut engine).unwrap(), 0_f64);
-    assert_eq!(f.to_number(&mut engine).unwrap(), 6.389_056_098_930_65);
+    assert!(float_cmp::approx_eq!(
+        f64,
+        c.to_number(&mut engine).unwrap(),
+        1.718_281_828_459_045
+    ));
+    assert!(float_cmp::approx_eq!(
+        f64,
+        d.to_number(&mut engine).unwrap(),
+        -0.632_120_558_828_557_7
+    ));
+    assert!(float_cmp::approx_eq!(
+        f64,
+        e.to_number(&mut engine).unwrap(),
+        0_f64
+    ));
+    assert!(float_cmp::approx_eq!(
+        f64,
+        f.to_number(&mut engine).unwrap(),
+        6.389_056_098_930_65
+    ));
 }
 
 #[test]


### PR DESCRIPTION
Added approx_eq! macro for expm1 tests due to floating point arithmetic
inaccuracies, using default ULP & epsilon values. approx_eq! macro does
not work for NaN values, however, for tests this should be okay anyway!
Solves #664.

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #664.

It changes the following:
 - `builtins::math::tests::expm1` strict equals assertion to approx_eq assertion
