### PR TITLE
Fix panic when calling function that mutates itself

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -20,12 +20,15 @@ use crate::{
     },
     environment::lexical_environment::Environment,
     exec::Interpreter,
-    syntax::ast::node::{FormalParameter, StatementList},
+    syntax::ast::node::{FormalParameter, RcStatementList},
     BoaProfiler, Result,
 };
 use bitflags::bitflags;
 use gc::{unsafe_empty_trace, Finalize, Trace};
 use std::fmt::{self, Debug};
+
+#[cfg(test)]
+mod tests;
 
 /// _fn(this, arguments, ctx) -> Result<Value>_ - The signature of a built-in function
 pub type NativeFunction = fn(&Value, &[Value], &mut Interpreter) -> Result<Value>;
@@ -102,7 +105,7 @@ pub enum Function {
     BuiltIn(BuiltInFunction, FunctionFlags),
     Ordinary {
         flags: FunctionFlags,
-        body: StatementList,
+        body: RcStatementList,
         params: Box<[FormalParameter]>,
         environment: Environment,
     },

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     realm::Realm,
     syntax::ast::{
         constant::Const,
-        node::{FormalParameter, Node, StatementList},
+        node::{FormalParameter, Node, RcStatementList, StatementList},
     },
     BoaProfiler, Result,
 };
@@ -141,7 +141,7 @@ impl Interpreter {
         let params_len = params.len();
         let func = Function::Ordinary {
             flags,
-            body: body.into(),
+            body: RcStatementList::from(body.into()),
             params,
             environment: self.realm.environment.get_current_environment().clone(),
         };

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -35,7 +35,7 @@ pub use self::{
     operator::{Assign, BinOp, UnaryOp},
     return_smt::Return,
     spread::Spread,
-    statement_list::StatementList,
+    statement_list::{RcStatementList, StatementList},
     switch::{Case, Switch},
     throw::Throw,
     try_node::{Catch, Finally, Try},


### PR DESCRIPTION
Fixes #663 

This commit fixes the panic when a function mutates itself. The issue happens since we borrow the object and when we call the statementList of the object we borrow_mut the object again to mutate it.
It changes the following:
 - This adds a RcStatementList to cheaply clone StatementList
 - It calls the run on the body of the function after dropping the first borrow by returning only the body after setting up the function local env

Thank you @HalidOdat for their help 😃 
