### PR TITLE
Add `#[track_caller]` to `GcObject` methods that can panic

### DIFF
--- a/boa/src/builtins/object/gcobject.rs
+++ b/boa/src/builtins/object/gcobject.rs
@@ -47,6 +47,7 @@ impl GcObject {
     ///# Panics
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[track_caller]
     pub fn borrow(&self) -> Ref<'_> {
         self.try_borrow().expect("Object already mutably borrowed")
     }
@@ -59,6 +60,7 @@ impl GcObject {
     ///# Panics
     /// Panics if the object is currently borrowed.
     #[inline]
+    #[track_caller]
     pub fn borrow_mut(&self) -> RefMut<'_> {
         self.try_borrow_mut().expect("Object already borrowed")
     }
@@ -97,6 +99,7 @@ impl GcObject {
     /// Panics if the object is currently mutably borrowed.
     // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
+    #[track_caller]
     pub fn call(&self, this: &Value, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let this_function_object = self.clone();
         let object = self.borrow();
@@ -172,6 +175,7 @@ impl GcObject {
     ///# Panics
     /// Panics if the object is currently mutably borrowed.
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
+    #[track_caller]
     pub fn construct(&self, args: &[Value], ctx: &mut Interpreter) -> Result<Value> {
         let this = Object::create(self.borrow().get(&PROTOTYPE.into())).into();
 


### PR DESCRIPTION
It changes the following:
 - Added `#[track_caller]` to `GcObject` methods that panic. This should make finding borrow error much easier.
