### PR TITLE
Formats dependabot.yml with Prettier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,27 @@
 ---
 version: 2
 updates:
-        - package-ecosystem: "npm"
-          directory: "/"
-          schedule:
-                  interval: "daily"
-        - package-ecosystem: "github-actions"
-          directory: "/"
-          schedule:
-                  interval: "daily"
-        - package-ecosystem: "cargo"
-          directory: "/"
-          schedule:
-                  interval: "daily"
-        - package-ecosystem: "cargo"
-          directory: "/boa/"
-          schedule:
-                  interval: "daily"
-        - package-ecosystem: "cargo"
-          directory: "/boa_cli/"
-          schedule:
-                  interval: "daily"
-        - package-ecosystem: "cargo"
-          directory: "/boa_wasm/"
-          schedule:
-                  interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/boa/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/boa_cli/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/boa_wasm/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Should stop webassembly CI from failing.

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes CI failing in latest push