### PR TITLE
Dependabot for `boa_tester`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,7 @@ updates:
     directory: "/boa_wasm/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "cargo"
+    directory: "/boa_tester/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Added `boa_tester` to `dependabot.yml` so dependabot can monitor its dependencies.