### PR TITLE
Feat: Rename Object::prototype() and Object::set_prototype()

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -42,14 +42,17 @@ impl Array {
                 .expect("Could not get global object"),
         ));
         array.set_data(ObjectData::Array);
-        array.as_object_mut().expect("array object").set_prototype(
-            interpreter
-                .realm()
-                .environment
-                .get_binding_value("Array")
-                .expect("Array was not initialized")
-                .get_field(PROTOTYPE),
-        );
+        array
+            .as_object_mut()
+            .expect("array object")
+            .set_prototype_instance(
+                interpreter
+                    .realm()
+                    .environment
+                    .get_binding_value("Array")
+                    .expect("Array was not initialized")
+                    .get_field(PROTOTYPE),
+            );
         array.set_field("length", Value::from(0));
         Ok(array)
     }
@@ -108,7 +111,7 @@ impl Array {
 
         this.as_object_mut()
             .expect("this should be an array object")
-            .set_prototype(prototype);
+            .set_prototype_instance(prototype);
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Array);

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -59,7 +59,11 @@ fn instances_have_correct_proto_set() {
     let bool_prototype = forward_val(&mut engine, "boolProto").expect("value expected");
 
     assert!(same_value(
-        &bool_instance.as_object().unwrap().prototype().clone(),
+        &bool_instance
+            .as_object()
+            .unwrap()
+            .prototype_instance()
+            .clone(),
         &bool_prototype
     ));
 }

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -270,13 +270,13 @@ fn json_parse_sets_prototypes() {
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype()
+        .prototype_instance()
         .clone();
     let array_prototype = forward_val(&mut engine, r#"jsonObj.arr"#)
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype()
+        .prototype_instance()
         .clone();
     let global_object_prototype = engine
         .global_object()

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -232,7 +232,7 @@ impl Map {
 
         this.as_object_mut()
             .expect("this is array object")
-            .set_prototype(prototype);
+            .set_prototype_instance(prototype);
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -82,16 +82,16 @@ impl Object {
     /// Get the `prototype` of an object.
     pub fn get_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
         let obj = args.get(0).expect("Cannot get object");
-        Ok(obj
-            .as_object()
-            .map_or_else(Value::undefined, |object| object.prototype().clone()))
+        Ok(obj.as_object().map_or_else(Value::undefined, |object| {
+            object.prototype_instance().clone()
+        }))
     }
 
     /// Set the `prototype` of an object.
     pub fn set_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
         let obj = args.get(0).expect("Cannot get object").clone();
         let proto = args.get(1).expect("Cannot get object").clone();
-        obj.as_object_mut().unwrap().set_prototype(proto);
+        obj.as_object_mut().unwrap().set_prototype_instance(proto);
         Ok(obj)
     }
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -333,13 +333,16 @@ impl Context {
                                 .expect("Could not get global object"),
                         ));
                         array.set_data(ObjectData::Array);
-                        array.as_object_mut().expect("object").set_prototype(
-                            self.realm()
-                                .environment
-                                .get_binding_value("Array")
-                                .expect("Array was not initialized")
-                                .get_field(PROTOTYPE),
-                        );
+                        array
+                            .as_object_mut()
+                            .expect("object")
+                            .set_prototype_instance(
+                                self.realm()
+                                    .environment
+                                    .get_binding_value("Array")
+                                    .expect("Array was not initialized")
+                                    .get_field(PROTOTYPE),
+                            );
                         array.set_field("0", key);
                         array.set_field("1", value);
                         array.set_field("length", Value::from(2));

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -759,7 +759,7 @@ mod in_operator {
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut engine, "Foo").unwrap();
         assert!(bar_obj
-            .prototype()
+            .prototype_instance()
             .strict_equals(&foo_val.get_field("prototype")));
     }
 }

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -392,11 +392,11 @@ impl Object {
         matches!(self.data, ObjectData::Ordinary)
     }
 
-    pub fn prototype(&self) -> &Value {
+    pub fn prototype_instance(&self) -> &Value {
         &self.prototype
     }
 
-    pub fn set_prototype(&mut self, prototype: Value) {
+    pub fn set_prototype_instance(&mut self, prototype: Value) {
         assert!(prototype.is_null() || prototype.is_object());
         self.prototype = prototype
     }

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -29,18 +29,18 @@ macro_rules! print_obj_value {
     (internals of $obj:expr, $display_fn:ident, $indent:expr, $encounters:expr) => {
         {
             let object = $obj.borrow();
-            if object.prototype().is_object() {
+            if object.prototype_instance().is_object() {
                 vec![format!(
                     "{:>width$}: {}",
                     "__proto__",
-                    $display_fn(object.prototype(), $encounters, $indent.wrapping_add(4), true),
+                    $display_fn(object.prototype_instance(), $encounters, $indent.wrapping_add(4), true),
                     width = $indent,
                 )]
             } else {
                 vec![format!(
                     "{:>width$}: {}",
                     "__proto__",
-                    object.prototype().display(),
+                    object.prototype_instance().display(),
                     width = $indent,
                 )]
             }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -168,7 +168,7 @@ impl Value {
     pub fn new_object_from_prototype(proto: Value, data: ObjectData) -> Self {
         let mut object = Object::default();
         object.data = data;
-        object.set_prototype(proto);
+        object.set_prototype_instance(proto);
         Self::object(object)
     }
 
@@ -472,7 +472,7 @@ impl Value {
                     return Some(property);
                 }
 
-                object.prototype().get_property(key)
+                object.prototype_instance().get_property(key)
             }
             _ => None,
         }


### PR DESCRIPTION
This Pull Request fixes/closes #607.

It changes the following:

- Rename `Object::prototype()` to `Object::prototype_instance()`
- Rename `Object::set_prototype()` to `Object::set_prototype_instance()`