### PR TITLE
Feature `gc` module

### DIFF
--- a/boa/examples/classes.rs
+++ b/boa/examples/classes.rs
@@ -1,7 +1,8 @@
 use boa::{
     class::{Class, ClassBuilder},
+    gc::{Finalize, Trace},
     property::Attribute,
-    Context, Finalize, Result, Trace, Value,
+    Context, Result, Value,
 };
 
 // We create a new struct that is going to represent a person.

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -5,7 +5,8 @@
 //!# use boa::{
 //!#    property::Attribute,
 //!#    class::{Class, ClassBuilder},
-//!#    Context, Finalize, Result, Trace, Value,
+//!#    gc::{Finalize, Trace},
+//!#    Context, Result, Value,
 //!# };
 //!#
 //! // This does not have to be an enum it can also be a struct.

--- a/boa/src/gc.rs
+++ b/boa/src/gc.rs
@@ -1,0 +1,11 @@
+//! This module represents the main way to interact with the garbacge collector.
+
+// This is because `rust-gc` unsafe_empty_trace has a `unsafe_`
+// when it should be `empty_trace`.
+#![allow(clippy::unsafe_removed_from_name)]
+
+pub use crate::object::GcObject;
+pub use ::gc::{
+    custom_trace, force_collect, unsafe_empty_trace as empty_trace, Finalize, GcCellRef as Ref,
+    GcCellRefMut as RefMut, Trace,
+};

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -38,6 +38,7 @@ pub mod builtins;
 pub mod class;
 pub mod environment;
 pub mod exec;
+pub mod gc;
 pub mod object;
 pub mod profiler;
 pub mod property;
@@ -50,7 +51,6 @@ mod context;
 use std::result::Result as StdResult;
 
 pub(crate) use crate::{exec::Executable, profiler::BoaProfiler};
-pub use gc::{custom_trace, unsafe_empty_trace, Finalize, Trace};
 
 // Export things to root level
 pub use crate::{context::Context, value::Value};


### PR DESCRIPTION
It changes the following:
 - Put the gc stuff in the `gc` module. This cleans the root imports and adds some other gc stuff in the `gc` module

Instead of this
```rust
boa::{Value, Result, Trace, Finalize};
```
we can do this:
```rust
boa::{
	gc::{Trace, Finalize},
	Value, Result,
};
```