### PR TITLE
Fix CI Commit failure

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -59,6 +59,7 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git pull
+          git add test262
           git commit -m "Add new test262 results" -a
           cd ..
       - name: Upload results


### PR DESCRIPTION
Unsure as to whether this should be committed or not, but should fix
failing CI

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:

- `test262.yml`'s commit section to add test262 as a tracked file
