### PR TITLE
fix Value::to_json order of items in array

### DIFF
--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -238,15 +238,23 @@ impl Value {
             Self::Boolean(b) => Ok(JSONValue::Bool(b)),
             Self::Object(ref obj) => {
                 if obj.borrow().is_array() {
-                    let mut arr: Vec<JSONValue> = Vec::new();
-                    for k in obj.borrow().keys() {
-                        if k != "length" {
-                            let value = self.get_field(k.to_string());
-                            if value.is_undefined() || value.is_function() || value.is_symbol() {
-                                arr.push(JSONValue::Null);
-                            } else {
-                                arr.push(self.get_field(k.to_string()).to_json(interpreter)?);
-                            }
+                    let len = obj
+                        .borrow()
+                        .keys()
+                        .into_iter()
+                        .filter(|k| match k {
+                            PropertyKey::Index(_) => true,
+                            _ => false,
+                        })
+                        .count();
+                    let mut arr: Vec<JSONValue> = Vec::with_capacity(len);
+                    for key in 0..len {
+                        let k = PropertyKey::Index(key as u32);
+                        let value = self.get_field(k);
+                        if value.is_undefined() || value.is_function() || value.is_symbol() {
+                            arr.push(JSONValue::Null);
+                        } else {
+                            arr.push(value.to_json(interpreter)?);
                         }
                     }
                     Ok(JSONValue::Array(arr))

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -238,19 +238,11 @@ impl Value {
             Self::Boolean(b) => Ok(JSONValue::Bool(b)),
             Self::Object(ref obj) => {
                 if obj.borrow().is_array() {
-                    let len = obj
-                        .borrow()
-                        .keys()
-                        .into_iter()
-                        .filter(|k| match k {
-                            PropertyKey::Index(_) => true,
-                            _ => false,
-                        })
-                        .count();
-                    let mut arr: Vec<JSONValue> = Vec::with_capacity(len);
-                    for key in 0..len {
-                        let k = PropertyKey::Index(key as u32);
-                        let value = self.get_field(k);
+                    let mut keys : Vec<u32> = obj.borrow().index_property_keys().cloned().collect();
+                    keys.sort();
+					let mut arr: Vec<JSONValue> = Vec::with_capacity(keys.len());
+                    for key in keys {
+                        let value = self.get_field(key);
                         if value.is_undefined() || value.is_function() || value.is_symbol() {
                             arr.push(JSONValue::Null);
                         } else {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -238,9 +238,9 @@ impl Value {
             Self::Boolean(b) => Ok(JSONValue::Bool(b)),
             Self::Object(ref obj) => {
                 if obj.borrow().is_array() {
-                    let mut keys : Vec<u32> = obj.borrow().index_property_keys().cloned().collect();
+                    let mut keys: Vec<u32> = obj.borrow().index_property_keys().cloned().collect();
                     keys.sort();
-					let mut arr: Vec<JSONValue> = Vec::with_capacity(keys.len());
+                    let mut arr: Vec<JSONValue> = Vec::with_capacity(keys.len());
                     for key in keys {
                         let value = self.get_field(key);
                         if value.is_undefined() || value.is_function() || value.is_symbol() {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #690.

It changes the following:
- preserve order of array items on Value::to_json
