### PR TITLE
Add support for >>>=

### DIFF
--- a/boa/src/exec/operator/mod.rs
+++ b/boa/src/exec/operator/mod.rs
@@ -173,6 +173,7 @@ impl BinOp {
             AssignOp::Xor => x.bitxor(&y, interpreter),
             AssignOp::Shl => x.shl(&y, interpreter),
             AssignOp::Shr => x.shr(&y, interpreter),
+            AssignOp::Ushr => x.ushr(&y, interpreter),
         }
     }
 }

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -938,7 +938,18 @@ pub enum AssignOp {
     /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators#Right_shift_assignment
     Shr,
-    // TODO: Add UShl (unsigned shift left).
+
+    /// The unsigned right shift assignment operator moves the specified amount of bits to the right and assigns the result to the variable.
+    ///
+    /// Syntax: `x >>>= y`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift_assignment
+    Ushr,
 }
 
 unsafe impl Trace for AssignOp {
@@ -962,6 +973,7 @@ impl Display for AssignOp {
                 Self::Xor => "^=",
                 Self::Shl => "<<=",
                 Self::Shr => ">>=",
+                Self::Ushr => ">>>=",
             }
         )
     }

--- a/boa/src/syntax/ast/punctuator.rs
+++ b/boa/src/syntax/ast/punctuator.rs
@@ -145,6 +145,7 @@ impl Punctuator {
             Self::AssignPow => Some(BinOp::Assign(AssignOp::Exp)),
             Self::AssignRightSh => Some(BinOp::Assign(AssignOp::Shr)),
             Self::AssignSub => Some(BinOp::Assign(AssignOp::Sub)),
+            Self::AssignURightSh => Some(BinOp::Assign(AssignOp::Ushr)),
             Self::AssignXor => Some(BinOp::Assign(AssignOp::Xor)),
             Self::Add => Some(BinOp::Num(NumOp::Add)),
             Self::Sub => Some(BinOp::Num(NumOp::Sub)),

--- a/boa/src/syntax/parser/expression/tests.rs
+++ b/boa/src/syntax/parser/expression/tests.rs
@@ -179,6 +179,10 @@ fn check_assign_operations() {
         vec![BinOp::new(AssignOp::Shr, Identifier::from("a"), Identifier::from("b")).into()],
     );
     check_parser(
+        "a >>>= b",
+        vec![BinOp::new(AssignOp::Ushr, Identifier::from("a"), Identifier::from("b")).into()],
+    );
+    check_parser(
         "a %= 10 / 2",
         vec![BinOp::new(
             AssignOp::Mod,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes #621 

It changes the following:

- Adds support for unsigned right shift assignment operator (>>>=)
- Adds a test for the operator
