### PR TITLE
Refactor: Value::to_object to return GcObject

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -960,7 +960,8 @@ impl Array {
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.reduce
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
     pub(crate) fn reduce(this: &Value, args: &[Value], interpreter: &mut Context) -> Result<Value> {
-        let this = this.to_object(interpreter)?;
+        let obj_this = this.to_object(interpreter)?;
+        let this = Value::Object(obj_this);
         let callback = match args.get(0) {
             Some(value) if value.is_function() => value,
             _ => return interpreter.throw_type_error("Reduce was called without a callback"),
@@ -1022,7 +1023,8 @@ impl Array {
         args: &[Value],
         interpreter: &mut Context,
     ) -> Result<Value> {
-        let this = this.to_object(interpreter)?;
+        let obj_this = this.to_object(interpreter)?;
+        let this = Value::Object(obj_this);
         let callback = match args.get(0) {
             Some(value) if value.is_function() => value,
             _ => return interpreter.throw_type_error("reduceRight was called without a callback"),

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -960,8 +960,7 @@ impl Array {
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.reduce
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
     pub(crate) fn reduce(this: &Value, args: &[Value], interpreter: &mut Context) -> Result<Value> {
-        let obj_this = this.to_object(interpreter)?;
-        let this = Value::Object(obj_this);
+        let this: Value = this.to_object(interpreter)?.into();
         let callback = match args.get(0) {
             Some(value) if value.is_function() => value,
             _ => return interpreter.throw_type_error("Reduce was called without a callback"),
@@ -1023,8 +1022,7 @@ impl Array {
         args: &[Value],
         interpreter: &mut Context,
     ) -> Result<Value> {
-        let obj_this = this.to_object(interpreter)?;
-        let this = Value::Object(obj_this);
+        let this: Value = this.to_object(interpreter)?.into();
         let callback = match args.get(0) {
             Some(value) if value.is_function() => value,
             _ => return interpreter.throw_type_error("reduceRight was called without a callback"),

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -33,7 +33,7 @@ impl Object {
     pub fn make_object(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         if let Some(arg) = args.get(0) {
             if !arg.is_null_or_undefined() {
-                return Ok(Value::Object(arg.to_object(ctx)?));
+                return Ok(arg.to_object(ctx)?.into());
             }
         }
         let global = ctx.global_object();
@@ -60,9 +60,10 @@ impl Object {
         }
 
         match prototype {
-            Value::Object(_) | Value::Null => Ok(Value::Object(
-                BuiltinObject::new_object_from_prototype(prototype, ObjectData::Ordinary),
-            )),
+            Value::Object(_) | Value::Null => Ok(Value::object(BuiltinObject::with_prototype(
+                prototype,
+                ObjectData::Ordinary,
+            ))),
             _ => interpreter.throw_type_error(format!(
                 "Object prototype may only be an Object or null: {}",
                 prototype.display()

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     builtins::function::{make_builtin_fn, make_constructor_fn},
-    object::ObjectData,
+    object::{Object as BuiltinObject, ObjectData},
     property::Property,
     value::{same_value, Value},
     BoaProfiler, Context, Result,
@@ -33,7 +33,7 @@ impl Object {
     pub fn make_object(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         if let Some(arg) = args.get(0) {
             if !arg.is_null_or_undefined() {
-                return arg.to_object(ctx);
+                return Ok(Value::Object(arg.to_object(ctx)?));
             }
         }
         let global = ctx.global_object();
@@ -60,9 +60,8 @@ impl Object {
         }
 
         match prototype {
-            Value::Object(_) | Value::Null => Ok(Value::new_object_from_prototype(
-                prototype,
-                ObjectData::Ordinary,
+            Value::Object(_) | Value::Null => Ok(Value::Object(
+                BuiltinObject::new_object_from_prototype(prototype, ObjectData::Ordinary),
             )),
             _ => interpreter.throw_type_error(format!(
                 "Object prototype may only be an Object or null: {}",
@@ -160,11 +159,9 @@ impl Object {
         };
 
         let key = key.to_property_key(ctx)?;
-        let own_property = this.to_object(ctx).map(|obj| {
-            obj.as_object()
-                .expect("Unable to deref object")
-                .get_own_property(&key)
-        });
+        let own_property = this
+            .to_object(ctx)
+            .map(|obj| obj.borrow().get_own_property(&key));
 
         Ok(own_property.map_or(Value::from(false), |own_prop| {
             Value::from(own_prop.enumerable_or(false))

--- a/boa/src/exec/call/mod.rs
+++ b/boa/src/exec/call/mod.rs
@@ -12,7 +12,7 @@ impl Executable for Call {
             Node::GetConstField(ref get_const_field) => {
                 let mut obj = get_const_field.obj().run(interpreter)?;
                 if obj.get_type() != Type::Object {
-                    obj = obj.to_object(interpreter)?;
+                    obj = Value::Object(obj.to_object(interpreter)?);
                 }
                 (obj.clone(), obj.get_field(get_const_field.field()))
             }

--- a/boa/src/exec/field/mod.rs
+++ b/boa/src/exec/field/mod.rs
@@ -9,7 +9,7 @@ impl Executable for GetConstField {
     fn run(&self, interpreter: &mut Context) -> Result<Value> {
         let mut obj = self.obj().run(interpreter)?;
         if obj.get_type() != Type::Object {
-            obj = obj.to_object(interpreter)?;
+            obj = Value::Object(obj.to_object(interpreter)?);
         }
 
         Ok(obj.get_field(self.field()))
@@ -20,7 +20,7 @@ impl Executable for GetField {
     fn run(&self, interpreter: &mut Context) -> Result<Value> {
         let mut obj = self.obj().run(interpreter)?;
         if obj.get_type() != Type::Object {
-            obj = obj.to_object(interpreter)?;
+            obj = Value::Object(obj.to_object(interpreter)?);
         }
         let field = self.field().run(interpreter)?;
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -402,11 +402,12 @@ impl Object {
     }
 
     /// Similar to `Value::new_object`, but you can pass a prototype to create from, plus a kind
-    pub fn new_object_from_prototype(proto: Value, data: ObjectData) -> GcObject {
+    #[inline]
+    pub fn with_prototype(proto: Value, data: ObjectData) -> Object {
         let mut object = Object::default();
         object.data = data;
         object.set_prototype_instance(proto);
-        GcObject::new(object)
+        object
     }
 
     /// Returns `true` if it holds an Rust type that implements `NativeObject`.

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -401,6 +401,14 @@ impl Object {
         self.prototype = prototype
     }
 
+    /// Similar to `Value::new_object`, but you can pass a prototype to create from, plus a kind
+    pub fn new_object_from_prototype(proto: Value, data: ObjectData) -> GcObject {
+        let mut object = Object::default();
+        object.data = data;
+        object.set_prototype_instance(proto);
+        GcObject::new(object)
+    }
+
     /// Returns `true` if it holds an Rust type that implements `NativeObject`.
     pub fn is_native_object(&self) -> bool {
         matches!(self.data, ObjectData::NativeObject(_))

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -181,9 +181,8 @@ impl Value {
                     .global_object()
                     .get_field("Array")
                     .get_field(PROTOTYPE);
-                let new_obj_obj =
-                    Object::new_object_from_prototype(global_array_prototype, ObjectData::Array);
-                let new_obj = Value::Object(new_obj_obj);
+                let new_obj_obj = Object::with_prototype(global_array_prototype, ObjectData::Array);
+                let new_obj = Value::object(new_obj_obj);
                 let length = vs.len();
                 for (idx, json) in vs.into_iter().enumerate() {
                     new_obj.set_property(
@@ -679,10 +678,10 @@ impl Value {
                     .expect("Boolean was not initialized")
                     .get_field(PROTOTYPE);
 
-                Ok(Object::new_object_from_prototype(
+                Ok(GcObject::new(Object::with_prototype(
                     proto,
                     ObjectData::Boolean(*boolean),
-                ))
+                )))
             }
             Value::Integer(integer) => {
                 let proto = ctx
@@ -691,10 +690,10 @@ impl Value {
                     .get_binding_value("Number")
                     .expect("Number was not initialized")
                     .get_field(PROTOTYPE);
-                Ok(Object::new_object_from_prototype(
+                Ok(GcObject::new(Object::with_prototype(
                     proto,
                     ObjectData::Number(f64::from(*integer)),
-                ))
+                )))
             }
             Value::Rational(rational) => {
                 let proto = ctx
@@ -704,10 +703,10 @@ impl Value {
                     .expect("Number was not initialized")
                     .get_field(PROTOTYPE);
 
-                Ok(Object::new_object_from_prototype(
+                Ok(GcObject::new(Object::with_prototype(
                     proto,
                     ObjectData::Number(*rational),
-                ))
+                )))
             }
             Value::String(ref string) => {
                 let proto = ctx
@@ -717,10 +716,10 @@ impl Value {
                     .expect("String was not initialized")
                     .get_field(PROTOTYPE);
 
-                Ok(Object::new_object_from_prototype(
+                Ok(GcObject::new(Object::with_prototype(
                     proto,
                     ObjectData::String(string.clone()),
-                ))
+                )))
             }
             Value::Symbol(ref symbol) => {
                 let proto = ctx
@@ -730,10 +729,10 @@ impl Value {
                     .expect("Symbol was not initialized")
                     .get_field(PROTOTYPE);
 
-                Ok(Object::new_object_from_prototype(
+                Ok(GcObject::new(Object::with_prototype(
                     proto,
                     ObjectData::Symbol(symbol.clone()),
-                ))
+                )))
             }
             Value::BigInt(ref bigint) => {
                 let proto = ctx
@@ -742,8 +741,10 @@ impl Value {
                     .get_binding_value("BigInt")
                     .expect("BigInt was not initialized")
                     .get_field(PROTOTYPE);
-                let bigint_obj =
-                    Object::new_object_from_prototype(proto, ObjectData::BigInt(bigint.clone()));
+                let bigint_obj = GcObject::new(Object::with_prototype(
+                    proto,
+                    ObjectData::BigInt(bigint.clone()),
+                ));
                 Ok(bigint_obj)
             }
             Value::Object(gcobject) => Ok(gcobject.clone()),


### PR DESCRIPTION
This Pull Request starts the work on #577.

It changes the following:

- `Value::to_object` now returns `Result<GcObject>` rather than `Result<Value>`
- Move `Value::new_object_from_prototype` to `Object::new_object_from_prototype`
- Minor changes in other files to accomodate the new API

I assume those minor changes will be cleaned up once the separation of the `Object` and `Value` API is complete.