### PR TITLE
perf(boa): test ahash perf change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,7 @@
 name = "Boa"
 version = "0.9.0"
 dependencies = [
+ "ahash",
  "bitflags",
  "chrono",
  "criterion",
@@ -18,10 +19,18 @@ dependencies = [
  "once_cell",
  "rand",
  "regex",
- "rustc-hash",
  "ryu-js",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ahash"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0adac150c2dd5a9c864d054e07bda5e6bc010cd10036ea5f17e82a2f5867f735"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -222,6 +231,26 @@ dependencies = [
  "atty",
  "lazy_static",
  "winapi",
+]
+
+[[package]]
+name = "const-random"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f1af9ac737b2dd2d577701e59fd09ba34822f6f2ebdb30a7647405d9e55e16a"
+dependencies = [
+ "const-random-macro",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e4c606eb459dd29f7c57b2e0879f2b6f14ee130918c2b78ccb58a9624e6c7a"
+dependencies = [
+ "getrandom",
+ "proc-macro-hack",
 ]
 
 [[package]]
@@ -713,6 +742,12 @@ dependencies = [
  "quote",
  "version_check",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro2"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.57"
 rand = "0.7.3"
 num-traits = "0.2.12"
 regex = "1.3.9"
-rustc-hash = "1.1.0"
+ahash = { version = "0.4.5", features = ["std"] }
 num-bigint = { version = "0.3.0", features = ["serde"] }
 num-integer = "0.1.43"
 bitflags = "1.2.1"

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -131,8 +131,8 @@ pub fn formatter(data: &[Value], ctx: &mut Context) -> Result<String> {
 /// This is the internal console object state.
 #[derive(Debug, Default)]
 pub(crate) struct Console {
-    count_map: HashMap<RcString, u32>,
-    timer_map: HashMap<RcString, u128>,
+    count_map: HashMap<RcString, u32, ahash::RandomState>,
+    timer_map: HashMap<RcString, u128, ahash::RandomState>,
     groups: Vec<String>,
 }
 

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     value::{display_obj, RcString, Value},
     BoaProfiler, Context, Result,
 };
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 /// This represents the different types of log messages.
@@ -131,8 +131,8 @@ pub fn formatter(data: &[Value], ctx: &mut Context) -> Result<String> {
 /// This is the internal console object state.
 #[derive(Debug, Default)]
 pub(crate) struct Console {
-    count_map: FxHashMap<RcString, u32>,
-    timer_map: FxHashMap<RcString, u128>,
+    count_map: HashMap<RcString, u32>,
+    timer_map: HashMap<RcString, u128>,
     groups: Vec<String>,
 }
 

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -21,6 +21,7 @@ use crate::{
     value::{display_obj, RcString, Value},
     BoaProfiler, Context, Result,
 };
+use ahash::RandomState;
 use std::collections::HashMap;
 use std::time::SystemTime;
 
@@ -131,8 +132,8 @@ pub fn formatter(data: &[Value], ctx: &mut Context) -> Result<String> {
 /// This is the internal console object state.
 #[derive(Debug, Default)]
 pub(crate) struct Console {
-    count_map: HashMap<RcString, u32, ahash::RandomState>,
-    timer_map: HashMap<RcString, u128, ahash::RandomState>,
+    count_map: HashMap<RcString, u32, RandomState>,
+    timer_map: HashMap<RcString, u128, RandomState>,
     groups: Vec<String>,
 }
 

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -32,7 +32,7 @@ pub struct DeclarativeEnvironmentRecordBinding {
 /// declarations contained within its scope.
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct DeclarativeEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, ahash::RandomState>,
     pub outer_env: Option<Environment>,
 }
 

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -13,7 +13,7 @@ use crate::{
     Value,
 };
 use gc::{Finalize, Trace};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 /// Declarative Bindings have a few properties for book keeping purposes, such as mutability (const vs let).
 /// Can it be deleted? and strict mode.
@@ -32,7 +32,7 @@ pub struct DeclarativeEnvironmentRecordBinding {
 /// declarations contained within its scope.
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct DeclarativeEnvironmentRecord {
-    pub env_rec: FxHashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
     pub outer_env: Option<Environment>,
 }
 

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     Value,
 };
+use ahash::RandomState;
 use gc::{Finalize, Trace};
 use std::collections::HashMap;
 
@@ -32,7 +33,7 @@ pub struct DeclarativeEnvironmentRecordBinding {
 /// declarations contained within its scope.
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct DeclarativeEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, ahash::RandomState>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, RandomState>,
     pub outer_env: Option<Environment>,
 }
 

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -17,6 +17,7 @@ use crate::{
     object::GcObject,
     Value,
 };
+use ahash::RandomState;
 use gc::{unsafe_empty_trace, Finalize, Trace};
 use std::collections::HashMap;
 
@@ -39,7 +40,7 @@ unsafe impl Trace for BindingStatus {
 /// <https://tc39.es/ecma262/#table-16>
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct FunctionEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, ahash::RandomState>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, RandomState>,
     /// This is the this value used for this invocation of the function.
     pub this_value: Value,
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -18,7 +18,7 @@ use crate::{
     Value,
 };
 use gc::{unsafe_empty_trace, Finalize, Trace};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 
 /// Different binding status for `this`.
 /// Usually set on a function environment record
@@ -39,7 +39,7 @@ unsafe impl Trace for BindingStatus {
 /// <https://tc39.es/ecma262/#table-16>
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct FunctionEnvironmentRecord {
-    pub env_rec: FxHashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
     /// This is the this value used for this invocation of the function.
     pub this_value: Value,
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -39,7 +39,7 @@ unsafe impl Trace for BindingStatus {
 /// <https://tc39.es/ecma262/#table-16>
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct FunctionEnvironmentRecord {
-    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding>,
+    pub env_rec: HashMap<String, DeclarativeEnvironmentRecordBinding, ahash::RandomState>,
     /// This is the this value used for this invocation of the function.
     pub this_value: Value,
     /// If the value is "lexical", this is an ArrowFunction and does not have a local this value.

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -17,6 +17,7 @@ use crate::{
     property::{Attribute, Property},
     Value,
 };
+use ahash::RandomState;
 use gc::{Finalize, Trace};
 use std::collections::HashSet;
 
@@ -25,7 +26,7 @@ pub struct GlobalEnvironmentRecord {
     pub object_record: ObjectEnvironmentRecord,
     pub global_this_binding: Value,
     pub declarative_record: DeclarativeEnvironmentRecord,
-    pub var_names: HashSet<String, ahash::RandomState>,
+    pub var_names: HashSet<String, RandomState>,
 }
 
 impl GlobalEnvironmentRecord {

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -18,14 +18,14 @@ use crate::{
     Value,
 };
 use gc::{Finalize, Trace};
-use rustc_hash::FxHashSet;
+use std::collections::HashSet;
 
 #[derive(Debug, Trace, Finalize, Clone)]
 pub struct GlobalEnvironmentRecord {
     pub object_record: ObjectEnvironmentRecord,
     pub global_this_binding: Value,
     pub declarative_record: DeclarativeEnvironmentRecord,
-    pub var_names: FxHashSet<String>,
+    pub var_names: HashSet<String>,
 }
 
 impl GlobalEnvironmentRecord {

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -25,7 +25,7 @@ pub struct GlobalEnvironmentRecord {
     pub object_record: ObjectEnvironmentRecord,
     pub global_this_binding: Value,
     pub declarative_record: DeclarativeEnvironmentRecord,
-    pub var_names: HashSet<String>,
+    pub var_names: HashSet<String, ahash::RandomState>,
 }
 
 impl GlobalEnvironmentRecord {

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -17,7 +17,7 @@ use crate::{
     BoaProfiler, Value,
 };
 use gc::{Gc, GcCell};
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
 use std::{collections::VecDeque, error, fmt};
 
 /// Environments are wrapped in a Box and then in a GC wrapper
@@ -218,7 +218,7 @@ impl LexicalEnvironment {
 pub fn new_declarative_environment(env: Option<Environment>) -> Environment {
     let _timer = BoaProfiler::global().start_event("new_declarative_environment", "env");
     let boxed_env = Box::new(DeclarativeEnvironmentRecord {
-        env_rec: FxHashMap::default(),
+        env_rec: HashMap::new(),
         outer_env: env,
     });
 
@@ -232,7 +232,7 @@ pub fn new_function_environment(
     binding_status: BindingStatus,
 ) -> Environment {
     let mut func_env = FunctionEnvironmentRecord {
-        env_rec: FxHashMap::default(),
+        env_rec: HashMap::new(),
         function: f,
         this_binding_status: binding_status,
         home_object: Value::undefined(),
@@ -273,7 +273,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
     };
 
     let dcl_rec = DeclarativeEnvironmentRecord {
-        env_rec: FxHashMap::default(),
+        env_rec: HashMap::new(),
         outer_env: None,
     };
 
@@ -281,7 +281,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: FxHashSet::default(),
+        var_names: HashSet::new(),
     })))
 }
 

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -16,6 +16,7 @@ use crate::{
     object::GcObject,
     BoaProfiler, Value,
 };
+use ahash::RandomState;
 use gc::{Gc, GcCell};
 use std::collections::{HashMap, HashSet};
 use std::{collections::VecDeque, error, fmt};
@@ -218,7 +219,7 @@ impl LexicalEnvironment {
 pub fn new_declarative_environment(env: Option<Environment>) -> Environment {
     let _timer = BoaProfiler::global().start_event("new_declarative_environment", "env");
     let boxed_env = Box::new(DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: HashMap::with_hasher(RandomState::new()),
         outer_env: env,
     });
 
@@ -232,7 +233,7 @@ pub fn new_function_environment(
     binding_status: BindingStatus,
 ) -> Environment {
     let mut func_env = FunctionEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: HashMap::with_hasher(RandomState::new()),
         function: f,
         this_binding_status: binding_status,
         home_object: Value::undefined(),
@@ -273,7 +274,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
     };
 
     let dcl_rec = DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: HashMap::with_hasher(RandomState::new()),
         outer_env: None,
     };
 
@@ -281,7 +282,7 @@ pub fn new_global_environment(global: Value, this_value: Value) -> Environment {
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: HashSet::new(),
+        var_names: HashSet::with_hasher(RandomState::new()),
     })))
 }
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     value::{RcBigInt, RcString, RcSymbol, Value},
     BoaProfiler,
 };
+use ahash::RandomState;
 use gc::{Finalize, Trace};
 use std::collections::HashMap;
 use std::fmt::{Debug, Display, Error, Formatter};
@@ -47,11 +48,11 @@ impl<T: Any + Debug + Trace> NativeObject for T {
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
-    indexed_properties: HashMap<u32, Property>,
+    indexed_properties: HashMap<u32, Property, RandomState>,
     /// Properties
-    string_properties: HashMap<RcString, Property>,
+    string_properties: HashMap<RcString, Property, RandomState>,
     /// Symbol Properties
-    symbol_properties: HashMap<RcSymbol, Property>,
+    symbol_properties: HashMap<RcSymbol, Property, RandomState>,
     /// Instance prototype `__proto__`.
     prototype: Value,
     /// Whether it can have new properties added to it.
@@ -108,9 +109,9 @@ impl Default for Object {
     fn default() -> Self {
         Self {
             data: ObjectData::Ordinary,
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }
@@ -129,9 +130,9 @@ impl Object {
 
         Self {
             data: ObjectData::Function(function),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype,
             extensible: true,
         }
@@ -154,9 +155,9 @@ impl Object {
     pub fn boolean(value: bool) -> Self {
         Self {
             data: ObjectData::Boolean(value),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }
@@ -166,9 +167,9 @@ impl Object {
     pub fn number(value: f64) -> Self {
         Self {
             data: ObjectData::Number(value),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }
@@ -181,9 +182,9 @@ impl Object {
     {
         Self {
             data: ObjectData::String(value.into()),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }
@@ -193,9 +194,9 @@ impl Object {
     pub fn bigint(value: RcBigInt) -> Self {
         Self {
             data: ObjectData::BigInt(value),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }
@@ -208,9 +209,9 @@ impl Object {
     {
         Self {
             data: ObjectData::NativeObject(Box::new(value)),
-            indexed_properties: HashMap::new(),
-            string_properties: HashMap::new(),
-            symbol_properties: HashMap::new(),
+            indexed_properties: HashMap::with_hasher(RandomState::new()),
+            string_properties: HashMap::with_hasher(RandomState::new()),
+            symbol_properties: HashMap::with_hasher(RandomState::new()),
             prototype: Value::null(),
             extensible: true,
         }

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     BoaProfiler,
 };
 use gc::{Finalize, Trace};
-use rustc_hash::FxHashMap;
+use std::collections::HashMap;
 use std::fmt::{Debug, Display, Error, Formatter};
 use std::{any::Any, result::Result as StdResult};
 
@@ -47,11 +47,11 @@ impl<T: Any + Debug + Trace> NativeObject for T {
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
-    indexed_properties: FxHashMap<u32, Property>,
+    indexed_properties: HashMap<u32, Property>,
     /// Properties
-    string_properties: FxHashMap<RcString, Property>,
+    string_properties: HashMap<RcString, Property>,
     /// Symbol Properties
-    symbol_properties: FxHashMap<RcSymbol, Property>,
+    symbol_properties: HashMap<RcSymbol, Property>,
     /// Instance prototype `__proto__`.
     prototype: Value,
     /// Whether it can have new properties added to it.
@@ -108,9 +108,9 @@ impl Default for Object {
     fn default() -> Self {
         Self {
             data: ObjectData::Ordinary,
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }
@@ -129,9 +129,9 @@ impl Object {
 
         Self {
             data: ObjectData::Function(function),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype,
             extensible: true,
         }
@@ -154,9 +154,9 @@ impl Object {
     pub fn boolean(value: bool) -> Self {
         Self {
             data: ObjectData::Boolean(value),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }
@@ -166,9 +166,9 @@ impl Object {
     pub fn number(value: f64) -> Self {
         Self {
             data: ObjectData::Number(value),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }
@@ -181,9 +181,9 @@ impl Object {
     {
         Self {
             data: ObjectData::String(value.into()),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }
@@ -193,9 +193,9 @@ impl Object {
     pub fn bigint(value: RcBigInt) -> Self {
         Self {
             data: ObjectData::BigInt(value),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }
@@ -208,9 +208,9 @@ impl Object {
     {
         Self {
             data: ObjectData::NativeObject(Box::new(value)),
-            indexed_properties: FxHashMap::default(),
-            string_properties: FxHashMap::default(),
-            symbol_properties: FxHashMap::default(),
+            indexed_properties: HashMap::new(),
+            string_properties: HashMap::new(),
+            symbol_properties: HashMap::new(),
             prototype: Value::null(),
             extensible: true,
         }

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -14,7 +14,7 @@ use crate::{
     BoaProfiler, Value,
 };
 use gc::{Gc, GcCell};
-use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::{HashMap, HashSet};
 
 /// Representation of a Realm.
 ///
@@ -61,7 +61,7 @@ fn new_global_environment(global: Value, this_value: Value) -> Gc<GcCell<GlobalE
     };
 
     let dcl_rec = DeclarativeEnvironmentRecord {
-        env_rec: FxHashMap::default(),
+        env_rec: HashMap::new(),
         outer_env: None,
     };
 
@@ -69,6 +69,6 @@ fn new_global_environment(global: Value, this_value: Value) -> Gc<GcCell<GlobalE
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: FxHashSet::default(),
+        var_names: HashSet::new(),
     }))
 }

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     BoaProfiler, Value,
 };
+use ahash::RandomState;
 use gc::{Gc, GcCell};
 use std::collections::{HashMap, HashSet};
 
@@ -61,7 +62,7 @@ fn new_global_environment(global: Value, this_value: Value) -> Gc<GcCell<GlobalE
     };
 
     let dcl_rec = DeclarativeEnvironmentRecord {
-        env_rec: HashMap::new(),
+        env_rec: HashMap::with_hasher(RandomState::new()),
         outer_env: None,
     };
 
@@ -69,6 +70,6 @@ fn new_global_environment(global: Value, this_value: Value) -> Gc<GcCell<GlobalE
         object_record: obj_rec,
         global_this_binding: this_value,
         declarative_record: dcl_rec,
-        var_names: HashSet::new(),
+        var_names: HashSet::with_hasher(RandomState::new()),
     }))
 }


### PR DESCRIPTION
opportunities to further improve performance are to use the trait
`ahash::CallHasher` for optimised hashing

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:

- Switches FxHash current usage with aHash
