### PR TITLE
`ConstructorBuilder`, `ObjectInitializer`, cache standard objects and fix global object attributes

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -96,7 +96,7 @@ impl ArrayIterator {
                     }
                     ArrayIterationKind::KeyAndValue => {
                         let element_value = array_iterator.array.get_field(index);
-                        let result = Array::make_array(
+                        let result = Array::constructor(
                             &Value::new_object(Some(ctx.global_object())),
                             &[index.into(), element_value],
                             ctx,

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -17,7 +17,9 @@
 mod tests;
 
 use crate::{
-    builtins::function::make_builtin_fn,
+    builtins::BuiltIn,
+    object::ObjectInitializer,
+    property::Attribute,
     value::{display_obj, RcString, Value},
     BoaProfiler, Context, Result,
 };
@@ -134,6 +136,41 @@ pub(crate) struct Console {
     count_map: FxHashMap<RcString, u32>,
     timer_map: FxHashMap<RcString, u128>,
     groups: Vec<String>,
+}
+
+impl BuiltIn for Console {
+    const NAME: &'static str = "console";
+
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+        let console = ObjectInitializer::new(context)
+            .function(Self::assert, "assert", 0)
+            .function(Self::clear, "clear", 0)
+            .function(Self::debug, "debug", 0)
+            .function(Self::error, "error", 0)
+            .function(Self::info, "info", 0)
+            .function(Self::log, "log", 0)
+            .function(Self::trace, "trace", 0)
+            .function(Self::warn, "warn", 0)
+            .function(Self::error, "exception", 0)
+            .function(Self::count, "count", 0)
+            .function(Self::count_reset, "countReset", 0)
+            .function(Self::group, "group", 0)
+            .function(Self::group, "groupCollapsed", 0)
+            .function(Self::group_end, "groupEnd", 0)
+            .function(Self::time, "time", 0)
+            .function(Self::time_log, "timeLog", 0)
+            .function(Self::time_end, "timeEnd", 0)
+            .function(Self::dir, "dir", 0)
+            .function(Self::dir, "dirxml", 0)
+            .build();
+
+        (Self::NAME, console.into(), Self::attribute())
+    }
 }
 
 impl Console {
@@ -494,36 +531,5 @@ impl Console {
         );
 
         Ok(Value::undefined())
-    }
-
-    /// Initialise the `console` object on the global object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        let console = Value::new_object(Some(global));
-
-        make_builtin_fn(Self::assert, "assert", &console, 0, interpreter);
-        make_builtin_fn(Self::clear, "clear", &console, 0, interpreter);
-        make_builtin_fn(Self::debug, "debug", &console, 0, interpreter);
-        make_builtin_fn(Self::error, "error", &console, 0, interpreter);
-        make_builtin_fn(Self::info, "info", &console, 0, interpreter);
-        make_builtin_fn(Self::log, "log", &console, 0, interpreter);
-        make_builtin_fn(Self::trace, "trace", &console, 0, interpreter);
-        make_builtin_fn(Self::warn, "warn", &console, 0, interpreter);
-        make_builtin_fn(Self::error, "exception", &console, 0, interpreter);
-        make_builtin_fn(Self::count, "count", &console, 0, interpreter);
-        make_builtin_fn(Self::count_reset, "countReset", &console, 0, interpreter);
-        make_builtin_fn(Self::group, "group", &console, 0, interpreter);
-        make_builtin_fn(Self::group, "groupCollapsed", &console, 0, interpreter);
-        make_builtin_fn(Self::group_end, "groupEnd", &console, 0, interpreter);
-        make_builtin_fn(Self::time, "time", &console, 0, interpreter);
-        make_builtin_fn(Self::time_log, "timeLog", &console, 0, interpreter);
-        make_builtin_fn(Self::time_end, "timeEnd", &console, 0, interpreter);
-        make_builtin_fn(Self::dir, "dir", &console, 0, interpreter);
-        make_builtin_fn(Self::dir, "dirxml", &console, 0, interpreter);
-
-        (Self::NAME, console)
     }
 }

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -10,9 +10,10 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError
 
 use crate::{
-    builtins::{function::make_builtin_fn, function::make_constructor_fn},
-    object::ObjectData,
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
+    property::Attribute,
     Context, Result, Value,
 };
 
@@ -20,15 +21,40 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct RangeError;
 
-impl RangeError {
-    /// The name of the object.
-    pub(crate) const NAME: &'static str = "RangeError";
+impl BuiltIn for RangeError {
+    const NAME: &'static str = "RangeError";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let error_prototype = context.standard_objects().error_object().prototype();
+        let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
+        let range_error_object = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().range_error_object().clone(),
+        )
+        .name(Self::NAME)
+        .length(Self::LENGTH)
+        .inherit(error_prototype.into())
+        .property("name", Self::NAME, attribute)
+        .property("message", "", attribute)
+        .build();
+
+        (Self::NAME, range_error_object.into(), Self::attribute())
+    }
+}
+
+impl RangeError {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn constructor(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -37,48 +63,5 @@ impl RangeError {
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);
         Err(this.clone())
-    }
-
-    /// `Error.prototype.toString()`
-    ///
-    /// The toString() method returns a string representing the specified Error object.
-    ///
-    /// More information:
-    ///  - [MDN documentation][mdn]
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Context) -> Result<Value> {
-        let name = this.get_field("name").to_string(ctx)?;
-        let message = this.get_field("message").to_string(ctx)?;
-
-        Ok(Value::from(format!("{}: {}", name, message)))
-    }
-
-    /// Initialise the global object with the `RangeError` object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        let prototype = Value::new_object(Some(global));
-        prototype.set_field("name", Self::NAME);
-        prototype.set_field("message", "");
-
-        make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
-
-        let range_error_object = make_constructor_fn(
-            Self::NAME,
-            Self::LENGTH,
-            Self::make_error,
-            global,
-            prototype,
-            true,
-            true,
-        );
-
-        (Self::NAME, range_error_object)
     }
 }

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -10,24 +10,50 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
 
 use crate::{
-    builtins::{function::make_builtin_fn, function::make_constructor_fn},
-    object::ObjectData,
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
+    property::Attribute,
     Context, Result, Value,
 };
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReferenceError;
 
-impl ReferenceError {
-    /// The name of the object.
-    pub(crate) const NAME: &'static str = "ReferenceError";
+impl BuiltIn for ReferenceError {
+    const NAME: &'static str = "ReferenceError";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let error_prototype = context.standard_objects().error_object().prototype();
+        let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
+        let reference_error_object = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().reference_error_object().clone(),
+        )
+        .name(Self::NAME)
+        .length(Self::LENGTH)
+        .inherit(error_prototype.into())
+        .property("name", Self::NAME, attribute)
+        .property("message", "", attribute)
+        .build();
+
+        (Self::NAME, reference_error_object.into(), Self::attribute())
+    }
+}
+
+impl ReferenceError {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn constructor(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -36,47 +62,5 @@ impl ReferenceError {
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);
         Err(this.clone())
-    }
-
-    /// `Error.prototype.toString()`
-    ///
-    /// The toString() method returns a string representing the specified Error object.
-    ///
-    /// More information:
-    ///  - [MDN documentation][mdn]
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], ctx: &mut Context) -> Result<Value> {
-        let name = this.get_field("name").to_string(ctx)?;
-        let message = this.get_field("message").to_string(ctx)?;
-
-        Ok(Value::from(format!("{}: {}", name, message)))
-    }
-
-    /// Initialise the global object with the `ReferenceError` object.
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        let prototype = Value::new_object(Some(global));
-        prototype.set_field("name", Self::NAME);
-        prototype.set_field("message", "");
-
-        make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
-
-        let reference_error_object = make_constructor_fn(
-            Self::NAME,
-            Self::LENGTH,
-            Self::make_error,
-            global,
-            prototype,
-            true,
-            true,
-        );
-
-        (Self::NAME, reference_error_object)
     }
 }

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -12,9 +12,10 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
 
 use crate::{
-    builtins::{function::make_builtin_fn, function::make_constructor_fn},
-    object::ObjectData,
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
+    property::Attribute,
     Context, Result, Value,
 };
 
@@ -22,15 +23,40 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SyntaxError;
 
-impl SyntaxError {
-    /// The name of the object.
-    pub(crate) const NAME: &'static str = "SyntaxError";
+impl BuiltIn for SyntaxError {
+    const NAME: &'static str = "SyntaxError";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let error_prototype = context.standard_objects().error_object().prototype();
+        let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
+        let syntax_error_object = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().syntax_error_object().clone(),
+        )
+        .name(Self::NAME)
+        .length(Self::LENGTH)
+        .inherit(error_prototype.into())
+        .property("name", Self::NAME, attribute)
+        .property("message", "", attribute)
+        .build();
+
+        (Self::NAME, syntax_error_object.into(), Self::attribute())
+    }
+}
+
+impl SyntaxError {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn make_error(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn constructor(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         if let Some(message) = args.get(0) {
             this.set_field("message", message.to_string(ctx)?);
         }
@@ -39,48 +65,5 @@ impl SyntaxError {
         // to its Javascript Identifier (global constructor method name)
         this.set_data(ObjectData::Error);
         Err(this.clone())
-    }
-
-    /// `Error.prototype.toString()`
-    ///
-    /// The toString() method returns a string representing the specified Error object.
-    ///
-    /// More information:
-    ///  - [MDN documentation][mdn]
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
-    #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
-        let name = this.get_field("name");
-        let message = this.get_field("message");
-        // FIXME: This should not use `.display()`
-        Ok(format!("{}: {}", name.display(), message.display()).into())
-    }
-
-    /// Initialise the global object with the `SyntaxError` object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        let prototype = Value::new_object(Some(global));
-        prototype.set_field("name", Self::NAME);
-        prototype.set_field("message", "");
-
-        make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
-
-        let syntax_error_object = make_constructor_fn(
-            Self::NAME,
-            Self::LENGTH,
-            Self::make_error,
-            global,
-            prototype,
-            true,
-            true,
-        );
-
-        (Self::NAME, syntax_error_object)
     }
 }

--- a/boa/src/builtins/global_this/mod.rs
+++ b/boa/src/builtins/global_this/mod.rs
@@ -10,7 +10,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-globalthis
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 
-use crate::{BoaProfiler, Context, Value};
+use crate::{builtins::BuiltIn, property::Attribute, BoaProfiler, Context, Value};
 
 #[cfg(test)]
 mod tests;
@@ -18,16 +18,20 @@ mod tests;
 /// The JavaScript `globalThis`.
 pub(crate) struct GlobalThis;
 
-impl GlobalThis {
-    /// The binding name of the property.
-    pub(crate) const NAME: &'static str = "globalThis";
+impl BuiltIn for GlobalThis {
+    const NAME: &'static str = "globalThis";
 
-    /// Initialize the `globalThis` property on the global object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        (Self::NAME, global.clone())
+        (
+            Self::NAME,
+            context.global_object().clone(),
+            Self::attribute(),
+        )
     }
 }

--- a/boa/src/builtins/infinity/mod.rs
+++ b/boa/src/builtins/infinity/mod.rs
@@ -12,21 +12,22 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{BoaProfiler, Context, Value};
+use crate::{builtins::BuiltIn, property::Attribute, BoaProfiler, Context, Value};
 
 /// JavaScript global `Infinity` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Infinity;
 
-impl Infinity {
-    /// The binding name of the property.
-    pub(crate) const NAME: &'static str = "Infinity";
+impl BuiltIn for Infinity {
+    const NAME: &'static str = "Infinity";
 
-    /// Initialize the `Infinity` property on the global object.
-    #[inline]
-    pub(crate) fn init(_interpreter: &mut Context) -> (&'static str, Value) {
+    fn attribute() -> Attribute {
+        Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
+    }
+
+    fn init(_context: &mut Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        (Self::NAME, Value::from(f64::INFINITY))
+        (Self::NAME, f64::INFINITY.into(), Self::attribute())
     }
 }

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::mutable_key_type)]
 
-use super::function::{make_builtin_fn, make_constructor_fn};
 use crate::{
-    object::{ObjectData, PROTOTYPE},
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
     property::{Attribute, Property},
     BoaProfiler, Context, Result, Value,
 };
@@ -15,10 +15,88 @@ mod tests;
 #[derive(Debug, Clone)]
 pub(crate) struct Map(OrderedMap<Value, Value>);
 
-impl Map {
-    pub(crate) const NAME: &'static str = "Map";
+impl BuiltIn for Map {
+    const NAME: &'static str = "Map";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let map_object = ConstructorBuilder::new(context, Self::constructor)
+            .name(Self::NAME)
+            .length(Self::LENGTH)
+            .method(Self::set, "set", 2)
+            .method(Self::delete, "delete", 1)
+            .method(Self::get, "get", 1)
+            .method(Self::clear, "clear", 0)
+            .method(Self::has, "has", 1)
+            .method(Self::for_each, "forEach", 1)
+            .callable(false)
+            .build();
+
+        (Self::NAME, map_object.into(), Self::attribute())
+    }
+}
+
+impl Map {
     pub(crate) const LENGTH: usize = 1;
+
+    /// Create a new map
+    pub(crate) fn constructor(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+        // Set Prototype
+        let prototype = ctx.global_object().get_field("Map").get_field(PROTOTYPE);
+
+        this.as_object_mut()
+            .expect("this is map object")
+            .set_prototype_instance(prototype);
+        // This value is used by console.log and other routines to match Object type
+        // to its Javascript Identifier (global constructor method name)
+
+        // add our arguments in
+        let data = match args.len() {
+            0 => OrderedMap::new(),
+            _ => match &args[0] {
+                Value::Object(object) => {
+                    let object = object.borrow();
+                    if let Some(map) = object.as_map_ref().cloned() {
+                        map
+                    } else if object.is_array() {
+                        let mut map = OrderedMap::new();
+                        let len = args[0].get_field("length").to_integer(ctx)? as i32;
+                        for i in 0..len {
+                            let val = &args[0].get_field(i.to_string());
+                            let (key, value) = Self::get_key_value(val).ok_or_else(|| {
+                                ctx.construct_type_error(
+                                    "iterable for Map should have array-like objects",
+                                )
+                            })?;
+                            map.insert(key, value);
+                        }
+                        map
+                    } else {
+                        return Err(ctx.construct_type_error(
+                            "iterable for Map should have array-like objects",
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(
+                        ctx.construct_type_error("iterable for Map should have array-like objects")
+                    )
+                }
+            },
+        };
+
+        // finally create length property
+        Self::set_size(this, data.len());
+
+        this.set_data(ObjectData::Map(data));
+
+        Ok(this.clone())
+    }
 
     /// Helper function to set the size property.
     fn set_size(this: &Value, size: usize) {
@@ -220,90 +298,5 @@ impl Map {
             }
         }
         None
-    }
-
-    /// Create a new map
-    pub(crate) fn make_map(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
-        // Make a new Object which will internally represent the Array (mapping
-        // between indices and values): this creates an Object with no prototype
-
-        // Set Prototype
-        let prototype = ctx.global_object().get_field("Map").get_field(PROTOTYPE);
-
-        this.as_object_mut()
-            .expect("this is array object")
-            .set_prototype_instance(prototype);
-        // This value is used by console.log and other routines to match Object type
-        // to its Javascript Identifier (global constructor method name)
-
-        // add our arguments in
-        let data = match args.len() {
-            0 => OrderedMap::new(),
-            _ => match &args[0] {
-                Value::Object(object) => {
-                    let object = object.borrow();
-                    if let Some(map) = object.as_map_ref().cloned() {
-                        map
-                    } else if object.is_array() {
-                        let mut map = OrderedMap::new();
-                        let len = args[0].get_field("length").to_integer(ctx)? as i32;
-                        for i in 0..len {
-                            let val = &args[0].get_field(i.to_string());
-                            let (key, value) = Self::get_key_value(val).ok_or_else(|| {
-                                ctx.construct_type_error(
-                                    "iterable for Map should have array-like objects",
-                                )
-                            })?;
-                            map.insert(key, value);
-                        }
-                        map
-                    } else {
-                        return Err(ctx.construct_type_error(
-                            "iterable for Map should have array-like objects",
-                        ));
-                    }
-                }
-                _ => {
-                    return Err(
-                        ctx.construct_type_error("iterable for Map should have array-like objects")
-                    )
-                }
-            },
-        };
-
-        // finally create length property
-        Self::set_size(this, data.len());
-
-        this.set_data(ObjectData::Map(data));
-
-        Ok(this.clone())
-    }
-
-    /// Initialise the `Map` object on the global object.
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        // Create prototype
-        let prototype = Value::new_object(Some(global));
-
-        make_builtin_fn(Self::set, "set", &prototype, 2, interpreter);
-        make_builtin_fn(Self::delete, "delete", &prototype, 1, interpreter);
-        make_builtin_fn(Self::get, "get", &prototype, 1, interpreter);
-        make_builtin_fn(Self::clear, "clear", &prototype, 0, interpreter);
-        make_builtin_fn(Self::has, "has", &prototype, 1, interpreter);
-        make_builtin_fn(Self::for_each, "forEach", &prototype, 1, interpreter);
-
-        let map_object = make_constructor_fn(
-            Self::NAME,
-            Self::LENGTH,
-            Self::make_map,
-            global,
-            prototype,
-            true,
-            false,
-        );
-
-        (Self::NAME, map_object)
     }
 }

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -11,7 +11,10 @@
 //! [spec]: https://tc39.es/ecma262/#sec-math-object
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math
 
-use crate::{builtins::function::make_builtin_fn, BoaProfiler, Context, Result, Value};
+use crate::{
+    builtins::BuiltIn, object::ObjectInitializer, property::Attribute, BoaProfiler, Context,
+    Result, Value,
+};
 use std::f64;
 
 #[cfg(test)]
@@ -21,10 +24,68 @@ mod tests;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Math;
 
-impl Math {
-    /// The name of the object.
-    pub(crate) const NAME: &'static str = "Math";
+impl BuiltIn for Math {
+    const NAME: &'static str = "Math";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+        let object = ObjectInitializer::new(context)
+            .property("E", f64::consts::E, attribute)
+            .property("LN2", f64::consts::LN_2, attribute)
+            .property("LN10", f64::consts::LN_10, attribute)
+            .property("LOG2E", f64::consts::LOG2_E, attribute)
+            .property("LOG10E", f64::consts::LOG10_E, attribute)
+            .property("SQRT1_2", 0.5_f64.sqrt(), attribute)
+            .property("SQRT2", f64::consts::SQRT_2, attribute)
+            .property("PI", f64::consts::PI, attribute)
+            .function(Self::abs, "abs", 1)
+            .function(Self::acos, "acos", 1)
+            .function(Self::acosh, "acosh", 1)
+            .function(Self::asin, "asin", 1)
+            .function(Self::asinh, "asinh", 1)
+            .function(Self::atan, "atan", 1)
+            .function(Self::atanh, "atanh", 1)
+            .function(Self::atan2, "atan2", 2)
+            .function(Self::cbrt, "cbrt", 1)
+            .function(Self::ceil, "ceil", 1)
+            .function(Self::clz32, "clz32", 1)
+            .function(Self::cos, "cos", 1)
+            .function(Self::cosh, "cosh", 1)
+            .function(Self::exp, "exp", 1)
+            .function(Self::expm1, "expm1", 1)
+            .function(Self::floor, "floor", 1)
+            .function(Self::fround, "fround", 1)
+            .function(Self::hypot, "hypot", 1)
+            .function(Self::imul, "imul", 1)
+            .function(Self::log, "log", 1)
+            .function(Self::log1p, "log1p", 1)
+            .function(Self::log10, "log10", 1)
+            .function(Self::log2, "log2", 1)
+            .function(Self::max, "max", 2)
+            .function(Self::min, "min", 2)
+            .function(Self::pow, "pow", 2)
+            .function(Self::random, "random", 0)
+            .function(Self::round, "round", 1)
+            .function(Self::sign, "sign", 1)
+            .function(Self::sin, "sin", 1)
+            .function(Self::sinh, "sinh", 1)
+            .function(Self::sqrt, "sqrt", 1)
+            .function(Self::tan, "tan", 1)
+            .function(Self::tanh, "tanh", 1)
+            .function(Self::trunc, "trunc", 1)
+            .build();
+
+        (Self::NAME, object.into(), Self::attribute())
+    }
+}
+
+impl Math {
     /// Get the absolute value of a number.
     ///
     /// More information:
@@ -631,70 +692,5 @@ impl Math {
             .transpose()?
             .map_or(f64::NAN, f64::trunc)
             .into())
-    }
-
-    /// Create a new `Math` object
-    pub(crate) fn create(interpreter: &mut Context) -> Value {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event("math:create", "init");
-        let math = Value::new_object(Some(global));
-
-        {
-            let mut properties = math.as_object_mut().unwrap();
-            properties.insert_field("E", Value::from(f64::consts::E));
-            properties.insert_field("LN2", Value::from(f64::consts::LN_2));
-            properties.insert_field("LN10", Value::from(f64::consts::LN_10));
-            properties.insert_field("LOG2E", Value::from(f64::consts::LOG2_E));
-            properties.insert_field("LOG10E", Value::from(f64::consts::LOG10_E));
-            properties.insert_field("SQRT1_2", Value::from(0.5_f64.sqrt()));
-            properties.insert_field("SQRT2", Value::from(f64::consts::SQRT_2));
-            properties.insert_field("PI", Value::from(f64::consts::PI));
-        }
-
-        make_builtin_fn(Self::abs, "abs", &math, 1, interpreter);
-        make_builtin_fn(Self::acos, "acos", &math, 1, interpreter);
-        make_builtin_fn(Self::acosh, "acosh", &math, 1, interpreter);
-        make_builtin_fn(Self::asin, "asin", &math, 1, interpreter);
-        make_builtin_fn(Self::asinh, "asinh", &math, 1, interpreter);
-        make_builtin_fn(Self::atan, "atan", &math, 1, interpreter);
-        make_builtin_fn(Self::atanh, "atanh", &math, 1, interpreter);
-        make_builtin_fn(Self::atan2, "atan2", &math, 2, interpreter);
-        make_builtin_fn(Self::cbrt, "cbrt", &math, 1, interpreter);
-        make_builtin_fn(Self::ceil, "ceil", &math, 1, interpreter);
-        make_builtin_fn(Self::clz32, "clz32", &math, 1, interpreter);
-        make_builtin_fn(Self::cos, "cos", &math, 1, interpreter);
-        make_builtin_fn(Self::cosh, "cosh", &math, 1, interpreter);
-        make_builtin_fn(Self::exp, "exp", &math, 1, interpreter);
-        make_builtin_fn(Self::expm1, "expm1", &math, 1, interpreter);
-        make_builtin_fn(Self::floor, "floor", &math, 1, interpreter);
-        make_builtin_fn(Self::fround, "fround", &math, 1, interpreter);
-        make_builtin_fn(Self::hypot, "hypot", &math, 1, interpreter);
-        make_builtin_fn(Self::imul, "imul", &math, 1, interpreter);
-        make_builtin_fn(Self::log, "log", &math, 1, interpreter);
-        make_builtin_fn(Self::log1p, "log1p", &math, 1, interpreter);
-        make_builtin_fn(Self::log10, "log10", &math, 1, interpreter);
-        make_builtin_fn(Self::log2, "log2", &math, 1, interpreter);
-        make_builtin_fn(Self::max, "max", &math, 2, interpreter);
-        make_builtin_fn(Self::min, "min", &math, 2, interpreter);
-        make_builtin_fn(Self::pow, "pow", &math, 2, interpreter);
-        make_builtin_fn(Self::random, "random", &math, 0, interpreter);
-        make_builtin_fn(Self::round, "round", &math, 1, interpreter);
-        make_builtin_fn(Self::sign, "sign", &math, 1, interpreter);
-        make_builtin_fn(Self::sin, "sin", &math, 1, interpreter);
-        make_builtin_fn(Self::sinh, "sinh", &math, 1, interpreter);
-        make_builtin_fn(Self::sqrt, "sqrt", &math, 1, interpreter);
-        make_builtin_fn(Self::tan, "tan", &math, 1, interpreter);
-        make_builtin_fn(Self::tanh, "tanh", &math, 1, interpreter);
-        make_builtin_fn(Self::trunc, "trunc", &math, 1, interpreter);
-
-        math
-    }
-
-    /// Initialise the `Math` object on the global object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        (Self::NAME, Self::create(interpreter))
     }
 }

--- a/boa/src/builtins/nan/mod.rs
+++ b/boa/src/builtins/nan/mod.rs
@@ -13,21 +13,22 @@
 #[cfg(test)]
 mod tests;
 
-use crate::{BoaProfiler, Context, Value};
+use crate::{builtins::BuiltIn, property::Attribute, BoaProfiler, Context, Value};
 
 /// JavaScript global `NaN` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct NaN;
 
-impl NaN {
-    /// The binding name of the property.
-    pub(crate) const NAME: &'static str = "NaN";
+impl BuiltIn for NaN {
+    const NAME: &'static str = "NaN";
 
-    /// Initialize the `NaN` property on the global object.
-    #[inline]
-    pub(crate) fn init(_interpreter: &mut Context) -> (&'static str, Value) {
+    fn attribute() -> Attribute {
+        Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
+    }
+
+    fn init(_context: &mut Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        (Self::NAME, Value::from(f64::NAN))
+        (Self::NAME, f64::NAN.into(), Self::attribute())
     }
 }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -14,9 +14,9 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 
 use crate::{
-    builtins::function::{make_builtin_fn, make_constructor_fn},
-    object::{Object as BuiltinObject, ObjectData},
-    property::Property,
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, Object as BuiltinObject, ObjectData},
+    property::{Attribute, Property},
     value::{same_value, Value},
     BoaProfiler, Context, Result,
 };
@@ -28,15 +28,48 @@ mod tests;
 #[derive(Debug, Clone, Copy)]
 pub struct Object;
 
+impl BuiltIn for Object {
+    const NAME: &'static str = "Object";
+
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let object = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().object_object().clone(),
+        )
+        .name(Self::NAME)
+        .length(Self::LENGTH)
+        .inherit(Value::null())
+        .method(Self::has_own_property, "hasOwnProperty", 0)
+        .method(Self::property_is_enumerable, "propertyIsEnumerable", 0)
+        .method(Self::to_string, "toString", 0)
+        .static_method(Self::create, "create", 2)
+        .static_method(Self::set_prototype_of, "setPrototypeOf", 2)
+        .static_method(Self::get_prototype_of, "getPrototypeOf", 1)
+        .static_method(Self::define_property, "defineProperty", 3)
+        .static_method(Self::is, "is", 2)
+        .build();
+
+        (Self::NAME, object.into(), Self::attribute())
+    }
+}
+
 impl Object {
-    /// Create a new object.
-    pub fn make_object(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    const LENGTH: usize = 1;
+
+    fn constructor(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
         if let Some(arg) = args.get(0) {
             if !arg.is_null_or_undefined() {
-                return Ok(arg.to_object(ctx)?.into());
+                return Ok(arg.to_object(context)?.into());
             }
         }
-        let global = ctx.global_object();
+        let global = context.global_object();
 
         Ok(Value::new_object(Some(global)))
     }
@@ -191,67 +224,5 @@ impl Object {
         Ok(own_property.map_or(Value::from(false), |own_prop| {
             Value::from(own_prop.enumerable_or(false))
         }))
-    }
-
-    /// Initialise the `Object` object on the global object.
-    #[inline]
-    pub fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let global = interpreter.global_object();
-        let _timer = BoaProfiler::global().start_event("object", "init");
-
-        let prototype = Value::new_object(None);
-
-        make_builtin_fn(
-            Self::has_own_property,
-            "hasOwnProperty",
-            &prototype,
-            0,
-            interpreter,
-        );
-        make_builtin_fn(
-            Self::property_is_enumerable,
-            "propertyIsEnumerable",
-            &prototype,
-            0,
-            interpreter,
-        );
-        make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
-
-        let object = make_constructor_fn(
-            "Object",
-            1,
-            Self::make_object,
-            global,
-            prototype,
-            true,
-            true,
-        );
-
-        // static methods of the builtin Object
-        make_builtin_fn(Self::create, "create", &object, 2, interpreter);
-        make_builtin_fn(
-            Self::set_prototype_of,
-            "setPrototypeOf",
-            &object,
-            2,
-            interpreter,
-        );
-        make_builtin_fn(
-            Self::get_prototype_of,
-            "getPrototypeOf",
-            &object,
-            1,
-            interpreter,
-        );
-        make_builtin_fn(
-            Self::define_property,
-            "defineProperty",
-            &object,
-            3,
-            interpreter,
-        );
-        make_builtin_fn(Self::is, "is", &object, 2, interpreter);
-
-        ("Object", object)
     }
 }

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -13,14 +13,10 @@ pub mod string_iterator;
 #[cfg(test)]
 mod tests;
 
-use super::function::{make_builtin_fn, make_constructor_fn};
-use crate::builtins::function::{BuiltInFunction, Function, FunctionFlags};
-use crate::builtins::string::string_iterator::StringIterator;
-use crate::object::PROTOTYPE;
 use crate::{
-    builtins::RegExp,
-    object::{Object, ObjectData},
-    property::Property,
+    builtins::{string::string_iterator::StringIterator, BuiltIn, RegExp},
+    object::{ConstructorBuilder, Object, ObjectData},
+    property::Attribute,
     value::{RcString, Value},
     BoaProfiler, Context, Result,
 };
@@ -65,40 +61,73 @@ fn is_trailing_surrogate(value: u16) -> bool {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct String;
 
-impl String {
-    /// The name of the object.
-    pub(crate) const NAME: &'static str = "String";
+impl BuiltIn for String {
+    const NAME: &'static str = "String";
 
+    fn attribute() -> Attribute {
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
+
+        let symbol_iterator = context.well_known_symbols().iterator_symbol();
+
+        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+        let string_object = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().string_object().clone(),
+        )
+        .name(Self::NAME)
+        .length(Self::LENGTH)
+        .property("length", 0, attribute)
+        .method(Self::char_at, "charAt", 1)
+        .method(Self::char_code_at, "charCodeAt", 1)
+        .method(Self::to_string, "toString", 0)
+        .method(Self::concat, "concat", 1)
+        .method(Self::repeat, "repeat", 1)
+        .method(Self::slice, "slice", 2)
+        .method(Self::starts_with, "startsWith", 1)
+        .method(Self::ends_with, "endsWith", 1)
+        .method(Self::includes, "includes", 1)
+        .method(Self::index_of, "indexOf", 1)
+        .method(Self::last_index_of, "lastIndexOf", 1)
+        .method(Self::r#match, "match", 1)
+        .method(Self::pad_end, "padEnd", 1)
+        .method(Self::pad_start, "padStart", 1)
+        .method(Self::trim, "trim", 0)
+        .method(Self::trim_start, "trimStart", 0)
+        .method(Self::trim_end, "trimEnd", 0)
+        .method(Self::to_lowercase, "toLowerCase", 0)
+        .method(Self::to_uppercase, "toUpperCase", 0)
+        .method(Self::substring, "substring", 2)
+        .method(Self::substr, "substr", 2)
+        .method(Self::value_of, "valueOf", 0)
+        .method(Self::match_all, "matchAll", 1)
+        .method(Self::replace, "replace", 2)
+        .method(Self::iterator, (symbol_iterator, "[Symbol.iterator]"), 0)
+        .build();
+
+        (Self::NAME, string_object.into(), Self::attribute())
+    }
+}
+
+impl String {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 1;
 
-    ///  JavaScript strings must be between `0` and less than positive `Infinity` and cannot be a negative number.
+    /// JavaScript strings must be between `0` and less than positive `Infinity` and cannot be a negative number.
     /// The range of allowed values can be described like this: `[0, +∞)`.
     ///
     /// The resulting string can also not be larger than the maximum string size,
     /// which can differ in JavaScript engines. In Boa it is `2^32 - 1`
     pub(crate) const MAX_STRING_LENGTH: f64 = u32::MAX as f64;
 
-    fn this_string_value(this: &Value, ctx: &mut Context) -> Result<RcString> {
-        match this {
-            Value::String(ref string) => return Ok(string.clone()),
-            Value::Object(ref object) => {
-                let object = object.borrow();
-                if let Some(string) = object.as_string() {
-                    return Ok(string);
-                }
-            }
-            _ => {}
-        }
-
-        Err(ctx.construct_type_error("'this' is not a string"))
-    }
-
-    /// [[Construct]] - Creates a new instance `this`
+    /// `String( value )`
     ///
-    /// [[Call]] - Returns a new native `string`
     /// <https://tc39.es/ecma262/#sec-string-constructor-string-value>
-    pub(crate) fn make_string(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn constructor(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         // This value is used by console.log and other routines to match Obexpecty"failed to parse argument for String method"pe
         // to its Javascript Identifier (global constructor method name)
         let string = match args.get(0) {
@@ -113,6 +142,21 @@ impl String {
         this.set_data(ObjectData::String(string.clone()));
 
         Ok(Value::from(string))
+    }
+
+    fn this_string_value(this: &Value, ctx: &mut Context) -> Result<RcString> {
+        match this {
+            Value::String(ref string) => return Ok(string.clone()),
+            Value::Object(ref object) => {
+                let object = object.borrow();
+                if let Some(string) = object.as_string() {
+                    return Ok(string);
+                }
+            }
+            _ => {}
+        }
+
+        Err(ctx.construct_type_error("'this' is not a string"))
     }
 
     /// Get the string value to a primitive string
@@ -720,7 +764,7 @@ impl String {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     pub(crate) fn r#match(this: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
-        let re = RegExp::make_regexp(&Value::from(Object::default()), &[args[0].clone()], ctx)?;
+        let re = RegExp::constructor(&Value::from(Object::default()), &[args[0].clone()], ctx)?;
         RegExp::r#match(&re, this.to_string(ctx)?, ctx)
     }
 
@@ -1073,13 +1117,13 @@ impl String {
         let re: Value = match args.get(0) {
             Some(arg) => {
                 if arg.is_null() {
-                    RegExp::make_regexp(
+                    RegExp::constructor(
                         &Value::from(Object::default()),
                         &[Value::from(arg.to_string(ctx)?), Value::from("g")],
                         ctx,
                     )
                 } else if arg.is_undefined() {
-                    RegExp::make_regexp(
+                    RegExp::constructor(
                         &Value::from(Object::default()),
                         &[Value::undefined(), Value::from("g")],
                         ctx,
@@ -1088,7 +1132,7 @@ impl String {
                     Ok(arg.clone())
                 }
             }
-            None => RegExp::make_regexp(
+            None => RegExp::constructor(
                 &Value::from(Object::default()),
                 &[Value::from(""), Value::from("g")],
                 ctx,
@@ -1100,83 +1144,5 @@ impl String {
 
     pub(crate) fn iterator(this: &Value, _args: &[Value], ctx: &mut Context) -> Result<Value> {
         StringIterator::create_string_iterator(ctx, this.clone())
-    }
-
-    /// Initialise the `String` object on the global object.
-    #[inline]
-    pub(crate) fn init(interpreter: &mut Context) -> (&'static str, Value) {
-        let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
-
-        // Create `String` `prototype`
-
-        let global = interpreter.global_object();
-        let prototype = Value::new_object(Some(global));
-        let length = Property::default().value(Value::from(0));
-
-        prototype.set_property("length", length);
-
-        make_builtin_fn(Self::char_at, "charAt", &prototype, 1, interpreter);
-        make_builtin_fn(Self::char_code_at, "charCodeAt", &prototype, 1, interpreter);
-        make_builtin_fn(Self::to_string, "toString", &prototype, 0, interpreter);
-        make_builtin_fn(Self::concat, "concat", &prototype, 1, interpreter);
-        make_builtin_fn(Self::repeat, "repeat", &prototype, 1, interpreter);
-        make_builtin_fn(Self::slice, "slice", &prototype, 2, interpreter);
-        make_builtin_fn(Self::starts_with, "startsWith", &prototype, 1, interpreter);
-        make_builtin_fn(Self::ends_with, "endsWith", &prototype, 1, interpreter);
-        make_builtin_fn(Self::includes, "includes", &prototype, 1, interpreter);
-        make_builtin_fn(Self::index_of, "indexOf", &prototype, 1, interpreter);
-        make_builtin_fn(
-            Self::last_index_of,
-            "lastIndexOf",
-            &prototype,
-            1,
-            interpreter,
-        );
-        make_builtin_fn(Self::r#match, "match", &prototype, 1, interpreter);
-        make_builtin_fn(Self::pad_end, "padEnd", &prototype, 1, interpreter);
-        make_builtin_fn(Self::pad_start, "padStart", &prototype, 1, interpreter);
-        make_builtin_fn(Self::trim, "trim", &prototype, 0, interpreter);
-        make_builtin_fn(Self::trim_start, "trimStart", &prototype, 0, interpreter);
-        make_builtin_fn(Self::trim_end, "trimEnd", &prototype, 0, interpreter);
-        make_builtin_fn(
-            Self::to_lowercase,
-            "toLowerCase",
-            &prototype,
-            0,
-            interpreter,
-        );
-        make_builtin_fn(
-            Self::to_uppercase,
-            "toUpperCase",
-            &prototype,
-            0,
-            interpreter,
-        );
-        make_builtin_fn(Self::substring, "substring", &prototype, 2, interpreter);
-        make_builtin_fn(Self::substr, "substr", &prototype, 2, interpreter);
-        make_builtin_fn(Self::value_of, "valueOf", &prototype, 0, interpreter);
-        make_builtin_fn(Self::match_all, "matchAll", &prototype, 1, interpreter);
-        make_builtin_fn(Self::replace, "replace", &prototype, 2, interpreter);
-
-        let symbol_iterator = interpreter.well_known_symbols().iterator_symbol();
-        let mut function = Object::function(
-            Function::BuiltIn(BuiltInFunction(Self::iterator), FunctionFlags::CALLABLE),
-            global.get_field("Function").get_field(PROTOTYPE),
-        );
-        function.insert_field("length", Value::from(0));
-        function.insert_field("name", Value::string("[Symbol.iterator]"));
-        prototype.set_field(symbol_iterator, Value::from(function));
-
-        let string_object = make_constructor_fn(
-            Self::NAME,
-            Self::LENGTH,
-            Self::make_string,
-            global,
-            prototype,
-            true,
-            true,
-        );
-
-        (Self::NAME, string_object)
     }
 }

--- a/boa/src/builtins/undefined/mod.rs
+++ b/boa/src/builtins/undefined/mod.rs
@@ -9,24 +9,25 @@
 //! [spec]: https://tc39.es/ecma262/#sec-undefined
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined
 
+use crate::{builtins::BuiltIn, property::Attribute, BoaProfiler, Context, Value};
+
 #[cfg(test)]
 mod tests;
-
-use crate::{BoaProfiler, Context, Value};
 
 /// JavaScript global `undefined` property.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) struct Undefined;
 
-impl Undefined {
-    /// The binding name of the property.
-    pub(crate) const NAME: &'static str = "undefined";
+impl BuiltIn for Undefined {
+    const NAME: &'static str = "undefined";
 
-    /// Initialize the `undefined` property on the global object.
-    #[inline]
-    pub(crate) fn init(_interpreter: &mut Context) -> (&'static str, Value) {
+    fn attribute() -> Attribute {
+        Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
+    }
+
+    fn init(_context: &mut Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
-        (Self::NAME, Value::undefined())
+        (Self::NAME, Value::undefined(), Self::attribute())
     }
 }

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -61,12 +61,11 @@
 //! [class-trait]: ./trait.Class.html
 
 use crate::{
-    builtins::function::{BuiltInFunction, Function, FunctionFlags, NativeFunction},
-    object::{GcObject, NativeObject, Object, ObjectData, PROTOTYPE},
-    property::{Attribute, Property, PropertyKey},
+    builtins::function::NativeFunction,
+    object::{ConstructorBuilder, GcObject, NativeObject, ObjectData},
+    property::{Attribute, PropertyKey},
     Context, Result, Value,
 };
-use std::fmt::Debug;
 
 /// Native class.
 pub trait Class: NativeObject + Sized {
@@ -108,157 +107,84 @@ impl<T: Class> ClassConstructor for T {
 /// Class builder which allows adding methods and static methods to the class.
 #[derive(Debug)]
 pub struct ClassBuilder<'context> {
-    /// The current context.
-    context: &'context mut Context,
-
-    /// The constructor object.
-    object: GcObject,
-
-    /// The prototype of the object.
-    prototype: GcObject,
+    builder: ConstructorBuilder<'context>,
 }
 
 impl<'context> ClassBuilder<'context> {
+    #[inline]
     pub(crate) fn new<T>(context: &'context mut Context) -> Self
     where
         T: ClassConstructor,
     {
-        let global = context.global_object();
-
-        let prototype = {
-            let object_prototype = global.get_field("Object").get_field(PROTOTYPE);
-
-            let object = Object::create(object_prototype);
-            GcObject::new(object)
-        };
-        // Create the native function
-        let function = Function::BuiltIn(
-            BuiltInFunction(T::raw_constructor),
-            FunctionFlags::CONSTRUCTABLE,
-        );
-
-        // Get reference to Function.prototype
-        // Create the function object and point its instance prototype to Function.prototype
-        let mut constructor =
-            Object::function(function, global.get_field("Function").get_field(PROTOTYPE));
-
-        let length = Property::data_descriptor(
-            T::LENGTH.into(),
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
-        );
-        constructor.insert_property("length", length);
-
-        let name = Property::data_descriptor(
-            T::NAME.into(),
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
-        );
-        constructor.insert_property("name", name);
-
-        let constructor = GcObject::new(constructor);
-
-        prototype
-            .borrow_mut()
-            .insert_field("constructor", constructor.clone().into());
-
-        constructor
-            .borrow_mut()
-            .insert_field(PROTOTYPE, prototype.clone().into());
-
-        Self {
-            context,
-            object: constructor,
-            prototype,
-        }
+        let mut builder = ConstructorBuilder::new(context, T::raw_constructor);
+        builder.name(T::NAME);
+        builder.length(T::LENGTH);
+        Self { builder }
     }
 
-    pub(crate) fn build(self) -> GcObject {
-        self.object
+    #[inline]
+    pub(crate) fn build(mut self) -> GcObject {
+        self.builder.build()
     }
 
     /// Add a method to the class.
     ///
     /// It is added to `prototype`.
-    pub fn method<N>(&mut self, name: N, length: usize, function: NativeFunction)
+    #[inline]
+    pub fn method<N>(&mut self, name: N, length: usize, function: NativeFunction) -> &mut Self
     where
-        N: Into<String>,
+        N: AsRef<str>,
     {
-        let name = name.into();
-        let mut function = Object::function(
-            Function::BuiltIn(function.into(), FunctionFlags::CALLABLE),
-            self.context
-                .global_object()
-                .get_field("Function")
-                .get_field("prototype"),
-        );
-
-        function.insert_field("length", Value::from(length));
-        function.insert_field("name", Value::from(name.as_str()));
-
-        self.prototype
-            .borrow_mut()
-            .insert_field(name, Value::from(function));
+        self.builder.method(function, name.as_ref(), length);
+        self
     }
 
     /// Add a static method to the class.
     ///
     /// It is added to class object itself.
-    pub fn static_method<N>(&mut self, name: N, length: usize, function: NativeFunction)
+    #[inline]
+    pub fn static_method<N>(
+        &mut self,
+        name: N,
+        length: usize,
+        function: NativeFunction,
+    ) -> &mut Self
     where
-        N: Into<String>,
+        N: AsRef<str>,
     {
-        let name = name.into();
-        let mut function = Object::function(
-            Function::BuiltIn(function.into(), FunctionFlags::CALLABLE),
-            self.context
-                .global_object()
-                .get_field("Function")
-                .get_field("prototype"),
-        );
-
-        function.insert_field("length", Value::from(length));
-        function.insert_field("name", Value::from(name.as_str()));
-
-        self.object
-            .borrow_mut()
-            .insert_field(name, Value::from(function));
+        self.builder.static_method(function, name.as_ref(), length);
+        self
     }
 
     /// Add a property to the class, with the specified attribute.
     ///
     /// It is added to `prototype`.
     #[inline]
-    pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute)
+    pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        // We bitwise or (`|`) with `Attribute::default()` (`READONLY | NON_ENUMERABLE | PERMANENT`)
-        // so we dont get an empty attribute.
-        let property = Property::data_descriptor(value.into(), attribute | Attribute::default());
-        self.prototype
-            .borrow_mut()
-            .insert_property(key.into(), property);
+        self.builder.property(key, value, attribute);
+        self
     }
 
     /// Add a static property to the class, with the specified attribute.
     ///
     /// It is added to class object itself.
     #[inline]
-    pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute)
+    pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        // We bitwise or (`|`) with `Attribute::default()` (`READONLY | NON_ENUMERABLE | PERMANENT`)
-        // so we dont get an empty attribute.
-        let property = Property::data_descriptor(value.into(), attribute | Attribute::default());
-        self.object
-            .borrow_mut()
-            .insert_property(key.into(), property);
+        self.builder.static_property(key, value, attribute);
+        self
     }
 
     /// Return the current context.
+    #[inline]
     pub fn context(&mut self) -> &'_ mut Context {
-        self.context
+        self.builder.context()
     }
 }

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -28,11 +28,136 @@ use crate::{
 };
 use std::result::Result as StdResult;
 
+/// Store a builtin constructor (such as `Object`) and its corresponding prototype.
+#[derive(Debug, Clone)]
+pub struct StandardConstructor {
+    pub(crate) constructor: GcObject,
+    pub(crate) prototype: GcObject,
+}
+
+impl Default for StandardConstructor {
+    fn default() -> Self {
+        Self {
+            constructor: GcObject::new(Object::default()),
+            prototype: GcObject::new(Object::default()),
+        }
+    }
+}
+
+impl StandardConstructor {
+    /// Return the constructor object.
+    ///
+    /// This is the same as `Object`, `Array`, etc.
+    #[inline]
+    pub fn constructor(&self) -> GcObject {
+        self.constructor.clone()
+    }
+
+    /// Return the prototype of the constructor object.
+    ///
+    /// This is the same as `Object.prototype`, `Array.prototype`, etc
+    #[inline]
+    pub fn prototype(&self) -> GcObject {
+        self.prototype.clone()
+    }
+}
+
+/// Cached core standard objects.
+#[derive(Debug, Clone, Default)]
+pub struct StandardObjects {
+    object: StandardConstructor,
+    function: StandardConstructor,
+    array: StandardConstructor,
+    bigint: StandardConstructor,
+    number: StandardConstructor,
+    boolean: StandardConstructor,
+    string: StandardConstructor,
+    regexp: StandardConstructor,
+    symbol: StandardConstructor,
+    error: StandardConstructor,
+    type_error: StandardConstructor,
+    referece_error: StandardConstructor,
+    range_error: StandardConstructor,
+    syntax_error: StandardConstructor,
+}
+
+impl StandardObjects {
+    #[inline]
+    pub fn object_object(&self) -> &StandardConstructor {
+        &self.object
+    }
+
+    #[inline]
+    pub fn function_object(&self) -> &StandardConstructor {
+        &self.function
+    }
+
+    #[inline]
+    pub fn array_object(&self) -> &StandardConstructor {
+        &self.array
+    }
+
+    #[inline]
+    pub fn bigint_object(&self) -> &StandardConstructor {
+        &self.bigint
+    }
+
+    #[inline]
+    pub fn number_object(&self) -> &StandardConstructor {
+        &self.number
+    }
+
+    #[inline]
+    pub fn boolean_object(&self) -> &StandardConstructor {
+        &self.boolean
+    }
+
+    #[inline]
+    pub fn string_object(&self) -> &StandardConstructor {
+        &self.string
+    }
+
+    #[inline]
+    pub fn regexp_object(&self) -> &StandardConstructor {
+        &self.regexp
+    }
+
+    #[inline]
+    pub fn symbol_object(&self) -> &StandardConstructor {
+        &self.symbol
+    }
+
+    #[inline]
+    pub fn error_object(&self) -> &StandardConstructor {
+        &self.error
+    }
+
+    #[inline]
+    pub fn reference_error_object(&self) -> &StandardConstructor {
+        &self.referece_error
+    }
+
+    #[inline]
+    pub fn type_error_object(&self) -> &StandardConstructor {
+        &self.type_error
+    }
+
+    #[inline]
+    pub fn range_error_object(&self) -> &StandardConstructor {
+        &self.range_error
+    }
+
+    #[inline]
+    pub fn syntax_error_object(&self) -> &StandardConstructor {
+        &self.syntax_error
+    }
+}
+
 /// Javascript context. It is the primary way to interact with the runtime.
 ///
-/// For each `Context` instance a new instance of runtime is created.
-/// It means that it is safe to use different contexts in different threads,
-/// but each `Context` instance must be used only from a single thread.
+/// `Context`s constructed in a thread share the same runtime, therefore it
+/// is possible to share objects from one context to another context, but they
+/// have to be in the same thread.
 #[derive(Debug)]
 pub struct Context {
     /// realm holds both the global object and the environment
@@ -52,7 +177,11 @@ pub struct Context {
     /// Cached well known symbols
     well_known_symbols: WellKnownSymbols,
 
+    /// Cached iterator prototypes.
     iterator_prototypes: IteratorPrototypes,
+
+    /// Cached standard objects and their prototypes
+    standard_objects: StandardObjects,
 }
 
 impl Default for Context {
@@ -67,6 +196,7 @@ impl Default for Context {
             console: Console::default(),
             well_known_symbols,
             iterator_prototypes: IteratorPrototypes::default(),
+            standard_objects: Default::default(),
         };
 
         // Add new builtIns to Context Realm
@@ -468,7 +598,7 @@ impl Context {
         self.global_object()
             .as_object_mut()
             .unwrap()
-            .insert_property(T::NAME, property);
+            .insert(T::NAME, property);
         Ok(())
     }
 
@@ -522,8 +652,15 @@ impl Context {
         &self.well_known_symbols
     }
 
+    /// Return the cached iterator prototypes.
     #[inline]
     pub fn iterator_prototypes(&self) -> &IteratorPrototypes {
         &self.iterator_prototypes
+    }
+
+    /// Return the core standard objects.
+    #[inline]
+    pub fn standard_objects(&self) -> &StandardObjects {
+        &self.standard_objects
     }
 }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -46,13 +46,14 @@ pub mod realm;
 pub mod syntax;
 pub mod value;
 
-mod context;
+pub mod context;
 
 use std::result::Result as StdResult;
 
 pub(crate) use crate::{exec::Executable, profiler::BoaProfiler};
 
 // Export things to root level
+#[doc(inline)]
 pub use crate::{context::Context, value::Value};
 
 use crate::syntax::{

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -168,7 +168,7 @@ impl Object {
                 return false;
             }
 
-            self.insert_property(key, desc);
+            self.insert(key, desc);
             return true;
         }
         // If every field is absent we don't need to set anything
@@ -207,7 +207,7 @@ impl Object {
                 current.set = None;
             }
 
-            self.insert_property(key, current);
+            self.insert(key, current);
             return true;
         // 7
         } else if current.is_data_descriptor() && desc.is_data_descriptor() {
@@ -247,7 +247,7 @@ impl Object {
             return true;
         }
         // 9
-        self.insert_property(key, desc);
+        self.insert(key, desc);
         true
     }
 
@@ -336,7 +336,7 @@ impl Object {
 
     /// Helper function for property insertion.
     #[inline]
-    pub(crate) fn insert_property<K>(&mut self, key: K, property: Property) -> Option<Property>
+    pub(crate) fn insert<K>(&mut self, key: K, property: Property) -> Option<Property>
     where
         K: Into<PropertyKey>,
     {
@@ -366,15 +366,24 @@ impl Object {
     /// If a field was already in the object with the same name that a `Some` is returned
     /// with that field, otherwise None is retuned.
     #[inline]
-    pub(crate) fn insert_field<K>(&mut self, key: K, value: Value) -> Option<Property>
+    pub(crate) fn insert_property<K, V>(
+        &mut self,
+        key: K,
+        value: V,
+        attribute: Attribute,
+    ) -> Option<Property>
     where
         K: Into<PropertyKey>,
+        V: Into<Value>,
     {
-        self.insert_property(
+        self.insert(
             key.into(),
             Property::data_descriptor(
-                value,
-                Attribute::WRITABLE | Attribute::ENUMERABLE | Attribute::CONFIGURABLE,
+                value.into(),
+                attribute
+                    | Attribute::HAS_WRITABLE
+                    | Attribute::HAS_ENUMERABLE
+                    | Attribute::HAS_CONFIGURABLE,
             ),
         )
     }

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -2,17 +2,24 @@
 
 use crate::{
     builtins::{
-        array::array_iterator::ArrayIterator, function::Function, map::ordered_map::OrderedMap,
-        string::string_iterator::StringIterator, BigInt, Date, RegExp,
+        array::array_iterator::ArrayIterator,
+        function::{BuiltInFunction, Function, FunctionFlags, NativeFunction},
+        map::ordered_map::OrderedMap,
+        string::string_iterator::StringIterator,
+        BigInt, Date, RegExp,
     },
-    property::{Property, PropertyKey},
+    context::StandardConstructor,
+    gc::{Finalize, Trace},
+    property::{Attribute, Property, PropertyKey},
     value::{RcBigInt, RcString, RcSymbol, Value},
-    BoaProfiler,
+    BoaProfiler, Context,
 };
-use gc::{Finalize, Trace};
 use rustc_hash::FxHashMap;
-use std::fmt::{Debug, Display, Error, Formatter};
-use std::{any::Any, result::Result as StdResult};
+use std::{
+    any::Any,
+    fmt::{self, Debug, Display},
+    ops::{Deref, DerefMut},
+};
 
 mod gcobject;
 mod internal_methods;
@@ -36,10 +43,12 @@ pub trait NativeObject: Debug + Any + Trace {
 }
 
 impl<T: Any + Debug + Trace> NativeObject for T {
+    #[inline]
     fn as_any(&self) -> &dyn Any {
         self as &dyn Any
     }
 
+    #[inline]
     fn as_mut_any(&mut self) -> &mut dyn Any {
         self as &mut dyn Any
     }
@@ -83,7 +92,7 @@ pub enum ObjectData {
 }
 
 impl Display for ObjectData {
-    fn fmt(&self, f: &mut Formatter<'_>) -> StdResult<(), Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}",
@@ -131,6 +140,7 @@ impl Object {
     }
 
     /// Return a new ObjectData struct, with `kind` set to Ordinary
+    #[inline]
     pub fn function(function: Function, prototype: Value) -> Self {
         let _timer = BoaProfiler::global().start_event("Object::Function", "object");
 
@@ -151,6 +161,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-objectcreate
     // TODO: proto should be a &Value here
+    #[inline]
     pub fn create(proto: Value) -> Self {
         let mut obj = Self::default();
         obj.prototype = proto;
@@ -158,6 +169,7 @@ impl Object {
     }
 
     /// Return a new Boolean object whose `[[BooleanData]]` internal slot is set to argument.
+    #[inline]
     pub fn boolean(value: bool) -> Self {
         Self {
             data: ObjectData::Boolean(value),
@@ -170,6 +182,7 @@ impl Object {
     }
 
     /// Return a new `Number` object whose `[[NumberData]]` internal slot is set to argument.
+    #[inline]
     pub fn number(value: f64) -> Self {
         Self {
             data: ObjectData::Number(value),
@@ -182,6 +195,7 @@ impl Object {
     }
 
     /// Return a new `String` object whose `[[StringData]]` internal slot is set to argument.
+    #[inline]
     pub fn string<S>(value: S) -> Self
     where
         S: Into<RcString>,
@@ -197,6 +211,7 @@ impl Object {
     }
 
     /// Return a new `BigInt` object whose `[[BigIntData]]` internal slot is set to argument.
+    #[inline]
     pub fn bigint(value: RcBigInt) -> Self {
         Self {
             data: ObjectData::BigInt(value),
@@ -209,6 +224,7 @@ impl Object {
     }
 
     /// Create a new native object of type `T`.
+    #[inline]
     pub fn native_object<T>(value: T) -> Self
     where
         T: NativeObject,
@@ -429,10 +445,13 @@ impl Object {
         matches!(self.data, ObjectData::Ordinary)
     }
 
+    #[inline]
     pub fn prototype_instance(&self) -> &Value {
         &self.prototype
     }
 
+    #[track_caller]
+    #[inline]
     pub fn set_prototype_instance(&mut self, prototype: Value) {
         assert!(prototype.is_null() || prototype.is_object());
         self.prototype = prototype
@@ -448,16 +467,17 @@ impl Object {
     }
 
     /// Returns `true` if it holds an Rust type that implements `NativeObject`.
+    #[inline]
     pub fn is_native_object(&self) -> bool {
         matches!(self.data, ObjectData::NativeObject(_))
     }
 
     /// Reeturn `true` if it is a native object and the native type is `T`.
+    #[inline]
     pub fn is<T>(&self) -> bool
     where
         T: NativeObject,
     {
-        use std::ops::Deref;
         match self.data {
             ObjectData::NativeObject(ref object) => object.deref().as_any().is::<T>(),
             _ => false,
@@ -466,11 +486,11 @@ impl Object {
 
     /// Downcast a reference to the object,
     /// if the object is type native object type `T`.
+    #[inline]
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
         T: NativeObject,
     {
-        use std::ops::Deref;
         match self.data {
             ObjectData::NativeObject(ref object) => object.deref().as_any().downcast_ref::<T>(),
             _ => None,
@@ -479,16 +499,509 @@ impl Object {
 
     /// Downcast a mutable reference to the object,
     /// if the object is type native object type `T`.
+    #[inline]
     pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
     where
         T: NativeObject,
     {
-        use std::ops::DerefMut;
         match self.data {
             ObjectData::NativeObject(ref mut object) => {
                 object.deref_mut().as_mut_any().downcast_mut::<T>()
             }
             _ => None,
         }
+    }
+}
+
+/// The functions binding.
+///
+/// Specifies what is the name of the function object (`name` property),
+/// and the binding name of the function object which can be different
+/// from the function name.
+///
+/// The only way to construct this is with the `From` trait.
+///
+/// There are two implementations:
+///  - From a single type `T` which implements `Into<FunctionBinding>` which sets the binding
+/// name and the function name to the same value
+///  - From a tuple `(B: Into<PropertyKey>, N: AsRef<str>)` the `B` is the binding name
+/// and the `N` is the function name.
+#[derive(Debug, Clone)]
+pub struct FunctionBinding {
+    binding: PropertyKey,
+    name: RcString,
+}
+
+impl From<&str> for FunctionBinding {
+    #[inline]
+    fn from(name: &str) -> Self {
+        let name: RcString = name.into();
+
+        Self {
+            binding: name.clone().into(),
+            name,
+        }
+    }
+}
+
+impl From<String> for FunctionBinding {
+    #[inline]
+    fn from(name: String) -> Self {
+        let name: RcString = name.into();
+
+        Self {
+            binding: name.clone().into(),
+            name,
+        }
+    }
+}
+
+impl From<RcString> for FunctionBinding {
+    #[inline]
+    fn from(name: RcString) -> Self {
+        Self {
+            binding: name.clone().into(),
+            name,
+        }
+    }
+}
+
+impl<B, N> From<(B, N)> for FunctionBinding
+where
+    B: Into<PropertyKey>,
+    N: AsRef<str>,
+{
+    #[inline]
+    fn from((binding, name): (B, N)) -> Self {
+        Self {
+            binding: binding.into(),
+            name: name.as_ref().into(),
+        }
+    }
+}
+
+/// Builder for creating native function objects
+#[derive(Debug)]
+pub struct FunctionBuilder<'context> {
+    context: &'context mut Context,
+    function: BuiltInFunction,
+    name: Option<String>,
+    length: usize,
+    callable: bool,
+    constructable: bool,
+}
+
+impl<'context> FunctionBuilder<'context> {
+    /// Create a new `FunctionBuilder`
+    #[inline]
+    pub fn new(context: &'context mut Context, function: NativeFunction) -> Self {
+        Self {
+            context,
+            function: function.into(),
+            name: None,
+            length: 0,
+            callable: true,
+            constructable: false,
+        }
+    }
+
+    /// Specify the name property of object function object.
+    ///
+    /// The default is `""` (empty string).
+    #[inline]
+    pub fn name<N>(&mut self, name: N) -> &mut Self
+    where
+        N: AsRef<str>,
+    {
+        self.name = Some(name.as_ref().into());
+        self
+    }
+
+    /// Specify the length property of object function object.
+    ///
+    /// How many arguments this function takes.
+    ///
+    /// The default is `0`.
+    #[inline]
+    pub fn length(&mut self, length: usize) -> &mut Self {
+        self.length = length;
+        self
+    }
+
+    /// Specify the whether the object function object can be called.
+    ///
+    /// The default is `true`.
+    #[inline]
+    pub fn callable(&mut self, yes: bool) -> &mut Self {
+        self.callable = yes;
+        self
+    }
+
+    /// Specify the whether the object function object can be called with `new` keyword.
+    ///
+    /// The default is `false`.
+    #[inline]
+    pub fn constructable(&mut self, yes: bool) -> &mut Self {
+        self.constructable = yes;
+        self
+    }
+
+    /// Build the function object.
+    #[inline]
+    pub fn build(&mut self) -> GcObject {
+        let mut function = Object::function(
+            Function::BuiltIn(
+                self.function,
+                FunctionFlags::from_parameters(self.callable, self.constructable),
+            ),
+            self.context
+                .standard_objects()
+                .function_object()
+                .prototype()
+                .into(),
+        );
+        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+        if let Some(name) = self.name.take() {
+            function.insert_property("name", name, attribute);
+        } else {
+            function.insert_property("name", "", attribute);
+        }
+        function.insert_property("length", self.length, attribute);
+
+        GcObject::new(function)
+    }
+}
+
+/// Builder for creating objects with properties.
+///
+/// # Examples
+///
+/// ```
+/// # use boa::{Context, Value, object::ObjectInitializer, property::Attribute};
+/// let mut context = Context::new();
+/// let object = ObjectInitializer::new(&mut context)
+///     .property("hello", "world", Attribute::all())
+///     .property(1, 1, Attribute::all())
+///     .function(|_, _, _| Ok(Value::undefined()), "func", 0)
+///     .build();
+/// ```
+///
+/// The equivalent in JavaScript would be:
+/// ```text
+/// let object = {
+///     hello: "world",
+///     "1": 1,
+///     func: function() {}
+/// }
+/// ```
+#[derive(Debug)]
+pub struct ObjectInitializer<'context> {
+    context: &'context mut Context,
+    object: GcObject,
+}
+
+impl<'context> ObjectInitializer<'context> {
+    /// Create a new `ObjectBuilder`.
+    #[inline]
+    pub fn new(context: &'context mut Context) -> Self {
+        let object = context.construct_object();
+        Self { context, object }
+    }
+
+    /// Add a function to the object.
+    #[inline]
+    pub fn function<B>(&mut self, function: NativeFunction, binding: B, length: usize) -> &mut Self
+    where
+        B: Into<FunctionBinding>,
+    {
+        let binding = binding.into();
+        let function = FunctionBuilder::new(self.context, function)
+            .name(binding.name)
+            .length(length)
+            .callable(true)
+            .constructable(false)
+            .build();
+
+        self.object.borrow_mut().insert_property(
+            binding.binding,
+            function,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+        );
+        self
+    }
+
+    /// Add a property to the object.
+    #[inline]
+    pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
+    where
+        K: Into<PropertyKey>,
+        V: Into<Value>,
+    {
+        let property = Property::data_descriptor(value.into(), attribute);
+        self.object.borrow_mut().insert(key, property);
+        self
+    }
+
+    /// Build the object.
+    #[inline]
+    pub fn build(&mut self) -> GcObject {
+        self.object.clone()
+    }
+}
+
+/// Builder for creating constructors objects, like `Array`.
+pub struct ConstructorBuilder<'context> {
+    context: &'context mut Context,
+    constrcutor_function: NativeFunction,
+    constructor_object: GcObject,
+    prototype: GcObject,
+    name: Option<String>,
+    length: usize,
+    callable: bool,
+    constructable: bool,
+    inherit: Option<Value>,
+}
+
+impl Debug for ConstructorBuilder<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConstructorBuilder")
+            .field("name", &self.name)
+            .field("length", &self.length)
+            .field("constructor", &self.constructor_object)
+            .field("prototype", &self.prototype)
+            .field("inherit", &self.inherit)
+            .field("callable", &self.callable)
+            .field("constructable", &self.constructable)
+            .finish()
+    }
+}
+
+impl<'context> ConstructorBuilder<'context> {
+    /// Create a new `ConstructorBuilder`.
+    #[inline]
+    pub fn new(context: &'context mut Context, constructor: NativeFunction) -> Self {
+        Self {
+            context,
+            constrcutor_function: constructor,
+            constructor_object: GcObject::new(Object::default()),
+            prototype: GcObject::new(Object::default()),
+            length: 0,
+            name: None,
+            callable: true,
+            constructable: true,
+            inherit: None,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn with_standard_object(
+        context: &'context mut Context,
+        constructor: NativeFunction,
+        object: StandardConstructor,
+    ) -> Self {
+        Self {
+            context,
+            constrcutor_function: constructor,
+            constructor_object: object.constructor,
+            prototype: object.prototype,
+            length: 0,
+            name: None,
+            callable: true,
+            constructable: true,
+            inherit: None,
+        }
+    }
+
+    /// Add new method to the constructors prototype.
+    #[inline]
+    pub fn method<B>(&mut self, function: NativeFunction, binding: B, length: usize) -> &mut Self
+    where
+        B: Into<FunctionBinding>,
+    {
+        let binding = binding.into();
+        let function = FunctionBuilder::new(self.context, function)
+            .name(binding.name)
+            .length(length)
+            .callable(true)
+            .constructable(false)
+            .build();
+
+        self.prototype.borrow_mut().insert_property(
+            binding.binding,
+            function,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+        );
+        self
+    }
+
+    /// Add new static method to the constructors object itself.
+    #[inline]
+    pub fn static_method<B>(
+        &mut self,
+        function: NativeFunction,
+        binding: B,
+        length: usize,
+    ) -> &mut Self
+    where
+        B: Into<FunctionBinding>,
+    {
+        let binding = binding.into();
+        let function = FunctionBuilder::new(self.context, function)
+            .name(binding.name)
+            .length(length)
+            .callable(true)
+            .constructable(false)
+            .build();
+
+        self.constructor_object.borrow_mut().insert_property(
+            binding.binding,
+            function,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+        );
+        self
+    }
+
+    /// Add new property to the constructors prototype.
+    #[inline]
+    pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
+    where
+        K: Into<PropertyKey>,
+        V: Into<Value>,
+    {
+        let property = Property::data_descriptor(value.into(), attribute);
+        self.prototype.borrow_mut().insert(key, property);
+        self
+    }
+
+    /// Add new static property to the constructors object itself.
+    #[inline]
+    pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
+    where
+        K: Into<PropertyKey>,
+        V: Into<Value>,
+    {
+        let property = Property::data_descriptor(value.into(), attribute);
+        self.constructor_object.borrow_mut().insert(key, property);
+        self
+    }
+
+    /// Specify how many arguments the constructor function takes.
+    ///
+    /// Default is `0`.
+    #[inline]
+    pub fn length(&mut self, length: usize) -> &mut Self {
+        self.length = length;
+        self
+    }
+
+    /// Specify the name of the constructor function.
+    ///
+    /// Default is `"[object]"`
+    #[inline]
+    pub fn name<N>(&mut self, name: N) -> &mut Self
+    where
+        N: AsRef<str>,
+    {
+        self.name = Some(name.as_ref().into());
+        self
+    }
+
+    /// Specify whether the constructor function can be called.
+    ///
+    /// Default is `true`
+    #[inline]
+    pub fn callable(&mut self, callable: bool) -> &mut Self {
+        self.callable = callable;
+        self
+    }
+
+    /// Specify whether the constructor function can be called with `new` keyword.
+    ///
+    /// Default is `true`
+    #[inline]
+    pub fn constructable(&mut self, constructable: bool) -> &mut Self {
+        self.constructable = constructable;
+        self
+    }
+
+    /// Specify the prototype this constructor object inherits from.
+    ///
+    /// Default is `Object.prototype`
+    #[inline]
+    pub fn inherit(&mut self, prototype: Value) -> &mut Self {
+        assert!(prototype.is_object() || prototype.is_null());
+        self.inherit = Some(prototype);
+        self
+    }
+
+    /// Return the current context.
+    #[inline]
+    pub fn context(&mut self) -> &'_ mut Context {
+        self.context
+    }
+
+    /// Build the constructor function object.
+    pub fn build(&mut self) -> GcObject {
+        // Create the native function
+        let function = Function::BuiltIn(
+            self.constrcutor_function.into(),
+            FunctionFlags::from_parameters(self.callable, self.constructable),
+        );
+
+        let length = Property::data_descriptor(
+            self.length.into(),
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+        );
+        let name = Property::data_descriptor(
+            self.name
+                .take()
+                .unwrap_or_else(|| String::from("[object]"))
+                .into(),
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+        );
+
+        {
+            let mut constructor = self.constructor_object.borrow_mut();
+            constructor.data = ObjectData::Function(function);
+            constructor.insert("length", length);
+            constructor.insert("name", name);
+
+            constructor.set_prototype_instance(
+                self.context
+                    .standard_objects()
+                    .function_object()
+                    .prototype()
+                    .into(),
+            );
+
+            constructor.insert_property(
+                PROTOTYPE,
+                self.prototype.clone(),
+                Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+            );
+        }
+
+        {
+            let mut prototype = self.prototype.borrow_mut();
+            prototype.insert_property(
+                "constructor",
+                self.constructor_object.clone(),
+                Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+            );
+
+            if let Some(proto) = self.inherit.take() {
+                prototype.set_prototype_instance(proto);
+            } else {
+                prototype.set_prototype_instance(
+                    self.context
+                        .standard_objects()
+                        .object_object()
+                        .prototype()
+                        .into(),
+                );
+            }
+        }
+
+        self.constructor_object.clone()
     }
 }

--- a/boa/src/value/conversions.rs
+++ b/boa/src/value/conversions.rs
@@ -127,7 +127,7 @@ where
     fn from(value: &[T]) -> Self {
         let mut array = Object::default();
         for (i, item) in value.iter().enumerate() {
-            array.insert_property(i, Property::default().value(item.clone().into()));
+            array.insert(i, Property::default().value(item.clone().into()));
         }
         Self::from(array)
     }
@@ -140,7 +140,7 @@ where
     fn from(value: Vec<T>) -> Self {
         let mut array = Object::default();
         for (i, item) in value.into_iter().enumerate() {
-            array.insert_property(i, Property::default().value(item.into()));
+            array.insert(i, Property::default().value(item.into()));
         }
         Value::from(array)
     }

--- a/boa/src/value/rcstring.rs
+++ b/boa/src/value/rcstring.rs
@@ -33,24 +33,28 @@ impl Display for RcString {
 }
 
 impl PartialEq<str> for RcString {
+    #[inline]
     fn eq(&self, other: &str) -> bool {
         self.as_str() == other
     }
 }
 
 impl PartialEq<RcString> for str {
+    #[inline]
     fn eq(&self, other: &RcString) -> bool {
         self == other.as_str()
     }
 }
 
 impl PartialEq<&str> for RcString {
+    #[inline]
     fn eq(&self, other: &&str) -> bool {
         self.as_str() == *other
     }
 }
 
 impl PartialEq<RcString> for &str {
+    #[inline]
     fn eq(&self, other: &RcString) -> bool {
         *self == other.as_str()
     }
@@ -69,6 +73,13 @@ impl Borrow<str> for RcString {
     #[inline]
     fn borrow(&self) -> &str {
         self.0.borrow()
+    }
+}
+
+impl AsRef<str> for RcString {
+    #[inline]
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #613.

It changes the following:
 - Add BuiltIn trait for builtins
 - Fixed global properties/objects/object methods/object properties attributes
 - Made `ClassBuilder` retun `&mut Self`
 - Add ConstructorBuilder for constructing constructors (builder pattern)
 - Add ObjectInitializer for constructing objects (builder pattern) 
 - Add FunctionBuilder for constructing function objects (builder pattern) 
 - Cache core standard objects