### PR TITLE
Add fast path for string concatenation

### DIFF
--- a/boa/src/value/operations.rs
+++ b/boa/src/value/operations.rs
@@ -11,6 +11,7 @@ impl Value {
             (Self::Integer(x), Self::Rational(y)) => Self::rational(f64::from(*x) + y),
             (Self::Rational(x), Self::Integer(y)) => Self::rational(x + f64::from(*y)),
 
+            (Self::String(ref x), Self::String(ref y)) => Self::string(format!("{}{}", x, y)),
             (Self::String(ref x), ref y) => Self::string(format!("{}{}", x, y.to_string(ctx)?)),
             (ref x, Self::String(ref y)) => Self::string(format!("{}{}", x.to_string(ctx)?, y)),
             (Self::BigInt(ref n1), Self::BigInt(ref n2)) => {


### PR DESCRIPTION
Add a fast path for addition of 2 values of kind `String` which doesn't require `Value::to_string` to be invoked on one of them.

Discussed on Discord with @HalidOdat who gave me the go-ahead