### PR TITLE
Ignore tests from codecov count and disable annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+github_checks:
+  annotations: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -85,6 +85,8 @@ jobs:
           args: -v
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --ignore-tests
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
It changes the following:
 - Disable codecov annotations in PR
 - Ignore tests when calculating coverage
