### PR TITLE
Fix output of Object.toString()

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -115,9 +115,9 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-object.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_string(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    pub fn to_string(_: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
         // FIXME: it should not display the object.
-        Ok(this.display().to_string().into())
+        Ok("[object Object]".into())
     }
 
     /// `Object.prototype.hasOwnPrototype( property )`

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -55,7 +55,7 @@ fn object_create_with_number() {
 
 #[test]
 #[ignore]
-// to test on __proto__ somehow. __proto__ getter is not working as expected currently
+// TODO: to test on __proto__ somehow. __proto__ getter is not working as expected currently
 fn object_create_with_function() {
     let mut engine = Context::new();
 
@@ -134,4 +134,44 @@ fn object_property_is_enumerable() {
         "false",
     );
     assert_eq!(forward(&mut engine, r#"x.propertyIsEnumerable()"#), "false",)
+}
+
+#[test]
+fn object_to_string() {
+    let mut ctx = Context::new();
+    let init = r#"
+        let u = undefined;
+        let n = null;
+        let a = [];
+        Array.prototype.toString = Object.prototype.toString;
+        let f = () => {};
+        Function.prototype.toString = Object.prototype.toString;
+        let b = Boolean();
+        Boolean.prototype.toString = Object.prototype.toString;
+        let i = Number(42);
+        Number.prototype.toString = Object.prototype.toString;
+        let s = String('boa');
+        String.prototype.toString = Object.prototype.toString;
+        let d = new Date(Date.now());
+        Date.prototype.toString = Object.prototype.toString;
+        let re = /boa/;
+        RegExp.prototype.toString = Object.prototype.toString;
+    "#;
+    eprintln!("{}", forward(&mut ctx, init));
+    // TODO: need Function.prototype.call to be implemented
+    // assert_eq!(
+    //     forward(&mut ctx, "Object.prototype.toString.call(u)"),
+    //     "\"[object Undefined]\""
+    // );
+    // assert_eq!(
+    //     forward(&mut ctx, "Object.prototype.toString.call(n)"),
+    //     "\"[object Null]\""
+    // );
+    assert_eq!(forward(&mut ctx, "a.toString()"), "\"[object Array]\"");
+    assert_eq!(forward(&mut ctx, "f.toString()"), "\"[object Function]\"");
+    assert_eq!(forward(&mut ctx, "b.toString()"), "\"[object Boolean]\"");
+    assert_eq!(forward(&mut ctx, "i.toString()"), "\"[object Number]\"");
+    assert_eq!(forward(&mut ctx, "s.toString()"), "\"[object String]\"");
+    assert_eq!(forward(&mut ctx, "d.toString()"), "\"[object Date]\"");
+    assert_eq!(forward(&mut ctx, "re.toString()"), "\"[object RegExp]\"");
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -156,6 +156,7 @@ fn object_to_string() {
         Date.prototype.toString = Object.prototype.toString;
         let re = /boa/;
         RegExp.prototype.toString = Object.prototype.toString;
+        let o = Object();
     "#;
     eprintln!("{}", forward(&mut ctx, init));
     // TODO: need Function.prototype.call to be implemented
@@ -174,4 +175,5 @@ fn object_to_string() {
     assert_eq!(forward(&mut ctx, "s.toString()"), "\"[object String]\"");
     assert_eq!(forward(&mut ctx, "d.toString()"), "\"[object Date]\"");
     assert_eq!(forward(&mut ctx, "re.toString()"), "\"[object RegExp]\"");
+    assert_eq!(forward(&mut ctx, "o.toString()"), "\"[object Object]\"");
 }


### PR DESCRIPTION
This Pull Request fixes/closes #729.

It changes the following:

- `Object::to_string`returns a `Value::String` respecting the spec: https://tc39.es/ecma262/#sec-object.prototype.tostring