### PR TITLE
chore(boa): update criterion from 0.3.2 to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,9 +234,9 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "criterion"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f696897c88b57f4ffe3c69d8e1a0613c7d0e6c4833363c8560fbde9c47b966"
+checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
 dependencies = [
  "atty",
  "cast",
@@ -251,6 +251,7 @@ dependencies = [
  "rayon",
  "regex",
  "serde",
+ "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -424,6 +425,12 @@ dependencies = [
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "hashbrown"
@@ -949,6 +956,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -33,7 +33,7 @@ measureme = { version = "0.7.1", optional = true }
 once_cell = { version = "1.4.1", optional = true }
 
 [dev-dependencies]
-criterion = "=0.3.2" # critcmp is not compatible with 0.3.3
+criterion = "0.3.3"
 float-cmp = "0.8.0"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]


### PR DESCRIPTION
was blocked due to incompatibilities with `critcmp`, however,
`critcmp` has released v0.1.4 and so `critcmp` is no longer functional
with older versions of criterion. This may require criterion compare
action modification

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

