### PR TITLE
remove deprecated comments

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -169,7 +169,6 @@ impl String {
             .nth(pos as usize)
             .expect("failed to get utf16 value");
         // If there is no element at that index, the result is NaN
-        // TODO: We currently don't have NaN
         Ok(Value::from(f64::from(utf16_val)))
     }
 

--- a/boa/src/exec/statement_list.rs
+++ b/boa/src/exec/statement_list.rs
@@ -22,13 +22,10 @@ impl Executable for StatementList {
                     break;
                 }
                 InterpreterState::Break(_label) => {
-                    // TODO, break to a label.
-
                     // Early break.
                     break;
                 }
                 InterpreterState::Continue(_label) => {
-                    // TODO, continue to a label.
                     break;
                 }
                 InterpreterState::Executing => {


### PR DESCRIPTION
both set of comments aren't needed.
We won't have labels at StatementList level so they can be ignored