### PR TITLE
Using the upstream version of the benchmark action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,12 +46,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run benchmark
-        run: cargo bench -p Boa | tee output.txt
+        run: cargo bench -p Boa -- --output-format bencher | tee output.txt
       - name: Store benchmark result
-        uses: jasonwilliams/github-action-benchmark@v1
+        uses: rhysd/github-action-benchmark@v1.8.1
         with:
           name: Boa Benchmarks
-          tool: "criterion"
+          tool: 'cargo'
           output-file-path: output.txt
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,7 +51,7 @@ jobs:
         uses: rhysd/github-action-benchmark@v1.8.1
         with:
           name: Boa Benchmarks
-          tool: 'cargo'
+          tool: "cargo"
           output-file-path: output.txt
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It seems that some benchmarks are not showing properly in the graphs. This might be because we are not using the upstream version of the GitHub action, which includes some fixes. This could potentially fix that, and if it does, I can retroactivelly fix the benchmarks, since they need a re-adjustment anyways.