### PR TITLE
Revert "Using the upstream version of the benchmark action"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,12 +46,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run benchmark
-        run: cargo bench -p Boa -- --output-format bencher | tee output.txt
+        run: cargo bench -p Boa | tee output.txt
       - name: Store benchmark result
-        uses: rhysd/github-action-benchmark@v1.8.1
+        uses: jasonwilliams/github-action-benchmark@v1
         with:
           name: Boa Benchmarks
-          tool: "cargo"
+          tool: "criterion"
           output-file-path: output.txt
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts boa-dev/boa#768. Until https://github.com/rhysd/github-action-benchmark/pull/48 gets merged, let's revert this. I tried to generate a release of the action myself, but I was unable to do it.