### PR TITLE
Throw TypeError if regexp is passed to startsWith, endsWith, includes

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -331,11 +331,15 @@ impl String {
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(ctx)?;
 
-        // TODO: Should throw TypeError if pattern is regular expression
-        let search_string = args
-            .get(0)
-            .expect("failed to get argument for String method")
-            .to_string(ctx)?;
+        let arg = args.get(0).cloned().unwrap_or_else(Value::undefined);
+
+        if Self::is_regexp_object(&arg) {
+            ctx.throw_type_error(
+                "First argument to String.prototype.startsWith must not be a regular expression",
+            )?;
+        }
+
+        let search_string = arg.to_string(ctx)?;
 
         let length = primitive_val.chars().count() as i32;
         let search_length = search_string.chars().count() as i32;
@@ -374,11 +378,15 @@ impl String {
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(ctx)?;
 
-        // TODO: Should throw TypeError if search_string is regular expression
-        let search_string = args
-            .get(0)
-            .expect("failed to get argument for String method")
-            .to_string(ctx)?;
+        let arg = args.get(0).cloned().unwrap_or_else(Value::undefined);
+
+        if Self::is_regexp_object(&arg) {
+            ctx.throw_type_error(
+                "First argument to String.prototype.endsWith must not be a regular expression",
+            )?;
+        }
+
+        let search_string = arg.to_string(ctx)?;
 
         let length = primitive_val.chars().count() as i32;
         let search_length = search_string.chars().count() as i32;
@@ -420,11 +428,15 @@ impl String {
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(ctx)?;
 
-        // TODO: Should throw TypeError if search_string is regular expression
-        let search_string = args
-            .get(0)
-            .expect("failed to get argument for String method")
-            .to_string(ctx)?;
+        let arg = args.get(0).cloned().unwrap_or_else(Value::undefined);
+
+        if Self::is_regexp_object(&arg) {
+            ctx.throw_type_error(
+                "First argument to String.prototype.includes must not be a regular expression",
+            )?;
+        }
+
+        let search_string = arg.to_string(ctx)?;
 
         let length = primitive_val.chars().count() as i32;
 
@@ -459,6 +471,13 @@ impl String {
                 "undefined".to_string()
             }
             _ => "undefined".to_string(),
+        }
+    }
+
+    fn is_regexp_object(value: &Value) -> bool {
+        match value {
+            Value::Object(ref obj) => obj.borrow().is_regexp(),
+            _ => false,
         }
     }
 

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -321,6 +321,26 @@ fn starts_with() {
 }
 
 #[test]
+fn starts_with_with_regex_arg() {
+    let mut engine = Context::new();
+
+    let scenario = r#"
+        try {
+            'Saturday night'.startsWith(/Saturday/);
+        } catch (e) {
+            e.toString();
+        }
+    "#;
+
+    assert_eq!(
+        forward(
+            &mut engine, scenario
+        ),
+        "\"TypeError: First argument to String.prototype.startsWith must not be a regular expression\""
+    )
+}
+
+#[test]
 fn ends_with() {
     let mut engine = Context::new();
     let init = r#"
@@ -342,6 +362,70 @@ fn ends_with() {
     assert_eq!(forward(&mut engine, "emptyLiteral.endsWith('')"), "true");
     assert_eq!(forward(&mut engine, "enLiteral.endsWith('h')"), "true");
     assert_eq!(forward(&mut engine, "zhLiteral.endsWith('文')"), "true");
+}
+
+#[test]
+fn ends_with_with_regex_arg() {
+    let mut engine = Context::new();
+
+    let scenario = r#"
+        try {
+            'Saturday night'.endsWith(/night/);
+        } catch (e) {
+            e.toString();
+        }
+    "#;
+
+    assert_eq!(
+        forward(
+            &mut engine, scenario
+        ),
+        "\"TypeError: First argument to String.prototype.endsWith must not be a regular expression\""
+    )
+}
+
+#[test]
+fn includes() {
+    let mut engine = Context::new();
+    let init = r#"
+        var empty = new String('');
+        var en = new String('english');
+        var zh = new String('中文');
+
+        var emptyLiteral = '';
+        var enLiteral = 'english';
+        var zhLiteral = '中文';
+        "#;
+
+    forward(&mut engine, init);
+
+    assert_eq!(forward(&mut engine, "empty.includes('')"), "true");
+    assert_eq!(forward(&mut engine, "en.includes('g')"), "true");
+    assert_eq!(forward(&mut engine, "zh.includes('文')"), "true");
+
+    assert_eq!(forward(&mut engine, "emptyLiteral.includes('')"), "true");
+    assert_eq!(forward(&mut engine, "enLiteral.includes('g')"), "true");
+    assert_eq!(forward(&mut engine, "zhLiteral.includes('文')"), "true");
+}
+
+#[test]
+fn includes_with_regex_arg() {
+    let mut engine = Context::new();
+
+    let scenario = r#"
+        try {
+            'Saturday night'.includes(/day/);
+        } catch (e) {
+            e.toString();
+        }
+    "#;
+
+    assert_eq!(
+        forward(
+            &mut engine, scenario
+        ),
+        "\"TypeError: First argument to String.prototype.includes must not be a regular expression\""
+    )
 }
 
 #[test]


### PR DESCRIPTION
This Pull Request fixes/closes #755.

It changes the following:

- Updating `startsWith`, `endsWith`, `includes` to throw `TypeError` if regex is passed in.
- Adding tests.
