### PR TITLE
Fix zero argument panic in JSON.parse()

### DIFF
--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -61,12 +61,12 @@ impl Json {
     /// [spec]: https://tc39.es/ecma262/#sec-json.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
     pub(crate) fn parse(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
-        match serde_json::from_str::<JSONValue>(
-            &args
-                .get(0)
-                .expect("cannot get argument for JSON.parse")
-                .to_string(ctx)?,
-        ) {
+        let arg = match args.get(0) {
+            Some(arg) => arg.to_string(ctx)?,
+            None => return ctx.throw_syntax_error("JSON.parse(): Expected argument"),
+        };
+
+        match serde_json::from_str::<JSONValue>(&arg) {
             Ok(json) => {
                 let j = Value::from_json(json, ctx);
                 match args.get(1) {

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -79,7 +79,7 @@ impl Json {
                     _ => Ok(j),
                 }
             }
-            Err(err) => Err(Value::from(err.to_string())),
+            Err(err) => ctx.throw_syntax_error(err.to_string()),
         }
     }
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -61,10 +61,11 @@ impl Json {
     /// [spec]: https://tc39.es/ecma262/#sec-json.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
     pub(crate) fn parse(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
-        let arg = match args.get(0) {
-            Some(arg) => arg.to_string(ctx)?,
-            None => return ctx.throw_syntax_error("JSON.parse(): Expected argument"),
-        };
+        let arg = args
+            .get(0)
+            .cloned()
+            .unwrap_or_else(Value::undefined)
+            .to_string(ctx)?;
 
         match serde_json::from_str::<JSONValue>(&arg) {
             Ok(json) => {

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -315,3 +315,10 @@ fn json_fields_should_be_enumerable() {
     assert_eq!(actual_object, expected);
     assert_eq!(actual_array_index, expected);
 }
+
+#[test]
+fn json_parse_with_no_args_throws_syntax_error() {
+    let mut engine = Context::new();
+    let result = forward(&mut engine, "JSON.parse();");
+    assert!(result.contains("SyntaxError"));
+}


### PR DESCRIPTION
This Pull Request closes #784.

It changes the following:
Instead of panicking when an argument is not provided to `JSON.parse()`, a syntax error is raised like other JavaScript implementations.
