### PR TITLE
Fixing a duplicated attribute in test262 results

### DIFF
--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -149,7 +149,7 @@ struct TestSuite {
 struct SuiteResult {
     #[serde(rename = "n")]
     name: Box<str>,
-    #[serde(rename = "t")]
+    #[serde(rename = "c")]
     total: usize,
     #[serde(rename = "p")]
     passed: usize,


### PR DESCRIPTION
This fixes a duplicate attribute name in the generated results for test262 tests.