### PR TITLE
Refactor `PropertyDescriptor`

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, Value},
     object::ObjectData,
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     BoaProfiler, Context, Result,
 };
 use gc::{Finalize, Trace};
@@ -131,8 +131,7 @@ impl ArrayIterator {
             .set_prototype_instance(iterator_prototype);
 
         let to_string_tag = ctx.well_known_symbols().to_string_tag_symbol();
-        let to_string_tag_property =
-            Property::data_descriptor(Value::string("Array Iterator"), Attribute::CONFIGURABLE);
+        let to_string_tag_property = DataDescriptor::new("Array Iterator", Attribute::CONFIGURABLE);
         array_iterator.set_property(to_string_tag, to_string_tag_property);
         array_iterator
     }

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     builtins::array::array_iterator::{ArrayIterationKind, ArrayIterator},
     builtins::BuiltIn,
     object::{ConstructorBuilder, FunctionBuilder, ObjectData, PROTOTYPE},
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     value::{same_value_zero, Value},
     BoaProfiler, Context, Result,
 };
@@ -129,8 +129,8 @@ impl Array {
         }
 
         // finally create length property
-        let length = Property::data_descriptor(
-            length.into(),
+        let length = DataDescriptor::new(
+            length,
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
 
@@ -171,8 +171,8 @@ impl Array {
         }
 
         // Create length
-        let length = Property::data_descriptor(
-            array_contents.len().into(),
+        let length = DataDescriptor::new(
+            array_contents.len(),
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
         array_obj_ptr.set_property("length".to_string(), length);

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -63,12 +63,11 @@ fn date_this_time_value() {
     let message_property = &error
         .get_property("message")
         .expect("Expected 'message' property")
-        .value;
+        .as_data_descriptor()
+        .unwrap()
+        .value();
 
-    assert_eq!(
-        &Some(Value::string("\'this\' is not a Date")),
-        message_property
-    );
+    assert_eq!(Value::string("\'this\' is not a Date"), *message_property);
 }
 
 #[test]

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     builtins::{Array, BuiltIn},
     environment::lexical_environment::Environment,
     object::{ConstructorBuilder, FunctionBuilder, Object, ObjectData, PROTOTYPE},
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     syntax::ast::node::{FormalParameter, RcStatementList},
     BoaProfiler, Context, Result, Value,
 };
@@ -174,16 +174,16 @@ pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
     let len = arguments_list.len();
     let mut obj = Object::default();
     // Set length
-    let length = Property::data_descriptor(
-        len.into(),
+    let length = DataDescriptor::new(
+        len,
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
     );
     // Define length as a property
-    obj.define_own_property("length", length);
+    obj.define_own_property("length", length.into());
     let mut index: usize = 0;
     while index < len {
         let val = arguments_list.get(index).expect("Could not get argument");
-        let prop = Property::data_descriptor(
+        let prop = DataDescriptor::new(
             val.clone(),
             Attribute::WRITABLE | Attribute::ENUMERABLE | Attribute::CONFIGURABLE,
         );
@@ -222,14 +222,14 @@ pub fn make_constructor_fn(
     let mut constructor =
         Object::function(function, global.get_field("Function").get_field(PROTOTYPE));
 
-    let length = Property::data_descriptor(
-        length.into(),
+    let length = DataDescriptor::new(
+        length,
         Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
     );
     constructor.insert("length", length);
 
-    let name = Property::data_descriptor(
-        name.into(),
+    let name = DataDescriptor::new(
+        name,
         Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
     );
     constructor.insert("name", name);

--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::string::string_iterator::StringIterator,
     builtins::ArrayIterator,
     object::{GcObject, ObjectInitializer},
-    property::Property,
+    property::{Attribute, DataDescriptor},
     BoaProfiler, Context, Result, Value,
 };
 
@@ -47,8 +47,9 @@ impl IteratorPrototypes {
 /// Generates an object supporting the IteratorResult interface.
 pub fn create_iter_result_object(ctx: &mut Context, value: Value, done: bool) -> Value {
     let object = Value::new_object(Some(ctx.global_object()));
-    let value_property = Property::default().value(value);
-    let done_property = Property::default().value(Value::boolean(done));
+    // TODO: Fix attributes of value and done
+    let value_property = DataDescriptor::new(value, Attribute::all());
+    let done_property = DataDescriptor::new(done, Attribute::all());
     object.set_property("value", value_property);
     object.set_property("done", done_property);
     object

--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -57,14 +57,15 @@ pub fn create_iter_result_object(ctx: &mut Context, value: Value, done: bool) ->
 
 /// Get an iterator record
 pub fn get_iterator(ctx: &mut Context, iterable: Value) -> Result<IteratorRecord> {
+    // TODO: Fix the accessor handling
     let iterator_function = iterable
         .get_property(ctx.well_known_symbols().iterator_symbol())
-        .and_then(|mut p| p.value.take())
+        .map(|p| p.as_data_descriptor().unwrap().value())
         .ok_or_else(|| ctx.construct_type_error("Not an iterable"))?;
     let iterator_object = ctx.call(&iterator_function, &iterable, &[])?;
     let next_function = iterator_object
         .get_property("next")
-        .and_then(|mut p| p.value.take())
+        .map(|p| p.as_data_descriptor().unwrap().value())
         .ok_or_else(|| ctx.construct_type_error("Could not find property `next`"))?;
     Ok(IteratorRecord::new(iterator_object, next_function))
 }
@@ -112,14 +113,17 @@ impl IteratorRecord {
     /// [spec]: https://tc39.es/ecma262/#sec-iteratornext
     pub(crate) fn next(&self, ctx: &mut Context) -> Result<IteratorResult> {
         let next = ctx.call(&self.next_function, &self.iterator_object, &[])?;
+        // FIXME: handle accessor descriptors
         let done = next
             .get_property("done")
-            .and_then(|mut p| p.value.take())
+            .map(|p| p.as_data_descriptor().unwrap().value())
             .and_then(|v| v.as_boolean())
             .ok_or_else(|| ctx.construct_type_error("Could not find property `done`"))?;
+
+        // FIXME: handle accessor descriptors
         let next_result = next
             .get_property("value")
-            .and_then(|mut p| p.value.take())
+            .map(|p| p.as_data_descriptor().unwrap().value())
             .unwrap_or_default();
         Ok(IteratorResult::new(next_result, done))
     }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -16,7 +16,7 @@
 use crate::{
     builtins::BuiltIn,
     object::ObjectInitializer,
-    property::{Attribute, Property, PropertyKey},
+    property::{Attribute, DataDescriptor, PropertyKey},
     BoaProfiler, Context, Result, Value,
 };
 use serde_json::{self, Value as JSONValue};
@@ -160,11 +160,14 @@ impl Json {
                         let this_arg = object.clone();
                         object_to_return.set_property(
                             key.to_owned(),
-                            Property::default().value(ctx.call(
-                                replacer,
-                                &this_arg,
-                                &[Value::from(key.clone()), val.clone()],
-                            )?),
+                            DataDescriptor::new(
+                                ctx.call(
+                                    replacer,
+                                    &this_arg,
+                                    &[Value::from(key.clone()), val.clone()],
+                                )?,
+                                Attribute::all(),
+                            ),
                         );
                     }
                     Ok(Value::from(object_to_return.to_json(ctx)?.to_string()))

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -155,7 +155,8 @@ impl Json {
                     let object_to_return = Value::new_object(None);
                     for (key, val) in obj
                         .iter()
-                        .filter_map(|(k, v)| v.value.as_ref().map(|value| (k, value)))
+                        // FIXME: handle accessor descriptors
+                        .map(|(k, v)| (k, v.as_data_descriptor().unwrap().value()))
                     {
                         let this_arg = object.clone();
                         object_to_return.set_property(
@@ -185,7 +186,8 @@ impl Json {
             for field in fields {
                 if let Some(value) = object
                     .get_property(field.to_string(ctx)?)
-                    .and_then(|prop| prop.value.as_ref().map(|v| v.to_json(ctx)))
+                    // FIXME: handle accessor descriptors
+                    .map(|prop| prop.as_data_descriptor().unwrap().value().to_json(ctx))
                     .transpose()?
                 {
                     obj_to_return.insert(field.to_string(ctx)?.to_string(), value);

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, ObjectData, PROTOTYPE},
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     BoaProfiler, Context, Result, Value,
 };
 use ordered_map::OrderedMap;
@@ -100,8 +100,8 @@ impl Map {
 
     /// Helper function to set the size property.
     fn set_size(this: &Value, size: usize) {
-        let size = Property::data_descriptor(
-            size.into(),
+        let size = DataDescriptor::new(
+            size,
             Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
 

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -43,7 +43,7 @@ pub(crate) use self::{
     undefined::Undefined,
 };
 use crate::{
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     Context, Value,
 };
 
@@ -96,7 +96,7 @@ pub fn init(context: &mut Context) {
 
     for init in &globals {
         let (name, value, attribute) = init(context);
-        let property = Property::data_descriptor(value, attribute);
+        let property = DataDescriptor::new(value, attribute);
         global_object.borrow_mut().insert(name, property);
     }
 }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -16,7 +16,7 @@
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, Object as BuiltinObject, ObjectData},
-    property::{Attribute, Property},
+    property::Attribute,
     value::{same_value, Value},
     BoaProfiler, Context, Result,
 };
@@ -134,13 +134,18 @@ impl Object {
     }
 
     /// Define a property in an object
-    pub fn define_property(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+    pub fn define_property(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
         let obj = args.get(0).expect("Cannot get object");
         let prop = args
             .get(1)
             .expect("Cannot get object")
-            .to_property_key(ctx)?;
-        let desc = Property::from(args.get(2).expect("Cannot get object"));
+            .to_property_key(context)?;
+
+        let desc = if let Value::Object(ref object) = args.get(2).cloned().unwrap_or_default() {
+            object.to_property_descriptor(context)?
+        } else {
+            return context.throw_type_error("Property description must be an object");
+        };
         obj.set_property(prop, desc);
         Ok(Value::undefined())
     }
@@ -246,12 +251,10 @@ impl Object {
         };
 
         let key = key.to_property_key(ctx)?;
-        let own_property = this
-            .to_object(ctx)
-            .map(|obj| obj.borrow().get_own_property(&key));
+        let own_property = this.to_object(ctx)?.borrow().get_own_property(&key);
 
         Ok(own_property.map_or(Value::from(false), |own_prop| {
-            Value::from(own_prop.enumerable_or(false))
+            Value::from(own_prop.enumerable())
         }))
     }
 }

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     builtins::BuiltIn,
     gc::{empty_trace, Finalize, Trace},
     object::{ConstructorBuilder, ObjectData},
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     value::{RcString, Value},
     BoaProfiler, Context, Result,
 };
@@ -370,9 +370,9 @@ impl RegExp {
                     let result = Value::from(result);
                     result.set_property(
                         "index",
-                        Property::default().value(Value::from(m.total().start)),
+                        DataDescriptor::new(m.total().start, Attribute::all()),
                     );
-                    result.set_property("input", Property::default().value(Value::from(arg_str)));
+                    result.set_property("input", DataDescriptor::new(arg_str, Attribute::all()));
                     result
                 } else {
                     if regex.use_last_index {
@@ -473,11 +473,11 @@ impl RegExp {
 
                 match_val.set_property(
                     "index",
-                    Property::default().value(Value::from(mat.total().start)),
+                    DataDescriptor::new(mat.total().start, Attribute::all()),
                 );
                 match_val.set_property(
                     "input",
-                    Property::default().value(Value::from(arg_str.clone())),
+                    DataDescriptor::new(arg_str.clone(), Attribute::all()),
                 );
                 matches.push(match_val);
 

--- a/boa/src/builtins/string/string_iterator.rs
+++ b/boa/src/builtins/string/string_iterator.rs
@@ -2,7 +2,7 @@ use crate::builtins::string::code_point_at;
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object},
     object::ObjectData,
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     BoaProfiler, Context, Result, Value,
 };
 use gc::{Finalize, Trace};
@@ -82,7 +82,7 @@ impl StringIterator {
 
         let to_string_tag = ctx.well_known_symbols().to_string_tag_symbol();
         let to_string_tag_property =
-            Property::data_descriptor(Value::string("String Iterator"), Attribute::CONFIGURABLE);
+            DataDescriptor::new("String Iterator", Attribute::CONFIGURABLE);
         array_iterator.set_property(to_string_tag, to_string_tag_property);
         array_iterator
     }

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -10,7 +10,7 @@ use crate::{
     class::{Class, ClassBuilder},
     exec::Interpreter,
     object::{GcObject, Object, ObjectData, PROTOTYPE},
-    property::{Property, PropertyKey},
+    property::{DataDescriptor, PropertyKey},
     realm::Realm,
     syntax::{
         ast::{
@@ -608,7 +608,7 @@ impl Context {
         T::init(&mut class_builder)?;
 
         let class = class_builder.build();
-        let property = Property::data_descriptor(class.into(), T::ATTRIBUTE);
+        let property = DataDescriptor::new(class, T::ATTRIBUTE);
         self.global_object()
             .as_object_mut()
             .unwrap()

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -14,7 +14,7 @@ use crate::{
         lexical_environment::{Environment, EnvironmentType},
         object_environment_record::ObjectEnvironmentRecord,
     },
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     Value,
 };
 use gc::{Finalize, Trace};
@@ -71,16 +71,16 @@ impl GlobalEnvironmentRecord {
         let global_object = &mut self.object_record.bindings;
         let existing_prop = global_object.get_property(name);
         if let Some(prop) = existing_prop {
-            if prop.value.is_none() || prop.configurable_or(false) {
+            if prop.value.is_none() || prop.configurable() {
                 let mut property =
-                    Property::data_descriptor(value, Attribute::WRITABLE | Attribute::ENUMERABLE);
+                    DataDescriptor::new(value, Attribute::WRITABLE | Attribute::ENUMERABLE);
                 property.set_configurable(deletion);
 
                 global_object.update_property(name, property);
             }
         } else {
             let mut property =
-                Property::data_descriptor(value, Attribute::WRITABLE | Attribute::ENUMERABLE);
+                DataDescriptor::new(value, Attribute::WRITABLE | Attribute::ENUMERABLE);
             property.set_configurable(deletion);
 
             global_object.update_property(name, property);

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -82,7 +82,10 @@ impl GlobalEnvironmentRecord {
             None => DataDescriptor::new(value, Attribute::empty()),
         };
 
-        global_object.update_property(name, desc);
+        global_object
+            .as_object_mut()
+            .expect("global object")
+            .insert(name, desc);
     }
 }
 

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -11,7 +11,7 @@ use crate::{
         environment_record_trait::EnvironmentRecordTrait,
         lexical_environment::{Environment, EnvironmentType},
     },
-    property::{Attribute, Property},
+    property::{Attribute, DataDescriptor},
     Value,
 };
 use gc::{Finalize, Trace};
@@ -39,7 +39,7 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         // TODO: could save time here and not bother generating a new undefined object,
         // only for it to be replace with the real value later. We could just add the name to a Vector instead
         let bindings = &mut self.bindings;
-        let mut prop = Property::data_descriptor(
+        let mut prop = DataDescriptor::new(
             Value::undefined(),
             Attribute::WRITABLE | Attribute::ENUMERABLE,
         );
@@ -63,7 +63,7 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
     fn set_mutable_binding(&mut self, name: &str, value: Value, strict: bool) {
         debug_assert!(value.is_object() || value.is_function());
 
-        let mut property = Property::data_descriptor(value, Attribute::ENUMERABLE);
+        let mut property = DataDescriptor::new(value, Attribute::ENUMERABLE);
         property.set_configurable(strict);
         self.bindings.update_property(name, property);
     }

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -65,7 +65,10 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
 
         let mut property = DataDescriptor::new(value, Attribute::ENUMERABLE);
         property.set_configurable(strict);
-        self.bindings.update_property(name, property);
+        self.bindings
+            .as_object_mut()
+            .expect("binding object")
+            .insert(name, property);
     }
 
     fn get_binding_value(&self, name: &str, strict: bool) -> Value {

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -6,13 +6,11 @@
 //! [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
 
 use crate::{
-    object::Object,
+    object::{GcObject, Object},
     property::{AccessorDescriptor, Attribute, DataDescriptor, PropertyDescriptor, PropertyKey},
     value::{same_value, Value},
     BoaProfiler, Context, Result,
 };
-
-use super::GcObject;
 
 impl Object {
     /// Check if object has property.
@@ -191,13 +189,13 @@ impl Object {
             }
             (PropertyDescriptor::Accessor(current), PropertyDescriptor::Accessor(desc)) => {
                 if !current.configurable() {
-                    if let (Some(current_get), Some(desc_get)) = (current.set(), desc.set()) {
+                    if let (Some(current_get), Some(desc_get)) = (current.getter(), desc.getter()) {
                         if !GcObject::equals(&current_get, &desc_get) {
                             return false;
                         }
                     }
 
-                    if let (Some(current_set), Some(desc_set)) = (current.set(), desc.set()) {
+                    if let (Some(current_set), Some(desc_set)) = (current.setter(), desc.setter()) {
                         if !GcObject::equals(&current_set, &desc_set) {
                             return false;
                         }

--- a/boa/src/object/iter.rs
+++ b/boa/src/object/iter.rs
@@ -1,4 +1,4 @@
-use super::{Object, Property, PropertyKey};
+use super::{Object, PropertyDescriptor, PropertyKey};
 use crate::value::{RcString, RcSymbol};
 use std::{collections::hash_map, iter::FusedIterator};
 
@@ -108,13 +108,13 @@ impl Object {
 /// An iterator over the property entries of an `Object`
 #[derive(Debug, Clone)]
 pub struct Iter<'a> {
-    indexed_properties: hash_map::Iter<'a, u32, Property>,
-    string_properties: hash_map::Iter<'a, RcString, Property>,
-    symbol_properties: hash_map::Iter<'a, RcSymbol, Property>,
+    indexed_properties: hash_map::Iter<'a, u32, PropertyDescriptor>,
+    string_properties: hash_map::Iter<'a, RcString, PropertyDescriptor>,
+    symbol_properties: hash_map::Iter<'a, RcSymbol, PropertyDescriptor>,
 }
 
 impl<'a> Iterator for Iter<'a> {
-    type Item = (PropertyKey, &'a Property);
+    type Item = (PropertyKey, &'a PropertyDescriptor);
     fn next(&mut self) -> Option<Self::Item> {
         if let Some((key, value)) = self.indexed_properties.next() {
             Some(((*key).into(), value))
@@ -162,7 +162,7 @@ impl FusedIterator for Keys<'_> {}
 pub struct Values<'a>(Iter<'a>);
 
 impl<'a> Iterator for Values<'a> {
-    type Item = &'a Property;
+    type Item = &'a PropertyDescriptor;
     fn next(&mut self) -> Option<Self::Item> {
         let (_, value) = self.0.next()?;
         Some(value)
@@ -180,10 +180,10 @@ impl FusedIterator for Values<'_> {}
 
 /// An iterator over the `Symbol` property entries of an `Object`
 #[derive(Debug, Clone)]
-pub struct SymbolProperties<'a>(hash_map::Iter<'a, RcSymbol, Property>);
+pub struct SymbolProperties<'a>(hash_map::Iter<'a, RcSymbol, PropertyDescriptor>);
 
 impl<'a> Iterator for SymbolProperties<'a> {
-    type Item = (&'a RcSymbol, &'a Property);
+    type Item = (&'a RcSymbol, &'a PropertyDescriptor);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -207,7 +207,7 @@ impl FusedIterator for SymbolProperties<'_> {}
 
 /// An iterator over the keys (`RcSymbol`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct SymbolPropertyKeys<'a>(hash_map::Keys<'a, RcSymbol, Property>);
+pub struct SymbolPropertyKeys<'a>(hash_map::Keys<'a, RcSymbol, PropertyDescriptor>);
 
 impl<'a> Iterator for SymbolPropertyKeys<'a> {
     type Item = &'a RcSymbol;
@@ -234,10 +234,10 @@ impl FusedIterator for SymbolPropertyKeys<'_> {}
 
 /// An iterator over the `Symbol` values (`Property`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct SymbolPropertyValues<'a>(hash_map::Values<'a, RcSymbol, Property>);
+pub struct SymbolPropertyValues<'a>(hash_map::Values<'a, RcSymbol, PropertyDescriptor>);
 
 impl<'a> Iterator for SymbolPropertyValues<'a> {
-    type Item = &'a Property;
+    type Item = &'a PropertyDescriptor;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -261,10 +261,10 @@ impl FusedIterator for SymbolPropertyValues<'_> {}
 
 /// An iterator over the indexed property entries of an `Object`
 #[derive(Debug, Clone)]
-pub struct IndexProperties<'a>(hash_map::Iter<'a, u32, Property>);
+pub struct IndexProperties<'a>(hash_map::Iter<'a, u32, PropertyDescriptor>);
 
 impl<'a> Iterator for IndexProperties<'a> {
-    type Item = (&'a u32, &'a Property);
+    type Item = (&'a u32, &'a PropertyDescriptor);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -288,7 +288,7 @@ impl FusedIterator for IndexProperties<'_> {}
 
 /// An iterator over the index keys (`u32`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct IndexPropertyKeys<'a>(hash_map::Keys<'a, u32, Property>);
+pub struct IndexPropertyKeys<'a>(hash_map::Keys<'a, u32, PropertyDescriptor>);
 
 impl<'a> Iterator for IndexPropertyKeys<'a> {
     type Item = &'a u32;
@@ -315,10 +315,10 @@ impl FusedIterator for IndexPropertyKeys<'_> {}
 
 /// An iterator over the index values (`Property`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct IndexPropertyValues<'a>(hash_map::Values<'a, u32, Property>);
+pub struct IndexPropertyValues<'a>(hash_map::Values<'a, u32, PropertyDescriptor>);
 
 impl<'a> Iterator for IndexPropertyValues<'a> {
-    type Item = &'a Property;
+    type Item = &'a PropertyDescriptor;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -342,10 +342,10 @@ impl FusedIterator for IndexPropertyValues<'_> {}
 
 /// An iterator over the `String` property entries of an `Object`
 #[derive(Debug, Clone)]
-pub struct StringProperties<'a>(hash_map::Iter<'a, RcString, Property>);
+pub struct StringProperties<'a>(hash_map::Iter<'a, RcString, PropertyDescriptor>);
 
 impl<'a> Iterator for StringProperties<'a> {
-    type Item = (&'a RcString, &'a Property);
+    type Item = (&'a RcString, &'a PropertyDescriptor);
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -369,7 +369,7 @@ impl FusedIterator for StringProperties<'_> {}
 
 /// An iterator over the string keys (`RcString`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct StringPropertyKeys<'a>(hash_map::Keys<'a, RcString, Property>);
+pub struct StringPropertyKeys<'a>(hash_map::Keys<'a, RcString, PropertyDescriptor>);
 
 impl<'a> Iterator for StringPropertyKeys<'a> {
     type Item = &'a RcString;
@@ -396,10 +396,10 @@ impl FusedIterator for StringPropertyKeys<'_> {}
 
 /// An iterator over the string values (`Property`) of an `Object`.
 #[derive(Debug, Clone)]
-pub struct StringPropertyValues<'a>(hash_map::Values<'a, RcString, Property>);
+pub struct StringPropertyValues<'a>(hash_map::Values<'a, RcString, PropertyDescriptor>);
 
 impl<'a> Iterator for StringPropertyValues<'a> {
-    type Item = &'a Property;
+    type Item = &'a PropertyDescriptor;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     context::StandardConstructor,
     gc::{Finalize, Trace},
-    property::{Attribute, Property, PropertyKey},
+    property::{Attribute, DataDescriptor, PropertyDescriptor, PropertyKey},
     value::{RcBigInt, RcString, RcSymbol, Value},
     BoaProfiler, Context,
 };
@@ -59,11 +59,11 @@ impl<T: Any + Debug + Trace> NativeObject for T {
 pub struct Object {
     /// The type of the object.
     pub data: ObjectData,
-    indexed_properties: FxHashMap<u32, Property>,
+    indexed_properties: FxHashMap<u32, PropertyDescriptor>,
     /// Properties
-    string_properties: FxHashMap<RcString, Property>,
+    string_properties: FxHashMap<RcString, PropertyDescriptor>,
     /// Symbol Properties
-    symbol_properties: FxHashMap<RcSymbol, Property>,
+    symbol_properties: FxHashMap<RcSymbol, PropertyDescriptor>,
     /// Instance prototype `__proto__`.
     prototype: Value,
     /// Whether it can have new properties added to it.
@@ -760,7 +760,7 @@ impl<'context> ObjectInitializer<'context> {
         K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        let property = Property::data_descriptor(value.into(), attribute);
+        let property = DataDescriptor::new(value, attribute);
         self.object.borrow_mut().insert(key, property);
         self
     }
@@ -891,7 +891,7 @@ impl<'context> ConstructorBuilder<'context> {
         K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        let property = Property::data_descriptor(value.into(), attribute);
+        let property = DataDescriptor::new(value, attribute);
         self.prototype.borrow_mut().insert(key, property);
         self
     }
@@ -903,7 +903,7 @@ impl<'context> ConstructorBuilder<'context> {
         K: Into<PropertyKey>,
         V: Into<Value>,
     {
-        let property = Property::data_descriptor(value.into(), attribute);
+        let property = DataDescriptor::new(value, attribute);
         self.constructor_object.borrow_mut().insert(key, property);
         self
     }
@@ -971,15 +971,12 @@ impl<'context> ConstructorBuilder<'context> {
             FunctionFlags::from_parameters(self.callable, self.constructable),
         );
 
-        let length = Property::data_descriptor(
-            self.length.into(),
+        let length = DataDescriptor::new(
+            self.length,
             Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
-        let name = Property::data_descriptor(
-            self.name
-                .take()
-                .unwrap_or_else(|| String::from("[object]"))
-                .into(),
+        let name = DataDescriptor::new(
+            self.name.take().unwrap_or_else(|| String::from("[object]")),
             Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
 

--- a/boa/src/property/attribute/mod.rs
+++ b/boa/src/property/attribute/mod.rs
@@ -18,32 +18,22 @@ bitflags! {
     #[derive(Finalize)]
     pub struct Attribute: u8 {
         /// The `Writable` attribute decides whether the value associated with the property can be changed or not, from its initial value.
-        const WRITABLE = 0b0000_0011;
-
-        /// The property is not writable.
-        const READONLY = 0b0000_0010;
-
-        /// Is the `Writable` flag defined.
-        const HAS_WRITABLE = 0b0000_0010;
+        const WRITABLE = 0b0000_0001;
 
         /// If the property can be enumerated by a `for-in` loop.
-        const ENUMERABLE = 0b0000_1100;
-
-        /// The property can not be enumerated in a `for-in` loop.
-        const NON_ENUMERABLE = 0b0000_1000;
-
-        /// Is the `Enumerable` flag defined.
-        const HAS_ENUMERABLE = 0b0000_1000;
+        const ENUMERABLE = 0b0000_0010;
 
         /// If the property descriptor can be changed later.
-        const CONFIGURABLE = 0b0011_0000;
+        const CONFIGURABLE = 0b0000_0100;
+
+        /// The property is not writable.
+        const READONLY = 0b0000_0000;
+
+        /// The property can not be enumerated in a `for-in` loop.
+        const NON_ENUMERABLE = 0b0000_0000;
 
         /// The property descriptor cannot be changed.
-        const PERMANENT = 0b0010_0000;
-
-        /// Is the `Configurable` flag defined.
-        const HAS_CONFIGURABLE = 0b0010_0000;
-
+        const PERMANENT = 0b0000_0000;
     }
 }
 
@@ -63,12 +53,6 @@ impl Attribute {
         self.bits = 0;
     }
 
-    /// Is the `writable` flag defined.
-    #[inline]
-    pub fn has_writable(self) -> bool {
-        self.contains(Self::HAS_WRITABLE)
-    }
-
     /// Sets the `writable` flag.
     #[inline]
     pub fn set_writable(&mut self, value: bool) {
@@ -82,14 +66,7 @@ impl Attribute {
     /// Gets the `writable` flag.
     #[inline]
     pub fn writable(self) -> bool {
-        debug_assert!(self.has_writable());
         self.contains(Self::WRITABLE)
-    }
-
-    /// Is the `enumerable` flag defined.
-    #[inline]
-    pub fn has_enumerable(self) -> bool {
-        self.contains(Self::HAS_ENUMERABLE)
     }
 
     /// Sets the `enumerable` flag.
@@ -105,14 +82,7 @@ impl Attribute {
     /// Gets the `enumerable` flag.
     #[inline]
     pub fn enumerable(self) -> bool {
-        debug_assert!(self.has_enumerable());
         self.contains(Self::ENUMERABLE)
-    }
-
-    /// Is the `configurable` flag defined.
-    #[inline]
-    pub fn has_configurable(self) -> bool {
-        self.contains(Self::HAS_CONFIGURABLE)
     }
 
     /// Sets the `configurable` flag.
@@ -128,7 +98,6 @@ impl Attribute {
     /// Gets the `configurable` flag.
     #[inline]
     pub fn configurable(self) -> bool {
-        debug_assert!(self.has_configurable());
         self.contains(Self::CONFIGURABLE)
     }
 }

--- a/boa/src/property/attribute/mod.rs
+++ b/boa/src/property/attribute/mod.rs
@@ -10,11 +10,12 @@ bitflags! {
     /// This struct constains the property flags as describen in the ECMAScript specification.
     ///
     /// It contains the following flags:
-    ///  - `[[Writable]]` (`WRITABLE`) - If `false`, attempts by ECMAScript code to change the property's `[[Value]]` attribute using `[[Set]]` will not succeed.
+    ///  - `[[Writable]]` (`WRITABLE`) - If `false`, attempts by ECMAScript code to change the property's
+    /// `[[Value]]` attribute using `[[Set]]` will not succeed.
     ///  - `[[Enumerable]]` (`ENUMERABLE`) - If the property will be enumerated by a for-in enumeration.
-    ///  - `[[Configurable]]` (`CONFIGURABLE`) - If `false`, attempts to delete the property, change the property to be an `accessor property`, or change its attributes (other than `[[Value]]`, or changing `[[Writable]]` to `false`) will fail.
-    ///
-    /// Additionaly there are flags for when the flags are defined.
+    ///  - `[[Configurable]]` (`CONFIGURABLE`) - If `false`, attempts to delete the property,
+    /// change the property to be an `accessor property`, or change its attributes (other than `[[Value]]`,
+    /// or changing `[[Writable]]` to `false`) will fail.
     #[derive(Finalize)]
     pub struct Attribute: u8 {
         /// The `Writable` attribute decides whether the value associated with the property can be changed or not, from its initial value.

--- a/boa/src/property/attribute/tests.rs
+++ b/boa/src/property/attribute/tests.rs
@@ -4,7 +4,6 @@ use super::Attribute;
 fn writable() {
     let attribute = Attribute::WRITABLE;
 
-    assert!(attribute.has_writable());
     assert!(attribute.writable());
 }
 
@@ -12,7 +11,6 @@ fn writable() {
 fn enumerable() {
     let attribute = Attribute::ENUMERABLE;
 
-    assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
 }
 
@@ -20,7 +18,6 @@ fn enumerable() {
 fn configurable() {
     let attribute = Attribute::CONFIGURABLE;
 
-    assert!(attribute.has_configurable());
     assert!(attribute.configurable());
 }
 
@@ -28,23 +25,17 @@ fn configurable() {
 fn writable_and_enumerable() {
     let attribute = Attribute::WRITABLE | Attribute::ENUMERABLE;
 
-    assert!(attribute.has_writable());
     assert!(attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
-
-    assert!(!attribute.has_configurable());
 }
 
 #[test]
 fn enumerable_configurable() {
     let attribute = Attribute::ENUMERABLE | Attribute::CONFIGURABLE;
 
-    assert!(!attribute.has_writable());
+    assert!(!attribute.writable());
 
-    assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(attribute.configurable());
 }
 
@@ -52,11 +43,8 @@ fn enumerable_configurable() {
 fn writable_enumerable_configurable() {
     let attribute = Attribute::WRITABLE | Attribute::ENUMERABLE | Attribute::CONFIGURABLE;
 
-    assert!(attribute.has_writable());
     assert!(attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(attribute.configurable());
 }
 
@@ -64,9 +52,9 @@ fn writable_enumerable_configurable() {
 fn default() {
     let attribute = Attribute::default();
 
-    assert!(attribute.has_writable());
-    assert!(attribute.has_enumerable());
-    assert!(attribute.has_configurable());
+    assert!(!attribute.writable());
+    assert!(!attribute.enumerable());
+    assert!(!attribute.configurable());
 }
 
 #[test]
@@ -75,9 +63,9 @@ fn clear() {
 
     attribute.clear();
 
-    assert!(!attribute.has_writable());
-    assert!(!attribute.has_enumerable());
-    assert!(!attribute.has_configurable());
+    assert!(!attribute.writable());
+    assert!(!attribute.enumerable());
+    assert!(!attribute.configurable());
 
     assert!(attribute.is_empty());
 }
@@ -88,11 +76,8 @@ fn set_writable_to_true() {
 
     attribute.set_writable(true);
 
-    assert!(attribute.has_writable());
     assert!(attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(!attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(!attribute.configurable());
 }
 
@@ -102,11 +87,8 @@ fn set_writable_to_false() {
 
     attribute.set_writable(false);
 
-    assert!(attribute.has_writable());
     assert!(!attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(!attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(!attribute.configurable());
 }
 
@@ -116,11 +98,8 @@ fn set_enumerable_to_true() {
 
     attribute.set_enumerable(true);
 
-    assert!(attribute.has_writable());
     assert!(!attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(!attribute.configurable());
 }
 
@@ -130,11 +109,8 @@ fn set_enumerable_to_false() {
 
     attribute.set_enumerable(false);
 
-    assert!(attribute.has_writable());
     assert!(!attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(!attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(!attribute.configurable());
 }
 
@@ -144,11 +120,8 @@ fn set_configurable_to_true() {
 
     attribute.set_configurable(true);
 
-    assert!(attribute.has_writable());
     assert!(!attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(!attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(attribute.configurable());
 }
 
@@ -158,10 +131,7 @@ fn set_configurable_to_false() {
 
     attribute.set_configurable(false);
 
-    assert!(attribute.has_writable());
     assert!(!attribute.writable());
-    assert!(attribute.has_enumerable());
     assert!(!attribute.enumerable());
-    assert!(attribute.has_configurable());
     assert!(!attribute.configurable());
 }

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -147,7 +147,7 @@ impl AccessorDescriptor {
         self.get.as_ref()
     }
 
-    /// Return the getter if it exists.
+    /// Return the setter if it exists.
     #[inline]
     pub fn setter(&self) -> Option<&GcObject> {
         self.set.as_ref()
@@ -277,7 +277,7 @@ impl PropertyDescriptor {
         }
     }
 
-    /// Check whether the descriptor is enumerable.
+    /// Check whether the descriptor is configurable.
     #[inline]
     pub fn configurable(&self) -> bool {
         match self {

--- a/boa/src/value/conversions.rs
+++ b/boa/src/value/conversions.rs
@@ -127,7 +127,7 @@ where
     fn from(value: &[T]) -> Self {
         let mut array = Object::default();
         for (i, item) in value.iter().enumerate() {
-            array.insert(i, Property::default().value(item.clone().into()));
+            array.insert(i, DataDescriptor::new(item.clone(), Attribute::all()));
         }
         Self::from(array)
     }
@@ -140,7 +140,7 @@ where
     fn from(value: Vec<T>) -> Self {
         let mut array = Object::default();
         for (i, item) in value.into_iter().enumerate() {
-            array.insert(i, Property::default().value(item.into()));
+            array.insert(i, DataDescriptor::new(item, Attribute::all()));
         }
         Value::from(array)
     }

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -94,6 +94,8 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                     let len = v
                         .borrow()
                         .get_own_property(&PropertyKey::from("length"))
+                        // TODO: do this in a better way `unwrap`
+                        .unwrap()
                         .value
                         .clone()
                         .expect("Could not borrow value")
@@ -112,6 +114,8 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                 log_string_from(
                                     &v.borrow()
                                         .get_own_property(&i.into())
+                                        // TODO: do this in a better way "unwrap"
+                                        .unwrap()
                                         .value
                                         .clone()
                                         .expect("Could not borrow value"),
@@ -131,6 +135,8 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                     let size = v
                         .borrow()
                         .get_own_property(&PropertyKey::from("size"))
+                        // TODO: do this in a better way "unwrap"
+                        .unwrap()
                         .value
                         .clone()
                         .expect("Could not borrow value")

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -49,9 +49,10 @@ macro_rules! print_obj_value {
     (props of $obj:expr, $display_fn:ident, $indent:expr, $encounters:expr, $print_internals:expr) => {
         print_obj_value!(impl $obj, |(key, val)| {
             let v = &val
-                .value
-                .as_ref()
-                .expect("Could not get the property's value");
+                // FIXME: handle accessor descriptors
+                .as_data_descriptor()
+                .unwrap()
+                .value();
 
             format!(
                 "{:>width$}: {}",
@@ -96,9 +97,10 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                         .get_own_property(&PropertyKey::from("length"))
                         // TODO: do this in a better way `unwrap`
                         .unwrap()
-                        .value
-                        .clone()
-                        .expect("Could not borrow value")
+                        // FIXME: handle accessor descriptors
+                        .as_data_descriptor()
+                        .unwrap()
+                        .value()
                         .as_number()
                         .unwrap() as i32;
 
@@ -116,9 +118,10 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                         .get_own_property(&i.into())
                                         // TODO: do this in a better way "unwrap"
                                         .unwrap()
-                                        .value
-                                        .clone()
-                                        .expect("Could not borrow value"),
+                                        // FIXME: handle accessor descriptors
+                                        .as_data_descriptor()
+                                        .unwrap()
+                                        .value(),
                                     print_internals,
                                     false,
                                 )
@@ -137,9 +140,10 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                         .get_own_property(&PropertyKey::from("size"))
                         // TODO: do this in a better way "unwrap"
                         .unwrap()
-                        .value
-                        .clone()
-                        .expect("Could not borrow value")
+                        // FIXME: handle accessor descriptors
+                        .as_data_descriptor()
+                        .unwrap()
+                        .value()
                         .as_number()
                         .unwrap() as i32;
                     if size == 0 {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -487,24 +487,10 @@ impl Value {
         let _timer = BoaProfiler::global().start_event("Value::get_field", "value");
         let key = key.into();
         match self.get_property(key) {
-            Some(prop) => {
-                // If the Property has [[Get]] set to a function, we should run that and return the Value
-                let prop_getter = match prop.get {
-                    Some(_) => None,
-                    None => None,
-                };
-
-                // If the getter is populated, use that. If not use [[Value]] instead
-                if let Some(val) = prop_getter {
-                    val
-                } else {
-                    let val = prop
-                        .value
-                        .as_ref()
-                        .expect("Could not get property as reference");
-                    val.clone()
-                }
-            }
+            Some(ref desc) => match desc {
+                PropertyDescriptor::Accessor(_) => todo!(),
+                PropertyDescriptor::Data(desc) => desc.value(),
+            },
             None => Value::undefined(),
         }
     }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -462,21 +462,6 @@ impl Value {
         }
     }
 
-    /// update_prop will overwrite individual [Property] fields, unlike
-    /// Set_prop, which will overwrite prop with a new Property
-    ///
-    /// Mostly used internally for now
-    pub(crate) fn update_property<P>(&self, field: &str, new_property: P)
-    where
-        P: Into<PropertyDescriptor>,
-    {
-        let _timer = BoaProfiler::global().start_event("Value::update_property", "value");
-
-        if let Some(ref mut object) = self.as_object_mut() {
-            object.insert(field, new_property.into());
-        }
-    }
-
     /// Resolve the property in the object and get its value, or undefined if this is not an object or the field doesn't exist
     /// get_field recieves a Property from get_prop(). It should then return the [[Get]] result value if that's set, otherwise fall back to [[Value]]
     /// TODO: this function should use the get Value if its set

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -190,7 +190,7 @@ impl Value {
                     );
                 }
                 new_obj.set_property(
-                    "length".to_string(),
+                    "length",
                     // TODO: Fix length attribute
                     DataDescriptor::new(length, Attribute::all()),
                 );

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::float_cmp)]
+
 use super::*;
 use crate::{forward, forward_val, Context};
 
@@ -557,7 +559,7 @@ mod cyclic_conversions {
 
         let value = forward_val(&mut engine, src).unwrap();
         let result = value.as_number().unwrap();
-        assert_eq!(result, 0.);
+        assert_eq!(result, 0.0);
     }
 
     #[test]


### PR DESCRIPTION
This PR adds a nice API for creating Property Descriptor (`DataDescriptor` and `AccessorDescriptor`) by making illegal state unrepresentable, for example `get` and `value` in the same property descriptor (which is not allowed, but was possible with the old implementation), which we needed dynamic checks to prove that it was not the case (performance penalty), but now we leverage the Type System for this as well as it makes implementing #591 and accessors so much easier.

It changes the following:
 - Rename `Property` => `PropertyDescriptor`
 - Add `DataDescriptor` for defining data descriptors
 - Add `AccessorDescriptor` for defining accessor descriptors
 - Make `PropertyDescriptor` an enum
 - Remove `HAS_*` form `Attribute`
 - Remove `Value::update_property` related to #577 