### PR TITLE
Implement Object.getOwnPropertyDescriptor() and Object.getOwnPropertyDescriptors()

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -13,7 +13,15 @@
 //! [spec]: https://tc39.es/ecma262/#sec-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-use crate::{BoaProfiler, Context, Result, builtins::BuiltIn, object::{ConstructorBuilder, Object as BuiltinObject, ObjectData, ObjectInitializer}, property::Attribute, property::DataDescriptor, property::PropertyDescriptor, value::{same_value, Value}};
+use crate::{
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, Object as BuiltinObject, ObjectData, ObjectInitializer},
+    property::Attribute,
+    property::DataDescriptor,
+    property::PropertyDescriptor,
+    value::{same_value, Value},
+    BoaProfiler, Context, Result,
+};
 
 #[cfg(test)]
 mod tests;
@@ -181,12 +189,11 @@ impl Object {
 
         if let PropertyDescriptor::Accessor(accessor_desc) = &desc {
             if let Some(setter) = accessor_desc.setter() {
-                descriptor.property("set", Value::Object(setter.to_owned()), Attribute::all());       
-            } 
+                descriptor.property("set", Value::Object(setter.to_owned()), Attribute::all());
+            }
             if let Some(getter) = accessor_desc.getter() {
                 descriptor.property("get", Value::Object(getter.to_owned()), Attribute::all());
             }
-
         }
 
         let writable = if let PropertyDescriptor::Data(data_desc) = &desc {

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -154,7 +154,7 @@ impl Object {
         args: &[Value],
         ctx: &mut Context,
     ) -> Result<Value> {
-        let object = args.get(0).unwrap().to_object(ctx)?;
+        let object = args.get(0).unwrap_or(&Value::undefined()).to_object(ctx)?;
         let descriptors = ctx.construct_object();
 
         for (key, _) in object.borrow().string_properties() {

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -16,7 +16,7 @@
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, Object as BuiltinObject, ObjectData},
-    property::{Attribute, Property, PropertyKey},
+    property::{Attribute, Property},
     value::{same_value, Value},
     BoaProfiler, Context, Result,
 };
@@ -158,7 +158,6 @@ impl Object {
         let descriptors = ctx.construct_object();
 
         for key in object.borrow().keys() {
-            let key = PropertyKey::from(key.clone());
             let desc = object.borrow().get_own_property(&key);
             let descriptor = Self::from_property_descriptor(desc, ctx)?;
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -191,17 +191,17 @@ impl Object {
         }
 
         descriptor
-                .property("writable", Value::from(desc.writable()), Attribute::all())
-                .property(
-                    "enumerable",
-                    Value::from(desc.enumerable()),
-                    Attribute::all(),
-                )
-                .property(
-                    "configurable",
-                    Value::from(desc.configurable()),
-                    Attribute::all(),
-                );
+            .property("writable", Value::from(desc.writable()), Attribute::all())
+            .property(
+                "enumerable",
+                Value::from(desc.enumerable()),
+                Attribute::all(),
+            )
+            .property(
+                "configurable",
+                Value::from(desc.configurable()),
+                Attribute::all(),
+            );
 
         Ok(descriptor.build().into())
     }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -157,12 +157,12 @@ impl Object {
         let object = args.get(0).unwrap_or(&Value::undefined()).to_object(ctx)?;
         let descriptors = ctx.construct_object();
 
-        for (key, _) in object.borrow().string_properties() {
+        for key in object.borrow().keys() {
             let key = PropertyKey::from(key.clone());
             let desc = object.borrow().get_own_property(&key);
             let descriptor = Self::from_property_descriptor(desc, ctx)?;
 
-            if descriptor != Value::undefined() {
+            if !descriptor.is_undefined() {
                 descriptors
                     .borrow_mut()
                     .insert(key, Property::data_descriptor(descriptor, Attribute::all()));

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -129,7 +129,7 @@ impl Object {
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://www.ecma-international.org/ecma-262/10.0/index.html#sec-object.getownpropertydescriptor
+    /// [spec]: https://tc39.es/ecma262/#sec-object.getownpropertydescriptor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor
     pub fn get_own_property_descriptor(
         _: &Value,
@@ -156,7 +156,7 @@ impl Object {
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://www.ecma-international.org/ecma-262/10.0/index.html#sec-object.getownpropertydescriptor
+    /// [spec]: https://tc39.es/ecma262/#sec-object.getownpropertydescriptors
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors
     pub fn get_own_property_descriptors(
         _: &Value,
@@ -186,7 +186,10 @@ impl Object {
         Ok(Value::Object(descriptors))
     }
 
-    /// https://www.ecma-international.org/ecma-262/10.0/index.html#sec-frompropertydescriptor
+    /// The abstract operation `FromPropertyDescriptor`.
+    ///
+    /// [ECMAScript reference][spec]
+    /// [spec]: https://tc39.es/ecma262/#sec-frompropertydescriptor
     fn from_property_descriptor(desc: PropertyDescriptor, ctx: &mut Context) -> Result<Value> {
         let mut descriptor = ObjectInitializer::new(ctx);
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -13,7 +13,13 @@
 //! [spec]: https://tc39.es/ecma262/#sec-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 
-use crate::{BoaProfiler, Context, Result, builtins::BuiltIn, object::{ConstructorBuilder, Object as BuiltinObject, ObjectData}, property::{Attribute, Property, PropertyKey}, value::{same_value, Value}};
+use crate::{
+    builtins::BuiltIn,
+    object::{ConstructorBuilder, Object as BuiltinObject, ObjectData},
+    property::{Attribute, Property, PropertyKey},
+    value::{same_value, Value},
+    BoaProfiler, Context, Result,
+};
 
 #[cfg(test)]
 mod tests;
@@ -134,9 +140,9 @@ impl Object {
     }
 
     /// `Object.getOwnPropertyDescriptors( object )`
-    /// 
-    /// Returns all own property descriptors of a given object. 
-    /// 
+    ///
+    /// Returns all own property descriptors of a given object.
+    ///
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
@@ -153,14 +159,15 @@ impl Object {
         let descriptors = ctx.construct_object();
 
         for (key, _) in object.borrow().string_properties() {
-
             let key = PropertyKey::from(key.clone());
 
             let desc = object.borrow().get_own_property(&key);
             let descriptor = Self::from_property_descriptor(desc, ctx)?;
 
             if descriptor != Value::undefined() {
-                descriptors.borrow_mut().insert(key, Property::data_descriptor(descriptor, Attribute::all()));
+                descriptors
+                    .borrow_mut()
+                    .insert(key, Property::data_descriptor(descriptor, Attribute::all()));
             }
         }
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -155,12 +155,10 @@ impl Object {
         ctx: &mut Context,
     ) -> Result<Value> {
         let object = args.get(0).unwrap().to_object(ctx)?;
-
         let descriptors = ctx.construct_object();
 
         for (key, _) in object.borrow().string_properties() {
             let key = PropertyKey::from(key.clone());
-
             let desc = object.borrow().get_own_property(&key);
             let descriptor = Self::from_property_descriptor(desc, ctx)?;
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -190,8 +190,7 @@ impl Object {
             descriptor.property("get", get, Attribute::all());
         }
 
-        Ok(Value::Object(
-            descriptor
+        descriptor
                 .property("writable", Value::from(desc.writable()), Attribute::all())
                 .property(
                     "enumerable",
@@ -202,9 +201,9 @@ impl Object {
                     "configurable",
                     Value::from(desc.configurable()),
                     Attribute::all(),
-                )
-                .build(),
-        ))
+                );
+
+        Ok(descriptor.build().into())
     }
 
     /// Uses the SameValue algorithm to check equality of objects

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -244,6 +244,7 @@ fn get_own_property_descriptors() {
     assert_eq!(forward(&mut ctx, "result.b.value"), "2");
 }
 
+#[test]
 fn object_define_properties() {
     let mut ctx = Context::new();
 

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -1,4 +1,6 @@
-use crate::{forward, Context};
+use std::collections::HashMap;
+
+use crate::{forward, property::Property, value::RcString, Context, Value};
 
 #[test]
 fn object_create_with_regular_object() {
@@ -190,4 +192,53 @@ fn define_symbol_property() {
     eprintln!("{}", forward(&mut ctx, init));
 
     assert_eq!(forward(&mut ctx, "obj[sym]"), "\"val\"");
+}
+
+#[test]
+fn get_own_property_descriptor_1_arg_returns_undefined() {
+    let mut ctx = Context::new();
+    let code = r#"
+        let obj = {a: 2};
+        Object.getOwnPropertyDescriptor(obj)
+    "#;
+    assert_eq!(ctx.eval(code).unwrap(), Value::undefined());
+}
+
+#[test]
+fn get_own_property_descriptor() {
+    let mut ctx = Context::new();
+    forward(
+        &mut ctx,
+        r#"
+        let obj = {a: 2};
+        let result = Object.getOwnPropertyDescriptor(obj, "a");
+    "#,
+    );
+
+    assert_eq!(forward(&mut ctx, "result.enumerable"), "true");
+    assert_eq!(forward(&mut ctx, "result.writable"), "true");
+    assert_eq!(forward(&mut ctx, "result.configurable"), "true");
+    assert_eq!(forward(&mut ctx, "result.value"), "2");
+}
+
+#[test]
+fn get_own_property_descriptors() {
+    let mut ctx = Context::new();
+    forward(
+        &mut ctx,
+        r#"
+        let obj = {a: 1, b: 2};
+        let result = Object.getOwnPropertyDescriptors(obj);
+    "#,
+    );
+
+    assert_eq!(forward(&mut ctx, "result.a.enumerable"), "true");
+    assert_eq!(forward(&mut ctx, "result.a.writable"), "true");
+    assert_eq!(forward(&mut ctx, "result.a.configurable"), "true");
+    assert_eq!(forward(&mut ctx, "result.a.value"), "1");
+
+    assert_eq!(forward(&mut ctx, "result.b.enumerable"), "true");
+    assert_eq!(forward(&mut ctx, "result.b.writable"), "true");
+    assert_eq!(forward(&mut ctx, "result.b.configurable"), "true");
+    assert_eq!(forward(&mut ctx, "result.b.value"), "2");
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-use crate::{forward, property::Property, value::RcString, Context, Value};
+use crate::{forward, Context, Value};
 
 #[test]
 fn object_create_with_regular_object() {


### PR DESCRIPTION
It changes the following:
- Implements `Object.getOwnPropertyDescriptor( object, property )` and `Object.getOwnPropertyDescriptors( object )`