### PR TITLE
Feature `console` crate feature

### DIFF
--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -13,6 +13,9 @@ edition = "2018"
 [features]
 profiler = ["measureme", "once_cell"]
 
+# Enable Boa's WHATWG console object implementation.
+console = []
+
 [dependencies]
 gc = { version = "0.3.6", features = ["derive"] }
 serde_json = "1.0.58"

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     builtins::BuiltIn,
     object::ObjectInitializer,
     property::Attribute,
-    value::{display_obj, RcString, Value},
+    value::{display::display_obj, RcString, Value},
     BoaProfiler, Context, Result,
 };
 use rustc_hash::FxHashMap;

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -3,6 +3,7 @@
 pub mod array;
 pub mod bigint;
 pub mod boolean;
+#[cfg(feature = "console")]
 pub mod console;
 pub mod date;
 pub mod error;
@@ -25,7 +26,6 @@ pub(crate) use self::{
     array::{array_iterator::ArrayIterator, Array},
     bigint::BigInt,
     boolean::Boolean,
-    console::Console,
     date::Date,
     error::{Error, RangeError, ReferenceError, SyntaxError, TypeError},
     function::BuiltInFunctionObject,
@@ -68,7 +68,6 @@ pub fn init(context: &mut Context) {
         BuiltInObjectObject::init,
         Math::init,
         Json::init,
-        Console::init,
         Array::init,
         BigInt::init,
         Boolean::init,
@@ -83,6 +82,8 @@ pub fn init(context: &mut Context) {
         ReferenceError::init,
         TypeError::init,
         SyntaxError::init,
+        #[cfg(feature = "console")]
+        console::Console::init,
     ];
 
     let global_object = if let Value::Object(global) = context.global_object() {

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -6,7 +6,6 @@ use crate::{
         function::{Function, FunctionFlags, NativeFunction},
         iterable::IteratorPrototypes,
         symbol::{Symbol, WellKnownSymbols},
-        Console,
     },
     class::{Class, ClassBuilder},
     exec::Interpreter,
@@ -27,6 +26,9 @@ use crate::{
     BoaProfiler, Executable, Result,
 };
 use std::result::Result as StdResult;
+
+#[cfg(feature = "console")]
+use crate::builtins::console::Console;
 
 /// Store a builtin constructor (such as `Object`) and its corresponding prototype.
 #[derive(Debug, Clone)]
@@ -172,6 +174,7 @@ pub struct Context {
     symbol_count: u32,
 
     /// console object state.
+    #[cfg(feature = "console")]
     console: Console,
 
     /// Cached well known symbols
@@ -193,6 +196,7 @@ impl Default for Context {
             realm,
             executor,
             symbol_count,
+            #[cfg(feature = "console")]
             console: Console::default(),
             well_known_symbols,
             iterator_prototypes: IteratorPrototypes::default(),
@@ -227,11 +231,13 @@ impl Context {
     }
 
     /// A helper function for getting a immutable reference to the `console` object.
+    #[cfg(feature = "console")]
     pub(crate) fn console(&self) -> &Console {
         &self.console
     }
 
     /// A helper function for getting a mutable reference to the `console` object.
+    #[cfg(feature = "console")]
     pub(crate) fn console_mut(&mut self) -> &mut Console {
         &mut self.console
     }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -2,7 +2,7 @@
 This is an experimental Javascript lexer, parser and compiler written in Rust. Currently, it has support for some of the language.
 
 # Crate Features
- - **serde** - Enables serialization and deserelization of the AST (Abstracr Syntax Tree).
+ - **serde** - Enables serialization and deserialization of the AST (Abstract Syntax Tree).
  - **console** - Enables `boa`s WHATWG `console` object implementation.
  - **profiler** - Enables profiling with measureme (this is mostly internal).
 

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -1,4 +1,12 @@
-//! This is an experimental Javascript lexer, parser and compiler written in Rust. Currently, it has support for some of the language.
+/*!
+This is an experimental Javascript lexer, parser and compiler written in Rust. Currently, it has support for some of the language.
+
+# Crate Features
+ - **serde** - Enables serialization and deserelization of the AST (Abstracr Syntax Tree).
+ - **console** - Enables `boa`s WHATWG `console` object implementation.
+ - **profiler** - Enables profiling with measureme (this is mostly internal).
+
+**/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/jasonwilliams/boa/master/assets/logo.svg",

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 mod conversions;
-mod display;
+pub(crate) mod display;
 mod equality;
 mod hash;
 mod operations;
@@ -35,7 +35,6 @@ mod rcsymbol;
 mod r#type;
 
 pub use conversions::*;
-pub(crate) use display::display_obj;
 pub use display::ValueDisplay;
 pub use equality::*;
 pub use hash::*;

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-Boa = { path = "../boa", features = ["serde"] }
+Boa = { path = "../boa", features = ["serde", "console"] }
 rustyline = "6.3.0"
 rustyline-derive = "0.3.1"
 structopt = "0.3.18"

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -11,7 +11,7 @@ exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
 
 [dependencies]
-Boa = { path = "../boa" }
+Boa = { path = "../boa", features = ["console"] }
 wasm-bindgen = "0.2.68"
 
 [lib]


### PR DESCRIPTION
This Pull Request fixes/closes #718 .

It changes the following:
- Put `console` object behind a feature flag 
- Documented features
