### PR TITLE
Make `Function.prototype` a function

### DIFF
--- a/boa/src/builtins/function/tests.rs
+++ b/boa/src/builtins/function/tests.rs
@@ -61,3 +61,56 @@ fn self_mutating_function_when_constructing() {
         3
     );
 }
+
+#[test]
+fn call_function_prototype() {
+    let mut engine = Context::new();
+    let func = r#"
+        Function.prototype()
+        "#;
+    let value = forward_val(&mut engine, func).unwrap();
+    assert!(value.is_undefined());
+}
+
+#[test]
+fn call_function_prototype_with_arguments() {
+    let mut engine = Context::new();
+    let func = r#"
+        Function.prototype(1, "", new String(""))
+        "#;
+    let value = forward_val(&mut engine, func).unwrap();
+    assert!(value.is_undefined());
+}
+
+#[test]
+fn call_function_prototype_with_new() {
+    let mut engine = Context::new();
+    let func = r#"
+        new Function.prototype()
+        "#;
+    let value = forward_val(&mut engine, func);
+    assert!(value.is_err());
+}
+
+#[test]
+fn function_prototype_name() {
+    let mut engine = Context::new();
+    let func = r#"
+        Function.prototype.name
+        "#;
+    let value = forward_val(&mut engine, func).unwrap();
+    assert!(value.is_string());
+    assert!(value.as_string().unwrap().is_empty());
+}
+
+#[test]
+#[allow(clippy::float_cmp)]
+fn function_prototype_length() {
+    let mut engine = Context::new();
+    let func = r#"
+        Function.prototype.length
+        "#;
+    let value = forward_val(&mut engine, func).unwrap();
+    assert!(value.is_number());
+    assert_eq!(value.as_number().unwrap(), 0.0);
+}

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -670,6 +670,29 @@ impl<'context> FunctionBuilder<'context> {
 
         GcObject::new(function)
     }
+
+    /// Initializes the `Function.prototype` function object.
+    pub(crate) fn build_function_prototype(&mut self, object: &GcObject) {
+        let mut object = object.borrow_mut();
+        object.data = ObjectData::Function(Function::BuiltIn(
+            self.function,
+            FunctionFlags::from_parameters(self.callable, self.constructable),
+        ));
+        object.set_prototype_instance(
+            self.context
+                .standard_objects()
+                .object_object()
+                .prototype()
+                .into(),
+        );
+        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+        if let Some(name) = self.name.take() {
+            object.insert_property("name", name, attribute);
+        } else {
+            object.insert_property("name", "", attribute);
+        }
+        object.insert_property("length", self.length, attribute);
+    }
 }
 
 /// Builder for creating objects with properties.


### PR DESCRIPTION
The `Function.prototype` is itself a function that has `__proto__ == Object.prototype`. I Know this is very weird

It changes the following:
- Make `Function.prototype` a function that return `undefined`
- Add tests

Here is the spec:
![Screenshot_2020-10-05_22-53-09](https://user-images.githubusercontent.com/8566042/95130926-91899d00-075d-11eb-94c1-49fab3b26860.png)
