### PR TITLE
Make boa::parse emit error on invalid input, not panic

### DIFF
--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -602,7 +602,7 @@ pub enum CompOp {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/in
     In,
 
-    /// The `instanceop` operator returns `true` if the specified object is an instance of the
+    /// The `instanceof` operator returns `true` if the specified object is an instance of the
     /// right hand side object.
     ///
     /// Syntax: `obj instanceof Object`

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -327,10 +327,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
                 TokenKind::NumericLiteral(numeric_literal),
                 Span::new(start_pos, cursor.pos()),
             )),
-            Err(error_message) => Err(Error::syntax(
-                error_message,
-                cursor.pos(),
-            )),
+            Err(error_message) => Err(Error::syntax(error_message, cursor.pos())),
         }
     }
 }

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -234,7 +234,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
                 return Err(Error::syntax(
                     "character was not in expected digit",
                     cursor.pos(),
-                ))
+                ));
             }
         }
         // Consume digits until a non-digit character is encountered or all the characters are consumed.

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -226,10 +226,9 @@ impl<R> Tokenizer<R> for NumberLiteral {
             }
         }
 
-        //Checks if the next
-        let digit_char = cursor.peek();
-
-        if let Some(digit) = digit_char? {
+        // Checks if the next char after '0x', '0o' or '0b' is a digit
+        // of that base. if not return an error. 
+        if let Some(digit) = cursor.peek()? {
             if !digit.is_digit(kind.base()) {
                 return Err(Error::syntax(
                     "expected digit after number base prefix",

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -232,7 +232,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
         if let Some(digit) = digit_char? {
             if !digit.is_digit(kind.base()) {
                 return Err(Error::syntax(
-                    "character was not in expected digit",
+                    "expected digit after number base prefix",
                     cursor.pos(),
                 ));
             }

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -158,6 +158,16 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
                         // HexIntegerLiteral
                         kind = NumericKind::Integer(16);
+
+                        // Checks if the next char after '0x' is a digit of that base. if not return an error.
+                        if let Some(digit) = cursor.peek()? {
+                            if !digit.is_digit(16) {
+                                return Err(Error::syntax(
+                                    "expected hexadecimal digit after number base prefix",
+                                    cursor.pos(),
+                                ));
+                            }
+                        }
                     }
                     'o' | 'O' => {
                         // Remove the initial '0' from buffer.
@@ -166,6 +176,16 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
                         // OctalIntegerLiteral
                         kind = NumericKind::Integer(8);
+
+                        // Checks if the next char after '0o' is a digit of that base. if not return an error.
+                        if let Some(digit) = cursor.peek()? {
+                            if !digit.is_digit(8) {
+                                return Err(Error::syntax(
+                                    "expected hexadecimal digit after number base prefix",
+                                    cursor.pos(),
+                                ));
+                            }
+                        }
                     }
                     'b' | 'B' => {
                         // Remove the initial '0' from buffer.
@@ -174,6 +194,16 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
                         // BinaryIntegerLiteral
                         kind = NumericKind::Integer(2);
+
+                        // Checks if the next char after '0b' is a digit of that base. if not return an error.
+                        if let Some(digit) = cursor.peek()? {
+                            if !digit.is_digit(2) {
+                                return Err(Error::syntax(
+                                    "expected hexadecimal digit after number base prefix",
+                                    cursor.pos(),
+                                ));
+                            }
+                        }
                     }
                     'n' => {
                         cursor.next_char()?.expect("n character vanished");
@@ -226,16 +256,6 @@ impl<R> Tokenizer<R> for NumberLiteral {
             }
         }
 
-        // Checks if the next char after '0x', '0o' or '0b' is a digit
-        // of that base. if not return an error. 
-        if let Some(digit) = cursor.peek()? {
-            if !digit.is_digit(kind.base()) {
-                return Err(Error::syntax(
-                    "expected digit after number base prefix",
-                    cursor.pos(),
-                ));
-            }
-        }
         // Consume digits until a non-digit character is encountered or all the characters are consumed.
         cursor.take_while_pred(&mut buf, &|c: char| c.is_digit(kind.base()))?;
 


### PR DESCRIPTION
This Pull Request fixes/closes #772 .

It changes the following:

- boa::parse panics on invalid input. This behavior is not expected, and I fixed this to emit error on invalid input
- fixed typo in boa/src/syntax/ast/op.rs
