### PR TITLE
Fix 2 bugs that stopped test262

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -1117,12 +1117,13 @@ impl Array {
                 );
             }
             let result = this.get_field(k);
-            k -= 1;
+            k = k.overflowing_sub(1).0;
             result
         } else {
             initial_value
         };
-        loop {
+        // usize::MAX is bigger than the maximum array size so we can use it check for integer undeflow
+        while k != usize::MAX {
             if this.has_field(k) {
                 let arguments = [accumulator, this.get_field(k), Value::from(k), this.clone()];
                 accumulator = interpreter.call(&callback, &Value::undefined(), &arguments)?;
@@ -1144,7 +1145,7 @@ impl Array {
             if k == 0 {
                 break;
             }
-            k -= 1;
+            k = k.overflowing_sub(1).0;
         }
         Ok(accumulator)
     }

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -591,15 +591,15 @@ impl Array {
         let callback = args.get(0).cloned().unwrap_or_else(Value::undefined);
         let this_val = args.get(1).cloned().unwrap_or_else(Value::undefined);
 
-        let length = this.get_field("length").as_number().unwrap() as i64;
+        let length = this.get_field("length").to_length(context)?;
 
-        if length > 2i64.pow(32) - 1 {
+        if length > 2usize.pow(32) - 1 {
             return context.throw_range_error("Invalid array length");
         }
 
         let new = Self::new_array(context)?;
 
-        let values: Vec<Value> = (0..length as i32)
+        let values: Vec<Value> = (0..length)
             .map(|idx| {
                 let element = this.get_field(idx);
                 let args = [element, Value::from(idx), new.clone()];


### PR DESCRIPTION
This Pull Request fixes the failure of test262 in CI by adding a check in `Array.prototype.map` and correcting `Array.prototype.reduceRight` for length 1.

It changes the following:

- `Array.prototype.map` now throws a `RangeError` if the `length` of the received object is greater than 2^32 - 1, as per the spec.
- `Array.prototype.reduceRight` now works correctly for length 1.