### PR TITLE
Fix tokenizing Unicode escape sequence in string literal

### DIFF
--- a/boa/src/syntax/lexer/cursor.rs
+++ b/boa/src/syntax/lexer/cursor.rs
@@ -297,7 +297,7 @@ where
                 let mut buf = [0u8; 4];
                 chr.encode_utf8(&mut buf);
                 Ok(Some(buf[0]))
-            },
+            }
             Ok(None) => Ok(None),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/boa/src/syntax/lexer/cursor.rs
+++ b/boa/src/syntax/lexer/cursor.rs
@@ -293,11 +293,7 @@ where
     #[inline]
     fn next_ascii(&mut self) -> io::Result<Option<u8>> {
         match self.next_char() {
-            Ok(Some(chr)) if chr.is_ascii() => {
-                let mut buf = [0u8; 4];
-                chr.encode_utf8(&mut buf);
-                Ok(Some(buf[0]))
-            }
+            Ok(Some(chr)) if chr.is_ascii() => Ok(Some(chr as u8)),
             Ok(None) => Ok(None),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -628,7 +628,7 @@ fn illegal_following_numeric_literal() {
 
 #[test]
 fn codepoint_with_no_braces() {
-    let mut lexer = Lexer::new(&br#""test\uD83Dtest""#[..]);
+    let mut lexer = Lexer::new(&br#""test\uD38Dtest""#[..]);
     assert!(lexer.next().is_ok());
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #808 .

It changes the following:

- Add `InnerIter::peek_iter()` and store the peeked char in `InnerIter` instance instead of `Cursor`
- Fix invalid Unicode code point in lexer test

The issue is caused by a bug in `Cursor::fill_bytes`. When `Cursor::fill_bytes` was called after `Cursor::peek`, the iter would be incremented to peek the next char but the peeked char would not be filled to the buffer. This PR introduces a new method `InnerIter::peek_char` and stores the peeked char in `InnerIter` so that it can fill the peeked char to input buffer when invoking `InnerIter::fill_bytes` correctly.

The test `syntax::lexer::tests::codepoint_with_no_braces` is updated in this PR. Since `\uD83D` is a surrogate code point, the test will panic when calling `decode_utf16` and trying to decode it. This bug should be fixed in another issue/PR to handle the invalid code point.
