### PR TITLE
Added a link to the Test262 results in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     />
 </p>
 
-This is an experimental Javascript lexer, parser and compiler written in Rust.
+This is an experimental Javascript lexer, parser and interpreter written in Rust.
 Currently, it has support for some of the language.
 
 [![Build Status][build_badge]][build_link]
@@ -28,6 +28,10 @@ You can get more verbose errors when running from the command line.
 ## Development documentation
 
 You can check the internal development docs at <https://boa-dev.github.io/boa/doc>.
+
+## Conformance
+
+To know how much of the ECMAScript specification does Boa cover, you can check out results running the ECMASCript Test262 test suite [here](https://boa-dev.github.io/boa/test262/).
 
 ## Benchmarks
 


### PR DESCRIPTION
This PR adds a link to the Test262 conformance test suite. I also modified the description of the project, since it seemed to be creating some misunderstandings. We are interpreting JavaScript, not so much compiling it to a different thing.
