### PR TITLE
Using unstable sort for sorting keys on `to_json()` for GC objects

### DIFF
--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -350,7 +350,7 @@ impl GcObject {
             Err(interpreter.construct_type_error("cyclic object value"))
         } else if self.borrow().is_array() {
             let mut keys: Vec<u32> = self.borrow().index_property_keys().cloned().collect();
-            keys.sort();
+            keys.sort_unstable();
             let mut arr: Vec<JSONValue> = Vec::with_capacity(keys.len());
             let this = Value::from(self.clone());
             for key in keys {


### PR DESCRIPTION
This solves the clippy warning we were getting, and it might speed up things a bit. As far as I understand, there is no need to use stable sorting, right? Especially since we don't have two keys with the same name.
