### PR TITLE
Move `Object` internal object methods to `GcObject`

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -53,7 +53,7 @@ impl ArrayIterator {
         let array_iterator = Value::new_object(Some(ctx.global_object()));
         array_iterator.set_data(ObjectData::ArrayIterator(Self::new(array, kind)));
         array_iterator
-            .as_object_mut()
+            .as_object()
             .expect("array iterator object")
             .set_prototype_instance(ctx.iterator_prototypes().array_iterator().into());
         Ok(array_iterator)
@@ -126,7 +126,7 @@ impl ArrayIterator {
         let array_iterator = Value::new_object(Some(global));
         make_builtin_fn(Self::next, "next", &array_iterator, 0, ctx);
         array_iterator
-            .as_object_mut()
+            .as_object()
             .expect("array iterator prototype object")
             .set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -186,7 +186,7 @@ impl Array {
             None => context.standard_objects().array_object().prototype(),
         };
 
-        this.as_object_mut()
+        this.as_object()
             .expect("this should be an array object")
             .set_prototype_instance(prototype.into());
         // This value is used by console.log and other routines to match Object type
@@ -213,7 +213,7 @@ impl Array {
         ));
         array.set_data(ObjectData::Array);
         array
-            .as_object_mut()
+            .as_object()
             .expect("array object")
             .set_prototype_instance(context.standard_objects().array_object().prototype().into());
         array.set_field("length", Value::from(0));
@@ -281,7 +281,7 @@ impl Array {
         _interpreter: &mut Context,
     ) -> Result<Value> {
         match args.get(0).and_then(|x| x.as_object()) {
-            Some(object) => Ok(Value::from(object.is_array())),
+            Some(object) => Ok(Value::from(object.borrow().is_array())),
             None => Ok(Value::from(false)),
         }
     }

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -59,11 +59,7 @@ fn instances_have_correct_proto_set() {
     let bool_prototype = forward_val(&mut engine, "boolProto").expect("value expected");
 
     assert!(same_value(
-        &bool_instance
-            .as_object()
-            .unwrap()
-            .prototype_instance()
-            .clone(),
+        &bool_instance.as_object().unwrap().prototype_instance(),
         &bool_prototype
     ));
 }

--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -20,16 +20,16 @@ impl IteratorPrototypes {
         let iterator_prototype = create_iterator_prototype(ctx);
         Self {
             iterator_prototype: iterator_prototype
-                .as_gc_object()
+                .as_object()
                 .expect("Iterator prototype is not an object"),
             array_iterator: ArrayIterator::create_prototype(ctx, iterator_prototype.clone())
-                .as_gc_object()
+                .as_object()
                 .expect("Array Iterator Prototype is not an object"),
             string_iterator: StringIterator::create_prototype(ctx, iterator_prototype.clone())
-                .as_gc_object()
+                .as_object()
                 .expect("String Iterator Prototype is not an object"),
             map_iterator: MapIterator::create_prototype(ctx, iterator_prototype)
-                .as_gc_object()
+                .as_object()
                 .expect("Map Iterator Prototype is not an object"),
         }
     }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -154,6 +154,7 @@ impl Json {
                 .map(|obj| {
                     let object_to_return = Value::new_object(None);
                     for (key, val) in obj
+                        .borrow()
                         .iter()
                         // FIXME: handle accessor descriptors
                         .map(|(k, v)| (k, v.as_data_descriptor().unwrap().value()))
@@ -176,6 +177,7 @@ impl Json {
                 .ok_or_else(Value::undefined)?
         } else if replacer_as_object.is_array() {
             let mut obj_to_return = serde_json::Map::new();
+            let replacer_as_object = replacer_as_object.borrow();
             let fields = replacer_as_object.keys().filter_map(|key| {
                 if key == "length" {
                     None

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -279,14 +279,12 @@ fn json_parse_sets_prototypes() {
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype_instance()
-        .clone();
+        .prototype_instance();
     let array_prototype = forward_val(&mut engine, r#"jsonObj.arr"#)
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype_instance()
-        .clone();
+        .prototype_instance();
     let global_object_prototype = engine
         .global_object()
         .get_field("Object")

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -53,7 +53,7 @@ impl MapIterator {
         let map_iterator = Value::new_object(Some(ctx.global_object()));
         map_iterator.set_data(ObjectData::MapIterator(Self::new(map, kind)));
         map_iterator
-            .as_object_mut()
+            .as_object()
             .expect("map iterator object")
             .set_prototype_instance(ctx.iterator_prototypes().map_iterator().into());
         Ok(map_iterator)
@@ -143,7 +143,7 @@ impl MapIterator {
         let map_iterator = Value::new_object(Some(global));
         make_builtin_fn(Self::next, "next", &map_iterator, 0, ctx);
         map_iterator
-            .as_object_mut()
+            .as_object()
             .expect("map iterator prototype object")
             .set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -73,7 +73,7 @@ impl Map {
         // Set Prototype
         let prototype = ctx.global_object().get_field("Map").get_field(PROTOTYPE);
 
-        this.as_object_mut()
+        this.as_object()
             .expect("this is map object")
             .set_prototype_instance(prototype);
         // This value is used by console.log and other routines to match Object type
@@ -354,7 +354,7 @@ impl Map {
     /// Helper function to get a key-value pair from an array.
     fn get_key_value(value: &Value) -> Option<(Value, Value)> {
         if let Value::Object(object) = value {
-            if object.borrow().is_array() {
+            if object.is_array() {
                 let (key, value) = match value.get_field("length").as_number().unwrap() as i32 {
                     0 => (Value::Undefined, Value::Undefined),
                     1 => (value.get_field("0"), Value::Undefined),

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -140,7 +140,7 @@ impl Object {
         if let Some(key) = args.get(1) {
             let key = key.to_property_key(ctx)?;
 
-            if let Some(desc) = object.borrow().get_own_property(&key) {
+            if let Some(desc) = object.get_own_property(&key) {
                 return Ok(Self::from_property_descriptor(desc, ctx)?);
             }
         }
@@ -169,7 +169,6 @@ impl Object {
         for key in object.borrow().keys() {
             let descriptor = {
                 let desc = object
-                    .borrow()
                     .get_own_property(&key)
                     .expect("Expected property to be on object.");
                 Self::from_property_descriptor(desc, ctx)?
@@ -239,16 +238,16 @@ impl Object {
     /// Get the `prototype` of an object.
     pub fn get_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
         let obj = args.get(0).expect("Cannot get object");
-        Ok(obj.as_object().map_or_else(Value::undefined, |object| {
-            object.prototype_instance().clone()
-        }))
+        Ok(obj
+            .as_object()
+            .map_or_else(Value::undefined, |object| object.prototype_instance()))
     }
 
     /// Set the `prototype` of an object.
     pub fn set_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
         let obj = args.get(0).expect("Cannot get object").clone();
         let proto = args.get(1).expect("Cannot get object").clone();
-        obj.as_object_mut().unwrap().set_prototype_instance(proto);
+        obj.as_object().unwrap().set_prototype_instance(proto);
         Ok(obj)
     }
 
@@ -281,11 +280,11 @@ impl Object {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperties
     pub fn define_properties(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
         let arg = args.get(0).cloned().unwrap_or_default();
-        let arg_obj = arg.as_object_mut();
+        let arg_obj = arg.as_object();
         if let Some(mut obj) = arg_obj {
             let props = args.get(1).cloned().unwrap_or_else(Value::undefined);
             obj.define_properties(props, ctx)?;
-            Ok(arg.clone())
+            Ok(arg)
         } else {
             ctx.throw_type_error("Expected an object")
         }
@@ -307,19 +306,21 @@ impl Object {
         } else if this.is_null() {
             Ok("[object Null]".into())
         } else {
-            let gc_o = this.to_object(ctx)?;
-            let o = gc_o.borrow();
-            let builtin_tag = match &o.data {
-                ObjectData::Array => "Array",
-                // TODO: Arguments Exotic Objects are currently not supported
-                ObjectData::Function(_) => "Function",
-                ObjectData::Error => "Error",
-                ObjectData::Boolean(_) => "Boolean",
-                ObjectData::Number(_) => "Number",
-                ObjectData::String(_) => "String",
-                ObjectData::Date(_) => "Date",
-                ObjectData::RegExp(_) => "RegExp",
-                _ => "Object",
+            let o = this.to_object(ctx)?;
+            let builtin_tag = {
+                let o = o.borrow();
+                match &o.data {
+                    ObjectData::Array => "Array",
+                    // TODO: Arguments Exotic Objects are currently not supported
+                    ObjectData::Function(_) => "Function",
+                    ObjectData::Error => "Error",
+                    ObjectData::Boolean(_) => "Boolean",
+                    ObjectData::Number(_) => "Number",
+                    ObjectData::String(_) => "String",
+                    ObjectData::Date(_) => "Date",
+                    ObjectData::RegExp(_) => "RegExp",
+                    _ => "Object",
+                }
             };
 
             let tag = o.get(&ctx.well_known_symbols().to_string_tag_symbol().into());
@@ -349,7 +350,6 @@ impl Object {
         };
         let own_property = this
             .as_object()
-            .as_deref()
             .expect("Cannot get THIS object")
             .get_own_property(&prop.expect("cannot get prop").into());
         if own_property.is_none() {
@@ -370,7 +370,7 @@ impl Object {
         };
 
         let key = key.to_property_key(ctx)?;
-        let own_property = this.to_object(ctx)?.borrow().get_own_property(&key);
+        let own_property = this.to_object(ctx)?.get_own_property(&key);
 
         Ok(own_property.map_or(Value::from(false), |own_prop| {
             Value::from(own_prop.enumerable())

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -309,6 +309,7 @@ impl RegExp {
             .to_string(ctx)?;
         let mut last_index = this.get_field("lastIndex").to_index(ctx)?;
         let result = if let Some(object) = this.as_object() {
+            let object = object.borrow();
             let regex = object.as_regexp().unwrap();
             let result =
                 if let Some(m) = regex.matcher.find_from(arg_str.as_str(), last_index).next() {
@@ -349,6 +350,7 @@ impl RegExp {
             .to_string(ctx)?;
         let mut last_index = this.get_field("lastIndex").to_index(ctx)?;
         let result = if let Some(object) = this.as_object() {
+            let object = object.borrow();
             let regex = object.as_regexp().unwrap();
             let result = {
                 if let Some(m) = regex.matcher.find_from(arg_str.as_str(), last_index).next() {
@@ -401,6 +403,7 @@ impl RegExp {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match
     pub(crate) fn r#match(this: &Value, arg: RcString, ctx: &mut Context) -> Result<Value> {
         let (matcher, flags) = if let Some(object) = this.as_object() {
+            let object = object.borrow();
             let regex = object.as_regexp().unwrap();
             (regex.matcher.clone(), regex.flags.clone())
         } else {
@@ -433,6 +436,7 @@ impl RegExp {
     #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         let (body, flags) = if let Some(object) = this.as_object() {
+            let object = object.borrow();
             let regex = object.as_regexp().unwrap();
             (regex.original_source.clone(), regex.flags.clone())
         } else {
@@ -457,6 +461,7 @@ impl RegExp {
     // TODO: it's returning an array, it should return an iterator
     pub(crate) fn match_all(this: &Value, arg_str: String) -> Result<Value> {
         let matches = if let Some(object) = this.as_object() {
+            let object = object.borrow();
             let regex = object.as_regexp().unwrap();
             let mut matches = Vec::new();
 

--- a/boa/src/builtins/string/string_iterator.rs
+++ b/boa/src/builtins/string/string_iterator.rs
@@ -25,7 +25,7 @@ impl StringIterator {
         let string_iterator = Value::new_object(Some(ctx.global_object()));
         string_iterator.set_data(ObjectData::StringIterator(Self::new(string)));
         string_iterator
-            .as_object_mut()
+            .as_object()
             .expect("array iterator object")
             .set_prototype_instance(ctx.iterator_prototypes().string_iterator().into());
         Ok(string_iterator)
@@ -76,7 +76,7 @@ impl StringIterator {
         let array_iterator = Value::new_object(Some(global));
         make_builtin_fn(Self::next, "next", &array_iterator, 0, ctx);
         array_iterator
-            .as_object_mut()
+            .as_object()
             .expect("array iterator prototype object")
             .set_prototype_instance(iterator_prototype);
 

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -43,7 +43,7 @@
 //!         class.method("speak", 0, |this, _args, _ctx| {
 //!             if let Some(object) = this.as_object() {
 //!                 if let Some(animal) = object.downcast_ref::<Animal>() {
-//!                     match animal {
+//!                     match &*animal {
 //!                         Self::Cat => println!("meow"),
 //!                         Self::Dog => println!("woof"),
 //!                         Self::Other => println!(r"¯\_(ツ)_/¯"),

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -482,15 +482,15 @@ impl Context {
 
         // Every new function has a prototype property pre-made
         let proto = Value::new_object(Some(self.global_object()));
-        let mut function = Object::function(
+        let mut function = GcObject::new(Object::function(
             Function::BuiltIn(body.into(), FunctionFlags::CALLABLE),
             function_prototype,
-        );
+        ));
         function.set(PROTOTYPE.into(), proto);
         function.set("length".into(), length.into());
         function.set("name".into(), name.into());
 
-        Ok(GcObject::new(function))
+        Ok(function)
     }
 
     /// Register a global function.
@@ -533,16 +533,13 @@ impl Context {
                                 .expect("Could not get global object"),
                         ));
                         array.set_data(ObjectData::Array);
-                        array
-                            .as_object_mut()
-                            .expect("object")
-                            .set_prototype_instance(
-                                self.realm()
-                                    .environment
-                                    .get_binding_value("Array")
-                                    .expect("Array was not initialized")
-                                    .get_field(PROTOTYPE),
-                            );
+                        array.as_object().expect("object").set_prototype_instance(
+                            self.realm()
+                                .environment
+                                .get_binding_value("Array")
+                                .expect("Array was not initialized")
+                                .get_field(PROTOTYPE),
+                        );
                         array.set_field("0", key);
                         array.set_field("1", value);
                         array.set_field("length", Value::from(2));
@@ -611,7 +608,7 @@ impl Context {
         let class = class_builder.build();
         let property = DataDescriptor::new(class, T::ATTRIBUTE);
         self.global_object()
-            .as_object_mut()
+            .as_object()
             .unwrap()
             .insert(T::NAME, property);
         Ok(())

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -83,7 +83,7 @@ impl GlobalEnvironmentRecord {
         };
 
         global_object
-            .as_object_mut()
+            .as_object()
             .expect("global object")
             .insert(name, desc);
     }

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -66,7 +66,7 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         let mut property = DataDescriptor::new(value, Attribute::ENUMERABLE);
         property.set_configurable(strict);
         self.bindings
-            .as_object_mut()
+            .as_object()
             .expect("binding object")
             .insert(name, property);
     }

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -483,6 +483,14 @@ impl Object {
         matches!(self.data, ObjectData::NativeObject(_))
     }
 
+    #[inline]
+    pub fn as_native_object(&self) -> Option<&dyn NativeObject> {
+        match self.data {
+            ObjectData::NativeObject(ref object) => Some(object.as_ref()),
+            _ => None,
+        }
+    }
+
     /// Reeturn `true` if it is a native object and the native type is `T`.
     #[inline]
     pub fn is<T>(&self) -> bool

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -93,7 +93,6 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 }
                 ObjectData::Array => {
                     let len = v
-                        .borrow()
                         .get_own_property(&PropertyKey::from("length"))
                         // TODO: do this in a better way `unwrap`
                         .unwrap()
@@ -114,8 +113,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                 // Introduce recursive call to stringify any objects
                                 // which are part of the Array
                                 log_string_from(
-                                    &v.borrow()
-                                        .get_own_property(&i.into())
+                                    &v.get_own_property(&i.into())
                                         // TODO: do this in a better way "unwrap"
                                         .unwrap()
                                         // FIXME: handle accessor descriptors
@@ -136,7 +134,6 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 }
                 ObjectData::Map(ref map) => {
                     let size = v
-                        .borrow()
                         .get_own_property(&PropertyKey::from("size"))
                         // TODO: do this in a better way "unwrap"
                         .unwrap()

--- a/boa/src/value/type.rs
+++ b/boa/src/value/type.rs
@@ -47,7 +47,7 @@ impl Value {
             Self::Undefined => Type::Undefined,
             Self::BigInt(_) => Type::BigInt,
             Self::Object(ref object) => {
-                if object.borrow().is_function() {
+                if object.is_function() {
                     Type::Function
                 } else {
                     Type::Object


### PR DESCRIPTION
**Why move the methods?**
Moving Object internal methods to `GcObject` because we borrow the object and we hold on to it and if an accessor (getters/setters) was to access the object it will give a borrow panic.

I expect some performance regression, since we do more borrow checks.

<!--
It changes the following:
-
-
-
-->
