### PR TITLE
Set default-run to `boa` removing need for `--bin`

### DIFF
--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -9,6 +9,7 @@ categories = ["command-line-utilities"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2018"
+default-run = "boa"
 
 [dependencies]
 Boa = { path = "../boa", features = ["serde", "console"] }


### PR DESCRIPTION
This PR makes it so `cargo run` runs the `boa` binary like it used to before `boa_tester` was introduced.
`boa_tester` can still be run with `cargo run --bin boa_tester`.

It changes the following:

-Sets the default run binary to `boa`