### PR TITLE
Bytecode Interpreter (new branch)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       "type": "process",
       "label": "Cargo Run (VM)",
       "command": "cargo",
-      "args": ["run", "--features", "vm", "../tests/js/test.js"],
+      "args": ["run", "--features", "vm Boa/profiler", "../tests/js/test.js"],
       "group": {
         "kind": "build",
         "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,26 @@
     },
     {
       "type": "process",
+      "label": "Cargo Run (VM)",
+      "command": "cargo",
+      "args": ["run", "--features", "vm", "../tests/js/test.js"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "presentation": {
+        "clear": true
+      },
+      "options": {
+        "cwd": "${workspaceFolder}/boa_cli",
+        "env": {
+          "RUST_BACKTRACE": "1"
+        }
+      },
+      "problemMatcher": []
+    },
+    {
+      "type": "process",
       "label": "Cargo Run (Profiler)",
       "command": "cargo",
       "args": ["run", "--features", "Boa/profiler", "../tests/js/test.js"],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,14 +12,15 @@
         "kind": "build",
         "isDefault": true
       },
-      "options": {
-        "env": {
-          "RUST_BACKTRACE": "full"
-        }
-      },
       "presentation": {
         "clear": true
-      }
+      },
+      "options": {
+        "env": {
+          "RUST_BACKTRACE": "1"
+        }
+      },
+      "problemMatcher": []
     },
     {
       "type": "process",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       "type": "process",
       "label": "Cargo Run (VM)",
       "command": "cargo",
-      "args": ["run", "--features", "vm Boa/profiler", "../tests/js/test.js"],
+      "args": ["run", "--features", "vm", "../tests/js/test.js"],
       "group": {
         "kind": "build",
         "isDefault": true

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -14,6 +14,9 @@ edition = "2018"
 profiler = ["measureme", "once_cell"]
 deser = []
 
+# Enable Bytecode generation & execution instead of tree walking
+vm = []
+
 # Enable Boa's WHATWG console object implementation.
 console = []
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -23,8 +23,6 @@ use crate::{
         Parser,
     },
     value::{RcString, RcSymbol, Value},
-    vm::compilation::Compiler,
-    vm::VM,
     BoaProfiler, Executable, Result,
 };
 use std::result::Result as StdResult;
@@ -33,7 +31,10 @@ use std::result::Result as StdResult;
 use crate::builtins::console::Console;
 
 #[cfg(feature = "vm")]
-use crate::vm::compilation::CodeGen;
+use crate::vm::{
+    compilation::{CodeGen, Compiler},
+    VM,
+};
 
 /// Store a builtin constructor (such as `Object`) and its corresponding prototype.
 #[derive(Debug, Clone)]

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -277,11 +277,6 @@ impl Context {
         &mut self.realm
     }
 
-    #[cfg(feature = "vm")]
-    pub fn instructions_mut(&mut self) -> &mut Vec<Instruction> {
-        &mut self.instruction_stack
-    }
-
     #[inline]
     pub fn executor(&mut self) -> &mut Interpreter {
         &mut self.executor
@@ -748,10 +743,11 @@ impl Context {
     /// ```
     #[cfg(feature = "vm")]
     #[allow(clippy::unit_arg, clippy::drop_copy)]
-    pub fn eval(&mut self, src: &str) -> Result<Value> {
+    pub fn eval<T: AsRef<[u8]>>(&mut self, src: T) -> Result<Value> {
         let main_timer = BoaProfiler::global().start_event("Main", "Main");
+        let src_bytes: &[u8] = src.as_ref();
 
-        let parsing_result = Parser::new(src.as_bytes())
+        let parsing_result = Parser::new(src_bytes, false)
             .parse_all()
             .map_err(|e| e.to_string());
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -23,12 +23,16 @@ use crate::{
         Parser,
     },
     value::{RcString, RcSymbol, Value},
+    vm::compilation::CodeGen,
     BoaProfiler, Executable, Result,
 };
 use std::result::Result as StdResult;
 
 #[cfg(feature = "console")]
 use crate::builtins::console::Console;
+
+#[cfg(feature = "vm")]
+use crate::vm::instructions::Instruction;
 
 /// Store a builtin constructor (such as `Object`) and its corresponding prototype.
 #[derive(Debug, Clone)]
@@ -227,6 +231,10 @@ pub struct Context {
 
     /// Cached standard objects and their prototypes
     standard_objects: StandardObjects,
+
+    /// Holds instructions for ByteCode generation
+    #[cfg(feature = "vm")]
+    instruction_stack: Vec<Instruction>,
 }
 
 impl Default for Context {
@@ -243,6 +251,8 @@ impl Default for Context {
             well_known_symbols,
             iterator_prototypes: IteratorPrototypes::default(),
             standard_objects: Default::default(),
+            #[cfg(feature = "vm")]
+            instruction_stack: vec![],
         };
 
         // Add new builtIns to Context Realm
@@ -722,6 +732,33 @@ impl Context {
         execution_result
     }
 
+    /// Evaluates the given code by compiling down to bytecode, then interpreting the bytecode into a value
+    ///
+    /// # Examples
+    /// ```
+    ///# use boa::Context;
+    /// let mut context = Context::new();
+    ///
+    /// let value = context.eval_bytecode("1 + 3").unwrap();
+    ///
+    /// assert!(value.is_number());
+    /// assert_eq!(value.as_number().unwrap(), 4.0);
+    /// ```
+    pub fn eval_bytecode(&mut self, src: &str) -> std::result::Result<(), &str> {
+        let main_timer = BoaProfiler::global().start_event("Main", "Main");
+
+        let result = match Self::parser_expr(src) {
+            Ok(ref expr) => expr.compile(self),
+            Err(e) => panic!(e),
+        };
+
+        // The main_timer needs to be dropped before the BoaProfiler is.
+        drop(main_timer);
+        BoaProfiler::global().drop();
+
+        Err("not implemented")
+    }
+
     /// Returns a structure that contains the JavaScript well known symbols.
     ///
     /// # Examples
@@ -748,5 +785,10 @@ impl Context {
     #[inline]
     pub fn standard_objects(&self) -> &StandardObjects {
         &self.standard_objects
+    }
+
+    // Add a new instruction
+    pub fn add_instruction(&mut self) {
+        self.instruction_stack.push(919);
     }
 }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -53,6 +53,7 @@ pub mod property;
 pub mod realm;
 pub mod syntax;
 pub mod value;
+#[cfg(feature = "vm")]
 pub mod vm;
 
 pub mod context;

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -53,6 +53,7 @@ pub mod property;
 pub mod realm;
 pub mod syntax;
 pub mod value;
+pub mod vm;
 
 pub mod context;
 

--- a/boa/src/profiler.rs
+++ b/boa/src/profiler.rs
@@ -12,8 +12,6 @@ use std::{
 };
 
 #[cfg(feature = "profiler")]
-type SerializationSink = measureme::SerializationSink;
-#[cfg(feature = "profiler")]
 pub struct BoaProfiler {
     profiler: Profiler,
 }

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
+    profiler::BoaProfiler,
     syntax::ast::{
         node::Node,
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
@@ -236,6 +237,7 @@ impl Executable for BinOp {
 #[cfg(feature = "vm")]
 impl CodeGen for BinOp {
     fn compile(&self, compiler: &mut Compiler) {
+        let _timer = BoaProfiler::global().start_event("binOp", "codeGen");
         match self.op() {
             op::BinOp::Num(op) => {
                 self.lhs().compile(compiler);

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -5,6 +5,7 @@ use crate::{
         node::Node,
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
+    vm::compilation::CodeGen,
     Context, Result, Value,
 };
 use std::fmt;
@@ -227,6 +228,20 @@ impl Executable for BinOp {
                 Ok(self.rhs().run(context)?)
             }
         }
+    }
+}
+
+impl CodeGen for BinOp {
+    fn compile(&self, ctx: &mut Context) -> std::result::Result<(), &str> {
+        match self.op() {
+            op::BinOp::Num(op) => {
+                self.lhs().compile(ctx);
+                self.rhs().compile(ctx);
+            }
+            _ => unimplemented!(),
+        }
+
+        Err("Fail")
     }
 }
 

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -5,15 +5,15 @@ use crate::{
         node::Node,
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
-    vm::compilation::CodeGen,
-    vm::compilation::Compiler,
-    vm::instructions::Instruction,
     Context, Result, Value,
 };
 use std::fmt;
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "vm")]
+use crate::vm::{compilation::CodeGen, Compiler, Instruction};
 
 /// Binary operators requires two operands, one before the operator and one after the operator.
 ///
@@ -233,6 +233,7 @@ impl Executable for BinOp {
     }
 }
 
+#[cfg(feature = "vm")]
 impl CodeGen for BinOp {
     fn compile(&self, compiler: &mut Compiler) {
         match self.op() {

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
-    profiler::BoaProfiler,
     syntax::ast::{
         node::Node,
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
@@ -14,7 +13,10 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "vm")]
-use crate::vm::{compilation::CodeGen, Compiler, Instruction};
+use crate::{
+    profiler::BoaProfiler,
+    vm::{compilation::CodeGen, Compiler, Instruction},
+};
 
 /// Binary operators requires two operands, one before the operator and one after the operator.
 ///

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -6,6 +6,7 @@ use crate::{
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
     vm::compilation::CodeGen,
+    vm::compilation::Compiler,
     vm::instructions::Instruction,
     Context, Result, Value,
 };
@@ -233,14 +234,46 @@ impl Executable for BinOp {
 }
 
 impl CodeGen for BinOp {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         match self.op() {
             op::BinOp::Num(op) => {
-                self.lhs().compile(ctx);
-                self.rhs().compile(ctx);
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
                 match op {
-                    NumOp::Add => ctx.add_instruction(Instruction::Add),
-                    _ => unimplemented!(),
+                    NumOp::Add => compiler.add_instruction(Instruction::Add),
+                    NumOp::Sub => compiler.add_instruction(Instruction::Sub),
+                    NumOp::Mul => compiler.add_instruction(Instruction::Mul),
+                    NumOp::Div => compiler.add_instruction(Instruction::Div),
+                    NumOp::Exp => compiler.add_instruction(Instruction::Pow),
+                    NumOp::Mod => compiler.add_instruction(Instruction::Mod),
+                }
+            }
+            op::BinOp::Bit(op) => {
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
+                match op {
+                    BitOp::And => compiler.add_instruction(Instruction::BitAnd),
+                    BitOp::Or => compiler.add_instruction(Instruction::BitOr),
+                    BitOp::Xor => compiler.add_instruction(Instruction::BitXor),
+                    BitOp::Shl => compiler.add_instruction(Instruction::Shl),
+                    BitOp::Shr => compiler.add_instruction(Instruction::Shr),
+                    BitOp::UShr => compiler.add_instruction(Instruction::UShr),
+                }
+            }
+            op::BinOp::Comp(op) => {
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
+                match op {
+                    CompOp::Equal => compiler.add_instruction(Instruction::Eq),
+                    CompOp::NotEqual => compiler.add_instruction(Instruction::NotEq),
+                    CompOp::StrictEqual => compiler.add_instruction(Instruction::StrictEq),
+                    CompOp::StrictNotEqual => compiler.add_instruction(Instruction::StrictNotEq),
+                    CompOp::GreaterThan => compiler.add_instruction(Instruction::Gt),
+                    CompOp::GreaterThanOrEqual => compiler.add_instruction(Instruction::Ge),
+                    CompOp::LessThan => compiler.add_instruction(Instruction::Lt),
+                    CompOp::LessThanOrEqual => compiler.add_instruction(Instruction::Le),
+                    CompOp::In => compiler.add_instruction(Instruction::In),
+                    CompOp::InstanceOf => compiler.add_instruction(Instruction::InstanceOf),
                 }
             }
             _ => unimplemented!(),

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -6,6 +6,7 @@ use crate::{
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
     vm::compilation::CodeGen,
+    vm::instructions::Instruction,
     Context, Result, Value,
 };
 use std::fmt;
@@ -232,16 +233,18 @@ impl Executable for BinOp {
 }
 
 impl CodeGen for BinOp {
-    fn compile(&self, ctx: &mut Context) -> std::result::Result<(), &str> {
+    fn compile(&self, ctx: &mut Context) {
         match self.op() {
             op::BinOp::Num(op) => {
                 self.lhs().compile(ctx);
                 self.rhs().compile(ctx);
+                match op {
+                    NumOp::Add => ctx.add_instruction(Instruction::Add),
+                    _ => unimplemented!(),
+                }
             }
             _ => unimplemented!(),
         }
-
-        Err("Fail")
     }
 }
 

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -1,7 +1,6 @@
 use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
-    profiler::BoaProfiler,
     syntax::ast::{node::Node, op},
     Context, Result, Value,
 };
@@ -11,7 +10,10 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "vm")]
-use crate::vm::{compilation::CodeGen, Compiler, Instruction};
+use crate::{
+    profiler::BoaProfiler,
+    vm::{compilation::CodeGen, Compiler, Instruction},
+};
 
 /// A unary operation is an operation with only one operand.
 ///

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -2,15 +2,15 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::{node::Node, op},
-    vm::compilation::CodeGen,
-    vm::Compiler,
-    vm::Instruction,
     Context, Result, Value,
 };
 use std::fmt;
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "vm")]
+use crate::vm::{compilation::CodeGen, Compiler, Instruction};
 
 /// A unary operation is an operation with only one operand.
 ///
@@ -129,6 +129,7 @@ impl From<UnaryOp> for Node {
     }
 }
 
+#[cfg(feature = "vm")]
 impl CodeGen for UnaryOp {
     fn compile(&self, compiler: &mut Compiler) {
         self.target().compile(compiler);

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -2,6 +2,9 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::{node::Node, op},
+    vm::compilation::CodeGen,
+    vm::Compiler,
+    vm::Instruction,
     Context, Result, Value,
 };
 use std::fmt;
@@ -123,5 +126,24 @@ impl fmt::Display for UnaryOp {
 impl From<UnaryOp> for Node {
     fn from(op: UnaryOp) -> Self {
         Self::UnaryOp(op)
+    }
+}
+
+impl CodeGen for UnaryOp {
+    fn compile(&self, compiler: &mut Compiler) {
+        self.target().compile(compiler);
+        match self.op {
+            op::UnaryOp::Void => compiler.add_instruction(Instruction::Void),
+            op::UnaryOp::Plus => compiler.add_instruction(Instruction::Pos),
+            op::UnaryOp::Minus => compiler.add_instruction(Instruction::Neg),
+            op::UnaryOp::TypeOf => compiler.add_instruction(Instruction::TypeOf),
+            op::UnaryOp::Not => compiler.add_instruction(Instruction::Not),
+            op::UnaryOp::Tilde => compiler.add_instruction(Instruction::BitNot),
+            op::UnaryOp::IncrementPost => {}
+            op::UnaryOp::IncrementPre => {}
+            op::UnaryOp::DecrementPost => {}
+            op::UnaryOp::DecrementPre => {}
+            op::UnaryOp::Delete => {}
+        }
     }
 }

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
+    profiler::BoaProfiler,
     syntax::ast::{node::Node, op},
     Context, Result, Value,
 };
@@ -132,6 +133,7 @@ impl From<UnaryOp> for Node {
 #[cfg(feature = "vm")]
 impl CodeGen for UnaryOp {
     fn compile(&self, compiler: &mut Compiler) {
+        let _timer = BoaProfiler::global().start_event("UnaryOp", "codeGen");
         self.target().compile(compiler);
         match self.op {
             op::UnaryOp::Void => compiler.add_instruction(Instruction::Void),

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -98,7 +98,7 @@ impl Executable for StatementList {
 #[cfg(feature = "vm")]
 impl CodeGen for StatementList {
     fn compile(&self, compiler: &mut Compiler) {
-        let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");
+        let _timer = BoaProfiler::global().start_event("StatementList - Code Gen", "codeGen");
 
         for item in self.statements().iter() {
             item.compile(compiler);

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     gc::{empty_trace, Finalize, Trace},
     syntax::ast::node::Node,
     vm::compilation::CodeGen,
+    vm::compilation::Compiler,
     BoaProfiler, Context, Result, Value,
 };
 use std::{fmt, ops::Deref, rc::Rc};
@@ -94,15 +95,11 @@ impl Executable for StatementList {
 }
 
 impl CodeGen for StatementList {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");
 
-        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
-        // The return value is uninitialized, which means it defaults to Value::Undefined
-        ctx.executor()
-            .set_current_state(InterpreterState::Executing);
-        for (i, item) in self.statements().iter().enumerate() {
-            item.compile(ctx);
+        for item in self.statements().iter() {
+            item.compile(compiler);
         }
     }
 }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -94,19 +94,16 @@ impl Executable for StatementList {
 }
 
 impl CodeGen for StatementList {
-    fn compile(&self, ctx: &mut Context) -> std::result::Result<(), &str> {
+    fn compile(&self, ctx: &mut Context) {
         let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");
 
         // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
         // The return value is uninitialized, which means it defaults to Value::Undefined
-        let mut obj = Value::default();
         ctx.executor()
             .set_current_state(InterpreterState::Executing);
         for (i, item) in self.statements().iter().enumerate() {
-            item.compile(ctx)?;
+            item.compile(ctx);
         }
-
-        Ok(())
     }
 }
 

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -4,14 +4,15 @@ use crate::{
     exec::{Executable, InterpreterState},
     gc::{empty_trace, Finalize, Trace},
     syntax::ast::node::Node,
-    vm::compilation::CodeGen,
-    vm::compilation::Compiler,
     BoaProfiler, Context, Result, Value,
 };
 use std::{fmt, ops::Deref, rc::Rc};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "vm")]
+use crate::vm::{compilation::CodeGen, Compiler};
 
 /// List of statements.
 ///
@@ -94,6 +95,7 @@ impl Executable for StatementList {
     }
 }
 
+#[cfg(feature = "vm")]
 impl CodeGen for StatementList {
     fn compile(&self, compiler: &mut Compiler) {
         let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -100,7 +100,7 @@ impl CodeGen for StatementList {
     fn compile(&self, compiler: &mut Compiler) {
         let _timer = BoaProfiler::global().start_event("StatementList - Code Gen", "codeGen");
 
-        for item in self.statements().iter() {
+        for item in self.items().iter() {
             item.compile(compiler);
         }
     }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     exec::{Executable, InterpreterState},
     gc::{empty_trace, Finalize, Trace},
     syntax::ast::node::Node,
+    vm::compilation::CodeGen,
     BoaProfiler, Context, Result, Value,
 };
 use std::{fmt, ops::Deref, rc::Rc};
@@ -89,6 +90,23 @@ impl Executable for StatementList {
         }
 
         Ok(obj)
+    }
+}
+
+impl CodeGen for StatementList {
+    fn compile(&self, ctx: &mut Context) -> std::result::Result<(), &str> {
+        let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");
+
+        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
+        // The return value is uninitialized, which means it defaults to Value::Undefined
+        let mut obj = Value::default();
+        ctx.executor()
+            .set_current_state(InterpreterState::Executing);
+        for (i, item) in self.statements().iter().enumerate() {
+            item.compile(ctx)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,21 +1,62 @@
 use super::*;
-use crate::{syntax::ast::Const, syntax::ast::Node, Context};
+use crate::{syntax::ast::Const, syntax::ast::Node, value::RcBigInt, value::RcString};
 
 #[derive(Debug, Default)]
-pub(crate) struct Compiler {
-    res: Vec<Instruction>,
-    next_free: u8,
+pub struct Compiler {
+    pub(super) instructions: Vec<Instruction>,
+    pub(super) pool: Vec<Value>,
+}
+
+impl Compiler {
+    // Add a new instruction.
+    pub fn add_instruction(&mut self, instr: Instruction) {
+        self.instructions.push(instr);
+    }
+
+    pub fn add_string_instruction<S>(&mut self, string: S)
+    where
+        S: Into<RcString>,
+    {
+        let index = self.pool.len();
+        self.add_instruction(Instruction::String(index));
+        self.pool.push(string.into().into());
+    }
+
+    pub fn add_bigint_instruction<B>(&mut self, bigint: B)
+    where
+        B: Into<RcBigInt>,
+    {
+        let index = self.pool.len();
+        self.add_instruction(Instruction::BigInt(index));
+        self.pool.push(bigint.into().into());
+    }
 }
 
 pub(crate) trait CodeGen {
-    fn compile(&self, ctx: &mut Context);
+    fn compile(&self, compiler: &mut Compiler);
 }
 
 impl CodeGen for Node {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         match *self {
-            Node::BinOp(ref op) => op.compile(ctx),
-            Node::Const(Const::Int(num)) => ctx.add_instruction(Instruction::Int32(num)),
+            Node::Const(Const::Undefined) => compiler.add_instruction(Instruction::Undefined),
+            Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
+            Node::Const(Const::Bool(true)) => compiler.add_instruction(Instruction::True),
+            Node::Const(Const::Bool(false)) => compiler.add_instruction(Instruction::False),
+            Node::Const(Const::Num(num)) => compiler.add_instruction(Instruction::Rational(num)),
+            Node::Const(Const::Int(num)) => match num {
+                0 => compiler.add_instruction(Instruction::Zero),
+                1 => compiler.add_instruction(Instruction::One),
+                _ => compiler.add_instruction(Instruction::Int32(num)),
+            },
+            Node::Const(Const::String(ref string)) => {
+                compiler.add_string_instruction(string.clone())
+            }
+            Node::Const(Const::BigInt(ref bigint)) => {
+                compiler.add_bigint_instruction(bigint.clone())
+            }
+            Node::BinOp(ref op) => op.compile(compiler),
+            Node::UnaryOp(ref op) => op.compile(compiler),
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -38,6 +38,7 @@ pub(crate) trait CodeGen {
 
 impl CodeGen for Node {
     fn compile(&self, compiler: &mut Compiler) {
+        let _timer = BoaProfiler::global().start_event(&format!("Node ({})", &self), "codeGen");
         match *self {
             Node::Const(Const::Undefined) => compiler.add_instruction(Instruction::Undefined),
             Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,6 +1,5 @@
 use super::*;
-use crate::{syntax::ast::Node, Context};
-use std::result::Result;
+use crate::{syntax::ast::Const, syntax::ast::Node, Context};
 
 #[derive(Debug, Default)]
 pub(crate) struct Compiler {
@@ -9,11 +8,15 @@ pub(crate) struct Compiler {
 }
 
 pub(crate) trait CodeGen {
-    fn compile(&self, ctx: &mut Context) -> Result<(), &str>;
+    fn compile(&self, ctx: &mut Context);
 }
 
 impl CodeGen for Node {
-    fn compile(&self, compiler: &mut Context) -> Result<(), &str> {
-        unimplemented!();
+    fn compile(&self, ctx: &mut Context) {
+        match *self {
+            Node::BinOp(ref op) => op.compile(ctx),
+            Node::Const(Const::Int(num)) => ctx.add_instruction(Instruction::Int32(num)),
+            _ => unimplemented!(),
+        }
     }
 }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,0 +1,19 @@
+use super::*;
+use crate::{syntax::ast::Node, Context};
+use std::result::Result;
+
+#[derive(Debug, Default)]
+pub(crate) struct Compiler {
+    res: Vec<Instruction>,
+    next_free: u8,
+}
+
+pub(crate) trait CodeGen {
+    fn compile(&self, ctx: &mut Context) -> Result<(), &str>;
+}
+
+impl CodeGen for Node {
+    fn compile(&self, compiler: &mut Context) -> Result<(), &str> {
+        unimplemented!();
+    }
+}

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -58,3 +58,48 @@ pub enum Instruction {
     BitNot,
     Not,
 }
+
+impl std::fmt::Display for Instruction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Self::Undefined => write!(f, "Undefined"),
+            Self::Null => write!(f, "Null"),
+            Self::True => write!(f, "True"),
+            Self::False => write!(f, "False"),
+            Self::Zero => write!(f, "Zero"),
+            Self::One => write!(f, "One"),
+            Self::String(usize) => write!(f, "String({})", usize),
+            Self::BigInt(usize) => write!(f, "BigInt({})", usize),
+            Self::Int32(i32) => write!(f, "Int32({})", i32),
+            Self::Rational(f64) => write!(f, "Rational({})", f64),
+            Self::Add => write!(f, "Add"),
+            Self::Sub => write!(f, "Sub"),
+            Self::Mul => write!(f, "Mul"),
+            Self::Div => write!(f, "Div"),
+            Self::Pow => write!(f, "Pow"),
+            Self::Mod => write!(f, "Mod"),
+            Self::BitAnd => write!(f, "BitAnd"),
+            Self::BitOr => write!(f, "BitOr"),
+            Self::BitXor => write!(f, "BitXor"),
+            Self::Shl => write!(f, "Shl"),
+            Self::Shr => write!(f, "Shr"),
+            Self::UShr => write!(f, "UShr"),
+            Self::Eq => write!(f, "Eq"),
+            Self::NotEq => write!(f, "NotEq"),
+            Self::StrictEq => write!(f, "StrictEq"),
+            Self::StrictNotEq => write!(f, "StrictNotEq"),
+            Self::Gt => write!(f, "Gt"),
+            Self::Ge => write!(f, "Ge"),
+            Self::Lt => write!(f, "Lt"),
+            Self::Le => write!(f, "Le"),
+            Self::In => write!(f, "In"),
+            Self::InstanceOf => write!(f, "InstanceOf"),
+            Self::Void => write!(f, "Void"),
+            Self::TypeOf => write!(f, "TypeOf"),
+            Self::Pos => write!(f, "Pos"),
+            Self::Neg => write!(f, "Neg"),
+            Self::BitNot => write!(f, "BitNot"),
+            Self::Not => write!(f, "Not"),
+        }
+    }
+}

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,20 +1,60 @@
-use std::fmt::{Debug, Error, Formatter};
-
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Instruction {
+    Undefined,
+    Null,
+    True,
+    False,
+    Zero,
+    One,
+    String(usize),
+    BigInt(usize),
+
+    /// Loads an i32 onto the stack
+    Int32(i32),
+
+    /// Loads an f32 onto the stack
+    Rational(f64),
+
     /// Adds the values from destination and source and stores the result in destination
     Add,
 
-    // Loads an i32 onto the stack
-    Int32(i32),
-}
+    /// subtracts the values from destination and source and stores the result in destination
+    Sub,
 
-impl Debug for Instruction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        match self {
-            Self::Add => write!(f, "Add"),
-            Self::Int32(i) => write!(f, "Int32\t{}", format!("{}", i)),
-            _ => write!(f, "unimplemented"),
-        }
-    }
+    /// Multiplies the values from destination and source and stores the result in destination
+    Mul,
+
+    /// Divides the values from destination and source and stores the result in destination
+    Div,
+
+    Pow,
+
+    Mod,
+
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
+    UShr,
+
+    Eq,
+    NotEq,
+    StrictEq,
+    StrictNotEq,
+
+    Gt,
+    Ge,
+    Lt,
+    Le,
+
+    In,
+    InstanceOf,
+
+    Void,
+    TypeOf,
+    Pos,
+    Neg,
+    BitNot,
+    Not,
 }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,24 +1,12 @@
-use crate::Value;
-
-use super::Reg;
 use std::fmt::{Debug, Error, Formatter};
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub enum Instruction {
-    // Loads an i32 onto the stack
-    Int32(i32),
-
-    /// Loads a value into a register
-    Ld(Reg, Value),
-
-    /// Loads a value into the accumulator
-    Lda(Value),
-
-    /// Binds a value from a register to an ident
-    Bind(Reg, String),
-
     /// Adds the values from destination and source and stores the result in destination
     Add,
+
+    // Loads an i32 onto the stack
+    Int32(i32),
 }
 
 impl Debug for Instruction {
@@ -26,8 +14,6 @@ impl Debug for Instruction {
         match self {
             Self::Add => write!(f, "Add"),
             Self::Int32(i) => write!(f, "Int32\t{}", format!("{}", i)),
-            Self::Bind(r, v) => write!(f, "Bind\t{}\t\t{}", r, format!("{:p}", v)),
-            Self::Ld(r, v) => write!(f, "Ld\t{}\t\t{}", r, format!("{:p}", v)),
             _ => write!(f, "unimplemented"),
         }
     }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,0 +1,30 @@
+use crate::Value;
+
+use super::Reg;
+use std::fmt::{Debug, Error, Formatter};
+
+#[derive(Clone)]
+pub(crate) enum Instruction {
+    /// Loads a value into a register
+    Ld(Reg, Value),
+
+    /// Loads a value into the accumulator
+    Lda(Value),
+
+    /// Binds a value from a register to an ident
+    Bind(Reg, String),
+
+    /// Adds the values from destination and source and stores the result in destination
+    Add { dest: Reg, src: Reg },
+}
+
+impl Debug for Instruction {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        match self {
+            Self::Ld(r, v) => write!(f, "Ld\t{}\t\t{}", r, format!("{:p}", v)),
+            Self::Bind(r, v) => write!(f, "Bind\t{}\t\t{}", r, format!("{:p}", v)),
+            Self::Add { dest, src } => write!(f, "Add\t{}\t\t{}", dest, src),
+            _ => write!(f, "unimplemented"),
+        }
+    }
+}

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -4,7 +4,10 @@ use super::Reg;
 use std::fmt::{Debug, Error, Formatter};
 
 #[derive(Clone)]
-pub(crate) enum Instruction {
+pub enum Instruction {
+    // Loads an i32 onto the stack
+    Int32(i32),
+
     /// Loads a value into a register
     Ld(Reg, Value),
 
@@ -15,15 +18,16 @@ pub(crate) enum Instruction {
     Bind(Reg, String),
 
     /// Adds the values from destination and source and stores the result in destination
-    Add { dest: Reg, src: Reg },
+    Add,
 }
 
 impl Debug for Instruction {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         match self {
-            Self::Ld(r, v) => write!(f, "Ld\t{}\t\t{}", r, format!("{:p}", v)),
+            Self::Add => write!(f, "Add"),
+            Self::Int32(i) => write!(f, "Int32\t{}", format!("{}", i)),
             Self::Bind(r, v) => write!(f, "Bind\t{}\t\t{}", r, format!("{:p}", v)),
-            Self::Add { dest, src } => write!(f, "Add\t{}\t\t{}", dest, src),
+            Self::Ld(r, v) => write!(f, "Ld\t{}\t\t{}", r, format!("{:p}", v)),
             _ => write!(f, "unimplemented"),
         }
     }

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -3,6 +3,7 @@ use crate::{Context, Result, Value};
 pub(crate) mod compilation;
 pub(crate) mod instructions;
 
+use crate::BoaProfiler;
 pub use compilation::Compiler;
 pub use instructions::Instruction;
 
@@ -44,9 +45,12 @@ impl<'a> VM<'a> {
     }
 
     pub fn run(&mut self) -> Result<Value> {
+        let _timer = BoaProfiler::global().start_event("runVM", "vm");
         let mut idx = 0;
 
         while idx < self.instructions.len() {
+            let _timer =
+                BoaProfiler::global().start_event(&self.instructions[idx].to_string(), "vm");
             match self.instructions[idx] {
                 Instruction::Undefined => self.push(Value::undefined()),
                 Instruction::Null => self.push(Value::null()),

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,50 +1,275 @@
-use self::instructions::Instruction;
-use crate::{Context, Value};
+use crate::{Context, Result, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
 
-// === Execution
+pub use compilation::Compiler;
+pub use instructions::Instruction;
+
+// Virtual Machine.
 #[derive(Debug)]
 pub struct VM<'a> {
     ctx: &'a mut Context,
     instructions: Vec<Instruction>,
+    pool: Vec<Value>,
     stack: Vec<Value>,
     stack_pointer: usize,
 }
 
 impl<'a> VM<'a> {
-    pub fn new(ctx: &'a mut Context) -> Self {
-        let instr = ctx.instructions_mut().clone();
-        VM {
+    pub fn new(compiler: Compiler, ctx: &'a mut Context) -> Self {
+        Self {
             ctx,
-            instructions: instr,
+            instructions: compiler.instructions,
+            pool: compiler.pool,
             stack: vec![],
             stack_pointer: 0,
         }
     }
 
-    pub fn run(&mut self) -> super::Result<Value> {
+    /// Push a value on the stack.
+    #[inline]
+    pub fn push(&mut self, value: Value) {
+        self.stack.push(value);
+    }
+
+    /// Pop a value off the stack.
+    ///
+    /// # Panics
+    ///
+    /// If there is nothing to pop, then this will panic.
+    #[inline]
+    pub fn pop(&mut self) -> Value {
+        self.stack.pop().unwrap()
+    }
+
+    pub fn run(&mut self) -> Result<Value> {
         let mut idx = 0;
 
         while idx < self.instructions.len() {
             match self.instructions[idx] {
-                Instruction::Int32(i) => self.stack.push(Value::Integer(i)),
+                Instruction::Undefined => self.push(Value::undefined()),
+                Instruction::Null => self.push(Value::null()),
+                Instruction::True => self.push(Value::boolean(true)),
+                Instruction::False => self.push(Value::boolean(false)),
+                Instruction::Zero => self.push(Value::integer(0)),
+                Instruction::One => self.push(Value::integer(1)),
+                Instruction::Int32(i) => self.push(Value::integer(i)),
+                Instruction::Rational(r) => self.push(Value::rational(r)),
+                Instruction::String(index) => {
+                    let value = self.pool[index].clone();
+                    self.push(value)
+                }
+                Instruction::BigInt(index) => {
+                    let value = self.pool[index].clone();
+                    self.push(value)
+                }
                 Instruction::Add => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.add(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
+                Instruction::Sub => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.sub(&r, self.ctx)?;
 
-                _ => unimplemented!(),
+                    self.push(val);
+                }
+                Instruction::Mul => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.mul(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Div => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.div(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Pow => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.pow(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Mod => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.rem(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::BitAnd => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.bitand(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::BitOr => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.bitor(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::BitXor => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.bitxor(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Shl => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.shl(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Shr => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.shr(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::UShr => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.ushr(&r, self.ctx)?;
+
+                    self.push(val);
+                }
+                Instruction::Eq => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.equals(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::NotEq => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = !l.equals(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::StrictEq => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.strict_equals(&r);
+
+                    self.push(val.into());
+                }
+                Instruction::StrictNotEq => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = !l.strict_equals(&r);
+
+                    self.push(val.into());
+                }
+                Instruction::Gt => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.ge(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::Ge => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.ge(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::Lt => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.lt(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::Le => {
+                    let r = self.pop();
+                    let l = self.pop();
+                    let val = l.le(&r, self.ctx)?;
+
+                    self.push(val.into());
+                }
+                Instruction::In => {
+                    let r = self.pop();
+                    let l = self.pop();
+
+                    if !r.is_object() {
+                        return self.ctx.throw_type_error(format!(
+                            "right-hand side of 'in' should be an object, got {}",
+                            r.get_type().as_str()
+                        ));
+                    }
+                    let key = l.to_property_key(self.ctx)?;
+                    let val = self.ctx.has_property(&r, &key);
+
+                    self.push(val.into());
+                }
+                Instruction::InstanceOf => {
+                    let r = self.pop();
+                    let _l = self.pop();
+                    if !r.is_object() {
+                        return self.ctx.throw_type_error(format!(
+                            "right-hand side of 'instanceof' should be an object, got {}",
+                            r.get_type().as_str()
+                        ));
+                    }
+
+                    // spec: https://tc39.es/ecma262/#sec-instanceofoperator
+                    todo!("instanceof operator")
+                }
+                Instruction::Void => {
+                    let _value = self.pop();
+                    self.push(Value::undefined());
+                }
+                Instruction::TypeOf => {
+                    let value = self.pop();
+                    self.push(value.get_type().as_str().into());
+                }
+                Instruction::Pos => {
+                    let value = self.pop();
+                    let value = value.to_number(self.ctx)?;
+                    self.push(value.into());
+                }
+                Instruction::Neg => {
+                    let value = self.pop();
+                    self.push(Value::from(!value.to_boolean()));
+                }
+                Instruction::Not => {
+                    let value = self.pop();
+                    self.push((!value.to_boolean()).into());
+                }
+                Instruction::BitNot => {
+                    let target = self.pop();
+                    let num = target.to_number(self.ctx)?;
+                    let value = if num.is_nan() {
+                        -1
+                    } else {
+                        // TODO: this is not spec compliant.
+                        !(num as i32)
+                    };
+                    self.push(value.into());
+                }
             }
 
             idx += 1;
         }
 
-        let res = self.stack.pop().unwrap();
+        let res = self.pop();
         Ok(res)
     }
 }

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,0 +1,92 @@
+use self::instructions::Instruction;
+use crate::{realm::Realm, Value};
+use std::fmt::{Display, Formatter, Result};
+
+pub(crate) mod compilation;
+pub(crate) mod instructions;
+
+// === Misc
+#[derive(Copy, Clone, Debug, Default)]
+pub struct Reg(u8);
+
+impl Display for Reg {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// === Execution
+#[derive(Debug)]
+pub struct VM {
+    realm: Realm,
+    accumulator: Value,
+    regs: Vec<Value>, // TODO: find a possible way of this being an array
+}
+
+impl VM {
+    /// Sets a register's value to `undefined` and returns its previous one
+    fn clear(&mut self, reg: Reg) -> Value {
+        let v = self.regs[reg.0 as usize].clone();
+        self.regs[reg.0 as usize] = Value::undefined();
+        v
+    }
+
+    pub fn new(realm: Realm) -> Self {
+        VM {
+            realm,
+            accumulator: Value::undefined(),
+            regs: vec![Value::undefined(); 8],
+        }
+    }
+
+    fn set(&mut self, reg: Reg, val: Value) {
+        self.regs[reg.0 as usize] = val;
+    }
+
+    fn set_accumulator(&mut self, val: Value) {
+        self.accumulator = val;
+    }
+
+    // pub fn run(&mut self, instrs: &[Instruction]) -> super::Result<Value> {
+    //     let mut idx = 0;
+
+    //     while idx < instrs.len() {
+    //         match &instrs[idx] {
+    //             Instruction::Ld(r, v) => self.set(*r, v.clone()),
+
+    //             Instruction::Lda(v) => self.set_accumulator(v.clone()),
+
+    //             Instruction::Bind(r, ident) => {
+    //                 let val = self.clear(*r);
+
+    //                 if self.realm.environment.has_binding(ident) {
+    //                     self.realm.environment.set_mutable_binding(ident, val, true);
+    //                 } else {
+    //                     self.realm.environment.create_mutable_binding(
+    //                         ident.clone(), // fix
+    //                         true,
+    //                         VariableScope::Function,
+    //                     );
+    //                     self.realm.environment.initialize_binding(ident, val);
+    //                 }
+    //             }
+
+    //             Instruction::Add { dest, src } => {
+    //                 let l = self.clear(*dest);
+    //                 let r = self.clear(*src);
+
+    //                 self.set(*dest, l + r);
+    //             }
+
+    //             _ => {
+    //                 dbg!(&instrs[idx]);
+    //                 panic!();
+    //             }
+    //         }
+
+    //         idx += 1;
+    //     }
+
+    //     Ok(Ok(self.clear(Reg(0))))
+    // }
+}

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,92 +1,50 @@
 use self::instructions::Instruction;
-use crate::{realm::Realm, Value};
-use std::fmt::{Display, Formatter, Result};
+use crate::{Context, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
 
-// === Misc
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Reg(u8);
-
-impl Display for Reg {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(f, "{}", self.0)
-    }
-}
-
 // === Execution
 #[derive(Debug)]
-pub struct VM {
-    realm: Realm,
-    accumulator: Value,
-    regs: Vec<Value>, // TODO: find a possible way of this being an array
+pub struct VM<'a> {
+    ctx: &'a mut Context,
+    instructions: Vec<Instruction>,
+    stack: Vec<Value>,
+    stack_pointer: usize,
 }
 
-impl VM {
-    /// Sets a register's value to `undefined` and returns its previous one
-    fn clear(&mut self, reg: Reg) -> Value {
-        let v = self.regs[reg.0 as usize].clone();
-        self.regs[reg.0 as usize] = Value::undefined();
-        v
-    }
-
-    pub fn new(realm: Realm) -> Self {
+impl<'a> VM<'a> {
+    pub fn new(ctx: &'a mut Context) -> Self {
+        let instr = ctx.instructions_mut().clone();
         VM {
-            realm,
-            accumulator: Value::undefined(),
-            regs: vec![Value::undefined(); 8],
+            ctx,
+            instructions: instr,
+            stack: vec![],
+            stack_pointer: 0,
         }
     }
 
-    fn set(&mut self, reg: Reg, val: Value) {
-        self.regs[reg.0 as usize] = val;
+    pub fn run(&mut self) -> super::Result<Value> {
+        let mut idx = 0;
+
+        while idx < self.instructions.len() {
+            match self.instructions[idx] {
+                Instruction::Int32(i) => self.stack.push(Value::Integer(i)),
+                Instruction::Add => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.add(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+
+                _ => unimplemented!(),
+            }
+
+            idx += 1;
+        }
+
+        let res = self.stack.pop().unwrap();
+        Ok(res)
     }
-
-    fn set_accumulator(&mut self, val: Value) {
-        self.accumulator = val;
-    }
-
-    // pub fn run(&mut self, instrs: &[Instruction]) -> super::Result<Value> {
-    //     let mut idx = 0;
-
-    //     while idx < instrs.len() {
-    //         match &instrs[idx] {
-    //             Instruction::Ld(r, v) => self.set(*r, v.clone()),
-
-    //             Instruction::Lda(v) => self.set_accumulator(v.clone()),
-
-    //             Instruction::Bind(r, ident) => {
-    //                 let val = self.clear(*r);
-
-    //                 if self.realm.environment.has_binding(ident) {
-    //                     self.realm.environment.set_mutable_binding(ident, val, true);
-    //                 } else {
-    //                     self.realm.environment.create_mutable_binding(
-    //                         ident.clone(), // fix
-    //                         true,
-    //                         VariableScope::Function,
-    //                     );
-    //                     self.realm.environment.initialize_binding(ident, val);
-    //                 }
-    //             }
-
-    //             Instruction::Add { dest, src } => {
-    //                 let l = self.clear(*dest);
-    //                 let r = self.clear(*src);
-
-    //                 self.set(*dest, l + r);
-    //             }
-
-    //             _ => {
-    //                 dbg!(&instrs[idx]);
-    //                 panic!();
-    //             }
-    //         }
-
-    //         idx += 1;
-    //     }
-
-    //     Ok(Ok(self.clear(Reg(0))))
-    // }
 }

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -21,6 +21,9 @@ colored = "2.0.0"
 regex = "1.4.2"
 lazy_static = "1.4.0"
 
+# [features]
+# vm = ["Boa/vm"]
+
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.3.2"
 

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -21,8 +21,8 @@ colored = "2.0.0"
 regex = "1.4.2"
 lazy_static = "1.4.0"
 
-# [features]
-# vm = ["Boa/vm"]
+[features]
+vm = ["Boa/vm"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.3.2"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -31,9 +31,6 @@ use rustyline::{config::Config, error::ReadlineError, EditMode, Editor};
 use std::{fs::read, path::PathBuf};
 use structopt::{clap::arg_enum, StructOpt};
 
-#[cfg(feature = "vm")]
-use boa::vm::VM;
-
 mod helper;
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -31,6 +31,9 @@ use rustyline::{config::Config, error::ReadlineError, EditMode, Editor};
 use std::{fs::read, path::PathBuf};
 use structopt::{clap::arg_enum, StructOpt};
 
+#[cfg(feature = "vm")]
+use boa::vm::VM;
+
 mod helper;
 
 #[cfg(all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"))]


### PR DESCRIPTION
This does run!

Nodes implement `CodeGen` which generates instructions onto a stack held in Context.
The `VM` will interpret the instructions from Context.

There are some issues:
- only basic instructions are added, but im working off https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Internals/Bytecode for now it should be easy to add more in.
- The Stack is a Vec, this isn't ideal (we may be able to live with it for now) but the stack should really be a fixed sized array. This isn't possible because Value can't be copied in there as it holds Rc and Gc values. Can we have fixed-sized Values that hold a pointer?
- I needed to copy the Instruction vec, i couldn't find a way to pass in both `ctx` and `ctx.instructions` together without it moaning about "mutable borrowing" twice.
- I need to change boa_cli back to the normal run.

As most of this is behind a feature flag it would be good to merge parts of it so we can work on as the main interpreter is active. Then one day we can switch over. 

for 

```js
2 + 2
```

The instructions generated are
```
[boa/src/context.rs:689] &self.instruction_stack = [
    Int32       2,
    Int32       2,
    Add,
]
4
```

We can optimize even further here and just do the addition at CodeGen level and throw 4 onto the stack

Fixes https://github.com/boa-dev/boa/issues/167
@Razican @HalidOdat 