### PR TITLE
More bytecodes

### DIFF
--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -683,6 +683,7 @@ impl Context {
 
         let mut compiler = Compiler::default();
         statement_list.compile(&mut compiler);
+        dbg!(&compiler);
 
         let mut vm = VM::new(compiler, self);
         // Generate Bytecode and place it into instruction_stack

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -5,6 +5,7 @@ use crate::{
         op::{self, AssignOp, BitOp, CompOp, LogOp, NumOp},
     },
     vm::compilation::CodeGen,
+    vm::compilation::Compiler,
     vm::instructions::Instruction,
     Context, Result, Value,
 };
@@ -188,14 +189,46 @@ impl Executable for BinOp {
 }
 
 impl CodeGen for BinOp {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         match self.op() {
             op::BinOp::Num(op) => {
-                self.lhs().compile(ctx);
-                self.rhs().compile(ctx);
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
                 match op {
-                    NumOp::Add => ctx.add_instruction(Instruction::Add),
-                    _ => unimplemented!(),
+                    NumOp::Add => compiler.add_instruction(Instruction::Add),
+                    NumOp::Sub => compiler.add_instruction(Instruction::Sub),
+                    NumOp::Mul => compiler.add_instruction(Instruction::Mul),
+                    NumOp::Div => compiler.add_instruction(Instruction::Div),
+                    NumOp::Exp => compiler.add_instruction(Instruction::Pow),
+                    NumOp::Mod => compiler.add_instruction(Instruction::Mod),
+                }
+            }
+            op::BinOp::Bit(op) => {
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
+                match op {
+                    BitOp::And => compiler.add_instruction(Instruction::BitAnd),
+                    BitOp::Or => compiler.add_instruction(Instruction::BitOr),
+                    BitOp::Xor => compiler.add_instruction(Instruction::BitXor),
+                    BitOp::Shl => compiler.add_instruction(Instruction::Shl),
+                    BitOp::Shr => compiler.add_instruction(Instruction::Shr),
+                    BitOp::UShr => compiler.add_instruction(Instruction::UShr),
+                }
+            }
+            op::BinOp::Comp(op) => {
+                self.lhs().compile(compiler);
+                self.rhs().compile(compiler);
+                match op {
+                    CompOp::Equal => compiler.add_instruction(Instruction::Eq),
+                    CompOp::NotEqual => compiler.add_instruction(Instruction::NotEq),
+                    CompOp::StrictEqual => compiler.add_instruction(Instruction::StrictEq),
+                    CompOp::StrictNotEqual => compiler.add_instruction(Instruction::StrictNotEq),
+                    CompOp::GreaterThan => compiler.add_instruction(Instruction::Gt),
+                    CompOp::GreaterThanOrEqual => compiler.add_instruction(Instruction::Ge),
+                    CompOp::LessThan => compiler.add_instruction(Instruction::Lt),
+                    CompOp::LessThanOrEqual => compiler.add_instruction(Instruction::Le),
+                    CompOp::In => compiler.add_instruction(Instruction::In),
+                    CompOp::InstanceOf => compiler.add_instruction(Instruction::InstanceOf),
                 }
             }
             _ => unimplemented!(),

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -1,6 +1,9 @@
 use crate::{
     exec::Executable,
     syntax::ast::{node::Node, op},
+    vm::compilation::CodeGen,
+    vm::Compiler,
+    vm::Instruction,
     Context, Result, Value,
 };
 use gc::{Finalize, Trace};
@@ -123,5 +126,24 @@ impl fmt::Display for UnaryOp {
 impl From<UnaryOp> for Node {
     fn from(op: UnaryOp) -> Self {
         Self::UnaryOp(op)
+    }
+}
+
+impl CodeGen for UnaryOp {
+    fn compile(&self, compiler: &mut Compiler) {
+        self.target().compile(compiler);
+        match self.op {
+            op::UnaryOp::Void => compiler.add_instruction(Instruction::Void),
+            op::UnaryOp::Plus => compiler.add_instruction(Instruction::Pos),
+            op::UnaryOp::Minus => compiler.add_instruction(Instruction::Neg),
+            op::UnaryOp::TypeOf => compiler.add_instruction(Instruction::TypeOf),
+            op::UnaryOp::Not => compiler.add_instruction(Instruction::Not),
+            op::UnaryOp::Tilde => compiler.add_instruction(Instruction::BitNot),
+            op::UnaryOp::IncrementPost => {}
+            op::UnaryOp::IncrementPre => {}
+            op::UnaryOp::DecrementPost => {}
+            op::UnaryOp::DecrementPre => {}
+            op::UnaryOp::Delete => {}
+        }
     }
 }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     exec::{Executable, InterpreterState},
     syntax::ast::node::Node,
     vm::compilation::CodeGen,
+    vm::compilation::Compiler,
     BoaProfiler, Context, Result, Value,
 };
 use gc::{unsafe_empty_trace, Finalize, Trace};
@@ -96,15 +97,11 @@ impl Executable for StatementList {
 }
 
 impl CodeGen for StatementList {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         let _timer = BoaProfiler::global().start_event("StatementList", "codeGen");
 
-        // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
-        // The return value is uninitialized, which means it defaults to Value::Undefined
-        ctx.executor()
-            .set_current_state(InterpreterState::Executing);
-        for (i, item) in self.statements().iter().enumerate() {
-            item.compile(ctx);
+        for item in self.statements().iter() {
+            item.compile(compiler);
         }
     }
 }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -43,7 +43,11 @@ impl CodeGen for Node {
             Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
             Node::Const(Const::Bool(true)) => compiler.add_instruction(Instruction::True),
             Node::Const(Const::Bool(false)) => compiler.add_instruction(Instruction::False),
-            Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
+            Node::Const(Const::Int(num)) => match num {
+                0 => compiler.add_instruction(Instruction::Zero),
+                1 => compiler.add_instruction(Instruction::One),
+                _ => compiler.add_instruction(Instruction::Int32(num)),
+            },
             Node::Const(Const::String(ref string)) => {
                 compiler.add_string_instruction(string.clone())
             }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -56,6 +56,7 @@ impl CodeGen for Node {
                 compiler.add_bigint_instruction(bigint.clone())
             }
             Node::BinOp(ref op) => op.compile(compiler),
+            Node::UnaryOp(ref op) => op.compile(compiler),
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -20,8 +20,11 @@ pub(crate) trait CodeGen {
 impl CodeGen for Node {
     fn compile(&self, compiler: &mut Compiler) {
         match *self {
-            Node::BinOp(ref op) => op.compile(compiler),
+            Node::Const(Const::Undefined) => compiler.add_instruction(Instruction::Undefined),
+            Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
+            Node::Const(Const::Bool(value)) => compiler.add_instruction(Instruction::Bool(value)),
             Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
+            Node::BinOp(ref op) => op.compile(compiler),
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,10 +1,10 @@
 use super::*;
-use crate::{syntax::ast::Const, syntax::ast::Node, value::RcString};
+use crate::{syntax::ast::Const, syntax::ast::Node, value::RcBigInt, value::RcString};
 
 #[derive(Debug, Default)]
 pub struct Compiler {
     pub(super) instructions: Vec<Instruction>,
-    pub(super) pool: Vec<RcString>,
+    pub(super) pool: Vec<Value>,
 }
 
 impl Compiler {
@@ -19,7 +19,16 @@ impl Compiler {
     {
         let index = self.pool.len();
         self.add_instruction(Instruction::String(index));
-        self.pool.push(string.into());
+        self.pool.push(string.into().into());
+    }
+
+    pub fn add_bigint_instruction<B>(&mut self, bigint: B)
+    where
+        B: Into<RcBigInt>,
+    {
+        let index = self.pool.len();
+        self.add_instruction(Instruction::BigInt(index));
+        self.pool.push(bigint.into().into());
     }
 }
 
@@ -36,6 +45,9 @@ impl CodeGen for Node {
             Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
             Node::Const(Const::String(ref string)) => {
                 compiler.add_string_instruction(string.clone())
+            }
+            Node::Const(Const::BigInt(ref bigint)) => {
+                compiler.add_bigint_instruction(bigint.clone())
             }
             Node::BinOp(ref op) => op.compile(compiler),
             _ => unimplemented!(),

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -43,6 +43,7 @@ impl CodeGen for Node {
             Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
             Node::Const(Const::Bool(true)) => compiler.add_instruction(Instruction::True),
             Node::Const(Const::Bool(false)) => compiler.add_instruction(Instruction::False),
+            Node::Const(Const::Num(num)) => compiler.add_instruction(Instruction::Rational(num)),
             Node::Const(Const::Int(num)) => match num {
                 0 => compiler.add_instruction(Instruction::Zero),
                 1 => compiler.add_instruction(Instruction::One),

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,15 +1,25 @@
 use super::*;
-use crate::{syntax::ast::Const, syntax::ast::Node};
+use crate::{syntax::ast::Const, syntax::ast::Node, value::RcString};
 
 #[derive(Debug, Default)]
 pub struct Compiler {
     pub(super) instructions: Vec<Instruction>,
+    pub(super) pool: Vec<RcString>,
 }
 
 impl Compiler {
     // Add a new instruction.
     pub fn add_instruction(&mut self, instr: Instruction) {
         self.instructions.push(instr);
+    }
+
+    pub fn add_string_instruction<S>(&mut self, string: S)
+    where
+        S: Into<RcString>,
+    {
+        let index = self.pool.len();
+        self.add_instruction(Instruction::String(index));
+        self.pool.push(string.into());
     }
 }
 
@@ -24,6 +34,9 @@ impl CodeGen for Node {
             Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
             Node::Const(Const::Bool(value)) => compiler.add_instruction(Instruction::Bool(value)),
             Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
+            Node::Const(Const::String(ref string)) => {
+                compiler.add_string_instruction(string.clone())
+            }
             Node::BinOp(ref op) => op.compile(compiler),
             _ => unimplemented!(),
         }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -41,7 +41,8 @@ impl CodeGen for Node {
         match *self {
             Node::Const(Const::Undefined) => compiler.add_instruction(Instruction::Undefined),
             Node::Const(Const::Null) => compiler.add_instruction(Instruction::Null),
-            Node::Const(Const::Bool(value)) => compiler.add_instruction(Instruction::Bool(value)),
+            Node::Const(Const::Bool(true)) => compiler.add_instruction(Instruction::True),
+            Node::Const(Const::Bool(false)) => compiler.add_instruction(Instruction::False),
             Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
             Node::Const(Const::String(ref string)) => {
                 compiler.add_string_instruction(string.clone())

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -1,21 +1,27 @@
 use super::*;
-use crate::{syntax::ast::Const, syntax::ast::Node, Context};
+use crate::{syntax::ast::Const, syntax::ast::Node};
 
 #[derive(Debug, Default)]
-pub(crate) struct Compiler {
-    res: Vec<Instruction>,
-    next_free: u8,
+pub struct Compiler {
+    pub(super) instructions: Vec<Instruction>,
+}
+
+impl Compiler {
+    // Add a new instruction.
+    pub fn add_instruction(&mut self, instr: Instruction) {
+        self.instructions.push(instr);
+    }
 }
 
 pub(crate) trait CodeGen {
-    fn compile(&self, ctx: &mut Context);
+    fn compile(&self, compiler: &mut Compiler);
 }
 
 impl CodeGen for Node {
-    fn compile(&self, ctx: &mut Context) {
+    fn compile(&self, compiler: &mut Compiler) {
         match *self {
-            Node::BinOp(ref op) => op.compile(ctx),
-            Node::Const(Const::Int(num)) => ctx.add_instruction(Instruction::Int32(num)),
+            Node::BinOp(ref op) => op.compile(compiler),
+            Node::Const(Const::Int(num)) => compiler.add_instruction(Instruction::Int32(num)),
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,5 +1,12 @@
 #[derive(Debug, Clone, Copy)]
 pub enum Instruction {
+    Undefined,
+    Null,
+    Bool(bool),
+
+    /// Loads an i32 onto the stack
+    Int32(i32),
+
     /// Adds the values from destination and source and stores the result in destination
     Add,
 
@@ -35,7 +42,4 @@ pub enum Instruction {
 
     In,
     InstanceOf,
-
-    // Loads an i32 onto the stack
-    Int32(i32),
 }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -50,4 +50,11 @@ pub enum Instruction {
 
     In,
     InstanceOf,
+
+    Void,
+    TypeOf,
+    Pos,
+    Neg,
+    BitNot,
+    Not,
 }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -4,6 +4,8 @@ pub enum Instruction {
     Null,
     True,
     False,
+    Zero,
+    One,
     String(usize),
     BigInt(usize),
 

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,20 +1,41 @@
-use std::fmt::{Debug, Error, Formatter};
-
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum Instruction {
     /// Adds the values from destination and source and stores the result in destination
     Add,
 
+    /// subtracts the values from destination and source and stores the result in destination
+    Sub,
+
+    /// Multiplies the values from destination and source and stores the result in destination
+    Mul,
+
+    /// Divides the values from destination and source and stores the result in destination
+    Div,
+
+    Pow,
+
+    Mod,
+
+    BitAnd,
+    BitOr,
+    BitXor,
+    Shl,
+    Shr,
+    UShr,
+
+    Eq,
+    NotEq,
+    StrictEq,
+    StrictNotEq,
+
+    Gt,
+    Ge,
+    Lt,
+    Le,
+
+    In,
+    InstanceOf,
+
     // Loads an i32 onto the stack
     Int32(i32),
-}
-
-impl Debug for Instruction {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        match self {
-            Self::Add => write!(f, "Add"),
-            Self::Int32(i) => write!(f, "Int32\t{}", format!("{}", i)),
-            _ => write!(f, "unimplemented"),
-        }
-    }
 }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -4,6 +4,7 @@ pub enum Instruction {
     Null,
     Bool(bool),
     String(usize),
+    BigInt(usize),
 
     /// Loads an i32 onto the stack
     Int32(i32),

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -2,7 +2,8 @@
 pub enum Instruction {
     Undefined,
     Null,
-    Bool(bool),
+    True,
+    False,
     String(usize),
     BigInt(usize),
 

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -3,6 +3,7 @@ pub enum Instruction {
     Undefined,
     Null,
     Bool(bool),
+    String(usize),
 
     /// Loads an i32 onto the stack
     Int32(i32),

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -12,6 +12,9 @@ pub enum Instruction {
     /// Loads an i32 onto the stack
     Int32(i32),
 
+    /// Loads an f32 onto the stack
+    Rational(f64),
+
     /// Adds the values from destination and source and stores the result in destination
     Add,
 

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Value};
+use crate::{Context, Result, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
@@ -43,14 +43,15 @@ impl<'a> VM<'a> {
         self.stack.pop().unwrap()
     }
 
-    pub fn run(&mut self) -> super::Result<Value> {
+    pub fn run(&mut self) -> Result<Value> {
         let mut idx = 0;
 
         while idx < self.instructions.len() {
             match self.instructions[idx] {
                 Instruction::Undefined => self.push(Value::undefined()),
                 Instruction::Null => self.push(Value::null()),
-                Instruction::Bool(value) => self.push(Value::boolean(value)),
+                Instruction::True => self.push(Value::boolean(true)),
+                Instruction::False => self.push(Value::boolean(false)),
                 Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::String(index) => {
                     let value = self.pool[index].clone();

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -52,6 +52,8 @@ impl<'a> VM<'a> {
                 Instruction::Null => self.push(Value::null()),
                 Instruction::True => self.push(Value::boolean(true)),
                 Instruction::False => self.push(Value::boolean(false)),
+                Instruction::Zero => self.push(Value::integer(0)),
+                Instruction::One => self.push(Value::integer(1)),
                 Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::String(index) => {
                     let value = self.pool[index].clone();

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -54,7 +54,8 @@ impl<'a> VM<'a> {
                 Instruction::False => self.push(Value::boolean(false)),
                 Instruction::Zero => self.push(Value::integer(0)),
                 Instruction::One => self.push(Value::integer(1)),
-                Instruction::Int32(i) => self.push(Value::Integer(i)),
+                Instruction::Int32(i) => self.push(Value::integer(i)),
+                Instruction::Rational(r) => self.push(Value::rational(r)),
                 Instruction::String(index) => {
                     let value = self.pool[index].clone();
                     self.push(value)

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,4 +1,4 @@
-use crate::{value::RcString, Context, Value};
+use crate::{Context, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
@@ -11,7 +11,7 @@ pub use instructions::Instruction;
 pub struct VM<'a> {
     ctx: &'a mut Context,
     instructions: Vec<Instruction>,
-    pool: Vec<RcString>,
+    pool: Vec<Value>,
     stack: Vec<Value>,
     stack_pointer: usize,
 }
@@ -51,11 +51,15 @@ impl<'a> VM<'a> {
                 Instruction::Undefined => self.push(Value::undefined()),
                 Instruction::Null => self.push(Value::null()),
                 Instruction::Bool(value) => self.push(Value::boolean(value)),
+                Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::String(index) => {
                     let value = self.pool[index].clone();
-                    self.push(value.into())
+                    self.push(value)
                 }
-                Instruction::Int32(i) => self.push(Value::Integer(i)),
+                Instruction::BigInt(index) => {
+                    let value = self.pool[index].clone();
+                    self.push(value)
+                }
                 Instruction::Add => {
                     let r = self.pop();
                     let l = self.pop();

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -232,6 +232,38 @@ impl<'a> VM<'a> {
                     // spec: https://tc39.es/ecma262/#sec-instanceofoperator
                     todo!("instanceof operator")
                 }
+                Instruction::Void => {
+                    let _value = self.pop();
+                    self.push(Value::undefined());
+                }
+                Instruction::TypeOf => {
+                    let value = self.pop();
+                    self.push(value.get_type().as_str().into());
+                }
+                Instruction::Pos => {
+                    let value = self.pop();
+                    let value = value.to_number(self.ctx)?;
+                    self.push(value.into());
+                }
+                Instruction::Neg => {
+                    let value = self.pop();
+                    self.push(Value::from(!value.to_boolean()));
+                }
+                Instruction::Not => {
+                    let value = self.pop();
+                    self.push((!value.to_boolean()).into());
+                }
+                Instruction::BitNot => {
+                    let target = self.pop();
+                    let num = target.to_number(self.ctx)?;
+                    let value = if num.is_nan() {
+                        -1
+                    } else {
+                        // TODO: this is not spec compliant.
+                        !(num as i32)
+                    };
+                    self.push(value.into());
+                }
             }
 
             idx += 1;

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,8 +1,10 @@
-use self::instructions::Instruction;
 use crate::{Context, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
+
+pub use compilation::Compiler;
+pub use instructions::Instruction;
 
 // === Execution
 #[derive(Debug)]
@@ -14,11 +16,10 @@ pub struct VM<'a> {
 }
 
 impl<'a> VM<'a> {
-    pub fn new(ctx: &'a mut Context) -> Self {
-        let instr = ctx.instructions_mut().clone();
+    pub fn new(compiler: Compiler, ctx: &'a mut Context) -> Self {
         VM {
             ctx,
-            instructions: instr,
+            instructions: compiler.instructions,
             stack: vec![],
             stack_pointer: 0,
         }
@@ -37,8 +38,167 @@ impl<'a> VM<'a> {
 
                     self.stack.push(val);
                 }
+                Instruction::Sub => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.sub(&r, self.ctx)?;
 
-                _ => unimplemented!(),
+                    self.stack.push(val);
+                }
+                Instruction::Mul => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.mul(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Div => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.div(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Pow => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.pow(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Mod => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.rem(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::BitAnd => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.bitand(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::BitOr => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.bitor(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::BitXor => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.bitxor(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Shl => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.shl(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Shr => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.shr(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::UShr => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.ushr(&r, self.ctx)?;
+
+                    self.stack.push(val);
+                }
+                Instruction::Eq => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.equals(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::NotEq => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = !l.equals(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::StrictEq => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.strict_equals(&r);
+
+                    self.stack.push(val.into());
+                }
+                Instruction::StrictNotEq => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = !l.strict_equals(&r);
+
+                    self.stack.push(val.into());
+                }
+                Instruction::Gt => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.ge(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::Ge => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.ge(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::Lt => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.lt(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::Le => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+                    let val = l.le(&r, self.ctx)?;
+
+                    self.stack.push(val.into());
+                }
+                Instruction::In => {
+                    let r = self.stack.pop().unwrap();
+                    let l = self.stack.pop().unwrap();
+
+                    if !r.is_object() {
+                        return self.ctx.throw_type_error(format!(
+                            "right-hand side of 'in' should be an object, got {}",
+                            r.get_type().as_str()
+                        ));
+                    }
+                    let key = l.to_property_key(self.ctx)?;
+                    let val = self.ctx.has_property(&r, &key);
+
+                    self.stack.push(val.into());
+                }
+                Instruction::InstanceOf => {
+                    let r = self.stack.pop().unwrap();
+                    let _l = self.stack.pop().unwrap();
+                    if !r.is_object() {
+                        return self.ctx.throw_type_error(format!(
+                            "right-hand side of 'instanceof' should be an object, got {}",
+                            r.get_type().as_str()
+                        ));
+                    }
+
+                    // spec: https://tc39.es/ecma262/#sec-instanceofoperator
+                    todo!("instanceof operator")
+                }
             }
 
             idx += 1;

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -1,4 +1,4 @@
-use crate::{Context, Value};
+use crate::{value::RcString, Context, Value};
 
 pub(crate) mod compilation;
 pub(crate) mod instructions;
@@ -11,15 +11,17 @@ pub use instructions::Instruction;
 pub struct VM<'a> {
     ctx: &'a mut Context,
     instructions: Vec<Instruction>,
+    pool: Vec<RcString>,
     stack: Vec<Value>,
     stack_pointer: usize,
 }
 
 impl<'a> VM<'a> {
     pub fn new(compiler: Compiler, ctx: &'a mut Context) -> Self {
-        VM {
+        Self {
             ctx,
             instructions: compiler.instructions,
+            pool: compiler.pool,
             stack: vec![],
             stack_pointer: 0,
         }
@@ -49,6 +51,10 @@ impl<'a> VM<'a> {
                 Instruction::Undefined => self.push(Value::undefined()),
                 Instruction::Null => self.push(Value::null()),
                 Instruction::Bool(value) => self.push(Value::boolean(value)),
+                Instruction::String(index) => {
+                    let value = self.pool[index].clone();
+                    self.push(value.into())
+                }
                 Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::Add => {
                     let r = self.pop();

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod instructions;
 pub use compilation::Compiler;
 pub use instructions::Instruction;
 
-// === Execution
+// Virtual Machine.
 #[derive(Debug)]
 pub struct VM<'a> {
     ctx: &'a mut Context,
@@ -25,155 +25,171 @@ impl<'a> VM<'a> {
         }
     }
 
+    /// Push a value on the stack.
+    #[inline]
+    pub fn push(&mut self, value: Value) {
+        self.stack.push(value);
+    }
+
+    /// Pop a value off the stack.
+    ///
+    /// # Panics
+    ///
+    /// If there is nothing to pop, then this will panic.
+    #[inline]
+    pub fn pop(&mut self) -> Value {
+        self.stack.pop().unwrap()
+    }
+
     pub fn run(&mut self) -> super::Result<Value> {
         let mut idx = 0;
 
         while idx < self.instructions.len() {
             match self.instructions[idx] {
-                Instruction::Int32(i) => self.stack.push(Value::Integer(i)),
+                Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::Add => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.add(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Sub => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.sub(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Mul => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.mul(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Div => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.div(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Pow => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.pow(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Mod => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.rem(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::BitAnd => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.bitand(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::BitOr => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.bitor(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::BitXor => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.bitxor(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Shl => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.shl(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Shr => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.shr(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::UShr => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.ushr(&r, self.ctx)?;
 
-                    self.stack.push(val);
+                    self.push(val);
                 }
                 Instruction::Eq => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.equals(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::NotEq => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = !l.equals(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::StrictEq => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.strict_equals(&r);
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::StrictNotEq => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = !l.strict_equals(&r);
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::Gt => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.ge(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::Ge => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.ge(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::Lt => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.lt(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::Le => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
                     let val = l.le(&r, self.ctx)?;
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::In => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let l = self.pop();
 
                     if !r.is_object() {
                         return self.ctx.throw_type_error(format!(
@@ -184,11 +200,11 @@ impl<'a> VM<'a> {
                     let key = l.to_property_key(self.ctx)?;
                     let val = self.ctx.has_property(&r, &key);
 
-                    self.stack.push(val.into());
+                    self.push(val.into());
                 }
                 Instruction::InstanceOf => {
-                    let r = self.stack.pop().unwrap();
-                    let _l = self.stack.pop().unwrap();
+                    let r = self.pop();
+                    let _l = self.pop();
                     if !r.is_object() {
                         return self.ctx.throw_type_error(format!(
                             "right-hand side of 'instanceof' should be an object, got {}",
@@ -204,7 +220,7 @@ impl<'a> VM<'a> {
             idx += 1;
         }
 
-        let res = self.stack.pop().unwrap();
+        let res = self.pop();
         Ok(res)
     }
 }

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -46,6 +46,9 @@ impl<'a> VM<'a> {
 
         while idx < self.instructions.len() {
             match self.instructions[idx] {
+                Instruction::Undefined => self.push(Value::undefined()),
+                Instruction::Null => self.push(Value::null()),
+                Instruction::Bool(value) => self.push(Value::boolean(value)),
                 Instruction::Int32(i) => self.push(Value::Integer(i)),
                 Instruction::Add => {
                     let r = self.pop();

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -152,7 +152,7 @@ pub fn main() -> Result<(), std::io::Error> {
                 eprintln!("{}", e);
             }
         } else {
-            match engine.eval_bytecode(&buffer) {
+            match engine.eval(&buffer) {
                 Ok(v) => println!("{}", v.display()),
                 Err(v) => eprintln!("Uncaught {}", v.display()),
             }


### PR DESCRIPTION
It changes the following:
- Added `-`, `*`, `/`, `**`, `%`, `&`, `|`, `<<`, `>>`, `>>>`, `<`, `>`, `==`, `===`, `!=`, `!==`, `=>`, `<=`, `in`, `instanceof` operators
- Added unary operators `+`, `-`, `typeof`, `void`, `!`, `~`
- Added undefined, null, bool, string, bigint, rational literals
- When the `vm` flag is set we use the eval bytecode version and when its not we use the regular.
