### PR TITLE
Removed cache from MacOS builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,14 +62,6 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - name: Cache cargo build
-        uses: actions/cache@v2
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -134,14 +126,6 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - name: Cache cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            target
-            ~/.cargo/git
-            ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/cargo@v1
         with:
           command: test


### PR DESCRIPTION
It seems that MacOS builds were failing in PRs because somehow the cache doesn't work on MacOS builds in PRs. So let's remove it. It will take a bit longer to compile, but benchmarks and test262 are the bottleneck anyways.
