### PR TITLE
Added "unimplemented" syntax errors

### DIFF
--- a/boa/src/syntax/parser/error.rs
+++ b/boa/src/syntax/parser/error.rs
@@ -46,6 +46,11 @@ pub enum ParseError {
         message: &'static str,
         position: Position,
     },
+    /// Unimplemented syntax error
+    Unimplemented {
+        message: &'static str,
+        position: Position,
+    },
 }
 
 impl ParseError {
@@ -90,6 +95,11 @@ impl ParseError {
     /// Creates a parsing error from a lexing error.
     pub(super) fn lex(e: LexError) -> Self {
         Self::Lex { err: e }
+    }
+
+    /// Creates a new `Unimplemented` parsing error.
+    pub(super) fn unimplemented(message: &'static str, position: Position) -> Self {
+        Self::Unimplemented { message, position }
     }
 }
 
@@ -156,6 +166,13 @@ impl fmt::Display for ParseError {
                 position.column_number()
             ),
             Self::Lex { err } => fmt::Display::fmt(err, f),
+            Self::Unimplemented { message, position } => write!(
+                f,
+                "{} not yet implemented at line {}, col {}",
+                message,
+                position.line_number(),
+                position.column_number()
+            ),
         }
     }
 }

--- a/boa/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/for_statement.rs
@@ -88,10 +88,13 @@ where
             _ => Some(Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?),
         };
 
-        // TODO: for..in, for..of
         match cursor.peek(0)? {
             Some(tok) if tok.kind() == &TokenKind::Keyword(Keyword::In) => {
-                unimplemented!("for...in statement")
+                // TODO: for...in
+                return Err(
+                    ParseError::unimplemented("for...in loops"),
+                    cursor.position(),
+                );
             }
             Some(tok) if tok.kind() == &TokenKind::Keyword(Keyword::Of) && init.is_some() => {
                 let _ = cursor.next();

--- a/boa/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/for_statement.rs
@@ -91,10 +91,10 @@ where
         match cursor.peek(0)? {
             Some(tok) if tok.kind() == &TokenKind::Keyword(Keyword::In) => {
                 // TODO: for...in
-                return Err(
-                    ParseError::unimplemented("for...in loops"),
-                    cursor.position(),
-                );
+                return Err(ParseError::unimplemented(
+                    "for...in loops",
+                    tok.span().start(),
+                ));
             }
             Some(tok) if tok.kind() == &TokenKind::Keyword(Keyword::Of) && init.is_some() => {
                 let _ = cursor.next();


### PR DESCRIPTION
This removes the panics in `for...in` parsing. It will still fail, but at least we don't bring the process down. This comes from the idea that "every panic is a bug", not just an unimplemented feature.