### PR TITLE
Upgraded regress to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,11 +970,12 @@ checksum = "8cab7a364d15cde1e505267766a2d3c4e22a843e1a601f0fa7564c0f82ced11c"
 
 [[package]]
 name = "regress"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d669f9db16c334d72d7f92d52874373eb0df8f642230401952a6901872fee4c5"
+checksum = "8ade8c280902120cc06e8694a76a5aa846e875df975da904d5a1a025fa7a5b4e"
 dependencies = [
  "memchr",
+ "structopt",
 ]
 
 [[package]]

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -21,7 +21,7 @@ gc = { version = "0.3.6", features = ["derive"] }
 serde_json = "1.0.59"
 rand = "0.7.3"
 num-traits = "0.2.12"
-regress = "0.1.4"
+regress = "0.2.0"
 rustc-hash = "1.1.0"
 num-bigint = { version = "0.3.0", features = ["serde"] }
 num-integer = "0.1.43"

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -321,7 +321,7 @@ impl RegExp {
             let result =
                 if let Some(m) = regex.matcher.find_from(arg_str.as_str(), last_index).next() {
                     if regex.use_last_index {
-                        last_index = m.range().end;
+                        last_index = m.end();
                     }
                     true
                 } else {
@@ -362,7 +362,7 @@ impl RegExp {
             let result = {
                 if let Some(m) = regex.matcher.find_from(arg_str.as_str(), last_index).next() {
                     if regex.use_last_index {
-                        last_index = m.range().end;
+                        last_index = m.end();
                     }
                     let groups = m.captures.len() + 1;
                     let mut result = Vec::with_capacity(groups);
@@ -377,10 +377,7 @@ impl RegExp {
                     }
 
                     let result = Value::from(result);
-                    result.set_property(
-                        "index",
-                        DataDescriptor::new(m.range().start, Attribute::all()),
-                    );
+                    result.set_property("index", DataDescriptor::new(m.start(), Attribute::all()));
                     result.set_property("input", DataDescriptor::new(arg_str, Attribute::all()));
                     result
                 } else {
@@ -483,10 +480,7 @@ impl RegExp {
 
                 let match_val = Value::from(match_vec);
 
-                match_val.set_property(
-                    "index",
-                    DataDescriptor::new(mat.range().start, Attribute::all()),
-                );
+                match_val.set_property("index", DataDescriptor::new(mat.start(), Attribute::all()));
                 match_val.set_property(
                     "input",
                     DataDescriptor::new(arg_str.clone(), Attribute::all()),

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -591,12 +591,12 @@ impl String {
                                 }
                                 (Some('`'), _) => {
                                     // $`
-                                    let start_of_match = mat.range().start;
+                                    let start_of_match = mat.start();
                                     result.push_str(&primitive_val[..start_of_match]);
                                 }
                                 (Some('\''), _) => {
                                     // $'
-                                    let end_of_match = mat.range().end;
+                                    let end_of_match = mat.end();
                                     result.push_str(&primitive_val[end_of_match..]);
                                 }
                                 (Some(second), Some(third))
@@ -666,7 +666,7 @@ impl String {
                         .collect();
 
                     // Returns the starting byte offset of the match
-                    let start = mat.range().start;
+                    let start = mat.start();
                     results.push(Value::from(start));
                     // Push the whole string being examined
                     results.push(Value::from(primitive_val.to_string()));

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -513,7 +513,7 @@ impl String {
 
                 if let Some(regexp) = obj.as_regexp() {
                     // first argument is another `RegExp` object, so copy its pattern and flags
-                    return regexp.original_source.clone();
+                    return regexp.original_source.clone().into();
                 }
                 "undefined".to_string()
             }
@@ -587,16 +587,16 @@ impl String {
                                 }
                                 (Some('&'), _) => {
                                     // $&
-                                    result.push_str(&primitive_val[mat.total()]);
+                                    result.push_str(&primitive_val[mat.range()]);
                                 }
                                 (Some('`'), _) => {
                                     // $`
-                                    let start_of_match = mat.total().start;
+                                    let start_of_match = mat.range().start;
                                     result.push_str(&primitive_val[..start_of_match]);
                                 }
                                 (Some('\''), _) => {
                                     // $'
-                                    let end_of_match = mat.total().end;
+                                    let end_of_match = mat.range().end;
                                     result.push_str(&primitive_val[end_of_match..]);
                                 }
                                 (Some(second), Some(third))
@@ -666,7 +666,7 @@ impl String {
                         .collect();
 
                     // Returns the starting byte offset of the match
-                    let start = mat.total().start;
+                    let start = mat.range().start;
                     results.push(Value::from(start));
                     // Push the whole string being examined
                     results.push(Value::from(primitive_val.to_string()));
@@ -682,7 +682,7 @@ impl String {
         };
 
         Ok(Value::from(primitive_val.replacen(
-            &primitive_val[mat.total()],
+            &primitive_val[mat.range()],
             &replace_value,
             1,
         )))


### PR DESCRIPTION
This supersedes both #903 and #904. It bumps `regress` to 0.2, which brings many nice and new features and fixes. I also took the opportunity to reduce a bit the size of the `RegExp` structure by changing strings to `Box<str>`, which might show a small performance increase.