### PR TITLE
Implementation of `instanceof` operator

### DIFF
--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -113,7 +113,7 @@ impl WellKnownSymbols {
     /// Called by the semantics of the instanceof operator.
     #[inline]
     pub fn has_instance_symbol(&self) -> RcSymbol {
-        self.async_iterator.clone()
+        self.has_instance.clone()
     }
 
     /// The `Symbol.isConcatSpreadable` well known symbol.

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -22,6 +22,9 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+#[cfg(test)]
+mod tests;
+
 mod gcobject;
 mod internal_methods;
 mod iter;

--- a/boa/src/object/tests.rs
+++ b/boa/src/object/tests.rs
@@ -1,0 +1,19 @@
+use crate::exec;
+
+#[test]
+fn ordinary_has_instance_nonobject_prototype() {
+    let scenario = r#"
+        try {
+          function C() {}
+          C.prototype = 1
+          String instanceof C
+        } catch (err) {
+          err.toString()
+        }
+        "#;
+
+    assert_eq!(
+        &exec(scenario),
+        "\"TypeError: function has non-object prototype in instanceof check\""
+    );
+}

--- a/boa/src/syntax/ast/node/operator/tests.rs
+++ b/boa/src/syntax/ast/node/operator/tests.rs
@@ -26,3 +26,37 @@ fn assignmentoperator_rhs_throws_error() {
 
     assert_eq!(&exec(scenario), "\"ReferenceError: b is not defined\"");
 }
+
+#[test]
+fn instanceofoperator_rhs_not_object() {
+    let scenario = r#"
+        try {
+          let s = new String();
+          s instanceof 1
+        } catch (err) {
+          err.toString()
+        }
+        "#;
+
+    assert_eq!(
+        &exec(scenario),
+        "\"TypeError: right-hand side of 'instanceof' should be an object, got number\""
+    );
+}
+
+#[test]
+fn instanceofoperator_rhs_not_callable() {
+    let scenario = r#"
+        try {
+          let s = new String();
+          s instanceof {}
+        } catch (err) {
+          err.toString()
+        }
+        "#;
+
+    assert_eq!(
+        &exec(scenario),
+        "\"TypeError: right-hand side of 'instanceof' is not callable\""
+    );
+}


### PR DESCRIPTION
- fixed @@hasinstance symbol call
- added `get_method()` and `ordinary_has_instance()` for `GcObject`
- implemented `instanceof` operator

This Pull Request fixes/closes #796.
