### PR TITLE
Swap the ordering of create_intrinsics() and only call if parsing is successful

### DIFF
--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -898,6 +898,7 @@ fn function_decl_hoisting() {
 #[test]
 fn to_bigint() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert!(Value::null().to_bigint(&mut engine).is_err());
     assert!(Value::undefined().to_bigint(&mut engine).is_err());
@@ -909,6 +910,7 @@ fn to_bigint() {
 #[test]
 fn to_index() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert_eq!(Value::undefined().to_index(&mut engine).unwrap(), 0);
     assert!(Value::integer(-1).to_index(&mut engine).is_err());
@@ -917,6 +919,7 @@ fn to_index() {
 #[test]
 fn to_integer() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert!(Number::equal(
         Value::number(f64::NAN).to_integer(&mut engine).unwrap(),
@@ -954,6 +957,7 @@ fn to_integer() {
 #[test]
 fn to_length() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert_eq!(Value::number(f64::NAN).to_length(&mut engine).unwrap(), 0);
     assert_eq!(
@@ -985,6 +989,7 @@ fn to_length() {
 #[test]
 fn to_int32() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     macro_rules! check_to_int32 {
         ($from:expr => $to:expr) => {
@@ -1098,6 +1103,7 @@ fn to_int32() {
 #[test]
 fn to_string() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert_eq!(Value::null().to_string(&mut engine).unwrap(), "null");
     assert_eq!(
@@ -1115,6 +1121,7 @@ fn to_string() {
 #[test]
 fn calling_function_with_unspecified_arguments() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let scenario = r#"
         function test(a, b) {
             return b;
@@ -1129,6 +1136,7 @@ fn calling_function_with_unspecified_arguments() {
 #[test]
 fn to_object() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
 
     assert!(Value::undefined()
         .to_object(&mut engine)
@@ -1143,6 +1151,7 @@ fn to_object() {
 #[test]
 fn check_this_binding_in_object_literal() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let init = r#"
         var foo = {
             a: 3,
@@ -1158,6 +1167,7 @@ fn check_this_binding_in_object_literal() {
 #[test]
 fn array_creation_benchmark() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let init = r#"
         (function(){
             let testArr = [];
@@ -1175,6 +1185,7 @@ fn array_creation_benchmark() {
 #[test]
 fn array_pop_benchmark() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let init = r#"
     (function(){
         let testArray = [83, 93, 27, 29, 2828, 234, 23, 56, 32, 56, 67, 77, 32,
@@ -1208,6 +1219,7 @@ fn array_pop_benchmark() {
 #[test]
 fn number_object_access_benchmark() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let init = r#"
     new Number(
         new Number(
@@ -1224,6 +1236,7 @@ fn number_object_access_benchmark() {
 #[test]
 fn not_a_function() {
     let mut engine = Context::new();
+    engine.create_intrinsics();
     let init = r#"
         let a = {};
         let b = true;

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -90,15 +90,10 @@ pub(crate) fn forward(engine: &mut Context, src: &str) -> String {
     let expr = match parse(src, false) {
         Ok(res) => res,
         Err(e) => {
-            return format!(
-                "Uncaught {}",
-                engine
-                    .throw_syntax_error(e.to_string())
-                    .expect_err("interpreter.throw_syntax_error() did not return an error")
-                    .display()
-            );
+            return format!("Uncaught \"SyntaxError\": \"{}\"", e);
         }
     };
+    engine.create_intrinsics();
     expr.run(engine).map_or_else(
         |e| format!("Uncaught {}", e.display()),
         |v| v.display().to_string(),
@@ -120,7 +115,10 @@ pub(crate) fn forward_val(engine: &mut Context, src: &str) -> Result<Value> {
                 .throw_syntax_error(e.to_string())
                 .expect_err("interpreter.throw_syntax_error() did not return an error")
         })
-        .and_then(|expr| expr.run(engine));
+        .and_then(|expr| {
+            engine.create_intrinsics();
+            expr.run(engine)
+        });
 
     // The main_timer needs to be dropped before the BoaProfiler is.
     drop(main_timer);


### PR DESCRIPTION
## Description

The main issue we have is that `create_intrinsics` fire regardless of syntax parsing status.
This means we spend a lot of time creating built-ins when we don't need to.

This PR swaps the order around (from intrinics then parsing, to parsing then intrinics).

I believe any test (test262) that relies on negative syntax, should fail a lot faster (70% faster).

## Main changes

* Create flag for when intriniscs are set, this is because eval can be called multiple times.
* Parsing Errors cannot utilise the realm
* Tests that don't go via forward need to call create_intrinsics()

Profiles taken below are for negative syntax

Before (15ms):
<img width="1291" alt="profile" src="https://user-images.githubusercontent.com/936006/96911213-737ba680-1498-11eb-9d50-26a69f61edc0.png">


After (0.7ms):
<img width="1294" alt="profile_after" src="https://user-images.githubusercontent.com/936006/96911234-7eced200-1498-11eb-8410-3ce007b3ccf2.png">