### PR TITLE
Change Symbol hash to `u64`

### DIFF
--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -46,7 +46,7 @@ pub struct WellKnownSymbols {
 }
 
 impl WellKnownSymbols {
-    pub(crate) fn new() -> (Self, u32) {
+    pub(crate) fn new() -> (Self, u64) {
         let mut count = 0;
 
         let async_iterator = Symbol::new(count, Some("Symbol.asyncIterator".into())).into();
@@ -223,12 +223,12 @@ impl WellKnownSymbols {
 
 #[derive(Debug, Finalize, Trace, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Symbol {
-    hash: u32,
+    hash: u64,
     description: Option<RcString>,
 }
 
 impl Symbol {
-    pub(crate) fn new(hash: u32, description: Option<RcString>) -> Self {
+    pub(crate) fn new(hash: u64, description: Option<RcString>) -> Self {
         Self { hash, description }
     }
 }
@@ -300,7 +300,7 @@ impl Symbol {
     }
 
     /// Returns the `Symbol`s hash.
-    pub fn hash(&self) -> u32 {
+    pub fn hash(&self) -> u64 {
         self.hash
     }
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -181,8 +181,8 @@ pub struct Context {
 
     /// Symbol hash.
     ///
-    /// For now this is an incremented u32 number.
-    symbol_count: u32,
+    /// For now this is an incremented u64 number.
+    symbol_count: u64,
 
     /// console object state.
     #[cfg(feature = "console")]
@@ -264,7 +264,7 @@ impl Context {
     ///
     /// This currently is an incremented value.
     #[inline]
-    fn generate_hash(&mut self) -> u32 {
+    fn generate_hash(&mut self) -> u64 {
         let hash = self.symbol_count;
         self.symbol_count += 1;
         hash


### PR DESCRIPTION
It changes the following:
- Change symbol hash from u32 to u64, This is done because it is possible to overflow the u32 hash since its only 4 bilion,  but a u64 is `18_446_744_073_709_551_616` even if we crated a symbol every `1ns` it would take `584` years (so... pretty much will never overflow)
