### PR TITLE
Added check to ignore semicolon in parser

### DIFF
--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -283,7 +283,6 @@ where
             self.allow_await,
             true,
             true,
-            true,
             &FUNCTION_BREAK_TOKENS,
         )
         .parse(cursor);

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -225,6 +225,9 @@ where
 /// [spec]: https://tc39.es/ecma262/#prod-FunctionBody
 pub(in crate::syntax::parser) type FunctionBody = FunctionStatementList;
 
+/// The possible TokenKind which indicate the end of a function statement.
+const FUNCTION_BREAK_TOKENS: [TokenKind; 1] = [TokenKind::Punctuator(Punctuator::CloseBlock)];
+
 /// A function statement list
 ///
 /// More information:
@@ -275,8 +278,15 @@ where
             }
         }
 
-        let stmlist =
-            StatementList::new(self.allow_yield, self.allow_await, true, true, true).parse(cursor);
+        let stmlist = StatementList::new(
+            self.allow_yield,
+            self.allow_await,
+            true,
+            true,
+            true,
+            &FUNCTION_BREAK_TOKENS,
+        )
+        .parse(cursor);
 
         // Reset strict mode back to the global scope.
         cursor.set_strict_mode(global_strict_mode);

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -9,7 +9,7 @@ mod statement;
 mod tests;
 
 pub use self::error::{ParseError, ParseResult};
-use crate::syntax::{ast::node::StatementList, ast::Punctuator, lexer::TokenKind};
+use crate::syntax::{ast::node::StatementList, lexer::TokenKind};
 
 use cursor::Cursor;
 
@@ -139,9 +139,6 @@ where
     }
 }
 
-/// The possible TokenKind which indicate the end of a case statement.
-const SCRIPT_BREAK_TOKENS: [TokenKind; 1] = [TokenKind::Punctuator(Punctuator::CloseBlock)];
-
 /// Parses a script body.
 ///
 /// More information:
@@ -158,7 +155,6 @@ where
     type Output = StatementList;
 
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        self::statement::StatementList::new(false, false, false, false, true, &SCRIPT_BREAK_TOKENS)
-            .parse(cursor)
+        self::statement::StatementList::new(false, false, false, true, &[]).parse(cursor)
     }
 }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -9,7 +9,7 @@ mod statement;
 mod tests;
 
 pub use self::error::{ParseError, ParseResult};
-use crate::syntax::{ast::node::StatementList, lexer::TokenKind};
+use crate::syntax::{ast::node::StatementList, ast::Punctuator, lexer::TokenKind};
 
 use cursor::Cursor;
 
@@ -139,6 +139,9 @@ where
     }
 }
 
+/// The possible TokenKind which indicate the end of a case statement.
+const SCRIPT_BREAK_TOKENS: [TokenKind; 1] = [TokenKind::Punctuator(Punctuator::CloseBlock)];
+
 /// Parses a script body.
 ///
 /// More information:
@@ -155,6 +158,7 @@ where
     type Output = StatementList;
 
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        self::statement::StatementList::new(false, false, false, false, true).parse(cursor)
+        self::statement::StatementList::new(false, false, false, false, true, &SCRIPT_BREAK_TOKENS)
+            .parse(cursor)
     }
 }

--- a/boa/src/syntax/parser/statement/block/mod.rs
+++ b/boa/src/syntax/parser/statement/block/mod.rs
@@ -23,6 +23,9 @@ use crate::{
 
 use std::io::Read;
 
+/// The possible TokenKind which indicate the end of a block statement.
+const BLOCK_BREAK_TOKENS: [TokenKind; 1] = [TokenKind::Punctuator(Punctuator::CloseBlock)];
+
 /// A `BlockStatement` is equivalent to a `Block`.
 ///
 /// More information:
@@ -84,6 +87,7 @@ where
             self.allow_return,
             true,
             true,
+            &BLOCK_BREAK_TOKENS,
         )
         .parse(cursor)
         .map(node::Block::from)?;

--- a/boa/src/syntax/parser/statement/block/mod.rs
+++ b/boa/src/syntax/parser/statement/block/mod.rs
@@ -86,7 +86,6 @@ where
             self.allow_await,
             self.allow_return,
             true,
-            true,
             &BLOCK_BREAK_TOKENS,
         )
         .parse(cursor)

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -214,15 +214,16 @@ where
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-StatementList
 #[derive(Debug, Clone, Copy)]
-pub(super) struct StatementList {
+pub(super) struct StatementList<'a> {
     allow_yield: AllowYield,
     allow_await: AllowAwait,
     allow_return: AllowReturn,
     break_when_closingbraces: bool,
     in_block: bool,
+    break_nodes: &'a [TokenKind],
 }
 
-impl StatementList {
+impl<'a> StatementList<'a> {
     /// Creates a new `StatementList` parser.
     pub(super) fn new<Y, A, R>(
         allow_yield: Y,
@@ -230,6 +231,7 @@ impl StatementList {
         allow_return: R,
         break_when_closingbraces: bool,
         in_block: bool,
+        break_nodes: &'a [TokenKind],
     ) -> Self
     where
         Y: Into<AllowYield>,
@@ -242,75 +244,34 @@ impl StatementList {
             allow_return: allow_return.into(),
             break_when_closingbraces,
             in_block,
+            break_nodes,
         }
-    }
-
-    /// The function parses a node::StatementList using the given break_nodes to know when to terminate.
-    ///
-    /// This ignores the break_when_closingbraces flag.
-    ///
-    /// Returns a ParseError::AbruptEnd if end of stream is reached before a break token.
-    ///
-    /// This is a more general version of the TokenParser parse function for StatementList which can exit based on multiple
-    /// different tokens. This may eventually replace the parse() function but is currently seperate to allow testing the
-    /// performance impact of this more general mechanism.
-    ///
-    /// Note that the last token which causes the parse to finish is not consumed.
-    pub(crate) fn parse_generalised<R>(
-        self,
-        cursor: &mut Cursor<R>,
-        break_nodes: &[TokenKind],
-    ) -> Result<node::StatementList, ParseError>
-    where
-        R: Read,
-    {
-        let mut items = Vec::new();
-
-        loop {
-            if let Some(token) = cursor.peek(0)? {
-                if break_nodes.contains(token.kind()) {
-                    break;
-                } else if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
-                    cursor.next()?;
-                    continue;
-                }
-            } else {
-                return Err(ParseError::AbruptEnd);
-            }
-
-            let item = StatementListItem::new(
-                self.allow_yield,
-                self.allow_await,
-                self.allow_return,
-                self.in_block,
-            )
-            .parse(cursor)?;
-
-            items.push(item);
-
-            // // move the cursor forward for any consecutive semicolon.
-            // while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
-        }
-
-        items.sort_by(Node::hoistable_order);
-
-        Ok(items.into())
     }
 }
 
-impl<R> TokenParser<R> for StatementList
+impl<R> TokenParser<R> for StatementList<'_>
 where
     R: Read,
 {
     type Output = node::StatementList;
 
+    /// The function parses a node::StatementList using the StatementList's
+    /// break_nodes to know when to terminate.
+    ///
+    /// Returns a ParseError::AbruptEnd if end of stream is reached before a
+    /// break token.
+    ///
+    /// Returns a ParseError::unexpected if an unexpected token is found.
+    ///
+    /// Note that the last token which causes the parse to finish is not
+    /// consumed.
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("StatementList", "Parsing");
         let mut items = Vec::new();
 
         loop {
             match cursor.peek(0)? {
-                Some(token) if token.kind() == &TokenKind::Punctuator(Punctuator::CloseBlock) => {
+                Some(token) if self.break_nodes.contains(token.kind()) => {
                     if self.break_when_closingbraces {
                         break;
                     } else {

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -267,10 +267,6 @@ where
         loop {
             match cursor.peek(0)? {
                 Some(token) if self.break_nodes.contains(token.kind()) => break,
-                Some(token) if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
-                    cursor.next()?;
-                    continue;
-                }
                 None => break,
                 _ => {}
             }
@@ -283,6 +279,9 @@ where
             )
             .parse(cursor)?;
             items.push(item);
+
+            // move the cursor forward for any consecutive semicolon.
+            while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
 
         items.sort_by(Node::hoistable_order);

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -270,6 +270,9 @@ impl StatementList {
             if let Some(token) = cursor.peek(0)? {
                 if break_nodes.contains(token.kind()) {
                     break;
+                } else if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
+                    cursor.next()?;
+                    continue;
                 }
             } else {
                 return Err(ParseError::AbruptEnd);
@@ -285,8 +288,8 @@ impl StatementList {
 
             items.push(item);
 
-            // move the cursor forward for any consecutive semicolon.
-            while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
+            // // move the cursor forward for any consecutive semicolon.
+            // while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
 
         items.sort_by(Node::hoistable_order);
@@ -314,6 +317,10 @@ where
                         return Err(ParseError::unexpected(token.clone(), None));
                     }
                 }
+                Some(token) if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
+                    cursor.next()?;
+                    continue;
+                }
                 None => {
                     if self.break_when_closingbraces {
                         return Err(ParseError::AbruptEnd);
@@ -332,9 +339,6 @@ where
             )
             .parse(cursor)?;
             items.push(item);
-
-            // move the cursor forward for any consecutive semicolon.
-            while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
 
         items.sort_by(Node::hoistable_order);

--- a/boa/src/syntax/parser/statement/switch/mod.rs
+++ b/boa/src/syntax/parser/statement/switch/mod.rs
@@ -131,8 +131,9 @@ where
                         self.allow_return,
                         true,
                         false,
+                        &CASE_BREAK_TOKENS,
                     )
-                    .parse_generalised(cursor, &CASE_BREAK_TOKENS)?;
+                    .parse(cursor)?;
 
                     cases.push(node::Case::new(cond, statement_list));
                 }
@@ -153,8 +154,9 @@ where
                         self.allow_return,
                         true,
                         false,
+                        &CASE_BREAK_TOKENS,
                     )
-                    .parse_generalised(cursor, &CASE_BREAK_TOKENS)?;
+                    .parse(cursor)?;
 
                     default = Some(statement_list);
                 }

--- a/boa/src/syntax/parser/statement/switch/mod.rs
+++ b/boa/src/syntax/parser/statement/switch/mod.rs
@@ -129,7 +129,6 @@ where
                         self.allow_yield,
                         self.allow_await,
                         self.allow_return,
-                        true,
                         false,
                         &CASE_BREAK_TOKENS,
                     )
@@ -152,7 +151,6 @@ where
                         self.allow_yield,
                         self.allow_await,
                         self.allow_return,
-                        true,
                         false,
                         &CASE_BREAK_TOKENS,
                     )


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request closes #892.

It changes the following:

- Empty statements are now parsed without error
- Semicolons are no longer skipped at the end of the parse loop

In the original issue, it was mentioned that there might be a problem with empty `StatementLists` as well. I couldn't find a case where it didn't work as is, but I still brought the semicolon skip up a little higher.

I'm not sure if any specific tests should be written for this, but if so I can add them.

This PR improves conformance by 0.07% :smile: 
