### PR TITLE
Fix unresolved links in documentation

### DIFF
--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -64,7 +64,7 @@ impl Boolean {
         Ok(Value::from(data))
     }
 
-    /// An Utility function used to get the internal [[BooleanData]].
+    /// An Utility function used to get the internal `[[BooleanData]]`.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -208,7 +208,7 @@ pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
 /// name: The name of the function (how it will be called but without the ()).
 /// parent: The object to register the function on, if the global object is used then the function is instead called as name()
 ///     without requiring the parent, see parseInt() as an example.
-/// length: As described at https://tc39.es/ecma262/#sec-function-instances-length, The value of the "length" property is an integer that
+/// length: As described at <https://tc39.es/ecma262/#sec-function-instances-length>, The value of the "length" property is an integer that
 ///     indicates the typical number of arguments expected by the function. However, the language permits the function to be invoked with
 ///     some other number of arguments.
 ///

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -18,7 +18,7 @@ pub enum MapIterationKind {
 /// More information:
 ///  - [ECMAScript reference][spec]
 ///
-/// [spec]: TODO https://tc39.es/ecma262/#sec-array-iterator-objects
+/// [spec]: https://tc39.es/ecma262/#sec-array-iterator-objects
 #[derive(Debug, Clone, Finalize, Trace)]
 pub struct MapIterator {
     iterated_map: Value,

--- a/boa/src/builtins/number/conversions.rs
+++ b/boa/src/builtins/number/conversions.rs
@@ -79,7 +79,7 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
 
 /// Converts a 64-bit floating point number to an `u32` according to the [`ToUint32`][ToUint32] algorithm.
 ///
-// [ToUint32]: https://tc39.es/ecma262/#sec-touint32
+/// [ToUint32]: https://tc39.es/ecma262/#sec-touint32
 #[inline]
 pub(crate) fn f64_to_uint32(number: f64) -> u32 {
     f64_to_int32(number) as u32

--- a/boa/src/builtins/number/conversions.rs
+++ b/boa/src/builtins/number/conversions.rs
@@ -79,7 +79,7 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
 
 /// Converts a 64-bit floating point number to an `u32` according to the [`ToUint32`][ToUint32] algorithm.
 ///
-// [ToInt32]: https://tc39.es/ecma262/#sec-touint32
+// [ToUint32]: https://tc39.es/ecma262/#sec-touint32
 #[inline]
 pub(crate) fn f64_to_uint32(number: f64) -> u32 {
     f64_to_int32(number) as u32

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -774,7 +774,7 @@ impl Number {
     /// The abstract operation Number::equal takes arguments
     /// x (a Number) and y (a Number). It performs the following steps when called:
     ///
-    /// https://tc39.es/ecma262/#sec-numeric-types-number-equal
+    /// <https://tc39.es/ecma262/#sec-numeric-types-number-equal>
     #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn equal(x: f64, y: f64) -> bool {
@@ -784,7 +784,7 @@ impl Number {
     /// The abstract operation Number::sameValue takes arguments
     /// x (a Number) and y (a Number). It performs the following steps when called:
     ///
-    /// https://tc39.es/ecma262/#sec-numeric-types-number-sameValue
+    /// <https://tc39.es/ecma262/#sec-numeric-types-number-sameValue>
     #[allow(clippy::float_cmp)]
     pub(crate) fn same_value(a: f64, b: f64) -> bool {
         if a.is_nan() && b.is_nan() {
@@ -806,7 +806,7 @@ impl Number {
     /// The abstract operation Number::sameValueZero takes arguments
     /// x (a Number) and y (a Number). It performs the following steps when called:
     ///
-    /// https://tc39.es/ecma262/#sec-numeric-types-number-sameValueZero
+    /// <https://tc39.es/ecma262/#sec-numeric-types-number-sameValueZero>
     #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn same_value_zero(x: f64, y: f64) -> bool {

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -194,6 +194,7 @@ impl Object {
     /// The abstract operation `FromPropertyDescriptor`.
     ///
     /// [ECMAScript reference][spec]
+    ///
     /// [spec]: https://tc39.es/ecma262/#sec-frompropertydescriptor
     fn from_property_descriptor(desc: PropertyDescriptor, context: &mut Context) -> Result<Value> {
         let mut descriptor = ObjectInitializer::new(context);

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -572,7 +572,7 @@ impl Context {
         Err(())
     }
 
-    /// https://tc39.es/ecma262/#sec-hasproperty
+    /// <https://tc39.es/ecma262/#sec-hasproperty>
     #[inline]
     pub(crate) fn has_property(&self, obj: &Value, key: &PropertyKey) -> bool {
         if let Some(obj) = obj.as_object() {

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -47,11 +47,11 @@ pub struct FunctionEnvironmentRecord {
     /// The function object whose invocation caused this Environment Record to be created.
     pub function: GcObject,
     /// If the associated function has super property accesses and is not an ArrowFunction,
-    /// [[HomeObject]] is the object that the function is bound to as a method.
-    /// The default value for [[HomeObject]] is undefined.
+    /// `[[HomeObject]]` is the object that the function is bound to as a method.
+    /// The default value for `[[HomeObject]]` is undefined.
     pub home_object: Value,
-    /// If this Environment Record was created by the [[Construct]] internal method,
-    /// [[NewTarget]] is the value of the [[Construct]] newTarget parameter.
+    /// If this Environment Record was created by the `[[Construct]]` internal method,
+    /// `[[NewTarget]]` is the value of the `[[Construct]]` newTarget parameter.
     /// Otherwise, its value is undefined.
     pub new_target: Value,
     /// Reference to the outer environment to help with the scope chain

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -288,7 +288,7 @@ impl GcObject {
     /// The spec doesn't mention what to do in this situation, but a naive implementation
     /// would overflow the stack recursively calling `toString()`. We follow v8 and SpiderMonkey
     /// instead by returning a default value for the given `hint` -- either `0.` or `""`.
-    /// Example in v8: https://repl.it/repls/IvoryCircularCertification#index.js
+    /// Example in v8: <https://repl.it/repls/IvoryCircularCertification#index.js>
     ///
     /// More information:
     ///  - [ECMAScript][spec]

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -69,8 +69,8 @@ impl GcObject {
         }
     }
 
-    /// [[Get]]
-    /// https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
+    /// `[[Get]]`
+    /// <https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver>
     pub fn get(&self, key: &PropertyKey) -> Value {
         match self.get_own_property(key) {
             None => {
@@ -90,7 +90,7 @@ impl GcObject {
         }
     }
 
-    /// [[Set]]
+    /// `[[Set]]`
     /// <https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver>
     pub fn set(&mut self, key: PropertyKey, val: Value) -> bool {
         let _timer = BoaProfiler::global().start_event("Object::set", "object");
@@ -239,7 +239,7 @@ impl GcObject {
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///
-    /// [spec](https://tc39.es/ecma262/#table-essential-internal-methods)
+    /// [spec]: https://tc39.es/ecma262/#table-essential-internal-methods
     #[inline]
     pub fn own_property_keys(&self) -> Vec<PropertyKey> {
         self.borrow().keys().collect()
@@ -323,6 +323,7 @@ impl GcObject {
     ///  - [MDN documentation][mdn]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf
     #[inline]
     pub fn get_prototype_of(&self) -> Value {
         self.borrow().prototype.clone()
@@ -362,7 +363,7 @@ impl GcObject {
         self.insert(key.into(), DataDescriptor::new(value, attribute))
     }
 
-    /// It determines if Object is a callable function with a [[Call]] internal method.
+    /// It determines if Object is a callable function with a `[[Call]]` internal method.
     ///
     /// More information:
     /// - [EcmaScript reference][spec]
@@ -374,7 +375,7 @@ impl GcObject {
         self.borrow().is_callable()
     }
 
-    /// It determines if Object is a function object with a [[Construct]] internal method.
+    /// It determines if Object is a function object with a `[[Construct]]` internal method.
     ///
     /// More information:
     /// - [EcmaScript reference][spec]

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -245,7 +245,7 @@ impl Object {
         }
     }
 
-    /// It determines if Object is a callable function with a [[Call]] internal method.
+    /// It determines if Object is a callable function with a `[[Call]]` internal method.
     ///
     /// More information:
     /// - [EcmaScript reference][spec]
@@ -256,7 +256,7 @@ impl Object {
         matches!(self.data, ObjectData::Function(ref f) if f.is_callable())
     }
 
-    /// It determines if Object is a function object with a [[Construct]] internal method.
+    /// It determines if Object is a function object with a `[[Construct]]` internal method.
     ///
     /// More information:
     /// - [EcmaScript reference][spec]

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -228,7 +228,7 @@ pub enum PropertyDescriptor {
 }
 
 impl PropertyDescriptor {
-    /// An accessor Property Descriptor is one that includes any fields named either [[Get]] or [[Set]].
+    /// An accessor Property Descriptor is one that includes any fields named either `[[Get]]` or `[[Set]]`.
     ///
     /// More information:
     /// - [ECMAScript reference][spec]
@@ -248,7 +248,7 @@ impl PropertyDescriptor {
         }
     }
 
-    /// A data Property Descriptor is one that includes any fields named either [[Value]] or [[Writable]].
+    /// A data Property Descriptor is one that includes any fields named either `[[Value]]` or `[[Writable]]`.
     ///
     /// More information:
     /// - [ECMAScript reference][spec]

--- a/boa/src/syntax/ast/node/field/get_field/mod.rs
+++ b/boa/src/syntax/ast/node/field/get_field/mod.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// This property accessor provides access to an object's properties by using the
 /// [bracket notation][mdn].
 ///
-/// In the object[property_name] syntax, the property_name is just a string or
+/// In the object\[property_name\] syntax, the property_name is just a string or
 /// [Symbol][symbol]. So, it can be any string, including '1foo', '!bar!', or even ' ' (a
 /// space).
 ///

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -677,11 +677,11 @@ pub enum LogOp {
     /// Syntax: `x || y`
     ///
     /// More information:
-    ///  - [ECMAScript reference](
+    ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: <https://tc39.es/ecma262/#prod-LogicalORExpression)>
-    /// [mdn]: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR>
+    /// [spec]: https://tc39.es/ecma262/#prod-LogicalORExpression
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR
     Or,
 }
 

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -680,8 +680,8 @@ pub enum LogOp {
     ///  - [ECMAScript reference](
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://tc39.es/ecma262/#prod-LogicalORExpression)
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR
+    /// [spec]: <https://tc39.es/ecma262/#prod-LogicalORExpression)>
+    /// [mdn]: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators#Logical_OR>
     Or,
 }
 
@@ -822,7 +822,7 @@ pub enum AssignOp {
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation](mdn)
+    ///  - [MDN documentation][mdn]
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators#Subtraction_assignment

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -398,7 +398,7 @@ where
 {
     type Output = Box<str>;
 
-    /// Strict mode parsing as per https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors.
+    /// Strict mode parsing as per <https://tc39.es/ecma262/#sec-identifiers-static-semantics-early-errors>.
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("BindingIdentifier", "Parsing");
 

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -247,8 +247,8 @@ impl Value {
     /// For scalar types it should be false, for objects check the private field for extensibilaty.
     /// By default true.
     ///
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal would turn extensible to false/>
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze would also turn extensible to false/>
+    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal> would turn extensible to false
+    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze> would also turn extensible to false
     pub fn is_extensible(&self) -> bool {
         true
     }
@@ -446,7 +446,7 @@ impl Value {
     }
 
     /// Resolve the property in the object and get its value, or undefined if this is not an object or the field doesn't exist
-    /// get_field recieves a Property from get_prop(). It should then return the [[Get]] result value if that's set, otherwise fall back to [[Value]]
+    /// get_field receives a Property from get_prop(). It should then return the `[[Get]]` result value if that's set, otherwise fall back to `[[Value]]`
     /// TODO: this function should use the get Value if its set
     pub fn get_field<K>(&self, key: K) -> Self
     where
@@ -798,7 +798,7 @@ impl Value {
     ///
     /// This function is equivalent to the unary `+` operator (`+value`) in JavaScript
     ///
-    /// See: https://tc39.es/ecma262/#sec-tonumber
+    /// See: <https://tc39.es/ecma262/#sec-tonumber>
     pub fn to_number(&self, context: &mut Context) -> Result<f64> {
         match *self {
             Value::Null => Ok(0.0),

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -247,8 +247,8 @@ impl Value {
     /// For scalar types it should be false, for objects check the private field for extensibilaty.
     /// By default true.
     ///
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal> would turn extensible to false
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze> would also turn extensible to false
+    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal> would turn `extensible` to `false`
+    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze> would also turn `extensible` to `false`
     pub fn is_extensible(&self) -> bool {
         true
     }

--- a/boa/src/value/type.rs
+++ b/boa/src/value/type.rs
@@ -1,6 +1,6 @@
 use super::Value;
 
-/// Possible types of values as defined at https://tc39.es/ecma262/#sec-typeof-operator.
+/// Possible types of values as defined at <https://tc39.es/ecma262/#sec-typeof-operator>.
 /// Note that an object which implements call is referred to here as 'Function'.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Type {
@@ -34,7 +34,7 @@ impl Type {
 impl Value {
     /// Get the type of the value.
     ///
-    /// This is similar to typeof as described at https://tc39.es/ecma262/#sec-typeof-operator but instead of
+    /// This is similar to typeof as described at <https://tc39.es/ecma262/#sec-typeof-operator> but instead of
     /// returning a string it returns a Type enum which implements fmt::Display to allow getting the string if
     /// required using to_string().
     pub fn get_type(&self) -> Type {


### PR DESCRIPTION
This Pull Request fixes #957.

It changes the following:
- Unresolved or misinterpreted links in the documentation
