### PR TITLE
Implement the optional `space` parameter in `JSON.stringify` 

### DIFF
--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -50,11 +50,14 @@ bench = false
 [[bench]]
 name = "parser"
 harness = false
+required-features = ["serde"]
 
 [[bench]]
 name = "exec"
 harness = false
+required-features = ["serde"]
 
 [[bench]]
 name = "full"
 harness = false
+required-features = ["serde"]

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -19,7 +19,8 @@ use crate::{
     property::{Attribute, DataDescriptor, PropertyKey},
     BoaProfiler, Context, Result, Value,
 };
-use serde_json::{self, Value as JSONValue};
+use serde::Serialize;
+use serde_json::{self, ser::PrettyFormatter, Serializer, Value as JSONValue};
 
 #[cfg(test)]
 mod tests;
@@ -144,6 +145,34 @@ impl Json {
             Some(replacer) if replacer.is_object() => replacer,
             _ => return Ok(Value::from(object.to_json(context)?.to_string())),
         };
+        const SPACE_INDENT: &str = "          ";
+        let space = match args.get(2) {
+            Some(indent) if indent.is_number() => {
+                if let Some(indent_length) = indent.as_number() {
+                    let indent_length = if indent_length > 10.0 {
+                        10.0
+                    } else {
+                        indent_length
+                    };
+                    let indent_length = if indent_length < 0.0 || indent_length.is_nan() {
+                        0.0
+                    } else {
+                        indent_length
+                    };
+                    &SPACE_INDENT[..indent_length as usize]
+                } else {
+                    ""
+                }
+            }
+            Some(space) if space.is_string() => {
+                if let Some(space) = space.as_string() {
+                    &space[..std::cmp::min(space.len(), 10)]
+                } else {
+                    ""
+                }
+            }
+            _ => "",
+        };
 
         let replacer_as_object = replacer
             .as_object()
@@ -172,7 +201,10 @@ impl Json {
                             ),
                         );
                     }
-                    Ok(Value::from(object_to_return.to_json(context)?.to_string()))
+                    Ok(Value::from(json_to_pretty_string(
+                        &object_to_return.to_json(context)?,
+                        space,
+                    )))
                 })
                 .ok_or_else(Value::undefined)?
         } else if replacer_as_object.is_array() {
@@ -195,9 +227,30 @@ impl Json {
                     obj_to_return.insert(field.to_string(context)?.to_string(), value);
                 }
             }
-            Ok(Value::from(JSONValue::Object(obj_to_return).to_string()))
+            Ok(Value::from(json_to_pretty_string(
+                &JSONValue::Object(obj_to_return),
+                space,
+            )))
         } else {
-            Ok(Value::from(object.to_json(context)?.to_string()))
+            Ok(Value::from(json_to_pretty_string(
+                &object.to_json(context)?,
+                space,
+            )))
         }
+    }
+}
+
+fn json_to_pretty_string(json: &JSONValue, space: &str) -> String {
+    if space.len() == 0 {
+        return json.to_string();
+    }
+    let formatter = PrettyFormatter::with_indent(space.as_bytes());
+    let mut writer = Vec::with_capacity(128);
+    let mut serializer = Serializer::with_formatter(&mut writer, formatter);
+    json.serialize(&mut serializer)
+        .expect("JSON serialization failed");
+    unsafe {
+        // The serde json serializer always produce correct UTF-8
+        String::from_utf8_unchecked(writer)
     }
 }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -141,10 +141,6 @@ impl Json {
             None => return Ok(Value::undefined()),
             Some(obj) => obj,
         };
-        let replacer = match args.get(1) {
-            Some(replacer) if replacer.is_object() => replacer,
-            _ => return Ok(Value::from(object.to_json(context)?.to_string())),
-        };
         const SPACE_INDENT: &str = "          ";
         let space = match args.get(2) {
             Some(indent) if indent.is_number() => {
@@ -172,6 +168,15 @@ impl Json {
                 }
             }
             _ => "",
+        };
+        let replacer = match args.get(1) {
+            Some(replacer) if replacer.is_object() => replacer,
+            _ => {
+                return Ok(Value::from(json_to_pretty_string(
+                    &object.to_json(context)?,
+                    space,
+                )))
+            }
         };
 
         let replacer_as_object = replacer

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -241,7 +241,7 @@ impl Json {
 }
 
 fn json_to_pretty_string(json: &JSONValue, space: &str) -> String {
-    if space.len() == 0 {
+    if space.is_empty() {
         return json.to_string();
     }
     let formatter = PrettyFormatter::with_indent(space.as_bytes());

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -208,6 +208,102 @@ fn json_stringify_fractional_numbers() {
 }
 
 #[test]
+fn json_stringify_pretty_print() {
+    let mut context = Context::new();
+
+    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, {}, 4)"#);
+    let expected = forward(
+        &mut context,
+        r#"'{
+    "a": "b",
+    "b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_four_spaces() {
+    let mut context = Context::new();
+
+    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, {}, 4.3)"#);
+    let expected = forward(
+        &mut context,
+        r#"'{
+    "a": "b",
+    "b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_twenty_spaces() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, ["a", "b"], 20)"#,
+    );
+    let expected = forward(
+        &mut context,
+        r#"'{
+          "a": "b",
+          "b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_bad_space_argument() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, ["a", "b"], [])"#,
+    );
+    let expected = forward(&mut context, r#"'{"a":"b","b":"c"}'"#);
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_with_string() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, {}, "abcd")"#,
+    );
+    let expected = forward(
+        &mut context,
+        r#"'{
+abcd"a": "b",
+abcd"b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_with_too_long_string() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, {}, "abcdefghijklmn")"#,
+    );
+    let expected = forward(
+        &mut context,
+        r#"'{
+abcdefghij"a": "b",
+abcdefghij"b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn json_parse_array_with_reviver() {
     let mut context = Context::new();
     let result = forward_val(

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -211,7 +211,10 @@ fn json_stringify_fractional_numbers() {
 fn json_stringify_pretty_print() {
     let mut context = Context::new();
 
-    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, undefined, 4)"#);
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, 4)"#,
+    );
     let expected = forward(
         &mut context,
         r#"'{

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -262,6 +262,24 @@ fn json_stringify_pretty_print_twenty_spaces() {
 }
 
 #[test]
+fn json_stringify_pretty_print_with_number_object() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, new Number(10))"#,
+    );
+    let expected = forward(
+        &mut context,
+        r#"'{
+          "a": "b",
+          "b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
 fn json_stringify_pretty_print_bad_space_argument() {
     let mut context = Context::new();
 
@@ -270,24 +288,6 @@ fn json_stringify_pretty_print_bad_space_argument() {
         r#"JSON.stringify({a: "b", b: "c"}, ["a", "b"], [])"#,
     );
     let expected = forward(&mut context, r#"'{"a":"b","b":"c"}'"#);
-    assert_eq!(actual, expected);
-}
-
-#[test]
-fn json_stringify_pretty_print_with_string() {
-    let mut context = Context::new();
-
-    let actual = forward(
-        &mut context,
-        r#"JSON.stringify({a: "b", b: "c"}, undefined, "abcd")"#,
-    );
-    let expected = forward(
-        &mut context,
-        r#"'{
-abcd"a": "b",
-abcd"b": "c"
-}'"#,
-    );
     assert_eq!(actual, expected);
 }
 
@@ -304,6 +304,24 @@ fn json_stringify_pretty_print_with_too_long_string() {
         r#"'{
 abcdefghij"a": "b",
 abcdefghij"b": "c"
+}'"#,
+    );
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn json_stringify_pretty_print_with_string_object() {
+    let mut context = Context::new();
+
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, new String("abcd"))"#,
+    );
+    let expected = forward(
+        &mut context,
+        r#"'{
+abcd"a": "b",
+abcd"b": "c"
 }'"#,
     );
     assert_eq!(actual, expected);

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -226,7 +226,10 @@ fn json_stringify_pretty_print() {
 fn json_stringify_pretty_print_four_spaces() {
     let mut context = Context::new();
 
-    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, {}, 4.3)"#);
+    let actual = forward(
+        &mut context,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, 4.3)"#,
+    );
     let expected = forward(
         &mut context,
         r#"'{

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -211,7 +211,7 @@ fn json_stringify_fractional_numbers() {
 fn json_stringify_pretty_print() {
     let mut context = Context::new();
 
-    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, {}, 4)"#);
+    let actual = forward(&mut context, r#"JSON.stringify({a: "b", b: "c"}, undefined, 4)"#);
     let expected = forward(
         &mut context,
         r#"'{
@@ -276,7 +276,7 @@ fn json_stringify_pretty_print_with_string() {
 
     let actual = forward(
         &mut context,
-        r#"JSON.stringify({a: "b", b: "c"}, {}, "abcd")"#,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, "abcd")"#,
     );
     let expected = forward(
         &mut context,
@@ -294,7 +294,7 @@ fn json_stringify_pretty_print_with_too_long_string() {
 
     let actual = forward(
         &mut context,
-        r#"JSON.stringify({a: "b", b: "c"}, {}, "abcdefghijklmn")"#,
+        r#"JSON.stringify({a: "b", b: "c"}, undefined, "abcdefghijklmn")"#,
     );
     let expected = forward(
         &mut context,


### PR DESCRIPTION

This Pull Request fixes/closes #346 .

It changes the following:

- `JSON.stringify()` now supports `space` parameter
