### PR TITLE
Fix enumerable attribute on array length property

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -58,7 +58,11 @@ impl BuiltIn for Array {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .property("length", 0, Attribute::WRITABLE | Attribute::NON_ENUMERABLE)
+        .property(
+            "length",
+            0,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+        )
         .property(
             "values",
             values_function.clone(),

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -221,7 +221,11 @@ impl Array {
             .as_object()
             .expect("array object")
             .set_prototype_instance(context.standard_objects().array_object().prototype().into());
-        array.set_field("length", Value::from(0));
+        let length = DataDescriptor::new(
+            Value::from(0),
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+        );
+        array.set_property("length", length);
         Ok(array)
     }
 

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -58,7 +58,7 @@ impl BuiltIn for Array {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .property("length", 0, Attribute::all())
+        .property("length", 0, Attribute::WRITABLE | Attribute::NON_ENUMERABLE)
         .property(
             "values",
             values_function.clone(),

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -1361,3 +1361,12 @@ fn get_relative_end() {
         Ok(10)
     );
 }
+
+#[test]
+fn array_length_is_not_enumerable() {
+    let mut context = Context::new();
+
+    let array = Array::new_array(&mut context).unwrap();
+    let desc = array.get_property("length").unwrap();
+    assert!(!desc.enumerable());
+}


### PR DESCRIPTION
This Pull Request fixes #971 .

It changes the following:

- The `length` property of an array is set to non enumerable

