### PR TITLE
Read file input in bytes instead of string

### DIFF
--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -677,10 +677,11 @@ impl Context {
     /// ```
     #[allow(clippy::unit_arg, clippy::drop_copy)]
     #[inline]
-    pub fn eval(&mut self, src: &str) -> Result<Value> {
+    pub fn eval<T: AsRef<[u8]>>(&mut self, src: T) -> Result<Value> {
         let main_timer = BoaProfiler::global().start_event("Main", "Main");
+        let src_bytes: &[u8] = src.as_ref();
 
-        let parsing_result = Parser::new(src.as_bytes(), false)
+        let parsing_result = Parser::new(src_bytes, false)
             .parse_all()
             .map_err(|e| e.to_string());
 

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -78,16 +78,19 @@ pub type Result<T> = StdResult<T, Value>;
 /// It will return either the statement list AST node for the code, or a parsing error if something
 /// goes wrong.
 #[inline]
-pub fn parse(src: &str, strict_mode: bool) -> StdResult<StatementList, ParseError> {
-    Parser::new(src.as_bytes(), strict_mode).parse_all()
+pub fn parse<T: AsRef<[u8]>>(src: T, strict_mode: bool) -> StdResult<StatementList, ParseError> {
+    let src_bytes: &[u8] = src.as_ref();
+    Parser::new(src_bytes, strict_mode).parse_all()
 }
 
 /// Execute the code using an existing Context
 /// The str is consumed and the state of the Context is changed
 #[cfg(test)]
-pub(crate) fn forward(context: &mut Context, src: &str) -> String {
+pub(crate) fn forward<T: AsRef<[u8]>>(context: &mut Context, src: T) -> String {
+    let src_bytes: &[u8] = src.as_ref();
+
     // Setup executor
-    let expr = match parse(src, false) {
+    let expr = match parse(src_bytes, false) {
         Ok(res) => res,
         Err(e) => {
             return format!(
@@ -111,10 +114,12 @@ pub(crate) fn forward(context: &mut Context, src: &str) -> String {
 /// If the interpreter fails parsing an error value is returned instead (error object)
 #[allow(clippy::unit_arg, clippy::drop_copy)]
 #[cfg(test)]
-pub(crate) fn forward_val(context: &mut Context, src: &str) -> Result<Value> {
+pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &mut Context, src: T) -> Result<Value> {
     let main_timer = BoaProfiler::global().start_event("Main", "Main");
+
+    let src_bytes: &[u8] = src.as_ref();
     // Setup executor
-    let result = parse(src, false)
+    let result = parse(src_bytes, false)
         .map_err(|e| {
             context
                 .throw_syntax_error(e.to_string())
@@ -131,8 +136,10 @@ pub(crate) fn forward_val(context: &mut Context, src: &str) -> Result<Value> {
 
 /// Create a clean Context and execute the code
 #[cfg(test)]
-pub(crate) fn exec(src: &str) -> String {
-    match Context::new().eval(src) {
+pub(crate) fn exec<T: AsRef<[u8]>>(src: T) -> String {
+    let src_bytes: &[u8] = src.as_ref();
+
+    match Context::new().eval(src_bytes) {
         Ok(value) => value.display().to_string(),
         Err(error) => error.display().to_string(),
     }

--- a/boa_tester/src/exec.rs
+++ b/boa_tester/src/exec.rs
@@ -128,7 +128,7 @@ impl Test {
 
                     match self.set_up_env(&harness, strict) {
                         Ok(mut context) => {
-                            let res = context.eval(&self.content);
+                            let res = context.eval(&self.content.as_ref());
 
                             let passed = res.is_ok();
                             let text = match res {
@@ -156,7 +156,7 @@ impl Test {
                         self.name
                     );
 
-                    match parse(&self.content, strict) {
+                    match parse(&self.content.as_ref(), strict) {
                         Ok(n) => (false, format!("{:?}", n)),
                         Err(e) => (true, format!("Uncaught {}", e)),
                     }
@@ -169,11 +169,11 @@ impl Test {
                     phase: Phase::Runtime,
                     ref error_type,
                 } => {
-                    if let Err(e) = parse(&self.content, strict) {
+                    if let Err(e) = parse(&self.content.as_ref(), strict) {
                         (false, format!("Uncaught {}", e))
                     } else {
                         match self.set_up_env(&harness, strict) {
-                            Ok(mut context) => match context.eval(&self.content) {
+                            Ok(mut context) => match context.eval(&self.content.as_ref()) {
                                 Ok(res) => (false, format!("{}", res.display())),
                                 Err(e) => {
                                     let passed =
@@ -271,10 +271,10 @@ impl Test {
         }
 
         context
-            .eval(&harness.assert)
+            .eval(&harness.assert.as_ref())
             .map_err(|e| format!("could not run assert.js:\n{}", e.display()))?;
         context
-            .eval(&harness.sta)
+            .eval(&harness.sta.as_ref())
             .map_err(|e| format!("could not run sta.js:\n{}", e.display()))?;
 
         for include in self.includes.iter() {
@@ -283,7 +283,8 @@ impl Test {
                     &harness
                         .includes
                         .get(include)
-                        .ok_or_else(|| format!("could not find the {} include file.", include))?,
+                        .ok_or_else(|| format!("could not find the {} include file.", include))?
+                        .as_ref(),
                 )
                 .map_err(|e| {
                     format!(


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request is a follow-up PR for #915, which closes #876.

This PR may also improve run-time performance slightly since it removes the unnecessary bytes to utf8 chars conversion when reading the files.

It changes the following:
- Read the file input in bytes (`boa_cli`)

Except for file input in `boa_cli`, all the other places still take input in str and convert it to bytes afterward:
#### `boa_cli` command prompt
The crate `rustyline` reads input in strings and takes care of it.
#### `boa_wasm`
`wasm_bindgen` makes JS interface and takes input in strings.
#### test/benchmark
The benchmark still uses `include_str!` to read the bench scripts. Since the files are read in compile-time, it does not affect the run-time performance. Keep it as it can also benefit because it checks if there are any invalid chars in the bench scripts in compile time.
Similar reasons for tests. Taking the input in str makes the tests simpler and clearer.