### PR TITLE
Implement Object.prototype.isPrototypeOf

### DIFF
--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -279,3 +279,14 @@ fn object_define_properties() {
 
     assert_eq!(forward(&mut context, "obj.p"), "42");
 }
+
+#[test]
+fn object_is_prototype_of() {
+    let mut context = Context::new();
+
+    let init = r#"
+        Object.prototype.isPrototypeOf(String.prototype)
+    "#;
+
+    assert_eq!(context.eval(init).unwrap(), Value::boolean(true));
+}

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -198,7 +198,6 @@ impl GcObject {
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
     #[track_caller]
     pub fn construct(&self, args: &[Value], context: &mut Context) -> Result<Value> {
-
         // If the prototype of the constructor is not an object, then use the default object
         // prototype as prototype for the new object
         // see <https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor>

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -198,7 +198,22 @@ impl GcObject {
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
     #[track_caller]
     pub fn construct(&self, args: &[Value], context: &mut Context) -> Result<Value> {
-        let this: Value = Object::create(self.get(&PROTOTYPE.into())).into();
+
+        // If the prototype of the constructor is not an object, then use the default object
+        // prototype as prototype for the new object
+        // see <https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor>
+        // see <https://tc39.es/ecma262/#sec-getprototypefromconstructor>
+        let proto = self.get(&PROTOTYPE.into());
+        let proto = if proto.is_object() {
+            proto
+        } else {
+            context
+                .standard_objects()
+                .object_object()
+                .prototype()
+                .into()
+        };
+        let this: Value = Object::create(proto).into();
 
         let this_function_object = self.clone();
         let body = if let Some(function) = self.borrow().as_function() {


### PR DESCRIPTION

This Pull Request closes #982 .

It changes the following:

- Implementation of `Object.prototype.isPrototypeOf
- Fix `construct` when the prototype of the constructor is not an object

