### PR TITLE
Add default parameter support

### DIFF
--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -145,6 +145,7 @@ impl GcObject {
                                 BindingStatus::Uninitialized
                             },
                         );
+                        context.realm_mut().environment.push(local_env.clone());
 
                         // Add argument bindings to the function environment
                         for (i, param) in params.iter().enumerate() {
@@ -154,7 +155,17 @@ impl GcObject {
                                 break;
                             }
 
-                            let value = args.get(i).cloned().unwrap_or_else(Value::undefined);
+                            let value = match args.get(i).cloned() {
+                                None | Some(Value::Undefined) => {
+                                    if let Some(init) = param.init() {
+                                        init.run(context).unwrap_or(Value::Undefined)
+                                    } else {
+                                        Value::Undefined
+                                    }
+                                }
+                                Some(value) => value,
+                            };
+
                             function.add_arguments_to_environment(param, value, &local_env);
                         }
 
@@ -166,8 +177,6 @@ impl GcObject {
                         local_env
                             .borrow_mut()
                             .initialize_binding("arguments", arguments_obj);
-
-                        context.realm_mut().environment.push(local_env);
 
                         FunctionBody::Ordinary(body.clone())
                     }
@@ -226,6 +235,7 @@ impl GcObject {
                                 BindingStatus::Uninitialized
                             },
                         );
+                        context.realm_mut().environment.push(local_env.clone());
 
                         // Add argument bindings to the function environment
                         for (i, param) in params.iter().enumerate() {
@@ -235,7 +245,17 @@ impl GcObject {
                                 break;
                             }
 
-                            let value = args.get(i).cloned().unwrap_or_else(Value::undefined);
+                            let value = match args.get(i).cloned() {
+                                None | Some(Value::Undefined) => {
+                                    if let Some(init) = param.init() {
+                                        init.run(context).unwrap_or(Value::Undefined)
+                                    } else {
+                                        Value::Undefined
+                                    }
+                                }
+                                Some(value) => value,
+                            };
+
                             function.add_arguments_to_environment(param, value, &local_env);
                         }
 
@@ -247,8 +267,6 @@ impl GcObject {
                         local_env
                             .borrow_mut()
                             .initialize_binding("arguments", arguments_obj);
-
-                        context.realm_mut().environment.push(local_env);
 
                         FunctionBody::Ordinary(body.clone())
                     }


### PR DESCRIPTION
Modern JavaScript has support for default parameters in functions. Boa has support for the syntax but currently default parameters are ignored. For example, this code:

```javascript
function test(a, b = 2, c = a + b) {
    console.log(a, b, c);
}
test()
test(1)
```

Result produced by current Boa master:

```
undefined undefined undefined
1 undefined undefined
undefined
```

Expected result:

```
undefined 2 NaN
1 2 3
undefined
```

This PR implements support for this feature.