### PR TITLE
Fix `Object.prototype.hasOwnProperty()`

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -379,20 +379,13 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-object.prototype.hasownproperty
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty
     pub fn has_own_property(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        let prop = if args.is_empty() {
-            None
-        } else {
-            Some(args.get(0).expect("Cannot get object").to_string(context)?)
-        };
-        let own_property = this
-            .as_object()
-            .expect("Cannot get THIS object")
-            .get_own_property(&prop.expect("cannot get prop").into());
-        if own_property.is_none() {
-            Ok(Value::from(false))
-        } else {
-            Ok(Value::from(true))
-        }
+        let key = args
+            .get(0)
+            .unwrap_or(&Value::undefined())
+            .to_property_key(context)?;
+        let object = this.to_object(context)?;
+
+        Ok(object.has_own_property(key).into())
     }
 
     pub fn property_is_enumerable(

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -727,7 +727,11 @@ impl GcObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinaryhasinstance
     #[inline]
-    pub fn ordinary_has_instance(&self, context: &mut Context, value: &Value) -> Result<bool> {
+    pub(crate) fn ordinary_has_instance(
+        &self,
+        context: &mut Context,
+        value: &Value,
+    ) -> Result<bool> {
         if !self.is_callable() {
             return Ok(false);
         }
@@ -754,6 +758,16 @@ impl GcObject {
         } else {
             Ok(false)
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    pub fn has_own_property<K>(&self, key: K) -> bool
+    where
+        K: Into<PropertyKey>,
+    {
+        let key = key.into();
+        self.get_own_property(&key).is_some()
     }
 }
 


### PR DESCRIPTION
It changes the following:
 - Fix panic when argument is not supplied.
 - Fix panic when `this` is not a object.
 - Fix Symbol property handling.