### PR TITLE
Modify environment binding behaviour of function

### DIFF
--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -94,17 +94,23 @@ impl Executable for FunctionDecl {
 
         // Set the name and assign it in the current environment
         val.set_field("name", self.name());
-        context
-            .realm_mut()
-            .environment
-            .create_mutable_binding(self.name().to_owned(), false, VariableScope::Function)
-            .map_err(|e| e.to_error(context))?;
 
-        context
-            .realm_mut()
-            .environment
-            .initialize_binding(self.name(), val)
-            .map_err(|e| e.to_error(context))?;
+        let environment = &mut context.realm_mut().environment;
+        if environment.has_binding(self.name()) {
+            environment
+                .set_mutable_binding(self.name(), val, true)
+                .map_err(|e| e.to_error(context))?;
+        } else {
+            environment
+                .create_mutable_binding(self.name().to_owned(), false, VariableScope::Function)
+                .map_err(|e| e.to_error(context))?;
+
+            context
+                .realm_mut()
+                .environment
+                .initialize_binding(self.name(), val)
+                .map_err(|e| e.to_error(context))?;
+        }
 
         Ok(Value::undefined())
     }

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -19,3 +19,6 @@ pub use self::{
     let_decl_list::{LetDecl, LetDeclList},
     var_decl_list::{VarDecl, VarDeclList},
 };
+
+#[cfg(test)]
+mod tests;

--- a/boa/src/syntax/ast/node/declaration/tests.rs
+++ b/boa/src/syntax/ast/node/declaration/tests.rs
@@ -1,0 +1,12 @@
+use crate::exec;
+
+#[test]
+fn duplicate_function_name() {
+    let scenario = r#"
+    function f () {}
+    function f () {return 12;}
+    f()
+    "#;
+
+    assert_eq!(&exec(scenario), "12");
+}


### PR DESCRIPTION
This Pull Request fixes/closes #669.

If a binding for the function name already exists, we should simply override it (`set_mutable_binding`), otherwise we need to create a new binding. For this to be accurate, we need to also fix #858, since now we are simply overriding the binding (potentially `let` or `const`).

This seems to fix it, however, I haven't found this in the documentation. The implementation of `var` also seems to follow this. Could anybody provide a link to the part where this is described in the documentation?