### PR TITLE
StatementList: Rename `statements` to `items`

### DIFF
--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -37,9 +37,9 @@ pub struct Block {
 }
 
 impl Block {
-    /// Gets the list of statements in this block.
-    pub(crate) fn statements(&self) -> &[Node] {
-        self.statements.statements()
+    /// Gets the list of statements and declarations in this block.
+    pub(crate) fn items(&self) -> &[Node] {
+        self.statements.items()
     }
 
     /// Implements the display formatting with indentation.
@@ -63,7 +63,7 @@ impl Executable for Block {
         // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
         // The return value is uninitialized, which means it defaults to Value::Undefined
         let mut obj = Value::default();
-        for statement in self.statements() {
+        for statement in self.items() {
             obj = statement.run(context)?;
 
             match context.executor().get_current_state() {

--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -50,7 +50,7 @@ impl ArrowFunctionDecl {
 
     /// Gets the body of the arrow function.
     pub(crate) fn body(&self) -> &[Node] {
-        &self.body.statements()
+        &self.body.items()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -54,7 +54,7 @@ impl AsyncFunctionDecl {
 
     /// Gets the body of the async function declaration.
     pub fn body(&self) -> &[Node] {
-        self.body.statements()
+        self.body.items()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
@@ -55,7 +55,7 @@ impl AsyncFunctionExpr {
 
     /// Gets the body of the function declaration.
     pub fn body(&self) -> &[Node] {
-        self.body.statements()
+        self.body.items()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -64,7 +64,7 @@ impl FunctionDecl {
 
     /// Gets the body of the function declaration.
     pub fn body(&self) -> &[Node] {
-        self.body.statements()
+        self.body.items()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -61,7 +61,7 @@ impl FunctionExpr {
 
     /// Gets the body of the function declaration.
     pub fn body(&self) -> &[Node] {
-        self.body.statements()
+        self.body.items()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -23,13 +23,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct StatementList {
     #[cfg_attr(feature = "deser", serde(flatten))]
-    statements: Box<[Node]>,
+    items: Box<[Node]>,
 }
 
 impl StatementList {
-    /// Gets the list of statements.
-    pub fn statements(&self) -> &[Node] {
-        &self.statements
+    /// Gets the list of items.
+    pub fn items(&self) -> &[Node] {
+        &self.items
     }
 
     /// Implements the display formatting with indentation.
@@ -40,7 +40,7 @@ impl StatementList {
     ) -> fmt::Result {
         let indent = "    ".repeat(indentation);
         // Print statements
-        for node in self.statements.iter() {
+        for node in self.items.iter() {
             f.write_str(&indent)?;
             node.display(f, indentation + 1)?;
 
@@ -64,7 +64,7 @@ impl Executable for StatementList {
         context
             .executor()
             .set_current_state(InterpreterState::Executing);
-        for (i, item) in self.statements().iter().enumerate() {
+        for (i, item) in self.items().iter().enumerate() {
             let val = item.run(context)?;
             match context.executor().get_current_state() {
                 InterpreterState::Return => {
@@ -83,7 +83,7 @@ impl Executable for StatementList {
                     // Continue execution
                 }
             }
-            if i + 1 == self.statements().len() {
+            if i + 1 == self.items().len() {
                 obj = val;
             }
         }
@@ -98,7 +98,7 @@ where
 {
     fn from(stm: T) -> Self {
         Self {
-            statements: stm.into(),
+            items: stm.into(),
         }
     }
 }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -97,9 +97,7 @@ where
     T: Into<Box<[Node]>>,
 {
     fn from(stm: T) -> Self {
-        Self {
-            items: stm.into(),
-        }
+        Self { items: stm.into() }
     }
 }
 

--- a/boa/src/syntax/ast/node/switch/mod.rs
+++ b/boa/src/syntax/ast/node/switch/mod.rs
@@ -98,7 +98,7 @@ impl Switch {
 
     /// Gets the default statement list, if any.
     pub fn default(&self) -> Option<&[Node]> {
-        self.default.as_ref().map(StatementList::statements)
+        self.default.as_ref().map(StatementList::items)
     }
 
     /// Implements the display formatting with indentation.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #842

It changes the following:

- Renames the `statements` property of the `StatementList` struct to `items`
- Renames the `StatementList::statements()` function to `StatementList::items()`
