### PR TITLE
Fix Clippy erorrs

### DIFF
--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -139,7 +139,7 @@ impl BigInt {
         } else {
             10
         };
-        if radix < 2 || radix > 36 {
+        if !(2..=36).contains(&radix) {
             return context
                 .throw_range_error("radix must be an integer at least 2 and no greater than 36");
         }

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -454,7 +454,7 @@ impl Date {
         let sec = sec as u32;
         let milli = milli as u32;
 
-        let year = if 0 <= year && year <= 99 {
+        let year = if (0..=99).contains(&year) {
             1900 + year
         } else {
             year
@@ -936,7 +936,7 @@ impl Date {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear
     pub fn set_year(&mut self, year: Option<f64>, month: Option<f64>, day: Option<f64>) {
         if let Some(mut year) = year {
-            year += if 0f64 <= year && year < 100f64 {
+            year += if (0f64..100f64).contains(&year) {
                 1900f64
             } else {
                 0f64
@@ -1330,7 +1330,7 @@ impl Date {
         let sec = sec as u32;
         let milli = milli as u32;
 
-        let year = if 0 <= year && year <= 99 {
+        let year = if (0..=99).contains(&year) {
             1900 + year
         } else {
             year

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -591,7 +591,7 @@ impl Number {
             .map_or(10, |radix| radix as u8);
 
         // 4. If radixNumber < 2 or radixNumber > 36, throw a RangeError exception.
-        if radix < 2 || radix > 36 {
+        if !(2..=36).contains(&radix) {
             return context
                 .throw_range_error("radix must be an integer at least 2 and no greater than 36");
         }

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -39,6 +39,8 @@ This is an experimental Javascript lexer, parser and compiler written in Rust. C
     clippy::missing_errors_doc,
     clippy::as_conversions,
     clippy::let_unit_value,
+    // NativeFunctions always return Result<Value>, so we sometimes need to wrap everything in Ok()
+    clippy::unnecessary_wraps,
     missing_doc_code_examples
 )]
 

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -39,8 +39,6 @@ This is an experimental Javascript lexer, parser and compiler written in Rust. C
     clippy::missing_errors_doc,
     clippy::as_conversions,
     clippy::let_unit_value,
-    // NativeFunctions always return Result<Value>, so we sometimes need to wrap everything in Ok()
-    clippy::unnecessary_wraps,
     missing_doc_code_examples
 )]
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -169,7 +169,7 @@ impl Object {
     // TODO: proto should be a &Value here
     #[inline]
     pub fn create(proto: Value) -> Self {
-        let mut obj = Self::default();
+        let mut obj = Self::new();
         obj.prototype = proto;
         obj
     }
@@ -474,7 +474,7 @@ impl Object {
     /// Similar to `Value::new_object`, but you can pass a prototype to create from, plus a kind
     #[inline]
     pub fn with_prototype(proto: Value, data: ObjectData) -> Object {
-        let mut object = Object::default();
+        let mut object = Object::new();
         object.data = data;
         object.set_prototype_instance(proto);
         object

--- a/boa/src/syntax/lexer/cursor.rs
+++ b/boa/src/syntax/lexer/cursor.rs
@@ -491,10 +491,7 @@ fn utf8_is_first_byte(byte: u8) -> bool {
 
 #[inline]
 fn unwrap_or_0(opt: Option<u8>) -> u8 {
-    match opt {
-        Some(byte) => byte,
-        None => 0,
-    }
+    opt.unwrap_or(0)
 }
 
 #[inline]

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -214,7 +214,7 @@ impl<R> Lexer<R> {
                     Span::new(start, self.cursor.pos()),
                 )),
                 '.' => {
-                    if self.cursor.peek()?.map(|c| c >= b'0' && c <= b'9') == Some(true) {
+                    if self.cursor.peek()?.map(|c| (b'0'..=b'9').contains(&c)) == Some(true) {
                         NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start)
                     } else {
                         SpreadLiteral::new().lex(&mut self.cursor, start)

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -759,6 +759,7 @@ fn illegal_code_point_following_numeric_literal() {
     let mut lexer = Lexer::new(&br#"17.4\u{2764}"#[..]);
     assert!(
         lexer.next().is_err(),
+        "{}",
         r#"IdentifierStart \u{2764} following NumericLiteral not rejected as expected"#
     );
 }


### PR DESCRIPTION
This PR changes the following:

- Fixes Clippy errors (based on `cargo clippy -Z unstable-options --fix`)
   - if we want to turn off the range.contains() thing that's okay too
- ~~Ignores the `unnecessary_wraps` Clippy lint; it looks like we want all `NativeFunction`s to return a Result, which entails "unnecessary" wrapping.~~ turns out this is just a Nightly Rust thing

