### PR TITLE
Implement early errors for non-assignable nodes in assignment

### DIFF
--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -217,5 +217,6 @@ where
 /// [spec]: https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
 #[inline]
 pub(crate) fn is_assignable(node: &Node) -> bool {
-    !matches!(node, Node::Const(_) | Node::ArrayDecl(_))
+    matches!(node, Node::GetConstField(_) | Node::GetField(_) | Node::Assign(_)
+                   | Node::Call(_) | Node::Identifier(_) | Node::Object(_))
 }


### PR DESCRIPTION

This Pull Request implements early error for non-assignable nodes in assignment.

It changes the following:

- `is_assignable` function in `Assignment` parsing

