### PR TITLE
Implement support of Symbol.toPrimitive

### DIFF
--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -527,18 +527,16 @@ impl Value {
         // 1. Assert: input is an ECMAScript language value. (always a value not need to check)
         // 2. If Type(input) is Object, then
         if let Value::Object(obj) = self {
-            let exotic_to_prim = obj.get(
-                &context.well_known_symbols().to_primitive_symbol().into(),
-                context,
-            )?;
-            if !exotic_to_prim.is_undefined() {
+            if let Some(exotic_to_prim) =
+                obj.get_method(context, context.well_known_symbols().to_primitive_symbol())?
+            {
                 let hint = match preferred_type {
                     PreferredType::String => "string",
                     PreferredType::Number => "number",
                     PreferredType::Default => "default",
                 }
                 .into();
-                let result = context.call(&exotic_to_prim, &self, &[hint])?;
+                let result = context.call(&exotic_to_prim.into(), &self, &[hint])?;
                 return if result.is_object() {
                     Err(context.construct_type_error("Symbol.toPrimitive cannot return an object"))
                 } else {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -536,7 +536,7 @@ impl Value {
                     PreferredType::Default => "default",
                 }
                 .into();
-                let result = context.call(&exotic_to_prim.into(), &self, &[hint])?;
+                let result = exotic_to_prim.call(&self, &[hint], context)?;
                 return if result.is_object() {
                     Err(context.construct_type_error("Symbol.toPrimitive cannot return an object"))
                 } else {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -527,11 +527,27 @@ impl Value {
         // 1. Assert: input is an ECMAScript language value. (always a value not need to check)
         // 2. If Type(input) is Object, then
         if let Value::Object(obj) = self {
+            let exotic_to_prim = obj.get(
+                &context.well_known_symbols().to_primitive_symbol().into(),
+                context,
+            )?;
+            if !exotic_to_prim.is_undefined() {
+                let hint = match preferred_type {
+                    PreferredType::String => "string",
+                    PreferredType::Number => "number",
+                    PreferredType::Default => "default",
+                }
+                .into();
+                let result = context.call(&exotic_to_prim, &self, &[hint])?;
+                return if result.is_object() {
+                    Err(context.construct_type_error("Symbol.toPrimitive cannot return an object"))
+                } else {
+                    Ok(result)
+                };
+            }
+
             let mut hint = preferred_type;
 
-            // Skip d, e we don't support Symbols yet
-            // TODO: add when symbols are supported
-            // TODO: Add other steps.
             if hint == PreferredType::Default {
                 hint = PreferredType::Number;
             };

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -619,6 +619,20 @@ fn test_accessors() {
     assert_eq!(forward(&mut context, "arr"), r#"[ "a" ]"#);
 }
 
+#[test]
+fn to_primitive() {
+    let mut context = Context::new();
+    let src = r#"
+    let a = {};
+    a[Symbol.toPrimitive] = function() {
+        return 42;
+    };
+    let primitive = a + 0;
+    "#;
+    context.eval(src).unwrap();
+    assert_eq!(forward(&mut context, "primitive"), r#"42"#);
+}
+
 /// Test cyclic conversions that previously caused stack overflows
 /// Relevant mitigations for these are in `GcObject::ordinary_to_primitive` and
 /// `GcObject::to_json`

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -630,7 +630,7 @@ fn to_primitive() {
     let primitive = a + 0;
     "#;
     context.eval(src).unwrap();
-    assert_eq!(forward(&mut context, "primitive"), r#"42"#);
+    assert_eq!(forward(&mut context, "primitive"), "42");
 }
 
 /// Test cyclic conversions that previously caused stack overflows


### PR DESCRIPTION

This Pull Request implements the use of  `Symbol.toPrimitive` in the `to_primitive` method of `Value`.

It changes the following:

- `to_primitive` method of `Value` to support `Symbol.toPrimitive`

