### PR TITLE
Fix spread in new and call expressions

### DIFF
--- a/boa/src/syntax/ast/node/call/mod.rs
+++ b/boa/src/syntax/ast/node/call/mod.rs
@@ -1,13 +1,11 @@
 use crate::{
+    builtins::iterable,
     exec::Executable,
     exec::InterpreterState,
     gc::{Finalize, Trace},
     syntax::ast::node::{join_nodes, Node},
     value::{Type, Value},
-    BoaProfiler,
-    Context,
-    Result,
-    builtins::iterable
+    BoaProfiler, Context, Result,
 };
 use std::fmt;
 

--- a/boa/src/syntax/ast/node/call/mod.rs
+++ b/boa/src/syntax/ast/node/call/mod.rs
@@ -4,7 +4,10 @@ use crate::{
     gc::{Finalize, Trace},
     syntax::ast::node::{join_nodes, Node},
     value::{Type, Value},
-    BoaProfiler, Context, Result,
+    BoaProfiler,
+    Context,
+    Result,
+    builtins::iterable
 };
 use std::fmt;
 
@@ -84,11 +87,19 @@ impl Executable for Call {
         for arg in self.args() {
             if let Node::Spread(ref x) = arg {
                 let val = x.run(context)?;
-                let mut vals = context.extract_array_properties(&val)?.unwrap();
-                v_args.append(&mut vals);
+                let iterator_record = iterable::get_iterator(context, val)?;
+                loop {
+                    let next = iterator_record.next(context)?;
+                    if next.is_done() {
+                        break;
+                    }
+                    let next_value = next.value();
+                    v_args.push(next_value.clone());
+                }
                 break; // after spread we don't accept any new arguments
+            } else {
+                v_args.push(arg.run(context)?);
             }
-            v_args.push(arg.run(context)?);
         }
 
         // execute the function call itself

--- a/boa/src/syntax/ast/node/new/mod.rs
+++ b/boa/src/syntax/ast/node/new/mod.rs
@@ -1,12 +1,10 @@
 use crate::{
+    builtins::iterable,
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::{Call, Node},
     value::Value,
-    BoaProfiler,
-    Context,
-    Result,
-    builtins::iterable
+    BoaProfiler, Context, Result,
 };
 use std::fmt;
 

--- a/boa/src/syntax/ast/node/spread/mod.rs
+++ b/boa/src/syntax/ast/node/spread/mod.rs
@@ -9,6 +9,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// The `spread` operator allows an iterable such as an array expression or string to be
 /// expanded.
 ///

--- a/boa/src/syntax/ast/node/spread/tests.rs
+++ b/boa/src/syntax/ast/node/spread/tests.rs
@@ -22,7 +22,7 @@ fn spread_with_call() {
         return m;
     }
     function g(...args) {
-        f(...args);
+        return f(...args);
     }
     let a = g('message');
     a;

--- a/boa/src/syntax/ast/node/spread/tests.rs
+++ b/boa/src/syntax/ast/node/spread/tests.rs
@@ -1,0 +1,31 @@
+use crate::exec;
+
+#[test]
+fn spread_with_new() {
+    let scenario = r#"
+    function F(m) {
+        this.m = m;
+    }
+    function f(...args) {
+        return new F(...args);
+    }
+    let a = f('message');
+    a.m;
+    "#;
+    assert_eq!(&exec(scenario), r#""message""#);
+}
+
+#[test]
+fn spread_with_call() {
+    let scenario = r#"
+    function f(m) {
+        return m;
+    }
+    function g(...args) {
+        f(...args);
+    }
+    let a = g('message');
+    a;
+    "#;
+    assert_eq!(&exec(scenario), r#""message""#);
+}


### PR DESCRIPTION
This Pull Request fixes spread in new and call expressions:

It changes the following:

- Execution of new and call expressions so that it can use an iterable in spread

