### PR TITLE
Fix attributes on properties of functions and constructors

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -237,12 +237,15 @@ pub fn make_builtin_fn<N>(
             .prototype()
             .into(),
     );
-    function.insert_property("length", length, Attribute::all());
+    let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
+    function.insert_property("length", length, attribute);
+    function.insert_property("name", name.as_str(), attribute);
 
-    parent
-        .as_object()
-        .unwrap()
-        .insert_property(name, function, Attribute::all());
+    parent.as_object().unwrap().insert_property(
+        name,
+        function,
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+    );
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -701,7 +701,7 @@ impl<'context> FunctionBuilder<'context> {
                 .prototype()
                 .into(),
         );
-        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
+        let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         if let Some(name) = self.name.take() {
             function.insert_property("name", name, attribute);
         } else {
@@ -1014,11 +1014,11 @@ impl<'context> ConstructorBuilder<'context> {
 
         let length = DataDescriptor::new(
             self.length,
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
         );
         let name = DataDescriptor::new(
             self.name.take().unwrap_or_else(|| String::from("[object]")),
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
         );
 
         {


### PR DESCRIPTION
This Pull Request fixes the attributes on properties `length` and `name` of functions and constructors. These properties should be configurable (see [spec for length][length-spec] and [spec for name][name-spec]).

It changes the following:

- Default attributes of `name` and `length` for functions and constructors
- Add `name` property to built-ins functions

[length-spec]: https://tc39.es/ecma262/#sec-function-instances-length
[name-spec]: https://tc39.es/ecma262/#sec-function-instances-name