### PR TITLE
Fix delete when the property is not configurable

### DIFF
--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -90,12 +90,15 @@ impl Executable for UnaryOp {
                     get_const_field
                         .obj()
                         .run(context)?
-                        .remove_property(get_const_field.field()),
+                        .to_object(context)?
+                        .delete(&get_const_field.field().into()),
                 ),
                 Node::GetField(ref get_field) => {
                     let obj = get_field.obj().run(context)?;
                     let field = &get_field.field().run(context)?;
-                    let res = obj.remove_property(field.to_string(context)?.as_str());
+                    let res = obj
+                        .to_object(context)?
+                        .delete(&field.to_string(context)?.as_str().into());
                     return Ok(Value::boolean(res));
                 }
                 Node::Identifier(_) => Value::boolean(false),

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -98,7 +98,7 @@ impl Executable for UnaryOp {
                     let field = &get_field.field().run(context)?;
                     let res = obj
                         .to_object(context)?
-                        .delete(&field.to_string(context)?.as_str().into());
+                        .delete(&field.to_property_key(context)?);
                     return Ok(Value::boolean(res));
                 }
                 Node::Identifier(_) => Value::boolean(false),


### PR DESCRIPTION

This Pull Request fixes an issue with `delete` when the property to delete is not configurable. In this case, `delete` should not remove the property from the object, and it should return `false`.

It changes the following:

- The execution of the `delete` operator

