### PR TITLE
wrap the regress error for now

### DIFF
--- a/boa/src/builtins/regexp/tests.rs
+++ b/boa/src/builtins/regexp/tests.rs
@@ -98,3 +98,12 @@ fn to_string() {
     );
     assert_eq!(forward(&mut context, "/\\n/g.toString()"), "\"/\\n/g\"");
 }
+
+#[test]
+fn no_panic_on_invalid_character_escape() {
+    let mut context = Context::new();
+
+    // This used to panic, we now return an error
+    // The line below should not cause Boa to panic
+    forward(&mut context, r"const a = /,\;/");
+}


### PR DESCRIPTION
Regress panics on "Invalid character escape"s.
However on V8 and other JS engines these seem to be acceptable.

```js
const a = /,\;/;
```

was causing issues in Boa, due to regress panicing and us not catching.
This PR now changes it to a SyntaxError, however this is a temporary fix, ideally it should be accepted.

Raised upstream:
https://github.com/ridiculousfish/regress/issues/26
