### PR TITLE
Fixed some panics

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     property::Attribute,
     property::DataDescriptor,
     property::PropertyDescriptor,
-    value::{same_value, Value},
+    value::{same_value, Type, Value},
     BoaProfiler, Context, Result,
 };
 
@@ -243,18 +243,62 @@ impl Object {
     }
 
     /// Get the `prototype` of an object.
-    pub fn get_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
-        let obj = args.get(0).expect("Cannot get object");
-        Ok(obj
-            .as_object()
-            .map_or_else(Value::undefined, |object| object.prototype_instance()))
+    pub fn get_prototype_of(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+        if args.is_empty() {
+            return ctx.throw_type_error(
+                "Object.getPrototypeOf: At least 1 argument required, but only 0 passed",
+            );
+        }
+
+        // 1. Let obj be ? ToObject(O).
+        let obj = args[0].clone().to_object(ctx)?;
+
+        // 2. Return ? obj.[[GetPrototypeOf]]().
+        Ok(obj.prototype_instance())
     }
 
     /// Set the `prototype` of an object.
-    pub fn set_prototype_of(_: &Value, args: &[Value], _: &mut Context) -> Result<Value> {
-        let obj = args.get(0).expect("Cannot get object").clone();
-        let proto = args.get(1).expect("Cannot get object").clone();
-        obj.as_object().unwrap().set_prototype_instance(proto);
+    ///
+    /// [More information][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-object.setprototypeof
+    pub fn set_prototype_of(_: &Value, args: &[Value], ctx: &mut Context) -> Result<Value> {
+        if args.len() < 2 {
+            return ctx.throw_type_error(format!(
+                "Object.setPrototypeOf: At least 2 arguments required, but only {} passed",
+                args.len()
+            ));
+        }
+
+        // 1. Set O to ? RequireObjectCoercible(O).
+        let obj = args.get(0).cloned().unwrap_or_default(); // TODO: RequireObjectCoercible
+
+        // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
+        let proto = args.get(1).cloned().unwrap_or_default();
+        if !matches!(proto.get_type(), Type::Object | Type::Null) {
+            return ctx.throw_type_error(format!(
+                "expected an object or null, got {}",
+                proto.get_type().as_str()
+            ));
+        }
+
+        // 3. If Type(O) is not Object, return O.
+        if obj.get_type() != Type::Object {
+            return Ok(obj);
+        }
+
+        // 4. Let status be ? O.[[SetPrototypeOf]](proto).
+        let status = obj
+            .as_object()
+            .expect("obj was not an object")
+            .set_prototype_instance(proto);
+
+        // 5. If status is false, throw a TypeError exception.
+        if !status {
+            return ctx.throw_type_error("can't set prototype of this object");
+        }
+
+        // 6. Return O.
         Ok(obj)
     }
 

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -275,7 +275,7 @@ impl Object {
             .get(0)
             .cloned()
             .unwrap_or_default()
-            .require_object_coercible(ctx);
+            .require_object_coercible(ctx)?.clone();
 
         // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
         let proto = args.get(1).cloned().unwrap_or_default();

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -275,7 +275,8 @@ impl Object {
             .get(0)
             .cloned()
             .unwrap_or_default()
-            .require_object_coercible(ctx)?.clone();
+            .require_object_coercible(ctx)?
+            .clone();
 
         // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
         let proto = args.get(1).cloned().unwrap_or_default();

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -271,7 +271,11 @@ impl Object {
         }
 
         // 1. Set O to ? RequireObjectCoercible(O).
-        let obj = args.get(0).cloned().unwrap_or_default(); // TODO: RequireObjectCoercible
+        let obj = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .require_object_coercible(ctx);
 
         // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
         let proto = args.get(1).cloned().unwrap_or_default();

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -550,7 +550,7 @@ impl GcObject {
     /// or if th prototype is not an object or undefined.
     #[inline]
     #[track_caller]
-    pub fn set_prototype_instance(&mut self, prototype: Value) {
+    pub fn set_prototype_instance(&mut self, prototype: Value) -> bool {
         self.borrow_mut().set_prototype_instance(prototype)
     }
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -483,13 +483,13 @@ impl Object {
         &self.prototype
     }
 
-    #[track_caller]
-    #[inline]
     /// Sets the prototype instance of the object.
     ///
     /// [More information][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods
+    #[inline]
+    #[track_caller]
     pub fn set_prototype_instance(&mut self, prototype: Value) -> bool {
         assert!(prototype.is_null() || prototype.is_object());
         if self.extensible {

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -495,12 +495,10 @@ impl Object {
         if self.extensible {
             self.prototype = prototype;
             true
-        } else if same_value(&prototype, &self.prototype) {
-            // unless V is the SameValue as the target's observed [[GetPrototypeOf]] value.
-            true
         } else {
             // If target is non-extensible, [[SetPrototypeOf]] must return false
-            false
+            // unless V is the SameValue as the target's observed [[GetPrototypeOf]] value.
+            same_value(&prototype, &self.prototype)
         }
     }
 

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -110,7 +110,8 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                         .unwrap()
                         .value()
                         .as_number()
-                        .unwrap() as i32;
+                        .map(|n| n as i32)
+                        .unwrap_or_default();
 
                     if print_children {
                         if len == 0 {


### PR DESCRIPTION
This Pull Request is related to #817.

It changes the following:

 - `Object.setPrototypeOf` and `Object.getPrototypeOf` are spec compliant
