### PR TITLE
Fixed a bunch of test262 panics (#817)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "criterion"
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8b34ba8cfb21243bd8df91854c830ff0d785fff2e82ebd4434c2644cb9ada18"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
 dependencies = [
  "getrandom 0.2.1",
 ]
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9802ddde94170d186eeee5005b798d9c159fa970403f1be19976d0cfb939b72"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1231,9 +1231,9 @@ dependencies = [
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -1364,9 +1364,9 @@ fn get_relative_end() {
 
 #[test]
 fn array_length_is_not_enumerable() {
-    let mut context = Context::new();
+    let context = Context::new();
 
-    let array = Array::new_array(&mut context).unwrap();
+    let array = Array::new_array(&context).unwrap();
     let desc = array.get_property("length").unwrap();
     assert!(!desc.enumerable());
 }

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -660,14 +660,16 @@ impl Number {
             let mut var_s = input_string.trim();
 
             // 3. Let sign be 1.
-            // 4. If S is not empty and the first code unit of S is the code unit 0x002D (HYPHEN-MINUS), set sign to -1.
+            // 4. If S is not empty and the first code unit of S is the code unit 0x002D (HYPHEN-MINUS),
+            //    set sign to -1.
             let sign = if !var_s.is_empty() && var_s.starts_with('\u{002D}') {
                 -1
             } else {
                 1
             };
 
-            // 5. If S is not empty and the first code unit of S is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from S.
+            // 5. If S is not empty and the first code unit of S is the code unit 0x002B (PLUS SIGN) or
+            //    the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from S.
             if !var_s.is_empty() {
                 var_s = var_s
                     .strip_prefix(&['\u{002B}', '\u{002D}'][..])
@@ -710,7 +712,8 @@ impl Number {
                 var_r = 16;
             }
 
-            // 11. If S contains a code unit that is not a radix-R digit, let end be the index within S of the first such code unit; otherwise, let end be the length of S.
+            // 11. If S contains a code unit that is not a radix-R digit, let end be the index within S of the
+            //     first such code unit; otherwise, let end be the length of S.
             let end = if let Some(index) = var_s.find(|c: char| !c.is_digit(var_r as u32)) {
                 index
             } else {
@@ -725,7 +728,12 @@ impl Number {
                 return Ok(Value::nan());
             }
 
-            // 14. Let mathInt be the integer value that is represented by Z in radix-R notation, using the letters A-Z and a-z for digits with values 10 through 35. (However, if R is 10 and Z contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if R is not 2, 4, 8, 10, 16, or 32, then mathInt may be an implementation-approximated value representing the integer value that is represented by Z in radix-R notation.)
+            // 14. Let mathInt be the integer value that is represented by Z in radix-R notation, using the
+            //     letters A-Z and a-z for digits with values 10 through 35. (However, if R is 10 and Z contains
+            //     more than 20 significant digits, every significant digit after the 20th may be replaced by a
+            //     0 digit, at the option of the implementation; and if R is not 2, 4, 8, 10, 16, or 32, then
+            //     mathInt may be an implementation-approximated value representing the integer value that is
+            //     represented by Z in radix-R notation.)
             let math_int = u64::from_str_radix(var_z, var_r as u32).map_or_else(
                 |_| f64::from_str_radix(var_z, var_r as u32).expect("invalid_float_conversion"),
                 |i| i as f64,

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     value::{AbstractRelation, IntegerOrInfinity, Value},
     BoaProfiler, Context, Result,
 };
-use num_traits::float::FloatCore;
+use num_traits::{float::FloatCore, Num};
 
 mod conversions;
 
@@ -651,54 +651,102 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parseint-string-radix
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-    pub(crate) fn parse_int(_: &Value, args: &[Value], _ctx: &mut Context) -> Result<Value> {
-        if let (Some(val), r) = (args.get(0), args.get(1)) {
-            let mut radix = if let Some(rx) = r {
-                if let Value::Integer(i) = rx {
-                    *i as u32
-                } else {
-                    // Handling a second argument that isn't an integer but was provided so cannot be defaulted.
-                    return Ok(Value::from(f64::NAN));
-                }
+    pub(crate) fn parse_int(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        if let (Some(val), radix) = (args.get(0), args.get(1)) {
+            // 1. Let inputString be ? ToString(string).
+            let input_string = val.to_string(context)?;
+
+            // 2. Let S be ! TrimString(inputString, start).
+            let mut var_s = input_string.trim();
+
+            // 3. Let sign be 1.
+            // 4. If S is not empty and the first code unit of S is the code unit 0x002D (HYPHEN-MINUS), set sign to -1.
+            let sign = if !var_s.is_empty() && var_s.starts_with('\u{002D}') {
+                -1
             } else {
-                // No second argument provided therefore radix is unknown
-                0
+                1
             };
 
-            match val {
-                Value::String(s) => {
-                    // Attempt to infer radix from given string.
+            // 5. If S is not empty and the first code unit of S is the code unit 0x002B (PLUS SIGN) or the code unit 0x002D (HYPHEN-MINUS), remove the first code unit from S.
+            if !var_s.is_empty() {
+                var_s = var_s
+                    .strip_prefix(&['\u{002B}', '\u{002D}'][..])
+                    .unwrap_or(var_s);
+            }
 
-                    if radix == 0 {
-                        if s.starts_with("0x") || s.starts_with("0X") {
-                            return if let Ok(i) = i32::from_str_radix(&s[2..], 16) {
-                                Ok(Value::integer(i))
-                            } else {
-                                // String can't be parsed.
-                                Ok(Value::from(f64::NAN))
-                            };
-                        } else {
-                            radix = 10
-                        };
-                    }
+            // 6. Let R be ℝ(? ToInt32(radix)).
+            let mut var_r = radix.cloned().unwrap_or_default().to_i32(context)?;
 
-                    if let Ok(i) = i32::from_str_radix(s, radix) {
-                        Ok(Value::integer(i))
-                    } else {
-                        // String can't be parsed.
-                        Ok(Value::from(f64::NAN))
-                    }
+            // 7. Let stripPrefix be true.
+            let mut strip_prefix = true;
+
+            // 8. If R ≠ 0, then
+            if var_r != 0 {
+                //     a. If R < 2 or R > 36, return NaN.
+                if !(2..=36).contains(&var_r) {
+                    return Ok(Value::nan());
                 }
-                Value::Integer(i) => Ok(Value::integer(*i)),
-                Value::Rational(f) => Ok(Value::integer(*f as i32)),
-                _ => {
-                    // Wrong argument type to parseInt.
-                    Ok(Value::from(f64::NAN))
+
+                //     b. If R ≠ 16, set stripPrefix to false.
+                if var_r != 16 {
+                    strip_prefix = false
+                }
+            } else {
+                // 9. Else,
+                //     a. Set R to 10.
+                var_r = 10;
+            }
+
+            // 10. If stripPrefix is true, then
+            //     a. If the length of S is at least 2 and the first two code units of S are either "0x" or "0X", then
+            //         i. Remove the first two code units from S.
+            //         ii. Set R to 16.
+            if strip_prefix
+                && var_s.len() >= 2
+                && (var_s.starts_with("0x") || var_s.starts_with("0X"))
+            {
+                var_s = var_s.split_at(2).1;
+
+                var_r = 16;
+            }
+
+            // 11. If S contains a code unit that is not a radix-R digit, let end be the index within S of the first such code unit; otherwise, let end be the length of S.
+            let end = if let Some(index) = var_s.find(|c: char| !c.is_digit(var_r as u32)) {
+                index
+            } else {
+                var_s.len()
+            };
+
+            // 12. Let Z be the substring of S from 0 to end.
+            let var_z = var_s.split_at(end).0;
+
+            // 13. If Z is empty, return NaN.
+            if var_z.is_empty() {
+                return Ok(Value::nan());
+            }
+
+            // 14. Let mathInt be the integer value that is represented by Z in radix-R notation, using the letters A-Z and a-z for digits with values 10 through 35. (However, if R is 10 and Z contains more than 20 significant digits, every significant digit after the 20th may be replaced by a 0 digit, at the option of the implementation; and if R is not 2, 4, 8, 10, 16, or 32, then mathInt may be an implementation-approximated value representing the integer value that is represented by Z in radix-R notation.)
+            let math_int = u64::from_str_radix(var_z, var_r as u32).map_or_else(
+                |_| f64::from_str_radix(var_z, var_r as u32).expect("invalid_float_conversion"),
+                |i| i as f64,
+            );
+
+            // 15. If mathInt = 0, then
+            //     a. If sign = -1, return -0𝔽.
+            //     b. Return +0𝔽.
+            if math_int == 0_f64 {
+                if sign == -1 {
+                    return Ok(Value::rational(-0_f64));
+                } else {
+                    return Ok(Value::rational(0_f64));
                 }
             }
+
+            // 16. Return 𝔽(sign × mathInt).
+            Ok(Value::rational(f64::from(sign) * math_int))
         } else {
             // Not enough arguments to parseInt.
-            Ok(Value::from(f64::NAN))
+            Ok(Value::nan())
         }
     }
 

--- a/boa/src/builtins/number/tests.rs
+++ b/boa/src/builtins/number/tests.rs
@@ -551,7 +551,7 @@ fn parse_int_float() {
 fn parse_int_float_str() {
     let mut context = Context::new();
 
-    assert_eq!(&forward(&mut context, "parseInt(\"100.5\")"), "NaN");
+    assert_eq!(&forward(&mut context, "parseInt(\"100.5\")"), "100");
 }
 
 #[test]

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -480,7 +480,12 @@ impl RegExp {
     pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         let (body, flags) = if let Some(object) = this.as_object() {
             let object = object.borrow();
-            let regex = object.as_regexp().unwrap();
+            let regex = object.as_regexp().ok_or_else(|| {
+                context.construct_type_error(format!(
+                    "Method RegExp.prototype.toString called on incompatible receiver {}",
+                    this.display()
+                ))
+            })?;
             (regex.original_source.clone(), regex.flags.clone())
         } else {
             return context.throw_type_error(format!(

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -636,7 +636,7 @@ impl Context {
                 let key = field.to_property_key(self)?;
                 Ok(get_field.obj().run(self)?.set_field(key, value, self)?)
             }
-            _ => panic!("TypeError: invalid assignment to {}", node),
+            _ => self.throw_type_error(format!("invalid assignment to {}", node)),
         }
     }
 

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -116,7 +116,7 @@ impl Executable for UnaryOp {
                 | Node::New(_)
                 | Node::Object(_)
                 | Node::UnaryOp(_) => Value::boolean(true),
-                _ => panic!("SyntaxError: wrong delete argument {}", self),
+                _ => return context.throw_syntax_error(format!("wrong delete argument {}", self)),
             },
             op::UnaryOp::TypeOf => Value::from(x.get_type().as_str()),
         })

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -227,9 +227,16 @@ impl Value {
             Self::Boolean(b) => Ok(JSONValue::Bool(b)),
             Self::Object(ref obj) => obj.to_json(context),
             Self::String(ref str) => Ok(JSONValue::String(str.to_string())),
-            Self::Rational(num) => Ok(JSONValue::Number(
-                JSONNumber::from_str(&Number::to_native_string(num)).unwrap(),
-            )),
+            Self::Rational(num) => {
+                if num.is_finite() {
+                    Ok(JSONValue::Number(
+                        JSONNumber::from_str(&Number::to_native_string(num))
+                            .expect("invalid number found"),
+                    ))
+                } else {
+                    Ok(JSONValue::Null)
+                }
+            }
             Self::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
             Self::BigInt(_) => {
                 Err(context.construct_type_error("BigInt value can't be serialized in JSON"))
@@ -716,7 +723,7 @@ impl Value {
     ///
     /// This function is equivalent to `value | 0` in JavaScript
     ///
-    /// See: <https://tc39.es/ecma262/#sec-toint32>
+    /// See: <https://tc39.es/ecma262/#sec-touint32>
     pub fn to_u32(&self, context: &mut Context) -> Result<u32> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Value::Integer(number) = *self {

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -144,17 +144,17 @@ fn hash_undefined() {
 }
 
 #[test]
+#[allow(clippy::eq_op)]
 fn hash_rational() {
     let value1 = Value::rational(1.0);
     let value2 = Value::rational(1.0);
     assert_eq!(value1, value2);
     assert_eq!(hash_value(&value1), hash_value(&value2));
 
-    let nan1 = Value::nan();
-    let nan2 = Value::nan();
-    assert_eq!(nan1, nan2);
-    assert_eq!(hash_value(&nan1), hash_value(&nan2));
-    assert_ne!(hash_value(&nan1), hash_value(&Value::rational(1.0)));
+    let nan = Value::nan();
+    assert_eq!(nan, nan);
+    assert_eq!(hash_value(&nan), hash_value(&nan));
+    assert_ne!(hash_value(&nan), hash_value(&Value::rational(1.0)));
 }
 
 #[test]

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -150,13 +150,15 @@ fn hash_rational() {
     assert_eq!(value1, value2);
     assert_eq!(hash_value(&value1), hash_value(&value2));
 
-    let nan = Value::nan();
-    assert_eq!(nan, nan);
-    assert_eq!(hash_value(&nan), hash_value(&nan));
-    assert_ne!(hash_value(&nan), hash_value(&Value::rational(1.0)));
+    let nan1 = Value::nan();
+    let nan2 = Value::nan();
+    assert_eq!(nan1, nan2);
+    assert_eq!(hash_value(&nan1), hash_value(&nan2));
+    assert_ne!(hash_value(&nan1), hash_value(&Value::rational(1.0)));
 }
 
 #[test]
+#[allow(clippy::eq_op)]
 fn hash_object() {
     let object1 = Value::object(Object::default());
     assert_eq!(object1, object1);

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [dependencies]
 Boa = { path = "../boa", features = ["console"] }
 wasm-bindgen = "0.2.69"
-getrandom = { version = "0.2.1", features = ["js"]}
+getrandom = { version = "0.2.1", features = ["js"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,9 +78,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.14.17"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.17.tgz#29fab92f3986c0e379968ad3c2043683d8020dbb"
-  integrity sha512-G0lD1/7qD60TJ/mZmhog76k7NcpLWkPVGgzkRy3CTlnFu4LUQh5v2Wa661z6vnXmD8EQrnALUyf0VRtrACYztw==
+  version "14.14.20"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.20.tgz#f7974863edd21d1f8a494a73e8e2b3658615c340"
+  integrity sha512-Y93R97Ouif9JEOWPIUyU+eyIdyRqQR0I8Ez1dzku4hDx34NWh4HbtIc3WNzwB1Y9ULvNGeu5B8h8bVL5cAk4/A==
 
 "@types/source-list-map@*":
   version "0.1.2"
@@ -524,7 +524,7 @@ bonjour@^3.5.0:
     multicast-dns "^6.0.1"
     multicast-dns-service-types "^1.1.0"
 
-boolbase@~1.0.0:
+boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
   integrity sha1-aN/1++YMUes3cl6p4+0xDcwed24=
@@ -566,15 +566,15 @@ braces@^3.0.1, braces@~3.0.2:
     fill-range "^7.0.1"
 
 browserslist@^4.14.5:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
-  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
+  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
   dependencies:
-    caniuse-lite "^1.0.30001165"
+    caniuse-lite "^1.0.30001173"
     colorette "^1.2.1"
-    electron-to-chromium "^1.3.621"
+    electron-to-chromium "^1.3.634"
     escalade "^3.1.1"
-    node-releases "^1.1.67"
+    node-releases "^1.1.69"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -637,10 +637,10 @@ camelcase@^6.2.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001165:
-  version "1.0.30001171"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001171.tgz#3291e11e02699ad0a29e69b8d407666fc843eba7"
-  integrity sha512-5Alrh8TTYPG9IH4UkRqEBZoEToWRLvPbSQokvzSz0lii8/FOWKG4keO1HoYfPWs8IF/NH/dyNPg1cmJGvV3Zlg==
+caniuse-lite@^1.0.30001173:
+  version "1.0.30001173"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz#3c47bbe3cd6d7a9eda7f50ac016d158005569f56"
+  integrity sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==
 
 chalk@^2.4.1:
   version "2.4.2"
@@ -671,9 +671,9 @@ chokidar@^2.1.8:
     fsevents "^1.2.7"
 
 chokidar@^3.4.1:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
-  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.0.tgz#458a4816a415e9d3b3caa4faec2b96a6935a9e65"
+  integrity sha512-JgQM9JS92ZbFR4P90EvmzNpSGhpPBGBSj10PILeDyYFwp4h2/D9OM03wsJ4zW1fEp4ka2DGrnUeD7FuvQ2aZ2Q==
   dependencies:
     anymatch "~3.1.1"
     braces "~3.0.2"
@@ -683,7 +683,7 @@ chokidar@^3.4.1:
     normalize-path "~3.0.0"
     readdirp "~3.5.0"
   optionalDependencies:
-    fsevents "~2.1.2"
+    fsevents "~2.3.1"
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -890,20 +890,20 @@ css-loader@^5.0.1:
     schema-utils "^3.0.0"
     semver "^7.3.2"
 
-css-select@^1.1.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
-  integrity sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=
+css-select@^2.0.2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-2.1.0.tgz#6a34653356635934a81baca68d0255432105dbef"
+  integrity sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==
   dependencies:
-    boolbase "~1.0.0"
-    css-what "2.1"
-    domutils "1.5.1"
-    nth-check "~1.0.1"
+    boolbase "^1.0.0"
+    css-what "^3.2.1"
+    domutils "^1.7.0"
+    nth-check "^1.0.2"
 
-css-what@2.1:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
-  integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+css-what@^3.2.1:
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
+  integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
 cssesc@^3.0.0:
   version "3.0.0"
@@ -1077,15 +1077,7 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
-domutils@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
-  integrity sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=
-  dependencies:
-    dom-serializer "0"
-    domelementtype "1"
-
-domutils@^1.5.1:
+domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"
   integrity sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
@@ -1106,10 +1098,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-electron-to-chromium@^1.3.621:
-  version "1.3.633"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz#16dd5aec9de03894e8d14a1db4cda8a369b9b7fe"
-  integrity sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==
+electron-to-chromium@^1.3.634:
+  version "1.3.634"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz#82ea400f520f739c4f6ff00c1f7524827a917d25"
+  integrity sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==
 
 emoji-regex@^7.0.1:
   version "7.0.3"
@@ -1529,10 +1521,10 @@ fsevents@^1.2.7:
     bindings "^1.5.0"
     nan "^2.12.1"
 
-fsevents@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
-  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+fsevents@~2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.1.tgz#b209ab14c61012636c8863507edf7fb68cc54e9f"
+  integrity sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -1603,9 +1595,9 @@ glob@^7.0.3, glob@^7.1.3:
     path-is-absolute "^1.0.0"
 
 globby@^11.0.1:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.1.tgz#9a2bf107a068f3ffeabc49ad702c79ede8cfd357"
-  integrity sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==
+  version "11.0.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.2.tgz#1af538b766a3b540ebfb58a32b2e2d5897321d83"
+  integrity sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
@@ -1736,7 +1728,7 @@ html-webpack-plugin@^4.5.1:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-htmlparser2@^3.3.0:
+htmlparser2@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -1786,9 +1778,9 @@ http-errors@~1.7.2:
     toidentifier "1.0.0"
 
 http-parser-js@>=0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.2.tgz#da2e31d237b393aae72ace43882dd7e270a8ff77"
-  integrity sha512-opCO9ASqg5Wy2FNo7A0sxy71yGbbkJJXLdgMK04Tcypw9jr2MgWbyubb0+WdmDmGnFflO7fRbqbaihh/ENDlRQ==
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.3.tgz#01d2709c79d41698bb01d4decc5e9da4e4a033d9"
+  integrity sha512-t7hjvef/5HEK7RWTdUzVUhl8zkEu+LlaE0IYzdMuvbSDipxBRpOn4Uhw8ZyECEa808iVT8XCjzo6xmYt4CiLZg==
 
 http-proxy-middleware@0.19.1:
   version "0.19.1"
@@ -2335,22 +2327,17 @@ micromatch@^4.0.2:
     braces "^3.0.1"
     picomatch "^2.0.5"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
-
-"mime-db@>= 1.43.0 < 2":
+mime-db@1.45.0, "mime-db@>= 1.43.0 < 2":
   version "1.45.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.45.0.tgz#cceeda21ccd7c3a745eba2decd55d4b73e7879ea"
   integrity sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
 
 mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.24:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.28"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.28.tgz#1160c4757eab2c5363888e005273ecf79d2a0ecd"
+  integrity sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.45.0"
 
 mime@1.6.0:
   version "1.6.0"
@@ -2492,10 +2479,10 @@ node-forge@^0.10.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
   integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
-node-releases@^1.1.67:
-  version "1.1.67"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
-  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
+node-releases@^1.1.69:
+  version "1.1.69"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.69.tgz#3149dbde53b781610cd8b486d62d86e26c3725f6"
+  integrity sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==
 
 normalize-path@^2.1.1:
   version "2.1.1"
@@ -2523,7 +2510,7 @@ npm-run-path@^4.0.1:
   dependencies:
     path-key "^3.0.0"
 
-nth-check@~1.0.1:
+nth-check@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.2.tgz#b2bd295c37e3dd58a3bf0700376663ba4d9cf05c"
   integrity sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==
@@ -3045,13 +3032,13 @@ remove-trailing-separator@^1.0.1:
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 renderkid@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.4.tgz#d325e532afb28d3f8796ffee306be8ffd6fc864c"
-  integrity sha512-K2eXrSOJdq+HuKzlcjOlGoOarUu5SDguDEhE7+Ah4zuOWL40j8A/oHvLlLob9PSTNvVnBd+/q0Er1QfpEuem5g==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-2.0.5.tgz#483b1ac59c6601ab30a7a596a5965cabccfdd0a5"
+  integrity sha512-ccqoLg+HLOHq1vdfYNm4TBeaCDIi1FLt3wGojTDSvdewUv65oTmI3cnT2E4hRjl1gzKZIPK+KZrXzlUYKnR+vQ==
   dependencies:
-    css-select "^1.1.0"
+    css-select "^2.0.2"
     dom-converter "^0.2"
-    htmlparser2 "^3.3.0"
+    htmlparser2 "^3.10.1"
     lodash "^4.17.20"
     strip-ansi "^3.0.0"
 
@@ -3639,9 +3626,9 @@ tslib@^1.9.0:
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tslib@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
-  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
This PR works towards a panic-free boa. It fixes:
 - Panics in `RegExp`
 - Wrong `delete` argument
 - `parseInt()` panics if radix was out of bounds.
 - Spec-compliant `parseInt()` function.

I also took the opportunity to update the dependencies and the test262 submodule, and fix a couple of clippy warnings in tests, along with a documentation link.