### PR TITLE
Support overriding the `arguments` variable

### DIFF
--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -162,7 +162,7 @@ impl GcObject {
                         let arguments_obj = create_unmapped_arguments_object(args);
                         local_env
                             .borrow_mut()
-                            .create_mutable_binding("arguments".to_string(), false, false)
+                            .create_mutable_binding("arguments".to_string(), false, true)
                             .map_err(|e| e.to_error(context))?;
                         local_env
                             .borrow_mut()
@@ -259,7 +259,7 @@ impl GcObject {
                         let arguments_obj = create_unmapped_arguments_object(args);
                         local_env
                             .borrow_mut()
-                            .create_mutable_binding("arguments".to_string(), false, false)
+                            .create_mutable_binding("arguments".to_string(), false, true)
                             .map_err(|e| e.to_error(context))?;
                         local_env
                             .borrow_mut()


### PR DESCRIPTION
This eliminates a number of panics in the Test262 suite.

This Pull Request works on #817.

It changes the following:

- allows name reuse when declaring the arguments variable
