### PR TITLE
More panic fixes

### DIFF
--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -185,9 +185,8 @@ impl Map {
             _ => (args[0].clone(), args[1].clone()),
         };
 
-        let size = if let Value::Object(ref object) = this {
-            let mut object = object.borrow_mut();
-            if let Some(map) = object.as_map_mut() {
+        let size = if let Some(object) = this.as_object() {
+            if let Some(map) = object.borrow_mut().as_map_mut() {
                 map.insert(key, value);
                 map.len()
             } else {
@@ -218,9 +217,8 @@ impl Map {
             _ => &args[0],
         };
 
-        let (deleted, size) = if let Value::Object(ref object) = this {
-            let mut object = object.borrow_mut();
-            if let Some(map) = object.as_map_mut() {
+        let (deleted, size) = if let Some(object) = this.as_object() {
+            if let Some(map) = object.borrow_mut().as_map_mut() {
                 let deleted = map.remove(key).is_some();
                 (deleted, map.len())
             } else {

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -692,7 +692,8 @@ impl String {
                                 }
                                 (Some('<'), _) => {
                                     // $<
-                                    todo!("named capture groups")
+                                    // TODO: named capture groups
+                                    result.push_str("$<");
                                 }
                                 _ => {
                                     // $?, ? is none of the above
@@ -845,7 +846,11 @@ impl String {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     pub(crate) fn r#match(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        let re = RegExp::constructor(&Value::from(Object::default()), &[args[0].clone()], context)?;
+        let re = RegExp::constructor(
+            &Value::from(Object::default()),
+            &[args.get(0).cloned().unwrap_or_default()],
+            context,
+        )?;
         RegExp::r#match(&re, this.to_string(context)?, context)
     }
 


### PR DESCRIPTION
This PR fixes a couple of panics when working with regular expressions. I also tried to fix a double-borrow in `Map` but I only got to a bit of a better syntax, without fixing the panic.