### PR TITLE
Arrow parse

### DIFF
--- a/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
@@ -11,7 +11,7 @@ use std::io::Read;
 mod tests;
 
 /// The maximum number of tokens which can be peeked ahead.
-const MAX_PEEK_SKIP: usize = 2;
+const MAX_PEEK_SKIP: usize = 3;
 
 /// The fixed size of the buffer used for storing values that are peeked ahead.
 ///
@@ -40,6 +40,8 @@ where
         Self {
             lexer,
             peeked: [
+                None::<Token>,
+                None::<Token>,
                 None::<Token>,
                 None::<Token>,
                 None::<Token>,

--- a/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
@@ -208,7 +208,7 @@ fn peek_skip_next_till_end() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
 
     let mut peeked: [Option<Token>; super::MAX_PEEK_SKIP + 1] =
-        [None::<Token>, None::<Token>, None::<Token>];
+        [None::<Token>, None::<Token>, None::<Token>, None::<Token>];
 
     loop {
         for (i, peek) in peeked.iter_mut().enumerate() {

--- a/boa/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -71,7 +71,12 @@ where
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ArrowFunction", "Parsing");
 
+        println!("Parsing arrow func");
+
         let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+
+        println!("Next token {}", next_token);
+
         let params = if let TokenKind::Punctuator(Punctuator::OpenParen) = &next_token.kind() {
             // CoverParenthesizedExpressionAndArrowParameterList
             cursor.expect(Punctuator::OpenParen, "arrow function")?;

--- a/boa/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -70,12 +70,7 @@ where
 
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ArrowFunction", "Parsing");
-
-        println!("Parsing arrow func");
-
         let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
-
-        println!("Next token {}", next_token);
 
         let params = if let TokenKind::Punctuator(Punctuator::OpenParen) = &next_token.kind() {
             // CoverParenthesizedExpressionAndArrowParameterList

--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -145,7 +145,7 @@ where
                                     TokenKind::Punctuator(Punctuator::CloseParen) => {
                                         // Need to check if the token after the close paren is an arrow, if so then this is an ArrowFunction
                                         // otherwise it is an expression of the form (b).
-                                        if let Some(t) = cursor.peek(2)? {
+                                        if let Some(t) = cursor.peek(3)? {
                                             if t.kind() == &TokenKind::Punctuator(Punctuator::Arrow)
                                             {
                                                 return ArrowFunction::new(

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -1,6 +1,7 @@
 use crate::syntax::{
     ast::node::{
-        ArrowFunctionDecl, BinOp, FormalParameter, FunctionDecl, Identifier, Node, Return, LetDecl, LetDeclList
+        ArrowFunctionDecl, BinOp, FormalParameter, FunctionDecl, Identifier, LetDecl, LetDeclList,
+        Node, Return,
     },
     ast::op::NumOp,
     parser::tests::check_parser,
@@ -177,130 +178,192 @@ fn check_arrow_empty_return_semicolon_insertion() {
     );
 }
 
-/// Checks an arrow function assignment.
 #[test]
 fn check_arrow_assignment() {
     check_parser(
-        "let foo = a => { return a };",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        "let foo = (a) => { return a };",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![FormalParameter::new("a", None, false)],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }
 
-/// Checks an arrow function assignment without {}.
 #[test]
 fn check_arrow_assignment_nobrackets() {
     check_parser(
-        "let foo = a => return a;",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        "let foo = (a) => a;",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![FormalParameter::new("a", None, false)],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }
 
-/// Checks an arrow function assignment with parenthesis.
 #[test]
-fn check_arrow_assignment_parenthesis_brackets() {
+fn check_arrow_assignment_noparenthesis() {
     check_parser(
-        "let foo = (a) => { return a };",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        "let foo = a => { return a };",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![FormalParameter::new("a", None, false)],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }
 
-/// Checks an arrow function assignment with parenthesis without {}.
 #[test]
-fn check_arrow_assignment_parenthesis_nobrackets() {
+fn check_arrow_assignment_noparenthesis_nobrackets() {
     check_parser(
-        "let foo = (a) => return a;",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        "let foo = a => a;",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![FormalParameter::new("a", None, false)],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }
 
-/// Checks an arrow function assignment with 2 arguments with parenthesis.
 #[test]
-fn check_arrow_assignment_2arg_parenthesis() {
+fn check_arrow_assignment_2arg() {
     check_parser(
         "let foo = (a, b) => { return a };",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                            FormalParameter::new("b", None, false)
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![
+                        FormalParameter::new("a", None, false),
+                        FormalParameter::new("b", None, false),
+                    ],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }
 
-/// Checks an arrow function assignment with 2 arguments with parenthesis.
 #[test]
-fn check_arrow_assignment_2arg_parenthesis_nobrackets() {
+fn check_arrow_assignment_2arg_nobrackets() {
     check_parser(
-        "let foo = (a, b) => return a;",
-        vec![LetDeclList::from(
-            vec![
-                LetDecl::new::<_, Option<Node>>(
-                     Identifier::from("foo"),
-                     Some(ArrowFunctionDecl::new(
-                        vec![
-                            FormalParameter::new("a", None, false),
-                            FormalParameter::new("b", None, false)
-                        ],
-                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
-                    ).into())
+        "let foo = (a, b) => a;",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![
+                        FormalParameter::new("a", None, false),
+                        FormalParameter::new("b", None, false),
+                    ],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
                 )
-            ]
-        ).into()]
+                .into(),
+            ),
+        )])
+        .into()],
+    );
+}
+
+#[test]
+fn check_arrow_assignment_3arg() {
+    check_parser(
+        "let foo = (a, b, c) => { return a };",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![
+                        FormalParameter::new("a", None, false),
+                        FormalParameter::new("b", None, false),
+                        FormalParameter::new("c", None, false),
+                    ],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
+                )
+                .into(),
+            ),
+        )])
+        .into()],
+    );
+}
+
+#[test]
+fn check_arrow_assignment_3arg_nobrackets() {
+    check_parser(
+        "let foo = (a, b, c) => a;",
+        vec![LetDeclList::from(vec![LetDecl::new::<_, Option<Node>>(
+            Identifier::from("foo"),
+            Some(
+                ArrowFunctionDecl::new(
+                    vec![
+                        FormalParameter::new("a", None, false),
+                        FormalParameter::new("b", None, false),
+                        FormalParameter::new("c", None, false),
+                    ],
+                    vec![Return::new::<Node, Option<_>, Option<_>>(
+                        Some(Identifier::from("a").into()),
+                        None,
+                    )
+                    .into()],
+                )
+                .into(),
+            ),
+        )])
+        .into()],
     );
 }

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
     ast::node::{
-        ArrowFunctionDecl, BinOp, FormalParameter, FunctionDecl, Identifier, Node, Return,
+        ArrowFunctionDecl, BinOp, FormalParameter, FunctionDecl, Identifier, Node, Return, LetDecl, LetDeclList
     },
     ast::op::NumOp,
     parser::tests::check_parser,
@@ -174,5 +174,133 @@ fn check_arrow_empty_return_semicolon_insertion() {
             vec![Return::new::<Node, Option<_>, Option<_>>(None, None).into()],
         )
         .into()],
+    );
+}
+
+/// Checks an arrow function assignment.
+#[test]
+fn check_arrow_assignment() {
+    check_parser(
+        "let foo = a => { return a };",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
+    );
+}
+
+/// Checks an arrow function assignment without {}.
+#[test]
+fn check_arrow_assignment_nobrackets() {
+    check_parser(
+        "let foo = a => return a;",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
+    );
+}
+
+/// Checks an arrow function assignment with parenthesis.
+#[test]
+fn check_arrow_assignment_parenthesis() {
+    check_parser(
+        "let foo = (a) => { return a };",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
+    );
+}
+
+/// Checks an arrow function assignment with parenthesis without {}.
+#[test]
+fn check_arrow_assignment_parenthesis_nobrackets() {
+    check_parser(
+        "let foo = (a) => return a;",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
+    );
+}
+
+/// Checks an arrow function assignment with 2 arguments with parenthesis.
+#[test]
+fn check_arrow_assignment_2arg_parenthesis() {
+    check_parser(
+        "let foo = (a, b) => { return a };",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                            FormalParameter::new("b", None, false)
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
+    );
+}
+
+/// Checks an arrow function assignment with 2 arguments with parenthesis.
+#[test]
+fn check_arrow_assignment_2arg_parenthesis_nobrackets() {
+    check_parser(
+        "let foo = (a, b) => return a;",
+        vec![LetDeclList::from(
+            vec![
+                LetDecl::new::<_, Option<Node>>(
+                     Identifier::from("foo"),
+                     Some(ArrowFunctionDecl::new(
+                        vec![
+                            FormalParameter::new("a", None, false),
+                            FormalParameter::new("b", None, false)
+                        ],
+                        vec![Return::new::<Node, Option<_>, Option<_>>(Some(Identifier::from("a").into()), None).into()],
+                    ).into())
+                )
+            ]
+        ).into()]
     );
 }

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -221,7 +221,7 @@ fn check_arrow_assignment_nobrackets() {
 
 /// Checks an arrow function assignment with parenthesis.
 #[test]
-fn check_arrow_assignment_parenthesis() {
+fn check_arrow_assignment_parenthesis_brackets() {
     check_parser(
         "let foo = (a) => { return a };",
         vec![LetDeclList::from(


### PR DESCRIPTION
Fixes #1032 
Fixes a bug in arrow function parsing which prevented the assignment of arrow functions with a single argument using parentheses (e.g. `let foo = (a) => a` )

Arrow functions with > 1 argument or arrow functions that don't use parentheses already parse correctly