### PR TITLE
Fix get/set as short method name in object

### DIFF
--- a/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -205,7 +205,14 @@ where
         let _timer = BoaProfiler::global().start_event("MethodDefinition", "Parsing");
 
         let (methodkind, prop_name, params) = match self.identifier.as_str() {
-            idn @ "get" | idn @ "set" => {
+            idn @ "get" | idn @ "set"
+                if matches!(
+                    cursor.peek(0)?.map(|t| t.kind()),
+                    Some(&TokenKind::Identifier(_)) | Some(&TokenKind::Keyword(_))
+                        | Some(&TokenKind::BooleanLiteral(_)) | Some(&TokenKind::NullLiteral)
+                        | Some(&TokenKind::NumericLiteral(_))
+                ) =>
+            {
                 let prop_name = cursor.next()?.ok_or(ParseError::AbruptEnd)?.to_string();
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenParen),

--- a/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -140,3 +140,45 @@ fn check_object_setter() {
         .into()],
     );
 }
+
+#[test]
+fn check_object_short_function_get() {
+    let object_properties = vec![PropertyDefinition::method_definition(
+        MethodDefinitionKind::Ordinary,
+        "get",
+        FunctionExpr::new(None, vec![], vec![]),
+    )];
+
+    check_parser(
+        "const x = {
+            get() {}
+         };
+        ",
+        vec![ConstDeclList::from(vec![ConstDecl::new(
+            "x",
+            Some(Object::from(object_properties)),
+        )])
+        .into()],
+    );
+}
+
+#[test]
+fn check_object_short_function_set() {
+    let object_properties = vec![PropertyDefinition::method_definition(
+        MethodDefinitionKind::Ordinary,
+        "set",
+        FunctionExpr::new(None, vec![], vec![]),
+    )];
+
+    check_parser(
+        "const x = {
+            set() {}
+         };
+        ",
+        vec![ConstDeclList::from(vec![ConstDecl::new(
+            "x",
+            Some(Object::from(object_properties)),
+        )])
+        .into()],
+    );
+}


### PR DESCRIPTION
Fix `get` and`set` so they can be used as short method name in object.
