### PR TITLE
Fix out-of-range panics of Date

### DIFF
--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -248,7 +248,8 @@ impl Date {
     ) {
         #[inline]
         fn num_days_in(year: i32, month: u32) -> Option<u32> {
-            let month = month.checked_add(1)?; // zero-based for calculations
+            let month = month + 1; // zero-based for calculations
+
             Some(
                 NaiveDate::from_ymd_opt(
                     match month {
@@ -257,7 +258,7 @@ impl Date {
                     },
                     match month {
                         12 => 1,
-                        _ => month.checked_add(1)?,
+                        _ => month + 1,
                     },
                     1,
                 )?

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -343,7 +343,6 @@ impl Date {
 
             NaiveDate::from_ymd_opt(year, month + 1, day + 1)
                 .and_then(|dt| dt.and_hms(0, 0, 0).checked_add_signed(duration))
-                .filter(|dt| Self::time_clip(dt.timestamp_millis() as f64).is_some())
                 .and_then(|dt| {
                     if utc {
                         Some(Utc.from_utc_datetime(&dt).naive_utc())
@@ -351,6 +350,7 @@ impl Date {
                         ignore_ambiguity(Local.from_local_datetime(&dt)).map(|dt| dt.naive_utc())
                     }
                 })
+                .filter(|dt| Self::time_clip(dt.timestamp_millis() as f64).is_some())
         });
     }
 
@@ -456,6 +456,7 @@ impl Date {
             },
         };
 
+        let tv = tv.filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
         let date = Date(tv);
         this.set_data(ObjectData::Date(date));
         Ok(this.clone())
@@ -518,7 +519,8 @@ impl Date {
         let final_date = NaiveDate::from_ymd_opt(year, month + 1, day)
             .and_then(|naive_date| naive_date.and_hms_milli_opt(hour, min, sec, milli))
             .and_then(|local| ignore_ambiguity(Local.from_local_datetime(&local)))
-            .map(|local| local.naive_utc());
+            .map(|local| local.naive_utc())
+            .filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
 
         let date = Date(final_date);
         this.set_data(ObjectData::Date(date));

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -15,7 +15,7 @@ use std::fmt::Display;
 /// The number of nanoseconds in a millisecond.
 const NANOS_PER_MS: i64 = 1_000_000;
 /// The number of milliseconds in an hour.
-const MILLIS_PER_HOUR: i64 = 3600_000;
+const MILLIS_PER_HOUR: i64 = 3_600_000;
 /// The number of milliseconds in a minute.
 const MILLIS_PER_MINUTE: i64 = 60_000;
 /// The number of milliseconds in a second.

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -191,6 +191,22 @@ impl Date {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 7;
 
+    /// Check if the time (number of miliseconds) is in the expected range.
+    /// Returns None if the time is not in the range, otherwise returns the time itself.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-timeclip
+    #[inline]
+    pub fn time_clip(time: f64) -> Option<f64> {
+        if time.abs() > 8.64e15 {
+            None
+        } else {
+            Some(time)
+        }
+    }
+
     /// Converts the `Date` to a local `DateTime`.
     ///
     /// If the `Date` is invalid (i.e. NAN), this function will return `None`.
@@ -313,6 +329,7 @@ impl Date {
                 + Duration::milliseconds(millisecond);
             NaiveDate::from_ymd_opt(year, month + 1, day + 1)
                 .and_then(|dt| dt.and_hms(0, 0, 0).checked_add_signed(duration))
+                .filter(|dt| Self::time_clip((dt.timestamp() as f64) * 1000.0).is_some())
                 .and_then(|dt| {
                     if utc {
                         Some(Utc.from_utc_datetime(&dt).naive_utc())

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -1379,9 +1379,8 @@ impl Date {
 
         NaiveDate::from_ymd_opt(year, month + 1, day)
             .and_then(|f| f.and_hms_milli_opt(hour, min, sec, milli))
-            .map_or(Ok(Value::number(f64::NAN)), |f| {
-                Ok(Value::number(f.timestamp_millis() as f64))
-            })
+            .and_then(|f| Self::time_clip(f.timestamp_millis() as f64))
+            .map_or(Ok(Value::number(f64::NAN)), |time| Ok(Value::number(time)))
     }
 }
 

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -329,7 +329,7 @@ impl Date {
                 + Duration::milliseconds(millisecond);
             NaiveDate::from_ymd_opt(year, month + 1, day + 1)
                 .and_then(|dt| dt.and_hms(0, 0, 0).checked_add_signed(duration))
-                .filter(|dt| Self::time_clip((dt.timestamp() as f64) * 1000.0).is_some())
+                .filter(|dt| Self::time_clip(dt.timestamp_millis() as f64).is_some())
                 .and_then(|dt| {
                     if utc {
                         Some(Utc.from_utc_datetime(&dt).naive_utc())

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -192,7 +192,7 @@ impl Date {
     pub(crate) const LENGTH: usize = 7;
 
     /// Check if the time (number of miliseconds) is in the expected range.
-    /// Returns None if the time is not in the range, otherwise returns the time itself.
+    /// Returns None if the time is not in the range, otherwise returns the time itself in option.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1054 

It changes the following:

- Add function `time_clip`
- Apply `time_clip` to methods of `Date`
- Add overflow checks when creating and setting `Date`

This PR resolves all known and unexplored out-of-range panics - more stable now. However, the test mentioned in the issue still failed. That is because the valid date range of `chrono::naive::NaiveDate` in Rust is smaller than the range of `Date` in JavaScript, which makes the behavior different.
