### PR TITLE
Fix internal methods

### DIFF
--- a/boa/examples/classes.rs
+++ b/boa/examples/classes.rs
@@ -26,7 +26,7 @@ struct Person {
 // or any function that matches that signature.
 impl Person {
     /// This function says hello
-    fn say_hello(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    fn say_hello(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         // We check if this is an object.
         if let Some(object) = this.as_object() {
             // If it is we downcast the type to type `Person`.
@@ -57,7 +57,8 @@ impl Class for Person {
     const LENGTH: usize = 2;
 
     // This is what is called when we do `new Person()`
-    fn constructor(_this: &Value, args: &[Value], context: &mut Context) -> Result<Self> {
+
+    fn constructor(_this: &Value, args: &[Value], context: &Context) -> Result<Self> {
         // We get the first argument. If it is unavailable we get `undefined`. And, then call `to_string()`.
         //
         // This is equivalent to `String(arg)`.

--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -67,7 +67,7 @@ impl ArrayIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
-    pub(crate) fn next(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn next(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         if let Value::Object(ref object) = this {
             let mut object = object.borrow_mut();
             if let Some(array_iterator) = object.as_array_iterator_mut() {
@@ -118,7 +118,7 @@ impl ArrayIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
-    pub(crate) fn create_prototype(context: &mut Context, iterator_prototype: Value) -> Value {
+    pub(crate) fn create_prototype(context: &Context, iterator_prototype: Value) -> Value {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -1367,6 +1367,6 @@ fn array_length_is_not_enumerable() {
     let context = Context::new();
 
     let array = Array::new_array(&context).unwrap();
-    let desc = array.get_property("length").unwrap();
+    let desc = array.get_property("length", &context).unwrap().unwrap();
     assert!(!desc.enumerable());
 }

--- a/boa/src/builtins/bigint/conversions.rs
+++ b/boa/src/builtins/bigint/conversions.rs
@@ -14,7 +14,7 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-stringtobigint
     #[inline]
-    pub(crate) fn from_string(string: &str, context: &mut Context) -> Result<Self, Value> {
+    pub(crate) fn from_string(string: &str, context: &Context) -> Result<Self, Value> {
         if string.trim().is_empty() {
             return Ok(BigInt::from(0));
         }

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -47,7 +47,7 @@ impl BuiltIn for BigInt {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let bigint_object = ConstructorBuilder::with_standard_object(
@@ -83,7 +83,7 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint-objects
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt
-    fn constructor(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    fn constructor(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let data = match args.get(0) {
             Some(ref value) => value.to_bigint(context)?,
             None => RcBigInt::from(Self::from(0)),
@@ -102,7 +102,7 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisbigintvalue
     #[inline]
-    fn this_bigint_value(value: &Value, context: &mut Context) -> Result<RcBigInt> {
+    fn this_bigint_value(value: &Value, context: &Context) -> Result<RcBigInt> {
         match value {
             // 1. If Type(value) is BigInt, return value.
             Value::BigInt(ref bigint) => return Ok(bigint.clone()),
@@ -133,7 +133,7 @@ impl BigInt {
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let radix = if !args.is_empty() {
             args[0].to_integer(context)? as i32
         } else {
@@ -158,7 +158,7 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf
-    pub(crate) fn value_of(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn value_of(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         Ok(Value::from(Self::this_bigint_value(this, context)?))
     }
 
@@ -169,7 +169,7 @@ impl BigInt {
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.asintn
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn as_int_n(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn as_int_n(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let (modulo, bits) = Self::calculate_as_uint_n(args, context)?;
 
         if bits > 0
@@ -196,7 +196,7 @@ impl BigInt {
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.asuintn
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn as_uint_n(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn as_uint_n(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let (modulo, _) = Self::calculate_as_uint_n(args, context)?;
 
         Ok(Value::from(modulo))
@@ -207,7 +207,7 @@ impl BigInt {
     /// This function expects the same arguments as `as_uint_n` and wraps the value of a `BigInt`.
     /// Additionally to the wrapped unsigned value it returns the converted `bits` argument, so it
     /// can be reused from the `as_int_n` method.
-    fn calculate_as_uint_n(args: &[Value], context: &mut Context) -> Result<(BigInt, u32)> {
+    fn calculate_as_uint_n(args: &[Value], context: &Context) -> Result<(BigInt, u32)> {
         use std::convert::TryFrom;
 
         let undefined_value = Value::undefined();

--- a/boa/src/builtins/bigint/tests.rs
+++ b/boa/src/builtins/bigint/tests.rs
@@ -395,7 +395,7 @@ fn as_uint_n_errors() {
     assert_throws(&mut context, "BigInt.asUintN(0n, 0n)", "TypeError");
 }
 
-fn assert_throws(context: &mut Context, src: &str, error_type: &str) {
+fn assert_throws(context: &Context, src: &str, error_type: &str) {
     let result = forward(context, src);
     assert!(result.contains(error_type));
 }

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -31,7 +31,7 @@ impl BuiltIn for Boolean {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let boolean_object = ConstructorBuilder::with_standard_object(
@@ -59,7 +59,7 @@ impl Boolean {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         // Get the argument, if any
         let data = args.get(0).map(|x| x.to_boolean()).unwrap_or(false);
@@ -92,7 +92,7 @@ impl Boolean {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisbooleanvalue
-    fn this_boolean_value(value: &Value, context: &mut Context) -> Result<bool> {
+    fn this_boolean_value(value: &Value, context: &Context) -> Result<bool> {
         match value {
             Value::Boolean(boolean) => return Ok(*boolean),
             Value::Object(ref object) => {
@@ -116,7 +116,7 @@ impl Boolean {
     /// [spec]: https://tc39.es/ecma262/#sec-boolean-object
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let boolean = Self::this_boolean_value(this, context)?;
         Ok(Value::from(boolean.to_string()))
     }
@@ -130,7 +130,7 @@ impl Boolean {
     /// [spec]: https://tc39.es/ecma262/#sec-boolean.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
     #[inline]
-    pub(crate) fn value_of(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn value_of(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         Ok(Value::from(Self::this_boolean_value(this, context)?))
     }
 }

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -38,13 +38,13 @@ fn ignore_ambiguity<T>(result: LocalResult<T>) -> Option<T> {
 
 macro_rules! getter_method {
     ($name:ident) => {{
-        fn get_value(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+        fn get_value(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
             Ok(Value::from(this_time_value(this, context)?.$name()))
         }
         get_value
     }};
     (Self::$name:ident) => {{
-        fn get_value(_: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+        fn get_value(_: &Value, _: &[Value], _: &Context) -> Result<Value> {
             Ok(Value::from(Date::$name()))
         }
         get_value
@@ -53,7 +53,7 @@ macro_rules! getter_method {
 
 macro_rules! setter_method {
     ($name:ident($($e:expr),* $(,)?)) => {{
-        fn set_value(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        fn set_value(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
             let mut result = this_time_value(this, context)?;
             result.$name(
                 $(
@@ -112,7 +112,7 @@ impl BuiltIn for Date {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let date_object = ConstructorBuilder::new(context, Self::constructor)
@@ -326,7 +326,7 @@ impl Date {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         if new_target.is_undefined() {
             Self::make_date_string()
@@ -396,7 +396,7 @@ impl Date {
     pub(crate) fn make_date_single(
         this: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let value = &args[0];
         let tv = match this_time_value(value, context) {
@@ -433,7 +433,7 @@ impl Date {
     pub(crate) fn make_date_multiple(
         this: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let year = args[0].to_number(context)?;
         let month = args[1].to_number(context)?;
@@ -1269,7 +1269,7 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.now
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
-    pub(crate) fn now(_: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    pub(crate) fn now(_: &Value, _: &[Value], _: &Context) -> Result<Value> {
         Ok(Value::from(Utc::now().timestamp_millis() as f64))
     }
 
@@ -1285,7 +1285,7 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
-    pub(crate) fn parse(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn parse(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // This method is implementation-defined and discouraged, so we just require the same format as the string
         // constructor.
 
@@ -1309,7 +1309,7 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.utc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC
-    pub(crate) fn utc(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn utc(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let year = args
             .get(0)
             .map_or(Ok(f64::NAN), |value| value.to_number(context))?;
@@ -1371,7 +1371,7 @@ impl Date {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
 #[inline]
-pub fn this_time_value(value: &Value, context: &mut Context) -> Result<Date> {
+pub fn this_time_value(value: &Value, context: &Context) -> Result<Date> {
     if let Value::Object(ref object) = value {
         if let ObjectData::Date(ref date) = object.borrow().data {
             return Ok(*date);

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -6,7 +6,7 @@ use chrono::prelude::*;
 // NOTE: Javascript Uses 0-based months, where chrono uses 1-based months. Many of the assertions look wrong because of
 // this.
 
-fn forward_dt_utc(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
+fn forward_dt_utc(context: &Context, src: &str) -> Option<NaiveDateTime> {
     let date_time = if let Ok(v) = forward_val(context, src) {
         v
     } else {
@@ -24,7 +24,7 @@ fn forward_dt_utc(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
     }
 }
 
-fn forward_dt_local(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
+fn forward_dt_local(context: &Context, src: &str) -> Option<NaiveDateTime> {
     let date_time = forward_dt_utc(context, src);
 
     // The timestamp is converted to UTC for internal representation
@@ -61,7 +61,8 @@ fn date_this_time_value() {
     )
     .expect_err("Expected error");
     let message_property = &error
-        .get_property("message")
+        .get_property("message", &context)
+        .unwrap()
         .expect("Expected 'message' property")
         .as_data_descriptor()
         .unwrap()

--- a/boa/src/builtins/error/eval.rs
+++ b/boa/src/builtins/error/eval.rs
@@ -31,7 +31,7 @@ impl BuiltIn for EvalError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -60,7 +60,7 @@ impl EvalError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -70,7 +70,7 @@ impl EvalError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| context.standard_objects().eval_error_object().prototype());
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -46,7 +46,7 @@ impl BuiltIn for Error {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
@@ -76,7 +76,7 @@ impl Error {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -113,7 +113,7 @@ impl Error {
     /// [spec]: https://tc39.es/ecma262/#sec-error.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         if !this.is_object() {
             return context.throw_type_error("'this' is not an Object");
         }

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -28,7 +28,7 @@ impl BuiltIn for RangeError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -57,7 +57,7 @@ impl RangeError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -67,7 +67,7 @@ impl RangeError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| context.standard_objects().range_error_object().prototype());
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -27,7 +27,7 @@ impl BuiltIn for ReferenceError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -56,7 +56,7 @@ impl ReferenceError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -66,7 +66,12 @@ impl ReferenceError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| {
+                context
+                    .standard_objects()
+                    .reference_error_object()
+                    .prototype()
+            });
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -30,7 +30,7 @@ impl BuiltIn for SyntaxError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -59,7 +59,7 @@ impl SyntaxError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -69,7 +69,7 @@ impl SyntaxError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| context.standard_objects().syntax_error_object().prototype());
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -33,7 +33,7 @@ impl BuiltIn for TypeError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -62,7 +62,7 @@ impl TypeError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -72,7 +72,7 @@ impl TypeError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| context.standard_objects().type_error_object().prototype());
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/error/uri.rs
+++ b/boa/src/builtins/error/uri.rs
@@ -29,7 +29,7 @@ impl BuiltIn for UriError {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let error_prototype = context.standard_objects().error_object().prototype();
@@ -58,7 +58,7 @@ impl UriError {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let prototype = new_target
             .as_object()
@@ -68,7 +68,7 @@ impl UriError {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+            .unwrap_or_else(|| context.standard_objects().uri_error_object().prototype());
         let mut obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);

--- a/boa/src/builtins/global_this/mod.rs
+++ b/boa/src/builtins/global_this/mod.rs
@@ -25,7 +25,7 @@ impl BuiltIn for GlobalThis {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (

--- a/boa/src/builtins/infinity/mod.rs
+++ b/boa/src/builtins/infinity/mod.rs
@@ -25,7 +25,7 @@ impl BuiltIn for Infinity {
         Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
     }
 
-    fn init(_: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(_: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, f64::INFINITY.into(), Self::attribute())

--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -18,7 +18,7 @@ pub struct IteratorPrototypes {
 }
 
 impl IteratorPrototypes {
-    pub(crate) fn init(context: &mut Context) -> Self {
+    pub(crate) fn init(context: &Context) -> Self {
         let iterator_prototype = create_iterator_prototype(context);
         Self {
             iterator_prototype: iterator_prototype
@@ -68,7 +68,7 @@ impl IteratorPrototypes {
 /// CreateIterResultObject( value, done )
 ///
 /// Generates an object supporting the IteratorResult interface.
-pub fn create_iter_result_object(context: &mut Context, value: Value, done: bool) -> Value {
+pub fn create_iter_result_object(context: &Context, value: Value, done: bool) -> Value {
     let object = Value::new_object(context);
     // TODO: Fix attributes of value and done
     let value_property = DataDescriptor::new(value, Attribute::all());
@@ -79,7 +79,7 @@ pub fn create_iter_result_object(context: &mut Context, value: Value, done: bool
 }
 
 /// Get an iterator record
-pub fn get_iterator(context: &mut Context, iterable: Value) -> Result<IteratorRecord> {
+pub fn get_iterator(context: &Context, iterable: Value) -> Result<IteratorRecord> {
     let iterator_function =
         iterable.get_field(context.well_known_symbols().iterator_symbol(), context)?;
     if iterator_function.is_null_or_undefined() {
@@ -99,7 +99,7 @@ pub fn get_iterator(context: &mut Context, iterable: Value) -> Result<IteratorRe
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-%iteratorprototype%-object
-fn create_iterator_prototype(context: &mut Context) -> Value {
+fn create_iterator_prototype(context: &Context) -> Value {
     let _timer = BoaProfiler::global().start_event("Iterator Prototype", "init");
 
     let symbol_iterator = context.well_known_symbols().iterator_symbol();
@@ -134,7 +134,7 @@ impl IteratorRecord {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratornext
-    pub(crate) fn next(&self, context: &mut Context) -> Result<IteratorResult> {
+    pub(crate) fn next(&self, context: &Context) -> Result<IteratorResult> {
         let next = context.call(&self.next_function, &self.iterator_object, &[])?;
         let done = next.get_field("done", context)?.to_boolean();
 

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -224,7 +224,7 @@ impl Json {
                     Some(
                         replacer
                             .get_property(key, context)
-                            .unwrap()
+                            .expect("'key' is one of the keys of 'replacer'")
                             .as_ref()
                             .and_then(|p| p.as_data_descriptor())
                             .map(|d| d.value())

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -38,7 +38,7 @@ impl BuiltIn for Json {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let json_object = ObjectInitializer::new(context)
@@ -63,7 +63,7 @@ impl Json {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-    pub(crate) fn parse(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn parse(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let arg = args
             .get(0)
             .cloned()
@@ -94,7 +94,7 @@ impl Json {
     /// [polyfill]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
     fn walk(
         reviver: &Value,
-        context: &mut Context,
+        context: &Context,
         holder: &mut Value,
         key: &PropertyKey,
     ) -> Result<Value> {
@@ -135,7 +135,7 @@ impl Json {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json.stringify
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-    pub(crate) fn stringify(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn stringify(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let object = match args.get(0) {
             Some(obj) if obj.is_symbol() || obj.is_function() || obj.is_undefined() => {
                 return Ok(Value::undefined())
@@ -223,7 +223,8 @@ impl Json {
                 } else {
                     Some(
                         replacer
-                            .get_property(key)
+                            .get_property(key, context)
+                            .unwrap()
                             .as_ref()
                             .and_then(|p| p.as_data_descriptor())
                             .map(|d| d.value())

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -67,7 +67,7 @@ impl MapIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
-    pub(crate) fn next(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn next(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         if let Value::Object(ref object) = this {
             let mut object = object.borrow_mut();
             if let Some(map_iterator) = object.as_map_iterator_mut() {
@@ -138,7 +138,7 @@ impl MapIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object
-    pub(crate) fn create_prototype(context: &mut Context, iterator_prototype: Value) -> Value {
+    pub(crate) fn create_prototype(context: &Context, iterator_prototype: Value) -> Value {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -25,7 +25,7 @@ impl BuiltIn for Map {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let iterator_symbol = context.well_known_symbols().iterator_symbol();
@@ -72,7 +72,7 @@ impl Map {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         if new_target.is_undefined() {
             return context.throw_type_error("Map requires new");
@@ -153,7 +153,7 @@ impl Map {
     ///
     /// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-map.prototype.entries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
-    pub(crate) fn entries(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn entries(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::KeyAndValue)
     }
 
@@ -167,7 +167,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
-    pub(crate) fn keys(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn keys(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Key)
     }
 
@@ -191,7 +191,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
-    pub(crate) fn set(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn set(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let (key, value) = match args.len() {
             0 => (Value::Undefined, Value::Undefined),
             1 => (args[0].clone(), Value::Undefined),
@@ -223,7 +223,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.delete
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
-    pub(crate) fn delete(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn delete(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -254,7 +254,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
-    pub(crate) fn get(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn get(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -285,7 +285,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
-    pub(crate) fn clear(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    pub(crate) fn clear(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
         this.set_data(ObjectData::Map(OrderedMap::new()));
 
         Self::set_size(this, 0);
@@ -303,7 +303,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn has(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let undefined = Value::Undefined;
         let key = match args.len() {
             0 => &undefined,
@@ -330,7 +330,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.foreach
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/forEach
-    pub(crate) fn for_each(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn for_each(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         if args.is_empty() {
             return Err(Value::from("Missing argument for Map.prototype.forEach"));
         }
@@ -362,12 +362,12 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.values
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values
-    pub(crate) fn values(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn values(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Value)
     }
 
     /// Helper function to get a key-value pair from an array.
-    fn get_key_value(value: &Value, context: &mut Context) -> Result<Option<(Value, Value)>> {
+    fn get_key_value(value: &Value, context: &Context) -> Result<Option<(Value, Value)>> {
         if let Value::Object(object) = value {
             if object.is_array() {
                 let (key, value) =

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -31,7 +31,7 @@ impl BuiltIn for Math {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
@@ -94,7 +94,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.abs
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
-    pub(crate) fn abs(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn abs(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -111,7 +111,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
-    pub(crate) fn acos(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn acos(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -128,7 +128,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
-    pub(crate) fn acosh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn acosh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -145,7 +145,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
-    pub(crate) fn asin(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn asin(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -162,7 +162,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
-    pub(crate) fn asinh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn asinh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -179,7 +179,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan
-    pub(crate) fn atan(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn atan(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -196,7 +196,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
-    pub(crate) fn atanh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn atanh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -213,7 +213,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
-    pub(crate) fn atan2(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn atan2(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_number(context)).transpose()?,
             args.get(1).map(|x| x.to_number(context)).transpose()?,
@@ -232,7 +232,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cbrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
-    pub(crate) fn cbrt(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn cbrt(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -249,7 +249,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.ceil
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
-    pub(crate) fn ceil(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn ceil(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -266,7 +266,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.clz32
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
-    pub(crate) fn clz32(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn clz32(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_u32(context))
@@ -284,7 +284,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
-    pub(crate) fn cos(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn cos(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -301,7 +301,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
-    pub(crate) fn cosh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn cosh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -318,7 +318,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.exp
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
-    pub(crate) fn exp(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn exp(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -337,7 +337,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.expm1
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1
-    pub(crate) fn expm1(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn expm1(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -354,7 +354,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.floor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
-    pub(crate) fn floor(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn floor(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -371,7 +371,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.fround
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
-    pub(crate) fn fround(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn fround(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -388,7 +388,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.hypot
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
-    pub(crate) fn hypot(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn hypot(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let mut result = 0f64;
         for arg in args {
             let x = arg.to_number(context)?;
@@ -405,7 +405,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.imul
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-    pub(crate) fn imul(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn imul(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_u32(context)).transpose()?,
             args.get(1).map(|x| x.to_u32(context)).transpose()?,
@@ -424,7 +424,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
-    pub(crate) fn log(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn log(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -441,7 +441,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log1p
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p
-    pub(crate) fn log1p(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn log1p(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -458,7 +458,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log10
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10
-    pub(crate) fn log10(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn log10(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -475,7 +475,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
-    pub(crate) fn log2(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn log2(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -492,7 +492,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.max
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max
-    pub(crate) fn max(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn max(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let mut max = f64::NEG_INFINITY;
         for arg in args {
             let num = arg.to_number(context)?;
@@ -509,7 +509,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.min
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min
-    pub(crate) fn min(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn min(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let mut min = f64::INFINITY;
         for arg in args {
             let num = arg.to_number(context)?;
@@ -526,7 +526,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.pow
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
-    pub(crate) fn pow(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn pow(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(match (
             args.get(0).map(|x| x.to_number(context)).transpose()?,
             args.get(1).map(|x| x.to_number(context)).transpose()?,
@@ -545,7 +545,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.random
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
-    pub(crate) fn random(_: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    pub(crate) fn random(_: &Value, _: &[Value], _: &Context) -> Result<Value> {
         Ok(rand::random::<f64>().into())
     }
 
@@ -557,7 +557,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
-    pub(crate) fn round(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn round(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -574,7 +574,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
-    pub(crate) fn sign(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn sign(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -600,7 +600,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
-    pub(crate) fn sin(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn sin(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -617,7 +617,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh
-    pub(crate) fn sinh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn sinh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -634,7 +634,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sqrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt
-    pub(crate) fn sqrt(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn sqrt(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -651,7 +651,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tan
-    pub(crate) fn tan(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn tan(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -668,7 +668,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh
-    pub(crate) fn tanh(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn tanh(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))
@@ -685,7 +685,7 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
-    pub(crate) fn trunc(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn trunc(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         Ok(args
             .get(0)
             .map(|x| x.to_number(context))

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -54,12 +54,12 @@ pub(crate) trait BuiltIn {
     const NAME: &'static str;
 
     fn attribute() -> Attribute;
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute);
+    fn init(context: &Context) -> (&'static str, Value, Attribute);
 }
 
 /// Initializes builtin objects and functions
 #[inline]
-pub fn init(context: &mut Context) {
+pub fn init(context: &Context) {
     let globals = [
         // Global properties.
         Undefined::init,

--- a/boa/src/builtins/nan/mod.rs
+++ b/boa/src/builtins/nan/mod.rs
@@ -26,7 +26,7 @@ impl BuiltIn for NaN {
         Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
     }
 
-    fn init(_: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(_: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, f64::NAN.into(), Self::attribute())

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -49,7 +49,7 @@ impl BuiltIn for Number {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
@@ -156,7 +156,7 @@ impl Number {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         let data = match args.get(0) {
             Some(ref value) => value.to_numeric_number(context)?,
@@ -192,7 +192,7 @@ impl Number {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisnumbervalue
-    fn this_number_value(value: &Value, context: &mut Context) -> Result<f64> {
+    fn this_number_value(value: &Value, context: &Context) -> Result<f64> {
         match *value {
             Value::Integer(integer) => return Ok(f64::from(integer)),
             Value::Rational(rational) => return Ok(rational),
@@ -227,11 +227,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.toexponential
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toExponential
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_exponential(
-        this: &Value,
-        _: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn to_exponential(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let this_num = Self::this_number_value(this, context)?;
         let this_str_num = Self::num_to_exponential(this_num);
         Ok(Value::from(this_str_num))
@@ -248,7 +244,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tofixed
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toFixed
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_fixed(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_fixed(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let this_num = Self::this_number_value(this, context)?;
         let precision = match args.get(0) {
             Some(n) => match n.to_integer(context)? as i32 {
@@ -275,11 +271,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tolocalestring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_locale_string(
-        this: &Value,
-        _: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn to_locale_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let this_num = Self::this_number_value(this, context)?;
         let this_str_num = format!("{}", this_num);
         Ok(Value::from(this_str_num))
@@ -353,11 +345,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.toprecision
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toPrecision
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_precision(
-        this: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn to_precision(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let precision_var = args.get(0).cloned().unwrap_or_default();
 
         // 1 & 6
@@ -594,7 +582,7 @@ impl Number {
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // 1. Let x be ? thisNumberValue(this value).
         let x = Self::this_number_value(this, context)?;
 
@@ -649,7 +637,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf
-    pub(crate) fn value_of(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn value_of(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         Ok(Value::from(Self::this_number_value(this, context)?))
     }
 
@@ -667,7 +655,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parseint-string-radix
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt
-    pub(crate) fn parse_int(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn parse_int(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         if let (Some(val), radix) = (args.get(0), args.get(1)) {
             // 1. Let inputString be ? ToString(string).
             let input_string = val.to_string(context)?;
@@ -789,7 +777,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parsefloat-string
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat
-    pub(crate) fn parse_float(_: &Value, args: &[Value], _ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn parse_float(_: &Value, args: &[Value], _ctx: &Context) -> Result<Value> {
         if let Some(val) = args.get(0) {
             match val {
                 Value::String(s) => {
@@ -831,11 +819,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isfinite-number
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite
-    pub(crate) fn global_is_finite(
-        _: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn global_is_finite(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(context)?;
             Ok(number.is_finite().into())
@@ -858,7 +842,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isnan-number
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN
-    pub(crate) fn global_is_nan(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn global_is_nan(_: &Value, args: &[Value], context: &Context) -> Result<Value> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(context)?;
             Ok(number.is_nan().into())
@@ -881,7 +865,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.isfinite
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite
-    pub(crate) fn number_is_finite(_: &Value, args: &[Value], _ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn number_is_finite(_: &Value, args: &[Value], _ctx: &Context) -> Result<Value> {
         Ok(Value::from(if let Some(val) = args.get(0) {
             match val {
                 Value::Integer(_) => true,
@@ -903,11 +887,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.isinteger
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
-    pub(crate) fn number_is_integer(
-        _: &Value,
-        args: &[Value],
-        _ctx: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn number_is_integer(_: &Value, args: &[Value], _ctx: &Context) -> Result<Value> {
         Ok(args.get(0).map_or(false, Self::is_integer).into())
     }
 
@@ -925,7 +905,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isnan-number
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
-    pub(crate) fn number_is_nan(_: &Value, args: &[Value], _ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn number_is_nan(_: &Value, args: &[Value], _ctx: &Context) -> Result<Value> {
         Ok(Value::from(if let Some(val) = args.get(0) {
             match val {
                 Value::Integer(_) => false,
@@ -951,7 +931,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isnan-number
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN
-    pub(crate) fn is_safe_integer(_: &Value, args: &[Value], _ctx: &mut Context) -> Result<Value> {
+    pub(crate) fn is_safe_integer(_: &Value, args: &[Value], _ctx: &Context) -> Result<Value> {
         Ok(Value::from(match args.get(0) {
             Some(Value::Integer(_)) => true,
             Some(Value::Rational(number)) if Self::is_float_integer(*number) => {

--- a/boa/src/builtins/object/for_in_iterator.rs
+++ b/boa/src/builtins/object/for_in_iterator.rs
@@ -63,14 +63,14 @@ impl ForInIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%.next
-    pub(crate) fn next(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn next(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         if let Value::Object(ref o) = this {
             let mut for_in_iterator = o.borrow_mut();
             if let Some(iterator) = for_in_iterator.as_for_in_iterator_mut() {
                 let mut object = iterator.object.to_object(context)?;
                 loop {
                     if !iterator.object_was_visited {
-                        let keys = object.own_property_keys();
+                        let keys = object.own_property_keys(context)?;
                         for k in keys {
                             match k {
                                 PropertyKey::String(ref k) => {
@@ -87,7 +87,7 @@ impl ForInIterator {
                     while let Some(r) = iterator.remaining_keys.pop_front() {
                         if !iterator.visited_keys.contains(&r) {
                             if let Some(desc) =
-                                object.get_own_property(&PropertyKey::from(r.clone()))
+                                object.get_own_property(&PropertyKey::from(r.clone()), context)?
                             {
                                 iterator.visited_keys.insert(r.clone());
                                 if desc.enumerable() {
@@ -125,7 +125,7 @@ impl ForInIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%-object
-    pub(crate) fn create_prototype(context: &mut Context, iterator_prototype: Value) -> Value {
+    pub(crate) fn create_prototype(context: &Context, iterator_prototype: Value) -> Value {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -68,7 +68,7 @@ impl BuiltIn for RegExp {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let regexp_object = ConstructorBuilder::with_standard_object(
@@ -98,11 +98,7 @@ impl RegExp {
     pub(crate) const LENGTH: usize = 2;
 
     /// Create a new `RegExp`
-    pub(crate) fn constructor(
-        new_target: &Value,
-        args: &[Value],
-        ctx: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn constructor(new_target: &Value, args: &[Value], ctx: &Context) -> Result<Value> {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
@@ -217,7 +213,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.dotAll
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
-    // fn get_dot_all(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_dot_all(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.dot_all)))
     // }
 
@@ -232,7 +228,7 @@ impl RegExp {
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.flags
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/flags
     // /// [flags]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Advanced_searching_with_flags_2
-    // fn get_flags(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_flags(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.flags.clone())))
     // }
 
@@ -246,7 +242,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.global
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/global
-    // fn get_global(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_global(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.global)))
     // }
 
@@ -260,7 +256,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.ignorecase
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/ignoreCase
-    // fn get_ignore_case(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_ignore_case(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.ignore_case)))
     // }
 
@@ -274,7 +270,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.multiline
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/multiline
-    // fn get_multiline(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_multiline(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.multiline)))
     // }
 
@@ -289,7 +285,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.source
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/source
-    // fn get_source(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_source(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     Ok(this.get_internal_slot("OriginalSource"))
     // }
 
@@ -303,7 +299,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.sticky
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/sticky
-    // fn get_sticky(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_sticky(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.sticky)))
     // }
 
@@ -318,7 +314,7 @@ impl RegExp {
     // ///
     // /// [spec]: https://tc39.es/ecma262/#sec-get-regexp.prototype.unicode
     // /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode
-    // fn get_unicode(this: &Value, _: &[Value], _: &mut Context) -> Result<Value> {
+    // fn get_unicode(this: &Value, _: &[Value], _: &Context) -> Result<Value> {
     //     this.with_internal_state_ref(|regex: &RegExp| Ok(Value::from(regex.unicode)))
     // }
 
@@ -334,7 +330,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.test
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
-    pub(crate) fn test(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn test(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let mut last_index = this.get_field("lastIndex", context)?.to_index(context)?;
         let result = if let Some(object) = this.as_object() {
             // 3. Let string be ? ToString(S).
@@ -387,7 +383,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.exec
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
-    pub(crate) fn exec(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn exec(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // 4. Return ? RegExpBuiltinExec(R, S).
         let mut last_index = this.get_field("lastIndex", context)?.to_index(context)?;
         let result = if let Some(object) = this.as_object() {
@@ -457,7 +453,7 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype-@@match
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match
-    pub(crate) fn r#match(this: &Value, arg: RcString, context: &mut Context) -> Result<Value> {
+    pub(crate) fn r#match(this: &Value, arg: RcString, context: &Context) -> Result<Value> {
         let (matcher, flags) = if let Some(object) = this.as_object() {
             let object = object.borrow();
             if let Some(regex) = object.as_regexp() {
@@ -495,20 +491,20 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let (body, flags) = if let Some(object) = this.as_object() {
             let object = object.borrow();
             let regex = object.as_regexp().ok_or_else(|| {
                 context.construct_type_error(format!(
                     "Method RegExp.prototype.toString called on incompatible receiver {}",
-                    this.display()
+                    this.display(context)
                 ))
             })?;
             (regex.original_source.clone(), regex.flags.clone())
         } else {
             return context.throw_type_error(format!(
                 "Method RegExp.prototype.toString called on incompatible receiver {}",
-                this.display()
+                this.display(context)
             ));
         };
         Ok(Value::from(format!("/{}/{}", body, flags)))
@@ -525,7 +521,7 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp-prototype-matchall
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
     // TODO: it's returning an array, it should return an iterator
-    pub(crate) fn match_all(this: &Value, arg_str: String, context: &mut Context) -> Result<Value> {
+    pub(crate) fn match_all(this: &Value, arg_str: String, context: &Context) -> Result<Value> {
         let matches = if let Some(object) = this.as_object() {
             let object = object.borrow();
             if let Some(regex) = object.as_regexp() {

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -71,7 +71,7 @@ impl BuiltIn for String {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         let symbol_iterator = context.well_known_symbols().iterator_symbol();
@@ -135,7 +135,7 @@ impl String {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
@@ -179,7 +179,7 @@ impl String {
         Ok(this)
     }
 
-    fn this_string_value(this: &Value, context: &mut Context) -> Result<RcString> {
+    fn this_string_value(this: &Value, context: &Context) -> Result<RcString> {
         match this {
             Value::String(ref string) => return Ok(string.clone()),
             Value::Object(ref object) => {
@@ -197,7 +197,7 @@ impl String {
     /// Get the string value to a primitive string
     #[allow(clippy::wrong_self_convention)]
     #[inline]
-    pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         // Get String from String Object and send it back as a new value
         Ok(Value::from(Self::this_string_value(this, context)?))
     }
@@ -218,7 +218,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.charat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charAt
-    pub(crate) fn char_at(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn char_at(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -258,11 +258,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.codepointat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/codePointAt
-    pub(crate) fn code_point_at(
-        this: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn code_point_at(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -298,11 +294,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.charcodeat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt
-    pub(crate) fn char_code_at(
-        this: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn char_code_at(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -341,7 +333,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.concat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/concat
-    pub(crate) fn concat(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn concat(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let object = this.require_object_coercible(context)?;
         let mut string = object.to_string(context)?.to_string();
 
@@ -363,7 +355,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.repeat
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat
-    pub(crate) fn repeat(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn repeat(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let object = this.require_object_coercible(context)?;
         let string = object.to_string(context)?;
 
@@ -397,7 +389,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.slice
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice
-    pub(crate) fn slice(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn slice(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -448,11 +440,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.startswith
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
-    pub(crate) fn starts_with(
-        this: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn starts_with(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -501,7 +489,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.endswith
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith
-    pub(crate) fn ends_with(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn ends_with(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -551,7 +539,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.includes
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
-    pub(crate) fn includes(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn includes(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -624,7 +612,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.replace
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
-    pub(crate) fn replace(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn replace(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // TODO: Support Symbol replacer
         let primitive_val = this.to_string(context)?;
         if args.is_empty() {
@@ -783,7 +771,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.indexof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf
-    pub(crate) fn index_of(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn index_of(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
 
@@ -826,11 +814,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.lastindexof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/lastIndexOf
-    pub(crate) fn last_index_of(
-        this: &Value,
-        args: &[Value],
-        context: &mut Context,
-    ) -> Result<Value> {
+    pub(crate) fn last_index_of(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
 
@@ -871,7 +855,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.match
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-    pub(crate) fn r#match(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn r#match(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let re = RegExp::constructor(
             &Value::from(Object::default()),
             &[args.get(0).cloned().unwrap_or_default()],
@@ -926,7 +910,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.padend
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
-    pub(crate) fn pad_end(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn pad_end(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let primitive = this.to_string(context)?;
         if args.is_empty() {
             return Err(Value::from("padEnd requires maxLength argument"));
@@ -953,7 +937,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.padstart
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart
-    pub(crate) fn pad_start(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn pad_start(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let primitive = this.to_string(context)?;
         if args.is_empty() {
             return Err(Value::from("padStart requires maxLength argument"));
@@ -1001,7 +985,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trim
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
-    pub(crate) fn trim(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn trim(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
         Ok(Value::from(
@@ -1021,7 +1005,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trimstart
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart
-    pub(crate) fn trim_start(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn trim_start(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let string = this.to_string(context)?;
         Ok(Value::from(
             string.trim_start_matches(Self::is_trimmable_whitespace),
@@ -1040,7 +1024,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trimend
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd
-    pub(crate) fn trim_end(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn trim_end(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
         Ok(Value::from(
@@ -1059,7 +1043,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.tolowercase
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_lowercase(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_lowercase(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let this_str = this.to_string(context)?;
@@ -1081,7 +1065,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.toUppercase
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_uppercase(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_uppercase(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let this_str = this.to_string(context)?;
@@ -1100,7 +1084,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.substring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring
-    pub(crate) fn substring(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn substring(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -1151,7 +1135,7 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.substr
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr
     /// <https://tc39.es/ecma262/#sec-string.prototype.substr>
-    pub(crate) fn substr(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn substr(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // First we get it the actual string a private field stored on the object only the context has access to.
         // Then we convert it into a Rust String by wrapping it in from_value
         let primitive_val = this.to_string(context)?;
@@ -1209,7 +1193,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.split
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
-    pub(crate) fn split(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn split(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
 
@@ -1279,7 +1263,7 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.value_of
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/valueOf
-    pub(crate) fn value_of(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn value_of(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         // Use the to_string method because it is specified to do the same thing in this case
         Self::to_string(this, args, context)
     }
@@ -1297,7 +1281,7 @@ impl String {
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     /// [cg]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
     // TODO: update this method to return iterator
-    pub(crate) fn match_all(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn match_all(this: &Value, args: &[Value], context: &Context) -> Result<Value> {
         let re: Value = match args.get(0) {
             Some(arg) => {
                 if arg.is_null() {
@@ -1326,7 +1310,7 @@ impl String {
         RegExp::match_all(&re, this.to_string(context)?.to_string(), context)
     }
 
-    pub(crate) fn iterator(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn iterator(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         StringIterator::create_string_iterator(context, this.clone())
     }
 }

--- a/boa/src/builtins/string/string_iterator.rs
+++ b/boa/src/builtins/string/string_iterator.rs
@@ -22,7 +22,7 @@ impl StringIterator {
         }
     }
 
-    pub fn create_string_iterator(context: &mut Context, string: Value) -> Result<Value> {
+    pub fn create_string_iterator(context: &Context, string: Value) -> Result<Value> {
         let string_iterator = Value::new_object(context);
         string_iterator.set_data(ObjectData::StringIterator(Self::new(string)));
         string_iterator
@@ -32,7 +32,7 @@ impl StringIterator {
         Ok(string_iterator)
     }
 
-    pub fn next(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub fn next(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         if let Value::Object(ref object) = this {
             let mut object = object.borrow_mut();
             if let Some(string_iterator) = object.as_string_iterator_mut() {
@@ -69,7 +69,7 @@ impl StringIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
-    pub(crate) fn create_prototype(context: &mut Context, iterator_prototype: Value) -> Value {
+    pub(crate) fn create_prototype(context: &Context, iterator_prototype: Value) -> Value {
         let _timer = BoaProfiler::global().start_event("String Iterator", "init");
 
         // Create prototype

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -240,7 +240,7 @@ impl BuiltIn for Symbol {
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
     }
 
-    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(context: &Context) -> (&'static str, Value, Attribute) {
         // https://tc39.es/ecma262/#sec-well-known-symbols
         let well_known_symbols = context.well_known_symbols();
 
@@ -318,7 +318,7 @@ impl Symbol {
     pub(crate) fn constructor(
         new_target: &Value,
         args: &[Value],
-        context: &mut Context,
+        context: &Context,
     ) -> Result<Value> {
         if new_target.is_undefined() {
             return context.throw_type_error("Symbol is not a constructor");
@@ -331,7 +331,7 @@ impl Symbol {
         Ok(context.construct_symbol(description).into())
     }
 
-    fn this_symbol_value(value: &Value, context: &mut Context) -> Result<RcSymbol> {
+    fn this_symbol_value(value: &Value, context: &Context) -> Result<RcSymbol> {
         match value {
             Value::Symbol(ref symbol) => return Ok(symbol.clone()),
             Value::Object(ref object) => {
@@ -357,7 +357,7 @@ impl Symbol {
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+    pub(crate) fn to_string(this: &Value, _: &[Value], context: &Context) -> Result<Value> {
         let symbol = Self::this_symbol_value(this, context)?;
         let description = symbol.description().unwrap_or("");
         Ok(Value::from(format!("Symbol({})", description)))

--- a/boa/src/builtins/symbol/tests.rs
+++ b/boa/src/builtins/symbol/tests.rs
@@ -19,7 +19,7 @@ fn print_symbol_expect_description() {
         "#;
     eprintln!("{}", forward(&mut context, init));
     let sym = forward_val(&mut context, "sym.toString()").unwrap();
-    assert_eq!(sym.display().to_string(), "\"Symbol(Hello)\"");
+    assert_eq!(sym.display(&context).to_string(), "\"Symbol(Hello)\"");
 }
 
 #[test]

--- a/boa/src/builtins/undefined/mod.rs
+++ b/boa/src/builtins/undefined/mod.rs
@@ -25,7 +25,7 @@ impl BuiltIn for Undefined {
         Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT
     }
 
-    fn init(_: &mut Context) -> (&'static str, Value, Attribute) {
+    fn init(_: &Context) -> (&'static str, Value, Attribute) {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         (Self::NAME, Value::undefined(), Self::attribute())

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -25,7 +25,7 @@
 //!     const LENGTH: usize = 1;
 //!
 //!     // This is what is called when we do `new Animal()`
-//!     fn constructor(_this: &Value, args: &[Value], context: &mut Context) -> Result<Self> {
+//!     fn constructor(_this: &Value, args: &[Value], context: &Context) -> Result<Self> {
 //!         // This is equivalent to `String(arg)`.
 //!         let kind = args.get(0).cloned().unwrap_or_default().to_string(context)?;
 //!
@@ -77,7 +77,7 @@ pub trait Class: NativeObject + Sized {
     const ATTRIBUTE: Attribute = Attribute::all();
 
     /// The constructor of the class.
-    fn constructor(this: &Value, args: &[Value], context: &mut Context) -> Result<Self>;
+    fn constructor(this: &Value, args: &[Value], context: &Context) -> Result<Self>;
 
     /// Initializes the internals and the methods of the class.
     fn init(class: &mut ClassBuilder<'_>) -> Result<()>;
@@ -88,13 +88,13 @@ pub trait Class: NativeObject + Sized {
 /// This is automatically implemented, when a type implements `Class`.
 pub trait ClassConstructor: Class {
     /// The raw constructor that mathces the `NativeFunction` signature.
-    fn raw_constructor(this: &Value, args: &[Value], context: &mut Context) -> Result<Value>
+    fn raw_constructor(this: &Value, args: &[Value], context: &Context) -> Result<Value>
     where
         Self: Sized;
 }
 
 impl<T: Class> ClassConstructor for T {
-    fn raw_constructor(this: &Value, args: &[Value], context: &mut Context) -> Result<Value>
+    fn raw_constructor(this: &Value, args: &[Value], context: &Context) -> Result<Value>
     where
         Self: Sized,
     {
@@ -112,7 +112,7 @@ pub struct ClassBuilder<'context> {
 
 impl<'context> ClassBuilder<'context> {
     #[inline]
-    pub(crate) fn new<T>(context: &'context mut Context) -> Self
+    pub(crate) fn new<T>(context: &'context Context) -> Self
     where
         T: ClassConstructor,
     {
@@ -184,7 +184,7 @@ impl<'context> ClassBuilder<'context> {
 
     /// Return the current context.
     #[inline]
-    pub fn context(&mut self) -> &'_ mut Context {
+    pub fn context(&mut self) -> &'_ Context {
         self.builder.context()
     }
 }

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -555,11 +555,7 @@ impl Context {
                         let array = Value::new_object(self);
                         array.set_data(ObjectData::Array);
                         array.as_object().expect("object").set_prototype_instance(
-                            self.realm()
-                                .environment
-                                .borrow()
-                                .get_binding_value("Array", self)?
-                                .get_field(PROTOTYPE, self)?,
+                            self.standard_objects().array_object().prototype().into(),
                         );
                         array.set_field(0, key, self)?;
                         array.set_field(1, value, self)?;

--- a/boa/src/environment/environment_record_trait.rs
+++ b/boa/src/environment/environment_record_trait.rs
@@ -8,21 +8,20 @@
 //!
 //! There are 5 Environment record kinds. They all have methods in common, these are implemented as a the `EnvironmentRecordTrait`
 //!
-use super::ErrorKind;
 use crate::{
     environment::lexical_environment::{Environment, EnvironmentType},
     gc::{Finalize, Trace},
-    Value,
+    Context, Result, Value,
 };
 use std::fmt::Debug;
 
 /// <https://tc39.es/ecma262/#sec-environment-records>
 ///
-/// In the ECMAScript specification Environment Records are hierachical and have a base class with abstract methods.
+/// In the ECMAScript specification Environment Records are hierarchical and have a base class with abstract methods.
 /// In this implementation we have a trait which represents the behaviour of all `EnvironmentRecord` types.
 pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Determine if an Environment Record has a binding for the String value N. Return true if it does and false if it does not.
-    fn has_binding(&self, name: &str) -> bool;
+    fn has_binding(&self, name: &str, context: &Context) -> Result<bool>;
 
     /// Create a new but uninitialized mutable binding in an Environment Record. The String value N is the text of the bound name.
     /// If the Boolean argument deletion is true the binding may be subsequently deleted.
@@ -30,24 +29,30 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// * `allow_name_reuse` - specifies whether or not reusing binding names is allowed.
     ///
     /// Most variable names cannot be reused, but functions in JavaScript are allowed to have multiple
-    /// paraments with the same name.
+    /// parameters with the same name.
     fn create_mutable_binding(
         &mut self,
         name: String,
         deletion: bool,
         allow_name_reuse: bool,
-    ) -> Result<(), ErrorKind>;
+        context: &Context,
+    ) -> Result<()>;
 
     /// Create a new but uninitialized immutable binding in an Environment Record.
     /// The String value N is the text of the bound name.
     /// If strict is true then attempts to set it after it has been initialized will always throw an exception,
     /// regardless of the strict mode setting of operations that reference that binding.
-    fn create_immutable_binding(&mut self, name: String, strict: bool) -> Result<(), ErrorKind>;
+    fn create_immutable_binding(
+        &mut self,
+        name: String,
+        strict: bool,
+        context: &Context,
+    ) -> Result<()>;
 
     /// Set the value of an already existing but uninitialized binding in an Environment Record.
     /// The String value N is the text of the bound name.
     /// V is the value for the binding and is a value of any ECMAScript language type.
-    fn initialize_binding(&mut self, name: &str, value: Value) -> Result<(), ErrorKind>;
+    fn initialize_binding(&mut self, name: &str, value: Value, context: &Context) -> Result<()>;
 
     /// Set the value of an already existing mutable binding in an Environment Record.
     /// The String value `name` is the text of the bound name.
@@ -58,26 +63,27 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
         name: &str,
         value: Value,
         strict: bool,
-    ) -> Result<(), ErrorKind>;
+        context: &Context,
+    ) -> Result<()>;
 
     /// Returns the value of an already existing binding from an Environment Record.
     /// The String value N is the text of the bound name.
     /// S is used to identify references originating in strict mode code or that
     /// otherwise require strict mode reference semantics.
-    fn get_binding_value(&self, name: &str, strict: bool) -> Result<Value, ErrorKind>;
+    fn get_binding_value(&self, name: &str, strict: bool, context: &Context) -> Result<Value>;
 
     /// Delete a binding from an Environment Record.
     /// The String value name is the text of the bound name.
     /// If a binding for name exists, remove the binding and return true.
     /// If the binding exists but cannot be removed return false. If the binding does not exist return true.
-    fn delete_binding(&mut self, name: &str) -> bool;
+    fn delete_binding(&mut self, name: &str, context: &Context) -> Result<bool>;
 
     /// Determine if an Environment Record establishes a this binding.
     /// Return true if it does and false if it does not.
     fn has_this_binding(&self) -> bool;
 
     /// Return the `this` binding from the environment
-    fn get_this_binding(&self) -> Result<Value, ErrorKind>;
+    fn get_this_binding(&self, context: &Context) -> Result<Value>;
 
     /// Determine if an Environment Record establishes a super method binding.
     /// Return true if it does and false if it does not.
@@ -85,7 +91,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
 
     /// If this Environment Record is associated with a with statement, return the with object.
     /// Otherwise, return undefined.
-    fn with_base_object(&self) -> Value;
+    fn with_base_object(&self, context: &Context) -> Result<Value>;
 
     /// Get the next environment up
     fn get_outer_environment(&self) -> Option<Environment>;

--- a/boa/src/environment/mod.rs
+++ b/boa/src/environment/mod.rs
@@ -1,4 +1,4 @@
-//! Environment handling, lexical, object, function and declaritive records
+//! Environment handling, lexical, object, function and declarative records
 
 pub mod declarative_environment_record;
 pub mod environment_record_trait;
@@ -6,35 +6,3 @@ pub mod function_environment_record;
 pub mod global_environment_record;
 pub mod lexical_environment;
 pub mod object_environment_record;
-
-#[derive(Debug)]
-pub enum ErrorKind {
-    ReferenceError(Box<str>),
-    TypeError(Box<str>),
-}
-
-use crate::value::Value;
-use crate::Context;
-
-impl ErrorKind {
-    pub fn to_error(&self, ctx: &mut Context) -> Value {
-        match self {
-            ErrorKind::ReferenceError(msg) => ctx.construct_reference_error(msg.clone()),
-            ErrorKind::TypeError(msg) => ctx.construct_type_error(msg.clone()),
-        }
-    }
-
-    pub fn new_reference_error<M>(msg: M) -> Self
-    where
-        M: Into<Box<str>>,
-    {
-        Self::ReferenceError(msg.into())
-    }
-
-    pub fn new_type_error<M>(msg: M) -> Self
-    where
-        M: Into<Box<str>>,
-    {
-        Self::TypeError(msg.into())
-    }
-}

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -6,7 +6,6 @@
 //! Property keys that are not strings in the form of an `IdentifierName` are not included in the set of bound identifiers.
 //! More info:  [Object Records](https://tc39.es/ecma262/#sec-object-environment-records)
 
-use super::*;
 use crate::property::PropertyDescriptor;
 use crate::{
     environment::{
@@ -15,7 +14,7 @@ use crate::{
     },
     gc::{Finalize, Trace},
     property::{Attribute, DataDescriptor},
-    Value,
+    Context, Result, Value,
 };
 
 #[derive(Debug, Trace, Finalize, Clone)]
@@ -26,14 +25,14 @@ pub struct ObjectEnvironmentRecord {
 }
 
 impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
-    fn has_binding(&self, name: &str) -> bool {
-        if self.bindings.has_field(name) {
+    fn has_binding(&self, name: &str, context: &Context) -> Result<bool> {
+        if self.bindings.has_field(name, context)? {
             if self.with_environment {
                 // TODO: implement unscopables
             }
-            true
+            Ok(true)
         } else {
-            false
+            Ok(false)
         }
     }
 
@@ -42,7 +41,8 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         name: String,
         deletion: bool,
         _allow_name_reuse: bool,
-    ) -> Result<(), ErrorKind> {
+        _context: &Context,
+    ) -> Result<()> {
         // TODO: could save time here and not bother generating a new undefined object,
         // only for it to be replace with the real value later. We could just add the name to a Vector instead
         let bindings = &mut self.bindings;
@@ -56,16 +56,21 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         Ok(())
     }
 
-    fn create_immutable_binding(&mut self, _name: String, _strict: bool) -> Result<(), ErrorKind> {
+    fn create_immutable_binding(
+        &mut self,
+        _name: String,
+        _strict: bool,
+        _context: &Context,
+    ) -> Result<()> {
         Ok(())
     }
 
-    fn initialize_binding(&mut self, name: &str, value: Value) -> Result<(), ErrorKind> {
+    fn initialize_binding(&mut self, name: &str, value: Value, context: &Context) -> Result<()> {
         // We should never need to check if a binding has been created,
         // As all calls to create_mutable_binding are followed by initialized binding
         // The below is just a check.
-        debug_assert!(self.has_binding(&name));
-        self.set_mutable_binding(name, value, false)
+        debug_assert!(self.has_binding(&name, context)?);
+        self.set_mutable_binding(name, value, false, context)
     }
 
     fn set_mutable_binding(
@@ -73,8 +78,10 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         name: &str,
         value: Value,
         strict: bool,
-    ) -> Result<(), ErrorKind> {
+        _context: &Context,
+    ) -> Result<()> {
         debug_assert!(value.is_object() || value.is_function());
+
         let mut property = DataDescriptor::new(value, Attribute::ENUMERABLE);
         property.set_configurable(strict);
         self.bindings
@@ -84,32 +91,29 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         Ok(())
     }
 
-    fn get_binding_value(&self, name: &str, strict: bool) -> Result<Value, ErrorKind> {
-        if self.bindings.has_field(name) {
-            match self.bindings.get_property(name) {
+    fn get_binding_value(&self, name: &str, strict: bool, context: &Context) -> Result<Value> {
+        if self.bindings.has_field(name, context)? {
+            match self.bindings.get_property(name, context)? {
                 Some(PropertyDescriptor::Data(ref d)) => Ok(d.value()),
                 _ => Ok(Value::undefined()),
             }
         } else if strict {
-            Err(ErrorKind::new_reference_error(format!(
-                "{} has no binding",
-                name
-            )))
+            context.throw_reference_error(format!("{} has no binding", name))
         } else {
             Ok(Value::undefined())
         }
     }
 
-    fn delete_binding(&mut self, name: &str) -> bool {
+    fn delete_binding(&mut self, name: &str, _context: &Context) -> Result<bool> {
         self.bindings.remove_property(name);
-        true
+        Ok(true)
     }
 
     fn has_this_binding(&self) -> bool {
         false
     }
 
-    fn get_this_binding(&self) -> Result<Value, ErrorKind> {
+    fn get_this_binding(&self, _context: &Context) -> Result<Value> {
         Ok(Value::undefined())
     }
 
@@ -117,14 +121,14 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         false
     }
 
-    fn with_base_object(&self) -> Value {
+    fn with_base_object(&self, _context: &Context) -> Result<Value> {
         // Object Environment Records return undefined as their
         // WithBaseObject unless their withEnvironment flag is true.
         if self.with_environment {
-            return self.bindings.clone();
+            return Ok(self.bindings.clone());
         }
 
-        Value::undefined()
+        Ok(Value::undefined())
     }
 
     fn get_outer_environment(&self) -> Option<Environment> {

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -7,7 +7,7 @@ use crate::{Context, Result, Value};
 
 pub trait Executable {
     /// Runs this executable in the given context.
-    fn run(&self, context: &mut Context) -> Result<Value>;
+    fn run(&self, context: &Context) -> Result<Value>;
 }
 
 #[derive(Debug, Eq, PartialEq)]

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -88,7 +88,7 @@ pub fn parse<T: AsRef<[u8]>>(src: T, strict_mode: bool) -> StdResult<StatementLi
 /// Execute the code using an existing Context
 /// The str is consumed and the state of the Context is changed
 #[cfg(test)]
-pub(crate) fn forward<T: AsRef<[u8]>>(context: &mut Context, src: T) -> String {
+pub(crate) fn forward<T: AsRef<[u8]>>(context: &Context, src: T) -> String {
     let src_bytes: &[u8] = src.as_ref();
 
     // Setup executor
@@ -100,13 +100,13 @@ pub(crate) fn forward<T: AsRef<[u8]>>(context: &mut Context, src: T) -> String {
                 context
                     .throw_syntax_error(e.to_string())
                     .expect_err("interpreter.throw_syntax_error() did not return an error")
-                    .display()
+                    .display(context)
             );
         }
     };
     expr.run(context).map_or_else(
-        |e| format!("Uncaught {}", e.display()),
-        |v| v.display().to_string(),
+        |e| format!("Uncaught {}", e.display(context)),
+        |v| v.display(context).to_string(),
     )
 }
 
@@ -116,7 +116,7 @@ pub(crate) fn forward<T: AsRef<[u8]>>(context: &mut Context, src: T) -> String {
 /// If the interpreter fails parsing an error value is returned instead (error object)
 #[allow(clippy::unit_arg, clippy::drop_copy)]
 #[cfg(test)]
-pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &mut Context, src: T) -> Result<Value> {
+pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &Context, src: T) -> Result<Value> {
     let main_timer = BoaProfiler::global().start_event("Main", "Main");
 
     let src_bytes: &[u8] = src.as_ref();
@@ -140,9 +140,9 @@ pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &mut Context, src: T) -> Resu
 #[cfg(test)]
 pub(crate) fn exec<T: AsRef<[u8]>>(src: T) -> String {
     let src_bytes: &[u8] = src.as_ref();
-
-    match Context::new().eval(src_bytes) {
-        Ok(value) => value.display().to_string(),
-        Err(error) => error.display().to_string(),
+    let mut context = Context::new();
+    match context.eval(src_bytes) {
+        Ok(value) => value.display(&context).to_string(),
+        Err(error) => error.display(&context).to_string(),
     }
 }

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -88,6 +88,7 @@ impl GcObject {
         self.borrow_mut().extensible = false;
         Ok(true)
     }
+
     /// Delete a property.
     ///
     /// More information:
@@ -588,12 +589,12 @@ impl GcObject {
         self.borrow().keys().collect()
     }
 
-    /// OwnPropertyKeys for ordinary objects
+    /// OwnPropertyKeys for string exotic objects
     ///
     /// More information:
     ///   - [ECMAScript reference][spec]
     ///
-    /// [spec]: https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
+    /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys
     pub fn string_own_property_keys(&self) -> Vec<PropertyKey> {
         let string = self.borrow().as_string().unwrap();
         let mut property_keys = Vec::new();

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -636,7 +636,7 @@ where
 /// Builder for creating native function objects
 #[derive(Debug)]
 pub struct FunctionBuilder<'context> {
-    context: &'context mut Context,
+    context: &'context Context,
     function: BuiltInFunction,
     name: Option<String>,
     length: usize,
@@ -647,7 +647,7 @@ pub struct FunctionBuilder<'context> {
 impl<'context> FunctionBuilder<'context> {
     /// Create a new `FunctionBuilder`
     #[inline]
-    pub fn new(context: &'context mut Context, function: NativeFunction) -> Self {
+    pub fn new(context: &'context Context, function: NativeFunction) -> Self {
         Self {
             context,
             function: function.into(),
@@ -772,14 +772,14 @@ impl<'context> FunctionBuilder<'context> {
 /// ```
 #[derive(Debug)]
 pub struct ObjectInitializer<'context> {
-    context: &'context mut Context,
+    context: &'context Context,
     object: GcObject,
 }
 
 impl<'context> ObjectInitializer<'context> {
     /// Create a new `ObjectBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context) -> Self {
+    pub fn new(context: &'context Context) -> Self {
         let object = context.construct_object();
         Self { context, object }
     }
@@ -827,7 +827,7 @@ impl<'context> ObjectInitializer<'context> {
 
 /// Builder for creating constructors objects, like `Array`.
 pub struct ConstructorBuilder<'context> {
-    context: &'context mut Context,
+    context: &'context Context,
     constructor_function: NativeFunction,
     constructor_object: GcObject,
     prototype: GcObject,
@@ -855,7 +855,7 @@ impl Debug for ConstructorBuilder<'_> {
 impl<'context> ConstructorBuilder<'context> {
     /// Create a new `ConstructorBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context, constructor: NativeFunction) -> Self {
+    pub fn new(context: &'context Context, constructor: NativeFunction) -> Self {
         Self {
             context,
             constructor_function: constructor,
@@ -871,7 +871,7 @@ impl<'context> ConstructorBuilder<'context> {
 
     #[inline]
     pub(crate) fn with_standard_object(
-        context: &'context mut Context,
+        context: &'context Context,
         constructor: NativeFunction,
         object: StandardConstructor,
     ) -> Self {
@@ -1012,7 +1012,7 @@ impl<'context> ConstructorBuilder<'context> {
 
     /// Return the current context.
     #[inline]
-    pub fn context(&mut self) -> &'_ mut Context {
+    pub fn context(&mut self) -> &'_ Context {
         self.context
     }
 

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -47,7 +47,7 @@ impl Realm {
         Self {
             global_object: gc_global.clone(),
             global_env,
-            environment: RefCell::LexicalEnvironment::new(gc_global.into()),
+            environment: RefCell::new(LexicalEnvironment::new(gc_global.into())),
         }
     }
 }

--- a/boa/src/realm.rs
+++ b/boa/src/realm.rs
@@ -16,6 +16,7 @@ use crate::{
 };
 use gc::{Gc, GcCell};
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 
 /// Representation of a Realm.
 ///
@@ -24,7 +25,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 pub struct Realm {
     pub global_object: Value,
     pub global_env: Gc<GcCell<GlobalEnvironmentRecord>>,
-    pub environment: LexicalEnvironment,
+    pub environment: RefCell<LexicalEnvironment>,
 }
 
 impl Realm {
@@ -43,7 +44,7 @@ impl Realm {
         Self {
             global_object: global.clone(),
             global_env,
-            environment: LexicalEnvironment::new(global),
+            environment: RefCell::new(LexicalEnvironment::new(global)),
         }
     }
 }

--- a/boa/src/syntax/ast/node/array/mod.rs
+++ b/boa/src/syntax/ast/node/array/mod.rs
@@ -36,7 +36,7 @@ pub struct ArrayDecl {
 }
 
 impl Executable for ArrayDecl {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("ArrayDecl", "exec");
         let array = Array::new_array(context)?;
         let mut elements = Vec::new();

--- a/boa/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa/src/syntax/ast/node/await_expr/mod.rs
@@ -24,7 +24,7 @@ pub struct AwaitExpr {
 }
 
 impl Executable for AwaitExpr {
-    fn run(&self, _: &mut Context) -> Result<Value> {
+    fn run(&self, _: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("AwaitExpression", "exec");
         // TODO: Implement AwaitExpr
         Ok(Value::Undefined)

--- a/boa/src/syntax/ast/node/break_node/mod.rs
+++ b/boa/src/syntax/ast/node/break_node/mod.rs
@@ -52,9 +52,10 @@ impl Break {
 }
 
 impl Executable for Break {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         context
             .executor()
+            .borrow_mut()
             .set_current_state(InterpreterState::Break(self.label().map(Box::from)));
 
         Ok(Value::undefined())

--- a/boa/src/syntax/ast/node/break_node/tests.rs
+++ b/boa/src/syntax/ast/node/break_node/tests.rs
@@ -13,7 +13,7 @@ fn check_post_state() {
     brk.run(&mut context).unwrap();
 
     assert_eq!(
-        context.executor().get_current_state(),
+        context.executor().borrow().get_current_state(),
         &InterpreterState::Break(Some("label".into()))
     );
 }

--- a/boa/src/syntax/ast/node/call/mod.rs
+++ b/boa/src/syntax/ast/node/call/mod.rs
@@ -58,7 +58,7 @@ impl Call {
 }
 
 impl Executable for Call {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Call", "exec");
         let (this, func) = match self.expr() {
             Node::GetConstField(ref get_const_field) => {
@@ -106,6 +106,7 @@ impl Executable for Call {
         // unset the early return flag
         context
             .executor()
+            .borrow_mut()
             .set_current_state(InterpreterState::Executing);
 
         fnct_result

--- a/boa/src/syntax/ast/node/conditional/conditional_op/mod.rs
+++ b/boa/src/syntax/ast/node/conditional/conditional_op/mod.rs
@@ -60,7 +60,7 @@ impl ConditionalOp {
 }
 
 impl Executable for ConditionalOp {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         Ok(if self.cond().run(context)?.to_boolean() {
             self.if_true().run(context)?
         } else {

--- a/boa/src/syntax/ast/node/conditional/if_node/mod.rs
+++ b/boa/src/syntax/ast/node/conditional/if_node/mod.rs
@@ -79,7 +79,7 @@ impl If {
 }
 
 impl Executable for If {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         Ok(if self.cond().run(context)?.to_boolean() {
             self.body().run(context)?
         } else if let Some(ref else_e) = self.else_node() {

--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -67,7 +67,7 @@ impl ArrowFunctionDecl {
 }
 
 impl Executable for ArrowFunctionDecl {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         Ok(context.create_function(
             self.params().to_vec(),
             self.body().to_vec(),

--- a/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -81,7 +81,7 @@ impl AsyncFunctionDecl {
 }
 
 impl Executable for AsyncFunctionDecl {
-    fn run(&self, _: &mut Context) -> Result<Value> {
+    fn run(&self, _: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("AsyncFunctionDecl", "exec");
         // TODO: Implement AsyncFunctionDecl
         Ok(Value::undefined())

--- a/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
@@ -79,7 +79,7 @@ impl AsyncFunctionExpr {
 }
 
 impl Executable for AsyncFunctionExpr {
-    fn run(&self, _: &mut Context) -> Result<Value> {
+    fn run(&self, _: &Context) -> Result<Value> {
         // TODO: Implement AsyncFunctionExpr
         Ok(Value::Undefined)
     }

--- a/boa/src/syntax/ast/node/declaration/const_decl_list/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/const_decl_list/mod.rs
@@ -36,7 +36,7 @@ pub struct ConstDeclList {
 }
 
 impl Executable for ConstDeclList {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         for decl in self.as_ref() {
             let val = if let Some(init) = decl.init() {
                 init.run(context)?
@@ -44,16 +44,21 @@ impl Executable for ConstDeclList {
                 return context.throw_syntax_error("missing = in const declaration");
             };
             context
-                .realm_mut()
+                .realm()
                 .environment
-                .create_immutable_binding(decl.name().to_owned(), false, VariableScope::Block)
-                .map_err(|e| e.to_error(context))?;
+                .borrow()
+                .create_immutable_binding(
+                    decl.name().to_owned(),
+                    false,
+                    VariableScope::Block,
+                    context,
+                )?;
 
             context
-                .realm_mut()
+                .realm()
                 .environment
-                .initialize_binding(decl.name(), val)
-                .map_err(|e| e.to_error(context))?;
+                .borrow()
+                .initialize_binding(decl.name(), val, context)?;
         }
         Ok(Value::undefined())
     }

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -85,7 +85,7 @@ impl FunctionExpr {
 }
 
 impl Executable for FunctionExpr {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let val = context.create_function(
             self.parameters().to_vec(),
             self.body().to_vec(),

--- a/boa/src/syntax/ast/node/declaration/let_decl_list/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/let_decl_list/mod.rs
@@ -35,22 +35,27 @@ pub struct LetDeclList {
 }
 
 impl Executable for LetDeclList {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         for var in self.as_ref() {
             let val = match var.init() {
                 Some(v) => v.run(context)?,
                 None => Value::undefined(),
             };
             context
-                .realm_mut()
+                .realm()
                 .environment
-                .create_mutable_binding(var.name().to_owned(), false, VariableScope::Block)
-                .map_err(|e| e.to_error(context))?;
+                .borrow()
+                .create_mutable_binding(
+                    var.name().to_owned(),
+                    false,
+                    VariableScope::Block,
+                    context,
+                )?;
             context
-                .realm_mut()
+                .realm()
                 .environment
-                .initialize_binding(var.name(), val)
-                .map_err(|e| e.to_error(context))?;
+                .borrow()
+                .initialize_binding(var.name(), val, context)?;
         }
         Ok(Value::undefined())
     }

--- a/boa/src/syntax/ast/node/field/get_const_field/mod.rs
+++ b/boa/src/syntax/ast/node/field/get_const_field/mod.rs
@@ -63,7 +63,7 @@ impl GetConstField {
 }
 
 impl Executable for GetConstField {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let mut obj = self.obj().run(context)?;
         if obj.get_type() != Type::Object {
             obj = Value::Object(obj.to_object(context)?);

--- a/boa/src/syntax/ast/node/field/get_field/mod.rs
+++ b/boa/src/syntax/ast/node/field/get_field/mod.rs
@@ -62,7 +62,7 @@ impl GetField {
 }
 
 impl Executable for GetField {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let mut obj = self.obj().run(context)?;
         if obj.get_type() != Type::Object {
             obj = Value::Object(obj.to_object(context)?);

--- a/boa/src/syntax/ast/node/identifier/mod.rs
+++ b/boa/src/syntax/ast/node/identifier/mod.rs
@@ -35,12 +35,12 @@ pub struct Identifier {
 }
 
 impl Executable for Identifier {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         context
             .realm()
             .environment
-            .get_binding_value(self.as_ref())
-            .map_err(|e| e.to_error(context))
+            .borrow()
+            .get_binding_value(self.as_ref(), context)
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
@@ -46,9 +46,10 @@ impl Continue {
 }
 
 impl Executable for Continue {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         context
             .executor()
+            .borrow_mut()
             .set_current_state(InterpreterState::Continue(self.label().map(Box::from)));
 
         Ok(Value::undefined())

--- a/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -71,17 +71,18 @@ impl DoWhileLoop {
 }
 
 impl Executable for DoWhileLoop {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let mut result;
         loop {
             result = self.body().run(context)?;
-            match context.executor().get_current_state() {
+            let executor = &mut context.executor().borrow_mut();
+            match executor.get_current_state() {
                 InterpreterState::Break(label) => {
-                    handle_state_with_labels!(self, label, context, break);
+                    handle_state_with_labels!(self, label, executor, break);
                     break;
                 }
                 InterpreterState::Continue(label) => {
-                    handle_state_with_labels!(self, label, context, continue);
+                    handle_state_with_labels!(self, label, executor, continue);
                 }
                 InterpreterState::Return => {
                     return Ok(result);

--- a/boa/src/syntax/ast/node/iteration/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/mod.rs
@@ -24,9 +24,7 @@ macro_rules! handle_state_with_labels {
             }
         }
 
-        $interpreter
-            .executor()
-            .set_current_state(InterpreterState::Executing);
+        $interpreter.set_current_state(InterpreterState::Executing);
     }};
 }
 

--- a/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
@@ -69,17 +69,18 @@ impl WhileLoop {
 }
 
 impl Executable for WhileLoop {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let mut result = Value::undefined();
         while self.cond().run(context)?.to_boolean() {
             result = self.expr().run(context)?;
-            match context.executor().get_current_state() {
+            let executor = &mut context.executor().borrow_mut();
+            match executor.get_current_state() {
                 InterpreterState::Break(label) => {
-                    handle_state_with_labels!(self, label, context, break);
+                    handle_state_with_labels!(self, label, executor, break);
                     break;
                 }
                 InterpreterState::Continue(label) => {
-                    handle_state_with_labels!(self, label, context, continue)
+                    handle_state_with_labels!(self, label, executor, continue)
                 }
                 InterpreterState::Return => {
                     return Ok(result);

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -279,7 +279,7 @@ impl Node {
 }
 
 impl Executable for Node {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Executable", "exec");
         match *self {
             Node::AsyncFunctionDecl(ref decl) => decl.run(context),
@@ -332,8 +332,8 @@ impl Executable for Node {
                 context
                     .realm()
                     .environment
-                    .get_this_binding()
-                    .map_err(|e| e.to_error(context))
+                    .borrow()
+                    .get_this_binding(context)
             }
             Node::Try(ref try_node) => try_node.run(context),
             Node::Break(ref break_node) => break_node.run(context),

--- a/boa/src/syntax/ast/node/new/mod.rs
+++ b/boa/src/syntax/ast/node/new/mod.rs
@@ -45,7 +45,7 @@ impl New {
 }
 
 impl Executable for New {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("New", "exec");
 
         let func_object = self.expr().run(context)?;

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -72,7 +72,7 @@ impl Object {
 }
 
 impl Executable for Object {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let obj = Value::new_object(context);
 
         // TODO: Implement the rest of the property types.
@@ -99,7 +99,7 @@ impl Executable for Object {
                     }
                     MethodDefinitionKind::Get => {
                         let set = obj
-                            .get_property(name.clone())
+                            .get_property(name.clone(), context)?
                             .as_ref()
                             .and_then(|p| p.as_accessor_descriptor())
                             .and_then(|a| a.setter().cloned());
@@ -116,7 +116,7 @@ impl Executable for Object {
                     }
                     MethodDefinitionKind::Set => {
                         let get = obj
-                            .get_property(name.clone())
+                            .get_property(name.clone(), context)?
                             .as_ref()
                             .and_then(|p| p.as_accessor_descriptor())
                             .and_then(|a| a.getter().cloned());

--- a/boa/src/syntax/ast/node/operator/assign/mod.rs
+++ b/boa/src/syntax/ast/node/operator/assign/mod.rs
@@ -53,30 +53,24 @@ impl Assign {
 }
 
 impl Executable for Assign {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("Assign", "exec");
         let val = self.rhs().run(context)?;
         match self.lhs() {
             Node::Identifier(ref name) => {
-                let environment = &mut context.realm_mut().environment;
+                let environment = &mut context.realm().environment.borrow();
 
-                if environment.has_binding(name.as_ref()) {
+                if environment.has_binding(name.as_ref(), context)? {
                     // Binding already exists
-                    environment
-                        .set_mutable_binding(name.as_ref(), val.clone(), true)
-                        .map_err(|e| e.to_error(context))?;
+                    environment.set_mutable_binding(name.as_ref(), val.clone(), true, context)?;
                 } else {
-                    environment
-                        .create_mutable_binding(
-                            name.as_ref().to_owned(),
-                            true,
-                            VariableScope::Function,
-                        )
-                        .map_err(|e| e.to_error(context))?;
-                    let environment = &mut context.realm_mut().environment;
-                    environment
-                        .initialize_binding(name.as_ref(), val.clone())
-                        .map_err(|e| e.to_error(context))?;
+                    environment.create_mutable_binding(
+                        name.as_ref().to_owned(),
+                        true,
+                        VariableScope::Function,
+                        context,
+                    )?;
+                    environment.initialize_binding(name.as_ref(), val.clone(), context)?;
                 }
             }
             Node::GetConstField(ref get_const_field) => {

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -54,7 +54,7 @@ impl UnaryOp {
 }
 
 impl Executable for UnaryOp {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let x = self.target().run(context)?;
 
         Ok(match self.op() {
@@ -97,14 +97,14 @@ impl Executable for UnaryOp {
                         .obj()
                         .run(context)?
                         .to_object(context)?
-                        .delete(&get_const_field.field().into()),
+                        .delete(&get_const_field.field().into(), context)?,
                 ),
                 Node::GetField(ref get_field) => {
                     let obj = get_field.obj().run(context)?;
                     let field = &get_field.field().run(context)?;
                     let res = obj
                         .to_object(context)?
-                        .delete(&field.to_property_key(context)?);
+                        .delete(&field.to_property_key(context)?, context)?;
                     return Ok(Value::boolean(res));
                 }
                 Node::Identifier(_) => Value::boolean(false),

--- a/boa/src/syntax/ast/node/return_smt/mod.rs
+++ b/boa/src/syntax/ast/node/return_smt/mod.rs
@@ -58,7 +58,7 @@ impl Return {
 }
 
 impl Executable for Return {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let result = match self.expr() {
             Some(ref v) => v.run(context),
             None => Ok(Value::undefined()),
@@ -66,6 +66,7 @@ impl Executable for Return {
         // Set flag for return
         context
             .executor()
+            .borrow_mut()
             .set_current_state(InterpreterState::Return);
         result
     }

--- a/boa/src/syntax/ast/node/spread/mod.rs
+++ b/boa/src/syntax/ast/node/spread/mod.rs
@@ -52,7 +52,7 @@ impl Spread {
 }
 
 impl Executable for Spread {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         // TODO: for now we can do nothing but return the value as-is
         self.val().run(context)
     }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -58,18 +58,21 @@ impl StatementList {
 }
 
 impl Executable for StatementList {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("StatementList", "exec");
 
         // https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation
         // The return value is uninitialized, which means it defaults to Value::Undefined
         let mut obj = Value::default();
-        context
-            .executor()
-            .set_current_state(InterpreterState::Executing);
+        {
+            context
+                .executor()
+                .borrow_mut()
+                .set_current_state(InterpreterState::Executing);
+        }
         for (i, item) in self.items().iter().enumerate() {
             let val = item.run(context)?;
-            match context.executor().get_current_state() {
+            match context.executor().borrow().get_current_state() {
                 InterpreterState::Return => {
                     // Early return.
                     obj = val;

--- a/boa/src/syntax/ast/node/template/mod.rs
+++ b/boa/src/syntax/ast/node/template/mod.rs
@@ -32,7 +32,7 @@ impl TemplateLit {
 }
 
 impl Executable for TemplateLit {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("TemplateLiteral", "exec");
         let mut result = String::new();
 
@@ -85,7 +85,7 @@ impl TaggedTemplate {
 }
 
 impl Executable for TaggedTemplate {
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         let _timer = BoaProfiler::global().start_event("TaggedTemplate", "exec");
 
         let template_object = Array::new_array(context)?;

--- a/boa/src/syntax/ast/node/throw/mod.rs
+++ b/boa/src/syntax/ast/node/throw/mod.rs
@@ -47,7 +47,7 @@ impl Throw {
 
 impl Executable for Throw {
     #[inline]
-    fn run(&self, context: &mut Context) -> Result<Value> {
+    fn run(&self, context: &Context) -> Result<Value> {
         Err(self.expr().run(context)?)
     }
 }

--- a/boa/src/value/equality.rs
+++ b/boa/src/value/equality.rs
@@ -37,7 +37,7 @@ impl Value {
     /// This method is executed when doing abstract equality comparisons with the `==` operator.
     ///  For more information, check <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
     #[allow(clippy::float_cmp)]
-    pub fn equals(&self, other: &Self, context: &mut Context) -> Result<bool> {
+    pub fn equals(&self, other: &Self, context: &Context) -> Result<bool> {
         // 1. If Type(x) is the same as Type(y), then
         //     a. Return the result of performing Strict Equality Comparison x === y.
         if self.get_type() == other.get_type() {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -604,11 +604,12 @@ impl Value {
     /// # Examples
     ///
     /// ```
-    /// use boa::Value;
+    /// use boa::{Context, Value};
+    ///
     /// let context = Context::new();
     /// let value = Value::number(3);
     ///
-    /// println!("{}", value.display(context));
+    /// println!("{}", value.display(&context));
     /// ```
     #[inline]
     pub fn display<'a>(&'a self, context: &'a Context) -> ValueDisplay<'a> {

--- a/boa/src/value/operations.rs
+++ b/boa/src/value/operations.rs
@@ -3,7 +3,7 @@ use crate::builtins::number::{f64_to_int32, f64_to_uint32, Number};
 
 impl Value {
     #[inline]
-    pub fn add(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn add(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) + f64::from(*y)),
@@ -45,7 +45,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn sub(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn sub(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) - f64::from(*y)),
@@ -73,7 +73,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn mul(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn mul(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) * f64::from(*y)),
@@ -101,7 +101,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn div(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn div(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x) / f64::from(*y)),
@@ -135,7 +135,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn rem(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn rem(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => {
@@ -172,7 +172,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn pow(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn pow(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::rational(f64::from(*x).powi(*y)),
@@ -206,7 +206,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitand(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn bitand(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x & y),
@@ -238,7 +238,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitor(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn bitor(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x | y),
@@ -270,7 +270,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn bitxor(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn bitxor(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x ^ y),
@@ -302,7 +302,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn shl(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn shl(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x.wrapping_shl(*y as u32)),
@@ -344,7 +344,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn shr(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn shr(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::integer(x.wrapping_shr(*y as u32)),
@@ -386,7 +386,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn ushr(&self, other: &Self, context: &mut Context) -> Result<Value> {
+    pub fn ushr(&self, other: &Self, context: &Context) -> Result<Value> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => {
@@ -421,7 +421,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn neg(&self, context: &mut Context) -> Result<Value> {
+    pub fn neg(&self, context: &Context) -> Result<Value> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::rational(NAN),
             Self::Object(_) => Self::rational(match self.to_numeric_number(context) {
@@ -441,7 +441,7 @@ impl Value {
     }
 
     #[inline]
-    pub fn not(&self, _: &mut Context) -> Result<bool> {
+    pub fn not(&self, _: &Context) -> Result<bool> {
         Ok(!self.to_boolean())
     }
 
@@ -466,7 +466,7 @@ impl Value {
         &self,
         other: &Self,
         left_first: bool,
-        context: &mut Context,
+        context: &Context,
     ) -> Result<AbstractRelation> {
         Ok(match (self, other) {
             // Fast path (for some common operations):
@@ -565,7 +565,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn lt(&self, other: &Self, context: &mut Context) -> Result<bool> {
+    pub fn lt(&self, other: &Self, context: &Context) -> Result<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -582,7 +582,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn le(&self, other: &Self, context: &mut Context) -> Result<bool> {
+    pub fn le(&self, other: &Self, context: &Context) -> Result<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),
@@ -599,7 +599,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn gt(&self, other: &Self, context: &mut Context) -> Result<bool> {
+    pub fn gt(&self, other: &Self, context: &Context) -> Result<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -616,7 +616,7 @@ impl Value {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn ge(&self, other: &Self, context: &mut Context) -> Result<bool> {
+    pub fn ge(&self, other: &Self, context: &Context) -> Result<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -23,9 +23,10 @@ fn string_to_value() {
 
 #[test]
 fn undefined() {
+    let context = Context::new();
     let u = Value::Undefined;
     assert_eq!(u.get_type(), Type::Undefined);
-    assert_eq!(u.display().to_string(), "undefined");
+    assert_eq!(u.display(&context).to_string(), "undefined");
 }
 
 #[test]
@@ -38,7 +39,7 @@ fn get_set_field() {
     assert_eq!(
         obj.get_field("foo", &mut context)
             .unwrap()
-            .display()
+            .display(&context)
             .to_string(),
         "\"bar\""
     );
@@ -229,7 +230,8 @@ fn get_types() {
 
 #[test]
 fn to_string() {
-    let f64_to_str = |f| Value::Rational(f).display().to_string();
+    let context = Context::new();
+    let f64_to_str = |f| Value::Rational(f).display(&context).to_string();
 
     assert_eq!(f64_to_str(f64::NAN), "NaN");
     assert_eq!(f64_to_str(0.0), "0");
@@ -267,7 +269,8 @@ fn string_length_is_not_enumerable() {
 
     let object = Value::from("foo").to_object(&mut context).unwrap();
     let length_desc = object
-        .get_own_property(&PropertyKey::from("length"))
+        .get_own_property(&PropertyKey::from("length"), &context)
+        .unwrap()
         .unwrap();
     assert!(!length_desc.enumerable());
 }
@@ -279,7 +282,8 @@ fn string_length_is_in_utf16_codeunits() {
     // 😀 is one Unicode code point, but 2 UTF-16 code units
     let object = Value::from("😀").to_object(&mut context).unwrap();
     let length_desc = object
-        .get_own_property(&PropertyKey::from("length"))
+        .get_own_property(&PropertyKey::from("length"), &context)
+        .unwrap()
         .unwrap();
     assert_eq!(
         length_desc
@@ -447,9 +451,10 @@ fn assign_pow_number_and_string() {
 
 #[test]
 fn display_string() {
+    let context = Context::new();
     let s = String::from("Hello");
     let v = Value::from(s);
-    assert_eq!(v.display().to_string(), "\"Hello\"");
+    assert_eq!(v.display(&context).to_string(), "\"Hello\"");
 }
 
 #[test]
@@ -457,7 +462,7 @@ fn display_array_string() {
     let mut context = Context::new();
 
     let value = forward_val(&mut context, "[\"Hello\"]").unwrap();
-    assert_eq!(value.display().to_string(), "[ \"Hello\" ]");
+    assert_eq!(value.display(&context).to_string(), "[ \"Hello\" ]");
 }
 
 #[test]
@@ -468,7 +473,7 @@ fn display_boolean_object() {
         bool
     "#;
     let value = forward_val(&mut context, d_obj).unwrap();
-    assert_eq!(value.display().to_string(), "Boolean { false }")
+    assert_eq!(value.display(&context).to_string(), "Boolean { false }")
 }
 
 #[test]
@@ -479,7 +484,7 @@ fn display_number_object() {
         num
     "#;
     let value = forward_val(&mut context, d_obj).unwrap();
-    assert_eq!(value.display().to_string(), "Number { 3.14 }")
+    assert_eq!(value.display(&context).to_string(), "Number { 3.14 }")
 }
 
 #[test]
@@ -490,7 +495,7 @@ fn display_negative_zero_object() {
         num
     "#;
     let value = forward_val(&mut context, d_obj).unwrap();
-    assert_eq!(value.display().to_string(), "Number { -0 }")
+    assert_eq!(value.display(&context).to_string(), "Number { -0 }")
 }
 
 #[test]
@@ -516,7 +521,7 @@ fn display_object() {
     "#;
     let value = forward_val(&mut context, d_obj).unwrap();
     assert_eq!(
-        value.display().to_string(),
+        value.display(&context).to_string(),
         r#"{
    a: "a",
 __proto__: {

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -218,7 +218,7 @@ impl<'a> VM<'a> {
                         ));
                     }
                     let key = l.to_property_key(self.ctx)?;
-                    let val = self.ctx.has_property(&r, &key);
+                    let val = self.ctx.has_property(&r, &key)?;
 
                     self.push(val.into());
                 }

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -152,8 +152,8 @@ pub fn main() -> Result<(), std::io::Error> {
             }
         } else {
             match context.eval(&buffer) {
-                Ok(v) => println!("{}", v.display()),
-                Err(v) => eprintln!("Uncaught {}", v.display()),
+                Ok(v) => println!("{}", v.display(&context)),
+                Err(v) => eprintln!("Uncaught {}", v.display(&context)),
             }
         }
     }
@@ -188,9 +188,13 @@ pub fn main() -> Result<(), std::io::Error> {
                         }
                     } else {
                         match context.eval(line.trim_end()) {
-                            Ok(v) => println!("{}", v.display()),
+                            Ok(v) => println!("{}", v.display(&context)),
                             Err(v) => {
-                                eprintln!("{}: {}", "Uncaught".red(), v.display().to_string().red())
+                                eprintln!(
+                                    "{}: {}",
+                                    "Uncaught".red(),
+                                    v.display(&context).to_string().red()
+                                )
                             }
                         }
                     }

--- a/boa_tester/src/exec.rs
+++ b/boa_tester/src/exec.rs
@@ -132,8 +132,8 @@ impl Test {
 
                             let passed = res.is_ok();
                             let text = match res {
-                                Ok(val) => format!("{}", val.display()),
-                                Err(e) => format!("Uncaught {}", e.display()),
+                                Ok(val) => format!("{}", val.display(&context)),
+                                Err(e) => format!("Uncaught {}", e.display(&context)),
                             };
 
                             (passed, text)
@@ -174,12 +174,14 @@ impl Test {
                     } else {
                         match self.set_up_env(&harness, strict) {
                             Ok(mut context) => match context.eval(&self.content.as_ref()) {
-                                Ok(res) => (false, format!("{}", res.display())),
+                                Ok(res) => (false, format!("{}", res.display(&context))),
                                 Err(e) => {
-                                    let passed =
-                                        e.display().to_string().contains(error_type.as_ref());
+                                    let passed = e
+                                        .display(&context)
+                                        .to_string()
+                                        .contains(error_type.as_ref());
 
-                                    (passed, format!("Uncaught {}", e.display()))
+                                    (passed, format!("Uncaught {}", e.display(&context)))
                                 }
                             },
                             Err(e) => (false, e),
@@ -259,7 +261,7 @@ impl Test {
             .map_err(|e| {
                 format!(
                     "could not register the global print() function:\n{}",
-                    e.display()
+                    e.display(&context)
                 )
             })?;
         // TODO: add the $262 object.
@@ -267,15 +269,15 @@ impl Test {
         if strict {
             context
                 .eval(r#""use strict";"#)
-                .map_err(|e| format!("could not set strict mode:\n{}", e.display()))?;
+                .map_err(|e| format!("could not set strict mode:\n{}", e.display(&context)))?;
         }
 
         context
             .eval(&harness.assert.as_ref())
-            .map_err(|e| format!("could not run assert.js:\n{}", e.display()))?;
+            .map_err(|e| format!("could not run assert.js:\n{}", e.display(&context)))?;
         context
             .eval(&harness.sta.as_ref())
-            .map_err(|e| format!("could not run sta.js:\n{}", e.display()))?;
+            .map_err(|e| format!("could not run sta.js:\n{}", e.display(&context)))?;
 
         for include in self.includes.iter() {
             context
@@ -290,7 +292,7 @@ impl Test {
                     format!(
                         "could not run the {} include file:\nUncaught {}",
                         include,
-                        e.display()
+                        e.display(&context)
                     )
                 })?;
         }
@@ -300,6 +302,6 @@ impl Test {
 }
 
 /// `print()` function required by the test262 suite.
-fn test262_print(_this: &Value, _: &[Value], _context: &mut Context) -> boa::Result<Value> {
+fn test262_print(_this: &Value, _: &[Value], _context: &Context) -> boa::Result<Value> {
     todo!("print() function");
 }

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -4,7 +4,7 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn evaluate(src: &str) -> Result<String, JsValue> {
     // Setup executor
-    let mut context = Context::new();
+    let context = Context::new();
 
     let expr = match parse(src, false) {
         Ok(res) => res,
@@ -14,12 +14,12 @@ pub fn evaluate(src: &str) -> Result<String, JsValue> {
                 context
                     .throw_syntax_error(e.to_string())
                     .expect_err("interpreter.throw_syntax_error() did not return an error")
-                    .display()
+                    .display(&context)
             )
             .into());
         }
     };
-    expr.run(&mut context)
-        .map_err(|e| JsValue::from(format!("Uncaught {}", e.display())))
-        .map(|v| v.display().to_string())
+    expr.run(&context)
+        .map_err(|e| JsValue::from(format!("Uncaught {}", e.display(&context))))
+        .map(|v| v.display(&context).to_string())
 }


### PR DESCRIPTION
This Pull Request fixes #591 and #602.

It changes the following:

- All internal methods of `GcObject` take a `&Context` and return a `Result`
- Implementation of specific internal methods for `String`
- `Context` becomes externally immutable, with only interior mutability
- `LexicalEnvironment` becomes externally immutable, with only interior mutability
