### PR TITLE
Fix lexing escapes in string literal and minor refactor

### DIFF
--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -129,8 +129,7 @@ impl StringLiteral {
                         '\\' => buf.push(0x005C /* \ */),
                         '0' if cursor
                             .peek()?
-                            .and_then(|next_byte| char::try_from(next_byte).ok())
-                            .filter(|next_ch| next_ch.is_digit(10))
+                            .filter(|next_byte| (b'0'..=b'9').contains(next_byte))
                             .is_none() =>
                         {
                             buf.push(0x0000 /* NULL */)
@@ -303,14 +302,14 @@ impl StringLiteral {
         // Grammar: ZeroToThree OctalDigit
         // Grammar: FourToSeven OctalDigit
         if let Some(byte) = cursor.peek()? {
-            if (b'0'..b'8').contains(&byte) {
+            if (b'0'..=b'7').contains(&byte) {
                 let _ = cursor.next_byte()?;
                 code_point = (code_point * 8) + (byte - b'0') as u32;
 
-                if (b'0'..b'4').contains(&init_byte) {
+                if (b'0'..=b'3').contains(&init_byte) {
                     // Grammar: ZeroToThree OctalDigit OctalDigit
                     if let Some(byte) = cursor.peek()? {
-                        if (b'0'..b'8').contains(&byte) {
+                        if (b'0'..=b'7').contains(&byte) {
                             let _ = cursor.next_byte()?;
                             code_point = (code_point * 8) + (byte - b'0') as u32;
                         }

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -107,7 +107,8 @@ impl StringLiteral {
                             b'f' => buf.push('\x0c' as u16),
                             b'0' if cursor
                                 .peek()?
-                                .filter(|next_byte| (*next_byte as char).is_digit(10))
+                                .and_then(|next_byte| char::try_from(next_byte).ok())
+                                .filter(|next_ch| next_ch.is_digit(10))
                                 .is_none() =>
                             {
                                 buf.push('\0' as u16)
@@ -197,7 +198,7 @@ impl StringLiteral {
 
             Ok(code_point)
         } else {
-            // Hex4Digits
+            // Grammar: Hex4Digits
             // Collect each character after \u e.g \uD83D will give "D83D"
             let mut code_point_utf8_bytes = [0u8; 4];
             cursor.fill_bytes(&mut code_point_utf8_bytes)?;

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -140,7 +140,18 @@ impl StringLiteral {
                         'u' => {
                             Self::take_unicode_escape_sequence(cursor, Some(&mut buf))?;
                         }
-                        _ if escape_ch.is_digit(10) => {
+                        '8' | '9' => {
+                            // Grammar: NonOctalDecimalEscapeSequence
+                            if strict_mode {
+                                return Err(Error::syntax(
+                                    "\\8 and \\9 are not allowed in strict mode.",
+                                    cursor.pos(),
+                                ));
+                            } else {
+                                buf.push(escape_ch as u16);
+                            }
+                        }
+                        _ if escape_ch.is_digit(8) => {
                             Self::take_legacy_octal_escape_sequence(
                                 cursor,
                                 Some(&mut buf),

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -58,14 +58,14 @@ impl<R> Tokenizer<R> for StringLiteral {
         let _timer = BoaProfiler::global().start_event("StringLiteral", "Lexing");
 
         let (lit, span) =
-            Self::unescape_string(cursor, start_pos, self.terminator, cursor.strict_mode())?;
+            Self::take_string_characters(cursor, start_pos, self.terminator, cursor.strict_mode())?;
 
         Ok(Token::new(TokenKind::string_literal(lit), span))
     }
 }
 
 impl StringLiteral {
-    pub(super) fn unescape_string<R>(
+    pub(super) fn take_string_characters<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
         terminator: StringTerminator,
@@ -114,13 +114,13 @@ impl StringLiteral {
                                 buf.push('\0' as u16)
                             }
                             b'x' => {
-                                Self::hex_escape_sequence(cursor, Some(&mut buf))?;
+                                Self::take_hex_escape_sequence(cursor, Some(&mut buf))?;
                             }
                             b'u' => {
-                                Self::unicode_escape_sequence(cursor, Some(&mut buf))?;
+                                Self::take_unicode_escape_sequence(cursor, Some(&mut buf))?;
                             }
                             byte if (b'0'..b'8').contains(&byte) => {
-                                Self::legacy_octal_escape_sequence(
+                                Self::take_legacy_octal_escape_sequence(
                                     cursor,
                                     Some(&mut buf),
                                     strict_mode,
@@ -160,7 +160,7 @@ impl StringLiteral {
     }
 
     #[inline]
-    pub(super) fn unicode_escape_sequence<R>(
+    pub(super) fn take_unicode_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         code_units_buf: Option<&mut Vec<u16>>,
     ) -> Result<u32, Error>
@@ -218,7 +218,7 @@ impl StringLiteral {
     }
 
     #[inline]
-    fn hex_escape_sequence<R>(
+    fn take_hex_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         code_units_buf: Option<&mut Vec<u16>>,
     ) -> Result<u32, Error>
@@ -240,7 +240,7 @@ impl StringLiteral {
     }
 
     #[inline]
-    fn legacy_octal_escape_sequence<R>(
+    fn take_legacy_octal_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         code_units_buf: Option<&mut Vec<u16>>,
         strict_mode: bool,

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -105,7 +105,13 @@ impl StringLiteral {
                             b't' => buf.push('\t' as u16),
                             b'b' => buf.push('\x08' as u16),
                             b'f' => buf.push('\x0c' as u16),
-                            b'0' => buf.push('\0' as u16),
+                            b'0' if cursor
+                                .peek()?
+                                .filter(|next_byte| (*next_byte as char).is_digit(10))
+                                .is_none() =>
+                            {
+                                buf.push('\0' as u16)
+                            }
                             b'x' => {
                                 Self::hex_escape_sequence(cursor, Some(&mut buf))?;
                             }

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -76,9 +76,9 @@ impl StringLiteral {
     {
         let mut buf = Vec::new();
         loop {
-            let next_chr = cursor.next_char()?.map(char::try_from).transpose().unwrap();
+            let next_ch = cursor.next_char()?.map(char::try_from).transpose().unwrap();
 
-            match next_chr {
+            match next_ch {
                 Some('\'') if terminator == StringTerminator::SingleQuote => {
                     break;
                 }
@@ -135,10 +135,10 @@ impl StringLiteral {
                     if next_ch.len_utf16() == 1 {
                         buf.push(next_ch as u16);
                     } else {
-                        let mut code_point_bytes_buf = [0u16; 2];
-                        let code_point_bytes = next_ch.encode_utf16(&mut code_point_bytes_buf);
+                        let mut code_units_buf = [0u16; 2];
+                        let code_units_buf = next_ch.encode_utf16(&mut code_units_buf);
 
-                        buf.extend(code_point_bytes.iter());
+                        buf.extend(code_units_buf.iter());
                     }
                 }
                 None if terminator != StringTerminator::End => {

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -160,7 +160,7 @@ impl StringLiteral {
                             )?;
                         }
                         _ if Self::is_line_terminator(escape_ch) => {
-                            // Match LineContinuation
+                            // Grammar: LineContinuation
                             // Grammar: \ LineTerminatorSequence
                             // LineContinuation is the empty String. Do nothing and continue lexing.
                         }

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -144,7 +144,7 @@ impl StringLiteral {
                             // Grammar: NonOctalDecimalEscapeSequence
                             if strict_mode {
                                 return Err(Error::syntax(
-                                    "\\8 and \\9 are not allowed in strict mode.",
+                                    "\\8 and \\9 are not allowed in strict mode",
                                     cursor.pos(),
                                 ));
                             } else {
@@ -287,7 +287,7 @@ impl StringLiteral {
     {
         if strict_mode {
             return Err(Error::syntax(
-                "octal escape sequences are deprecated",
+                "octal escape sequences are not allowed in strict mode",
                 cursor.pos(),
             ));
         }

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -58,171 +58,219 @@ impl<R> Tokenizer<R> for StringLiteral {
         let _timer = BoaProfiler::global().start_event("StringLiteral", "Lexing");
 
         let (lit, span) =
-            unescape_string(cursor, start_pos, self.terminator, cursor.strict_mode())?;
+            Self::unescape_string(cursor, start_pos, self.terminator, cursor.strict_mode())?;
 
         Ok(Token::new(TokenKind::string_literal(lit), span))
     }
 }
 
-pub(super) fn unescape_string<R>(
-    cursor: &mut Cursor<R>,
-    start_pos: Position,
-    terminator: StringTerminator,
-    strict_mode: bool,
-) -> Result<(String, Span), Error>
-where
-    R: Read,
-{
-    let mut buf = Vec::new();
-    loop {
-        let next_chr = cursor.next_char()?.map(char::try_from).transpose().unwrap();
+impl StringLiteral {
+    pub(super) fn unescape_string<R>(
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        terminator: StringTerminator,
+        strict_mode: bool,
+    ) -> Result<(String, Span), Error>
+    where
+        R: Read,
+    {
+        let mut buf = Vec::new();
+        loop {
+            let next_chr = cursor.next_char()?.map(char::try_from).transpose().unwrap();
 
-        match next_chr {
-            Some('\'') if terminator == StringTerminator::SingleQuote => {
-                break;
-            }
-            Some('"') if terminator == StringTerminator::DoubleQuote => {
-                break;
-            }
-            Some('\\') => {
-                let _timer =
-                    BoaProfiler::global().start_event("StringLiteral - escape sequence", "Lexing");
+            match next_chr {
+                Some('\'') if terminator == StringTerminator::SingleQuote => {
+                    break;
+                }
+                Some('"') if terminator == StringTerminator::DoubleQuote => {
+                    break;
+                }
+                Some('\\') => {
+                    let _timer = BoaProfiler::global()
+                        .start_event("StringLiteral - escape sequence", "Lexing");
 
-                let escape = cursor.peek()?.ok_or_else(|| {
-                    Error::from(io::Error::new(
+                    let escape = cursor.peek()?.ok_or_else(|| {
+                        Error::from(io::Error::new(
+                            ErrorKind::UnexpectedEof,
+                            "unterminated escape sequence in literal",
+                        ))
+                    })?;
+
+                    if escape <= 0x7f {
+                        let _ = cursor.next_byte()?;
+                        match escape {
+                            b'\n' => (),
+                            b'n' => buf.push('\n' as u16),
+                            b'r' => buf.push('\r' as u16),
+                            b't' => buf.push('\t' as u16),
+                            b'b' => buf.push('\x08' as u16),
+                            b'f' => buf.push('\x0c' as u16),
+                            b'0' => buf.push('\0' as u16),
+                            b'x' => {
+                                Self::hex_escape_sequence(cursor, Some(&mut buf))?;
+                            }
+                            b'u' => {
+                                Self::unicode_escape_sequence(cursor, Some(&mut buf))?;
+                            }
+                            n if char::is_digit(char::from(n), 8) => {
+                                Self::legacy_octal_escape_sequence(
+                                    cursor,
+                                    Some(&mut buf),
+                                    strict_mode,
+                                    n,
+                                )?;
+                            }
+                            _ => buf.push(escape as u16),
+                        };
+                    }
+                }
+                Some(next_ch) => {
+                    if next_ch.len_utf16() == 1 {
+                        buf.push(next_ch as u16);
+                    } else {
+                        let mut code_point_bytes_buf = [0u16; 2];
+                        let code_point_bytes = next_ch.encode_utf16(&mut code_point_bytes_buf);
+
+                        buf.extend(code_point_bytes.iter());
+                    }
+                }
+                None if terminator != StringTerminator::End => {
+                    return Err(Error::from(io::Error::new(
                         ErrorKind::UnexpectedEof,
-                        "unterminated escape sequence in literal",
-                    ))
-                })?;
-
-                if escape <= 0x7f {
-                    let _ = cursor.next_byte()?;
-                    match escape {
-                        b'\n' => (),
-                        b'n' => buf.push('\n' as u16),
-                        b'r' => buf.push('\r' as u16),
-                        b't' => buf.push('\t' as u16),
-                        b'b' => buf.push('\x08' as u16),
-                        b'f' => buf.push('\x0c' as u16),
-                        b'0' => buf.push('\0' as u16),
-                        b'x' => {
-                            let mut code_point_utf8_bytes = [0u8; 2];
-                            cursor.fill_bytes(&mut code_point_utf8_bytes)?;
-                            let code_point_str = str::from_utf8(&code_point_utf8_bytes)
-                                .expect("malformed Hexadecimal character escape sequence");
-                            let code_point =
-                                u16::from_str_radix(&code_point_str, 16).map_err(|_| {
-                                    Error::syntax(
-                                        "invalid Hexadecimal escape sequence",
-                                        cursor.pos(),
-                                    )
-                                })?;
-
-                            buf.push(code_point);
-                        }
-                        b'u' => {
-                            // Support \u{X..X} (Unicode Codepoint)
-                            if cursor.next_is(b'{')? {
-                                // TODO: use bytes for a bit better performance (using stack)
-                                let mut code_point_buf = Vec::with_capacity(6);
-                                cursor.take_until(b'}', &mut code_point_buf)?;
-
-                                let code_point_str =
-                                    unsafe { str::from_utf8_unchecked(code_point_buf.as_slice()) };
-                                // We know this is a single unicode codepoint, convert to u32
-                                let code_point =
-                                    u32::from_str_radix(&code_point_str, 16).map_err(|_| {
-                                        Error::syntax(
-                                            "malformed Unicode character escape sequence",
-                                            cursor.pos(),
-                                        )
-                                    })?;
-
-                                // UTF16Encoding of a numeric code point value
-                                if code_point > 0x10_FFFF {
-                                    return Err(Error::syntax("Unicode codepoint must not be greater than 0x10FFFF in escape sequence", cursor.pos()));
-                                } else if code_point <= 65535 {
-                                    buf.push(code_point as u16);
-                                } else {
-                                    let cu1 = ((code_point - 65536) / 1024 + 0xD800) as u16;
-                                    let cu2 = ((code_point - 65536) % 1024 + 0xDC00) as u16;
-                                    buf.push(cu1);
-                                    buf.push(cu2);
-                                }
-                            } else {
-                                // Collect each character after \u e.g \uD83D will give "D83D"
-                                let mut code_point_utf8_bytes = [0u8; 4];
-                                cursor.fill_bytes(&mut code_point_utf8_bytes)?;
-
-                                // Convert to u16
-                                let code_point_str = str::from_utf8(&code_point_utf8_bytes)
-                                    .expect("malformed Unicode character escape sequence");
-                                let code_point =
-                                    u16::from_str_radix(code_point_str, 16).map_err(|_| {
-                                        Error::syntax(
-                                            "invalid Unicode escape sequence",
-                                            cursor.pos(),
-                                        )
-                                    })?;
-
-                                buf.push(code_point);
-                            }
-                        }
-                        n if char::is_digit(char::from(n), 8) => {
-                            if strict_mode {
-                                return Err(Error::syntax(
-                                    "octal escape sequences are deprecated",
-                                    cursor.pos(),
-                                ));
-                            }
-                            let mut o = char::from(n).to_digit(8).unwrap();
-
-                            match cursor.peek()? {
-                                Some(c) if char::is_digit(char::from(c), 8) => {
-                                    let _ = cursor.next_byte()?;
-                                    o = o * 8 + char::from(n).to_digit(8).unwrap();
-                                    if n <= b'3' {
-                                        match cursor.peek()? {
-                                            Some(c) if char::is_digit(char::from(c), 8) => {
-                                                let _ = cursor.next_byte();
-                                                o = o * 8 + char::from(n).to_digit(8).unwrap();
-                                            }
-                                            _ => (),
-                                        }
-                                    }
-                                }
-                                _ => (),
-                            }
-                            buf.push(o as u16);
-                        }
-                        _ => buf.push(escape as u16),
-                    };
+                        "unterminated string literal",
+                    )));
+                }
+                None => {
+                    break;
                 }
             }
-            Some(next_ch) => {
-                if next_ch.len_utf16() == 1 {
-                    buf.push(next_ch as u16);
+        }
+
+        Ok((
+            String::from_utf16_lossy(buf.as_slice()),
+            Span::new(start_pos, cursor.pos()),
+        ))
+    }
+
+    #[inline]
+    pub(super) fn unicode_escape_sequence<R>(
+        cursor: &mut Cursor<R>,
+        code_units_buf: Option<&mut Vec<u16>>,
+    ) -> Result<u32, Error>
+    where
+        R: Read,
+    {
+        // Support \u{X..X} (Unicode CodePoint)
+        if cursor.next_is(b'{')? {
+            // TODO: use bytes for a bit better performance (using stack)
+            let mut code_point_buf = Vec::with_capacity(6);
+            cursor.take_until(b'}', &mut code_point_buf)?;
+
+            let code_point_str = unsafe { str::from_utf8_unchecked(code_point_buf.as_slice()) };
+            // We know this is a single unicode codepoint, convert to u32
+            let code_point = u32::from_str_radix(&code_point_str, 16).map_err(|_| {
+                Error::syntax("malformed Unicode character escape sequence", cursor.pos())
+            })?;
+
+            // UTF16Encoding of a numeric code point value
+            if code_point > 0x10_FFFF {
+                return Err(Error::syntax(
+                    "Unicode codepoint must not be greater than 0x10FFFF in escape sequence",
+                    cursor.pos(),
+                ));
+            } else if let Some(code_units_buf) = code_units_buf {
+                if code_point <= 65535 {
+                    code_units_buf.push(code_point as u16);
                 } else {
-                    let mut code_point_bytes_buf = [0u16; 2];
-                    let code_point_bytes = next_ch.encode_utf16(&mut code_point_bytes_buf);
-
-                    buf.extend(code_point_bytes.iter());
+                    let cu1 = ((code_point - 65536) / 1024 + 0xD800) as u16;
+                    let cu2 = ((code_point - 65536) % 1024 + 0xDC00) as u16;
+                    code_units_buf.push(cu1);
+                    code_units_buf.push(cu2);
                 }
             }
-            None if terminator != StringTerminator::End => {
-                return Err(Error::from(io::Error::new(
-                    ErrorKind::UnexpectedEof,
-                    "unterminated string literal",
-                )));
+
+            Ok(code_point)
+        } else {
+            // Hex4Digits
+            // Collect each character after \u e.g \uD83D will give "D83D"
+            let mut code_point_utf8_bytes = [0u8; 4];
+            cursor.fill_bytes(&mut code_point_utf8_bytes)?;
+
+            // Convert to u16
+            let code_point_str = str::from_utf8(&code_point_utf8_bytes)
+                .expect("malformed Unicode character escape sequence");
+            let code_point = u16::from_str_radix(code_point_str, 16)
+                .map_err(|_| Error::syntax("invalid Unicode escape sequence", cursor.pos()))?;
+
+            if let Some(code_units_buf) = code_units_buf {
+                code_units_buf.push(code_point);
             }
-            None => {
-                break;
-            }
+
+            Ok(code_point as u32)
         }
     }
 
-    Ok((
-        String::from_utf16_lossy(buf.as_slice()),
-        Span::new(start_pos, cursor.pos()),
-    ))
+    #[inline]
+    fn hex_escape_sequence<R>(
+        cursor: &mut Cursor<R>,
+        code_units_buf: Option<&mut Vec<u16>>,
+    ) -> Result<u32, Error>
+    where
+        R: Read,
+    {
+        let mut code_point_utf8_bytes = [0u8; 2];
+        cursor.fill_bytes(&mut code_point_utf8_bytes)?;
+        let code_point_str = str::from_utf8(&code_point_utf8_bytes)
+            .expect("malformed Hexadecimal character escape sequence");
+        let code_point = u16::from_str_radix(&code_point_str, 16)
+            .map_err(|_| Error::syntax("invalid Hexadecimal escape sequence", cursor.pos()))?;
+
+        if let Some(code_units_buf) = code_units_buf {
+            code_units_buf.push(code_point);
+        }
+
+        Ok(code_point as u32)
+    }
+
+    #[inline]
+    fn legacy_octal_escape_sequence<R>(
+        cursor: &mut Cursor<R>,
+        code_units_buf: Option<&mut Vec<u16>>,
+        strict_mode: bool,
+        init: u8,
+    ) -> Result<u32, Error>
+    where
+        R: Read,
+    {
+        if strict_mode {
+            return Err(Error::syntax(
+                "octal escape sequences are deprecated",
+                cursor.pos(),
+            ));
+        }
+        let mut code_point = char::from(init).to_digit(8).unwrap();
+
+        match cursor.peek()? {
+            Some(c) if char::is_digit(char::from(c), 8) => {
+                let _ = cursor.next_byte()?;
+                code_point = code_point * 8 + char::from(init).to_digit(8).unwrap();
+                if init <= b'3' {
+                    match cursor.peek()? {
+                        Some(c) if char::is_digit(char::from(c), 8) => {
+                            let _ = cursor.next_byte();
+                            code_point = code_point * 8 + char::from(init).to_digit(8).unwrap();
+                        }
+                        _ => (),
+                    }
+                }
+            }
+            _ => (),
+        }
+
+        if let Some(code_units_buf) = code_units_buf {
+            code_units_buf.push(code_point as u16);
+        }
+
+        Ok(code_point)
+    }
 }

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -212,8 +212,9 @@ impl StringLiteral {
             let mut code_point_buf = Vec::with_capacity(6);
             cursor.take_until(b'}', &mut code_point_buf)?;
 
+            // Safty: invalid UTF-8 bytes will be handled by returning Err in the following `u32::from_str_radix`
             let code_point_str = unsafe { str::from_utf8_unchecked(code_point_buf.as_slice()) };
-            // We know this is a single unicode codepoint, convert to u32
+            // The `code_point_str` should represent a single unicode codepoint, convert to u32
             let code_point = u32::from_str_radix(&code_point_str, 16).map_err(|_| {
                 Error::syntax("malformed Unicode character escape sequence", start_pos)
             })?;

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -246,10 +246,10 @@ impl StringLiteral {
             cursor.fill_bytes(&mut code_point_utf8_bytes)?;
 
             // Convert to u16
-            let code_point_str = str::from_utf8(&code_point_utf8_bytes)
-                .expect("malformed Unicode character escape sequence");
-            let code_point = u16::from_str_radix(code_point_str, 16)
-                .map_err(|_| Error::syntax("invalid Unicode escape sequence", start_pos))?;
+            let code_point = str::from_utf8(&code_point_utf8_bytes)
+                .ok()
+                .and_then(|code_point_str| u16::from_str_radix(&code_point_str, 16).ok())
+                .ok_or_else(|| Error::syntax("invalid Unicode escape sequence", start_pos))?;
 
             if let Some(code_units_buf) = code_units_buf {
                 code_units_buf.push(code_point);
@@ -270,10 +270,10 @@ impl StringLiteral {
     {
         let mut code_point_utf8_bytes = [0u8; 2];
         cursor.fill_bytes(&mut code_point_utf8_bytes)?;
-        let code_point_str = str::from_utf8(&code_point_utf8_bytes)
-            .expect("malformed Hexadecimal character escape sequence");
-        let code_point = u16::from_str_radix(&code_point_str, 16)
-            .map_err(|_| Error::syntax("invalid Hexadecimal escape sequence", start_pos))?;
+        let code_point = str::from_utf8(&code_point_utf8_bytes)
+            .ok()
+            .and_then(|code_point_str| u16::from_str_radix(&code_point_str, 16).ok())
+            .ok_or_else(|| Error::syntax("invalid Hexadecimal escape sequence", start_pos))?;
 
         if let Some(code_units_buf) = code_units_buf {
             code_units_buf.push(code_point);

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -212,7 +212,7 @@ impl StringLiteral {
             let mut code_point_buf = Vec::with_capacity(6);
             cursor.take_until(b'}', &mut code_point_buf)?;
 
-            // Safty: invalid UTF-8 bytes will be handled by returning Err in the following `u32::from_str_radix`
+            // Safety: invalid UTF-8 bytes will be handled by returning Err in the following `u32::from_str_radix`
             let code_point_str = unsafe { str::from_utf8_unchecked(code_point_buf.as_slice()) };
             // The `code_point_str` should represent a single unicode codepoint, convert to u32
             let code_point = u32::from_str_radix(&code_point_str, 16).map_err(|_| {

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -117,22 +117,22 @@ impl StringLiteral {
                         })?;
 
                     match escape_ch {
-                        'b' => buf.push('\u{0008}' as u16 /* <BS> */),
-                        't' => buf.push('\u{0009}' as u16 /* <HT> */),
-                        'n' => buf.push('\u{000A}' as u16 /* <LF> */),
-                        'v' => buf.push('\u{000B}' as u16 /* <VT> */),
-                        'f' => buf.push('\u{000C}' as u16 /* <FF> */),
-                        'r' => buf.push('\u{000D}' as u16 /* <CR> */),
-                        '"' => buf.push('\u{0022}' as u16 /* " */),
-                        '\'' => buf.push('\u{0027}' as u16 /* ' */),
-                        '\\' => buf.push('\u{005C}' as u16 /* \ */),
+                        'b' => buf.push(0x0008 /* <BS> */),
+                        't' => buf.push(0x0009 /* <HT> */),
+                        'n' => buf.push(0x000A /* <LF> */),
+                        'v' => buf.push(0x000B /* <VT> */),
+                        'f' => buf.push(0x000C /* <FF> */),
+                        'r' => buf.push(0x000D /* <CR> */),
+                        '"' => buf.push(0x0022 /* " */),
+                        '\'' => buf.push(0x0027 /* ' */),
+                        '\\' => buf.push(0x005C /* \ */),
                         '0' if cursor
                             .peek()?
                             .and_then(|next_byte| char::try_from(next_byte).ok())
                             .filter(|next_ch| next_ch.is_digit(10))
                             .is_none() =>
                         {
-                            buf.push('\u{0000}' as u16 /* NULL */)
+                            buf.push(0x0000 /* NULL */)
                         }
                         'x' => {
                             Self::take_hex_escape_sequence(cursor, Some(&mut buf))?;

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -117,11 +117,15 @@ impl StringLiteral {
                         })?;
 
                     match escape_ch {
-                        'b' => buf.push('\x08' as u16),
-                        'f' => buf.push('\x0c' as u16),
-                        'n' => buf.push('\n' as u16),
-                        'r' => buf.push('\r' as u16),
-                        't' => buf.push('\t' as u16),
+                        'b' => buf.push('\u{0008}' as u16 /* <BS> */),
+                        't' => buf.push('\u{0009}' as u16 /* <HT> */),
+                        'n' => buf.push('\u{000A}' as u16 /* <LF> */),
+                        'v' => buf.push('\u{000B}' as u16 /* <VT> */),
+                        'f' => buf.push('\u{000C}' as u16 /* <FF> */),
+                        'r' => buf.push('\u{000D}' as u16 /* <CR> */),
+                        '"' => buf.push('\u{0022}' as u16 /* " */),
+                        '\'' => buf.push('\u{0027}' as u16 /* ' */),
+                        '\\' => buf.push('\u{005C}' as u16 /* \ */),
                         '0' if cursor
                             .peek()?
                             .and_then(|next_byte| char::try_from(next_byte).ok())
@@ -145,9 +149,9 @@ impl StringLiteral {
                             )?;
                         }
                         _ if Self::is_line_terminator(escape_ch) => {
-                            // Check match LineContinuation
+                            // Match LineContinuation
                             // Grammar: \ LineTerminatorSequence
-                            // do nothing, continue lexing
+                            // LineContinuation is the empty String. Do nothing and continue lexing.
                         }
                         _ => buf.push(escape_ch as u16),
                     };

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -85,6 +85,9 @@ impl StringLiteral {
                 Some('"') if terminator == StringTerminator::DoubleQuote => {
                     break;
                 }
+                None if terminator == StringTerminator::End => {
+                    break;
+                }
                 Some('\\') => {
                     let _timer = BoaProfiler::global()
                         .start_event("StringLiteral - escape sequence", "Lexing");
@@ -141,14 +144,11 @@ impl StringLiteral {
                         buf.extend(code_units_buf.iter());
                     }
                 }
-                None if terminator != StringTerminator::End => {
+                None => {
                     return Err(Error::from(io::Error::new(
                         ErrorKind::UnexpectedEof,
                         "unterminated string literal",
                     )));
-                }
-                None => {
-                    break;
                 }
             }
         }

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -44,7 +44,7 @@ impl<R> Tokenizer<R> for TemplateLiteral {
             match next_chr {
                 '`' => {
                     let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = StringLiteral::unescape_string(
+                    let (cooked, _) = StringLiteral::take_string_characters(
                         &mut Cursor::with_position(raw.as_bytes(), start_pos),
                         start_pos,
                         StringTerminator::End,
@@ -58,7 +58,7 @@ impl<R> Tokenizer<R> for TemplateLiteral {
                 '$' if cursor.peek()? == Some(b'{') => {
                     let _ = cursor.next_byte()?;
                     let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = StringLiteral::unescape_string(
+                    let (cooked, _) = StringLiteral::take_string_characters(
                         &mut Cursor::with_position(raw.as_bytes(), start_pos),
                         start_pos,
                         StringTerminator::End,

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -3,7 +3,7 @@
 use super::{Cursor, Error, Tokenizer};
 use crate::{
     profiler::BoaProfiler,
-    syntax::lexer::string::{unescape_string, StringTerminator},
+    syntax::lexer::string::{StringLiteral, StringTerminator},
     syntax::{
         ast::{Position, Span},
         lexer::{Token, TokenKind},
@@ -44,7 +44,7 @@ impl<R> Tokenizer<R> for TemplateLiteral {
             match next_chr {
                 '`' => {
                     let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = unescape_string(
+                    let (cooked, _) = StringLiteral::unescape_string(
                         &mut Cursor::with_position(raw.as_bytes(), start_pos),
                         start_pos,
                         StringTerminator::End,
@@ -58,7 +58,7 @@ impl<R> Tokenizer<R> for TemplateLiteral {
                 '$' if cursor.peek()? == Some(b'{') => {
                     let _ = cursor.next_byte()?;
                     let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = unescape_string(
+                    let (cooked, _) = StringLiteral::unescape_string(
                         &mut Cursor::with_position(raw.as_bytes(), start_pos),
                         start_pos,
                         StringTerminator::End,

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -917,13 +917,19 @@ fn take_string_characters_legacy_octal_escape() {
 
     for (s, _) in test_cases.iter() {
         let mut cursor = Cursor::new(s.as_bytes());
-        StringLiteral::take_string_characters(
+
+        if let Error::Syntax(_, pos) = StringLiteral::take_string_characters(
             &mut cursor,
             Position::new(1, 1),
             StringTerminator::End,
             true,
         )
-        .expect_err("Octal-escape in strict mode not rejected as expected");
+        .expect_err("Octal-escape in strict mode not rejected as expected")
+        {
+            assert_eq!(pos, Position::new(1, 1));
+        } else {
+            panic!("invalid error type");
+        }
     }
 }
 
@@ -964,13 +970,19 @@ fn take_string_characters_non_octal_decimal_escape() {
 
     for (s, _) in test_cases.iter() {
         let mut cursor = Cursor::new(s.as_bytes());
-        StringLiteral::take_string_characters(
+
+        if let Error::Syntax(_, pos) = StringLiteral::take_string_characters(
             &mut cursor,
             Position::new(1, 1),
             StringTerminator::End,
             true,
         )
-        .expect_err("Non-octal-decimal-escape in strict mode not rejected as expected");
+        .expect_err("Non-octal-decimal-escape in strict mode not rejected as expected")
+        {
+            assert_eq!(pos, Position::new(1, 1));
+        } else {
+            panic!("invalid error type");
+        }
     }
 }
 

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -914,6 +914,17 @@ fn legacy_octal_escape() {
 
         assert_eq!(s, *expected);
     }
+
+    for (s, _) in test_cases.iter() {
+        let mut cursor = Cursor::new(s.as_bytes());
+        StringLiteral::take_string_characters(
+            &mut cursor,
+            Position::new(1, 1),
+            StringTerminator::End,
+            true,
+        )
+        .expect_err("Octal-escape in strict mode not rejected as expected");
+    }
 }
 
 #[test]
@@ -932,6 +943,50 @@ fn zero_escape() {
 
         assert_eq!(s, *expected);
     }
+}
+
+#[test]
+fn non_octal_decimal_escape() {
+    let test_cases = [(r#"\8"#, "8"), (r#"\9"#, "9")];
+
+    for (s, expected) in test_cases.iter() {
+        let mut cursor = Cursor::new(s.as_bytes());
+        let (s, _) = StringLiteral::take_string_characters(
+            &mut cursor,
+            Position::new(1, 1),
+            StringTerminator::End,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s, *expected);
+    }
+
+    for (s, _) in test_cases.iter() {
+        let mut cursor = Cursor::new(s.as_bytes());
+        StringLiteral::take_string_characters(
+            &mut cursor,
+            Position::new(1, 1),
+            StringTerminator::End,
+            true,
+        )
+        .expect_err("Non-octal-decimal-escape in strict mode not rejected as expected");
+    }
+}
+
+#[test]
+fn line_continuation() {
+    let s = "hello \\\nworld";
+    let mut cursor = Cursor::new(s.as_bytes());
+    let (s, _) = StringLiteral::take_string_characters(
+        &mut cursor,
+        Position::new(1, 1),
+        StringTerminator::End,
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(s, "hello world");
 }
 
 mod carriage_return {

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -890,6 +890,50 @@ fn unescape_string_with_single_escape() {
     assert_eq!(s, "Б");
 }
 
+#[test]
+fn legacy_octal_escape() {
+    let test_cases = [
+        (r#"\3"#, "\u{3}"),
+        (r#"\03"#, "\u{3}"),
+        (r#"\003"#, "\u{3}"),
+        (r#"\0003"#, "\u{0}3"),
+        (r#"\43"#, "#"),
+        (r#"\043"#, "#"),
+        (r#"\101"#, "A"),
+    ];
+
+    for (s, expected) in test_cases.iter() {
+        let mut cursor = Cursor::new(s.as_bytes());
+        let (s, _) = StringLiteral::unescape_string(
+            &mut cursor,
+            Position::new(1, 1),
+            StringTerminator::End,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s, *expected);
+    }
+}
+
+#[test]
+fn zero_escape() {
+    let test_cases = [(r#"\0"#, "\u{0}"), (r#"\0A"#, "\u{0}A")];
+
+    for (s, expected) in test_cases.iter() {
+        let mut cursor = Cursor::new(s.as_bytes());
+        let (s, _) = StringLiteral::unescape_string(
+            &mut cursor,
+            Position::new(1, 1),
+            StringTerminator::End,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(s, *expected);
+    }
+}
+
 mod carriage_return {
     use super::*;
 

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -6,7 +6,7 @@ use super::token::Numeric;
 use super::*;
 use super::{Error, Position};
 use crate::syntax::ast::Keyword;
-use crate::syntax::lexer::string::{unescape_string, StringTerminator};
+use crate::syntax::lexer::string::{StringLiteral, StringTerminator};
 use std::str;
 
 fn span(start: (u32, u32), end: (u32, u32)) -> Span {
@@ -864,7 +864,7 @@ fn unicode_escape_with_braces_() {
 
     let mut cursor = Cursor::new(s.as_bytes());
 
-    if let Ok((s, _)) = unescape_string(
+    if let Ok((s, _)) = StringLiteral::unescape_string(
         &mut cursor,
         Position::new(1, 1),
         StringTerminator::End,
@@ -880,7 +880,7 @@ fn unicode_escape_with_braces_() {
 fn unescape_string_with_single_escape() {
     let s = r#"\Б"#.to_string();
     let mut cursor = Cursor::new(s.as_bytes());
-    let (s, _) = unescape_string(
+    let (s, _) = StringLiteral::unescape_string(
         &mut cursor,
         Position::new(1, 1),
         StringTerminator::End,

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -795,7 +795,7 @@ fn illegal_following_numeric_literal() {
 }
 
 #[test]
-fn codepoint_with_no_braces() {
+fn string_codepoint_with_no_braces() {
     let mut lexer = Lexer::new(&br#""test\uD38Dtest""#[..]);
     assert!(lexer.next().is_ok());
 }
@@ -814,7 +814,7 @@ fn illegal_code_point_following_numeric_literal() {
 }
 
 #[test]
-fn non_english_str() {
+fn string_unicode() {
     let str = r#"'中文';"#;
 
     let mut lexer = Lexer::new(str.as_bytes());
@@ -828,7 +828,7 @@ fn non_english_str() {
 }
 
 #[test]
-fn unicode_escape_with_braces() {
+fn string_unicode_escape_with_braces() {
     let mut lexer = Lexer::new(&br#"'{\u{20ac}\u{a0}\u{a0}}'"#[..]);
 
     let expected = [TokenKind::StringLiteral("{\u{20ac}\u{a0}\u{a0}}".into())];
@@ -859,7 +859,7 @@ fn unicode_escape_with_braces() {
 }
 
 #[test]
-fn unicode_escape_with_braces_() {
+fn take_string_characters_unicode_escape_with_braces_2() {
     let s = r#"\u{20ac}\u{a0}\u{a0}"#.to_string();
 
     let mut cursor = Cursor::new(s.as_bytes());
@@ -877,7 +877,7 @@ fn unicode_escape_with_braces_() {
 }
 
 #[test]
-fn unescape_string_with_single_escape() {
+fn take_string_characters_with_single_escape() {
     let s = r#"\Б"#.to_string();
     let mut cursor = Cursor::new(s.as_bytes());
     let (s, _) = StringLiteral::take_string_characters(
@@ -891,7 +891,7 @@ fn unescape_string_with_single_escape() {
 }
 
 #[test]
-fn legacy_octal_escape() {
+fn take_string_characters_legacy_octal_escape() {
     let test_cases = [
         (r#"\3"#, "\u{3}"),
         (r#"\03"#, "\u{3}"),
@@ -928,7 +928,7 @@ fn legacy_octal_escape() {
 }
 
 #[test]
-fn zero_escape() {
+fn take_string_characters_zero_escape() {
     let test_cases = [(r#"\0"#, "\u{0}"), (r#"\0A"#, "\u{0}A")];
 
     for (s, expected) in test_cases.iter() {
@@ -946,7 +946,7 @@ fn zero_escape() {
 }
 
 #[test]
-fn non_octal_decimal_escape() {
+fn take_string_characters_non_octal_decimal_escape() {
     let test_cases = [(r#"\8"#, "8"), (r#"\9"#, "9")];
 
     for (s, expected) in test_cases.iter() {
@@ -975,7 +975,7 @@ fn non_octal_decimal_escape() {
 }
 
 #[test]
-fn line_continuation() {
+fn take_string_characters_line_continuation() {
     let s = "hello \\\nworld";
     let mut cursor = Cursor::new(s.as_bytes());
     let (s, _) = StringLiteral::take_string_characters(

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -864,7 +864,7 @@ fn unicode_escape_with_braces_() {
 
     let mut cursor = Cursor::new(s.as_bytes());
 
-    if let Ok((s, _)) = StringLiteral::unescape_string(
+    if let Ok((s, _)) = StringLiteral::take_string_characters(
         &mut cursor,
         Position::new(1, 1),
         StringTerminator::End,
@@ -880,7 +880,7 @@ fn unicode_escape_with_braces_() {
 fn unescape_string_with_single_escape() {
     let s = r#"\Б"#.to_string();
     let mut cursor = Cursor::new(s.as_bytes());
-    let (s, _) = StringLiteral::unescape_string(
+    let (s, _) = StringLiteral::take_string_characters(
         &mut cursor,
         Position::new(1, 1),
         StringTerminator::End,
@@ -904,7 +904,7 @@ fn legacy_octal_escape() {
 
     for (s, expected) in test_cases.iter() {
         let mut cursor = Cursor::new(s.as_bytes());
-        let (s, _) = StringLiteral::unescape_string(
+        let (s, _) = StringLiteral::take_string_characters(
             &mut cursor,
             Position::new(1, 1),
             StringTerminator::End,
@@ -922,7 +922,7 @@ fn zero_escape() {
 
     for (s, expected) in test_cases.iter() {
         let mut cursor = Cursor::new(s.as_bytes());
-        let (s, _) = StringLiteral::unescape_string(
+        let (s, _) = StringLiteral::take_string_characters(
             &mut cursor,
             Position::new(1, 1),
             StringTerminator::End,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1078 and some bugs mentioned in the discussion of this PR.

It changes the following:

- Minor refactor string literal lexer (for future use in lexing unicode escape in identifier name)
- Fix lexing octal escape sequence in string literal
- Fix behavior of zero escape sequence
- Fix `\` followed by a line terminator sequence
- Fix `\v`
- Fix lexing `\8` and `\9` in strict mode.
- Add more tests
