### PR TITLE
Fix line terminator in string literal

### DIFF
--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -217,10 +217,10 @@ fn json_stringify_pretty_print() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-    "a": "b",
-    "b": "c"
-}'"#,
+        r#"'{\n'
+            +'    "a": "b",\n'
+            +'    "b": "c"\n'
+            +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -235,10 +235,10 @@ fn json_stringify_pretty_print_four_spaces() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-    "a": "b",
-    "b": "c"
-}'"#,
+        r#"'{\n'
+            +'    "a": "b",\n'
+            +'    "b": "c"\n'
+            +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -253,10 +253,10 @@ fn json_stringify_pretty_print_twenty_spaces() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-          "a": "b",
-          "b": "c"
-}'"#,
+        r#"'{\n'
+            +'          "a": "b",\n'
+            +'          "b": "c"\n'
+            +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -271,10 +271,10 @@ fn json_stringify_pretty_print_with_number_object() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-          "a": "b",
-          "b": "c"
-}'"#,
+        r#"'{\n'
+        +'          "a": "b",\n'
+        +'          "b": "c"\n'
+        +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -301,10 +301,10 @@ fn json_stringify_pretty_print_with_too_long_string() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-abcdefghij"a": "b",
-abcdefghij"b": "c"
-}'"#,
+        r#"'{\n'
+            +'abcdefghij"a": "b",\n'
+            +'abcdefghij"b": "c"\n'
+            +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -319,10 +319,10 @@ fn json_stringify_pretty_print_with_string_object() {
     );
     let expected = forward(
         &mut context,
-        r#"'{
-abcd"a": "b",
-abcd"b": "c"
-}'"#,
+        r#"'{\n'
+            +'abcd"a": "b",\n'
+            +'abcd"b": "c"\n'
+            +'}'"#,
     );
     assert_eq!(actual, expected);
 }
@@ -404,10 +404,7 @@ fn json_parse_object_with_reviver() {
 fn json_parse_sets_prototypes() {
     let mut context = Context::new();
     let init = r#"
-        const jsonString = "{
-            \"ob\":{\"ject\":1},
-            \"arr\": [0,1]
-        }";
+        const jsonString = "{\"ob\":{\"ject\":1},\"arr\": [0,1]}";
         const jsonObj = JSON.parse(jsonString);
     "#;
     eprintln!("{}", forward(&mut context, init));

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -533,34 +533,46 @@ fn test_match() {
 #[test]
 fn trim() {
     let mut context = Context::new();
-    assert_eq!(forward(&mut context, "'Hello'.trim()"), "\"Hello\"");
-    assert_eq!(forward(&mut context, "' \nHello'.trim()"), "\"Hello\"");
-    assert_eq!(forward(&mut context, "'Hello \n\r'.trim()"), "\"Hello\"");
-    assert_eq!(forward(&mut context, "' Hello '.trim()"), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"'Hello'.trim()"#), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"' \nHello'.trim()"#), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"'Hello \n\r'.trim()"#), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"' Hello '.trim()"#), "\"Hello\"");
 }
 
 #[test]
 fn trim_start() {
     let mut context = Context::new();
-    assert_eq!(forward(&mut context, "'Hello'.trimStart()"), "\"Hello\"");
-    assert_eq!(forward(&mut context, "' \nHello'.trimStart()"), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"'Hello'.trimStart()"#), "\"Hello\"");
     assert_eq!(
-        forward(&mut context, "'Hello \n'.trimStart()"),
+        forward(&mut context, r#"' \nHello'.trimStart()"#),
+        "\"Hello\""
+    );
+    assert_eq!(
+        forward(&mut context, r#"'Hello \n'.trimStart()"#),
         "\"Hello \n\""
     );
-    assert_eq!(forward(&mut context, "' Hello '.trimStart()"), "\"Hello \"");
+    assert_eq!(
+        forward(&mut context, r#"' Hello '.trimStart()"#),
+        "\"Hello \""
+    );
 }
 
 #[test]
 fn trim_end() {
     let mut context = Context::new();
-    assert_eq!(forward(&mut context, "'Hello'.trimEnd()"), "\"Hello\"");
+    assert_eq!(forward(&mut context, r#"'Hello'.trimEnd()"#), "\"Hello\"");
     assert_eq!(
-        forward(&mut context, "' \nHello'.trimEnd()"),
+        forward(&mut context, r#"' \nHello'.trimEnd()"#),
         "\" \nHello\""
     );
-    assert_eq!(forward(&mut context, "'Hello \n'.trimEnd()"), "\"Hello\"");
-    assert_eq!(forward(&mut context, "' Hello '.trimEnd()"), "\" Hello\"");
+    assert_eq!(
+        forward(&mut context, r#"'Hello \n'.trimEnd()"#),
+        "\"Hello\""
+    );
+    assert_eq!(
+        forward(&mut context, r#"' Hello '.trimEnd()"#),
+        "\" Hello\""
+    );
 }
 
 #[test]

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -3,13 +3,12 @@
 use super::{Cursor, Error, Tokenizer};
 use crate::{
     profiler::BoaProfiler,
-    syntax::lexer::string::{StringLiteral, StringTerminator},
+    syntax::lexer::string::{StringLiteral, UTF16CodeUnitsBuffer},
     syntax::{
         ast::{Position, Span},
         lexer::{Token, TokenKind},
     },
 };
-use std::convert::TryFrom;
 use std::io::{self, ErrorKind, Read};
 
 /// Template literal lexing.
@@ -34,65 +33,92 @@ impl<R> Tokenizer<R> for TemplateLiteral {
 
         let mut buf = Vec::new();
         loop {
-            let next_chr = char::try_from(cursor.next_char()?.ok_or_else(|| {
+            let ch = cursor.next_char()?.ok_or_else(|| {
                 Error::from(io::Error::new(
                     ErrorKind::UnexpectedEof,
                     "unterminated template literal",
                 ))
-            })?)
-            .unwrap();
-            match next_chr {
-                '`' => {
-                    let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = StringLiteral::take_string_characters(
-                        &mut Cursor::with_position(raw.as_bytes(), start_pos),
-                        start_pos,
-                        StringTerminator::End,
-                        true,
-                    )?;
+            })?;
+
+            match ch {
+                0x0060 /* ` */ => {
+                    let raw = buf.to_string_lossy();
+                    // TODO: Cook the raw string only when needed (lazy evaluation)
+                    let cooked = Self::cook_template_string(&raw, start_pos, cursor.strict_mode())?;
+
                     return Ok(Token::new(
                         TokenKind::template_no_substitution(raw, cooked),
                         Span::new(start_pos, cursor.pos()),
                     ));
                 }
-                '$' if cursor.peek()? == Some(b'{') => {
-                    let _ = cursor.next_byte()?;
-                    let raw = String::from_utf16_lossy(buf.as_slice());
-                    let (cooked, _) = StringLiteral::take_string_characters(
-                        &mut Cursor::with_position(raw.as_bytes(), start_pos),
-                        start_pos,
-                        StringTerminator::End,
-                        true,
-                    )?;
+                0x0024 /* $ */ if cursor.next_is(b'{')? => {
+                    let raw = buf.to_string_lossy();
+                    // TODO: Cook the raw string only when needed (lazy evaluation)
+                    let cooked = Self::cook_template_string(&raw, start_pos, cursor.strict_mode())?;
+
                     return Ok(Token::new(
                         TokenKind::template_middle(raw, cooked),
                         Span::new(start_pos, cursor.pos()),
                     ));
                 }
-                '\\' => {
-                    let escape = cursor.peek()?.ok_or_else(|| {
+                0x005C /* \ */ => {
+                    let escape_ch = cursor.peek()?.ok_or_else(|| {
                         Error::from(io::Error::new(
                             ErrorKind::UnexpectedEof,
                             "unterminated escape sequence in literal",
                         ))
                     })?;
-                    buf.push('\\' as u16);
-                    match escape {
+
+                    buf.push(b'\\' as u16);
+                    match escape_ch {
                         b'`' | b'$' | b'\\' => buf.push(cursor.next_byte()?.unwrap() as u16),
                         _ => continue,
                     }
                 }
-                next_ch => {
-                    if next_ch.len_utf16() == 1 {
-                        buf.push(next_ch as u16);
-                    } else {
-                        let mut code_point_bytes_buf = [0u16; 2];
-                        let code_point_bytes = next_ch.encode_utf16(&mut code_point_bytes_buf);
-
-                        buf.extend(code_point_bytes.iter());
-                    }
+                ch => {
+                    buf.push_code_point(ch);
                 }
             }
         }
+    }
+}
+
+impl TemplateLiteral {
+    fn cook_template_string(
+        raw: &str,
+        start_pos: Position,
+        is_strict_mode: bool,
+    ) -> Result<String, Error> {
+        let mut cursor = Cursor::with_position(raw.as_bytes(), start_pos);
+        let mut buf: Vec<u16> = Vec::new();
+
+        loop {
+            let ch_start_pos = cursor.pos();
+            let ch = cursor.next_char()?;
+
+            match ch {
+                Some(0x005C /* \ */) => {
+                    if let Some(escape_value) =
+                        StringLiteral::take_escape_sequence_or_line_continuation(
+                            &mut cursor,
+                            ch_start_pos,
+                            is_strict_mode,
+                            true,
+                        )?
+                    {
+                        buf.push_code_point(escape_value);
+                    }
+                }
+                Some(ch) => {
+                    // The caller guarantees that sequences '`' and '${' never appear
+                    // LineTerminatorSequence <CR> <LF> is consumed by `cursor.next_char()` and returns <LF>,
+                    // which matches the TV of <CR> <LF>
+                    buf.push_code_point(ch);
+                }
+                None => break,
+            }
+        }
+
+        Ok(buf.to_string_lossy())
     }
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->
This Pull Request fixes/closes #1083.

It changes the following:

- Handle line terminator in string literal
- Fix broken tests
- Refactor and fix line terminator in template literal
- Support invalid character in string/template literal (like `"\����"`)
- Modify existing tests

Since template literal now has its own method to process characters, I unexported the method `StringLiteral::take_string_characters` and remove `StringTerminator::End`. Some tests on `take_string_characters` are modified to test on lexer directly.