### PR TITLE
Add primitive promotion for method calls on GetField

### DIFF
--- a/boa/src/syntax/ast/node/call/mod.rs
+++ b/boa/src/syntax/ast/node/call/mod.rs
@@ -72,7 +72,10 @@ impl Executable for Call {
                 )
             }
             Node::GetField(ref get_field) => {
-                let obj = get_field.obj().run(context)?;
+                let mut obj = get_field.obj().run(context)?;
+                if obj.get_type() != Type::Object {
+                    obj = Value::Object(obj.to_object(context)?);
+                }
                 let field = get_field.field().run(context)?;
                 (
                     obj.clone(),

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -446,7 +446,6 @@ impl Value {
 
     /// Resolve the property in the object and get its value, or undefined if this is not an object or the field doesn't exist
     /// get_field receives a Property from get_prop(). It should then return the `[[Get]]` result value if that's set, otherwise fall back to `[[Value]]`
-    /// TODO: this function should use the get Value if its set
     pub fn get_field<K>(&self, key: K, context: &mut Context) -> Result<Self>
     where
         K: Into<PropertyKey>,


### PR DESCRIPTION
It changes the following:

- Add primitive promotion to objects for method calls on primitives when non const `GetField` is used
- Remove a forgotten TODO comment