### PR TITLE
Support Unicode escape in identifier names

### DIFF
--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -199,6 +199,16 @@ pub enum Keyword {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/extends
     Extends,
 
+    /// The `false` keyword.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-BooleanLiteral
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+    False,
+
     /// The `finally` keyword.
     ///
     /// More information:
@@ -301,6 +311,16 @@ pub enum Keyword {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new
     New,
 
+    /// The `null` keyword.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-NullLiteral
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/null
+    Null,
+
     /// The `of` keyword.
     ///
     /// More information:
@@ -368,6 +388,16 @@ pub enum Keyword {
     /// [spec]: https://tc39.es/ecma262/#prod-ArrowFunction
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
     Throw,
+
+    /// The `true` keyword
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-BooleanLiteral
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
+    True,
 
     /// The `try` keyword.
     ///
@@ -479,6 +509,7 @@ impl Keyword {
             Self::Enum => "enum",
             Self::Extends => "extends",
             Self::Export => "export",
+            Self::False => "false",
             Self::Finally => "finally",
             Self::For => "for",
             Self::Function => "function",
@@ -488,12 +519,14 @@ impl Keyword {
             Self::Import => "import",
             Self::Let => "let",
             Self::New => "new",
+            Self::Null => "null",
             Self::Of => "of",
             Self::Return => "return",
             Self::Super => "super",
             Self::Switch => "switch",
             Self::This => "this",
             Self::Throw => "throw",
+            Self::True => "true",
             Self::Try => "try",
             Self::TypeOf => "typeof",
             Self::Var => "var",
@@ -552,6 +585,7 @@ impl FromStr for Keyword {
             "enum" => Ok(Self::Enum),
             "extends" => Ok(Self::Extends),
             "export" => Ok(Self::Export),
+            "false" => Ok(Self::False),
             "finally" => Ok(Self::Finally),
             "for" => Ok(Self::For),
             "function" => Ok(Self::Function),
@@ -561,12 +595,14 @@ impl FromStr for Keyword {
             "import" => Ok(Self::Import),
             "let" => Ok(Self::Let),
             "new" => Ok(Self::New),
+            "null" => Ok(Self::Null),
             "of" => Ok(Self::Of),
             "return" => Ok(Self::Return),
             "super" => Ok(Self::Super),
             "switch" => Ok(Self::Switch),
             "this" => Ok(Self::This),
             "throw" => Ok(Self::Throw),
+            "true" => Ok(Self::True),
             "try" => Ok(Self::Try),
             "typeof" => Ok(Self::TypeOf),
             "var" => Ok(Self::Var),

--- a/boa/src/syntax/lexer/cursor.rs
+++ b/boa/src/syntax/lexer/cursor.rs
@@ -130,6 +130,7 @@ where
     /// predicate on the ascii char
     ///
     /// The buffer is not incremented.
+    #[allow(dead_code)]
     #[inline]
     pub(super) fn next_is_char_pred<F>(&mut self, pred: &F) -> io::Result<bool>
     where
@@ -191,6 +192,7 @@ where
     /// It also stops when there is no next character.
     ///
     /// Note that all characters up until the stop character are added to the buffer, including the character right before.
+    #[allow(dead_code)]
     pub(super) fn take_while_char_pred<F>(&mut self, buf: &mut Vec<u8>, pred: &F) -> io::Result<()>
     where
         F: Fn(u32) -> bool,

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -246,11 +246,14 @@ impl<R> Lexer<R> {
                 '=' | '*' | '+' | '-' | '%' | '|' | '&' | '^' | '<' | '>' | '!' | '~' | '?' => {
                     Operator::new(next_ch as u8).lex(&mut self.cursor, start)
                 }
-                _ if c.is_digit(10) => {
-                    NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start)
+                '\\' if self.cursor.peek()? == Some(b'u') => {
+                    Identifier::new(c).lex(&mut self.cursor, start)
                 }
                 _ if Identifier::is_identifier_start(c as u32) => {
                     Identifier::new(c).lex(&mut self.cursor, start)
+                }
+                _ if c.is_digit(10) => {
+                    NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start)
                 }
                 _ => {
                     let details = format!(

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -72,7 +72,7 @@ fn check_multi_line_comment() {
 
 #[test]
 fn check_identifier() {
-    let s = "x x1 _x $x __ $$ Ѐ ЀЀ x\u{200C}\u{200D}";
+    let s = "x x1 _x $x __ $$ Ѐ ЀЀ x\u{200C}\u{200D} \\u0078 \\u0078\\u0078 \\u{0078}x\\u{0078}";
     let mut lexer = Lexer::new(s.as_bytes());
 
     let expected = [
@@ -85,6 +85,9 @@ fn check_identifier() {
         TokenKind::identifier("Ѐ"),
         TokenKind::identifier("ЀЀ"),
         TokenKind::identifier("x\u{200C}\u{200D}"),
+        TokenKind::identifier("x"),
+        TokenKind::identifier("xx"),
+        TokenKind::identifier("xxx"),
     ];
 
     expect_tokens(&mut lexer, &expected);


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request add the support of Unicode escapes (`\uXXXX` and `\u{ cp }`) in identifier names. An example for this is:
```javascript
let \u0078 = 10;
console.log(x); // x = 10
```


It changes the following:

- Update identifier lexer
- Throw syntax error when there are Unicode escapes in keyword
- Add True, False, Null to keywords (used only in lexing)
- Add unit tests

Some methods in `lexer/cursor.rs` are not used after this PR. Instead of removing them from the source code, I kept them for future use. The `#[allow(dead_code)]` is added to prevent clippy error. 
