### PR TITLE
Lazy evaluation for cooked template string

### DIFF
--- a/boa/src/syntax/ast/node/template/mod.rs
+++ b/boa/src/syntax/ast/node/template/mod.rs
@@ -69,12 +69,17 @@ impl fmt::Display for TemplateLit {
 pub struct TaggedTemplate {
     tag: Box<Node>,
     raws: Vec<Box<str>>,
-    cookeds: Vec<Box<str>>,
+    cookeds: Vec<Option<Box<str>>>,
     exprs: Vec<Node>,
 }
 
 impl TaggedTemplate {
-    pub fn new(tag: Node, raws: Vec<Box<str>>, cookeds: Vec<Box<str>>, exprs: Vec<Node>) -> Self {
+    pub fn new(
+        tag: Node,
+        raws: Vec<Box<str>>,
+        cookeds: Vec<Option<Box<str>>>,
+        exprs: Vec<Node>,
+    ) -> Self {
         Self {
             tag: Box::new(tag),
             raws,
@@ -96,7 +101,11 @@ impl Executable for TaggedTemplate {
         }
 
         for (i, cooked) in self.cookeds.iter().enumerate() {
-            template_object.set_field(i, Value::from(cooked), context)?;
+            if let Some(cooked) = cooked {
+                template_object.set_field(i, Value::from(cooked), context)?;
+            } else {
+                template_object.set_field(i, Value::undefined(), context)?;
+            }
         }
         template_object.set_field("raw", raw_array, context)?;
 

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -51,11 +51,6 @@ impl TemplateString {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-templatestrings
     pub fn to_owned_cooked(&self) -> Result<Box<str>, Error> {
-        self.cook_template_string()
-    }
-
-    #[inline]
-    fn cook_template_string(&self) -> Result<Box<str>, Error> {
         let mut cursor = Cursor::with_position(self.raw.as_bytes(), self.start_pos);
         let mut buf: Vec<u16> = Vec::new();
 

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -11,6 +11,72 @@ use crate::{
 };
 use std::io::{self, ErrorKind, Read};
 
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
+#[derive(Clone, PartialEq, Debug)]
+pub struct TemplateString {
+    start_pos: Position,
+    /// The raw string with escape sequences processed.
+    raw: Box<str>,
+}
+
+impl TemplateString {
+    pub fn new<R>(raw: R, start_pos: Position) -> Self
+    where
+        R: Into<Box<str>>,
+    {
+        Self {
+            start_pos,
+            raw: raw.into(),
+        }
+    }
+
+    pub fn as_raw(&self) -> &str {
+        self.raw.as_ref()
+    }
+
+    pub fn to_owned_cooked(&self) -> Result<Box<str>, Error> {
+        self.cook_template_string()
+    }
+
+    #[inline]
+    fn cook_template_string(&self) -> Result<Box<str>, Error> {
+        let mut cursor = Cursor::with_position(self.raw.as_bytes(), self.start_pos);
+        let mut buf: Vec<u16> = Vec::new();
+
+        loop {
+            let ch_start_pos = cursor.pos();
+            let ch = cursor.next_char()?;
+
+            match ch {
+                Some(0x005C /* \ */) => {
+                    let escape_value = StringLiteral::take_escape_sequence_or_line_continuation(
+                        &mut cursor,
+                        ch_start_pos,
+                        true,
+                        true,
+                    )?;
+
+                    if let Some(escape_value) = escape_value {
+                        buf.push_code_point(escape_value);
+                    }
+                }
+                Some(ch) => {
+                    // The caller guarantees that sequences '`' and '${' never appear
+                    // LineTerminatorSequence <CR> <LF> is consumed by `cursor.next_char()` and returns <LF>,
+                    // which matches the TV of <CR> <LF>
+                    buf.push_code_point(ch);
+                }
+                None => break,
+            }
+        }
+
+        Ok(buf.to_string_lossy().into())
+    }
+}
+
 /// Template literal lexing.
 ///
 /// Expects: Initial ` to already be consumed by cursor.
@@ -43,21 +109,19 @@ impl<R> Tokenizer<R> for TemplateLiteral {
             match ch {
                 0x0060 /* ` */ => {
                     let raw = buf.to_string_lossy();
-                    // TODO: Cook the raw string only when needed (lazy evaluation)
-                    let cooked = Self::cook_template_string(&raw, start_pos, cursor.strict_mode())?;
+                    let template_string = TemplateString::new(raw, start_pos);
 
                     return Ok(Token::new(
-                        TokenKind::template_no_substitution(raw, cooked),
+                        TokenKind::template_no_substitution(template_string),
                         Span::new(start_pos, cursor.pos()),
                     ));
                 }
                 0x0024 /* $ */ if cursor.next_is(b'{')? => {
                     let raw = buf.to_string_lossy();
-                    // TODO: Cook the raw string only when needed (lazy evaluation)
-                    let cooked = Self::cook_template_string(&raw, start_pos, cursor.strict_mode())?;
+                    let template_string = TemplateString::new(raw, start_pos);
 
                     return Ok(Token::new(
-                        TokenKind::template_middle(raw, cooked),
+                        TokenKind::template_middle(template_string),
                         Span::new(start_pos, cursor.pos()),
                     ));
                 }
@@ -80,45 +144,5 @@ impl<R> Tokenizer<R> for TemplateLiteral {
                 }
             }
         }
-    }
-}
-
-impl TemplateLiteral {
-    fn cook_template_string(
-        raw: &str,
-        start_pos: Position,
-        is_strict_mode: bool,
-    ) -> Result<String, Error> {
-        let mut cursor = Cursor::with_position(raw.as_bytes(), start_pos);
-        let mut buf: Vec<u16> = Vec::new();
-
-        loop {
-            let ch_start_pos = cursor.pos();
-            let ch = cursor.next_char()?;
-
-            match ch {
-                Some(0x005C /* \ */) => {
-                    if let Some(escape_value) =
-                        StringLiteral::take_escape_sequence_or_line_continuation(
-                            &mut cursor,
-                            ch_start_pos,
-                            is_strict_mode,
-                            true,
-                        )?
-                    {
-                        buf.push_code_point(escape_value);
-                    }
-                }
-                Some(ch) => {
-                    // The caller guarantees that sequences '`' and '${' never appear
-                    // LineTerminatorSequence <CR> <LF> is consumed by `cursor.next_char()` and returns <LF>,
-                    // which matches the TV of <CR> <LF>
-                    buf.push_code_point(ch);
-                }
-                None => break,
-            }
-        }
-
-        Ok(buf.to_string_lossy())
     }
 }

--- a/boa/src/syntax/lexer/template.rs
+++ b/boa/src/syntax/lexer/template.rs
@@ -17,8 +17,9 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug)]
 pub struct TemplateString {
+    /// The start position of the template string. Used to make lexer error if `to_owned_cooked` failed.
     start_pos: Position,
-    /// The raw string with escape sequences processed.
+    /// The template string of template literal with argument `raw` true.
     raw: Box<str>,
 }
 
@@ -33,10 +34,22 @@ impl TemplateString {
         }
     }
 
+    /// Converts the raw template string into a mutable string slice.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-templatestrings
     pub fn as_raw(&self) -> &str {
         self.raw.as_ref()
     }
 
+    /// Creats a new cooked template string. Returns a lexer error if it fails to cook the template string.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-templatestrings
     pub fn to_owned_cooked(&self) -> Result<Box<str>, Error> {
         self.cook_template_string()
     }

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -6,6 +6,7 @@ use super::token::Numeric;
 use super::*;
 use super::{Error, Position};
 use crate::syntax::ast::Keyword;
+use crate::syntax::lexer::template::TemplateString;
 use std::str;
 
 fn span(start: (u32, u32), end: (u32, u32)) -> Span {
@@ -136,7 +137,10 @@ fn check_template_literal_simple() {
 
     assert_eq!(
         lexer.next().unwrap().unwrap().kind(),
-        &TokenKind::template_no_substitution("I'm a template literal", "I'm a template literal")
+        &TokenKind::template_no_substitution(TemplateString::new(
+            "I'm a template literal",
+            Position::new(1, 1)
+        ))
     );
 }
 

--- a/boa/src/syntax/parser/expression/left_hand_side/template.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/template.rs
@@ -59,9 +59,9 @@ where
 
         loop {
             match token.kind() {
-                TokenKind::TemplateMiddle { raw, cooked } => {
-                    raws.push(raw.clone());
-                    cookeds.push(cooked.clone());
+                TokenKind::TemplateMiddle(template_string) => {
+                    raws.push(template_string.as_raw().to_owned().into_boxed_str());
+                    cookeds.push(template_string.to_owned_cooked().ok());
                     exprs.push(
                         Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?,
                     );
@@ -70,9 +70,9 @@ where
                         "template literal",
                     )?;
                 }
-                TokenKind::TemplateNoSubstitution { raw, cooked } => {
-                    raws.push(raw.clone());
-                    cookeds.push(cooked.clone());
+                TokenKind::TemplateNoSubstitution(template_string) => {
+                    raws.push(template_string.as_raw().to_owned().into_boxed_str());
+                    cookeds.push(template_string.to_owned_cooked().ok());
                     return Ok(Node::from(TaggedTemplate::new(
                         self.tag, raws, cookeds, exprs,
                     )));

--- a/boa/src/syntax/parser/expression/primary/template/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/template/mod.rs
@@ -74,10 +74,10 @@ where
 
         loop {
             match cursor.lex_template(self.start)?.kind() {
-                TokenKind::TemplateMiddle {
-                    cooked: template, ..
-                } => {
-                    elements.push(TemplateElement::String(template.to_owned()));
+                TokenKind::TemplateMiddle(template_string) => {
+                    let cooked = template_string.to_owned_cooked().map_err(ParseError::lex)?;
+
+                    elements.push(TemplateElement::String(cooked));
                     elements.push(TemplateElement::Expr(
                         Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?,
                     ));
@@ -86,10 +86,10 @@ where
                         "template literal",
                     )?;
                 }
-                TokenKind::TemplateNoSubstitution {
-                    cooked: template, ..
-                } => {
-                    elements.push(TemplateElement::String(template.to_owned()));
+                TokenKind::TemplateNoSubstitution(template_string) => {
+                    let cooked = template_string.to_owned_cooked().map_err(ParseError::lex)?;
+
+                    elements.push(TemplateElement::String(cooked));
                     return Ok(TemplateLit::new(elements));
                 }
                 _ => {

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -269,11 +269,8 @@ where
                 TokenKind::Punctuator(Punctuator::CloseBlock) => {
                     return Ok(Vec::new().into());
                 }
-                TokenKind::StringLiteral(string)
-                | TokenKind::TemplateNoSubstitution { cooked: string, .. } => {
-                    if string == &"use strict".into() {
-                        cursor.set_strict_mode(true);
-                    }
+                TokenKind::StringLiteral(string) if string.as_ref() == "use strict" => {
+                    cursor.set_strict_mode(true);
                 }
                 _ => {}
             }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -125,11 +125,8 @@ where
         match cursor.peek(0)? {
             Some(tok) => {
                 match tok.kind() {
-                    TokenKind::StringLiteral(string)
-                    | TokenKind::TemplateNoSubstitution { cooked: string, .. } => {
-                        if string.as_ref() == "use strict" {
-                            cursor.set_strict_mode(true);
-                        }
+                    TokenKind::StringLiteral(string) if string.as_ref() == "use strict" => {
+                        cursor.set_strict_mode(true);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request makes the evaluation of cooked template strings lazily, which improves the performance in some cases and fixes invalid escapes in raw template strings. The following sample is now supported
```javascript
function hello(s) { 
    return s.raw; 
}

hello`\u\x`;
```

It changes the following:

- Add struct `TemplateString` and update template related keywords
- Update tests
- Fix bug: `` `use strict`; `` can not be used to invoke strict mode
