### PR TITLE
Fix parsing floats panics and bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ dependencies = [
  "boa_unicode",
  "chrono",
  "criterion",
+ "fast-float",
  "float-cmp",
  "gc",
  "indexmap",
@@ -360,6 +361,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "fast-float"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "float-cmp"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -35,6 +35,7 @@ bitflags = "1.2.1"
 indexmap = "1.6.1"
 ryu-js = "0.2.1"
 chrono = "0.4.19"
+fast-float = "0.2.0"
 
 # Optional Dependencies
 measureme = { version = "9.0.0", optional = true }

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -815,7 +815,7 @@ impl Number {
                             Value::nan()
                         }
                     })
-                    .unwrap_or(Value::nan()))
+                    .unwrap_or_else(|_| Value::nan()))
             }
         } else {
             // Not enough arguments to parseFloat.

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -796,6 +796,7 @@ impl Number {
             let s = input_string.trim_start_matches(is_trimmable_whitespace);
             let s_prefix_lower = s.chars().take(4).collect::<String>().to_ascii_lowercase();
 
+            // TODO: write our own lexer to match syntax StrDecimalLiteral
             if s.starts_with("Infinity") || s.starts_with("+Infinity") {
                 Ok(Value::from(f64::INFINITY))
             } else if s.starts_with("-Infinity") {

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -65,7 +65,7 @@ pub(crate) fn is_trimmable_whitespace(c: char) -> bool {
     matches!(
         c,
         '\u{0009}' | '\u{000B}' | '\u{000C}' | '\u{0020}' | '\u{00A0}' | '\u{FEFF}' |
-    // Unicode Space_Seperator category
+    // Unicode Space_Separator category
     '\u{1680}' | '\u{2000}'
             ..='\u{200A}' | '\u{202F}' | '\u{205F}' | '\u{3000}' |
     // Line terminators: https://tc39.es/ecma262/#sec-line-terminators

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -52,6 +52,27 @@ pub(crate) fn code_point_at(string: RcString, position: i32) -> Option<(u32, u8,
     Some((cp, 2, false))
 }
 
+/// Helper function to check if a `char` is trimmable.
+#[inline]
+pub(crate) fn is_trimmable_whitespace(c: char) -> bool {
+    // The rust implementation of `trim` does not regard the same characters whitespace as ecma standard does
+    //
+    // Rust uses \p{White_Space} by default, which also includes:
+    // `\u{0085}' (next line)
+    // And does not include:
+    // '\u{FEFF}' (zero width non-breaking space)
+    // Explicit whitespace: https://tc39.es/ecma262/#sec-white-space
+    matches!(
+        c,
+        '\u{0009}' | '\u{000B}' | '\u{000C}' | '\u{0020}' | '\u{00A0}' | '\u{FEFF}' |
+    // Unicode Space_Seperator category
+    '\u{1680}' | '\u{2000}'
+            ..='\u{200A}' | '\u{202F}' | '\u{205F}' | '\u{3000}' |
+    // Line terminators: https://tc39.es/ecma262/#sec-line-terminators
+    '\u{000A}' | '\u{000D}' | '\u{2028}' | '\u{2029}'
+    )
+}
+
 fn is_leading_surrogate(value: u16) -> bool {
     (0xD800..=0xDBFF).contains(&value)
 }
@@ -968,27 +989,6 @@ impl String {
         Self::string_pad(primitive, max_length, fill_string, true)
     }
 
-    /// Helper function to check if a `char` is trimmable.
-    #[inline]
-    fn is_trimmable_whitespace(c: char) -> bool {
-        // The rust implementation of `trim` does not regard the same characters whitespace as ecma standard does
-        //
-        // Rust uses \p{White_Space} by default, which also includes:
-        // `\u{0085}' (next line)
-        // And does not include:
-        // '\u{FEFF}' (zero width non-breaking space)
-        // Explicit whitespace: https://tc39.es/ecma262/#sec-white-space
-        matches!(
-            c,
-            '\u{0009}' | '\u{000B}' | '\u{000C}' | '\u{0020}' | '\u{00A0}' | '\u{FEFF}' |
-        // Unicode Space_Seperator category
-        '\u{1680}' | '\u{2000}'
-                ..='\u{200A}' | '\u{202F}' | '\u{205F}' | '\u{3000}' |
-        // Line terminators: https://tc39.es/ecma262/#sec-line-terminators
-        '\u{000A}' | '\u{000D}' | '\u{2028}' | '\u{2029}'
-        )
-    }
-
     /// String.prototype.trim()
     ///
     /// The `trim()` method removes whitespace from both ends of a string.
@@ -1005,7 +1005,7 @@ impl String {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
         Ok(Value::from(
-            string.trim_matches(Self::is_trimmable_whitespace),
+            string.trim_matches(is_trimmable_whitespace),
         ))
     }
 
@@ -1024,7 +1024,7 @@ impl String {
     pub(crate) fn trim_start(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         let string = this.to_string(context)?;
         Ok(Value::from(
-            string.trim_start_matches(Self::is_trimmable_whitespace),
+            string.trim_start_matches(is_trimmable_whitespace),
         ))
     }
 
@@ -1044,7 +1044,7 @@ impl String {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
         Ok(Value::from(
-            string.trim_end_matches(Self::is_trimmable_whitespace),
+            string.trim_end_matches(is_trimmable_whitespace),
         ))
     }
 

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1004,9 +1004,7 @@ impl String {
     pub(crate) fn trim(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         let this = this.require_object_coercible(context)?;
         let string = this.to_string(context)?;
-        Ok(Value::from(
-            string.trim_matches(is_trimmable_whitespace),
-        ))
+        Ok(Value::from(string.trim_matches(is_trimmable_whitespace)))
     }
 
     /// `String.prototype.trimStart()`

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -9,8 +9,8 @@ use crate::{
         lexer::{token::Numeric, Token},
     },
 };
+use std::io::Read;
 use std::str;
-use std::{io::Read, str::FromStr};
 
 /// Number literal lexing.
 ///
@@ -381,7 +381,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
                     )
             }
             NumericKind::Rational /* base: 10 */ => {
-                let val = f64::from_str(num_str).expect("Failed to parse float after checks");
+                let val: f64 = fast_float::parse(num_str).expect("Failed to parse float after checks");
                 let int_val = val as i32;
 
                 // The truncated float should be identically to the non-truncated float for the conversion to be loss-less,

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -813,6 +813,7 @@ impl Value {
             Value::String(ref string) => {
                 let string = string.trim_matches(is_trimmable_whitespace);
 
+                // TODO: write our own lexer to match syntax StrDecimalLiteral
                 match string {
                     "" => Ok(0.0),
                     "Infinity" | "+Infinity" => Ok(f64::INFINITY),

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -814,7 +814,7 @@ impl Value {
                 if string.trim().is_empty() {
                     return Ok(0.0);
                 }
-                Ok(string.parse().unwrap_or(f64::NAN))
+                Ok(fast_float::parse(string.as_str()).unwrap_or(f64::NAN))
             }
             Value::Rational(number) => Ok(number),
             Value::Integer(integer) => Ok(f64::from(integer)),


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1063 .

It changes the following:

- Add dependency `fast_float` to parse float string
- Fix parsing floats panic in number lexer
- Fix bugs in `parseFloat`, `parseInt`, and `Value::to_number`