### PR TITLE
Fully implement EmptyStatement

### DIFF
--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -1519,3 +1519,13 @@ fn test_strict_mode_dup_func_parameters() {
 
     assert!(string.starts_with("Uncaught \"SyntaxError\": "));
 }
+
+#[test]
+fn test_empty_statement() {
+    let src = r#"
+        ;;;let a = 10;;
+        if(a) ;
+        a
+    "#;
+    assert_eq!(&exec(src), "10");
+}

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -196,6 +196,8 @@ pub enum Node {
 
     /// A 'while {...}' node. [More information](./iteration/struct.WhileLoop.html).
     WhileLoop(WhileLoop),
+
+    Empty,
 }
 
 impl Display for Node {
@@ -274,6 +276,7 @@ impl Node {
             Self::AsyncFunctionDecl(ref decl) => decl.display(f, indentation),
             Self::AsyncFunctionExpr(ref expr) => expr.display(f, indentation),
             Self::AwaitExpr(ref expr) => expr.display(f, indentation),
+            Self::Empty => write!(f, "Empty"),
         }
     }
 }
@@ -338,6 +341,7 @@ impl Executable for Node {
             Node::Try(ref try_node) => try_node.run(context),
             Node::Break(ref break_node) => break_node.run(context),
             Node::Continue(ref continue_node) => continue_node.run(context),
+            Node::Empty => Ok(Value::Undefined)
         }
     }
 }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -286,7 +286,7 @@ impl Node {
             Self::AsyncFunctionDecl(ref decl) => decl.display(f, indentation),
             Self::AsyncFunctionExpr(ref expr) => expr.display(f, indentation),
             Self::AwaitExpr(ref expr) => expr.display(f, indentation),
-            Self::Empty => write!(f, "Empty"),
+            Self::Empty => write!(f, ";"),
         }
     }
 }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -197,6 +197,16 @@ pub enum Node {
     /// A 'while {...}' node. [More information](./iteration/struct.WhileLoop.html).
     WhileLoop(WhileLoop),
 
+    /// A empty node.
+    ///
+    /// Empty statement do nothing, just return undefined.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-EmptyStatement
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/Empty
     Empty,
 }
 

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -351,7 +351,7 @@ impl Executable for Node {
             Node::Try(ref try_node) => try_node.run(context),
             Node::Break(ref break_node) => break_node.run(context),
             Node::Continue(ref continue_node) => continue_node.run(context),
-            Node::Empty => Ok(Value::Undefined)
+            Node::Empty => Ok(Value::Undefined),
         }
     }
 }

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -178,6 +178,10 @@ where
                     .parse(cursor)
                     .map(Node::from)
             }
+            TokenKind::Punctuator(Punctuator::Semicolon) => {
+                cursor.next().expect("semicolon disappeared");
+                Ok(Node::Empty)
+            }
             TokenKind::Identifier(_) => {
                 // Labelled Statement check
                 cursor.set_goal(InputElement::Div);

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -179,6 +179,7 @@ where
                     .map(Node::from)
             }
             TokenKind::Punctuator(Punctuator::Semicolon) => {
+                // parse the EmptyStatement
                 cursor.next().expect("semicolon disappeared");
                 Ok(Node::Empty)
             }

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -5,7 +5,7 @@ use crate::syntax::ast::{
     node::{
         field::GetConstField, ArrowFunctionDecl, Assign, BinOp, Call, FormalParameter,
         FunctionDecl, Identifier, LetDecl, LetDeclList, New, Node, Return, StatementList, UnaryOp,
-        VarDecl, VarDeclList,
+        VarDecl, VarDeclList, If
     },
     op::{self, CompOp, LogOp, NumOp},
     Const,
@@ -209,7 +209,7 @@ fn assignment_line_terminator() {
     let s = r#"
     let a = 3;
 
-    a = 
+    a =
     5;
     "#;
 
@@ -232,7 +232,7 @@ fn assignment_multiline_terminator() {
     let a = 3;
 
 
-    a = 
+    a =
 
 
     5;
@@ -289,6 +289,25 @@ fn spread_in_arrow_function() {
                 vec![Identifier::from("b").into()].into(),
             )
             .into(),
+        ],
+    );
+}
+
+#[test]
+fn empty_statement() {
+    check_parser(
+        r"
+            ;;var a = 10;
+            if(a) ;
+        ",
+        vec![
+            Node::Empty
+            ,VarDeclList::from(vec![VarDecl::new(
+                "a",
+                Node::from(Const::from(10)),
+            )])
+            .into(),
+            Node::If(If::new::<_, _, Node, _>(Identifier::from("a"), Node::Empty, None))
         ],
     );
 }

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -4,8 +4,8 @@ use super::Parser;
 use crate::syntax::ast::{
     node::{
         field::GetConstField, ArrowFunctionDecl, Assign, BinOp, Call, FormalParameter,
-        FunctionDecl, Identifier, LetDecl, LetDeclList, New, Node, Return, StatementList, UnaryOp,
-        VarDecl, VarDeclList, If
+        FunctionDecl, Identifier, If, LetDecl, LetDeclList, New, Node, Return, StatementList,
+        UnaryOp, VarDecl, VarDeclList,
     },
     op::{self, CompOp, LogOp, NumOp},
     Const,
@@ -301,13 +301,13 @@ fn empty_statement() {
             if(a) ;
         ",
         vec![
-            Node::Empty
-            ,VarDeclList::from(vec![VarDecl::new(
-                "a",
-                Node::from(Const::from(10)),
-            )])
-            .into(),
-            Node::If(If::new::<_, _, Node, _>(Identifier::from("a"), Node::Empty, None))
+            Node::Empty,
+            VarDeclList::from(vec![VarDecl::new("a", Node::from(Const::from(10)))]).into(),
+            Node::If(If::new::<_, _, Node, _>(
+                Identifier::from("a"),
+                Node::Empty,
+                None,
+            )),
         ],
     );
 }


### PR DESCRIPTION
This Pull Request fixes/closes #892.

It changes the following:

- Add a new Node type: `Empty`.
- Parse the Empty

### Why didn't I remove this [line](https://github.com/boa-dev/boa/blob/c0e7791c49e73f562efb96fd4ca4d7ff40e16443/boa/src/syntax/parser/statement/mod.rs#L284)
If we remove this line, `var a;` will be two statements, a VariableStatement and an EmptyStatement. That's not what we want.

### Why we must add this Empty Node?
Otherwise, `if(foo()) ;` won't work. We must do the same as [statement section in ecma262 spec](https://tc39.es/ecma262/#prod-Statement).
