### PR TITLE
Rework environment records

### DIFF
--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -184,8 +184,8 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
         Value::undefined()
     }
 
-    fn get_outer_environment(&self) -> Option<Environment> {
-        self.outer_env.as_ref().cloned()
+    fn get_outer_environment_ref(&self) -> Option<&Environment> {
+        self.outer_env.as_ref()
     }
 
     fn set_outer_environment(&mut self, env: Environment) {

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -13,7 +13,7 @@ use crate::{
     environment::{
         declarative_environment_record::DeclarativeEnvironmentRecord,
         environment_record_trait::EnvironmentRecordTrait,
-        lexical_environment::{Environment, EnvironmentType},
+        lexical_environment::{Environment, EnvironmentType, VariableScope},
     },
     gc::{empty_trace, Finalize, Trace},
     object::GcObject,
@@ -174,5 +174,23 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn get_global_object(&self) -> Option<Value> {
         self.declarative_record.get_global_object()
+    }
+
+    fn recursive_create_mutable_binding(
+        &mut self,
+        name: String,
+        deletion: bool,
+        _scope: VariableScope,
+    ) -> Result<(), ErrorKind> {
+        self.create_mutable_binding(name, deletion, false)
+    }
+
+    fn recursive_create_immutable_binding(
+        &mut self,
+        name: String,
+        deletion: bool,
+        _scope: VariableScope,
+    ) -> Result<(), ErrorKind> {
+        self.create_immutable_binding(name, deletion)
     }
 }

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -160,8 +160,8 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
         Value::undefined()
     }
 
-    fn get_outer_environment(&self) -> Option<Environment> {
-        self.declarative_record.get_outer_environment()
+    fn get_outer_environment_ref(&self) -> Option<&Environment> {
+        self.declarative_record.get_outer_environment_ref()
     }
 
     fn set_outer_environment(&mut self, env: Environment) {

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -120,10 +120,6 @@ impl GlobalEnvironmentRecord {
 }
 
 impl EnvironmentRecordTrait for GlobalEnvironmentRecord {
-    fn get_this_binding(&self) -> Result<Value, ErrorKind> {
-        Ok(self.global_this_binding.clone())
-    }
-
     fn has_binding(&self, name: &str) -> bool {
         if self.declarative_record.has_binding(name) {
             return true;
@@ -214,6 +210,10 @@ impl EnvironmentRecordTrait for GlobalEnvironmentRecord {
 
     fn has_this_binding(&self) -> bool {
         true
+    }
+
+    fn get_this_binding(&self) -> Result<Value, ErrorKind> {
+        Ok(self.global_this_binding.clone())
     }
 
     fn has_super_binding(&self) -> bool {

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -12,7 +12,7 @@ use crate::{
     environment::{
         declarative_environment_record::DeclarativeEnvironmentRecord,
         environment_record_trait::EnvironmentRecordTrait,
-        lexical_environment::{Environment, EnvironmentType},
+        lexical_environment::{Environment, EnvironmentType, VariableScope},
         object_environment_record::ObjectEnvironmentRecord,
     },
     gc::{Finalize, Trace},
@@ -243,5 +243,36 @@ impl EnvironmentRecordTrait for GlobalEnvironmentRecord {
 
     fn get_global_object(&self) -> Option<Value> {
         Some(self.global_this_binding.clone())
+    }
+
+    fn recursive_create_mutable_binding(
+        &mut self,
+        name: String,
+        deletion: bool,
+        _scope: VariableScope,
+    ) -> Result<(), ErrorKind> {
+        self.create_mutable_binding(name, deletion, false)
+    }
+
+    fn recursive_create_immutable_binding(
+        &mut self,
+        name: String,
+        deletion: bool,
+        _scope: VariableScope,
+    ) -> Result<(), ErrorKind> {
+        self.create_immutable_binding(name, deletion)
+    }
+
+    fn recursive_set_mutable_binding(
+        &mut self,
+        name: &str,
+        value: Value,
+        strict: bool,
+    ) -> Result<(), ErrorKind> {
+        self.set_mutable_binding(name, value, strict)
+    }
+
+    fn recursive_initialize_binding(&mut self, name: &str, value: Value) -> Result<(), ErrorKind> {
+        self.initialize_binding(name, value)
     }
 }

--- a/boa/src/environment/global_environment_record.rs
+++ b/boa/src/environment/global_environment_record.rs
@@ -228,6 +228,10 @@ impl EnvironmentRecordTrait for GlobalEnvironmentRecord {
         None
     }
 
+    fn get_outer_environment_ref(&self) -> Option<&Environment> {
+        None
+    }
+
     fn set_outer_environment(&mut self, _env: Environment) {
         // TODO: Implement
         panic!("Not implemented yet")

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -373,6 +373,25 @@ mod tests {
     }
 
     #[test]
+    fn functions_use_declaration_scope() {
+        let scenario = r#"
+          function foo() {
+            try {
+                bar;
+            } catch (err) {
+                return err.message;
+            }
+          }
+          {
+            let bar = "bar";
+            foo();
+          }
+        "#;
+
+        assert_eq!(&exec(scenario), "\"bar is not defined\"");
+    }
+
+    #[test]
     fn set_outer_var_in_blockscope() {
         let scenario = r#"
           var bar;

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -270,12 +270,14 @@ pub fn new_function_environment(
     new_target: Value,
 ) -> Environment {
     let mut func_env = FunctionEnvironmentRecord {
-        env_rec: FxHashMap::default(),
+        declarative_record: DeclarativeEnvironmentRecord {
+            env_rec: FxHashMap::default(),
+            outer_env: outer, // this will come from Environment set as a private property of F - https://tc39.es/ecma262/#sec-ecmascript-function-objects
+        },
         function: f,
         this_binding_status: binding_status,
         home_object: Value::undefined(),
         new_target,
-        outer_env: outer, // this will come from Environment set as a private property of F - https://tc39.es/ecma262/#sec-ecmascript-function-objects
         this_value: Value::undefined(),
     };
     // If a `this` value has been passed, bind it to the environment

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -127,11 +127,8 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
         Value::undefined()
     }
 
-    fn get_outer_environment(&self) -> Option<Environment> {
-        match &self.outer_env {
-            Some(outer) => Some(outer.clone()),
-            None => None,
-        }
+    fn get_outer_environment_ref(&self) -> Option<&Environment> {
+        self.outer_env.as_ref()
     }
 
     fn set_outer_environment(&mut self, env: Environment) {

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -305,7 +305,11 @@ impl GcObject {
                 let _ = body.run(context);
 
                 // local_env gets dropped here, its no longer needed
-                let result = context.realm_mut().environment.get_this_binding().map_err(|e| e.to_error(context));
+                let result = context
+                    .realm_mut()
+                    .environment
+                    .get_this_binding()
+                    .map_err(|e| e.to_error(context));
                 context.realm_mut().environment.pop();
                 result
             }

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -305,8 +305,9 @@ impl GcObject {
                 let _ = body.run(context);
 
                 // local_env gets dropped here, its no longer needed
-                let binding = context.realm_mut().environment.get_this_binding();
-                binding.map_err(|e| e.to_error(context))
+                let result = context.realm_mut().environment.get_this_binding().map_err(|e| e.to_error(context));
+                context.realm_mut().environment.pop();
+                result
             }
             FunctionBody::BuiltInFunction(_) => unreachable!("Cannot have a function in construct"),
         }

--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -64,7 +64,12 @@ impl Executable for Block {
         // The return value is uninitialized, which means it defaults to Value::Undefined
         let mut obj = Value::default();
         for statement in self.items() {
-            obj = statement.run(context)?;
+            obj = statement.run(context).or_else(|e| {
+                // No matter how control leaves the Block the LexicalEnvironment is always
+                // restored to its former state.
+                context.realm_mut().environment.pop();
+                Err(e)
+            })?;
 
             match context.executor().get_current_state() {
                 InterpreterState::Return => {

--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -64,11 +64,11 @@ impl Executable for Block {
         // The return value is uninitialized, which means it defaults to Value::Undefined
         let mut obj = Value::default();
         for statement in self.items() {
-            obj = statement.run(context).or_else(|e| {
+            obj = statement.run(context).map_err(|e| {
                 // No matter how control leaves the Block the LexicalEnvironment is always
                 // restored to its former state.
                 context.realm_mut().environment.pop();
-                Err(e)
+                e
             })?;
 
             match context.executor().get_current_state() {

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -100,6 +100,7 @@ impl Executable for ForInLoop {
             }
             let iterator_result = iterator.next(context)?;
             if iterator_result.is_done() {
+                context.realm_mut().environment.pop();
                 break;
             }
             let next_result = iterator_result.value();

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -90,6 +90,7 @@ impl Executable for ForOfLoop {
             }
             let iterator_result = iterator.next(context)?;
             if iterator_result.is_done() {
+                context.realm_mut().environment.pop();
                 break;
             }
             let next_result = iterator_result.value();


### PR DESCRIPTION
This Pull Request fixes/closes #989 by changing the environment traversal logic to use outer environments rather than the lexical environment stack.

This is implemented by moving much of `LexicalEnvironment` logic into `EnvironmentRecordTrait` and making it recursive, allowing for most of the tasks to be implemented without cloning any `Gc` values while still keeping the borrow checker happy.

In addition to that, `FunctionEnvironmentRecord` has been updated to use `DeclarativeEnvironmentRecord` to remove duplicated code. This is similar to how `GlobalEnvironmentRecord` currently works.

Finally, an additional test for #989 was added. 