### PR TITLE
Deactivating cargo tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -93,6 +93,7 @@ jobs:
         uses: actions-rs/tarpaulin@v0.1
         with:
           args: --ignore-tests
+          version: '0.17.0'
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -89,13 +89,13 @@ jobs:
         with:
           command: test
           args: -v
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: --ignore-tests
-          version: '0.17.0'
-      - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+      # Waiting for https://github.com/rust-lang/cargo/pull/9229 to land
+      # - name: Run cargo-tarpaulin
+      #   uses: actions-rs/tarpaulin@v0.1
+      #   with:
+      #     args: --ignore-tests
+      # - name: Upload to codecov.io
+      #   uses: codecov/codecov-action@v1
 
   test_on_windows:
     name: Test Suite on Windows


### PR DESCRIPTION
`cargo tarpaulin` is failing on every commit due to https://github.com/xd009642/tarpaulin/issues/517, which is also reported in cargo in https://github.com/rust-lang/cargo/issues/9220, and should be fixed when https://github.com/rust-lang/cargo/pull/9229 lands.

For the time being, we can deactivate coverage checks, which should make builds start to pass again.