### PR TITLE
Include name in verbose results output of boa-tester

### DIFF
--- a/boa_tester/src/exec.rs
+++ b/boa_tester/src/exec.rs
@@ -58,7 +58,8 @@ impl TestSuite {
 
         if verbose != 0 {
             println!(
-                "Results: total: {}, passed: {}, ignored: {}, failed: {} (panics: {}{}), conformance: {:.2}%",
+                "Suite {} results: total: {}, passed: {}, ignored: {}, failed: {} (panics: {}{}), conformance: {:.2}%",
+                self.name,
                 total,
                 passed.to_string().green(),
                 ignored.to_string().yellow(),

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -163,7 +163,7 @@ static IGNORED: Lazy<Ignored> = Lazy::new(|| {
 #[derive(StructOpt, Debug)]
 #[structopt(name = "Boa test262 tester")]
 enum Cli {
-    /// Run the test suitr.
+    /// Run the test suite.
     Run {
         /// Whether to show verbose output.
         #[structopt(short, long, parse(from_occurrences))]


### PR DESCRIPTION
Small change that would make the logs a lot more readable.