### PR TITLE
Return optional value in to_json functions (fixes #1064)

### DIFF
--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -242,12 +242,10 @@ impl Json {
                 &JSONValue::Object(obj_to_return),
                 gap,
             )))
+        } else if let Some(value) = object.to_json(context)? {
+            Ok(Value::from(json_to_pretty_string(&value, gap)))
         } else {
-            if let Some(value) = object.to_json(context)? {
-                Ok(Value::from(json_to_pretty_string(&value, gap)))
-            } else {
-                Ok(Value::undefined())
-            }
+            Ok(Value::undefined())
         }
     }
 }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -178,10 +178,11 @@ impl Json {
         let replacer = match args.get(1) {
             Some(replacer) if replacer.is_object() => replacer,
             _ => {
-                return Ok(Value::from(json_to_pretty_string(
-                    &object.to_json(context)?,
-                    gap,
-                )))
+                if let Some(value) = object.to_json(context)? {
+                    return Ok(Value::from(json_to_pretty_string(&value, gap)));
+                } else {
+                    return Ok(Value::undefined());
+                }
             }
         };
 
@@ -208,10 +209,11 @@ impl Json {
                             ),
                         );
                     }
-                    Ok(Value::from(json_to_pretty_string(
-                        &object_to_return.to_json(context)?,
-                        gap,
-                    )))
+                    if let Some(value) = object_to_return.to_json(context)? {
+                        Ok(Value::from(json_to_pretty_string(&value, gap)))
+                    } else {
+                        Ok(Value::undefined())
+                    }
                 })
                 .ok_or_else(Value::undefined)?
         } else if replacer_as_object.is_array() {
@@ -234,8 +236,9 @@ impl Json {
             for field in fields {
                 let v = object.get_field(field.to_string(context)?, context)?;
                 if !v.is_undefined() {
-                    let value = v.to_json(context)?;
-                    obj_to_return.insert(field.to_string(context)?.to_string(), value);
+                    if let Some(value) = v.to_json(context)? {
+                        obj_to_return.insert(field.to_string(context)?.to_string(), value);
+                    }
                 }
             }
             Ok(Value::from(json_to_pretty_string(
@@ -243,10 +246,11 @@ impl Json {
                 gap,
             )))
         } else {
-            Ok(Value::from(json_to_pretty_string(
-                &object.to_json(context)?,
-                gap,
-            )))
+            if let Some(value) = object.to_json(context)? {
+                Ok(Value::from(json_to_pretty_string(&value, gap)))
+            } else {
+                Ok(Value::undefined())
+            }
         }
     }
 }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -137,9 +137,6 @@ impl Json {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
     pub(crate) fn stringify(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
         let object = match args.get(0) {
-            Some(obj) if obj.is_symbol() || obj.is_function() || obj.is_undefined() => {
-                return Ok(Value::undefined())
-            }
             None => return Ok(Value::undefined()),
             Some(obj) => obj,
         };

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -215,7 +215,7 @@ impl Value {
     }
 
     /// Converts the `Value` to `JSON`.
-    pub fn to_json(&self, context: &mut Context) -> Result<JSONValue> {
+    pub fn to_json(&self, context: &mut Context) -> Result<Option<JSONValue>> {
         let to_json = self.get_field("toJSON", context)?;
         if to_json.is_function() {
             let json_value = context.call(&to_json, self, &[])?;
@@ -223,27 +223,25 @@ impl Value {
         }
 
         match *self {
-            Self::Null => Ok(JSONValue::Null),
-            Self::Boolean(b) => Ok(JSONValue::Bool(b)),
+            Self::Null => Ok(Some(JSONValue::Null)),
+            Self::Boolean(b) => Ok(Some(JSONValue::Bool(b))),
             Self::Object(ref obj) => obj.to_json(context),
-            Self::String(ref str) => Ok(JSONValue::String(str.to_string())),
+            Self::String(ref str) => Ok(Some(JSONValue::String(str.to_string()))),
             Self::Rational(num) => {
                 if num.is_finite() {
-                    Ok(JSONValue::Number(
+                    Ok(Some(JSONValue::Number(
                         JSONNumber::from_str(&Number::to_native_string(num))
                             .expect("invalid number found"),
-                    ))
+                    )))
                 } else {
-                    Ok(JSONValue::Null)
+                    Ok(Some(JSONValue::Null))
                 }
             }
-            Self::Integer(val) => Ok(JSONValue::Number(JSONNumber::from(val))),
+            Self::Integer(val) => Ok(Some(JSONValue::Number(JSONNumber::from(val)))),
             Self::BigInt(_) => {
                 Err(context.construct_type_error("BigInt value can't be serialized in JSON"))
             }
-            Self::Symbol(_) | Self::Undefined => {
-                unreachable!("Symbols and Undefined JSON Values depend on parent type");
-            }
+            Self::Symbol(_) | Self::Undefined => Ok(None),
         }
     }
 

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -222,6 +222,10 @@ impl Value {
             return json_value.to_json(context);
         }
 
+        if self.is_function() {
+            return Ok(None);
+        }
+
         match *self {
             Self::Null => Ok(Some(JSONValue::Null)),
             Self::Boolean(b) => Ok(Some(JSONValue::Bool(b))),


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1064.

It changes the following:

- Makes `Value::to_json`, `GcObject::to_json` return an optional `JSONValue`. If the value cannot be converted into a JSON value, the functions return `None`.
