### PR TITLE
Improved conformance comment format

### DIFF
--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -250,7 +250,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             diff_format(panic_diff),
         );
         println!(
-            "| Conformance | {:.2} | {:.2} | {} |",
+            "| Conformance | {:.2}% | {:.2}% | {} |",
             base_conformance,
             new_conformance,
             format!(


### PR DESCRIPTION
When the test262 conformance comments are added to a PR, it will now show the percentage symbol for the conformance, to show up it's actually a conformance percentage.

This is just a small cosmetic change for PR comments.