### PR TITLE
Make `same_value` and `same_value_zero` static methods

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     object::{ConstructorBuilder, FunctionBuilder, GcObject, ObjectData, PROTOTYPE},
     property::{Attribute, DataDescriptor},
     symbol::WellKnownSymbols,
-    value::{same_value_zero, IntegerOrInfinity, Value},
+    value::{IntegerOrInfinity, Value},
     BoaProfiler, Context, Result,
 };
 use num_traits::*;
@@ -1154,7 +1154,7 @@ impl Array {
         for idx in 0..length {
             let check_element = this.get_field(idx, context)?.clone();
 
-            if same_value_zero(&check_element, &search_element) {
+            if Value::same_value_zero(&check_element, &search_element) {
                 return Ok(Value::from(true));
             }
         }

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -1,4 +1,4 @@
-use crate::{forward, forward_val, value::same_value, Context};
+use crate::{forward, forward_val, Context, Value};
 
 /// Test the correct type is returned from call and construct
 #[allow(clippy::unwrap_used)]
@@ -58,7 +58,7 @@ fn instances_have_correct_proto_set() {
     let bool_instance = forward_val(&mut context, "boolInstance").expect("value expected");
     let bool_prototype = forward_val(&mut context, "boolProto").expect("value expected");
 
-    assert!(same_value(
+    assert!(Value::same_value(
         &bool_instance.as_object().unwrap().prototype_instance(),
         &bool_prototype
     ));

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -1,4 +1,4 @@
-use crate::{forward, forward_val, value::same_value, Context, Value};
+use crate::{forward, forward_val, Context, Value};
 
 #[test]
 fn json_sanity() {
@@ -426,10 +426,13 @@ fn json_parse_sets_prototypes() {
     let global_array_prototype: Value =
         context.standard_objects().array_object().prototype().into();
     assert_eq!(
-        same_value(&object_prototype, &global_object_prototype),
+        Value::same_value(&object_prototype, &global_object_prototype),
         true
     );
-    assert_eq!(same_value(&array_prototype, &global_array_prototype), true);
+    assert_eq!(
+        Value::same_value(&array_prototype, &global_array_prototype),
+        true
+    );
 }
 
 #[test]

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     property::DataDescriptor,
     property::PropertyDescriptor,
     symbol::WellKnownSymbols,
-    value::{same_value, Type, Value},
+    value::{Type, Value},
     BoaProfiler, Context, Result,
 };
 
@@ -261,7 +261,7 @@ impl Object {
         let x = args.get(0).cloned().unwrap_or_else(Value::undefined);
         let y = args.get(1).cloned().unwrap_or_else(Value::undefined);
 
-        Ok(same_value(&x, &y).into())
+        Ok(Value::same_value(&x, &y).into())
     }
 
     /// Get the `prototype` of an object.
@@ -351,7 +351,7 @@ impl Object {
             if v.is_null() {
                 return Ok(Value::Boolean(false));
             }
-            if same_value(&o, &v) {
+            if Value::same_value(&o, &v) {
                 return Ok(Value::Boolean(true));
             }
         }

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -8,7 +8,7 @@
 use crate::{
     object::{GcObject, Object, ObjectData},
     property::{AccessorDescriptor, Attribute, DataDescriptor, PropertyDescriptor, PropertyKey},
-    value::{same_value, Type, Value},
+    value::{Type, Value},
     BoaProfiler, Context, Result,
 };
 
@@ -245,7 +245,7 @@ impl GcObject {
                         return false;
                     }
 
-                    if !same_value(&desc.value(), &current.value()) {
+                    if !Value::same_value(&desc.value(), &current.value()) {
                         return false;
                     }
                 }
@@ -468,7 +468,7 @@ impl GcObject {
     pub fn set_prototype_of(&mut self, val: Value) -> bool {
         debug_assert!(val.is_object() || val.is_null());
         let current = self.get_prototype_of();
-        if same_value(&current, &val) {
+        if Value::same_value(&current, &val) {
             return true;
         }
         if !self.is_extensible() {
@@ -479,7 +479,7 @@ impl GcObject {
         while !done {
             if p.is_null() {
                 done = true
-            } else if same_value(&Value::from(self.clone()), &p) {
+            } else if Value::same_value(&Value::from(self.clone()), &p) {
                 return false;
             } else {
                 let prototype = p

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     gc::{Finalize, Trace},
     property::{AccessorDescriptor, Attribute, DataDescriptor, PropertyDescriptor, PropertyKey},
     symbol::RcSymbol,
-    value::{same_value, RcBigInt, RcString, Value},
+    value::{RcBigInt, RcString, Value},
     BoaProfiler, Context,
 };
 use rustc_hash::FxHashMap;
@@ -534,7 +534,7 @@ impl Object {
         } else {
             // If target is non-extensible, [[SetPrototypeOf]] must return false
             // unless V is the SameValue as the target's observed [[GetPrototypeOf]] value.
-            same_value(&prototype, &self.prototype)
+            Value::same_value(&prototype, &self.prototype)
         }
     }
 

--- a/boa/src/value/hash.rs
+++ b/boa/src/value/hash.rs
@@ -5,7 +5,7 @@ use std::hash::{Hash, Hasher};
 
 impl PartialEq for Value {
     fn eq(&self, other: &Self) -> bool {
-        same_value_zero(self, other)
+        Self::same_value_zero(self, other)
     }
 }
 


### PR DESCRIPTION
This makes the API much more intuitive.

It changes the following:
- Make `same_value` a static method of `Value`
- Make `same_value_zero` a static method of `Value`
