### PR TITLE
Fix GcObject to_json mutable borrow panic

### DIFF
--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -412,7 +412,8 @@ impl GcObject {
         } else {
             let mut new_obj = Map::new();
             let this = Value::from(self.clone());
-            for k in self.borrow().keys() {
+            let keys: Vec<PropertyKey> = self.borrow().keys().collect();
+            for k in keys {
                 let key = k.clone();
                 let value = this.get_field(k.to_string(), context)?;
                 if let Some(value) = value.to_json(context)? {


### PR DESCRIPTION
This Pull Request fixes #1059. The object was getting borrowed in `to_json` to iterate over its keys, preventing mutable borrows. The fix was to collect the keys first and to iterate over them. This will also make the test behave as expected as it will prevent properties added during iteration from being enumerated. 