### PR TITLE
Fixed hypot length bug

### DIFF
--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -63,7 +63,7 @@ impl BuiltIn for Math {
             .function(Self::expm1, "expm1", 1)
             .function(Self::floor, "floor", 1)
             .function(Self::fround, "fround", 1)
-            .function(Self::hypot, "hypot", 1)
+            .function(Self::hypot, "hypot", 2)
             .function(Self::imul, "imul", 1)
             .function(Self::log, "log", 1)
             .function(Self::log1p, "log1p", 1)


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes [#1269](https://github.com/boa-dev/boa/issues/1269)

It changes the following:

- `Math.hypot.length` to be `2`
