### PR TITLE
Support GetOwnProperty for string exotic object

### DIFF
--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -1102,4 +1102,5 @@ fn string_get_property() {
     assert_eq!(forward(&mut context, "'abc'[2]"), "\"c\"");
     assert_eq!(forward(&mut context, "'abc'[3]"), "undefined");
     assert_eq!(forward(&mut context, "'abc'['foo']"), "undefined");
+    assert_eq!(forward(&mut context, "'😀'[0]"), "\"\\ud83d\"");
 }

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -1093,3 +1093,13 @@ fn unicode_iter() {
     assert_eq!(forward(&mut context, "next.value"), "undefined");
     assert_eq!(forward(&mut context, "next.done"), "true");
 }
+
+#[test]
+fn string_get_property() {
+    let mut context = Context::new();
+    assert_eq!(forward(&mut context, "'abc'[-1]"), "undefined");
+    assert_eq!(forward(&mut context, "'abc'[1]"), "\"b\"");
+    assert_eq!(forward(&mut context, "'abc'[2]"), "\"c\"");
+    assert_eq!(forward(&mut context, "'abc'[3]"), "undefined");
+    assert_eq!(forward(&mut context, "'abc'['foo']"), "undefined");
+}

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -423,7 +423,12 @@ impl GcObject {
                 }
 
                 let result_str = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
-                    Value::from(char::from_u32(u32::from(utf16_val)).expect("invalid u32 character"))
+                    let chr_option = char::from_u32(u32::from(utf16_val));
+
+                    match chr_option {
+                        Some(chr) => Value::from(chr),
+                        None => Value::from(format!("\\u{:x}", utf16_val)),
+                    }
                 } else {
                     return None;
                 };

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -430,7 +430,7 @@ impl GcObject {
 
                 let desc = PropertyDescriptor::from(DataDescriptor::new(
                     result_str,
-                    Attribute::ENUMERABLE,
+                    Attribute::READONLY | Attribute::ENUMERABLE | Attribute::PERMANENT,
                 ));
 
                 Some(desc)

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -12,8 +12,6 @@ use crate::{
     BoaProfiler, Context, Result,
 };
 
-use std::char::from_u32;
-
 impl GcObject {
     /// Check if object has property.
     ///
@@ -425,7 +423,7 @@ impl GcObject {
                 }
 
                 let result_str = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
-                    Value::from(from_u32(utf16_val as u32).unwrap())
+                    Value::from(char::from_u32(utf16_val as u32).unwrap())
                 } else {
                     return None;
                 };

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -423,7 +423,7 @@ impl GcObject {
                 }
 
                 let result_str = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
-                    Value::from(char::from_u32(utf16_val as u32).unwrap())
+                    Value::from(char::from_u32(u32::from(utf16_val)).expect("invalid u32 character"))
                 } else {
                     return None;
                 };

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -424,14 +424,16 @@ impl GcObject {
                     return None;
                 }
 
-                let char = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
+                let result_str = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
                     Value::from(from_u32(utf16_val as u32).unwrap())
                 } else {
                     return None;
                 };
 
-                let desc =
-                    PropertyDescriptor::from(DataDescriptor::new(char, Attribute::ENUMERABLE));
+                let desc = PropertyDescriptor::from(DataDescriptor::new(
+                    result_str,
+                    Attribute::ENUMERABLE,
+                ));
 
                 Some(desc)
             }

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -449,7 +449,7 @@ impl GcObject {
     pub fn string_exotic_get_own_property(&self, key: &PropertyKey) -> Option<PropertyDescriptor> {
         let desc = self.ordinary_get_own_property(key);
 
-        if let Some(_) = desc {
+        if desc.is_some() {
             desc
         } else {
             self.string_get_own_property(key)

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -422,16 +422,10 @@ impl GcObject {
                     return None;
                 }
 
-                let result_str = if let Some(utf16_val) = string.encode_utf16().nth(pos) {
-                    let chr_option = char::from_u32(u32::from(utf16_val));
-
-                    match chr_option {
-                        Some(chr) => Value::from(chr),
-                        None => Value::from(format!("\\u{:x}", utf16_val)),
-                    }
-                } else {
-                    return None;
-                };
+                let result_str = string.encode_utf16().nth(pos).map(|utf16_val| {
+                    char::from_u32(u32::from(utf16_val))
+                        .map_or_else(|| Value::from(format!("\\u{:x}", utf16_val)), Value::from)
+                })?;
 
                 let desc = PropertyDescriptor::from(DataDescriptor::new(
                     result_str,


### PR DESCRIPTION
This Pull Request makes ```GetOwnProperty``` for ```String``` objects behave according to specification ( https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p )

```
const str = "abc";
console.log(str[0]);
```
previously resulted in printing ```undefined```, now it results in printing ```"a"```

