### PR TITLE
Fix test262 comment formatting

### DIFF
--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -275,7 +275,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         if !test_diff.fixed.is_empty() {
             println!();
             println!("<details><summary><b>Fixed tests:</b></summary>");
-            println!("```");
+            println!("\n```");
             for test in test_diff.fixed {
                 println!("{}", test);
             }
@@ -286,7 +286,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         if !test_diff.broken.is_empty() {
             println!();
             println!("<details><summary><b>Broken tests:</b></summary>");
-            println!("```");
+            println!("\n```");
             for test in test_diff.broken {
                 println!("{}", test);
             }
@@ -297,7 +297,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         if !test_diff.new_panics.is_empty() {
             println!();
             println!("<details><summary><b>New panics:</b></summary>");
-            println!("```");
+            println!("\n```");
             for test in test_diff.new_panics {
                 println!("{}", test);
             }
@@ -308,7 +308,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         if !test_diff.panic_fixes.is_empty() {
             println!();
             println!("<details><summary><b>Fixed panics:</b></summary>");
-            println!("```");
+            println!("\n```");
             for test in test_diff.panic_fixes {
                 println!("{}", test);
             }


### PR DESCRIPTION
This pull request fixes code tags not being applied to test262 comments correctly. 