### PR TITLE
Don't consider panic fixes as "new failures"

### DIFF
--- a/boa_tester/src/read.rs
+++ b/boa_tester/src/read.rs
@@ -103,15 +103,6 @@ pub(super) fn read_harness(test262_path: &Path) -> io::Result<Harness> {
 
 /// Reads a test suite in the given path.
 pub(super) fn read_suite(path: &Path) -> io::Result<TestSuite> {
-    use once_cell::sync::Lazy;
-    use regex::Regex;
-
-    /// Regular expression to retrieve the metadata of a test.
-    static FIXTURE_REGEX: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r#".*_FIXTURE.js(on)?"#)
-            .expect("could not compile fixture retrieval regular expression")
-    });
-
     let name = path
         .file_name()
         .ok_or_else(|| {
@@ -137,7 +128,7 @@ pub(super) fn read_suite(path: &Path) -> io::Result<TestSuite> {
 
         if entry.file_type()?.is_dir() {
             suites.push(read_suite(entry.path().as_path())?);
-        } else if FIXTURE_REGEX.is_match(&entry.file_name().to_string_lossy()) {
+        } else if entry.file_name().to_string_lossy().contains("_FIXTURE") {
             continue;
         } else if IGNORED.contains_file(&entry.file_name().to_string_lossy()) {
             let mut test = Test::default();

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -430,8 +430,8 @@ fn compute_result_diff(
             match (base_test.result, new_test.result) {
                 (a, b) if a == b => {}
 
-                (TestOutcomeResult::Panic, _) => final_diff.panic_fixes.push(test_name),
                 (_, TestOutcomeResult::Passed) => final_diff.fixed.push(test_name),
+                (TestOutcomeResult::Panic, _) => final_diff.panic_fixes.push(test_name),
                 (_, TestOutcomeResult::Failed) => final_diff.broken.push(test_name),
                 (_, TestOutcomeResult::Panic) => final_diff.new_panics.push(test_name),
 

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -433,10 +433,14 @@ fn compute_result_diff(
                 | (TestOutcomeResult::Failed, TestOutcomeResult::Failed)
                 | (TestOutcomeResult::Panic, TestOutcomeResult::Panic) => {}
 
+                (TestOutcomeResult::Panic, TestOutcomeResult::Failed) => {
+                    final_diff.panic_fixes.push(test_name)
+                }
+
                 (_, TestOutcomeResult::Passed) => final_diff.fixed.push(test_name),
                 (_, TestOutcomeResult::Failed) => final_diff.broken.push(test_name),
                 (_, TestOutcomeResult::Panic) => final_diff.new_panics.push(test_name),
-                (TestOutcomeResult::Panic, _) => final_diff.panic_fixes.push(test_name),
+
                 _ => {}
             }
         }

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -428,15 +428,9 @@ fn compute_result_diff(
             .into_boxed_str();
 
             match (base_test.result, new_test.result) {
-                (TestOutcomeResult::Passed, TestOutcomeResult::Passed)
-                | (TestOutcomeResult::Ignored, TestOutcomeResult::Ignored)
-                | (TestOutcomeResult::Failed, TestOutcomeResult::Failed)
-                | (TestOutcomeResult::Panic, TestOutcomeResult::Panic) => {}
+                (a, b) if a == b => {}
 
-                (TestOutcomeResult::Panic, TestOutcomeResult::Failed) => {
-                    final_diff.panic_fixes.push(test_name)
-                }
-
+                (TestOutcomeResult::Panic, _) => final_diff.panic_fixes.push(test_name),
                 (_, TestOutcomeResult::Passed) => final_diff.fixed.push(test_name),
                 (_, TestOutcomeResult::Failed) => final_diff.broken.push(test_name),
                 (_, TestOutcomeResult::Panic) => final_diff.new_panics.push(test_name),

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -4,6 +4,7 @@ flag:async
 
 // Non-implemented features:
 feature:TypedArray
+feature:json-modules
 //feature:generators
 //feature:async-iteration
 //feature:class


### PR DESCRIPTION
Previously, if a panic was fixed and it was now failing, it would be considered as a "new failure". This considers it a panic fix.