### PR TITLE
fix VM branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,28 @@ jobs:
       #     args: --ignore-tests
       # - name: Upload to codecov.io
       #   uses: codecov/codecov-action@v1
+  test_vm_on_linux:
+    name: Test VM on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.4
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Cache cargo
+        uses: actions/cache@v2.1.6
+        with:
+          path: |
+            target
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: ---package Boa --lib --all-features -- vm --nocapture
 
   test_on_windows:
     name: Test Suite on Windows

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,7 +117,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ---package Boa --lib --all-features -- vm --nocapture
+          args: ---package Boa --lib --features=vm -- vm --nocapture
 
   test_on_windows:
     name: Test Suite on Windows

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -61,6 +61,30 @@
     },
     {
       "type": "process",
+      "label": "Cargo Run (Profiler & VM)",
+      "command": "cargo",
+      "args": [
+        "run",
+        "--features",
+        "Boa/profiler",
+        "--features",
+        "vm",
+        "../tests/js/test.js"
+      ],
+      "group": "build",
+      "options": {
+        "env": {
+          "RUST_BACKTRACE": "full"
+        },
+        "cwd": "${workspaceFolder}/boa_cli"
+      },
+      "presentation": {
+        "clear": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "type": "process",
       "label": "Get Tokens",
       "command": "cargo",
       "args": ["run", "--bin", "boa", "--", "-t=Debug", "./tests/js/test.js"],

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -652,6 +652,7 @@ impl Context {
         drop(main_timer);
         BoaProfiler::global().drop();
 
+        println!("{:?}", &execution_result);
         execution_result
     }
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -652,7 +652,6 @@ impl Context {
         drop(main_timer);
         BoaProfiler::global().drop();
 
-        println!("{:?}", &execution_result);
         execution_result
     }
 

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -14,6 +14,7 @@ pub trait Executable {
 pub(crate) enum InterpreterState {
     Executing,
     Return,
+    #[cfg(feature = "vm")]
     Error,
     Break(Option<Box<str>>),
     Continue(Option<Box<str>>),

--- a/boa/src/exec/mod.rs
+++ b/boa/src/exec/mod.rs
@@ -14,6 +14,7 @@ pub trait Executable {
 pub(crate) enum InterpreterState {
     Executing,
     Return,
+    Error,
     Break(Option<Box<str>>),
     Continue(Option<Box<str>>),
 }

--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -84,9 +84,11 @@ impl Executable for Block {
                     // TODO, continue to a label
                     break;
                 }
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
         }
 

--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -84,7 +84,7 @@ impl Executable for Block {
                     // TODO, continue to a label
                     break;
                 }
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution
                 }
             }

--- a/boa/src/syntax/ast/node/identifier/mod.rs
+++ b/boa/src/syntax/ast/node/identifier/mod.rs
@@ -11,6 +11,12 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "vm")]
+use crate::{
+    syntax::lexer::BoaProfiler,
+    vm::{compilation::CodeGen, Compiler, Instruction},
+};
+
 /// An `identifier` is a sequence of characters in the code that identifies a variable,
 /// function, or property.
 ///
@@ -37,6 +43,14 @@ pub struct Identifier {
 impl Executable for Identifier {
     fn run(&self, context: &mut Context) -> Result<Value> {
         context.get_binding_value(self.as_ref())
+    }
+}
+
+#[cfg(feature = "vm")]
+impl CodeGen for Identifier {
+    fn compile(&self, compiler: &mut Compiler) {
+        let _timer = BoaProfiler::global().start_event("Identifier", "codeGen");
+        compiler.add_instruction(Instruction::GetName(String::from(self.ident.as_ref())));
     }
 }
 

--- a/boa/src/syntax/ast/node/identifier/mod.rs
+++ b/boa/src/syntax/ast/node/identifier/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::Node,
-    Context, Result, Value,
+    BoaProfiler, Context, Result, Value,
 };
 use std::fmt;
 
@@ -12,10 +12,7 @@ use std::fmt;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "vm")]
-use crate::{
-    syntax::lexer::BoaProfiler,
-    vm::{compilation::CodeGen, Compiler, Instruction},
-};
+use crate::vm::{compilation::CodeGen, Compiler, Instruction};
 
 /// An `identifier` is a sequence of characters in the code that identifies a variable,
 /// function, or property.
@@ -42,6 +39,7 @@ pub struct Identifier {
 
 impl Executable for Identifier {
     fn run(&self, context: &mut Context) -> Result<Value> {
+        let _timer = BoaProfiler::global().start_event("Identifier", "exec");
         context.get_binding_value(self.as_ref())
     }
 }

--- a/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -86,9 +86,11 @@ impl Executable for DoWhileLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution.
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
             if !self.cond().run(context)?.to_boolean() {
                 break;

--- a/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -86,7 +86,7 @@ impl Executable for DoWhileLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution.
                 }
             }

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -202,9 +202,11 @@ impl Executable for ForInLoop {
                     handle_state_with_labels!(self, label, context, continue);
                 }
                 InterpreterState::Return => return Ok(result),
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution.
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
             let _ = context.pop_environment();
         }

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -202,7 +202,7 @@ impl Executable for ForInLoop {
                     handle_state_with_labels!(self, label, context, continue);
                 }
                 InterpreterState::Return => return Ok(result),
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution.
                 }
             }

--- a/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
@@ -130,7 +130,7 @@ impl Executable for ForLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution.
                 }
             }

--- a/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
@@ -130,9 +130,11 @@ impl Executable for ForLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution.
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
 
             if let Some(final_expr) = self.final_expr() {

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -193,7 +193,7 @@ impl Executable for ForOfLoop {
                     handle_state_with_labels!(self, label, context, continue);
                 }
                 InterpreterState::Return => return Ok(result),
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution.
                 }
             }

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -193,9 +193,11 @@ impl Executable for ForOfLoop {
                     handle_state_with_labels!(self, label, context, continue);
                 }
                 InterpreterState::Return => return Ok(result),
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution.
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
             let _ = context.pop_environment();
         }

--- a/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
@@ -84,9 +84,11 @@ impl Executable for WhileLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution.
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
         }
         Ok(result)

--- a/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
@@ -84,7 +84,7 @@ impl Executable for WhileLoop {
                 InterpreterState::Return => {
                     return Ok(result);
                 }
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution.
                 }
             }

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -5,12 +5,15 @@ use crate::{
     gc::{Finalize, Trace},
     property::{AccessorDescriptor, Attribute, DataDescriptor, PropertyDescriptor},
     syntax::ast::node::{MethodDefinitionKind, Node, PropertyDefinition},
-    Context, Result, Value,
+    BoaProfiler, Context, Result, Value,
 };
 use std::fmt;
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "vm")]
+use crate::vm::{compilation::CodeGen, Compiler, Instruction};
 
 /// Objects in JavaScript may be defined as an unordered collection of related data, of
 /// primitive or reference types, in the form of “key: value” pairs.
@@ -71,8 +74,23 @@ impl Object {
     }
 }
 
+#[cfg(feature = "vm")]
+impl CodeGen for Object {
+    fn compile(&self, compiler: &mut Compiler) {
+        let _timer = BoaProfiler::global().start_event("object", "codeGen");
+        // Is it a new empty object?
+        if self.properties.len() == 0 {
+            compiler.add_instruction(Instruction::NewObject);
+            return;
+        }
+
+        unimplemented!()
+    }
+}
+
 impl Executable for Object {
     fn run(&self, context: &mut Context) -> Result<Value> {
+        let _timer = BoaProfiler::global().start_event("object", "exec");
         let obj = Value::new_object(context);
 
         // TODO: Implement the rest of the property types.

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -120,7 +120,7 @@ impl Executable for StatementList {
                 InterpreterState::Continue(_label) => {
                     break;
                 }
-                InterpreterState::Executing => {
+                InterpreterState::Executing | InterpreterState::Error => {
                     // Continue execution
                 }
             }

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -120,9 +120,11 @@ impl Executable for StatementList {
                 InterpreterState::Continue(_label) => {
                     break;
                 }
-                InterpreterState::Executing | InterpreterState::Error => {
+                InterpreterState::Executing => {
                     // Continue execution
                 }
+                #[cfg(feature = "vm")]
+                InterpreterState::Error => {}
             }
             if i + 1 == self.items().len() {
                 obj = val;

--- a/boa/src/syntax/ast/node/switch/mod.rs
+++ b/boa/src/syntax/ast/node/switch/mod.rs
@@ -157,10 +157,12 @@ impl Executable for Switch {
                         // TODO, continue to a label.
                         break;
                     }
-                    InterpreterState::Executing | InterpreterState::Error => {
+                    InterpreterState::Executing => {
                         // Continuing execution / falling through to next case statement(s).
                         fall_through = true;
                     }
+                    #[cfg(feature = "vm")]
+                    InterpreterState::Error => {}
                 }
             }
         }

--- a/boa/src/syntax/ast/node/switch/mod.rs
+++ b/boa/src/syntax/ast/node/switch/mod.rs
@@ -157,7 +157,7 @@ impl Executable for Switch {
                         // TODO, continue to a label.
                         break;
                     }
-                    InterpreterState::Executing => {
+                    InterpreterState::Executing | InterpreterState::Error => {
                         // Continuing execution / falling through to next case statement(s).
                         fall_through = true;
                     }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -103,6 +103,7 @@ impl CodeGen for Node {
                     };
                 }
             }
+            Node::Identifier(ref name) => name.compile(compiler),
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/compilation.rs
+++ b/boa/src/vm/compilation.rs
@@ -104,6 +104,8 @@ impl CodeGen for Node {
                 }
             }
             Node::Identifier(ref name) => name.compile(compiler),
+            Node::Object(ref obj) => obj.compile(compiler),
+
             _ => unimplemented!(),
         }
     }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -67,9 +67,12 @@ pub enum Instruction {
     /// The usize is the index of the value to initiate the variable with in the pool
     InitLexical(usize),
 
-    // Getting Binding values
+    // Binding values
     /// Find a binding on the environment chain and push its value.
     GetName(String),
+    // Objects
+    // Create and push a new object onto the stack
+    NewObject,
 }
 
 impl std::fmt::Display for Instruction {
@@ -118,6 +121,7 @@ impl std::fmt::Display for Instruction {
             Self::DefLet(name) => write!(f, "DefLet({})", name),
             Self::DefConst(name) => write!(f, "DefConst({})", name),
             Self::InitLexical(value) => write!(f, "InitLexical({})", value),
+            Self::NewObject => write!(f, "NewObject"),
         }
     }
 }

--- a/boa/src/vm/instructions.rs
+++ b/boa/src/vm/instructions.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug)]
 pub enum Instruction {
     Undefined,
     Null,
@@ -66,6 +66,10 @@ pub enum Instruction {
     DefConst(usize),
     /// The usize is the index of the value to initiate the variable with in the pool
     InitLexical(usize),
+
+    // Getting Binding values
+    /// Find a binding on the environment chain and push its value.
+    GetName(String),
 }
 
 impl std::fmt::Display for Instruction {
@@ -90,6 +94,7 @@ impl std::fmt::Display for Instruction {
             Self::BitAnd => write!(f, "BitAnd"),
             Self::BitOr => write!(f, "BitOr"),
             Self::BitXor => write!(f, "BitXor"),
+            Self::GetName(ref name) => write!(f, "GetName({})", name),
             Self::Shl => write!(f, "Shl"),
             Self::Shr => write!(f, "Shr"),
             Self::UShr => write!(f, "UShr"),

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -227,44 +227,40 @@ impl<'a> VM<'a> {
                 Instruction::DefVar(name_index) => {
                     let name: String = self.pool[name_index].to_string(self.ctx)?.to_string();
 
-                    self.ctx
-                        .realm_mut()
-                        .environment
-                        .create_mutable_binding(name.to_string(), false, VariableScope::Function)
-                        .map_err(|e| e.to_error(self.ctx))?;
+                    self.ctx.create_mutable_binding(
+                        name.to_string(),
+                        false,
+                        VariableScope::Function,
+                    )?;
 
                     None
                 }
                 Instruction::DefLet(name_index) => {
                     let name = self.pool[name_index].to_string(self.ctx)?;
 
-                    self.ctx
-                        .realm_mut()
-                        .environment
-                        .create_mutable_binding(name.to_string(), false, VariableScope::Block)
-                        .map_err(|e| e.to_error(self.ctx))?;
+                    self.ctx.create_mutable_binding(
+                        name.to_string(),
+                        false,
+                        VariableScope::Block,
+                    )?;
 
                     None
                 }
                 Instruction::DefConst(name_index) => {
                     let name = self.pool[name_index].to_string(self.ctx)?;
 
-                    self.ctx
-                        .realm_mut()
-                        .environment
-                        .create_immutable_binding(name.to_string(), false, VariableScope::Block)
-                        .map_err(|e| e.to_error(self.ctx))?;
+                    self.ctx.create_immutable_binding(
+                        name.to_string(),
+                        false,
+                        VariableScope::Block,
+                    )?;
 
                     None
                 }
                 Instruction::InitLexical(name_index) => {
                     let name = self.pool[name_index].to_string(self.ctx)?;
                     let value = self.pop();
-                    self.ctx
-                        .realm_mut()
-                        .environment
-                        .initialize_binding(&name, value.clone())
-                        .map_err(|e| e.to_error(self.ctx))?;
+                    self.ctx.initialize_binding(&name, value.clone())?;
 
                     Some(value)
                 }

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -268,23 +268,20 @@ impl<'a> VM<'a> {
                     let value = self.pop();
                     self.ctx.initialize_binding(&name, value.clone())?;
 
-                    Some(value)
-                }
-                // Find a binding on the environment chain and push its value.
-                Instruction::GetName(ref name) => {
-                    match self.ctx.get_binding_value(&name) {
-                        Ok(val) => {
-                            self.push(val);
-                        }
-                        Err(val) => {
-                            self.push(val);
-                            self.ctx
-                                .executor()
-                                .set_current_state(InterpreterState::Error)
-                        }
-                    }
                     None
                 }
+                // Find a binding on the environment chain and push its value.
+                Instruction::GetName(ref name) => match self.ctx.get_binding_value(&name) {
+                    Ok(val) => Some(val),
+                    Err(val) => {
+                        self.ctx
+                            .executor()
+                            .set_current_state(InterpreterState::Error);
+                        Some(val)
+                    }
+                },
+                // Create a new object and push to the stack
+                Instruction::NewObject => Some(Value::new_object(self.ctx)),
             };
 
             if let Some(value) = result {

--- a/boa/src/vm/tests.rs
+++ b/boa/src/vm/tests.rs
@@ -1,7 +1,7 @@
 use crate::exec;
 
 #[test]
-fn vm_typeof_string() {
+fn typeof_string() {
     let typeof_object = r#"
         const a = "hello";
         typeof a;
@@ -10,10 +10,20 @@ fn vm_typeof_string() {
 }
 
 #[test]
-fn vm_typeof_number() {
+fn typeof_number() {
     let typeof_number = r#"
         let a = 1234;
         typeof a;
     "#;
     assert_eq!(&exec(typeof_number), "\"number\"");
+}
+
+#[test]
+fn basic_op() {
+    let basic_op = r#"
+        const a = 1;
+        const b = 2;
+        a + b
+    "#;
+    assert_eq!(&exec(basic_op), "3");
 }

--- a/boa/src/vm/tests.rs
+++ b/boa/src/vm/tests.rs
@@ -1,0 +1,19 @@
+use crate::exec;
+
+#[test]
+fn vm_typeof_string() {
+    let typeof_object = r#"
+        const a = "hello";
+        typeof a;
+    "#;
+    assert_eq!(&exec(typeof_object), "\"string\"");
+}
+
+#[test]
+fn vm_typeof_number() {
+    let typeof_number = r#"
+        let a = 1234;
+        typeof a;
+    "#;
+    assert_eq!(&exec(typeof_number), "\"number\"");
+}


### PR DESCRIPTION
The VM branch was failing to build. This uses the latest API changes made on Context.
This PR also introduces a new state to the executor, the `Error` state. This lets the VM know that an error has happened and immediately stops, leaving the error value on the top of the stack. Going forward this can be used to unwind the stack.
As the current path doesn't make use of this arm it should be backwards compatible.