### PR TITLE
Fix display for nodes

### DIFF
--- a/boa/src/syntax/ast/node/array/mod.rs
+++ b/boa/src/syntax/ast/node/array/mod.rs
@@ -12,6 +12,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// An array is an ordered collection of data (either primitive or object depending upon the
 /// language).
 ///

--- a/boa/src/syntax/ast/node/array/tests.rs
+++ b/boa/src/syntax/ast/node/array/tests.rs
@@ -1,0 +1,14 @@
+use crate::parse;
+
+#[test]
+fn fmt() {
+    let scenario = r#"
+        let a = [1, 2, 3, "words", "more words"];
+        let b = [];
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| l.trim()) // Remove trailing whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+}

--- a/boa/src/syntax/ast/node/array/tests.rs
+++ b/boa/src/syntax/ast/node/array/tests.rs
@@ -1,14 +1,9 @@
-use crate::parse;
-
 #[test]
 fn fmt() {
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         let a = [1, 2, 3, "words", "more words"];
         let b = [];
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| l.trim()) // Remove trailing whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa/src/syntax/ast/node/await_expr/mod.rs
@@ -31,14 +31,6 @@ impl Executable for AwaitExpr {
     }
 }
 
-impl AwaitExpr {
-    /// Implements the display formatting with indentation.
-    pub(super) fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
-        write!(f, "await ")?;
-        self.expr.display(f, 0)
-    }
-}
-
 impl<T> From<T> for AwaitExpr
 where
     T: Into<Box<Node>>,
@@ -50,7 +42,8 @@ where
 
 impl fmt::Display for AwaitExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.display(f, 0)
+        write!(f, "await ")?;
+        self.expr.display(f, 0)
     }
 }
 

--- a/boa/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa/src/syntax/ast/node/await_expr/mod.rs
@@ -34,8 +34,8 @@ impl Executable for AwaitExpr {
 impl AwaitExpr {
     /// Implements the display formatting with indentation.
     pub(super) fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
-        writeln!(f, "await ")?;
-        self.expr.display(f, indentation)
+        write!(f, "await ")?;
+        self.expr.display(f, 0)
     }
 }
 

--- a/boa/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa/src/syntax/ast/node/await_expr/mod.rs
@@ -8,6 +8,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// An await expression is used within an async function to pause execution and wait for a
 /// promise to resolve.
 ///

--- a/boa/src/syntax/ast/node/await_expr/tests.rs
+++ b/boa/src/syntax/ast/node/await_expr/tests.rs
@@ -1,14 +1,9 @@
-use crate::parse;
-
 #[test]
 fn fmt() {
     // TODO: `let a = await fn()` is invalid syntax as of writing. It should be tested here once implemented.
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         await function_call();
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| l.trim()) // Remove trailing whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/await_expr/tests.rs
+++ b/boa/src/syntax/ast/node/await_expr/tests.rs
@@ -1,0 +1,14 @@
+use crate::parse;
+
+#[test]
+fn fmt() {
+    // TODO: `let a = await fn()` is invalid syntax as of writing. It should be tested here once implemented.
+    let scenario = r#"
+        await function_call();
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| l.trim()) // Remove trailing whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+}

--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -13,6 +13,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// A `block` statement (or compound statement in other languages) is used to group zero or
 /// more statements.
 ///

--- a/boa/src/syntax/ast/node/block/tests.rs
+++ b/boa/src/syntax/ast/node/block/tests.rs
@@ -1,30 +1,22 @@
-use crate::parse;
-
 #[test]
 fn fmt() {
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         {
             let a = function_call();
             console.log("hello");
         }
         another_statement();
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| &l[8..]) // Remove preceding whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
     // TODO: Once block labels are implemtned, this should be tested:
-    // let scenario = r#"
+    // super::super::test_formatting(
+    //     r#"
     //     block_name: {
     //         let a = function_call();
     //         console.log("hello");
     //     }
     //     another_statement();
-    //     "#[1..] // Remove the preceding newline
-    //     .lines()
-    //     .map(|l| &l[8..]) // Remove preceding whitespace from each line
-    //     .collect::<Vec<&'static str>>()
-    //     .join("\n");
-    // assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+    //     "#,
+    // );
 }

--- a/boa/src/syntax/ast/node/block/tests.rs
+++ b/boa/src/syntax/ast/node/block/tests.rs
@@ -1,0 +1,17 @@
+use crate::parse;
+
+#[test]
+fn fmt() {
+    let scenario = r#"
+        {
+            let a = function_call();
+            console.log("hello");
+        }
+        another_statement();
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| &l[8..]) // Remove preceding whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+}

--- a/boa/src/syntax/ast/node/block/tests.rs
+++ b/boa/src/syntax/ast/node/block/tests.rs
@@ -14,4 +14,17 @@ fn fmt() {
         .collect::<Vec<&'static str>>()
         .join("\n");
     assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+    // TODO: Once block labels are implemtned, this should be tested:
+    // let scenario = r#"
+    //     block_name: {
+    //         let a = function_call();
+    //         console.log("hello");
+    //     }
+    //     another_statement();
+    //     "#[1..] // Remove the preceding newline
+    //     .lines()
+    //     .map(|l| &l[8..]) // Remove preceding whitespace from each line
+    //     .collect::<Vec<&'static str>>()
+    //     .join("\n");
+    // assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
 }

--- a/boa/src/syntax/ast/node/break_node/tests.rs
+++ b/boa/src/syntax/ast/node/break_node/tests.rs
@@ -1,5 +1,6 @@
 use crate::{
     exec::{Executable, InterpreterState},
+    parse,
     syntax::ast::node::Break,
     Context,
 };
@@ -16,4 +17,38 @@ fn check_post_state() {
         context.executor().get_current_state(),
         &InterpreterState::Break(Some("label".into()))
     );
+}
+
+#[test]
+fn fmt() {
+    // Blocks do not store their label, so we cannot test with
+    // the outer block having a label.
+    //
+    // TODO: Once block labels are implemented, this test should
+    // include them:
+    //
+    // ```
+    // outer: {
+    //     while (true) {
+    //         break outer;
+    //     }
+    //     skipped_call();
+    // }
+    // ```
+    let scenario = r#"
+        {
+            while (true) {
+                break outer;
+            }
+            skipped_call();
+        }
+        while (true) {
+            break;
+        }
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| &l[8..]) // Remove preceding whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
 }

--- a/boa/src/syntax/ast/node/break_node/tests.rs
+++ b/boa/src/syntax/ast/node/break_node/tests.rs
@@ -1,6 +1,5 @@
 use crate::{
     exec::{Executable, InterpreterState},
-    parse,
     syntax::ast::node::Break,
     Context,
 };
@@ -35,7 +34,8 @@ fn fmt() {
     //     skipped_call();
     // }
     // ```
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         {
             while (true) {
                 break outer;
@@ -45,10 +45,6 @@ fn fmt() {
         while (true) {
             break;
         }
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| &l[8..]) // Remove preceding whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/call/mod.rs
+++ b/boa/src/syntax/ast/node/call/mod.rs
@@ -12,6 +12,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// Calling the function actually performs the specified actions with the indicated parameters.
 ///
 /// Defining a function does not execute it. Defining it simply names the function and

--- a/boa/src/syntax/ast/node/call/tests.rs
+++ b/boa/src/syntax/ast/node/call/tests.rs
@@ -1,0 +1,15 @@
+use crate::parse;
+
+#[test]
+fn fmt() {
+    let scenario = r#"
+        call_1(1, 2, 3);
+        call_2("argument here");
+        call_3();
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| &l[8..]) // Remove preceding whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+}

--- a/boa/src/syntax/ast/node/call/tests.rs
+++ b/boa/src/syntax/ast/node/call/tests.rs
@@ -1,15 +1,10 @@
-use crate::parse;
-
 #[test]
 fn fmt() {
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         call_1(1, 2, 3);
         call_2("argument here");
         call_3();
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| &l[8..]) // Remove preceding whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/conditional/mod.rs
+++ b/boa/src/syntax/ast/node/conditional/mod.rs
@@ -4,3 +4,6 @@ pub mod conditional_op;
 pub mod if_node;
 
 pub use self::{conditional_op::ConditionalOp, if_node::If};
+
+#[cfg(test)]
+mod tests;

--- a/boa/src/syntax/ast/node/conditional/tests.rs
+++ b/boa/src/syntax/ast/node/conditional/tests.rs
@@ -1,0 +1,13 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        let a = true ? 5 : 6;
+        if (false) {
+            a = 10;
+        } else {
+            a = 20;
+        }
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -61,8 +61,13 @@ impl ArrowFunctionDecl {
     ) -> fmt::Result {
         write!(f, "(")?;
         join_nodes(f, &self.params)?;
-        f.write_str(") => ")?;
-        self.body.display(f, indentation)
+        if self.body().is_empty() {
+            f.write_str(") => {}")
+        } else {
+            f.write_str(") => {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -68,11 +68,13 @@ impl AsyncFunctionDecl {
             None => write!(f, "async function (")?,
         }
         join_nodes(f, &self.parameters)?;
-        writeln!(f, ") {{")?;
-
-        self.body.display(f, indentation + 1)?;
-
-        writeln!(f, "}}")
+        if self.body().is_empty() {
+            f.write_str(") {}")
+        } else {
+            f.write_str(") {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -64,15 +64,11 @@ impl AsyncFunctionDecl {
         indentation: usize,
     ) -> fmt::Result {
         match &self.name {
-            Some(name) => {
-                write!(f, "async function {}(", name)?;
-            }
-            None => {
-                write!(f, "async function (")?;
-            }
+            Some(name) => write!(f, "async function {}(", name)?,
+            None => write!(f, "async function (")?,
         }
         join_nodes(f, &self.parameters)?;
-        f.write_str(") {{")?;
+        writeln!(f, ") {{")?;
 
         self.body.display(f, indentation + 1)?;
 

--- a/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
@@ -64,7 +64,7 @@ impl AsyncFunctionExpr {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
-        f.write_str("function")?;
+        f.write_str("async function")?;
         if let Some(ref name) = self.name {
             write!(f, " {}", name)?;
         }

--- a/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_expr/mod.rs
@@ -70,11 +70,13 @@ impl AsyncFunctionExpr {
         }
         f.write_str("(")?;
         join_nodes(f, &self.parameters)?;
-        f.write_str(") {{")?;
-
-        self.body.display(f, indentation + 1)?;
-
-        writeln!(f, "}}")
+        if self.body().is_empty() {
+            f.write_str(") {}")
+        } else {
+            f.write_str(") {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -75,11 +75,13 @@ impl FunctionDecl {
     ) -> fmt::Result {
         write!(f, "function {}(", self.name)?;
         join_nodes(f, &self.parameters)?;
-        writeln!(f, ") {{")?;
-
-        self.body.display(f, indentation + 1)?;
-
-        writeln!(f, "{}}}", "    ".repeat(indentation))
+        if self.body().is_empty() {
+            f.write_str(") {}")
+        } else {
+            f.write_str(") {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -75,11 +75,11 @@ impl FunctionDecl {
     ) -> fmt::Result {
         write!(f, "function {}(", self.name)?;
         join_nodes(f, &self.parameters)?;
-        f.write_str(") {{")?;
+        writeln!(f, ") {{")?;
 
         self.body.display(f, indentation + 1)?;
 
-        writeln!(f, "}}")
+        writeln!(f, "{}}}", "    ".repeat(indentation))
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -76,10 +76,21 @@ impl FunctionExpr {
         }
         f.write_str("(")?;
         join_nodes(f, &self.parameters)?;
+        f.write_str(") ")?;
+        self.display_block(f, indentation)
+    }
+
+    /// Displays the function's body. This includes the curly braces at the start and end.
+    /// This will not indent the first brace, but will indent the last brace.
+    pub(in crate::syntax::ast::node) fn display_block(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        indentation: usize,
+    ) -> fmt::Result {
         if self.body().is_empty() {
-            f.write_str(") {}")
+            f.write_str("{}")
         } else {
-            f.write_str(") {\n")?;
+            f.write_str("{\n")?;
             self.body.display(f, indentation + 1)?;
             write!(f, "{}}}", "    ".repeat(indentation))
         }

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -76,11 +76,13 @@ impl FunctionExpr {
         }
         f.write_str("(")?;
         join_nodes(f, &self.parameters)?;
-        writeln!(f, ") {{")?;
-
-        self.body.display(f, indentation + 1)?;
-
-        write!(f, "}}")
+        if self.body().is_empty() {
+            f.write_str(") {}")
+        } else {
+            f.write_str(") {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -76,11 +76,11 @@ impl FunctionExpr {
         }
         f.write_str("(")?;
         join_nodes(f, &self.parameters)?;
-        f.write_str(") {{")?;
+        writeln!(f, ") {{")?;
 
         self.body.display(f, indentation + 1)?;
 
-        writeln!(f, "}}")
+        write!(f, "}}")
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/tests.rs
+++ b/boa/src/syntax/ast/node/declaration/tests.rs
@@ -13,8 +13,14 @@ fn duplicate_function_name() {
 
 #[test]
 fn fmt() {
+    // TODO: Async function expr are considered valid syntax, but are converted
+    // into normal functions somewhere in the parser.
     super::super::test_formatting(
         r#"
+        function func(a, b) {
+            console.log(a);
+        };
+        function func_2(a, b) {};
         let arrow_func = (a, b) => {
             console.log("in multi statement arrow");
             console.log(b);
@@ -22,19 +28,15 @@ fn fmt() {
         async function async_func(a, b) {
             console.log(a);
         };
-        pass_async_func(async function(a, b) {
+        pass_async_func(function(a, b) {
             console.log("in async callback", a);
         });
-        function func(a, b) {
-            console.log(a);
-        };
         pass_func(function(a, b) {
             console.log("in callback", a);
         });
         let arrow_func_2 = (a, b) => {};
         async function async_func_2(a, b) {};
-        pass_async_func(async function(a, b) {});
-        function func_2(a, b) {};
+        pass_async_func(function(a, b) {});
         pass_func(function(a, b) {});
         "#,
     );

--- a/boa/src/syntax/ast/node/declaration/tests.rs
+++ b/boa/src/syntax/ast/node/declaration/tests.rs
@@ -13,8 +13,6 @@ fn duplicate_function_name() {
 
 #[test]
 fn fmt() {
-    // TODO: Async function expr are considered valid syntax, but are converted
-    // into normal functions somewhere in the parser.
     super::super::test_formatting(
         r#"
         function func(a, b) {
@@ -28,7 +26,7 @@ fn fmt() {
         async function async_func(a, b) {
             console.log(a);
         };
-        pass_async_func(function(a, b) {
+        pass_async_func(async function(a, b) {
             console.log("in async callback", a);
         });
         pass_func(function(a, b) {
@@ -36,7 +34,7 @@ fn fmt() {
         });
         let arrow_func_2 = (a, b) => {};
         async function async_func_2(a, b) {};
-        pass_async_func(function(a, b) {});
+        pass_async_func(async function(a, b) {});
         pass_func(function(a, b) {});
         "#,
     );

--- a/boa/src/syntax/ast/node/declaration/tests.rs
+++ b/boa/src/syntax/ast/node/declaration/tests.rs
@@ -10,3 +10,32 @@ fn duplicate_function_name() {
 
     assert_eq!(&exec(scenario), "12");
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        let arrow_func = (a, b) => {
+            console.log("in multi statement arrow");
+            console.log(b);
+        };
+        async function async_func(a, b) {
+            console.log(a);
+        };
+        pass_async_func(async function(a, b) {
+            console.log("in async callback", a);
+        });
+        function func(a, b) {
+            console.log(a);
+        };
+        pass_func(function(a, b) {
+            console.log("in callback", a);
+        });
+        let arrow_func_2 = (a, b) => {};
+        async function async_func_2(a, b) {};
+        pass_async_func(async function(a, b) {});
+        function func_2(a, b) {};
+        pass_func(function(a, b) {});
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/field/mod.rs
+++ b/boa/src/syntax/ast/node/field/mod.rs
@@ -4,3 +4,6 @@ pub mod get_const_field;
 pub mod get_field;
 
 pub use self::{get_const_field::GetConstField, get_field::GetField};
+
+#[cfg(test)]
+mod tests;

--- a/boa/src/syntax/ast/node/field/tests.rs
+++ b/boa/src/syntax/ast/node/field/tests.rs
@@ -1,0 +1,10 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        a.field_name;
+        a[5];
+        a["other_field_name"];
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
@@ -57,15 +57,11 @@ impl Executable for Continue {
 
 impl fmt::Display for Continue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "continue{}",
-            if let Some(label) = self.label() {
-                format!(" {}", label)
-            } else {
-                String::new()
-            }
-        )
+        write!(f, "continue")?;
+        if let Some(label) = self.label() {
+            write!(f, " {}", label)?;
+        }
+        Ok(())
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -64,6 +64,9 @@ impl DoWhileLoop {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
+        if let Some(ref label) = self.label {
+            write!(f, "{}: ", label)?;
+        }
         write!(f, "do ")?;
         self.body().display(f, indentation)?;
         write!(f, " while ({})", self.cond())

--- a/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -64,9 +64,9 @@ impl DoWhileLoop {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
-        write!(f, "do")?;
+        write!(f, "do ")?;
         self.body().display(f, indentation)?;
-        write!(f, "while ({})", self.cond())
+        write!(f, " while ({})", self.cond())
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -59,9 +59,8 @@ impl ForInLoop {
     }
 
     pub fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
-        write!(f, "for ({} in {}) {{", self.variable, self.expr,)?;
-        self.body().display(f, indentation + 1)?;
-        f.write_str("}")
+        write!(f, "for ({} in {}) ", self.variable, self.expr)?;
+        self.body().display(f, indentation)
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -59,6 +59,9 @@ impl ForInLoop {
     }
 
     pub fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
+        if let Some(ref label) = self.label {
+            write!(f, "{}: ", label)?;
+        }
         write!(f, "for ({} in {}) ", self.variable, self.expr)?;
         self.body().display(f, indentation)
     }

--- a/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
@@ -73,19 +73,16 @@ impl ForLoop {
         if let Some(init) = self.init() {
             fmt::Display::fmt(init, f)?;
         }
-        f.write_str(";")?;
+        f.write_str("; ")?;
         if let Some(condition) = self.condition() {
             fmt::Display::fmt(condition, f)?;
         }
-        f.write_str(";")?;
+        f.write_str("; ")?;
         if let Some(final_expr) = self.final_expr() {
             fmt::Display::fmt(final_expr, f)?;
         }
-        writeln!(f, ") {{")?;
-
-        self.inner.body().display(f, indentation + 1)?;
-
-        write!(f, "}}")
+        write!(f, ") ")?;
+        self.inner.body().display(f, indentation)
     }
 
     pub fn label(&self) -> Option<&str> {

--- a/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_loop/mod.rs
@@ -69,6 +69,9 @@ impl ForLoop {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
+        if let Some(ref label) = self.label {
+            write!(f, "{}: ", label)?;
+        }
         f.write_str("for (")?;
         if let Some(init) = self.init() {
             fmt::Display::fmt(init, f)?;

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -59,9 +59,8 @@ impl ForOfLoop {
     }
 
     pub fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
-        write!(f, "for ({} of {}) {{", self.variable, self.iterable)?;
-        self.body().display(f, indentation + 1)?;
-        f.write_str("}")
+        write!(f, "for ({} of {}) ", self.variable, self.iterable)?;
+        self.body().display(f, indentation)
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -59,6 +59,9 @@ impl ForOfLoop {
     }
 
     pub fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
+        if let Some(ref label) = self.label {
+            write!(f, "{}: ", label)?;
+        }
         write!(f, "for ({} of {}) ", self.variable, self.iterable)?;
         self.body().display(f, indentation)
     }

--- a/boa/src/syntax/ast/node/iteration/tests.rs
+++ b/boa/src/syntax/ast/node/iteration/tests.rs
@@ -505,11 +505,12 @@ fn for_in_continue_label() {
 
 #[test]
 fn fmt() {
+    // Labeled and unlabeled for in loops
     super::super::test_formatting(
         r#"
         var str = "";
         outer: for (let i in [1, 2]) {
-            inner: for (let b in [2, 3, 4]) {
+            for (let b in [2, 3, 4]) {
                 if (b === "1") {
                     continue outer;
                 }

--- a/boa/src/syntax/ast/node/iteration/tests.rs
+++ b/boa/src/syntax/ast/node/iteration/tests.rs
@@ -502,3 +502,22 @@ fn for_in_continue_label() {
     "#;
     assert_eq!(&exec(scenario), "\"00\"")
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        var str = "";
+        outer: for (let i in [1, 2]) {
+            inner: for (let b in [2, 3, 4]) {
+                if (b === "1") {
+                    continue outer;
+                }
+                str = str + b;
+            };
+            str = str + i;
+        };
+        str;
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/iteration/tests.rs
+++ b/boa/src/syntax/ast/node/iteration/tests.rs
@@ -521,4 +521,57 @@ fn fmt() {
         str;
         "#,
     );
+    // Labeled and unlabeled for loops
+    super::super::test_formatting(
+        r#"
+        var str = "";
+        outer: for (let i = 0; i < 10; i++) {
+            for (let j = 3; j < 6; j++) {
+                if (j === "1") {
+                    continue outer;
+                }
+                str = str + j;
+            };
+            str = str + i;
+        };
+        str;
+        "#,
+    );
+    // Labeled and unlabeled for of loops
+    super::super::test_formatting(
+        r#"
+        for (i of [1, 2, 3]) {
+            if (false) {
+                break;
+            }
+        }
+        label: for (i of [1, 2, 3]) {
+            if (false) {
+                break label;
+            }
+        }
+        "#,
+    );
+    // Labeled and unlabeled do while loops
+    super::super::test_formatting(
+        r#"
+        do {
+            break;
+        } while (true);
+        label: do {
+            break label;
+        } while (true);
+        "#,
+    );
+    // Labeled and unlabeled while loops
+    super::super::test_formatting(
+        r#"
+        while (true) {
+            break;
+        }
+        label: while (true) {
+            break label;
+        }
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/iteration/tests.rs
+++ b/boa/src/syntax/ast/node/iteration/tests.rs
@@ -525,8 +525,8 @@ fn fmt() {
     super::super::test_formatting(
         r#"
         var str = "";
-        outer: for (let i = 0; i < 10; i++) {
-            for (let j = 3; j < 6; j++) {
+        outer: for (let i = 0; i < 10; ++i) {
+            for (let j = 3; j < 6; ++j) {
                 if (j === "1") {
                     continue outer;
                 }
@@ -544,12 +544,12 @@ fn fmt() {
             if (false) {
                 break;
             }
-        }
+        };
         label: for (i of [1, 2, 3]) {
             if (false) {
                 break label;
             }
-        }
+        };
         "#,
     );
     // Labeled and unlabeled do while loops

--- a/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/while_loop/mod.rs
@@ -63,6 +63,9 @@ impl WhileLoop {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
+        if let Some(ref label) = self.label {
+            write!(f, "{}: ", label)?;
+        }
         write!(f, "while ({}) ", self.cond())?;
         self.expr().display(f, indentation)
     }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -239,14 +239,28 @@ impl Node {
         Self::This
     }
 
-    /// Implements the display formatting with indentation.
+    /// Displays the value of the node with the given indentation. For example, an indent
+    /// level of 2 would produce this:
+    ///
+    /// ```js
+    ///         function hello() {
+    ///             console.log("hello");
+    ///         }
+    ///         hello();
+    ///         a = 2;
+    /// ```
     fn display(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
         let indent = "    ".repeat(indentation);
         match *self {
             Self::Block(_) => {}
             _ => write!(f, "{}", indent)?,
         }
+        self.display_no_indent(f, indentation)
+    }
 
+    /// Implements the display formatting with indentation. This will not prefix the value with
+    /// any indentation. If you want to prefix this with proper indents, use [`display`](Self::display).
+    fn display_no_indent(&self, f: &mut fmt::Formatter<'_>, indentation: usize) -> fmt::Result {
         match *self {
             Self::Call(ref expr) => Display::fmt(expr, f),
             Self::Const(ref c) => write!(f, "{}", c),

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -588,3 +588,33 @@ pub enum MethodDefinitionKind {
 unsafe impl Trace for MethodDefinitionKind {
     empty_trace!();
 }
+
+/// This parses the given source code, and then makes sure that
+/// the resulting StatementList is formatted in the same manner
+/// as the source code. This is expected to have a preceding
+/// newline.
+///
+/// This is a utility function for tests. It was made in case people
+/// are using different indents in their source files. This fixes
+/// any strings which may have been changed in a different indent
+/// level.
+#[cfg(test)]
+fn test_formatting(source: &'static str) {
+    // Remove preceding newline.
+    let source = &source[1..];
+
+    // Find out how much the code is indented
+    let first_line = &source[..source.find('\n').unwrap()];
+    let trimmed_first_line = first_line.trim();
+    let characters_to_remove = first_line.len() - trimmed_first_line.len();
+
+    let scenario = source
+        .lines()
+        .map(|l| &l[characters_to_remove..]) // Remove preceding whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(
+        format!("{}", crate::parse(&scenario, false).unwrap()),
+        scenario
+    );
+}

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -629,11 +629,11 @@ fn test_formatting(source: &'static str) {
         .join("\n");
     let result = format!("{}", crate::parse(&scenario, false).unwrap());
     if scenario != result {
-        print!("========= Expected:\n{}", scenario);
-        print!("========= Got:\n{}", result);
+        eprint!("========= Expected:\n{}", scenario);
+        eprint!("========= Got:\n{}", result);
         // Might be helpful to find differing whitespace
-        println!("========= Expected: {:?}", scenario);
-        println!("========= Got:      {:?}", result);
+        eprintln!("========= Expected: {:?}", scenario);
+        eprintln!("========= Got:      {:?}", result);
         panic!("parsing test did not give the correct result (see above)");
     }
 }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -285,7 +285,7 @@ impl Node {
             Self::ConstDeclList(ref decl) => Display::fmt(decl, f),
             Self::AsyncFunctionDecl(ref decl) => decl.display(f, indentation),
             Self::AsyncFunctionExpr(ref expr) => expr.display(f, indentation),
-            Self::AwaitExpr(ref expr) => expr.display(f, indentation),
+            Self::AwaitExpr(ref expr) => Display::fmt(expr, f),
             Self::Empty => write!(f, ";"),
         }
     }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -613,8 +613,13 @@ fn test_formatting(source: &'static str) {
         .map(|l| &l[characters_to_remove..]) // Remove preceding whitespace from each line
         .collect::<Vec<&'static str>>()
         .join("\n");
-    assert_eq!(
-        format!("{}", crate::parse(&scenario, false).unwrap()),
-        scenario
-    );
+    let result = format!("{}", crate::parse(&scenario, false).unwrap());
+    if scenario != result {
+        print!("========= Expected:\n{}", scenario);
+        print!("========= Got:\n{}", result);
+        // Might be helpful to find differing whitespace
+        println!("========= Expected: {:?}", scenario);
+        println!("========= Got:      {:?}", result);
+        panic!("parsing test did not give the correct result (see above)");
+    }
 }

--- a/boa/src/syntax/ast/node/new/mod.rs
+++ b/boa/src/syntax/ast/node/new/mod.rs
@@ -11,6 +11,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// The `new` operator lets developers create an instance of a user-defined object type or of
 /// one of the built-in object types that has a constructor function.
 ///

--- a/boa/src/syntax/ast/node/new/tests.rs
+++ b/boa/src/syntax/ast/node/new/tests.rs
@@ -1,0 +1,9 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        function MyClass() {};
+        let inst = new MyClass();
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -15,6 +15,9 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "vm")]
 use crate::vm::{compilation::CodeGen, Compiler, Instruction};
 
+#[cfg(test)]
+mod tests;
+
 /// Objects in JavaScript may be defined as an unordered collection of related data, of
 /// primitive or reference types, in the form of “key: value” pairs.
 ///

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -53,16 +53,17 @@ impl Object {
         indent: usize,
     ) -> fmt::Result {
         f.write_str("{\n")?;
+        let indent = "    ".repeat(indent + 1);
         for property in self.properties().iter() {
             match property {
                 PropertyDefinition::IdentifierReference(key) => {
-                    write!(f, "{}    {},", indent, key)?;
+                    writeln!(f, "{}{},", indent, key)?;
                 }
                 PropertyDefinition::Property(key, value) => {
-                    write!(f, "{}    {}: {},", indent, key, value)?;
+                    writeln!(f, "{}{}: {},", indent, key, value)?;
                 }
                 PropertyDefinition::SpreadObject(key) => {
-                    write!(f, "{}    ...{},", indent, key)?;
+                    writeln!(f, "{}...{},", indent, key)?;
                 }
                 PropertyDefinition::MethodDefinition(_kind, _key, _node) => {
                     // TODO: Implement display for PropertyDefinition::MethodDefinition.

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -63,14 +63,9 @@ impl Object {
                     writeln!(f, "{}{},", indentation, key)?;
                 }
                 PropertyDefinition::Property(key, value) => {
-                    dbg!(&value);
-                    if let Node::Object(ref inner) = value {
-                        write!(f, "{}{}: ", indentation, key)?;
-                        inner.display(f, indent + 1)?;
-                        writeln!(f, ",")?;
-                    } else {
-                        writeln!(f, "{}{}: {},", indentation, key, value)?;
-                    }
+                    write!(f, "{}{}: ", indentation, key,)?;
+                    value.display_no_indent(f, indent + 1)?;
+                    writeln!(f, ",")?;
                 }
                 PropertyDefinition::SpreadObject(key) => {
                     writeln!(f, "{}...{},", indentation, key)?;

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     property::{AccessorDescriptor, Attribute, DataDescriptor, PropertyDescriptor},
-    syntax::ast::node::{MethodDefinitionKind, Node, PropertyDefinition},
+    syntax::ast::node::{join_nodes, MethodDefinitionKind, Node, PropertyDefinition},
     BoaProfiler, Context, Result, Value,
 };
 use std::fmt;
@@ -70,9 +70,18 @@ impl Object {
                 PropertyDefinition::SpreadObject(key) => {
                     writeln!(f, "{}...{},", indentation, key)?;
                 }
-                PropertyDefinition::MethodDefinition(_kind, _key, _node) => {
-                    // TODO: Implement display for PropertyDefinition::MethodDefinition.
-                    unimplemented!("Display for PropertyDefinition::MethodDefinition");
+                PropertyDefinition::MethodDefinition(kind, key, node) => {
+                    write!(f, "{}", indentation)?;
+                    match &kind {
+                        MethodDefinitionKind::Get => write!(f, "get ")?,
+                        MethodDefinitionKind::Set => write!(f, "set ")?,
+                        MethodDefinitionKind::Ordinary => (),
+                    }
+                    write!(f, "{}(", key)?;
+                    join_nodes(f, &node.parameters())?;
+                    write!(f, ") ")?;
+                    node.display_block(f, indent + 1)?;
+                    writeln!(f, ",")?;
                 }
             }
         }

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -56,17 +56,24 @@ impl Object {
         indent: usize,
     ) -> fmt::Result {
         f.write_str("{\n")?;
-        let indent = "    ".repeat(indent + 1);
+        let indentation = "    ".repeat(indent + 1);
         for property in self.properties().iter() {
             match property {
                 PropertyDefinition::IdentifierReference(key) => {
-                    writeln!(f, "{}{},", indent, key)?;
+                    writeln!(f, "{}{},", indentation, key)?;
                 }
                 PropertyDefinition::Property(key, value) => {
-                    writeln!(f, "{}{}: {},", indent, key, value)?;
+                    dbg!(&value);
+                    if let Node::Object(ref inner) = value {
+                        write!(f, "{}{}: ", indentation, key)?;
+                        inner.display(f, indent + 1)?;
+                        writeln!(f, ",")?;
+                    } else {
+                        writeln!(f, "{}{}: {},", indentation, key, value)?;
+                    }
                 }
                 PropertyDefinition::SpreadObject(key) => {
-                    writeln!(f, "{}...{},", indent, key)?;
+                    writeln!(f, "{}...{},", indentation, key)?;
                 }
                 PropertyDefinition::MethodDefinition(_kind, _key, _node) => {
                     // TODO: Implement display for PropertyDefinition::MethodDefinition.
@@ -74,7 +81,7 @@ impl Object {
                 }
             }
         }
-        f.write_str("}")
+        write!(f, "{}}}", "    ".repeat(indent))
     }
 }
 

--- a/boa/src/syntax/ast/node/object/tests.rs
+++ b/boa/src/syntax/ast/node/object/tests.rs
@@ -15,7 +15,10 @@ fn fmt() {
             ...other,
             say_hi: function() {
                 console.log("hello!");
-            }
+            },
+            get a() {
+                return this.a + 1;
+            },
         };
         "#,
     );

--- a/boa/src/syntax/ast/node/object/tests.rs
+++ b/boa/src/syntax/ast/node/object/tests.rs
@@ -1,0 +1,18 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        let inst = {
+            a: 5,
+            b: "hello world",
+            nested: {
+                a: 5,
+                b: 6,
+            },
+            say_hi: function() {
+                console.log("hello!");
+            }
+        };
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/object/tests.rs
+++ b/boa/src/syntax/ast/node/object/tests.rs
@@ -2,6 +2,9 @@
 fn fmt() {
     super::super::test_formatting(
         r#"
+        let other = {
+            c: 10,
+        };
         let inst = {
             a: 5,
             b: "hello world",
@@ -9,6 +12,7 @@ fn fmt() {
                 a: 5,
                 b: 6,
             },
+            ...other,
             say_hi: function() {
                 console.log("hello!");
             }

--- a/boa/src/syntax/ast/node/object/tests.rs
+++ b/boa/src/syntax/ast/node/object/tests.rs
@@ -6,7 +6,7 @@ fn fmt() {
             c: 10,
         };
         let inst = {
-            a: 5,
+            val: 5,
             b: "hello world",
             nested: {
                 a: 5,
@@ -17,9 +17,18 @@ fn fmt() {
                 console.log("hello!");
             },
             get a() {
-                return this.a + 1;
+                return this.val + 1;
+            },
+            set a(new_value) {
+                this.val = new_value;
+            },
+            say_hello(msg) {
+                console.log("hello " + msg);
             },
         };
+        inst.a = 20;
+        inst.a;
+        inst.say_hello("humans");
         "#,
     );
 }

--- a/boa/src/syntax/ast/node/operator/tests.rs
+++ b/boa/src/syntax/ast/node/operator/tests.rs
@@ -1,4 +1,4 @@
-use crate::exec;
+use crate::{exec, parse};
 
 #[test]
 fn assignmentoperator_lhs_not_defined() {
@@ -112,4 +112,32 @@ fn logical_assignment() {
         "#;
 
     assert_eq!(&exec(scenario), "20");
+}
+
+#[test]
+fn fmt() {
+    let scenario = r#"
+        let a = 20;
+        a += 10;
+        a -= 10;
+        a *= 10;
+        a **= 10;
+        a /= 10;
+        a %= 10;
+        a &= 10;
+        a |= 10;
+        a ^= 10;
+        a <<= 10;
+        a >>= 10;
+        a >>>= 10;
+        a &&= 10;
+        a ||= 10;
+        a ??= 10;
+        a;
+        "#[1..] // Remove the preceding newline
+        .lines()
+        .map(|l| l.trim()) // Remove trailing whitespace from each line
+        .collect::<Vec<&'static str>>()
+        .join("\n");
+    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
 }

--- a/boa/src/syntax/ast/node/operator/tests.rs
+++ b/boa/src/syntax/ast/node/operator/tests.rs
@@ -1,4 +1,4 @@
-use crate::{exec, parse};
+use crate::exec;
 
 #[test]
 fn assignmentoperator_lhs_not_defined() {

--- a/boa/src/syntax/ast/node/operator/tests.rs
+++ b/boa/src/syntax/ast/node/operator/tests.rs
@@ -116,7 +116,8 @@ fn logical_assignment() {
 
 #[test]
 fn fmt() {
-    let scenario = r#"
+    super::super::test_formatting(
+        r#"
         let a = 20;
         a += 10;
         a -= 10;
@@ -134,10 +135,6 @@ fn fmt() {
         a ||= 10;
         a ??= 10;
         a;
-        "#[1..] // Remove the preceding newline
-        .lines()
-        .map(|l| l.trim()) // Remove trailing whitespace from each line
-        .collect::<Vec<&'static str>>()
-        .join("\n");
-    assert_eq!(format!("{}", parse(&scenario, false).unwrap()), scenario);
+        "#,
+    );
 }

--- a/boa/src/syntax/ast/node/return_smt/mod.rs
+++ b/boa/src/syntax/ast/node/return_smt/mod.rs
@@ -9,6 +9,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// The `return` statement ends function execution and specifies a value to be returned to the
 /// function caller.
 ///

--- a/boa/src/syntax/ast/node/return_smt/tests.rs
+++ b/boa/src/syntax/ast/node/return_smt/tests.rs
@@ -1,0 +1,16 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        function say_hello(msg) {
+            if (msg === "") {
+                return 0;
+            }
+            console.log("hello " + msg);
+            return;
+        };
+        say_hello("");
+        say_hello("world");
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/spread/tests.rs
+++ b/boa/src/syntax/ast/node/spread/tests.rs
@@ -29,3 +29,19 @@ fn spread_with_call() {
     "#;
     assert_eq!(&exec(scenario), r#""message""#);
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        function f(m) {
+            return m;
+        };
+        function g(...args) {
+            return f(...args);
+        };
+        let a = g("message");
+        a;
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -41,11 +41,9 @@ impl StatementList {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
-        let indent = "    ".repeat(indentation);
         // Print statements
         for node in self.items.iter() {
-            f.write_str(&indent)?;
-            // Never used except in the top-level list of nodes, so we don't add to indentation here.
+            // We rely on the node to add the correct indent.
             node.display(f, indentation)?;
 
             match node {

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -45,7 +45,8 @@ impl StatementList {
         // Print statements
         for node in self.items.iter() {
             f.write_str(&indent)?;
-            node.display(f, indentation + 1)?;
+            // Never used except in the top-level list of nodes, so we don't add to indentation here.
+            node.display(f, indentation)?;
 
             match node {
                 Node::Block(_) | Node::If(_) | Node::Switch(_) | Node::WhileLoop(_) => {}

--- a/boa/src/syntax/ast/node/switch/mod.rs
+++ b/boa/src/syntax/ast/node/switch/mod.rs
@@ -105,19 +105,20 @@ impl Switch {
     pub(in crate::syntax::ast::node) fn display(
         &self,
         f: &mut fmt::Formatter<'_>,
-        indent: usize,
+        indentation: usize,
     ) -> fmt::Result {
+        let indent = "    ".repeat(indentation);
         writeln!(f, "switch ({}) {{", self.val())?;
         for e in self.cases().iter() {
-            writeln!(f, "{}case {}:", indent, e.condition())?;
-            e.body().display(f, indent)?;
+            writeln!(f, "{}    case {}:", indent, e.condition())?;
+            e.body().display(f, indentation + 2)?;
         }
 
         if let Some(ref default) = self.default {
-            writeln!(f, "{}default:", indent)?;
-            default.display(f, indent + 1)?;
+            writeln!(f, "{}    default:", indent)?;
+            default.display(f, indentation + 2)?;
         }
-        writeln!(f, "{}}}", indent)
+        write!(f, "{}}}", indent)
     }
 }
 

--- a/boa/src/syntax/ast/node/switch/tests.rs
+++ b/boa/src/syntax/ast/node/switch/tests.rs
@@ -206,3 +206,39 @@ fn bigger_switch_example() {
         assert_eq!(&exec(&scenario), val);
     }
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        let a = 3;
+        let b = "unknown";
+        switch (a) {
+            case 0:
+                b = "Mon";
+                break;
+            case 1:
+                b = "Tue";
+                break;
+            case 2:
+                b = "Wed";
+                break;
+            case 3:
+                b = "Thurs";
+                break;
+            case 4:
+                b = "Fri";
+                break;
+            case 5:
+                b = "Sat";
+                break;
+            case 6:
+                b = "Sun";
+                break;
+            default:
+                b = "Unknown";
+        }
+        b;
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/template/tests.rs
+++ b/boa/src/syntax/ast/node/template/tests.rs
@@ -29,3 +29,20 @@ fn tagged_template() {
         r#"[ "result: ", " & ", "", "result: ", " \x26 ", "", 10, 20 ]"#
     );
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        function tag(t, ...args) {
+            let a = [];
+            a = a.concat([t[0], t[1], t[2]]);
+            a = a.concat([t.raw[0], t.raw[1], t.raw[2]]);
+            a = a.concat([args[0], args[1]]);
+            return a;
+        };
+        let a = 10;
+        tag`result: ${a} \x26 ${a + 10}`;
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/throw/mod.rs
+++ b/boa/src/syntax/ast/node/throw/mod.rs
@@ -9,6 +9,9 @@ use std::fmt;
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
+#[cfg(test)]
+mod tests;
+
 /// The `throw` statement throws a user-defined exception.
 ///
 /// Syntax: `throw expression;`

--- a/boa/src/syntax/ast/node/throw/tests.rs
+++ b/boa/src/syntax/ast/node/throw/tests.rs
@@ -1,0 +1,12 @@
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        try {
+            throw "hello";
+        } catch(e) {
+            console.log(e);
+        };
+        "#,
+    );
+}

--- a/boa/src/syntax/ast/node/try_node/tests.rs
+++ b/boa/src/syntax/ast/node/try_node/tests.rs
@@ -93,3 +93,23 @@ fn catch_binding_finally() {
     "#;
     assert_eq!(&exec(scenario), "30");
 }
+
+#[test]
+fn fmt() {
+    super::super::test_formatting(
+        r#"
+        try {
+            throw "hello";
+        } catch(e) {
+            console.log(e);
+        } finally {
+            console.log("things");
+        };
+        try {
+            throw "hello";
+        } catch {
+            console.log("something went wrong");
+        };
+        "#,
+    );
+}


### PR DESCRIPTION
This Pull Request fixes/closes #1311 

This is a collection of fixes for the `fmt::Display` functions on various nodes. With this PR, you can print a `StatementList` to stdout in nearly the same format as the source code.