### PR TITLE
Implement typed arrays

### DIFF
--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -50,7 +50,17 @@ pub(crate) use self::{
     symbol::Symbol,
     undefined::Undefined,
 };
-use crate::builtins::typed_arrays::uint8_array::UInt8Array;
+use crate::builtins::typed_arrays::bigint64_array::BigInt64Array;
+use crate::builtins::typed_arrays::biguint64_array::BigUint64Array;
+use crate::builtins::typed_arrays::f32_array::Float32Array;
+use crate::builtins::typed_arrays::f64_array::Float64Array;
+use crate::builtins::typed_arrays::int16_array::Int16Array;
+use crate::builtins::typed_arrays::int32_array::Int32Array;
+use crate::builtins::typed_arrays::int8_array::Int8Array;
+use crate::builtins::typed_arrays::uint16_array::Uint16Array;
+use crate::builtins::typed_arrays::uint32_array::Uint32Array;
+use crate::builtins::typed_arrays::uint8_array::Uint8Array;
+use crate::builtins::typed_arrays::uint8_clamped_array::Uint8ClampedArray;
 use crate::{
     property::{Attribute, DataDescriptor},
     Context, Value,
@@ -95,7 +105,17 @@ pub fn init(context: &mut Context) {
         EvalError::init,
         UriError::init,
         Reflect::init,
-        UInt8Array::init,
+        BigUint64Array::init,
+        BigInt64Array::init,
+        Float64Array::init,
+        Float32Array::init,
+        Int32Array::init,
+        Uint32Array::init,
+        Int16Array::init,
+        Uint16Array::init,
+        Uint8Array::init,
+        Uint8ClampedArray::init,
+        Int8Array::init,
         #[cfg(feature = "console")]
         console::Console::init,
     ];

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -57,6 +57,7 @@ use crate::builtins::typed_arrays::f64_array::Float64Array;
 use crate::builtins::typed_arrays::int16_array::Int16Array;
 use crate::builtins::typed_arrays::int32_array::Int32Array;
 use crate::builtins::typed_arrays::int8_array::Int8Array;
+use crate::builtins::typed_arrays::typed_array::TypedArray;
 use crate::builtins::typed_arrays::uint16_array::Uint16Array;
 use crate::builtins::typed_arrays::uint32_array::Uint32Array;
 use crate::builtins::typed_arrays::uint8_array::Uint8Array;
@@ -121,11 +122,11 @@ pub fn init(context: &mut Context) {
     ];
 
     let global_object = context.global_object();
+    TypedArray::init(context);
 
     // We want the methods in `TypedArray` to be bound to the corresponding
     // standard object but we don't really need a reference to the constructor.
     // So we discard the constructor.
-    typed_arrays::typed_array::TypedArray::init(context);
 
     for init in &globals {
         let (name, value, attribute) = init(context);

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -117,16 +117,19 @@ pub fn init(context: &mut Context) {
         Uint8Array::init,
         Uint8ClampedArray::init,
         Int8Array::init,
+        // Uncomment this and comment the one below to explosions
+        // TypedArray::init,
         #[cfg(feature = "console")]
         console::Console::init,
     ];
 
     let global_object = context.global_object();
-    TypedArray::init(context);
 
-    // We want the methods in `TypedArray` to be bound to the corresponding
-    // standard object but we don't really need a reference to the constructor.
-    // So we discard the constructor.
+    // For some reason if I put this here and discard the value completely
+    // all of the methods of the array sublcasses work just fine.
+    // if I stick it in the array above, the `TypedArray` constructor is called
+    // instead of the subtype and throws an error.
+    TypedArray::init(context);
 
     for init in &globals {
         let (name, value, attribute) = init(context);

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -22,6 +22,7 @@ pub mod regexp;
 pub mod set;
 pub mod string;
 pub mod symbol;
+pub mod typed_arrays;
 pub mod undefined;
 
 pub(crate) use self::{
@@ -49,6 +50,7 @@ pub(crate) use self::{
     symbol::Symbol,
     undefined::Undefined,
 };
+use crate::builtins::typed_arrays::uint8_array::UInt8Array;
 use crate::{
     property::{Attribute, DataDescriptor},
     Context, Value,
@@ -93,6 +95,7 @@ pub fn init(context: &mut Context) {
         EvalError::init,
         UriError::init,
         Reflect::init,
+        UInt8Array::init,
         #[cfg(feature = "console")]
         console::Console::init,
     ];

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -123,10 +123,7 @@ pub fn init(context: &mut Context) {
 
     let global_object = context.global_object();
 
-    // For some reason if I put this here and discard the value completely
-    // all of the methods of the array sublcasses work just fine.
-    // if I stick it in the array above, the `TypedArray` constructor is called
-    // instead of the subtype and throws an error.
+    // The root typed array constructor is not available on the global object
     TypedArray::init(context);
 
     for init in &globals {

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -102,6 +102,11 @@ pub fn init(context: &mut Context) {
 
     let global_object = context.global_object();
 
+    // We want the methods in `TypedArray` to be bound to the corresponding
+    // standard object but we don't really need a reference to the constructor.
+    // So we discard the constructor.
+    typed_arrays::typed_array::TypedArray::init(context);
+
     for init in &globals {
         let (name, value, attribute) = init(context);
         let property = DataDescriptor::new(value, attribute);

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -117,8 +117,6 @@ pub fn init(context: &mut Context) {
         Uint8Array::init,
         Uint8ClampedArray::init,
         Int8Array::init,
-        // Uncomment this and comment the one below to explosions
-        // TypedArray::init,
         #[cfg(feature = "console")]
         console::Console::init,
     ];

--- a/boa/src/builtins/typed_arrays/bigint64_array.rs
+++ b/boa/src/builtins/typed_arrays/bigint64_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BigInt64Array;
+
+impl TypedArrayInstance for BigInt64Array {
+    const BYTES_PER_ELEMENT: usize = 8;
+    const NAME: &'static str = "BigInt64Array";
+}

--- a/boa/src/builtins/typed_arrays/bigint64_array.rs
+++ b/boa/src/builtins/typed_arrays/bigint64_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigInt64Array;
 
 impl TypedArrayInstance for BigInt64Array {
-    const BYTES_PER_ELEMENT: usize = 8;
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::BigInt;
     const NAME: &'static str = "BigInt64Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::BigInt64(Vec::with_capacity(capacity))
-    }
 }

--- a/boa/src/builtins/typed_arrays/bigint64_array.rs
+++ b/boa/src/builtins/typed_arrays/bigint64_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigInt64Array;
@@ -6,4 +6,8 @@ pub(crate) struct BigInt64Array;
 impl TypedArrayInstance for BigInt64Array {
     const BYTES_PER_ELEMENT: usize = 8;
     const NAME: &'static str = "BigInt64Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::BigInt64(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/bigint64_array.rs
+++ b/boa/src/builtins/typed_arrays/bigint64_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigInt64Array;

--- a/boa/src/builtins/typed_arrays/biguint64_array.rs
+++ b/boa/src/builtins/typed_arrays/biguint64_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigUint64Array;
 
 impl TypedArrayInstance for BigUint64Array {
-    const BYTES_PER_ELEMENT: usize = 8;
     const NAME: &'static str = "BigUint64Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::BigInt64(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::BigUint;
 }

--- a/boa/src/builtins/typed_arrays/biguint64_array.rs
+++ b/boa/src/builtins/typed_arrays/biguint64_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigUint64Array;
@@ -6,4 +6,8 @@ pub(crate) struct BigUint64Array;
 impl TypedArrayInstance for BigUint64Array {
     const BYTES_PER_ELEMENT: usize = 8;
     const NAME: &'static str = "BigUint64Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::BigInt64(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/biguint64_array.rs
+++ b/boa/src/builtins/typed_arrays/biguint64_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BigUint64Array;
+
+impl TypedArrayInstance for BigUint64Array {
+    const BYTES_PER_ELEMENT: usize = 8;
+    const NAME: &'static str = "BigUint64Array";
+}

--- a/boa/src/builtins/typed_arrays/biguint64_array.rs
+++ b/boa/src/builtins/typed_arrays/biguint64_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct BigUint64Array;

--- a/boa/src/builtins/typed_arrays/f32_array.rs
+++ b/boa/src/builtins/typed_arrays/f32_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Float32Array;
+
+impl TypedArrayInstance for Float32Array {
+    const BYTES_PER_ELEMENT: usize = 4;
+    const NAME: &'static str = "Float32Array ";
+}

--- a/boa/src/builtins/typed_arrays/f32_array.rs
+++ b/boa/src/builtins/typed_arrays/f32_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float32Array;
 
 impl TypedArrayInstance for Float32Array {
-    const BYTES_PER_ELEMENT: usize = 4;
     const NAME: &'static str = "Float32Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::F32(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::F32;
 }

--- a/boa/src/builtins/typed_arrays/f32_array.rs
+++ b/boa/src/builtins/typed_arrays/f32_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float32Array;

--- a/boa/src/builtins/typed_arrays/f32_array.rs
+++ b/boa/src/builtins/typed_arrays/f32_array.rs
@@ -5,5 +5,5 @@ pub(crate) struct Float32Array;
 
 impl TypedArrayInstance for Float32Array {
     const BYTES_PER_ELEMENT: usize = 4;
-    const NAME: &'static str = "Float32Array ";
+    const NAME: &'static str = "Float32Array";
 }

--- a/boa/src/builtins/typed_arrays/f32_array.rs
+++ b/boa/src/builtins/typed_arrays/f32_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float32Array;
@@ -6,4 +6,8 @@ pub(crate) struct Float32Array;
 impl TypedArrayInstance for Float32Array {
     const BYTES_PER_ELEMENT: usize = 4;
     const NAME: &'static str = "Float32Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::F32(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/f64_array.rs
+++ b/boa/src/builtins/typed_arrays/f64_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float64Array;

--- a/boa/src/builtins/typed_arrays/f64_array.rs
+++ b/boa/src/builtins/typed_arrays/f64_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float64Array;
 
 impl TypedArrayInstance for Float64Array {
-    const BYTES_PER_ELEMENT: usize = 8;
     const NAME: &'static str = "Float64Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::F64(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::F64;
 }

--- a/boa/src/builtins/typed_arrays/f64_array.rs
+++ b/boa/src/builtins/typed_arrays/f64_array.rs
@@ -5,5 +5,5 @@ pub(crate) struct Float64Array;
 
 impl TypedArrayInstance for Float64Array {
     const BYTES_PER_ELEMENT: usize = 8;
-    const NAME: &'static str = "Float64Array ";
+    const NAME: &'static str = "Float64Array";
 }

--- a/boa/src/builtins/typed_arrays/f64_array.rs
+++ b/boa/src/builtins/typed_arrays/f64_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Float64Array;
+
+impl TypedArrayInstance for Float64Array {
+    const BYTES_PER_ELEMENT: usize = 8;
+    const NAME: &'static str = "Float64Array ";
+}

--- a/boa/src/builtins/typed_arrays/f64_array.rs
+++ b/boa/src/builtins/typed_arrays/f64_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Float64Array;
@@ -6,4 +6,8 @@ pub(crate) struct Float64Array;
 impl TypedArrayInstance for Float64Array {
     const BYTES_PER_ELEMENT: usize = 8;
     const NAME: &'static str = "Float64Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::F64(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/int16_array.rs
+++ b/boa/src/builtins/typed_arrays/int16_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int16Array;
@@ -6,4 +6,8 @@ pub(crate) struct Int16Array;
 impl TypedArrayInstance for Int16Array {
     const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Int16Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::I16(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/int16_array.rs
+++ b/boa/src/builtins/typed_arrays/int16_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int16Array;
 
 impl TypedArrayInstance for Int16Array {
-    const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Int16Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::I16(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::I16;
 }

--- a/boa/src/builtins/typed_arrays/int16_array.rs
+++ b/boa/src/builtins/typed_arrays/int16_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Int16Array;
+
+impl TypedArrayInstance for Int16Array {
+    const BYTES_PER_ELEMENT: usize = 2;
+    const NAME: &'static str = "Int16Array";
+}

--- a/boa/src/builtins/typed_arrays/int16_array.rs
+++ b/boa/src/builtins/typed_arrays/int16_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int16Array;

--- a/boa/src/builtins/typed_arrays/int32_array.rs
+++ b/boa/src/builtins/typed_arrays/int32_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int32Array;
 
 impl TypedArrayInstance for Int32Array {
-    const BYTES_PER_ELEMENT: usize = 4;
     const NAME: &'static str = "Int32Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::I32(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::I32;
 }

--- a/boa/src/builtins/typed_arrays/int32_array.rs
+++ b/boa/src/builtins/typed_arrays/int32_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int32Array;

--- a/boa/src/builtins/typed_arrays/int32_array.rs
+++ b/boa/src/builtins/typed_arrays/int32_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int32Array;
@@ -6,4 +6,8 @@ pub(crate) struct Int32Array;
 impl TypedArrayInstance for Int32Array {
     const BYTES_PER_ELEMENT: usize = 4;
     const NAME: &'static str = "Int32Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::I32(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/int32_array.rs
+++ b/boa/src/builtins/typed_arrays/int32_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Int32Array;
+
+impl TypedArrayInstance for Int32Array {
+    const BYTES_PER_ELEMENT: usize = 4;
+    const NAME: &'static str = "Int32Array";
+}

--- a/boa/src/builtins/typed_arrays/int8_array.rs
+++ b/boa/src/builtins/typed_arrays/int8_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int8Array;
 
 impl TypedArrayInstance for Int8Array {
-    const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Int8Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::I8(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::I8;
 }

--- a/boa/src/builtins/typed_arrays/int8_array.rs
+++ b/boa/src/builtins/typed_arrays/int8_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Int8Array;
+
+impl TypedArrayInstance for Int8Array {
+    const BYTES_PER_ELEMENT: usize = 1;
+    const NAME: &'static str = "Int8Array";
+}

--- a/boa/src/builtins/typed_arrays/int8_array.rs
+++ b/boa/src/builtins/typed_arrays/int8_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int8Array;
@@ -6,4 +6,8 @@ pub(crate) struct Int8Array;
 impl TypedArrayInstance for Int8Array {
     const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Int8Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::I8(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/int8_array.rs
+++ b/boa/src/builtins/typed_arrays/int8_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Int8Array;

--- a/boa/src/builtins/typed_arrays/mod.rs
+++ b/boa/src/builtins/typed_arrays/mod.rs
@@ -10,3 +10,5 @@ pub(crate) mod uint16_array;
 pub(crate) mod uint32_array;
 pub(crate) mod uint8_array;
 pub(crate) mod uint8_clamped_array;
+
+mod storage_class;

--- a/boa/src/builtins/typed_arrays/mod.rs
+++ b/boa/src/builtins/typed_arrays/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod typed_array;
+pub(crate) mod uint8_array;

--- a/boa/src/builtins/typed_arrays/mod.rs
+++ b/boa/src/builtins/typed_arrays/mod.rs
@@ -1,2 +1,12 @@
+pub(crate) mod bigint64_array;
+pub(crate) mod biguint64_array;
+pub(crate) mod f32_array;
+pub(crate) mod f64_array;
+pub(crate) mod int16_array;
+pub(crate) mod int32_array;
+pub(crate) mod int8_array;
 pub(crate) mod typed_array;
+pub(crate) mod uint16_array;
+pub(crate) mod uint32_array;
 pub(crate) mod uint8_array;
+pub(crate) mod uint8_clamped_array;

--- a/boa/src/builtins/typed_arrays/storage_class.rs
+++ b/boa/src/builtins/typed_arrays/storage_class.rs
@@ -1,0 +1,115 @@
+use gc::{Finalize, Trace};
+
+use crate::builtins::BigInt;
+use crate::{Context, Value};
+
+#[derive(Debug, Clone, PartialOrd, PartialEq, Trace, Finalize)]
+pub(crate) enum TypedArrayStorageClass {
+    I8(Vec<i8>),
+    U8(Vec<u8>),
+    I16(Vec<i16>),
+    U16(Vec<u16>),
+    I32(Vec<i32>),
+    U32(Vec<u32>),
+    F32(Vec<f32>),
+    F64(Vec<f64>),
+    BigInt64(Vec<BigInt>),
+}
+
+impl TypedArrayStorageClass {
+    pub(crate) fn get_typed_array_content_type(&self) -> TypedArrayContentType {
+        match self {
+            Self::BigInt64(_) => TypedArrayContentType::BigInt,
+            _ => TypedArrayContentType::Number,
+        }
+    }
+
+    pub(crate) unsafe fn set_length(&mut self, len: usize) {
+        use TypedArrayStorageClass::*;
+        match self {
+            I8(value) => value.set_len(len),
+            U8(value) => value.set_len(len),
+            I16(value) => value.set_len(len),
+            U16(value) => value.set_len(len),
+            I32(value) => value.set_len(len),
+            U32(value) => value.set_len(len),
+            F32(value) => value.set_len(len),
+            F64(value) => value.set_len(len),
+            BigInt64(value) => value.set_len(len),
+        }
+    }
+
+    pub(crate) fn set_value_at_index(
+        &mut self,
+        index: u32,
+        value: Value,
+        context: &mut Context,
+    ) -> crate::Result<Value> {
+        use crate::value::Numeric;
+        use TypedArrayStorageClass::*;
+        let numeric = value.to_numeric(context)?;
+        //  TODO: implement the type conversion methods
+        let index = index as usize;
+        // TODO: Handle out of bounds exceptions here
+        match (self, numeric) {
+            (I8(value), Numeric::Number(number)) => value[index] = number as i8,
+            (U8(value), Numeric::Number(number)) => value[index] = number as u8,
+            (I16(value), Numeric::Number(number)) => value[index] = number as i16,
+            (U16(value), Numeric::Number(number)) => value[index] = number as u16,
+            (I32(value), Numeric::Number(number)) => value[index] = number as i32,
+            (U32(value), Numeric::Number(number)) => value[index] = number as u32,
+            (F32(value), Numeric::Number(number)) => value[index] = number as f32,
+            (F64(value), Numeric::Number(number)) => value[index] = number,
+            (BigInt64(value), Numeric::BigInt(big_int)) => {
+                value[index] = big_int.as_inner().clone()
+            }
+            _ => return context.throw_type_error("Must set numeric value for typed array"),
+        };
+
+        Ok(Value::undefined())
+    }
+
+    pub(crate) fn get_value_at_index(&self, index: u32) -> Option<Value> {
+        use crate::value::Numeric;
+        use TypedArrayStorageClass::*;
+        let numeric = match self {
+            I8(value) => value.get(index as usize).cloned().map(Numeric::from),
+            U8(value) => value.get(index as usize).cloned().map(Numeric::from),
+            I16(value) => value.get(index as usize).cloned().map(Numeric::from),
+            U16(value) => value.get(index as usize).cloned().map(Numeric::from),
+            I32(value) => value.get(index as usize).cloned().map(Numeric::from),
+            U32(value) => value.get(index as usize).cloned().map(Numeric::from),
+            F32(value) => value
+                .get(index as usize)
+                .cloned()
+                .map(|v| Numeric::from(v as f64)),
+            F64(value) => value.get(index as usize).cloned().map(Numeric::from),
+            BigInt64(value) => value.get(index as usize).cloned().map(Numeric::from),
+        };
+
+        Some(numeric.map(Value::from).unwrap_or(Value::undefined()))
+    }
+
+    pub(crate) fn length(&self) -> usize {
+        use TypedArrayStorageClass::*;
+        let capacity = match self {
+            I8(value) => value.capacity(),
+            U8(value) => value.capacity(),
+            I16(value) => value.capacity(),
+            U16(value) => value.capacity(),
+            I32(value) => value.capacity(),
+            U32(value) => value.capacity(),
+            F32(value) => value.capacity(),
+            F64(value) => value.capacity(),
+            BigInt64(value) => value.capacity(),
+        };
+
+        capacity
+    }
+}
+
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Trace, Finalize)]
+pub(crate) enum TypedArrayContentType {
+    Number,
+    BigInt,
+}

--- a/boa/src/builtins/typed_arrays/storage_class.rs
+++ b/boa/src/builtins/typed_arrays/storage_class.rs
@@ -27,15 +27,60 @@ impl TypedArrayStorageClass {
     pub(crate) unsafe fn set_length(&mut self, len: usize) {
         use TypedArrayStorageClass::*;
         match self {
-            I8(value) => value.set_len(len),
-            U8(value) => value.set_len(len),
-            I16(value) => value.set_len(len),
-            U16(value) => value.set_len(len),
-            I32(value) => value.set_len(len),
-            U32(value) => value.set_len(len),
-            F32(value) => value.set_len(len),
-            F64(value) => value.set_len(len),
-            BigInt64(value) => value.set_len(len),
+            I8(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            U8(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            I16(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            U16(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            I32(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            U32(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0
+                }
+            }
+            F32(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0.0
+                }
+            }
+            F64(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = 0.0
+                }
+            }
+            BigInt64(value) => {
+                value.set_len(len);
+                for i in 0..len {
+                    value[i] = BigInt::from(0);
+                }
+            }
         }
     }
 
@@ -51,20 +96,20 @@ impl TypedArrayStorageClass {
         //  TODO: implement the type conversion methods
         let index = index as usize;
         // TODO: Handle out of bounds exceptions here
-        match (self, numeric) {
-            (I8(value), Numeric::Number(number)) => value[index] = number as i8,
-            (U8(value), Numeric::Number(number)) => value[index] = number as u8,
-            (I16(value), Numeric::Number(number)) => value[index] = number as i16,
-            (U16(value), Numeric::Number(number)) => value[index] = number as u16,
-            (I32(value), Numeric::Number(number)) => value[index] = number as i32,
-            (U32(value), Numeric::Number(number)) => value[index] = number as u32,
-            (F32(value), Numeric::Number(number)) => value[index] = number as f32,
-            (F64(value), Numeric::Number(number)) => value[index] = number,
-            (BigInt64(value), Numeric::BigInt(big_int)) => {
-                value[index] = big_int.as_inner().clone()
-            }
-            _ => return context.throw_type_error("Must set numeric value for typed array"),
-        };
+        // match (self, numeric) {
+        //     (I8(value), Numeric::Number(number)) => value[index] = number as i8,
+        //     (U8(value), Numeric::Number(number)) => value[index] = number as u8,
+        //     (I16(value), Numeric::Number(number)) => value[index] = number as i16,
+        //     (U16(value), Numeric::Number(number)) => value[index] = number as u16,
+        //     (I32(value), Numeric::Number(number)) => value[index] = number as i32,
+        //     (U32(value), Numeric::Number(number)) => value[index] = number as u32,
+        //     (F32(value), Numeric::Number(number)) => value[index] = number as f32,
+        //     (F64(value), Numeric::Number(number)) => value[index] = number,
+        //     (BigInt64(value), Numeric::BigInt(big_int)) => {
+        //         value[index] = big_int.as_inner().clone()
+        //     }
+        //     _ => return context.throw_type_error("Must set numeric value for typed array"),
+        // };
 
         Ok(Value::undefined())
     }

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -197,6 +197,7 @@ pub(crate) trait TypedArrayInstance {
         // SAFETY: We guarantee here that we always set the length of the array to its
         // actual internal capacity.
         unsafe { storage_class.set_length(storage_class.length()) };
+        debug_assert!(storage_class.length() == capacity);
         storage_class
     }
 

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -1,0 +1,52 @@
+/*
+https://tc39.es/ecma262/#sec-typedarray-objects
+The %TypedArray% intrinsic object:
+
+* is a constructor function object that all of the TypedArray constructor objects inherit from.
+* along with its corresponding prototype object, provides common properties that are inherited
+  by all TypedArray constructors and their instances.
+* does not have a global name or appear as a property of the global object.
+* acts as the abstract superclass of the various TypedArray constructors.
+* will throw an error when invoked, because it is an abstract class constructor.
+  The TypedArray constructors do not perform a super call to it.
+*/
+
+use crate::builtins::BuiltIn;
+use crate::object::{ConstructorBuilder, GcObject, Object};
+use crate::property::Attribute;
+use crate::symbol::WellKnownSymbols;
+use crate::{Context, Result, Value};
+
+pub(crate) struct TypedArray;
+
+impl TypedArray {
+    pub(crate) fn init(context: &mut Context) -> GcObject {
+        let constructor = ConstructorBuilder::with_standard_object(
+            context,
+            Self::construct,
+            context.standard_objects().typed_array_object().clone(),
+        )
+        .method(Self::sanity, "sanity", 0)
+        .property(
+            "length",
+            0,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+        )
+        .build();
+
+        constructor
+    }
+
+    // This is a sanity check to see if objects that inherit from this can call this method
+    fn sanity(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        Ok("sanity check".into())
+    }
+
+    pub(crate) fn construct(
+        new_target: &Value,
+        args: &[Value],
+        context: &mut Context,
+    ) -> Result<Value> {
+        context.throw_type_error("not a constructor")
+    }
+}

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -12,7 +12,8 @@ The %TypedArray% intrinsic object:
 */
 
 use crate::builtins::BuiltIn;
-use crate::object::{ConstructorBuilder, PROTOTYPE};
+use crate::context::StandardConstructor;
+use crate::object::{ConstructorBuilder, GcObject, PROTOTYPE};
 use crate::property::{Attribute, DataDescriptor};
 use crate::{Context, Result, Value};
 
@@ -176,12 +177,38 @@ where
     }
 
     fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let typed_array_prototype = context
+            .standard_objects()
+            .typed_array_object()
+            .prototype()
+            .clone()
+            .into();
+
         let constructor = ConstructorBuilder::with_standard_object(
             context,
             Self::constructor,
-            context.standard_objects().typed_array_object().clone(),
+            StandardConstructor::default(),
         )
+        .property(
+            "BYTES_PER_ELEMENT",
+            Self::BYTES_PER_ELEMENT,
+            Attribute::READONLY | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
+        )
+        .inherit(typed_array_prototype)
+        .property(
+            "BYTES_PER_ELEMENT",
+            Self::BYTES_PER_ELEMENT,
+            Attribute::PERMANENT | Attribute::READONLY,
+        )
+        .static_property(
+            "BYTES_PER_ELEMENT",
+            Self::BYTES_PER_ELEMENT,
+            Attribute::PERMANENT | Attribute::READONLY,
+        )
+        .static_method(TypedArray::from, "from", 3)
+        .static_method(TypedArray::of, "of", 0)
         .name(Self::NAME)
+        .length(3)
         .build();
 
         (Self::NAME, constructor.into(), Self::attribute())

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -12,7 +12,7 @@ The %TypedArray% intrinsic object:
 */
 
 use crate::builtins::BuiltIn;
-use crate::object::{ConstructorBuilder, GcObject, PROTOTYPE};
+use crate::object::{ConstructorBuilder, PROTOTYPE};
 use crate::property::{Attribute, DataDescriptor};
 use crate::{Context, Result, Value};
 
@@ -41,11 +41,7 @@ impl TypedArray {
             Self::construct,
             context.standard_objects().typed_array_object().clone(),
         )
-        .property(
-            "name",
-            "TypedArray",
-            Attribute::READONLY | Attribute::PERMANENT,
-        )
+        .name(Self::NAME)
         .static_method(Self::from, "from", 3)
         .static_method(Self::of, "of", 1)
         .build();
@@ -134,14 +130,6 @@ pub(crate) trait TypedArrayInstance {
     const NAME: &'static str;
 
     fn constructor(new_target: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        // Check if the argument is a number
-        // -- instantiate a new array with that capacity
-        // if it's an existing instance of a UInt8Array
-
-        // -- return a value with a prototype of context.typed_array_prototype
-
-        // TODO: Figure out this magical incantation -- from what i can tell this should result in the value
-        // returned from TypedArray:init
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
@@ -154,7 +142,7 @@ pub(crate) trait TypedArrayInstance {
                 context
                     .standard_objects()
                     .typed_array_object()
-                    .prototype
+                    .constructor
                     .clone()
             });
 
@@ -167,7 +155,7 @@ pub(crate) trait TypedArrayInstance {
 
         let length = DataDescriptor::new(
             args[0].clone(),
-            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
         );
 
         typed_array.set_property("length", length);

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -12,123 +12,14 @@ The %TypedArray% intrinsic object:
 */
 
 use crate::builtins::array::array_iterator::ArrayIterationKind;
-use crate::builtins::{ArrayIterator, BigInt, BuiltIn};
+use crate::builtins::typed_arrays::storage_class::{TypedArrayContentType, TypedArrayStorageClass};
+use crate::builtins::{ArrayIterator, BuiltIn};
 use crate::context::StandardConstructor;
 use crate::gc::{Finalize, Trace};
 use crate::object::{ConstructorBuilder, FunctionBuilder, GcObject, ObjectData, PROTOTYPE};
 use crate::property::{Attribute, DataDescriptor};
 use crate::symbol::WellKnownSymbols;
-use crate::value::Numeric;
 use crate::{Context, Result, Value};
-
-#[derive(Debug, Clone, PartialOrd, PartialEq, Trace, Finalize)]
-pub(crate) enum TypedArrayStorageClass {
-    I8(Vec<i8>),
-    U8(Vec<u8>),
-    I16(Vec<i16>),
-    U16(Vec<u16>),
-    I32(Vec<i32>),
-    U32(Vec<u32>),
-    F32(Vec<f32>),
-    F64(Vec<f64>),
-    BigInt64(Vec<BigInt>),
-}
-
-impl TypedArrayStorageClass {
-    fn get_typed_array_content_type(&self) -> TypedArrayContentType {
-        match self {
-            Self::BigInt64(_) => TypedArrayContentType::BigInt,
-            _ => TypedArrayContentType::Number,
-        }
-    }
-
-    unsafe fn set_length(&mut self, len: usize) {
-        use TypedArrayStorageClass::*;
-        match self {
-            I8(value) => value.set_len(len),
-            U8(value) => value.set_len(len),
-            I16(value) => value.set_len(len),
-            U16(value) => value.set_len(len),
-            I32(value) => value.set_len(len),
-            U32(value) => value.set_len(len),
-            F32(value) => value.set_len(len),
-            F64(value) => value.set_len(len),
-            BigInt64(value) => value.set_len(len),
-        }
-    }
-
-    pub(crate) fn set_value_at_index(
-        &mut self,
-        index: u32,
-        value: Value,
-        context: &mut Context,
-    ) -> Result<Value> {
-        use TypedArrayStorageClass::*;
-        let numeric = value.to_numeric(context)?;
-        //  TODO: implement the type conversion methods
-        let index = index as usize;
-        // TODO: Handle out of bounds exceptions here
-        match (self, numeric) {
-            (I8(value), Numeric::Number(number)) => value[index] = number as i8,
-            (U8(value), Numeric::Number(number)) => value[index] = number as u8,
-            (I16(value), Numeric::Number(number)) => value[index] = number as i16,
-            (U16(value), Numeric::Number(number)) => value[index] = number as u16,
-            (I32(value), Numeric::Number(number)) => value[index] = number as i32,
-            (U32(value), Numeric::Number(number)) => value[index] = number as u32,
-            (F32(value), Numeric::Number(number)) => value[index] = number as f32,
-            (F64(value), Numeric::Number(number)) => value[index] = number,
-            (BigInt64(value), Numeric::BigInt(big_int)) => {
-                value[index] = big_int.as_inner().clone()
-            }
-            _ => return context.throw_type_error("Must set numeric value for typed array"),
-        };
-
-        Ok(Value::undefined())
-    }
-
-    pub(crate) fn get_value_at_index(&self, index: u32) -> Option<Value> {
-        use TypedArrayStorageClass::*;
-        let numeric = match self {
-            I8(value) => value.get(index as usize).cloned().map(Numeric::from),
-            U8(value) => value.get(index as usize).cloned().map(Numeric::from),
-            I16(value) => value.get(index as usize).cloned().map(Numeric::from),
-            U16(value) => value.get(index as usize).cloned().map(Numeric::from),
-            I32(value) => value.get(index as usize).cloned().map(Numeric::from),
-            U32(value) => value.get(index as usize).cloned().map(Numeric::from),
-            F32(value) => value
-                .get(index as usize)
-                .cloned()
-                .map(|v| Numeric::from(v as f64)),
-            F64(value) => value.get(index as usize).cloned().map(Numeric::from),
-            BigInt64(value) => value.get(index as usize).cloned().map(Numeric::from),
-        };
-
-        Some(numeric.map(Value::from).unwrap_or(Value::undefined()))
-    }
-
-    pub(crate) fn length(&self) -> usize {
-        use TypedArrayStorageClass::*;
-        let capacity = match self {
-            I8(value) => value.capacity(),
-            U8(value) => value.capacity(),
-            I16(value) => value.capacity(),
-            U16(value) => value.capacity(),
-            I32(value) => value.capacity(),
-            U32(value) => value.capacity(),
-            F32(value) => value.capacity(),
-            F64(value) => value.capacity(),
-            BigInt64(value) => value.capacity(),
-        };
-
-        capacity
-    }
-}
-
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Trace, Finalize)]
-pub(crate) enum TypedArrayContentType {
-    Number,
-    BigInt,
-}
 
 // Corresponds to internal slots
 // TODO: Make buffer an acual buffer instead of a Vec<_>

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -13,8 +13,10 @@ The %TypedArray% intrinsic object:
 
 use crate::builtins::BuiltIn;
 use crate::context::StandardConstructor;
-use crate::object::{ConstructorBuilder, GcObject, PROTOTYPE};
+use crate::object::{ConstructorBuilder, FunctionBuilder, GcObject, PROTOTYPE};
 use crate::property::{Attribute, DataDescriptor};
+use crate::symbol::WellKnownSymbols;
+use crate::value::Value::Symbol;
 use crate::{Context, Result, Value};
 
 pub(crate) struct TypedArray;
@@ -124,6 +126,10 @@ impl TypedArray {
     ) -> Result<Value> {
         context.throw_type_error("Cannot call TypedArray as a constructor")
     }
+
+    fn get_species(this: &Value, _args: &[Value], _context: &mut Context) -> Result<Value> {
+        Ok(this.clone())
+    }
 }
 
 pub(crate) trait TypedArrayInstance {
@@ -195,6 +201,18 @@ where
             Attribute::READONLY | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
         )
         .inherit(typed_array_prototype)
+        .static_accessor(
+            WellKnownSymbols::species(),
+            Some(
+                FunctionBuilder::new(context, TypedArray::get_species)
+                    .name("get [Symbol.species]")
+                    .callable(true)
+                    .constructable(false)
+                    .build(),
+            ),
+            None,
+            Attribute::CONFIGURABLE,
+        )
         .property(
             "BYTES_PER_ELEMENT",
             Self::BYTES_PER_ELEMENT,

--- a/boa/src/builtins/typed_arrays/typed_array.rs
+++ b/boa/src/builtins/typed_arrays/typed_array.rs
@@ -47,8 +47,26 @@ impl TypedArray {
             Attribute::READONLY | Attribute::PERMANENT,
         )
         .static_method(Self::from, "from", 3)
+        .static_method(Self::of, "of", 1)
         .build();
         constructor.into()
+    }
+
+    pub(crate) fn of(this: &Value, arguments: &[Value], context: &mut Context) -> Result<Value> {
+        let length: Value = arguments.len().into();
+
+        let constructed_value = this
+            .as_object()
+            .ok_or_else(|| -> Value { "Not a constructor".into() })?
+            .call(&this, &[length], context)?;
+        for (index, value) in arguments.iter().enumerate() {
+            constructed_value.set_property(
+                index.to_string(),
+                DataDescriptor::new(value.clone(), Attribute::WRITABLE | Attribute::ENUMERABLE),
+            );
+        }
+
+        Ok(constructed_value)
     }
 
     pub(crate) fn from(this: &Value, arguments: &[Value], context: &mut Context) -> Result<Value> {

--- a/boa/src/builtins/typed_arrays/uint16_array.rs
+++ b/boa/src/builtins/typed_arrays/uint16_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint16Array;
 
 impl TypedArrayInstance for Uint16Array {
-    const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Uint16Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::U16(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::U16;
 }

--- a/boa/src/builtins/typed_arrays/uint16_array.rs
+++ b/boa/src/builtins/typed_arrays/uint16_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Uint16Array;
+
+impl TypedArrayInstance for Uint16Array {
+    const BYTES_PER_ELEMENT: usize = 2;
+    const NAME: &'static str = "Uint16Array";
+}

--- a/boa/src/builtins/typed_arrays/uint16_array.rs
+++ b/boa/src/builtins/typed_arrays/uint16_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint16Array;
@@ -6,4 +6,8 @@ pub(crate) struct Uint16Array;
 impl TypedArrayInstance for Uint16Array {
     const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Uint16Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::U16(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/uint16_array.rs
+++ b/boa/src/builtins/typed_arrays/uint16_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint16Array;

--- a/boa/src/builtins/typed_arrays/uint32_array.rs
+++ b/boa/src/builtins/typed_arrays/uint32_array.rs
@@ -5,5 +5,5 @@ pub(crate) struct Uint32Array;
 
 impl TypedArrayInstance for Uint32Array {
     const BYTES_PER_ELEMENT: usize = 2;
-    const NAME: &'static str = "Uint16Array";
+    const NAME: &'static str = "Uint32Array";
 }

--- a/boa/src/builtins/typed_arrays/uint32_array.rs
+++ b/boa/src/builtins/typed_arrays/uint32_array.rs
@@ -1,0 +1,9 @@
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Uint32Array;
+
+impl TypedArrayInstance for Uint32Array {
+    const BYTES_PER_ELEMENT: usize = 2;
+    const NAME: &'static str = "Uint16Array";
+}

--- a/boa/src/builtins/typed_arrays/uint32_array.rs
+++ b/boa/src/builtins/typed_arrays/uint32_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint32Array;
 
 impl TypedArrayInstance for Uint32Array {
-    const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Uint32Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::U32(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::U32;
 }

--- a/boa/src/builtins/typed_arrays/uint32_array.rs
+++ b/boa/src/builtins/typed_arrays/uint32_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint32Array;
@@ -6,4 +6,8 @@ pub(crate) struct Uint32Array;
 impl TypedArrayInstance for Uint32Array {
     const BYTES_PER_ELEMENT: usize = 2;
     const NAME: &'static str = "Uint32Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::U32(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/uint32_array.rs
+++ b/boa/src/builtins/typed_arrays/uint32_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint32Array;

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -1,0 +1,68 @@
+use crate::builtins::BuiltIn;
+use crate::object::{ConstructorBuilder, PROTOTYPE};
+use crate::property::{Attribute, DataDescriptor};
+use crate::{Context, Result, Value};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct UInt8Array;
+
+impl BuiltIn for UInt8Array {
+    const NAME: &'static str = "Uint8Array";
+
+    fn attribute() -> Attribute {
+        // TODO: Figure out what this means because :shrug:
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE
+    }
+
+    fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
+        let prototype = context.typed_array_prototype().clone().into();
+        let constructor = ConstructorBuilder::new(context, Self::constructor)
+            .inherit(prototype)
+            .build();
+
+        (Self::NAME, constructor.into(), Self::attribute())
+    }
+}
+
+impl UInt8Array {
+    fn constructor(new_target: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // Check if the argument is a number
+        // -- instantiate a new array with that capacity
+        // if it's an existing instance of a UInt8Array
+
+        // -- return a value with a prototype of context.typed_array_prototype
+
+        // TODO: Figure out this magical incantation -- from what i can tell this should result in the value
+        // returned from TypedArray:init
+        let prototype = new_target
+            .as_object()
+            .and_then(|obj| {
+                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                    .map(|o| o.as_object())
+                    .transpose()
+            })
+            .transpose()?
+            .unwrap_or_else(|| context.typed_array_prototype().clone());
+
+        let argument = args.get(0).expect("Expected an argument");
+        match argument {
+            Value::Integer(v) => {
+                let typed_array = Value::new_object(context);
+                typed_array
+                    .as_object()
+                    .expect("'Invariant. typed_array was created as an object'")
+                    .set_prototype_instance(prototype.into());
+                let length = DataDescriptor::new(
+                    *v,
+                    Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
+                );
+                typed_array.set_property("length", length);
+
+                Ok(typed_array)
+            }
+            _ => {
+                todo!()
+            }
+        }
+    }
+}

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8Array;
 
 impl TypedArrayInstance for Uint8Array {
-    const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Uint8Array";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::U8(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::U8;
 }

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8Array;

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -15,10 +15,12 @@ impl BuiltIn for UInt8Array {
     }
 
     fn init(context: &mut Context) -> (&'static str, Value, Attribute) {
-        let prototype = context.typed_array_prototype().clone().into();
-        let constructor = ConstructorBuilder::new(context, Self::constructor)
-            .inherit(prototype)
-            .build();
+        let constructor = ConstructorBuilder::with_standard_object(
+            context,
+            Self::constructor,
+            context.standard_objects().typed_array_object().clone(),
+        )
+        .build();
 
         (Self::NAME, constructor.into(), Self::attribute())
     }

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -44,7 +44,13 @@ impl UInt8Array {
                     .transpose()
             })
             .transpose()?
-            .unwrap_or_else(|| context.typed_array_prototype().clone());
+            .unwrap_or_else(|| {
+                context
+                    .standard_objects()
+                    .typed_array_object()
+                    .prototype
+                    .clone()
+            });
 
         let argument = args.get(0).expect("Expected an argument");
         match argument {

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8Array;
@@ -6,4 +6,8 @@ pub(crate) struct Uint8Array;
 impl TypedArrayInstance for Uint8Array {
     const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Uint8Array";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::U8(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/builtins/typed_arrays/uint8_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_array.rs
@@ -20,6 +20,7 @@ impl BuiltIn for UInt8Array {
             Self::constructor,
             context.standard_objects().typed_array_object().clone(),
         )
+        .name(Self::NAME)
         .build();
 
         (Self::NAME, constructor.into(), Self::attribute())

--- a/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
@@ -1,9 +1,9 @@
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Uint8Array;
+pub(crate) struct Uint8ClampedArray;
 
-impl TypedArrayInstance for Uint8Array {
+impl TypedArrayInstance for Uint8ClampedArray {
     const BYTES_PER_ELEMENT: usize = 1;
-    const NAME: &'static str = "Uint8Array";
+    const NAME: &'static str = "Uint8ClampedArray ";
 }

--- a/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
@@ -1,14 +1,10 @@
-use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::storage_class::TypedArrayElement;
 use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8ClampedArray;
 
 impl TypedArrayInstance for Uint8ClampedArray {
-    const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Uint8ClampedArray";
-
-    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
-        TypedArrayStorageClass::U8(Vec::with_capacity(capacity))
-    }
+    const ELEMENT_KIND: TypedArrayElement = TypedArrayElement::U8C;
 }

--- a/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
@@ -1,4 +1,5 @@
-use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
+use crate::builtins::typed_arrays::storage_class::TypedArrayStorageClass;
+use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8ClampedArray;

--- a/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
@@ -5,5 +5,5 @@ pub(crate) struct Uint8ClampedArray;
 
 impl TypedArrayInstance for Uint8ClampedArray {
     const BYTES_PER_ELEMENT: usize = 1;
-    const NAME: &'static str = "Uint8ClampedArray ";
+    const NAME: &'static str = "Uint8ClampedArray";
 }

--- a/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
+++ b/boa/src/builtins/typed_arrays/uint8_clamped_array.rs
@@ -1,4 +1,4 @@
-use crate::builtins::typed_arrays::typed_array::TypedArrayInstance;
+use crate::builtins::typed_arrays::typed_array::{TypedArrayInstance, TypedArrayStorageClass};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Uint8ClampedArray;
@@ -6,4 +6,8 @@ pub(crate) struct Uint8ClampedArray;
 impl TypedArrayInstance for Uint8ClampedArray {
     const BYTES_PER_ELEMENT: usize = 1;
     const NAME: &'static str = "Uint8ClampedArray";
+
+    fn get_storage_class(capacity: usize) -> TypedArrayStorageClass {
+        TypedArrayStorageClass::U8(Vec::with_capacity(capacity))
+    }
 }

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -267,12 +267,6 @@ impl Default for Context {
             standard_objects: Default::default(),
             trace: false,
         };
-
-        // We want the methods in `TypedArray` to be bound to the corresponding
-        // standard object but we don't really need a reference to the constructor.
-        // So we discard the constructor.
-        TypedArray::init(&mut context);
-
         // Add new builtIns to Context Realm
         // At a later date this can be removed from here and called explicitly,
         // but for now we almost always want these default builtins

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -1,6 +1,5 @@
 //! Javascript context.
 
-use crate::builtins::typed_arrays::typed_array::TypedArray;
 use crate::{
     builtins::{
         self,

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -244,7 +244,6 @@ pub struct Context {
     /// console object state.
     #[cfg(feature = "console")]
     console: Console,
-    typed_array_prototype: GcObject,
     /// Cached iterator prototypes.
     iterator_prototypes: IteratorPrototypes,
 
@@ -264,13 +263,16 @@ impl Default for Context {
             executor,
             #[cfg(feature = "console")]
             console: Console::default(),
-            typed_array_prototype: Default::default(),
             iterator_prototypes: IteratorPrototypes::default(),
             standard_objects: Default::default(),
             trace: false,
         };
 
-        context.typed_array_prototype = TypedArray::init(&mut context);
+        // We want the methods in `TypedArray` to be bound to the corresponding
+        // standard object but we don't really need a reference to the constructor.
+        // So we discard the constructor.
+        TypedArray::init(&mut context);
+
         // Add new builtIns to Context Realm
         // At a later date this can be removed from here and called explicitly,
         // but for now we almost always want these default builtins
@@ -713,11 +715,6 @@ impl Context {
     #[inline]
     pub fn iterator_prototypes(&self) -> &IteratorPrototypes {
         &self.iterator_prototypes
-    }
-
-    #[inline]
-    pub fn typed_array_prototype(&self) -> &GcObject {
-        &self.typed_array_prototype
     }
 
     /// Return the core standard objects.

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -625,6 +625,15 @@ impl GcObject {
         self.borrow().is_array()
     }
 
+    /// Checks if it is a TypedArray object.
+    //  # Panics
+    //  Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_array(&self) -> bool {
+        self.borrow().is_typed_array()
+    }
+
     /// Checks if it is an `ArrayIterator` object.
     ///
     /// # Panics

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -398,6 +398,13 @@ impl GcObject {
 
         let object = self.borrow();
         match object.data {
+            ObjectData::TypedArray(ref typed_array) => match key {
+                PropertyKey::Index(index) => Some(PropertyDescriptor::from(DataDescriptor::new(
+                    typed_array.buffer.get_value_at_index(*index),
+                    Attribute::WRITABLE, // TODO: Figure out this value
+                ))),
+                _ => self.ordinary_get_own_property(key),
+            },
             ObjectData::String(_) => self.string_exotic_get_own_property(key),
             _ => self.ordinary_get_own_property(key),
         }

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -400,7 +400,10 @@ impl GcObject {
         match object.data {
             ObjectData::TypedArray(ref typed_array) => match key {
                 PropertyKey::Index(index) => Some(PropertyDescriptor::from(DataDescriptor::new(
-                    typed_array.buffer.get_value_at_index(*index),
+                    typed_array
+                        .buffer
+                        .get_value_at_offset(*index)
+                        .unwrap_or(Value::undefined()),
                     Attribute::WRITABLE, // TODO: Figure out this value
                 ))),
                 _ => self.ordinary_get_own_property(key),

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -287,6 +287,11 @@ impl Object {
     }
 
     #[inline]
+    pub fn is_typed_array(&self) -> bool {
+        matches!(self.data, ObjectData::TypedArray(_))
+    }
+
+    #[inline]
     pub fn as_array(&self) -> Option<()> {
         match self.data {
             ObjectData::Array => Some(()),

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -33,6 +33,7 @@ mod internal_methods;
 mod iter;
 
 use crate::builtins::object::for_in_iterator::ForInIterator;
+use crate::builtins::typed_arrays::typed_array::TypedArray;
 pub use gcobject::{GcObject, RecursionLimiter, Ref, RefMut};
 pub use iter::*;
 
@@ -84,6 +85,7 @@ pub enum ObjectData {
     Array,
     ArrayIterator(ArrayIterator),
     Map(OrderedMap<Value, Value>),
+    TypedArray(TypedArray),
     MapIterator(MapIterator),
     RegExp(Box<RegExp>),
     BigInt(RcBigInt),
@@ -129,6 +131,7 @@ impl Display for ObjectData {
                 Self::Date(_) => "Date",
                 Self::Global => "Global",
                 Self::NativeObject(_) => "NativeObject",
+                Self::TypedArray(_) => "TypedArray",
             }
         )
     }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -58,6 +58,8 @@ pub enum Value {
     Rational(f64),
     /// `Number` - A 32-bit integer, such as `42`.
     Integer(i32),
+    // TODO: Figure out if value should contain types like these
+    // TypedInt(TypedInt),
     /// `BigInt` - holds any arbitrary large signed integer.
     BigInt(RcBigInt),
     /// `Object` - An object, such as `Math`, represented by a binary tree of string keys to Javascript values.
@@ -65,6 +67,12 @@ pub enum Value {
     /// `Symbol` - A Symbol Primitive type.
     Symbol(RcSymbol),
 }
+
+// Integer values for typed_arrays and other size defined integer values
+// pub enum TypedInt {
+//     I8(i8),
+//     U8(u8),
+// }
 
 /// Represents the result of ToIntegerOrInfinity operation
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -3,7 +3,7 @@ flag:module
 flag:async
 
 // Non-implemented features:
-feature:TypedArray
+// feature:TypedArray
 feature:json-modules
 //feature:generators
 //feature:async-iteration

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -3,7 +3,7 @@ flag:module
 flag:async
 
 // Non-implemented features:
-// feature:TypedArray
+feature:TypedArray
 feature:json-modules
 //feature:generators
 //feature:async-iteration


### PR DESCRIPTION
### Tracking PR for #893
Requires #1322 

Current changes:
I have been able to grok bits of the codebase to understand how to initialize a new constructor. However, i still have a bunch of unanswered questions. 

* How does the new_target interact with the init construction?
* Does having a typed array constructor definition actually work and do uint8 arrays inherit from TypedArray
* Why can't sanity be called?

* Should `Value` encapsulate `u8, i8, u16, i16, u32, i32` as an enum member?
Tested with 
```
const x = new Uint8Array(3);

console.log(x.length);
x.sanity()
```
where x.sanity is a method that is supposed to print out "sanity check"
