### PR TITLE
Implement parsing for object shorthand properties

### DIFF
--- a/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -1,8 +1,8 @@
 use crate::syntax::{
     ast::{
         node::{
-            Declaration, DeclarationList, FormalParameter, FunctionExpr, MethodDefinitionKind,
-            Object, PropertyDefinition,
+            Declaration, DeclarationList, FormalParameter, FunctionExpr, Identifier,
+            MethodDefinitionKind, Object, PropertyDefinition,
         },
         Const,
     },
@@ -201,5 +201,63 @@ fn check_object_short_function_set() {
             .into(),
         )
         .into()],
+    );
+}
+
+#[test]
+fn check_object_shorthand_property_names() {
+    let object_properties = vec![PropertyDefinition::property("a", Identifier::from("a"))];
+
+    check_parser(
+        "const a = true;
+            const x = { a };
+        ",
+        vec![
+            DeclarationList::Const(
+                vec![Declaration::new("a", Some(Const::from(true).into()))].into(),
+            )
+            .into(),
+            DeclarationList::Const(
+                vec![Declaration::new(
+                    "x",
+                    Some(Object::from(object_properties).into()),
+                )]
+                .into(),
+            )
+            .into(),
+        ],
+    );
+}
+
+#[test]
+fn check_object_shorthand_multiple_properties() {
+    let object_properties = vec![
+        PropertyDefinition::property("a", Identifier::from("a")),
+        PropertyDefinition::property("b", Identifier::from("b")),
+    ];
+
+    check_parser(
+        "const a = true;
+            const b = false;
+            const x = { a, b, };
+        ",
+        vec![
+            DeclarationList::Const(
+                vec![Declaration::new("a", Some(Const::from(true).into()))].into(),
+            )
+            .into(),
+            DeclarationList::Const(
+                vec![Declaration::new("b", Some(Const::from(false).into()))].into(),
+            )
+            .into(),
+            DeclarationList::Const(
+                vec![Declaration::new(
+                    "x",
+                    Some(Object::from(object_properties).into()),
+                )]
+                .into(),
+            )
+            .into(),
+        ],
     );
 }


### PR DESCRIPTION
This Pull Request fixes/closes #1308.

It changes the following:

- Adds to the PropertyDefinition parser to look for object shorthand properties

This takes a shortcut from [the spec](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-object-initializer), it skips the use of `IdentifierReference` from the Object Initializer portion of the spec and instead parses `prop` as if it was `prop: prop` (`PropertyName/AssignmentExpression` pair).

This allows the change to only occur in the parser, as we [currently don't have an evaluation](https://github.com/boa-dev/boa/blob/master/boa/src/syntax/ast/node/object/mod.rs#L91) for `IdentifierReference`. The [evaluation semantics](https://tc39.es/ecma262/#sec-runtime-semantics-propertydefinitionevaluation) for `IdentifierReference` appear to be a subset of the evaluation semantics for a `PropertyName/AssignmentExpression` pair, so this shortcut is likely OK, but could be worth others checking/thinking about that.

```js
const message = "hello"
const obj1 = { message }   // parsed as if it was { message: message }
const obj2 = { message, }  // parsed as if it was { message: message }
```