### PR TITLE
start execution context

### DIFF
--- a/boa/src/vm/exec_context.rs
+++ b/boa/src/vm/exec_context.rs
@@ -9,14 +9,15 @@
 
 use crate::Value;
 
+#[derive(Debug)]
 pub struct ExecContext {
-    /// The stack will hold values as the execution context runs
+    /// The stack will hold values as the execution context runs.
     /// As these values are only temporarily held onto the stack and not accessed
     /// anywhere else they don't need to be GC'd
-    pub stack: Vec<Value>,
+    stack: Vec<Value>,
     /// Points to where in the instructions this context should start executing
     /// As the instructions already exist on another stack this only needs to reference the index.
-    pub inst_pc: usize,
+    inst_pc: usize,
 }
 
 impl Default for ExecContext {

--- a/boa/src/vm/exec_context.rs
+++ b/boa/src/vm/exec_context.rs
@@ -1,0 +1,29 @@
+//! This module implements an Execution Context.
+//!
+//! The execution context is used to track the runtime evalutation of code.
+//! Each function's invocation is an execution context, each context has its own "owned" stack.
+//!
+//! More information:
+//! - [ECMAScript reference][spec]
+//! [spec]: https://tc39.es/ecma262/#sec-execution-contexts
+
+use crate::Value;
+
+pub struct ExecContext {
+    /// The stack will hold values as the execution context runs
+    /// As these values are only temporarily held onto the stack and not accessed
+    /// anywhere else they don't need to be GC'd
+    pub stack: Vec<Value>,
+    /// Points to where in the instructions this context should start executing
+    /// As the instructions already exist on another stack this only needs to reference the index.
+    pub inst_pc: usize,
+}
+
+impl Default for ExecContext {
+    fn default() -> Self {
+        ExecContext {
+            stack: vec![],
+            inst_pc: 0,
+        }
+    }
+}

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 
 pub(crate) mod compilation;
+pub(crate) mod exec_context;
 pub(crate) mod instructions;
 
 pub use compilation::Compiler;

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod exec_context;
 pub(crate) mod instructions;
 
 pub use compilation::Compiler;
+pub use exec_context::ExecContext;
 pub use instructions::Instruction;
 use std::time::{Duration, Instant};
 
@@ -25,6 +26,7 @@ pub struct VM<'a> {
     stack_pointer: usize,
     profile: Profiler,
     is_trace: bool,
+    execution_context_stack: Vec<ExecContext>,
 }
 /// This profiler is used to output trace information when `--trace` is provided by the CLI or trace is set to `true` on the [`VM`] object
 #[derive(Debug)]
@@ -49,6 +51,7 @@ impl<'a> VM<'a> {
             stack: vec![],
             stack_pointer: 0,
             is_trace: trace,
+            execution_context_stack: vec![ExecContext::default()],
             profile: Profiler {
                 instant: Instant::now(),
                 prev_time: Duration::from_secs(0),
@@ -72,6 +75,18 @@ impl<'a> VM<'a> {
     #[inline]
     pub fn pop(&mut self) -> Value {
         self.stack.pop().unwrap()
+    }
+
+    /// Gets a reference to the Execution Context sitting at the top of the stack
+    pub fn get_current_ec(&mut self) -> &mut ExecContext {
+        self.execution_context_stack
+            .last_mut()
+            .expect("failed to get Execution Context")
+    }
+
+    /// Sets the current execution context
+    pub fn set_current_ec(&mut self, exec_context: ExecContext) {
+        self.execution_context_stack.push(exec_context);
     }
 
     pub fn run(&mut self) -> Result<Value> {


### PR DESCRIPTION
Currently the VM directly manipulates a global stack.
This PR will move to execution contexts which hold their own stack values and will manipulate those instead. The VM will then call on each execution context as each function is invoked. 
These will live on the execution context stack.

This should unblock us from `eval`, `stack traces`, `implementing functions in the VM` etc

* We may need to rename `Context` to `AgentContext` to disassociate it with an Execution Context, which is the context surrounding a running function

fixes #186