### PR TITLE
Implement `delete_property_or_throw`

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -482,7 +482,7 @@ impl Array {
         }
         let pop_index = curr_length.wrapping_sub(1);
         let pop_value: Value = this.get_field(pop_index.to_string(), context)?;
-        this.remove_property(pop_index);
+        this.delete_property_or_throw(pop_index, context)?;
         this.set_field("length", Value::from(pop_index), true, context)?;
         Ok(pop_value)
     }
@@ -621,10 +621,10 @@ impl Array {
                 this.set_property(lower, DataDescriptor::new(upper_value, Attribute::all()));
             } else if upper_exists {
                 this.set_property(lower, DataDescriptor::new(upper_value, Attribute::all()));
-                this.remove_property(upper);
+                this.delete_property_or_throw(upper, context)?;
             } else if lower_exists {
                 this.set_property(upper, DataDescriptor::new(lower_value, Attribute::all()));
-                this.remove_property(lower);
+                this.delete_property_or_throw(lower, context)?;
             }
         }
 
@@ -657,14 +657,14 @@ impl Array {
 
             let from_value = this.get_field(from, context)?;
             if from_value.is_undefined() {
-                this.remove_property(to);
+                this.delete_property_or_throw(to, context)?;
             } else {
                 this.set_property(to, DataDescriptor::new(from_value, Attribute::all()));
             }
         }
 
         let final_index = len.wrapping_sub(1);
-        this.remove_property(final_index);
+        this.delete_property_or_throw(final_index, context)?;
         this.set_field("length", Value::from(final_index), true, context)?;
 
         Ok(first)
@@ -694,7 +694,7 @@ impl Array {
 
                 let from_value = this.get_field(from, context)?;
                 if from_value.is_undefined() {
-                    this.remove_property(to);
+                    this.delete_property_or_throw(to, context)?;
                 } else {
                     this.set_property(to, DataDescriptor::new(from_value, Attribute::all()));
                 }
@@ -1624,7 +1624,7 @@ impl Array {
                 let val = this.get_field(from, context)?;
                 this.set_field(to, val, true, context)?;
             } else {
-                this.remove_property(to);
+                this.delete_property_or_throw(to, context)?;
             }
             match direction {
                 Direction::Forward => {

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -69,6 +69,24 @@ impl GcObject {
         }
     }
 
+    /// Abstract operation `DeletePropertyOrThrow ( O, P )`
+    ///
+    /// More information:
+    ///  - [ECMAScript][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
+    pub fn delete_property_or_throw(
+        &mut self,
+        key: &PropertyKey,
+        context: &mut Context,
+    ) -> Result<()> {
+        if self.delete(key) {
+            Ok(())
+        } else {
+            Err(context.construct_type_error("Failed deleting property of Object"))
+        }
+    }
+
     /// `[[Get]]`
     /// <https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver>
     pub fn get(&self, key: &PropertyKey, receiver: Value, context: &mut Context) -> Result<Value> {

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -423,6 +423,22 @@ impl Value {
             .is_some()
     }
 
+    /// Abstract operation `DeletePropertyOrThrow ( O, P )`
+    ///
+    /// More information:
+    ///  - [ECMAScript][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
+    // todo: remove function after separation of Value and Object
+    pub fn delete_property_or_throw<Key>(&self, key: Key, context: &mut Context) -> Result<()>
+    where
+        Key: Into<PropertyKey>,
+    {
+        self.as_object()
+            .expect("expected object type")
+            .delete_property_or_throw(&key.into(), context)
+    }
+
     /// Resolve the property in the object.
     ///
     /// A copy of the Property is returned.


### PR DESCRIPTION
Some functions of `Array` use `remove_property` as an equivalent for `DeletePropertyOrThrow ( O, P )`, but this function is not spec compliant in some cases, as it silently fails when there's an error deleting a property.

This PR changes the following:

- Adds the function `delete_property_or_throw` for `GcObject`
- Adds the function `delete_property_or_throw` for `Value` (temporarily until we separate Objects from Values)
- Replaces instances of `remove_property` with `delete_property_or_throw` in `Array` functions 


