### PR TITLE
fix(boa): fix stringpad abstract operation

### DIFF
--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -920,7 +920,7 @@ impl String {
 
         let filler = fill_string.as_deref().unwrap_or(" ");
 
-        if filler == "" {
+        if filler.is_empty() {
             return Value::from(primitive);
         }
 

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -918,13 +918,17 @@ impl String {
             return Value::from(primitive);
         }
 
-        let filter = fill_string.as_deref().unwrap_or(" ");
+        let filler = fill_string.as_deref().unwrap_or(" ");
+
+        if filler == "" {
+            return Value::from(primitive);
+        }
 
         let fill_len = max_length.wrapping_sub(primitive_length);
         let mut fill_str = StdString::new();
 
         while fill_str.len() < fill_len as usize {
-            fill_str.push_str(filter);
+            fill_str.push_str(filler);
         }
         // Cut to size max_length
         let concat_fill_str: StdString = fill_str.chars().take(fill_len as usize).collect();

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -12,7 +12,6 @@ feature:json-modules
 // These seem to run forever:
 arg-length-exceeding-integer-limit
 15.4.4.19-8-c-ii-1
-fill-string-empty
 length-boundaries
 throws-if-integer-limit-exceeded
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1306.

It changes the following:

- renames filter to filler in accordance with spec
- adds empty string check to StringPad function
