### PR TITLE
Refactor / Implement RegExp functions

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -206,7 +206,11 @@ impl Array {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraycreate
-    fn array_create(length: u32, prototype: Option<GcObject>, context: &mut Context) -> Value {
+    pub(crate) fn array_create(
+        length: u32,
+        prototype: Option<GcObject>,
+        context: &mut Context,
+    ) -> Value {
         let prototype = match prototype {
             Some(prototype) => prototype,
             None => context.standard_objects().array_object().prototype(),

--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -1,9 +1,9 @@
 use crate::{
-    builtins::string::string_iterator::StringIterator,
-    builtins::ArrayIterator,
-    builtins::ForInIterator,
-    builtins::MapIterator,
-    builtins::SetIterator,
+    builtins::{
+        regexp::regexp_string_iterator::RegExpStringIterator,
+        string::string_iterator::StringIterator, ArrayIterator, ForInIterator, MapIterator,
+        SetIterator,
+    },
     object::{GcObject, ObjectInitializer},
     property::{Attribute, DataDescriptor},
     symbol::WellKnownSymbols,
@@ -16,6 +16,7 @@ pub struct IteratorPrototypes {
     array_iterator: GcObject,
     set_iterator: GcObject,
     string_iterator: GcObject,
+    regexp_string_iterator: GcObject,
     map_iterator: GcObject,
     for_in_iterator: GcObject,
 }
@@ -30,6 +31,10 @@ impl IteratorPrototypes {
             ),
             set_iterator: SetIterator::create_prototype(context, iterator_prototype.clone().into()),
             string_iterator: StringIterator::create_prototype(
+                context,
+                iterator_prototype.clone().into(),
+            ),
+            regexp_string_iterator: RegExpStringIterator::create_prototype(
                 context,
                 iterator_prototype.clone().into(),
             ),
@@ -60,6 +65,11 @@ impl IteratorPrototypes {
     #[inline]
     pub fn string_iterator(&self) -> GcObject {
         self.string_iterator.clone()
+    }
+
+    #[inline]
+    pub fn regexp_string_iterator(&self) -> GcObject {
+        self.regexp_string_iterator.clone()
     }
 
     #[inline]

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -559,10 +559,7 @@ impl RegExp {
 
             for c in src.chars() {
                 match c {
-                    '/' => {
-                        s.push('\\');
-                        s.push(c);
-                    }
+                    '/' => s.push_str("\\/"),
                     '\n' => s.push_str("\\\\n"),
                     '\r' => s.push_str("\\\\r"),
                     _ => s.push(c),
@@ -760,9 +757,9 @@ impl RegExp {
             if input.get(last_index..).is_none() {
                 return Ok(Value::null());
             }
-            let m = matcher.find_from(&input, last_index).next();
+            let r = matcher.find_from(&input, last_index).next();
 
-            match m {
+            match r {
                 // c. If r is failure, then
                 None => {
                     // i. If sticky is true, then

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -9,15 +9,18 @@
 //! [spec]: https://tc39.es/ecma262/#sec-regexp-constructor
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp
 
+pub mod regexp_string_iterator;
+
 use crate::{
-    builtins::BuiltIn,
+    builtins::{array::Array, BuiltIn},
     gc::{empty_trace, Finalize, Trace},
     object::{ConstructorBuilder, FunctionBuilder, GcObject, ObjectData, PROTOTYPE},
     property::{Attribute, DataDescriptor},
     symbol::WellKnownSymbols,
-    value::{RcString, Value},
+    value::{IntegerOrInfinity, RcString, Value},
     BoaProfiler, Context, Result,
 };
+use regexp_string_iterator::RegExpStringIterator;
 use regress::Regex;
 
 #[cfg(test)]
@@ -134,9 +137,29 @@ impl BuiltIn for RegExp {
         .method(Self::exec, "exec", 1)
         .method(Self::to_string, "toString", 0)
         .method(
+            Self::r#match,
+            (WellKnownSymbols::match_(), "[Symbol.match]"),
+            1,
+        )
+        .method(
+            Self::match_all,
+            (WellKnownSymbols::match_all(), "[Symbol.matchAll]"),
+            1,
+        )
+        .method(
+            Self::replace,
+            (WellKnownSymbols::replace(), "[Symbol.replace]"),
+            2,
+        )
+        .method(
             Self::search,
             (WellKnownSymbols::search(), "[Symbol.search]"),
             1,
+        )
+        .method(
+            Self::split,
+            (WellKnownSymbols::split(), "[Symbol.split]"),
+            2,
         )
         .accessor("global", Some(get_global), None, flag_attributes)
         .accessor("ignoreCase", Some(get_ignore_case), None, flag_attributes)
@@ -499,45 +522,29 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.test
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
     pub(crate) fn test(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        // 22.2.5.2.2.4 really says to use "toLength" and not "toIndex"
-        let mut last_index = this.get_field("lastIndex", context)?.to_length(context)?;
-        let result = if let Some(object) = this.as_object() {
-            // 3. Let string be ? ToString(S).
-            let arg_str = args
-                .get(0)
-                .cloned()
-                .unwrap_or_default()
-                .to_string(context)?;
-
-            // 4. Let match be ? RegExpExec(R, string).
-            let object = object.borrow();
-            if let Some(regex) = object.as_regexp() {
-                let result =
-                    if let Some(m) = regex.matcher.find_from(arg_str.as_str(), last_index).next() {
-                        if regex.use_last_index {
-                            last_index = m.end();
-                        }
-                        true
-                    } else {
-                        if regex.use_last_index {
-                            last_index = 0;
-                        }
-                        false
-                    };
-
-                // 5. If match is not null, return true; else return false.
-                Ok(Value::boolean(result))
-            } else {
-                return context
-                    .throw_type_error("RegExp.prototype.exec method called on incompatible value");
-            }
-        } else {
-            // 2. If Type(R) is not Object, throw a TypeError exception.
+        // 1. Let R be the this value.
+        // 2. If Type(R) is not Object, throw a TypeError exception.
+        if !this.is_object() {
             return context
-                .throw_type_error("RegExp.prototype.exec method called on incompatible value");
-        };
-        this.set_field("lastIndex", Value::from(last_index), true, context)?;
-        result
+                .throw_type_error("RegExp.prototype.test method called on incompatible value");
+        }
+
+        // 3. Let string be ? ToString(S).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
+
+        // 4. Let match be ? RegExpExec(R, string).
+        let m = Self::abstract_exec(this, arg_str, context)?;
+
+        // 5. If match is not null, return true; else return false.
+        if !m.is_null() {
+            Ok(Value::Boolean(true))
+        } else {
+            Ok(Value::Boolean(false))
+        }
     }
 
     /// `RegExp.prototype.exec( string )`
@@ -553,71 +560,273 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.exec
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec
     pub(crate) fn exec(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let R be the this value.
+        // 2. Perform ? RequireInternalSlot(R, [[RegExpMatcher]]).
+        {
+            let obj = this.as_object().unwrap_or_default();
+            let obj = obj.borrow();
+            obj.as_regexp().ok_or_else(|| {
+                context.construct_type_error("RegExp.prototype.exec called with invalid value")
+            })?;
+        }
+
+        // 3. Let S be ? ToString(string).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
+
         // 4. Return ? RegExpBuiltinExec(R, S).
-        // 22.2.5.2.2.4 really says to use "toLength" and not "toIndex"
-        let mut last_index = this.get_field("lastIndex", context)?.to_length(context)?;
-        let result = if let Some(object) = this.as_object() {
-            let object = object.borrow();
-            if let Some(regex) = object.as_regexp() {
-                // 3. Let S be ? ToString(string).
-                let arg_str = args
-                    .get(0)
-                    .cloned()
-                    .unwrap_or_default()
-                    .to_string(context)?;
+        Self::abstract_builtin_exec(this, arg_str, context)
+    }
 
-                let result = {
-                    if last_index > arg_str.len() {
-                        if regex.use_last_index {
-                            last_index = 0;
-                        }
-                        Value::null()
-                    } else if let Some(m) =
-                        regex.matcher.find_from(arg_str.as_str(), last_index).next()
-                    {
-                        if regex.use_last_index {
-                            last_index = m.end();
-                        }
-                        let groups = m.captures.len() + 1;
-                        let mut result = Vec::with_capacity(groups);
-                        for i in 0..groups {
-                            if let Some(range) = m.group(i) {
-                                result.push(Value::from(
-                                    arg_str.get(range).expect("Could not get slice"),
-                                ));
-                            } else {
-                                result.push(Value::undefined());
-                            }
-                        }
+    /// `22.2.5.2.1 RegExpExec ( R, S )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-regexpexec
+    pub(crate) fn abstract_exec(
+        this: &Value,
+        input: RcString,
+        context: &mut Context,
+    ) -> Result<Value> {
+        // 1. Assert: Type(R) is Object.
+        let object = this
+            .as_object()
+            .ok_or_else(|| context.construct_type_error("RegExpExec called with invalid value"))?;
+        // 2. Assert: Type(S) is String.
 
-                        let result = Value::from(result);
-                        result.set_property(
-                            "index",
-                            DataDescriptor::new(m.start(), Attribute::all()),
-                        );
-                        result
-                            .set_property("input", DataDescriptor::new(arg_str, Attribute::all()));
-                        result
-                    } else {
-                        if regex.use_last_index {
-                            last_index = 0;
-                        }
-                        Value::null()
-                    }
-                };
+        // 3. Let exec be ? Get(R, "exec").
+        let exec = this.get_field("exec", context)?;
 
-                Ok(result)
-            } else {
-                // 2. Perform ? RequireInternalSlot(R, [[RegExpMatcher]]).
-                context
-                    .throw_type_error("RegExp.prototype.exec method called on incompatible value")
+        // 4. If IsCallable(exec) is true, then
+        if exec.is_function() {
+            // a. Let result be ? Call(exec, R, « S »).
+            let result = context.call(&exec, this, &[input.into()])?;
+
+            // b. If Type(result) is neither Object nor Null, throw a TypeError exception.
+            if !result.is_object() && !result.is_null() {
+                return context.throw_type_error("regexp exec returned neither object nor null");
             }
-        } else {
-            return context.throw_type_error("exec method called on incompatible value");
+
+            // c. Return result.
+            return Ok(result);
+        }
+
+        // 5. Perform ? RequireInternalSlot(R, [[RegExpMatcher]]).
+        object
+            .borrow()
+            .as_regexp()
+            .ok_or_else(|| context.construct_type_error("RegExpExec called with invalid value"))?;
+
+        // 6. Return ? RegExpBuiltinExec(R, S).
+        Self::abstract_builtin_exec(this, input, context)
+    }
+
+    /// `22.2.5.2.2 RegExpBuiltinExec ( R, S )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-regexpbuiltinexec
+    pub(crate) fn abstract_builtin_exec(
+        this: &Value,
+        input: RcString,
+        context: &mut Context,
+    ) -> Result<Value> {
+        // 1. Assert: R is an initialized RegExp instance.
+        let rx = {
+            let obj = this.as_object().unwrap_or_default();
+            let obj = obj.borrow();
+            obj.as_regexp()
+                .ok_or_else(|| {
+                    context.construct_type_error("RegExpBuiltinExec called with invalid value")
+                })?
+                .clone()
         };
 
-        this.set_field("lastIndex", Value::from(last_index), true, context)?;
-        result
+        // 2. Assert: Type(S) is String.
+
+        // 3. Let length be the number of code units in S.
+        // Regress only works with utf8. According to the spec we would use the utf16 encoded count.
+        let length = input.chars().count();
+
+        // 4. Let lastIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
+        let mut last_index = this.get_field("lastIndex", context)?.to_length(context)?;
+
+        // 5. Let flags be R.[[OriginalFlags]].
+        let flags = rx.original_flags;
+
+        // 6. If flags contains "g", let global be true; else let global be false.
+        let global = flags.contains('g');
+
+        // 7. If flags contains "y", let sticky be true; else let sticky be false.
+        let sticky = flags.contains('y');
+
+        // 8. If global is false and sticky is false, set lastIndex to 0.
+        if !global && !sticky {
+            last_index = 0;
+        }
+
+        // 9. Let matcher be R.[[RegExpMatcher]].
+        let matcher = rx.matcher;
+
+        // 10. If flags contains "u", let fullUnicode be true; else let fullUnicode be false.
+        let unicode = flags.contains('u');
+
+        // 11. Let matchSucceeded be false.
+        // 12. Repeat, while matchSucceeded is false,
+        let match_value = loop {
+            // a. If lastIndex > length, then
+            if last_index > length {
+                // i. If global is true or sticky is true, then
+                if global || sticky {
+                    // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
+                    this.set_field("lastIndex", 0, true, context)?;
+                }
+
+                // ii. Return null.
+                return Ok(Value::null());
+            }
+
+            // b. Let r be matcher(S, lastIndex).
+            // Check if last_index is a valid utf8 index into input.
+            if input.get(last_index..).is_none() {
+                return Ok(Value::null());
+            }
+            let m = matcher.find_from(&input, last_index).next();
+
+            match m {
+                // c. If r is failure, then
+                None => {
+                    // i. If sticky is true, then
+                    if sticky {
+                        // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
+                        this.set_field("lastIndex", 0, true, context)?;
+
+                        // 2. Return null.
+                        return Ok(Value::null());
+                    }
+
+                    // ii. Set lastIndex to AdvanceStringIndex(S, lastIndex, fullUnicode).
+                    last_index = advance_string_index(input.clone(), last_index, unicode);
+                }
+
+                Some(m) => {
+                    // c. If r is failure, then
+                    // d. Else,
+                    if m.start() != last_index {
+                        // i. If sticky is true, then
+                        if sticky {
+                            // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
+                            this.set_field("lastIndex", 0, true, context)?;
+
+                            // 2. Return null.
+                            return Ok(Value::null());
+                        }
+
+                        // ii. Set lastIndex to AdvanceStringIndex(S, lastIndex, fullUnicode).
+                        last_index = advance_string_index(input.clone(), last_index, unicode);
+                    } else {
+                        //i. Assert: r is a State.
+                        //ii. Set matchSucceeded to true.
+                        break m;
+                    }
+                }
+            }
+        };
+
+        // 13. Let e be r's endIndex value.
+        let mut e = match_value.end();
+
+        // 14. If fullUnicode is true, then
+        if unicode {
+            // e is an index into the Input character list, derived from S, matched by matcher.
+            // Let eUTF be the smallest index into S that corresponds to the character at element e of Input.
+            // If e is greater than or equal to the number of elements in Input, then eUTF is the number of code units in S.
+            // b. Set e to eUTF.
+            // Regress only works with utf8. According to the spec we would use the utf16 encoded count.
+            e = input.split_at(e).0.chars().count() + 1;
+        }
+
+        // 15. If global is true or sticky is true, then
+        if global || sticky {
+            // a. Perform ? Set(R, "lastIndex", 𝔽(e), true).
+            this.set_field("lastIndex", e, true, context)?;
+        }
+
+        // 16. Let n be the number of elements in r's captures List. (This is the same value as 22.2.2.1's NcapturingParens.)
+        // 17. Assert: n < 23^2 - 1.
+        let n: u32 = match_value.captures.len() as u32;
+
+        // 18. Let A be ! ArrayCreate(n + 1).
+        // 19. Assert: The mathematical value of A's "length" property is n + 1.
+        let a = Array::array_create(n + 1, None, context);
+
+        // 20. Perform ! CreateDataPropertyOrThrow(A, "index", 𝔽(lastIndex)).
+        a.set_property(
+            "index",
+            DataDescriptor::new(match_value.start(), Attribute::all()),
+        );
+
+        // 21. Perform ! CreateDataPropertyOrThrow(A, "input", S).
+        a.set_property(
+            "input",
+            DataDescriptor::new(input.clone(), Attribute::all()),
+        );
+
+        // 22. Let matchedSubstr be the substring of S from lastIndex to e.
+        let matched_substr = if let Some(s) = input.get(match_value.range()) {
+            s
+        } else {
+            ""
+        };
+
+        // 23. Perform ! CreateDataPropertyOrThrow(A, "0", matchedSubstr).
+        a.set_property("0", DataDescriptor::new(matched_substr, Attribute::all()));
+
+        // TODO: named capture groups
+        // 24. If R contains any GroupName, then
+        //     a. Let groups be ! OrdinaryObjectCreate(null).
+        // 25. Else,
+        //     a. Let groups be undefined.
+        let groups = Value::undefined();
+
+        // 26. Perform ! CreateDataPropertyOrThrow(A, "groups", groups).
+        a.set_property("groups", DataDescriptor::new(groups, Attribute::all()));
+
+        // 27. For each integer i such that i ≥ 1 and i ≤ n, in ascending order, do
+        for i in 1..=n {
+            // a. Let captureI be ith element of r's captures List.
+            let capture = match_value.group(i as usize);
+
+            let captured_value = match capture {
+                // b. If captureI is undefined, let capturedValue be undefined.
+                None => Value::undefined(),
+                // c. Else if fullUnicode is true, then
+                // d. Else,
+                Some(range) => {
+                    if let Some(s) = input.get(range) {
+                        s.into()
+                    } else {
+                        "".into()
+                    }
+                }
+            };
+
+            // e. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).
+            a.set_property(i, DataDescriptor::new(captured_value, Attribute::all()));
+
+            // TODO: named capture groups
+            // f. If the ith capture of R was defined with a GroupName, then
+            // i. Let s be the CapturingGroupName of the corresponding RegExpIdentifierName.
+            // ii. Perform ! CreateDataPropertyOrThrow(groups, s, capturedValue).
+        }
+
+        // 28. Return A.
+        Ok(a)
     }
 
     /// `RegExp.prototype[ @@match ]( string )`
@@ -630,30 +839,83 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype-@@match
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@match
-    pub(crate) fn r#match(this: &Value, arg: RcString, context: &mut Context) -> Result<Value> {
-        let (matcher, flags) = if let Some(object) = this.as_object() {
-            let object = object.borrow();
-            if let Some(regex) = object.as_regexp() {
-                (regex.matcher.clone(), regex.flags.clone())
-            } else {
-                return context
-                    .throw_type_error("RegExp.prototype.exec method called on incompatible value");
-            }
-        } else {
+    pub(crate) fn r#match(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let rx be the this value.
+        // 2. If Type(rx) is not Object, throw a TypeError exception.
+        if !this.is_object() {
             return context
                 .throw_type_error("RegExp.prototype.match method called on incompatible value");
-        };
-        if flags.contains('g') {
-            let mut matches = Vec::new();
-            for mat in matcher.find_iter(&arg) {
-                matches.push(Value::from(&arg[mat.range()]));
-            }
-            if matches.is_empty() {
-                return Ok(Value::null());
-            }
-            Ok(Value::from(matches))
+        }
+
+        // 3. Let S be ? ToString(string).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
+
+        // 4. Let global be ! ToBoolean(? Get(rx, "global")).
+        let global = this.get_field("global", context)?.to_boolean();
+
+        // 5. If global is false, then
+        // 6. Else,
+        if !global {
+            // a. Return ? RegExpExec(rx, S).
+            Self::abstract_exec(this, arg_str, context)
         } else {
-            Self::exec(this, &[Value::from(arg)], context)
+            // a. Assert: global is true.
+
+            // b. Let fullUnicode be ! ToBoolean(? Get(rx, "unicode")).
+            let unicode = this.get_field("unicode", context)?.to_boolean();
+
+            // c. Perform ? Set(rx, "lastIndex", +0𝔽, true).
+            this.set_field("lastIndex", Value::from(0), true, context)?;
+
+            // d. Let A be ! ArrayCreate(0).
+            let a = Array::array_create(0, None, context);
+
+            // e. Let n be 0.
+            let mut n = 0;
+
+            // f. Repeat,
+            loop {
+                // i. Let result be ? RegExpExec(rx, S).
+                let result = Self::abstract_exec(this, arg_str.clone(), context)?;
+
+                // ii. If result is null, then
+                // iii. Else,
+                if result.is_null() {
+                    // 1. If n = 0, return null.
+                    // 2. Return A.
+                    if n == 0 {
+                        return Ok(Value::null());
+                    } else {
+                        return Ok(a);
+                    }
+                } else {
+                    // 1. Let matchStr be ? ToString(? Get(result, "0")).
+                    let match_str = result.get_field("0", context)?.to_string(context)?;
+
+                    // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), matchStr).
+                    Array::add_to_array_object(&a, &[match_str.clone().into()], context)?;
+
+                    // 3. If matchStr is the empty String, then
+                    if match_str.is_empty() {
+                        // a. Let thisIndex be ℝ(? ToLength(? Get(rx, "lastIndex"))).
+                        let this_index =
+                            this.get_field("lastIndex", context)?.to_length(context)?;
+
+                        // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
+                        let next_index = advance_string_index(arg_str.clone(), this_index, unicode);
+
+                        // c. Perform ? Set(rx, "lastIndex", 𝔽(nextIndex), true).
+                        this.set_field("lastIndex", Value::from(next_index), true, context)?;
+                    }
+
+                    // 4. Set n to n + 1.
+                    n += 1;
+                }
+            }
         }
     }
 
@@ -684,7 +946,7 @@ impl RegExp {
                 this.display()
             ));
         };
-        Ok(Value::from(format!("/{}/{}", body, flags)))
+        Ok(format!("/{}/{}", body, flags).into())
     }
 
     /// `RegExp.prototype[ @@matchAll ]( string )`
@@ -697,55 +959,287 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp-prototype-matchall
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@matchAll
-    // TODO: it's returning an array, it should return an iterator
-    pub(crate) fn match_all(this: &Value, arg_str: String, context: &mut Context) -> Result<Value> {
-        let matches = if let Some(object) = this.as_object() {
-            let object = object.borrow();
-            if let Some(regex) = object.as_regexp() {
-                let mut matches = Vec::new();
-
-                for mat in regex.matcher.find_iter(&arg_str) {
-                    let match_vec: Vec<Value> = mat
-                        .groups()
-                        .map(|group| match group {
-                            Some(range) => Value::from(&arg_str[range]),
-                            None => Value::undefined(),
-                        })
-                        .collect();
-
-                    let match_val = Value::from(match_vec);
-
-                    match_val
-                        .set_property("index", DataDescriptor::new(mat.start(), Attribute::all()));
-                    match_val.set_property(
-                        "input",
-                        DataDescriptor::new(arg_str.clone(), Attribute::all()),
-                    );
-                    matches.push(match_val);
-
-                    if !regex.flags.contains('g') {
-                        break;
-                    }
-                }
-
-                matches
-            } else {
-                return context.throw_type_error(
-                    "RegExp.prototype.match_all method called on incompatible value",
-                );
-            }
-        } else {
+    pub(crate) fn match_all(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let R be the this value.
+        // 2. If Type(R) is not Object, throw a TypeError exception.
+        if !this.is_object() {
             return context.throw_type_error(
                 "RegExp.prototype.match_all method called on incompatible value",
             );
-        };
+        }
 
-        let length = matches.len();
-        let result = Value::from(matches);
-        result.set_field("length", Value::from(length), false, context)?;
-        result.set_data(ObjectData::Array);
+        // 3. Let S be ? ToString(string).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
 
-        Ok(result)
+        // 4. Let C be ? SpeciesConstructor(R, %RegExp%).
+        let c = this
+            .as_object()
+            .unwrap_or_default()
+            .species_constructor(context.standard_objects().regexp_object().clone(), context)?;
+
+        // 5. Let flags be ? ToString(? Get(R, "flags")).
+        let flags = this.get_field("flags", context)?.to_string(context)?;
+
+        // 6. Let matcher be ? Construct(C, « R, flags »).
+        let matcher = RegExp::constructor(&c, &[this.clone(), flags.clone().into()], context)?;
+
+        // 7. Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
+        let last_index = this.get_field("lastIndex", context)?.to_length(context)?;
+
+        // 8. Perform ? Set(matcher, "lastIndex", lastIndex, true).
+        matcher.set_field("lastIndex", last_index, true, context)?;
+
+        // 9. If flags contains "g", let global be true.
+        // 10. Else, let global be false.
+        let global = flags.contains('g');
+
+        // 11. If flags contains "u", let fullUnicode be true.
+        // 12. Else, let fullUnicode be false.
+        let unicode = flags.contains('u');
+
+        // 13. Return ! CreateRegExpStringIterator(matcher, S, global, fullUnicode).
+        RegExpStringIterator::create_regexp_string_iterator(
+            &matcher, arg_str, global, unicode, context,
+        )
+    }
+
+    /// `RegExp.prototype [ @@replace ] ( string, replaceValue )`
+    ///
+    /// The [@@replace]() method replaces some or all matches of a this pattern in a string by a replacement,
+    /// and returns the result of the replacement as a new string.
+    /// The replacement can be a string or a function to be called for each match.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype-@@replace
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@replace
+    pub(crate) fn replace(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let rx be the this value.
+        // 2. If Type(rx) is not Object, throw a TypeError exception.
+        if !this.is_object() {
+            return context.throw_type_error(
+                "RegExp.prototype[Symbol.replace] method called on incompatible value",
+            );
+        }
+
+        // 3. Let S be ? ToString(string).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
+
+        // 4. Let lengthS be the number of code unit elements in S.
+        // Regress only works with utf8. According to the spec we would use the utf16 encoded count.
+        let length_arg_str = arg_str.chars().count();
+
+        // 5. Let functionalReplace be IsCallable(replaceValue).
+        let replace_value = args.get(1).cloned().unwrap_or_default();
+        let functional_replace = replace_value.is_function();
+
+        // 6. If functionalReplace is false, then
+        // a. Set replaceValue to ? ToString(replaceValue).
+
+        // 7. Let global be ! ToBoolean(? Get(rx, "global")).
+        let global = this.get_field("global", context)?.to_boolean();
+
+        // 8. If global is true, then
+        // a. Let fullUnicode be ! ToBoolean(? Get(rx, "unicode")).
+        let unicode = this.get_field("unicode", context)?.to_boolean();
+        if global {
+            // b. Perform ? Set(rx, "lastIndex", +0𝔽, true).
+            this.set_field("lastIndex", 0, true, context)?;
+        }
+
+        //  9. Let results be a new empty List.
+        let mut results = Vec::new();
+
+        // 10. Let done be false.
+        // 11. Repeat, while done is false,
+        loop {
+            // a. Let result be ? RegExpExec(rx, S).
+            let result = Self::abstract_exec(this, arg_str.clone(), context)?;
+
+            // b. If result is null, set done to true.
+            // c. Else,
+            if result.is_null() {
+                break;
+            } else {
+                // i. Append result to the end of results.
+                results.push(result.clone());
+
+                // ii. If global is false, set done to true.
+                // iii. Else,
+                if !global {
+                    break;
+                } else {
+                    // 1. Let matchStr be ? ToString(? Get(result, "0")).
+                    let match_str = result.get_field("0", context)?.to_string(context)?;
+
+                    // 2. If matchStr is the empty String, then
+                    if match_str.is_empty() {
+                        // a. Let thisIndex be ℝ(? ToLength(? Get(rx, "lastIndex"))).
+                        let this_index =
+                            this.get_field("lastIndex", context)?.to_length(context)?;
+
+                        // b. Let nextIndex be AdvanceStringIndex(S, thisIndex, fullUnicode).
+                        let next_index = advance_string_index(arg_str.clone(), this_index, unicode);
+
+                        // c. Perform ? Set(rx, "lastIndex", 𝔽(nextIndex), true).
+                        this.set_field("lastIndex", Value::from(next_index), true, context)?;
+                    }
+                }
+            }
+        }
+
+        // 12. Let accumulatedResult be the empty String.
+        let mut accumulated_result = RcString::from("");
+
+        // 13. Let nextSourcePosition be 0.
+        let mut next_source_position = 0;
+
+        // 14. For each element result of results, do
+        for result in results {
+            // a. Let resultLength be ? LengthOfArrayLike(result).
+            let result_length = result.get_field("length", context)?.to_length(context)? as isize;
+
+            // b. Let nCaptures be max(resultLength - 1, 0).
+            let n_captures = std::cmp::max(result_length - 1, 0);
+
+            // c. Let matched be ? ToString(? Get(result, "0")).
+            let matched = result.get_field("0", context)?.to_string(context)?;
+
+            // d. Let matchLength be the number of code units in matched.
+            // Regress only works with utf8. According to the spec we would use the utf16 encoded count.
+            let match_length = matched.chars().count();
+
+            // e. Let position be ? ToIntegerOrInfinity(? Get(result, "index")).
+            let position = result
+                .get_field("index", context)?
+                .to_integer_or_infinity(context)?;
+
+            // f. Set position to the result of clamping position between 0 and lengthS.
+            //position = position.
+            let position = match position {
+                IntegerOrInfinity::Integer(i) => {
+                    if i < 0 {
+                        0
+                    } else if i as usize > length_arg_str {
+                        length_arg_str
+                    } else {
+                        i as usize
+                    }
+                }
+                IntegerOrInfinity::PositiveInfinity => length_arg_str,
+                IntegerOrInfinity::NegativeInfinity => 0,
+            };
+
+            // h. Let captures be a new empty List.
+            let mut captures = Vec::new();
+
+            // g. Let n be 1.
+            // i. Repeat, while n ≤ nCaptures,
+            for n in 1..=n_captures {
+                // i. Let capN be ? Get(result, ! ToString(𝔽(n))).
+                let mut cap_n = result.get_field(n.to_string(), context)?;
+
+                // ii. If capN is not undefined, then
+                if !cap_n.is_undefined() {
+                    // 1. Set capN to ? ToString(capN).
+                    cap_n = cap_n.to_string(context)?.into();
+                }
+
+                // iii. Append capN as the last element of captures.
+                captures.push(cap_n);
+
+                // iv. Set n to n + 1.
+            }
+
+            // j. Let namedCaptures be ? Get(result, "groups").
+            let mut named_captures = result.get_field("groups", context)?;
+
+            // k. If functionalReplace is true, then
+            // l. Else,
+            let replacement: RcString;
+            if functional_replace {
+                // i. Let replacerArgs be « matched ».
+                let mut replacer_args = vec![Value::from(matched)];
+
+                // ii. Append in List order the elements of captures to the end of the List replacerArgs.
+                replacer_args.extend(captures);
+
+                // iii. Append 𝔽(position) and S to replacerArgs.
+                replacer_args.push(position.into());
+                replacer_args.push(arg_str.clone().into());
+
+                // iv. If namedCaptures is not undefined, then
+                if !named_captures.is_undefined() {
+                    // 1. Append namedCaptures as the last element of replacerArgs.
+                    replacer_args.push(named_captures);
+                }
+
+                // v. Let replValue be ? Call(replaceValue, undefined, replacerArgs).
+                let repl_value = context.call(&replace_value, &Value::Undefined, &replacer_args)?;
+
+                // vi. Let replacement be ? ToString(replValue).
+                replacement = repl_value.to_string(context)?;
+            } else {
+                // i. If namedCaptures is not undefined, then
+                if !named_captures.is_undefined() {
+                    // 1. Set namedCaptures to ? ToObject(namedCaptures).
+                    named_captures = named_captures.to_object(context)?.into();
+                }
+
+                // ii. Let replacement be ? GetSubstitution(matched, S, position, captures, namedCaptures, replaceValue).
+                replacement = crate::builtins::string::get_substitution(
+                    matched.to_string(),
+                    arg_str.to_string(),
+                    position,
+                    captures,
+                    named_captures,
+                    replace_value.to_string(context)?.to_string(),
+                )?;
+            }
+
+            // m. If position ≥ nextSourcePosition, then
+            if position >= next_source_position {
+                // i. NOTE: position should not normally move backwards.
+                //    If it does, it is an indication of an ill-behaving RegExp subclass
+                //    or use of an access triggered side-effect to change the global flag or other characteristics of rx.
+                //    In such cases, the corresponding substitution is ignored.
+                // ii. Set accumulatedResult to the string-concatenation of accumulatedResult,
+                //     the substring of S from nextSourcePosition to position, and replacement.
+                accumulated_result = format!(
+                    "{}{}{}",
+                    accumulated_result,
+                    arg_str.get(next_source_position..position).unwrap(),
+                    replacement
+                )
+                .into();
+
+                // iii. Set nextSourcePosition to position + matchLength.
+                next_source_position = position + match_length;
+            }
+        }
+
+        // 15. If nextSourcePosition ≥ lengthS, return accumulatedResult.
+        if next_source_position >= length_arg_str {
+            return Ok(accumulated_result.into());
+        }
+
+        // 16. Return the string-concatenation of accumulatedResult and the substring of S from nextSourcePosition.
+        Ok(format!(
+            "{}{}",
+            accumulated_result,
+            arg_str.get(next_source_position..).unwrap()
+        )
+        .into())
     }
 
     /// `RegExp.prototype[ @@search ]( string )`
@@ -784,7 +1278,7 @@ impl RegExp {
         }
 
         // 6. Let result be ? RegExpExec(rx, S).
-        let result = Self::exec(this, &[Value::from(arg_str)], context)?;
+        let result = Self::abstract_exec(this, arg_str, context)?;
 
         // 7. Let currentLastIndex be ? Get(rx, "lastIndex").
         let current_last_index = this.get_field("lastIndex", context)?.to_length(context)?;
@@ -805,4 +1299,223 @@ impl RegExp {
                 .map_err(|_| context.construct_type_error("Could not find property `index`"))
         }
     }
+
+    /// `RegExp.prototype [ @@split ] ( string, limit )`
+    ///
+    /// The [@@split]() method splits a String object into an array of strings by separating the string into substrings.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype-@@split
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split
+    pub(crate) fn split(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let rx be the this value.
+        // 2. If Type(rx) is not Object, throw a TypeError exception.
+        if !this.is_object() {
+            return context
+                .throw_type_error("RegExp.prototype.split method called on incompatible value");
+        }
+
+        // 3. Let S be ? ToString(string).
+        let arg_str = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_string(context)?;
+
+        // 4. Let C be ? SpeciesConstructor(rx, %RegExp%).
+        let constructor = this
+            .as_object()
+            .unwrap_or_default()
+            .species_constructor(context.standard_objects().regexp_object().clone(), context)?;
+
+        // 5. Let flags be ? ToString(? Get(rx, "flags")).
+        let flags = this.get_field("flags", context)?.to_string(context)?;
+
+        // 6. If flags contains "u", let unicodeMatching be true.
+        // 7. Else, let unicodeMatching be false.
+        let unicode = flags.contains('u');
+
+        // 8. If flags contains "y", let newFlags be flags.
+        // 9. Else, let newFlags be the string-concatenation of flags and "y".
+        let new_flags = if flags.contains('y') {
+            flags.to_string()
+        } else {
+            format!("{}{}", flags, 'y')
+        };
+
+        // 10. Let splitter be ? Construct(C, « rx, newFlags »).
+        let splitter =
+            RegExp::constructor(&constructor, &[this.clone(), new_flags.into()], context)?;
+
+        // 11. Let A be ! ArrayCreate(0).
+        let a = Array::array_create(0, None, context);
+
+        // 12. Let lengthA be 0.
+        let mut length_a = 0;
+
+        // 13. If limit is undefined, let lim be 2^32 - 1; else let lim be ℝ(? ToUint32(limit)).
+        let limit = args.get(1).cloned().unwrap_or_default();
+        let lim = if limit.is_undefined() {
+            u32::MAX
+        } else {
+            limit.to_u32(context)?
+        };
+
+        // 14. If lim is 0, return A.
+        if lim == 0 {
+            return Ok(a);
+        }
+
+        // 15. Let size be the length of S.
+        let size = arg_str.chars().count();
+
+        // 16. If size is 0, then
+        if size == 0 {
+            // a. Let z be ? RegExpExec(splitter, S).
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
+
+            // b. If z is not null, return A.
+            if !result.is_null() {
+                return Ok(a);
+            }
+
+            // c. Perform ! CreateDataPropertyOrThrow(A, "0", S).
+            Array::add_to_array_object(&a, &[Value::from(arg_str)], context)?;
+
+            // d. Return A.
+            return Ok(a);
+        }
+
+        // 17. Let p be 0.
+        // 18. Let q be p.
+        let mut p = 0;
+        let mut q = p;
+
+        // 19. Repeat, while q < size,
+        while q < size {
+            // a. Perform ? Set(splitter, "lastIndex", 𝔽(q), true).
+            splitter.set_field("lastIndex", Value::from(q), true, context)?;
+
+            // b. Let z be ? RegExpExec(splitter, S).
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
+
+            // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
+            // d. Else,
+            if result.is_null() {
+                q = advance_string_index(arg_str.clone(), q, unicode);
+            } else {
+                // i. Let e be ℝ(? ToLength(? Get(splitter, "lastIndex"))).
+                let mut e = splitter
+                    .get_field("lastIndex", context)?
+                    .to_length(context)?;
+
+                // ii. Set e to min(e, size).
+                e = std::cmp::min(e, size);
+
+                // iii. If e = p, set q to AdvanceStringIndex(S, q, unicodeMatching).
+                // iv. Else,
+                if e == p {
+                    q = advance_string_index(arg_str.clone(), q, unicode);
+                } else {
+                    // 1. Let T be the substring of S from p to q.
+                    //let arg_str_substring = arg_str
+                    //    .get(p..q)
+                    //    .expect("invalid index into string to split");
+                    let arg_str_substring: String = arg_str.chars().skip(p).take(q - p).collect();
+
+                    // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
+                    Array::add_to_array_object(&a, &[Value::from(arg_str_substring)], context)?;
+
+                    // 3. Set lengthA to lengthA + 1.
+                    length_a += 1;
+
+                    // 4. If lengthA = lim, return A.
+                    if length_a == lim {
+                        return Ok(a);
+                    }
+
+                    // 5. Set p to e.
+                    p = e;
+
+                    // 6. Let numberOfCaptures be ? LengthOfArrayLike(z).
+                    let mut number_of_captures =
+                        result.get_field("length", context)?.to_length(context)?;
+
+                    // 7. Set numberOfCaptures to max(numberOfCaptures - 1, 0).
+                    number_of_captures = if number_of_captures == 0 {
+                        0
+                    } else {
+                        std::cmp::max(number_of_captures - 1, 0)
+                    };
+
+                    // 8. Let i be 1.
+                    // 9. Repeat, while i ≤ numberOfCaptures,
+                    for i in 1..=number_of_captures {
+                        // a. Let nextCapture be ? Get(z, ! ToString(𝔽(i))).
+                        let next_capture = result.get_field(i.to_string(), context)?;
+
+                        // b. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), nextCapture).
+                        Array::add_to_array_object(&a, &[next_capture], context)?;
+
+                        // d. Set lengthA to lengthA + 1.
+                        length_a += 1;
+
+                        // e. If lengthA = lim, return A.
+                        if length_a == lim {
+                            return Ok(a);
+                        }
+                    }
+
+                    // 10. Set q to p.
+                    q = p;
+                }
+            }
+        }
+
+        // 20. Let T be the substring of S from p to size.
+        let arg_str_substring: String = arg_str.chars().skip(p).take(size - p).collect();
+
+        // 21. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
+        Array::add_to_array_object(&a, &[Value::from(arg_str_substring)], context)?;
+
+        // 22. Return A.
+        Ok(a)
+    }
+}
+
+/// `22.2.5.2.3 AdvanceStringIndex ( S, index, unicode )`
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-advancestringindex
+fn advance_string_index(s: RcString, index: usize, unicode: bool) -> usize {
+    // Regress only works with utf8, so this function differs from the spec.
+
+    // 1. Assert: index ≤ 2^53 - 1.
+
+    // 2. If unicode is false, return index + 1.
+    if !unicode {
+        return index + 1;
+    }
+
+    // 3. Let length be the number of code units in S.
+    let length = s.chars().count();
+
+    // 4. If index + 1 ≥ length, return index + 1.
+    if index + 1 > length {
+        return index + 1;
+    }
+
+    // 5. Let cp be ! CodePointAt(S, index).
+    let offset = if let Some(c) = s.chars().nth(index) {
+        c.len_utf8()
+    } else {
+        1
+    };
+
+    index + offset
 }

--- a/boa/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa/src/builtins/regexp/regexp_string_iterator.rs
@@ -138,10 +138,10 @@ impl RegExpStringIterator {
                 // vi. Perform ? Yield(match).
                 Ok(create_iter_result_object(context, m, false))
             } else {
-                context.throw_type_error("`this` is not an RegExpStringIterator")
+                context.throw_type_error("`this` is not a RegExpStringIterator")
             }
         } else {
-            context.throw_type_error("`this` is not an RegExpStringIterator")
+            context.throw_type_error("`this` is not a RegExpStringIterator")
         }
     }
 

--- a/boa/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa/src/builtins/regexp/regexp_string_iterator.rs
@@ -138,10 +138,10 @@ impl RegExpStringIterator {
                 // vi. Perform ? Yield(match).
                 Ok(create_iter_result_object(context, m, false))
             } else {
-                context.throw_type_error("`this` is not an ArrayIterator")
+                context.throw_type_error("`this` is not an RegExpStringIterator")
             }
         } else {
-            context.throw_type_error("`this` is not an ArrayIterator")
+            context.throw_type_error("`this` is not an RegExpStringIterator")
         }
     }
 

--- a/boa/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa/src/builtins/regexp/regexp_string_iterator.rs
@@ -1,0 +1,170 @@
+//! This module implements the global `RegExp String Iterator` object.
+//!
+//! A RegExp String Iterator is an object, that represents a specific iteration over some specific String instance object, matching against some specific RegExp instance object.
+//! There is not a named constructor for RegExp String Iterator objects.
+//! Instead, RegExp String Iterator objects are created by calling certain methods of RegExp instance objects.
+//!
+//! More information:
+//!  - [ECMAScript reference][spec]
+//!
+//! [spec]: https://tc39.es/ecma262/#sec-regexp-string-iterator-objects
+
+use regexp::{advance_string_index, RegExp};
+
+use crate::{
+    builtins::{function::make_builtin_fn, iterable::create_iter_result_object, regexp},
+    gc::{Finalize, Trace},
+    object::{GcObject, ObjectData},
+    property::{Attribute, DataDescriptor},
+    symbol::WellKnownSymbols,
+    value::RcString,
+    BoaProfiler, Context, Result, Value,
+};
+
+// TODO: See todos in create_regexp_string_iterator and next.
+#[derive(Debug, Clone, Finalize, Trace)]
+pub struct RegExpStringIterator {
+    matcher: Value,
+    string: RcString,
+    global: bool,
+    unicode: bool,
+    completed: bool,
+}
+
+// TODO: See todos in create_regexp_string_iterator and next.
+impl RegExpStringIterator {
+    fn new(matcher: Value, string: RcString, global: bool, unicode: bool) -> Self {
+        Self {
+            matcher,
+            string,
+            global,
+            unicode,
+            completed: false,
+        }
+    }
+
+    /// `22.2.7.1 CreateRegExpStringIterator ( R, S, global, fullUnicode )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-createregexpstringiterator
+    pub(crate) fn create_regexp_string_iterator(
+        matcher: &Value,
+        string: RcString,
+        global: bool,
+        unicode: bool,
+        context: &mut Context,
+    ) -> Result<Value> {
+        // TODO: Implement this with closures and generators.
+        //       For now all values of the closure are stored in RegExpStringIterator and the actual closure execution is in `.next()`.
+
+        // 1. Assert: Type(S) is String.
+        // 2. Assert: Type(global) is Boolean.
+        // 3. Assert: Type(fullUnicode) is Boolean.
+
+        // 4. Let closure be a new Abstract Closure with no parameters that captures R, S, global,
+        //    and fullUnicode and performs the following steps when called:
+
+        // 5. Return ! CreateIteratorFromClosure(closure, "%RegExpStringIteratorPrototype%", %RegExpStringIteratorPrototype%).
+        let regexp_string_iterator = Value::new_object(context);
+        regexp_string_iterator.set_data(ObjectData::RegExpStringIterator(Self::new(
+            matcher.clone(),
+            string,
+            global,
+            unicode,
+        )));
+        regexp_string_iterator
+            .as_object()
+            .expect("regexp string iterator object")
+            .set_prototype_instance(
+                context
+                    .iterator_prototypes()
+                    .regexp_string_iterator()
+                    .into(),
+            );
+
+        Ok(regexp_string_iterator)
+    }
+
+    pub fn next(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
+        if let Value::Object(ref object) = this {
+            let mut object = object.borrow_mut();
+            if let Some(iterator) = object.as_regexp_string_iterator_mut() {
+                if iterator.completed {
+                    return Ok(create_iter_result_object(context, Value::undefined(), true));
+                }
+
+                // TODO: This is the code that should be created as a closure in create_regexp_string_iterator.
+
+                // i. Let match be ? RegExpExec(R, S).
+                let m = RegExp::abstract_exec(&iterator.matcher, iterator.string.clone(), context)?;
+
+                // ii. If match is null, return undefined.
+                if m.is_null() {
+                    iterator.completed = true;
+                    return Ok(create_iter_result_object(context, Value::undefined(), true));
+                }
+
+                // iii. If global is false, then
+                if !iterator.global {
+                    // 1. Perform ? Yield(match).
+                    // 2. Return undefined.
+                    iterator.completed = true;
+                    return Ok(create_iter_result_object(context, m, false));
+                }
+
+                // iv. Let matchStr be ? ToString(? Get(match, "0")).
+                let m_str = m.get_field("0", context)?.to_string(context)?;
+
+                // v. If matchStr is the empty String, then
+                if m_str.is_empty() {
+                    // 1. Let thisIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
+                    let this_index = iterator
+                        .matcher
+                        .get_field("lastIndex", context)?
+                        .to_length(context)?;
+
+                    // 2. Let nextIndex be ! AdvanceStringIndex(S, thisIndex, fullUnicode).
+                    let next_index =
+                        advance_string_index(iterator.string.clone(), this_index, iterator.unicode);
+
+                    // 3. Perform ? Set(R, "lastIndex", 𝔽(nextIndex), true).
+                    iterator
+                        .matcher
+                        .set_field("lastIndex", next_index, true, context)?;
+                }
+
+                // vi. Perform ? Yield(match).
+                Ok(create_iter_result_object(context, m, false))
+            } else {
+                context.throw_type_error("`this` is not an ArrayIterator")
+            }
+        } else {
+            context.throw_type_error("`this` is not an ArrayIterator")
+        }
+    }
+
+    /// Create the %ArrayIteratorPrototype% object
+    ///
+    /// More information:
+    ///  - [ECMA reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
+    pub(crate) fn create_prototype(context: &mut Context, iterator_prototype: Value) -> GcObject {
+        let _timer = BoaProfiler::global().start_event("RegExp String Iterator", "init");
+
+        // Create prototype
+        let mut result = context.construct_object();
+        make_builtin_fn(Self::next, "next", &result, 0, context);
+        result.set_prototype_instance(iterator_prototype);
+
+        let to_string_tag = WellKnownSymbols::to_string_tag();
+        let to_string_tag_property = DataDescriptor::new(
+            "RegExp String Iterator",
+            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+        );
+        result.insert(to_string_tag, to_string_tag_property);
+        result
+    }
+}

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -1356,7 +1356,7 @@ impl String {
             if let Some(matcher) = regexp
                 .as_object()
                 .unwrap_or_default()
-                .get_method(context, "matchAll")?
+                .get_method(context, WellKnownSymbols::match_all())?
             {
                 // i. Return ? Call(matcher, regexp, « O »).
                 return matcher.call(&regexp, &[object.clone()], context);

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -24,7 +24,6 @@ use crate::{
     value::{RcString, Value},
     BoaProfiler, Context, Result,
 };
-use regress::Regex;
 use std::{
     char::{decode_utf16, from_u32},
     cmp::{max, min},
@@ -607,23 +606,6 @@ impl String {
         Ok(Value::from(this_string.contains(search_string.as_str())))
     }
 
-    /// Return either the string itself or the string of the regex equivalent
-    fn get_regex_string(value: &Value) -> StdString {
-        match value {
-            Value::String(ref body) => body.to_string(),
-            Value::Object(ref obj) => {
-                let obj = obj.borrow();
-
-                if let Some(regexp) = obj.as_regexp() {
-                    // first argument is another `RegExp` object, so copy its pattern and flags
-                    return regexp.original_source.clone().into();
-                }
-                "undefined".to_string()
-            }
-            _ => "undefined".to_string(),
-        }
-    }
-
     fn is_regexp_object(value: &Value) -> bool {
         match value {
             Value::Object(ref obj) => obj.borrow().is_regexp(),
@@ -647,149 +629,100 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.replace
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace
     pub(crate) fn replace(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        // TODO: Support Symbol replacer
-        let primitive_val = this.to_string(context)?;
-        if args.is_empty() {
-            return Ok(Value::from(primitive_val));
+        // 1. Let O be ? RequireObjectCoercible(this value).
+        this.require_object_coercible(context)?;
+
+        let search_value = args.get(0).cloned().unwrap_or_default();
+
+        let replace_value = args.get(1).cloned().unwrap_or_default();
+
+        // 2. If searchValue is neither undefined nor null, then
+        if !search_value.is_null_or_undefined() {
+            // a. Let replacer be ? GetMethod(searchValue, @@replace).
+            let replacer = search_value
+                .as_object()
+                .unwrap_or_default()
+                .get_method(context, WellKnownSymbols::replace())?;
+
+            // b. If replacer is not undefined, then
+            if let Some(replacer) = replacer {
+                // i. Return ? Call(replacer, searchValue, « O, replaceValue »).
+                return context.call(
+                    &replacer.into(),
+                    &search_value,
+                    &[this.clone(), replace_value],
+                );
+            }
         }
 
-        let regex_body = Self::get_regex_string(args.get(0).expect("Value needed"));
-        let re = Regex::new(&regex_body).expect("unable to convert regex to regex object");
-        let mat = match re.find(&primitive_val) {
-            Some(mat) => mat,
-            None => return Ok(Value::from(primitive_val)),
-        };
-        let caps = re
-            .find(&primitive_val)
-            .expect("unable to get capture groups from text")
-            .captures;
+        // 3. Let string be ? ToString(O).
+        let this_str = this.to_string(context)?;
 
-        let replace_value = if args.len() > 1 {
-            // replace_object could be a string or function or not exist at all
-            let replace_object: &Value = args.get(1).expect("second argument expected");
-            match replace_object {
-                Value::String(val) => {
-                    // https://tc39.es/ecma262/#table-45
-                    let mut result = StdString::new();
-                    let mut chars = val.chars().peekable();
+        // 4. Let searchString be ? ToString(searchValue).
+        let search_str = search_value.to_string(context)?;
 
-                    let m = caps.len();
+        // 5. Let functionalReplace be IsCallable(replaceValue).
+        let functional_replace = replace_value.is_function();
 
-                    while let Some(first) = chars.next() {
-                        if first == '$' {
-                            let second = chars.next();
-                            let second_is_digit = second.map_or(false, |ch| ch.is_digit(10));
-                            // we use peek so that it is still in the iterator if not used
-                            let third = if second_is_digit { chars.peek() } else { None };
-                            let third_is_digit = third.map_or(false, |ch| ch.is_digit(10));
+        // 6. If functionalReplace is false, then
+        // a. Set replaceValue to ? ToString(replaceValue).
 
-                            match (second, third) {
-                                (Some('$'), _) => {
-                                    // $$
-                                    result.push('$');
-                                }
-                                (Some('&'), _) => {
-                                    // $&
-                                    result.push_str(&primitive_val[mat.range()]);
-                                }
-                                (Some('`'), _) => {
-                                    // $`
-                                    let start_of_match = mat.start();
-                                    result.push_str(&primitive_val[..start_of_match]);
-                                }
-                                (Some('\''), _) => {
-                                    // $'
-                                    let end_of_match = mat.end();
-                                    result.push_str(&primitive_val[end_of_match..]);
-                                }
-                                (Some(second), Some(third))
-                                    if second_is_digit && third_is_digit =>
-                                {
-                                    // $nn
-                                    let tens = second.to_digit(10).unwrap() as usize;
-                                    let units = third.to_digit(10).unwrap() as usize;
-                                    let nn = 10 * tens + units;
-                                    if nn == 0 || nn > m {
-                                        result.push(first);
-                                        result.push(second);
-                                        if let Some(ch) = chars.next() {
-                                            result.push(ch);
-                                        }
-                                    } else {
-                                        let group = match mat.group(nn) {
-                                            Some(range) => &primitive_val[range.clone()],
-                                            _ => "",
-                                        };
-                                        result.push_str(group);
-                                        chars.next(); // consume third
-                                    }
-                                }
-                                (Some(second), _) if second_is_digit => {
-                                    // $n
-                                    let n = second.to_digit(10).unwrap() as usize;
-                                    if n == 0 || n > m {
-                                        result.push(first);
-                                        result.push(second);
-                                    } else {
-                                        let group = match mat.group(n) {
-                                            Some(range) => &primitive_val[range.clone()],
-                                            _ => "",
-                                        };
-                                        result.push_str(group);
-                                    }
-                                }
-                                (Some('<'), _) => {
-                                    // $<
-                                    // TODO: named capture groups
-                                    result.push_str("$<");
-                                }
-                                _ => {
-                                    // $?, ? is none of the above
-                                    // we can consume second because it isn't $
-                                    result.push(first);
-                                    if let Some(second) = second {
-                                        result.push(second);
-                                    }
-                                }
-                            }
-                        } else {
-                            result.push(first);
-                        }
-                    }
+        // 7. Let searchLength be the length of searchString.
+        let search_length = search_str.len();
 
-                    result
-                }
-                Value::Object(_) => {
-                    // This will return the matched substring first, then captured parenthesized groups later
-                    let mut results: Vec<Value> = mat
-                        .groups()
-                        .map(|group| match group {
-                            Some(range) => Value::from(&primitive_val[range]),
-                            None => Value::undefined(),
-                        })
-                        .collect();
+        // 8. Let position be ! StringIndexOf(string, searchString, 0).
+        let position = this_str.find(search_str.as_str());
 
-                    // Returns the starting byte offset of the match
-                    let start = mat.start();
-                    results.push(Value::from(start));
-                    // Push the whole string being examined
-                    results.push(Value::from(primitive_val.to_string()));
+        // 9. If position is -1, return string.
+        if position.is_none() {
+            return Ok(this_str.into());
+        }
 
-                    let result = context.call(&replace_object, this, &results)?;
+        // 10. Let preserved be the substring of string from 0 to position.
+        let preserved = this_str.get(..position.unwrap());
 
-                    result.to_string(context)?.to_string()
-                }
-                _ => "undefined".to_string(),
-            }
+        // 11. If functionalReplace is true, then
+        // 12. Else,
+        let replacement: RcString;
+        if functional_replace {
+            // a. Let replacement be ? ToString(? Call(replaceValue, undefined, « searchString, 𝔽(position), string »)).
+            replacement = context
+                .call(
+                    &replace_value,
+                    &Value::Undefined,
+                    &[
+                        search_str.into(),
+                        position.unwrap().into(),
+                        this_str.clone().into(),
+                    ],
+                )?
+                .to_string(context)?;
         } else {
-            "undefined".to_string()
-        };
+            // a. Assert: Type(replaceValue) is String.
+            // b. Let captures be a new empty List.
+            let captures = Vec::new();
 
-        Ok(Value::from(primitive_val.replacen(
-            &primitive_val[mat.range()],
-            &replace_value,
-            1,
-        )))
+            // c. Let replacement be ! GetSubstitution(searchString, string, position, captures, undefined, replaceValue).
+            replacement = get_substitution(
+                search_str.to_string(),
+                this_str.to_string(),
+                position.unwrap(),
+                captures,
+                Value::undefined(),
+                replace_value.to_string(context)?.to_string(),
+            )?;
+        }
+
+        // 13. Return the string-concatenation of preserved, replacement, and the substring of string from position + searchLength.
+        Ok(format!(
+            "{}{}{}",
+            preserved.unwrap_or_default(),
+            replacement,
+            this_str
+                .get((position.unwrap() + search_length)..)
+                .unwrap_or_default()
+        )
+        .into())
     }
 
     /// `String.prototype.indexOf( searchValue[, fromIndex] )`
@@ -894,12 +827,32 @@ impl String {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     pub(crate) fn r#match(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        let re = RegExp::constructor(
-            &Value::from(Object::default()),
-            &[args.get(0).cloned().unwrap_or_default()],
-            context,
-        )?;
-        RegExp::r#match(&re, this.to_string(context)?, context)
+        // 1. Let O be ? RequireObjectCoercible(this value).
+        let object = this.require_object_coercible(context)?;
+
+        // 2. If regexp is neither undefined nor null, then
+        let regexp = args.get(0).cloned().unwrap_or_default();
+        if !regexp.is_null_or_undefined() {
+            // a. Let matcher be ? GetMethod(regexp, @@match).
+            // b. If matcher is not undefined, then
+            if let Some(matcher) = regexp
+                .as_object()
+                .unwrap_or_default()
+                .get_method(context, "match")?
+            {
+                // i. Return ? Call(matcher, regexp, « O »).
+                return matcher.call(&regexp, &[object.clone()], context);
+            }
+        }
+
+        // 3. Let S be ? ToString(O).
+        let arg_str = object.to_string(context)?;
+
+        // 4. Let rx be ? RegExpCreate(regexp, undefined).
+        let rx = RegExp::constructor(&Value::from(Object::default()), &[regexp], context)?;
+
+        // 5. Return ? Invoke(rx, @@match, « S »).
+        RegExp::r#match(&rx, &[Value::from(arg_str)], context)
     }
 
     /// Abstract method `StringPad`.
@@ -1196,11 +1149,10 @@ impl String {
         }
     }
 
-    /// String.prototype.split()
+    /// `String.prototype.split ( separator, limit )`
     ///
-    /// The `split()` method divides a String into an ordered list of substrings, puts these substrings into an array, and returns the array.
-    ///
-    /// The division is done by searching for a pattern; where the pattern is provided as the first parameter in the method's call.
+    /// The split() method divides a String into an ordered list of substrings, puts these substrings into an array, and returns the array.
+    /// The division is done by searching for a pattern; where the pattern is provided as the first parameter in the method's call.  
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -1209,63 +1161,143 @@ impl String {
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.split
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split
     pub(crate) fn split(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
+        // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible(context)?;
-        let string = this.to_string(context)?;
 
-        let separator = args.get(0).filter(|value| !value.is_null_or_undefined());
+        let separator = args.get(0).cloned().unwrap_or_default();
+        let limit = args.get(1).cloned().unwrap_or_default();
 
-        if let Some(result) = separator
-            .and_then(|separator| separator.as_object())
-            .and_then(|separator| {
-                let key = WellKnownSymbols::split();
-
-                match separator.get_method(context, key) {
-                    Ok(splitter) => splitter.map(|splitter| {
-                        let arguments = &[
-                            Value::from(string.clone()),
-                            args.get(1)
-                                .map(|x| x.to_owned())
-                                .unwrap_or(Value::Undefined),
-                        ];
-                        splitter.call(this, arguments, context)
-                    }),
-                    Err(_) => Some(Err(
-                        context.construct_type_error("separator[Symbol.split] is not a function")
-                    )),
-                }
-            })
-        {
-            return result;
+        // 2. If separator is neither undefined nor null, then
+        if !separator.is_null_or_undefined() {
+            // a. Let splitter be ? GetMethod(separator, @@split).
+            // b. If splitter is not undefined, then
+            if let Some(splitter) = separator
+                .as_object()
+                .unwrap_or_default()
+                .get_method(context, WellKnownSymbols::split())?
+            {
+                // i. Return ? Call(splitter, separator, « O, limit »).
+                return splitter.call(&separator, &[this.clone(), limit], context);
+            }
         }
 
-        let separator = separator
-            .map(|separator| separator.to_string(context))
-            .transpose()?;
+        // 3. Let S be ? ToString(O).
+        let this_str = this.to_string(context)?;
 
-        let limit = args
-            .get(1)
-            .map(|arg| arg.to_integer(context).map(|limit| limit as usize))
-            .transpose()?
-            .unwrap_or(u32::MAX as usize);
+        // 4. Let A be ! ArrayCreate(0).
+        let a = Array::array_create(0, None, context);
 
-        let values: Vec<Value> = match separator {
-            None if limit == 0 => vec![],
-            None => vec![Value::from(string)],
-            Some(separator) if separator.is_empty() => string
-                .encode_utf16()
-                // TODO: Support keeping invalid code point in string
-                .map(|cp| Value::from(std::string::String::from_utf16_lossy(&[cp])))
-                .take(limit)
-                .collect(),
-            Some(separator) => string
-                .split(separator.as_str())
-                .map(&Value::from)
-                .take(limit)
-                .collect(),
+        // 5. Let lengthA be 0.
+        let mut length_a = 0;
+
+        // 6.  If limit is undefined, let lim be 2^32 - 1; else let lim be ℝ(? ToUint32(limit)).
+        let lim = if limit.is_undefined() {
+            u32::MAX
+        } else {
+            limit.to_u32(context)?
         };
 
-        let new = Array::new_array(context);
-        Array::construct_array(&new, &values, context)
+        // 7. Let R be ? ToString(separator).
+        let separator_str = separator.to_string(context)?;
+
+        // 8. If lim = 0, return A.
+        if lim == 0 {
+            return Ok(a);
+        }
+
+        // 9. If separator is undefined, then
+        if separator.is_undefined() {
+            // a. Perform ! CreateDataPropertyOrThrow(A, "0", S).
+            Array::add_to_array_object(&a, &[Value::from(this_str)], context)?;
+
+            // b. Return A.
+            return Ok(a);
+        }
+
+        // 10. Let s be the length of S.
+        let this_str_length = this_str.encode_utf16().count();
+
+        // 11. If s = 0, then
+        if this_str_length == 0 {
+            // a. If R is not the empty String, then
+            if !separator_str.is_empty() {
+                // i. Perform ! CreateDataPropertyOrThrow(A, "0", S).
+                Array::add_to_array_object(&a, &[Value::from(this_str)], context)?;
+            }
+
+            // b. Return A.
+            return Ok(a);
+        }
+
+        // 12. Let p be 0.
+        // 13. Let q be p.
+        let mut p = 0;
+        let mut q = p;
+
+        // 14. Repeat, while q ≠ s,
+        while q != this_str_length {
+            // a. Let e be SplitMatch(S, q, R).
+            let e = split_match(&this_str, q, &separator_str);
+
+            match e {
+                // b. If e is not-matched, set q to q + 1.
+                None => q += 1,
+                // c. Else,
+                Some(e) => {
+                    // i. Assert: e is a non-negative integer ≤ s.
+                    // ii. If e = p, set q to q + 1.
+                    // iii. Else,
+                    if e == p {
+                        q += 1;
+                    } else {
+                        // 1. Let T be the substring of S from p to q.
+                        let this_str_substring = StdString::from_utf16_lossy(
+                            &this_str
+                                .encode_utf16()
+                                .skip(p)
+                                .take(q - p)
+                                .collect::<Vec<u16>>(),
+                        );
+
+                        // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
+                        Array::add_to_array_object(
+                            &a,
+                            &[Value::from(this_str_substring)],
+                            context,
+                        )?;
+
+                        // 3. Set lengthA to lengthA + 1.
+                        length_a += 1;
+
+                        // 4. If lengthA = lim, return A.
+                        if length_a == lim {
+                            return Ok(a);
+                        }
+
+                        // 5. Set p to e.
+                        p = e;
+
+                        // 6. Set q to p.
+                        q = p;
+                    }
+                }
+            }
+        }
+
+        // 15. Let T be the substring of S from p to s.
+        let this_str_substring = StdString::from_utf16_lossy(
+            &this_str
+                .encode_utf16()
+                .skip(p)
+                .take(this_str_length - p)
+                .collect::<Vec<u16>>(),
+        );
+
+        // 16. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
+        Array::add_to_array_object(&a, &[Value::from(this_str_substring)], context)?;
+
+        // 17. Return A.
+        Ok(a)
     }
 
     /// String.prototype.valueOf()
@@ -1295,34 +1327,54 @@ impl String {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll
     /// [regex]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
     /// [cg]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Groups_and_Ranges
-    // TODO: update this method to return iterator
     pub(crate) fn match_all(this: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        let re: Value = match args.get(0) {
-            Some(arg) => {
-                if arg.is_null() {
-                    RegExp::constructor(
-                        &Value::from(Object::default()),
-                        &[Value::from(arg.to_string(context)?), Value::from("g")],
-                        context,
-                    )
-                } else if arg.is_undefined() {
-                    RegExp::constructor(
-                        &Value::from(Object::default()),
-                        &[Value::undefined(), Value::from("g")],
-                        context,
-                    )
-                } else {
-                    Ok(arg.clone())
+        // 1. Let O be ? RequireObjectCoercible(this value).
+        let object = this.require_object_coercible(context)?;
+
+        // 2. If regexp is neither undefined nor null, then
+        let regexp = args.get(0).cloned().unwrap_or_default();
+        if !regexp.is_null_or_undefined() {
+            // a. Let isRegExp be ? IsRegExp(regexp).
+            // b. If isRegExp is true, then
+            if regexp.as_object().unwrap_or_default().is_regexp() {
+                // i. Let flags be ? Get(regexp, "flags").
+                let flags = regexp.get_field("flags", context)?;
+
+                // ii. Perform ? RequireObjectCoercible(flags).
+                flags.require_object_coercible(context)?;
+
+                // iii. If ? ToString(flags) does not contain "g", throw a TypeError exception.
+                if !flags.to_string(context)?.contains('g') {
+                    return context.throw_type_error(
+                        "String.prototype.matchAll called with a non-global RegExp argument",
+                    );
                 }
             }
-            None => RegExp::constructor(
-                &Value::from(Object::default()),
-                &[Value::from(""), Value::from("g")],
-                context,
-            ),
-        }?;
 
-        RegExp::match_all(&re, this.to_string(context)?.to_string(), context)
+            // c. Let matcher be ? GetMethod(regexp, @@matchAll).
+            // d. If matcher is not undefined, then
+            if let Some(matcher) = regexp
+                .as_object()
+                .unwrap_or_default()
+                .get_method(context, "matchAll")?
+            {
+                // i. Return ? Call(matcher, regexp, « O »).
+                return matcher.call(&regexp, &[object.clone()], context);
+            }
+        }
+
+        // 3. Let S be ? ToString(O).
+        let arg_str = object.to_string(context)?;
+
+        // 4. Let rx be ? RegExpCreate(regexp, "g").
+        let rx = RegExp::constructor(
+            &Value::from(Object::default()),
+            &[regexp, Value::from("g")],
+            context,
+        )?;
+
+        // 5. Return ? Invoke(rx, @@matchAll, « S »).
+        RegExp::match_all(&rx, &[Value::from(arg_str)], context)
     }
 
     /// `String.prototype.search( regexp )`
@@ -1373,4 +1425,186 @@ impl String {
     pub(crate) fn iterator(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         StringIterator::create_string_iterator(context, this.clone())
     }
+}
+
+/// `22.1.3.17.1 GetSubstitution ( matched, str, position, captures, namedCaptures, replacement )`
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-getsubstitution
+pub(crate) fn get_substitution(
+    matched: StdString,
+    str: StdString,
+    position: usize,
+    captures: Vec<Value>,
+    _named_captures: Value,
+    replacement: StdString,
+) -> Result<RcString> {
+    // 1. Assert: Type(matched) is String.
+
+    // 2. Let matchLength be the number of code units in matched.
+    let match_length = matched.chars().count();
+
+    // 3. Assert: Type(str) is String.
+
+    // 4. Let stringLength be the number of code units in str.
+    let str_length = str.chars().count();
+
+    // 5. Assert: position ≤ stringLength.
+    // 6. Assert: captures is a possibly empty List of Strings.
+    // 7. Assert: Type(replacement) is String.
+
+    // 8. Let tailPos be position + matchLength.
+    let tail_pos = position + match_length;
+
+    // 9. Let m be the number of elements in captures.
+    let m = captures.len();
+
+    // 10. Let result be the String value derived from replacement by copying code unit elements
+    //     from replacement to result while performing replacements as specified in Table 58.
+    //     These $ replacements are done left-to-right, and, once such a replacement is performed,
+    //     the new replacement text is not subject to further replacements.
+    let mut result = StdString::new();
+    let mut chars = replacement.chars().peekable();
+
+    while let Some(first) = chars.next() {
+        if first == '$' {
+            let second = chars.next();
+            let second_is_digit = second.map_or(false, |ch| ch.is_digit(10));
+            // we use peek so that it is still in the iterator if not used
+            let third = if second_is_digit { chars.peek() } else { None };
+            let third_is_digit = third.map_or(false, |ch| ch.is_digit(10));
+
+            match (second, third) {
+                // $$
+                (Some('$'), _) => {
+                    // $
+                    result.push('$');
+                }
+                // $&
+                (Some('&'), _) => {
+                    // matched
+                    result.push_str(&matched);
+                }
+                // $`
+                (Some('`'), _) => {
+                    // The replacement is the substring of str from 0 to position.
+                    result.push_str(&str[..position]);
+                }
+                // $'
+                (Some('\''), _) => {
+                    // If tailPos ≥ stringLength, the replacement is the empty String.
+                    // Otherwise the replacement is the substring of str from tailPos.
+                    if tail_pos >= str_length {
+                        result.push_str("");
+                    } else {
+                        result.push_str(&str[tail_pos..]);
+                    }
+                }
+                // $nn
+                (Some(second), Some(third)) if second_is_digit && third_is_digit => {
+                    // The nnth element of captures, where nn is a two-digit decimal number in the range 01 to 99.
+                    // If nn ≤ m and the nnth element of captures is undefined, use the empty String instead.
+                    // If nn is 00 or nn > m, no replacement is done.
+                    let tens = second.to_digit(10).unwrap() as usize;
+                    let units = third.to_digit(10).unwrap() as usize;
+                    let nn = 10 * tens + units;
+                    let capture = if let Some(v) = captures.get(nn - 1) {
+                        v.clone()
+                    } else {
+                        Value::undefined()
+                    };
+
+                    if nn <= m && capture.is_undefined() {
+                        result.push_str("")
+                    } else if nn == 0 || nn > m {
+                        result.push('$');
+                        result.push(first);
+                        result.push(second);
+                    } else if let Some(s) = capture.as_string() {
+                        result.push_str(s);
+                        break;
+                    }
+                }
+                // $n
+                (Some(first), second) if second_is_digit => {
+                    // The nth element of captures, where n is a single digit in the range 1 to 9.
+                    // If n ≤ m and the nth element of captures is undefined, use the empty String instead.
+                    // If n > m, no replacement is done.
+                    let n = first.to_digit(10).unwrap() as usize;
+                    let capture = if let Some(v) = captures.get(n - 1) {
+                        v.clone()
+                    } else {
+                        Value::undefined()
+                    };
+
+                    if n <= m && capture.is_undefined() {
+                        result.push_str("")
+                    } else if n > m {
+                        result.push('$');
+                        result.push(first);
+                        if let Some(second) = second {
+                            result.push(*second)
+                        }
+                    } else if let Some(s) = capture.as_string() {
+                        result.push_str(s);
+                    }
+                }
+                // $<
+                (Some('<'), _) => {
+                    // TODO: named capture groups
+                    // 1. If namedCaptures is undefined, the replacement text is the String "$<".
+                    result.push_str("$<");
+                }
+                // $?, ? is none of the above
+                _ => {
+                    result.push('$');
+                    if let Some(second) = second {
+                        result.push(second);
+                    }
+                }
+            }
+        } else {
+            result.push(first);
+        }
+    }
+
+    // 11. Return result.
+    Ok(result.into())
+}
+
+/// `22.1.3.21.1 SplitMatch ( S, q, R )`
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-splitmatch
+fn split_match(s_str: &str, q: usize, r_str: &str) -> Option<usize> {
+    // 1. Let r be the number of code units in R.
+    let r = r_str.encode_utf16().count();
+
+    // 2. Let s be the number of code units in S.
+    let s = s_str.encode_utf16().count();
+
+    // 3. If q + r > s, return not-matched.
+    if q + r > s {
+        return None;
+    }
+
+    // 4. If there exists an integer i between 0 (inclusive) and r (exclusive)
+    //    such that the code unit at index q + i within S is different from the code unit at index i within R,
+    //    return not-matched.
+    for i in 0..r {
+        if let Some(s_char) = s_str.encode_utf16().nth(q + i) {
+            if let Some(r_char) = r_str.encode_utf16().nth(i) {
+                if s_char != r_char {
+                    return None;
+                }
+            }
+        }
+    }
+
+    // 5. Return q + r.
+    Some(q + r)
 }

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -448,42 +448,75 @@ fn includes_with_regex_arg() {
 fn match_all() {
     let mut context = Context::new();
 
-    assert_eq!(forward(&mut context, "'aa'.matchAll(null).length"), "0");
-    assert_eq!(forward(&mut context, "'aa'.matchAll(/b/).length"), "0");
-    assert_eq!(forward(&mut context, "'aa'.matchAll(/a/).length"), "1");
-    assert_eq!(forward(&mut context, "'aa'.matchAll(/a/g).length"), "2");
+    forward(
+        &mut context,
+        r#"
+        var groupMatches = 'test1test2'.matchAll(/t(e)(st(\d?))/g);
+        var m1 = groupMatches.next();
+        var m2 = groupMatches.next();
+        var m3 = groupMatches.next();
+        "#,
+    );
+
+    assert_eq!(forward(&mut context, "m1.done"), "false");
+    assert_eq!(forward(&mut context, "m2.done"), "false");
+    assert_eq!(forward(&mut context, "m3.done"), "true");
+
+    assert_eq!(forward(&mut context, "m1.value[0]"), "\"test1\"");
+    assert_eq!(forward(&mut context, "m1.value[1]"), "\"e\"");
+    assert_eq!(forward(&mut context, "m1.value[2]"), "\"st1\"");
+    assert_eq!(forward(&mut context, "m1.value[3]"), "\"1\"");
+    assert_eq!(forward(&mut context, "m1.value[4]"), "undefined");
+    assert_eq!(forward(&mut context, "m1.value.index"), "0");
+    assert_eq!(forward(&mut context, "m1.value.input"), "\"test1test2\"");
+    assert_eq!(forward(&mut context, "m1.value.groups"), "undefined");
+
+    assert_eq!(forward(&mut context, "m2.value[0]"), "\"test2\"");
+    assert_eq!(forward(&mut context, "m2.value[1]"), "\"e\"");
+    assert_eq!(forward(&mut context, "m2.value[2]"), "\"st2\"");
+    assert_eq!(forward(&mut context, "m2.value[3]"), "\"2\"");
+    assert_eq!(forward(&mut context, "m2.value[4]"), "undefined");
+    assert_eq!(forward(&mut context, "m2.value.index"), "5");
+    assert_eq!(forward(&mut context, "m2.value.input"), "\"test1test2\"");
+    assert_eq!(forward(&mut context, "m2.value.groups"), "undefined");
+
+    assert_eq!(forward(&mut context, "m3.value"), "undefined");
 
     forward(
         &mut context,
-        "var groupMatches = 'test1test2'.matchAll(/t(e)(st(\\d?))/g)",
-    );
-
-    assert_eq!(forward(&mut context, "groupMatches.length"), "2");
-    assert_eq!(forward(&mut context, "groupMatches[0][1]"), "\"e\"");
-    assert_eq!(forward(&mut context, "groupMatches[0][2]"), "\"st1\"");
-    assert_eq!(forward(&mut context, "groupMatches[0][3]"), "\"1\"");
-    assert_eq!(forward(&mut context, "groupMatches[1][3]"), "\"2\"");
-
-    assert_eq!(
-        forward(
-            &mut context,
-            "'test1test2'.matchAll(/t(e)(st(\\d?))/).length"
-        ),
-        "1"
-    );
-
-    let init = r#"
+        r#"
         var regexp = RegExp('foo[a-z]*','g');
         var str = 'table football, foosball';
         var matches = str.matchAll(regexp);
-        "#;
+        var m1 = matches.next();
+        var m2 = matches.next();
+        var m3 = matches.next();
+        "#,
+    );
 
-    forward(&mut context, init);
+    assert_eq!(forward(&mut context, "m1.done"), "false");
+    assert_eq!(forward(&mut context, "m2.done"), "false");
+    assert_eq!(forward(&mut context, "m3.done"), "true");
 
-    assert_eq!(forward(&mut context, "matches[0][0]"), "\"football\"");
-    assert_eq!(forward(&mut context, "matches[0].index"), "6");
-    assert_eq!(forward(&mut context, "matches[1][0]"), "\"foosball\"");
-    assert_eq!(forward(&mut context, "matches[1].index"), "16");
+    assert_eq!(forward(&mut context, "m1.value[0]"), "\"football\"");
+    assert_eq!(forward(&mut context, "m1.value[1]"), "undefined");
+    assert_eq!(forward(&mut context, "m1.value.index"), "6");
+    assert_eq!(
+        forward(&mut context, "m1.value.input"),
+        "\"table football, foosball\""
+    );
+    assert_eq!(forward(&mut context, "m1.value.groups"), "undefined");
+
+    assert_eq!(forward(&mut context, "m2.value[0]"), "\"foosball\"");
+    assert_eq!(forward(&mut context, "m2.value[1]"), "undefined");
+    assert_eq!(forward(&mut context, "m2.value.index"), "16");
+    assert_eq!(
+        forward(&mut context, "m1.value.input"),
+        "\"table football, foosball\""
+    );
+    assert_eq!(forward(&mut context, "m2.value.groups"), "undefined");
+
+    assert_eq!(forward(&mut context, "m3.value"), "undefined");
 }
 
 #[test]
@@ -694,7 +727,7 @@ fn split_with_symbol_split_method() {
             }
         "#
         ),
-        "\"TypeError: separator[Symbol.split] is not a function\""
+        "\"TypeError: value returned for property of object is not a function\""
     );
 }
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -6,6 +6,7 @@ use crate::{
         function::{BuiltInFunction, Function, FunctionFlags, NativeFunction},
         map::map_iterator::MapIterator,
         map::ordered_map::OrderedMap,
+        regexp::regexp_string_iterator::RegExpStringIterator,
         set::ordered_set::OrderedSet,
         set::set_iterator::SetIterator,
         string::string_iterator::StringIterator,
@@ -86,6 +87,7 @@ pub enum ObjectData {
     Map(OrderedMap<Value, Value>),
     MapIterator(MapIterator),
     RegExp(Box<RegExp>),
+    RegExpStringIterator(RegExpStringIterator),
     BigInt(RcBigInt),
     Boolean(bool),
     ForInIterator(ForInIterator),
@@ -114,6 +116,7 @@ impl Display for ObjectData {
                 Self::ForInIterator(_) => "ForInIterator",
                 Self::Function(_) => "Function",
                 Self::RegExp(_) => "RegExp",
+                Self::RegExpStringIterator(_) => "RegExpStringIterator",
                 Self::Map(_) => "Map",
                 Self::MapIterator(_) => "MapIterator",
                 Self::Set(_) => "Set",
@@ -317,6 +320,14 @@ impl Object {
     pub fn as_string_iterator_mut(&mut self) -> Option<&mut StringIterator> {
         match &mut self.data {
             ObjectData::StringIterator(iter) => Some(iter),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    pub fn as_regexp_string_iterator_mut(&mut self) -> Option<&mut RegExpStringIterator> {
+        match &mut self.data {
+            ObjectData::RegExpStringIterator(iter) => Some(iter),
             _ => None,
         }
     }


### PR DESCRIPTION
Relates to #1304

It changes the following:

- Refactor regexp exec function
- Refactor regexp match function
- Refactor regexp matchAll function
- Refactor regexp test function
- Implement regexp split function
- Refactor string split function
- Implement RegExpStringIterator
- Implement get RegExp.prototype.source
