### PR TITLE
Use lock for map iteration

### DIFF
--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -88,7 +88,7 @@ impl MapIterator {
 
                 if let Value::Object(ref object) = m {
                     if let Some(entries) = object.borrow().as_map_ref() {
-                        let num_entries = entries.len();
+                        let num_entries = entries.full_len();
                         while index < num_entries {
                             let e = entries.get_index(index);
                             index += 1;

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -24,12 +24,14 @@ use ordered_map::OrderedMap;
 pub mod map_iterator;
 use map_iterator::{MapIterationKind, MapIterator};
 
+use self::ordered_map::MapLock;
+
 pub mod ordered_map;
 #[cfg(test)]
 mod tests;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Map(OrderedMap<Value, Value>);
+pub(crate) struct Map(OrderedMap<Value>);
 
 impl BuiltIn for Map {
     const NAME: &'static str = "Map";
@@ -198,11 +200,7 @@ impl Map {
     /// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-map.prototype.entries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
     pub(crate) fn entries(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
-        Ok(MapIterator::create_map_iterator(
-            context,
-            this.clone(),
-            MapIterationKind::KeyAndValue,
-        ))
+        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::KeyAndValue)
     }
 
     /// `Map.prototype.keys()`
@@ -216,11 +214,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
     pub(crate) fn keys(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
-        Ok(MapIterator::create_map_iterator(
-            context,
-            this.clone(),
-            MapIterationKind::Key,
-        ))
+        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Key)
     }
 
     /// Helper function to set the size property.
@@ -392,6 +386,8 @@ impl Map {
 
         let mut index = 0;
 
+        let lock = Map::lock(this, context)?;
+
         while index < Map::get_size(this, context)? {
             let arguments = if let Value::Object(ref object) = this {
                 let object = object.borrow();
@@ -415,6 +411,8 @@ impl Map {
             index += 1;
         }
 
+        drop(lock);
+
         Ok(Value::Undefined)
     }
 
@@ -424,6 +422,20 @@ impl Map {
             let object = object.borrow();
             if let Some(map) = object.as_map_ref() {
                 Ok(map.len())
+            } else {
+                Err(context.construct_type_error("'this' is not a Map"))
+            }
+        } else {
+            Err(context.construct_type_error("'this' is not a Map"))
+        }
+    }
+
+    /// Helper function to lock the map.
+    fn lock(map: &Value, context: &mut Context) -> Result<MapLock> {
+        if let Value::Object(ref object) = map {
+            let mut map = object.borrow_mut();
+            if let Some(map) = map.as_map_mut() {
+                Ok(map.lock(object.clone()))
             } else {
                 Err(context.construct_type_error("'this' is not a Map"))
             }
@@ -443,11 +455,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.values
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/values
     pub(crate) fn values(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
-        Ok(MapIterator::create_map_iterator(
-            context,
-            this.clone(),
-            MapIterationKind::Value,
-        ))
+        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Value)
     }
 
     /// Helper function to get a key-value pair from an array.

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -388,7 +388,7 @@ impl Map {
 
         let lock = Map::lock(this, context)?;
 
-        while index < Map::get_size(this, context)? {
+        while index < Map::get_full_len(this, context)? {
             let arguments = if let Value::Object(ref object) = this {
                 let object = object.borrow();
                 if let Some(map) = object.as_map_ref() {
@@ -416,12 +416,12 @@ impl Map {
         Ok(Value::Undefined)
     }
 
-    /// Helper function to get the size of the map.
-    fn get_size(map: &Value, context: &mut Context) -> Result<usize> {
+    /// Helper function to get the full size of the map.
+    fn get_full_len(map: &Value, context: &mut Context) -> Result<usize> {
         if let Value::Object(ref object) = map {
             let object = object.borrow();
             if let Some(map) = object.as_map_ref() {
-                Ok(map.len())
+                Ok(map.full_len())
             } else {
                 Err(context.construct_type_error("'this' is not a Map"))
             }

--- a/boa/src/builtins/map/ordered_map.rs
+++ b/boa/src/builtins/map/ordered_map.rs
@@ -200,7 +200,6 @@ pub(crate) struct MapLock(GcObject);
 
 impl Clone for MapLock {
     fn clone(&self) -> Self {
-        println!("Clone called");
         let mut map = self.0.borrow_mut();
         let map = map.as_map_mut().expect("MapLock does not point to a map");
         map.lock(self.0.clone())

--- a/boa/src/builtins/map/ordered_map.rs
+++ b/boa/src/builtins/map/ordered_map.rs
@@ -1,63 +1,107 @@
-use crate::gc::{custom_trace, Finalize, Trace};
-use indexmap::{map::IntoIter, map::Iter, map::IterMut, IndexMap};
+use crate::{
+    gc::{custom_trace, Finalize, Trace},
+    object::GcObject,
+    Value,
+};
+use indexmap::{Equivalent, IndexMap};
 use std::{
     collections::hash_map::RandomState,
     fmt::Debug,
-    hash::{BuildHasher, Hash},
+    hash::{BuildHasher, Hash, Hasher},
 };
+
+#[derive(PartialEq, Eq, Clone, Debug)]
+enum MapKey {
+    Key(Value),
+    Empty(usize), // Necessary to ensure empty keys are still unique.
+}
+
+// This ensures that a MapKey::Key(value) hashes to the same as value. The derived PartialEq implementation still holds.
+#[allow(clippy::derive_hash_xor_eq)]
+impl Hash for MapKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            MapKey::Key(v) => v.hash(state),
+            MapKey::Empty(e) => e.hash(state),
+        }
+    }
+}
+
+impl Equivalent<MapKey> for Value {
+    fn equivalent(&self, key: &MapKey) -> bool {
+        match key {
+            MapKey::Key(v) => v == self,
+            _ => false,
+        }
+    }
+}
 
 /// A newtype wrapping indexmap::IndexMap
 #[derive(Clone)]
-pub struct OrderedMap<K, V, S = RandomState>(IndexMap<K, V, S>)
-where
-    K: Hash + Eq;
+pub struct OrderedMap<V, S = RandomState> {
+    map: IndexMap<MapKey, Option<V>, S>,
+    lock: u32,
+    empty_count: usize,
+}
 
-impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Finalize for OrderedMap<K, V, S> {}
-unsafe impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Trace for OrderedMap<K, V, S> {
+impl<V: Trace, S: BuildHasher> Finalize for OrderedMap<V, S> {}
+unsafe impl<V: Trace, S: BuildHasher> Trace for OrderedMap<V, S> {
     custom_trace!(this, {
-        for (k, v) in this.0.iter() {
-            mark(k);
+        for (k, v) in this.map.iter() {
+            if let MapKey::Key(key) = k {
+                mark(key);
+            }
             mark(v);
         }
     });
 }
 
-impl<K: Hash + Eq + Debug, V: Debug> Debug for OrderedMap<K, V> {
+impl<V: Debug> Debug for OrderedMap<V> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        self.0.fmt(formatter)
+        self.map.fmt(formatter)
     }
 }
 
-impl<K: Hash + Eq, V> Default for OrderedMap<K, V> {
+impl<V> Default for OrderedMap<V> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K, V> OrderedMap<K, V>
-where
-    K: Hash + Eq,
-{
+impl<V> OrderedMap<V> {
     pub fn new() -> Self {
-        OrderedMap(IndexMap::new())
+        OrderedMap {
+            map: IndexMap::new(),
+            lock: 0,
+            empty_count: 0,
+        }
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        OrderedMap(IndexMap::with_capacity(capacity))
+        OrderedMap {
+            map: IndexMap::with_capacity(capacity),
+            lock: 0,
+            empty_count: 0,
+        }
     }
 
     /// Return the number of key-value pairs in the map.
     ///
     /// Computes in **O(1)** time.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.map.len()
+    }
+
+    /// Gets the number of
+    pub fn num_values(&self) -> usize {
+        self.map.len() - self.empty_count
     }
 
     /// Returns true if the map contains no elements.
     ///
     /// Computes in **O(1)** time.
     pub fn is_empty(&self) -> bool {
-        self.0.len() == 0
+        self.map.len() == 0
     }
 
     /// Insert a key-value pair in the map.
@@ -70,8 +114,8 @@ where
     /// inserted, last in order, and `None` is returned.
     ///
     /// Computes in **O(1)** time (amortized average).
-    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
-        self.0.insert(key, value)
+    pub fn insert(&mut self, key: Value, value: V) -> Option<V> {
+        self.map.insert(MapKey::Key(key), Some(value)).flatten()
     }
 
     /// Remove the key-value pair equivalent to `key` and return
@@ -84,70 +128,89 @@ where
     /// Return `None` if `key` is not in map.
     ///
     /// Computes in **O(n)** time (average).
-    pub fn remove(&mut self, key: &K) -> Option<V> {
-        self.0.shift_remove(key)
+    pub fn remove(&mut self, key: &Value) -> Option<V> {
+        if self.lock == 0 {
+            self.map.shift_remove(key).flatten()
+        } else if self.map.contains_key(key) {
+            self.map.insert(MapKey::Empty(self.empty_count), None);
+            self.empty_count += 1;
+            self.map.swap_remove(key).flatten()
+        } else {
+            None
+        }
     }
 
     /// Return a reference to the value stored for `key`, if it is present,
     /// else `None`.
     ///
     /// Computes in **O(1)** time (average).
-    pub fn get(&self, key: &K) -> Option<&V> {
-        self.0.get(key)
+    pub fn get(&self, key: &Value) -> Option<&V> {
+        self.map.get(key).map(Option::as_ref).flatten()
     }
 
     /// Get a key-value pair by index
     /// Valid indices are 0 <= index < self.len()
     /// Computes in O(1) time.
-    pub fn get_index(&self, index: usize) -> Option<(&K, &V)> {
-        self.0.get_index(index)
+    pub fn get_index(&self, index: usize) -> Option<(&Value, &V)> {
+        if let (MapKey::Key(key), Some(value)) = self.map.get_index(index)? {
+            Some((key, value))
+        } else {
+            None
+        }
     }
 
     /// Return an iterator over the key-value pairs of the map, in their order
-    pub fn iter(&self) -> Iter<'_, K, V> {
-        self.0.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (&Value, &V)> {
+        self.map.iter().filter_map(|o| {
+            if let (MapKey::Key(key), Some(value)) = o {
+                Some((key, value))
+            } else {
+                None
+            }
+        })
     }
 
     /// Return `true` if an equivalent to `key` exists in the map.
     ///
     /// Computes in **O(1)** time (average).
-    pub fn contains_key(&self, key: &K) -> bool {
-        self.0.contains_key(key)
+    pub fn contains_key(&self, key: &Value) -> bool {
+        self.map.contains_key(key)
+    }
+
+    /// Increases the lock counter and returns a lock object that will decrement the counter when dropped.
+    ///
+    /// This allows objects to be removed from the map during iteration without affecting the indexes until the iteration has completed.
+    pub(crate) fn lock(&mut self, map: GcObject) -> MapLock {
+        self.lock += 1;
+        MapLock(map)
+    }
+
+    /// Decreases the lock counter and, if 0, removes all empty entries.
+    fn unlock(&mut self) {
+        self.lock -= 1;
+        if self.lock == 0 {
+            self.map.retain(|k, _| matches!(k, MapKey::Key(_)));
+            self.empty_count = 0;
+        }
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a OrderedMap<K, V, S>
-where
-    K: Hash + Eq,
-    S: BuildHasher,
-{
-    type Item = (&'a K, &'a V);
-    type IntoIter = Iter<'a, K, V>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter()
+#[derive(Debug, Trace)]
+pub(crate) struct MapLock(GcObject);
+
+impl Clone for MapLock {
+    fn clone(&self) -> Self {
+        println!("Clone called");
+        let mut map = self.0.borrow_mut();
+        let map = map.as_map_mut().expect("MapLock does not point to a map");
+        map.lock(self.0.clone())
     }
 }
 
-impl<'a, K, V, S> IntoIterator for &'a mut OrderedMap<K, V, S>
-where
-    K: Hash + Eq,
-    S: BuildHasher,
-{
-    type Item = (&'a K, &'a mut V);
-    type IntoIter = IterMut<'a, K, V>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.iter_mut()
-    }
-}
-
-impl<K, V, S> IntoIterator for OrderedMap<K, V, S>
-where
-    K: Hash + Eq,
-    S: BuildHasher,
-{
-    type Item = (K, V);
-    type IntoIter = IntoIter<K, V>;
-    fn into_iter(self) -> IntoIter<K, V> {
-        self.0.into_iter()
+impl Finalize for MapLock {
+    fn finalize(&self) {
+        let mut map = self.0.borrow_mut();
+        let map = map.as_map_mut().expect("MapLock does not point to a map");
+        map.unlock();
     }
 }

--- a/boa/src/builtins/map/ordered_map.rs
+++ b/boa/src/builtins/map/ordered_map.rs
@@ -85,15 +85,17 @@ impl<V> OrderedMap<V> {
         }
     }
 
-    /// Return the number of key-value pairs in the map.
+    /// Return the number of key-value pairs in the map, including empty values.
     ///
     /// Computes in **O(1)** time.
-    pub fn len(&self) -> usize {
+    pub fn full_len(&self) -> usize {
         self.map.len()
     }
 
-    /// Gets the number of
-    pub fn num_values(&self) -> usize {
+    /// Gets the number of key-value pairs in the map, not including empty values.
+    ///
+    /// Computes in **O(1)** time.
+    pub fn len(&self) -> usize {
         self.map.len() - self.empty_count
     }
 

--- a/boa/src/builtins/map/ordered_map.rs
+++ b/boa/src/builtins/map/ordered_map.rs
@@ -103,7 +103,7 @@ impl<V> OrderedMap<V> {
     ///
     /// Computes in **O(1)** time.
     pub fn is_empty(&self) -> bool {
-        self.map.len() == 0
+        self.len() == 0
     }
 
     /// Insert a key-value pair in the map.
@@ -151,7 +151,7 @@ impl<V> OrderedMap<V> {
     }
 
     /// Get a key-value pair by index
-    /// Valid indices are 0 <= index < self.len()
+    /// Valid indices are 0 <= index < self.full_len()
     /// Computes in O(1) time.
     pub fn get_index(&self, index: usize) -> Option<(&Value, &V)> {
         if let (MapKey::Key(key), Some(value)) = self.map.get_index(index)? {
@@ -197,6 +197,7 @@ impl<V> OrderedMap<V> {
     }
 }
 
+/// Increases the lock count of the map for the lifetime of the guard. This should not be dropped until iteration has completed.
 #[derive(Debug, Trace)]
 pub(crate) struct MapLock(GcObject);
 

--- a/boa/src/builtins/map/tests.rs
+++ b/boa/src/builtins/map/tests.rs
@@ -354,3 +354,53 @@ fn not_a_function() {
         "\"TypeError: calling a builtin Map constructor without new is forbidden\""
     );
 }
+
+#[test]
+fn for_each_delete() {
+    let mut context = Context::new();
+    let init = r#"
+        let map = new Map([[0, "a"], [1, "b"], [2, "c"]]);
+        let result = [];
+        map.forEach(function(value, key) {
+            if (key === 0) {
+                map.delete(0);
+                map.set(3, "d");
+            }
+            result.push([key, value]);
+        })
+    "#;
+    forward(&mut context, init);
+    assert_eq!(forward(&mut context, "result[0][0]"), "0");
+    assert_eq!(forward(&mut context, "result[0][1]"), "\"a\"");
+    assert_eq!(forward(&mut context, "result[1][0]"), "1");
+    assert_eq!(forward(&mut context, "result[1][1]"), "\"b\"");
+    assert_eq!(forward(&mut context, "result[2][0]"), "2");
+    assert_eq!(forward(&mut context, "result[2][1]"), "\"c\"");
+    assert_eq!(forward(&mut context, "result[3][0]"), "3");
+    assert_eq!(forward(&mut context, "result[3][1]"), "\"d\"");
+}
+
+#[test]
+fn for_of_delete() {
+    let mut context = Context::new();
+    let init = r#"
+        let map = new Map([[0, "a"], [1, "b"], [2, "c"]]);
+        let result = [];
+        for (a of map) {
+            if (a[0] === 0) {
+                map.delete(0);
+                map.set(3, "d");
+            }
+            result.push([a[0], a[1]]);
+        }
+    "#;
+    forward(&mut context, init);
+    assert_eq!(forward(&mut context, "result[0][0]"), "0");
+    assert_eq!(forward(&mut context, "result[0][1]"), "\"a\"");
+    assert_eq!(forward(&mut context, "result[1][0]"), "1");
+    assert_eq!(forward(&mut context, "result[1][1]"), "\"b\"");
+    assert_eq!(forward(&mut context, "result[2][0]"), "2");
+    assert_eq!(forward(&mut context, "result[2][1]"), "\"c\"");
+    assert_eq!(forward(&mut context, "result[3][0]"), "3");
+    assert_eq!(forward(&mut context, "result[3][1]"), "\"d\"");
+}

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -83,7 +83,7 @@ pub struct Object {
 pub enum ObjectData {
     Array,
     ArrayIterator(ArrayIterator),
-    Map(OrderedMap<Value, Value>),
+    Map(OrderedMap<Value>),
     MapIterator(MapIterator),
     RegExp(Box<RegExp>),
     BigInt(RcBigInt),
@@ -344,7 +344,7 @@ impl Object {
     }
 
     #[inline]
-    pub fn as_map_ref(&self) -> Option<&OrderedMap<Value, Value>> {
+    pub fn as_map_ref(&self) -> Option<&OrderedMap<Value>> {
         match self.data {
             ObjectData::Map(ref map) => Some(map),
             _ => None,
@@ -352,7 +352,7 @@ impl Object {
     }
 
     #[inline]
-    pub fn as_map_mut(&mut self) -> Option<&mut OrderedMap<Value, Value>> {
+    pub fn as_map_mut(&mut self) -> Option<&mut OrderedMap<Value>> {
         match &mut self.data {
             ObjectData::Map(map) => Some(map),
             _ => None,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes #1092.

It changes the following:

- Changes the key of `OrderedMap` to a `MapKey`, which contains either a key or an empty value.
- Allows locking a map to allow safe iteration.
- When an entry is deleted while the map is locked, it replaces the entry with an empty value to maintain the indexes.
- When the map is unlocked any empty entries are deleted.
- Locks are implemented as a guard object so that they are released even if an error occurs.

**Concerns/Questions**
- Due to the requirements of the `indexmap::Equivalent` trait `OrderedMap` now has the key as a `Value` rather than a generic parameter. I think this should be fine as I don't think there are other uses of `OrderedMap` that might require a different key. It may even be possible to implement the `Equivalent` trait in such a way that it allows the generic parameter to be maintained, but I couldn't find one with a fair amount of experimentation.
- I think the implementation of the `MapLock` struct is sound, but there might be a better way to do it. I originally just had methods to lock and unlock that would be called before and after iteration, but if an error occured during iteration the unlock function would never be called.
- Are there other ways to trigger this behaviour? Perhaps should all methods on map call `lock`?