### PR TITLE
Lexically declared names

### DIFF
--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -687,6 +687,7 @@ unsafe impl Trace for MethodDefinitionKind {
 /// any strings which may have been changed in a different indent
 /// level.
 #[cfg(test)]
+#[track_caller]
 fn test_formatting(source: &'static str) {
     // Remove preceding newline.
     let source = &source[1..];

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -308,7 +308,7 @@ impl Node {
 
     /// Returns the var declared names of this node, according to
     /// the [spec](https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames).
-    pub(crate) fn var_declared_names(&self) -> HashSet<&str> {
+    pub fn var_declared_names(&self) -> HashSet<&str> {
         match self {
             Node::Block(ref block) => {
                 let mut names = HashSet::new();

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -78,6 +78,10 @@ impl StatementList {
         set
     }
 
+    #[deprecated(
+        since = "0.13.0",
+        note = "Use `Node::var_declared_names` instead. This function is out of date, and does not correctly get all var declared names."
+    )]
     pub fn var_declared_names(&self) -> HashSet<&str> {
         let mut set = HashSet::new();
         for stmt in self.items() {

--- a/boa/src/syntax/parser/expression/assignment/exponentiation.rs
+++ b/boa/src/syntax/parser/expression/assignment/exponentiation.rs
@@ -18,7 +18,7 @@ use crate::{
         },
         parser::{
             expression::{unary::UnaryExpression, update::UpdateExpression},
-            AllowAwait, AllowYield, Cursor, ParseResult, TokenParser,
+            AllowAwait, AllowYield, Cursor, DeclaredNames, ParseResult, TokenParser,
         },
     },
     BoaProfiler,
@@ -81,18 +81,18 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, env: &mut DeclaredNames) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("ExponentiationExpression", "Parsing");
 
         if is_unary_expression(cursor)? {
-            return UnaryExpression::new(self.allow_yield, self.allow_await).parse(cursor);
+            return UnaryExpression::new(self.allow_yield, self.allow_await).parse(cursor, env);
         }
 
-        let lhs = UpdateExpression::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let lhs = UpdateExpression::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
         if let Some(tok) = cursor.peek(0)? {
             if let TokenKind::Punctuator(Punctuator::Exp) = tok.kind() {
                 cursor.next()?.expect("** token vanished"); // Consume the token.
-                return Ok(BinOp::new(NumOp::Exp, lhs, self.parse(cursor)?).into());
+                return Ok(BinOp::new(NumOp::Exp, lhs, self.parse(cursor, env)?).into());
             }
         }
         Ok(lhs)

--- a/boa/src/syntax/parser/expression/await_expr.rs
+++ b/boa/src/syntax/parser/expression/await_expr.rs
@@ -12,7 +12,7 @@ use super::unary::UnaryExpression;
 use crate::syntax::{
     ast::{node::AwaitExpr, Keyword},
     lexer::TokenKind,
-    parser::{AllowYield, Cursor, ParseError, TokenParser},
+    parser::{AllowYield, Cursor, DeclaredNames, ParseError, TokenParser},
 };
 use std::io::Read;
 
@@ -47,12 +47,16 @@ where
 {
     type Output = AwaitExpr;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         cursor.expect(
             TokenKind::Keyword(Keyword::Await),
             "Await expression parsing",
         )?;
-        let expr = UnaryExpression::new(self.allow_yield, true).parse(cursor)?;
+        let expr = UnaryExpression::new(self.allow_yield, true).parse(cursor, env)?;
         Ok(expr.into())
     }
 }

--- a/boa/src/syntax/parser/expression/left_hand_side/arguments.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/arguments.rs
@@ -13,8 +13,8 @@ use crate::{
         ast::{node::Spread, Node, Punctuator},
         lexer::InputElement,
         parser::{
-            expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, ParseError,
-            TokenParser,
+            expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, DeclaredNames,
+            ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -56,7 +56,11 @@ where
 {
     type Output = Box<[Node]>;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Arguments", "Parsing");
 
         cursor.expect(Punctuator::OpenParen, "arguments")?;
@@ -98,7 +102,7 @@ where
                 args.push(
                     Spread::new(
                         AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                            .parse(cursor)?,
+                            .parse(cursor, env)?,
                     )
                     .into(),
                 );
@@ -106,7 +110,7 @@ where
                 cursor.set_goal(InputElement::RegExp);
                 args.push(
                     AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                        .parse(cursor)?,
+                        .parse(cursor, env)?,
                 );
             }
         }

--- a/boa/src/syntax/parser/expression/left_hand_side/mod.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     syntax::{
         ast::{Node, Punctuator},
         lexer::{InputElement, TokenKind},
-        parser::{AllowAwait, AllowYield, Cursor, ParseError, TokenParser},
+        parser::{AllowAwait, AllowYield, Cursor, DeclaredNames, ParseError, TokenParser},
     },
 };
 
@@ -58,16 +58,21 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("LeftHandSIdeExpression", "Parsing");
 
         cursor.set_goal(InputElement::TemplateTail);
 
         // TODO: Implement NewExpression: new MemberExpression
-        let lhs = MemberExpression::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let lhs = MemberExpression::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
         if let Some(tok) = cursor.peek(0)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
-                return CallExpression::new(self.allow_yield, self.allow_await, lhs).parse(cursor);
+                return CallExpression::new(self.allow_yield, self.allow_await, lhs)
+                    .parse(cursor, env);
             }
         }
         Ok(lhs)

--- a/boa/src/syntax/parser/expression/left_hand_side/template.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/template.rs
@@ -5,8 +5,8 @@ use crate::{
         ast::{Node, Position, Punctuator},
         lexer::TokenKind,
         parser::{
-            cursor::Cursor, expression::Expression, AllowAwait, AllowYield, ParseError,
-            ParseResult, TokenParser,
+            cursor::Cursor, expression::Expression, AllowAwait, AllowYield, DeclaredNames,
+            ParseError, ParseResult, TokenParser,
         },
     },
 };
@@ -48,7 +48,7 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, env: &mut DeclaredNames) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("TaggedTemplateLiteral", "Parsing");
 
         let mut raws = Vec::new();
@@ -63,7 +63,8 @@ where
                     raws.push(template_string.as_raw().to_owned().into_boxed_str());
                     cookeds.push(template_string.to_owned_cooked().ok());
                     exprs.push(
-                        Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?,
+                        Expression::new(true, self.allow_yield, self.allow_await)
+                            .parse(cursor, env)?,
                     );
                     cursor.expect(
                         TokenKind::Punctuator(Punctuator::CloseBlock),

--- a/boa/src/syntax/parser/expression/primary/array_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/array_initializer/mod.rs
@@ -17,8 +17,8 @@ use crate::{
             Const, Punctuator,
         },
         parser::{
-            expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, ParseError,
-            TokenParser,
+            expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, DeclaredNames,
+            ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -60,7 +60,11 @@ where
 {
     type Output = ArrayDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ArrayLiteral", "Parsing");
         let mut elements = Vec::new();
 
@@ -78,12 +82,12 @@ where
 
             if cursor.next_if(Punctuator::Spread)?.is_some() {
                 let node = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                    .parse(cursor)?;
+                    .parse(cursor, env)?;
                 elements.push(Spread::new(node).into());
             } else {
                 elements.push(
                     AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                        .parse(cursor)?,
+                        .parse(cursor, env)?,
                 );
             }
             cursor.next_if(Punctuator::Comma)?;

--- a/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -19,7 +19,8 @@ use crate::{
         parser::{
             expression::AssignmentExpression,
             function::{FormalParameters, FunctionBody},
-            AllowAwait, AllowIn, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
+            AllowAwait, AllowIn, AllowYield, Cursor, DeclaredNames, ParseError, ParseResult,
+            TokenParser,
         },
     },
     BoaProfiler,
@@ -60,7 +61,11 @@ where
 {
     type Output = Object;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ObjectLiteral", "Parsing");
         let mut elements = Vec::new();
 
@@ -69,8 +74,9 @@ where
                 break;
             }
 
-            elements
-                .push(PropertyDefinition::new(self.allow_yield, self.allow_await).parse(cursor)?);
+            elements.push(
+                PropertyDefinition::new(self.allow_yield, self.allow_await).parse(cursor, env)?,
+            );
 
             if cursor.next_if(Punctuator::CloseBlock)?.is_some() {
                 break;
@@ -125,19 +131,23 @@ where
 {
     type Output = node::PropertyDefinition;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("PropertyDefinition", "Parsing");
 
         if cursor.next_if(Punctuator::Spread)?.is_some() {
             let node = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
+                .parse(cursor, env)?;
             return Ok(node::PropertyDefinition::SpreadObject(node));
         }
 
         let prop_name = cursor.next()?.ok_or(ParseError::AbruptEnd)?.to_string();
         if cursor.next_if(Punctuator::Colon)?.is_some() {
             let val = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
+                .parse(cursor, env)?;
             return Ok(node::PropertyDefinition::property(prop_name, val));
         }
 
@@ -158,7 +168,7 @@ where
             || ["get", "set"].contains(&prop_name.as_str())
         {
             return MethodDefinition::new(self.allow_yield, self.allow_await, prop_name)
-                .parse(cursor);
+                .parse(cursor, env);
         }
 
         let pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
@@ -201,7 +211,11 @@ where
 {
     type Output = node::PropertyDefinition;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("MethodDefinition", "Parsing");
 
         let (methodkind, prop_name, params) = match self.identifier.as_str() {
@@ -221,7 +235,7 @@ where
                     "property method definition",
                 )?;
                 let first_param = cursor.peek(0)?.expect("current token disappeared").clone();
-                let params = FormalParameters::new(false, false).parse(cursor)?;
+                let params = FormalParameters::new(false, false).parse(cursor, env)?;
                 cursor.expect(Punctuator::CloseParen, "method definition")?;
                 if idn == "get" {
                     if !params.is_empty() {
@@ -242,7 +256,7 @@ where
                 }
             }
             prop_name => {
-                let params = FormalParameters::new(false, false).parse(cursor)?;
+                let params = FormalParameters::new(false, false).parse(cursor, env)?;
                 cursor.expect(Punctuator::CloseParen, "method definition")?;
                 (
                     MethodDefinitionKind::Ordinary,
@@ -256,7 +270,7 @@ where
             TokenKind::Punctuator(Punctuator::OpenBlock),
             "property method definition",
         )?;
-        let body = FunctionBody::new(false, false).parse(cursor)?;
+        let body = FunctionBody::new(false, false).parse(cursor, env)?;
         cursor.expect(
             TokenKind::Punctuator(Punctuator::CloseBlock),
             "property method definition",
@@ -309,10 +323,11 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, env: &mut DeclaredNames) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("Initializer", "Parsing");
 
         cursor.expect(Punctuator::Assign, "initializer")?;
-        AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await).parse(cursor)
+        AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await)
+            .parse(cursor, env)
     }
 }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -9,7 +9,10 @@ mod statement;
 mod tests;
 
 pub use self::error::{ParseError, ParseResult};
-use crate::syntax::{ast::node::StatementList, lexer::TokenKind};
+use crate::syntax::{
+    ast::node::StatementList,
+    lexer::{Error as LexError, Position, TokenKind},
+};
 
 use cursor::Cursor;
 
@@ -98,6 +101,39 @@ impl Default for DeclaredNames {
         DeclaredNames {
             vars: HashSet::new(),
             lex: HashSet::new(),
+        }
+    }
+}
+
+impl DeclaredNames {
+    /// Inserts a new variable name.
+    pub fn insert_var_name(&mut self, name: &str) -> bool {
+        self.vars.insert(name.into())
+    }
+    /// Returns an error if the a variable with the same name already has been declared.
+    pub fn check_var_name(&mut self, name: &str, pos: Position) -> Result<(), ParseError> {
+        if self.vars.contains(name) {
+            Err(ParseError::lex(LexError::Syntax(
+                format!("Redeclaration of variable `{}`", name).into(),
+                pos,
+            )))
+        } else {
+            Ok(())
+        }
+    }
+    /// Inserts a lexically declared name.
+    pub fn insert_lex_name(&mut self, name: &str) -> bool {
+        self.vars.insert(name.into())
+    }
+    /// Returns an error if the a lexically declared name already exists.
+    pub fn check_lex_name(&mut self, name: &str, pos: Position) -> Result<(), ParseError> {
+        if self.vars.contains(name) {
+            Err(ParseError::lex(LexError::Syntax(
+                format!("Redeclaration of variable `{}`", name).into(),
+                pos,
+            )))
+        } else {
+            Ok(())
         }
     }
 }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -162,6 +162,31 @@ impl DeclaredNames {
     ///
     /// // env.pop_lex_restore(); Will panic
     /// ```
+    ///
+    /// For variables (not lexically declared names) there is slightly different behavior:
+    /// ```
+    /// # use boa::syntax::lexer::Position;
+    /// use boa::syntax::parser::DeclaredNames;
+    ///
+    /// let mut env = DeclaredNames::default();
+    ///
+    /// env.insert_var_name("hello", Position::new(1, 1));
+    /// env.insert_var_name("world", Position::new(1, 1));
+    /// env.push_stack(); // Env is now empty again
+    /// env.insert_var_name("second", Position::new(1, 1));
+    /// env.insert_var_name("level", Position::new(1, 1)); // Env now has two lexically declared names.
+    /// env.push_stack(); // Env is empty again
+    ///
+    /// assert!(env.pop_stack().is_ok()); // Env now has two lexically declared names ("second" and "level").
+    /// assert!(env.pop_stack().is_ok()); // Env now has all of the lexically declared names.
+    ///
+    /// // env.pop_lex_restore(); Will panic
+    /// ```
+    ///
+    /// The reason these act differently is a matter of scope. A `let` or `const` statement only lives
+    /// within the current block, so `pop_stack` should remove the value from scope. However, `var` lives
+    /// within the scope of the function. Therefore, `pop_stack` only merges the inner `var` statements
+    /// and the outer `var` list each time you call `pop_stack`.
     pub fn push_stack(&mut self) {
         // When moving to a new stack level, we clear all declared variables. This is because
         // variable declarations are parsed the same way no matter what order the inner statements

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -139,7 +139,7 @@ impl DeclaredNames {
                 pos,
             )))
         } else {
-            if let Some(restore) = self.lex_restore.last() {
+            if let Some(restore) = self.lex_restore.last_mut() {
                 restore.insert(name.into());
             }
             Ok(())

--- a/boa/src/syntax/parser/statement/block/mod.rs
+++ b/boa/src/syntax/parser/statement/block/mod.rs
@@ -17,7 +17,9 @@ use crate::{
     profiler::BoaProfiler,
     syntax::{
         ast::{node, Punctuator},
-        parser::{AllowAwait, AllowReturn, AllowYield, Cursor, ParseError, TokenParser},
+        parser::{
+            AllowAwait, AllowReturn, AllowYield, Cursor, DeclaredNames, ParseError, TokenParser,
+        },
     },
 };
 
@@ -71,7 +73,11 @@ where
 {
     type Output = node::Block;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Block", "Parsing");
         cursor.expect(Punctuator::OpenBlock, "block")?;
         if let Some(tk) = cursor.peek(0)? {
@@ -88,7 +94,7 @@ where
             true,
             &BLOCK_BREAK_TOKENS,
         )
-        .parse(cursor)
+        .parse(cursor, env)
         .map(node::Block::from)?;
         cursor.expect(Punctuator::CloseBlock, "block")?;
 

--- a/boa/src/syntax/parser/statement/break_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/break_stm/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         ast::{node::Break, Keyword, Punctuator},
         parser::{
             cursor::{Cursor, SemicolonResult},
-            AllowAwait, AllowYield, ParseError, TokenParser,
+            AllowAwait, AllowYield, DeclaredNames, ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -60,7 +60,11 @@ where
 {
     type Output = Break;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("BreakStatement", "Parsing");
         cursor.expect(Keyword::Break, "break statement")?;
 
@@ -74,7 +78,8 @@ where
 
             None
         } else {
-            let label = LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
+            let label =
+                LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
             cursor.expect_semicolon("break statement")?;
 
             Some(label)

--- a/boa/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/continue_stm/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         parser::{
             cursor::{Cursor, SemicolonResult},
             statement::LabelIdentifier,
-            AllowAwait, AllowYield, ParseError, TokenParser,
+            AllowAwait, AllowYield, DeclaredNames, ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -59,7 +59,11 @@ where
 {
     type Output = Continue;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ContinueStatement", "Parsing");
         cursor.expect(Keyword::Continue, "continue statement")?;
 
@@ -73,7 +77,8 @@ where
 
             None
         } else {
-            let label = LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
+            let label =
+                LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
             cursor.expect_semicolon("continue statement")?;
 
             Some(label)

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -113,9 +113,8 @@ where
             }
         }
 
-        // Functions act like `var` statements
         if let Some(ref name) = name {
-            env.insert_var_name(name, pos)?;
+            env.insert_func_name(name, pos)?;
         }
 
         Ok(AsyncFunctionDecl::new(name, params, body))

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -83,7 +83,15 @@ where
         cursor.expect(Punctuator::CloseParen, "async function declaration")?;
         cursor.expect(Punctuator::OpenBlock, "async function declaration")?;
 
-        let body = FunctionBody::new(false, true).parse(cursor, env)?;
+        let mut inner_env = DeclaredNames::default();
+        for param in params.iter() {
+            // This can never fail, as FormalParameters makes sure that there
+            // are not duplicate names.
+            inner_env
+                .insert_var_name(param.name(), Position::new(1, 1))
+                .unwrap();
+        }
+        let body = FunctionBody::new(false, true).parse(cursor, &mut inner_env)?;
 
         cursor.expect(Punctuator::CloseBlock, "async function declaration")?;
 

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -60,7 +60,9 @@ where
         cursor.expect(Keyword::Function, "async function declaration")?;
         let tok = cursor.peek(0)?;
 
+        let pos;
         let name = if let Some(token) = tok {
+            pos = token.span().start();
             match token.kind() {
                 TokenKind::Punctuator(Punctuator::OpenParen) => {
                     if !self.is_default.0 {
@@ -107,6 +109,11 @@ where
                     )));
                 }
             }
+        }
+
+        // Functions act like `var` statements
+        if let Some(ref name) = name {
+            env.insert_var_name(name, pos)?;
         }
 
         Ok(AsyncFunctionDecl::new(name, params, body))

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -7,7 +7,7 @@ use crate::syntax::{
         function::FormalParameters,
         function::FunctionBody,
         statement::{BindingIdentifier, LexError, Position},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        AllowAwait, AllowDefault, AllowYield, Cursor, DeclaredNames, ParseError, TokenParser,
     },
 };
 use std::io::Read;
@@ -50,20 +50,24 @@ where
 {
     type Output = FunctionDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         cursor.expect(Keyword::Function, "function declaration")?;
 
         // TODO: If self.is_default, then this can be empty.
-        let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect(Punctuator::OpenParen, "function declaration")?;
 
-        let params = FormalParameters::new(false, false).parse(cursor)?;
+        let params = FormalParameters::new(false, false).parse(cursor, env)?;
 
         cursor.expect(Punctuator::CloseParen, "function declaration")?;
         cursor.expect(Punctuator::OpenBlock, "function declaration")?;
 
-        let body = FunctionBody::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let body = FunctionBody::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect(Punctuator::CloseBlock, "function declaration")?;
 

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -58,6 +58,7 @@ where
         cursor.expect(Keyword::Function, "function declaration")?;
 
         // TODO: If self.is_default, then this can be empty.
+        let pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
         let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect(Punctuator::OpenParen, "function declaration")?;
@@ -88,6 +89,9 @@ where
                 }
             }
         }
+
+        // Functions act like `var` statements
+        env.insert_var_name(&name, pos)?;
 
         Ok(FunctionDecl::new(name, params, body))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -76,28 +76,11 @@ where
             // are not duplicate names.
             inner_env.insert_var_name(param.name(), params_pos).unwrap();
         }
+        // This checks for variable name collisions.
         let body =
             FunctionBody::new(self.allow_yield, self.allow_await).parse(cursor, &mut inner_env)?;
 
         cursor.expect(Punctuator::CloseBlock, "function declaration")?;
-
-        // It is a Syntax Error if any element of the BoundNames of FormalParameters
-        // also occurs in the LexicallyDeclaredNames of FunctionBody.
-        // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
-        {
-            let lexically_declared_names = body.lexically_declared_names();
-            for param in params.as_ref() {
-                if lexically_declared_names.contains(param.name()) {
-                    return Err(ParseError::lex(LexError::Syntax(
-                        format!("Redeclaration of formal parameter `{}`", param.name()).into(),
-                        match cursor.peek(0)? {
-                            Some(token) => token.span().end(),
-                            None => Position::new(1, 1),
-                        },
-                    )));
-                }
-            }
-        }
 
         // Functions act like `var` statements
         env.insert_var_name(&name, pos)?;

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -71,10 +71,11 @@ where
 
         let mut inner_env = DeclaredNames::default();
         for param in params.iter() {
-            // TODO: Generate a better position for each parameter.
             // This can never fail, as FormalParameters makes sure that there
             // are not duplicate names.
-            inner_env.insert_var_name(param.name(), params_pos).unwrap();
+            inner_env
+                .insert_var_name(param.name(), Position::new(1, 1))
+                .unwrap();
         }
         // This checks for variable name collisions.
         let body =

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -63,7 +63,6 @@ where
 
         cursor.expect(Punctuator::OpenParen, "function declaration")?;
 
-        let params_pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
         let params = FormalParameters::new(false, false).parse(cursor, env)?;
 
         cursor.expect(Punctuator::CloseParen, "function declaration")?;
@@ -83,8 +82,7 @@ where
 
         cursor.expect(Punctuator::CloseBlock, "function declaration")?;
 
-        // Functions act like `var` statements
-        env.insert_var_name(&name, pos)?;
+        env.insert_func_name(&name, pos)?;
 
         Ok(FunctionDecl::new(name, params, body))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -19,7 +19,8 @@ use crate::{
         ast::{Keyword, Node},
         lexer::TokenKind,
         parser::{
-            AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
+            AllowAwait, AllowDefault, AllowYield, Cursor, DeclaredNames, ParseError, ParseResult,
+            TokenParser,
         },
     },
     BoaProfiler,
@@ -61,19 +62,19 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, env: &mut DeclaredNames) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("HoistableDeclaration", "Parsing");
         let tok = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
             TokenKind::Keyword(Keyword::Function) => {
                 FunctionDeclaration::new(self.allow_yield, self.allow_await, self.is_default)
-                    .parse(cursor)
+                    .parse(cursor, env)
                     .map(Node::from)
             }
             TokenKind::Keyword(Keyword::Async) => {
                 AsyncFunctionDeclaration::new(self.allow_yield, self.allow_await, false)
-                    .parse(cursor)
+                    .parse(cursor, env)
                     .map(Node::from)
             }
             _ => unreachable!("unknown token found: {:?}", tok),

--- a/boa/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa/src/syntax/parser/statement/declaration/lexical.rs
@@ -252,6 +252,7 @@ where
     ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("LexicalBinding", "Parsing");
 
+        let pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
         let ident =
             BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
 
@@ -268,6 +269,7 @@ where
             None
         };
 
+        env.insert_lex_name(&ident, pos)?;
         Ok((ident, init))
     }
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -260,4 +260,7 @@ fn redeclaration_errors() {
 
     check_invalid("let f; function f() {}");
     check_invalid("var f; function f() {}");
+    check_invalid("function f() {}; let f");
+    check_invalid("function f() {}; var f");
+    check_valid("function f() {}; function f() {}");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -239,5 +239,13 @@ fn redeclaration_errors() {
     check_valid("var a; { let a }");
     check_valid("let a; { let a }");
     check_valid("var a; { var a }");
-    panic!();
+    // Multiple blocks
+    check_invalid("let a; { var a } { let a }");
+    check_valid("var a; { let a } { let a }");
+    check_valid("let a; { let a } { let a }");
+    check_valid("var a; { var a } { let a }");
+    check_invalid("let a; { var a } { var a }");
+    check_valid("var a; { let a } { var a }");
+    check_invalid("let a; { let a } { var a }");
+    check_valid("var a; { var a } { var a }");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -236,7 +236,7 @@ fn redeclaration_errors() {
     check_valid("{ var a }; var a;");
     // Second in block
     check_invalid("let a; { var a }");
-    check_invalid("var a; { let a }");
-    check_invalid("let a; { let a }");
+    check_valid("var a; { let a }"); // This is valid because new blocks get empty lex names
+    check_valid("let a; { let a }");
     check_valid("var a; { var a }");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -230,13 +230,14 @@ fn redeclaration_errors() {
     check_invalid("let a; let a;");
     check_valid("var a; var a;");
     // First in block
-    check_valid("{ let a }; var a;"); // let stays within its scope
-    check_invalid("{ var a }; let a;"); // vars live in function scope
+    check_valid("{ let a }; var a;");
+    check_invalid("{ var a }; let a;");
     check_valid("{ let a }; let a;");
     check_valid("{ var a }; var a;");
     // Second in block
-    check_invalid("let a; { var a }"); // var is within the scope of let
-    check_valid("var a; { let a }"); // let is in its own scope
+    check_invalid("let a; { var a }");
+    check_valid("var a; { let a }");
     check_valid("let a; { let a }");
     check_valid("var a; { var a }");
+    panic!();
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -230,13 +230,13 @@ fn redeclaration_errors() {
     check_invalid("let a; let a;");
     check_valid("var a; var a;");
     // First in block
-    check_valid("{ let a }; var a;");
-    check_invalid("{ var a }; let a;");
+    check_valid("{ let a }; var a;"); // let stays within its scope
+    check_invalid("{ var a }; let a;"); // vars live in function scope
     check_valid("{ let a }; let a;");
     check_valid("{ var a }; var a;");
     // Second in block
-    check_invalid("let a; { var a }");
-    check_valid("var a; { let a }"); // This is valid because new blocks get empty lex names
+    check_invalid("let a; { var a }"); // var is within the scope of let
+    check_valid("var a; { let a }"); // let is in its own scope
     check_valid("let a; { let a }");
     check_valid("var a; { var a }");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -215,14 +215,23 @@ fn multiple_const_declaration() {
 /// Checks for redeclaration errors.
 #[test]
 fn redeclaration_errors() {
-    // Throughout this test, we test four combinations:
+    // Most of these tests seem crazy at first. But they follow
+    // a few simple rules:
     //
-    // - let-var
-    // - var-let
-    // - let-let
-    // - var-var
+    // - Let statements stay within their block scope.
+    // - Var statements stay within their function scope.
+    // - The only time you can redeclare is when you use `var` and `var`.
+    // - We always check the innermost block first.
     //
-    // Depending on the block/function scope, these are sometimes valid, and sometimes not valid.
+    // This explains most of the tests. For example, `var a; { let a; }`
+    // seems like it should be invalid, but because we always check the
+    // innermost block first, it ends up evaluating to this: `{ let a; }; var a`.
+    // And now the solution is clear: the `let` goes out of scope before
+    // the var is declared.
+    //
+    // I think this entire system makes no sense, and I would never implement
+    // it this way if it were up to me. However, this is how all js parsers
+    // work, so this is how its implemented.
 
     // Same scope
     check_invalid("let a; var a;");
@@ -249,6 +258,10 @@ fn redeclaration_errors() {
     check_invalid("let a; { let a } { var a }");
     check_valid("var a; { var a } { var a }");
 
+    // Inside a function, everything is simple. The parameters act like `var`
+    // declarations, and they have the same scope as the outermost function
+    // block. Any surrounding variables do not exist when inside a function.
+
     // Function scoping
     check_invalid("function f(a) { let a; }");
     check_valid("function f(a) { var a; }");
@@ -258,9 +271,30 @@ fn redeclaration_errors() {
     check_valid("let a; function f(a) {}");
     check_valid("var a; function f(a) {}");
 
+    check_valid("let a; function f() { var a; }");
+    check_valid("var a; function f() { let a; }");
+    check_valid("let a; function f() { let a; }");
+    check_valid("var a; function f() { var a; }");
+
+    // Functions names are a bit more complex. They have the scope of `let`, but
+    // they can only be redeclared with themselves. So they will conflict with
+    // existing `let` and `var` statements. Once again, innermost blocks are
+    // evaluated first, so `function f() {}; { var f }` is invalid.
+
+    // Function definitions
     check_invalid("let f; function f() {}");
     check_invalid("var f; function f() {}");
     check_invalid("function f() {}; let f");
     check_invalid("function f() {}; var f");
     check_valid("function f() {}; function f() {}");
+
+    check_valid("{ function f() {} }; let f");
+    check_valid("{ function f() {} }; var f");
+    check_valid("let f; { function f() {} }");
+    check_valid("var f; { function f() {} }");
+
+    check_invalid("{ var f }; function f() {}");
+    check_valid("{ let f }; function f() {}");
+    check_invalid("function f() {}; { var f }");
+    check_valid("function f() {}; { let f }");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -248,4 +248,13 @@ fn redeclaration_errors() {
     check_valid("var a; { let a } { var a }");
     check_invalid("let a; { let a } { var a }");
     check_valid("var a; { var a } { var a }");
+
+    // Function scoping
+    check_invalid("function f(a) { let a; }");
+    check_valid("function f(a) { var a; }");
+    check_valid("function f(a) { { let a; } }");
+    check_valid("function f(a) { { var a; } }");
+
+    check_valid("let a; function f(a) {}");
+    check_valid("var a; function f(a) {}");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
     ast::{
-        node::{Declaration, DeclarationList, Node},
+        node::{Block, Declaration, DeclarationList, Node},
         Const,
     },
     parser::tests::{check_invalid, check_parser},
@@ -210,4 +210,32 @@ fn multiple_const_declaration() {
         )
         .into()],
     );
+}
+
+/// Checks for redeclaration errors.
+#[test]
+fn redeclaration_errors() {
+    check_invalid("let a; var a;");
+    check_invalid("let a; let a;");
+    check_invalid("var a; let a;");
+    check_parser(
+        "var a; var a;",
+        vec![
+            DeclarationList::Var(vec![Declaration::new("a", None)].into()).into(),
+            DeclarationList::Var(vec![Declaration::new("a", None)].into()).into(),
+        ],
+    );
+    // Scoping errors
+    check_parser(
+        "{ let a }; var a;",
+        vec![
+            Block::from(vec![DeclarationList::Let(
+                vec![Declaration::new("a", None)].into(),
+            )
+            .into()])
+            .into(),
+            DeclarationList::Var(vec![Declaration::new("a", None)].into()).into(),
+        ],
+    );
+    check_invalid("{ var a }; let a;");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -257,4 +257,7 @@ fn redeclaration_errors() {
 
     check_valid("let a; function f(a) {}");
     check_valid("var a; function f(a) {}");
+
+    check_invalid("let f; function f() {}");
+    check_invalid("var f; function f() {}");
 }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
     ast::{
-        node::{Block, Declaration, DeclarationList, Node},
+        node::{Declaration, DeclarationList, Node},
         Const,
     },
     parser::tests::{check_invalid, check_parser, check_valid},

--- a/boa/src/syntax/parser/statement/expression/mod.rs
+++ b/boa/src/syntax/parser/statement/expression/mod.rs
@@ -2,7 +2,7 @@ use super::super::{expression::Expression, ParseResult};
 use crate::{
     syntax::{
         ast::node::Node,
-        parser::{AllowAwait, AllowYield, Cursor, TokenParser},
+        parser::{AllowAwait, AllowYield, Cursor, DeclaredNames, TokenParser},
     },
     BoaProfiler,
 };
@@ -40,10 +40,10 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, env: &mut DeclaredNames) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("ExpressionStatement", "Parsing");
         // TODO: lookahead
-        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect_semicolon("expression statement")?;
 

--- a/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
@@ -13,7 +13,7 @@ use crate::{
         ast::{node::DoWhileLoop, Keyword, Punctuator},
         parser::{
             expression::Expression, statement::Statement, AllowAwait, AllowReturn, AllowYield,
-            Cursor, ParseError, TokenParser,
+            Cursor, DeclaredNames, ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -61,12 +61,16 @@ where
 {
     type Output = DoWhileLoop;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("DoWhileStatement", "Parsing");
         cursor.expect(Keyword::Do, "do while statement")?;
 
-        let body =
-            Statement::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?;
+        let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+            .parse(cursor, env)?;
 
         let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
 
@@ -82,7 +86,7 @@ where
 
         cursor.expect(Punctuator::OpenParen, "do while statement")?;
 
-        let cond = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let cond = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect(Punctuator::CloseParen, "do while statement")?;
 

--- a/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
@@ -69,6 +69,8 @@ where
         let _timer = BoaProfiler::global().start_event("DoWhileStatement", "Parsing");
         cursor.expect(Keyword::Do, "do while statement")?;
 
+        env.push_stack();
+
         let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
             .parse(cursor, env)?;
 
@@ -98,6 +100,8 @@ where
                 cursor.next()?;
             }
         }
+
+        env.pop_stack()?;
 
         Ok(DoWhileLoop::new(body, cond))
     }

--- a/boa/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/for_statement.rs
@@ -76,6 +76,9 @@ where
         cursor.expect(Keyword::For, "for statement")?;
         cursor.expect(Punctuator::OpenParen, "for statement")?;
 
+        // The init decl is within the scope of the for loop.
+        env.push_stack();
+
         let init = match cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind() {
             TokenKind::Keyword(Keyword::Var) => {
                 let _ = cursor.next()?;
@@ -141,6 +144,8 @@ where
 
         let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
             .parse(cursor, env)?;
+
+        env.pop_stack()?;
 
         // TODO: do not encapsulate the `for` in a block just to have an inner scope.
         Ok(ForLoop::new(init, cond, step, body).into())

--- a/boa/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/while_statement.rs
@@ -3,7 +3,7 @@ use crate::{
         ast::{node::WhileLoop, Keyword, Punctuator},
         parser::{
             expression::Expression, statement::Statement, AllowAwait, AllowReturn, AllowYield,
-            Cursor, ParseError, TokenParser,
+            Cursor, DeclaredNames, ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -52,18 +52,22 @@ where
 {
     type Output = WhileLoop;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("WhileStatement", "Parsing");
         cursor.expect(Keyword::While, "while statement")?;
 
         cursor.expect(Punctuator::OpenParen, "while statement")?;
 
-        let cond = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let cond = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect(Punctuator::CloseParen, "while statement")?;
 
-        let body =
-            Statement::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?;
+        let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+            .parse(cursor, env)?;
 
         Ok(WhileLoop::new(cond, body))
     }

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -278,7 +278,7 @@ where
         let _timer = BoaProfiler::global().start_event("StatementList", "Parsing");
         let mut items = Vec::new();
 
-        env.push_lex_restore();
+        env.push_stack();
         loop {
             match cursor.peek(0)? {
                 Some(token) if self.break_nodes.contains(token.kind()) => break,
@@ -298,9 +298,7 @@ where
             // move the cursor forward for any consecutive semicolon.
             while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
-        // This makes sure that any variable declared with
-        // `let` does not live outside of the StatementList scope.
-        env.pop_lex_restore();
+        env.pop_stack()?;
 
         items.sort_by(Node::hoistable_order);
 

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -278,6 +278,7 @@ where
         let _timer = BoaProfiler::global().start_event("StatementList", "Parsing");
         let mut items = Vec::new();
 
+        env.push_lex_restore();
         loop {
             match cursor.peek(0)? {
                 Some(token) if self.break_nodes.contains(token.kind()) => break,
@@ -297,6 +298,9 @@ where
             // move the cursor forward for any consecutive semicolon.
             while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
+        // This makes sure that any variable declared with
+        // `let` does not live outside of the StatementList scope.
+        env.pop_lex_restore();
 
         // Handle any redeclarations
         // https://tc39.es/ecma262/#sec-block-static-semantics-early-errors

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -278,7 +278,7 @@ where
         let _timer = BoaProfiler::global().start_event("StatementList", "Parsing");
         let mut items = Vec::new();
 
-        env.push_stack();
+        // We don't call `env.push_stack` here, as that should happen in `Block` (that's what usually calls this).
         loop {
             match cursor.peek(0)? {
                 Some(token) if self.break_nodes.contains(token.kind()) => break,
@@ -298,7 +298,6 @@ where
             // move the cursor forward for any consecutive semicolon.
             while cursor.next_if(Punctuator::Semicolon)?.is_some() {}
         }
-        env.pop_stack()?;
 
         items.sort_by(Node::hoistable_order);
 

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -302,64 +302,6 @@ where
         // `let` does not live outside of the StatementList scope.
         env.pop_lex_restore();
 
-        // Handle any redeclarations
-        // https://tc39.es/ecma262/#sec-block-static-semantics-early-errors
-        {
-            let mut lexically_declared_names: HashSet<&str> = HashSet::new();
-            let mut var_declared_names: HashSet<&str> = HashSet::new();
-
-            // TODO: Use more helpful positions in errors when spans are added to Nodes
-            for item in &items {
-                for new_name in item.var_declared_names() {
-                    if lexically_declared_names.contains(new_name) {
-                        return Err(ParseError::lex(LexError::Syntax(
-                            format!("Redeclaration of variable `{}`", new_name).into(),
-                            match cursor.peek(0)? {
-                                Some(token) => token.span().end(),
-                                None => Position::new(1, 1),
-                            },
-                        )));
-                    }
-                    var_declared_names.insert(new_name);
-                }
-                // This is an inline impl of item.lexically_declared_names(). This will be its own function soon.
-                match item {
-                    Node::LetDeclList(decl_list) | Node::ConstDeclList(decl_list) => {
-                        for decl in decl_list.as_ref() {
-                            // if name in VarDeclaredNames or can't be added to
-                            // LexicallyDeclaredNames, raise an error
-                            if var_declared_names.contains(decl.name())
-                                || !lexically_declared_names.insert(decl.name())
-                            {
-                                return Err(ParseError::lex(LexError::Syntax(
-                                    format!("Redeclaration of variable `{}`", decl.name()).into(),
-                                    match cursor.peek(0)? {
-                                        Some(token) => token.span().end(),
-                                        None => Position::new(1, 1),
-                                    },
-                                )));
-                            }
-                        }
-                    }
-                    Node::FunctionDecl(decl) => {
-                        // Function declarations act like `let`
-                        if var_declared_names.contains(decl.name())
-                            || !lexically_declared_names.insert(decl.name())
-                        {
-                            return Err(ParseError::lex(LexError::Syntax(
-                                format!("Redeclaration of variable `{}`", decl.name()).into(),
-                                match cursor.peek(0)? {
-                                    Some(token) => token.span().end(),
-                                    None => Position::new(1, 1),
-                                },
-                            )));
-                        }
-                    }
-                    _ => (),
-                }
-            }
-        }
-
         items.sort_by(Node::hoistable_order);
 
         Ok(items.into())

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -48,7 +48,6 @@ use crate::{
 };
 use labelled_stm::LabelledStatement;
 
-use std::collections::HashSet;
 use std::io::Read;
 
 /// Statement parsing.
@@ -420,7 +419,7 @@ where
     fn parse(
         self,
         cursor: &mut Cursor<R>,
-        env: &mut DeclaredNames,
+        _env: &mut DeclaredNames,
     ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("BindingIdentifier", "Parsing");
 

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -316,6 +316,20 @@ where
                             }
                         }
                     }
+                    Node::FunctionDecl(decl) => {
+                        // Function declarations act like `let`
+                        if var_declared_names.contains(decl.name())
+                            || !lexically_declared_names.insert(decl.name())
+                        {
+                            return Err(ParseError::lex(LexError::Syntax(
+                                format!("Redeclaration of variable `{}`", decl.name()).into(),
+                                match cursor.peek(0)? {
+                                    Some(token) => token.span().end(),
+                                    None => Position::new(1, 1),
+                                },
+                            )));
+                        }
+                    }
                     Node::VarDeclList(decl_list) => {
                         for decl in decl_list.as_ref() {
                             // if name in LexicallyDeclaredNames, raise an error

--- a/boa/src/syntax/parser/statement/return_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/return_stm/mod.rs
@@ -8,7 +8,7 @@ use crate::{
         parser::{
             cursor::{Cursor, SemicolonResult},
             expression::Expression,
-            AllowAwait, AllowYield, ParseError, TokenParser,
+            AllowAwait, AllowYield, DeclaredNames, ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -50,7 +50,11 @@ where
 {
     type Output = Return;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ReturnStatement", "Parsing");
         cursor.expect(Keyword::Return, "return statement")?;
 
@@ -65,7 +69,7 @@ where
             return Ok(Return::new::<Node, Option<_>, Option<_>>(None, None));
         }
 
-        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         cursor.expect_semicolon("return statement")?;
 

--- a/boa/src/syntax/parser/statement/throw/mod.rs
+++ b/boa/src/syntax/parser/statement/throw/mod.rs
@@ -5,7 +5,10 @@ use crate::syntax::lexer::TokenKind;
 use crate::{
     syntax::{
         ast::{node::Throw, Keyword, Punctuator},
-        parser::{expression::Expression, AllowAwait, AllowYield, Cursor, ParseError, TokenParser},
+        parser::{
+            expression::Expression, AllowAwait, AllowYield, Cursor, DeclaredNames, ParseError,
+            TokenParser,
+        },
     },
     BoaProfiler,
 };
@@ -46,13 +49,17 @@ where
 {
     type Output = Throw;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ThrowStatement", "Parsing");
         cursor.expect(Keyword::Throw, "throw statement")?;
 
         cursor.peek_expect_no_lineterminator(0, "throw statement")?;
 
-        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, env)?;
         if let Some(tok) = cursor.peek(0)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                 let _ = cursor.next();

--- a/boa/src/syntax/parser/statement/try_stm/finally.rs
+++ b/boa/src/syntax/parser/statement/try_stm/finally.rs
@@ -2,8 +2,8 @@ use crate::{
     syntax::{
         ast::{node, Keyword},
         parser::{
-            statement::block::Block, AllowAwait, AllowReturn, AllowYield, Cursor, ParseError,
-            TokenParser,
+            statement::block::Block, AllowAwait, AllowReturn, AllowYield, Cursor, DeclaredNames,
+            ParseError, TokenParser,
         },
     },
     BoaProfiler,
@@ -48,12 +48,16 @@ where
 {
     type Output = node::Finally;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        env: &mut DeclaredNames,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Finally", "Parsing");
         cursor.expect(Keyword::Finally, "try statement")?;
         Ok(
             Block::new(self.allow_yield, self.allow_await, self.allow_return)
-                .parse(cursor)?
+                .parse(cursor, env)?
                 .into(),
         )
     }

--- a/boa/src/syntax/parser/statement/variable/mod.rs
+++ b/boa/src/syntax/parser/statement/variable/mod.rs
@@ -197,9 +197,7 @@ where
             None
         };
 
-        env.check_lex_name(&name, pos)?;
-        env.insert_var_name(&name);
-
+        env.insert_var_name(&name, pos)?;
         let decl = Declaration::new(name, init);
         Ok(decl)
     }

--- a/boa/src/syntax/parser/statement/variable/mod.rs
+++ b/boa/src/syntax/parser/statement/variable/mod.rs
@@ -181,6 +181,7 @@ where
     ) -> Result<Self::Output, ParseError> {
         // TODO: BindingPattern
 
+        let pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
         let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, env)?;
 
         let init = if let Some(t) = cursor.peek(0)? {
@@ -195,6 +196,9 @@ where
         } else {
             None
         };
+
+        env.check_lex_name(&name, pos)?;
+        env.insert_var_name(&name);
 
         let decl = Declaration::new(name, init);
         Ok(decl)

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -377,23 +377,23 @@ fn declared_names_test() {
 
     env.insert_var_name("hello", Position::new(1, 1)).unwrap();
     env.insert_var_name("world", Position::new(1, 1)).unwrap();
-    assert_eq!(env.names.lex.len(), 2);
+    assert_eq!(env.names.var.len(), 2);
     env.push_stack();
-    assert_eq!(env.names.lex.len(), 0);
+    assert_eq!(env.names.var.len(), 0);
     env.insert_var_name("second", Position::new(1, 1)).unwrap();
     env.insert_var_name("level", Position::new(1, 1)).unwrap();
-    assert_eq!(env.names.lex.len(), 2);
+    assert_eq!(env.names.var.len(), 2);
     env.push_stack();
-    assert_eq!(env.names.lex.len(), 0);
+    assert_eq!(env.names.var.len(), 0);
 
     assert!(env.pop_stack().is_ok());
-    assert_eq!(env.names.lex.len(), 2);
-    assert!(env.names.lex.contains_key("second"));
-    assert!(env.names.lex.contains_key("level"));
+    assert_eq!(env.names.var.len(), 2);
+    assert!(env.names.var.contains_key("second"));
+    assert!(env.names.var.contains_key("level"));
     assert!(env.pop_stack().is_ok());
-    assert_eq!(env.names.lex.len(), 4);
-    assert!(env.names.lex.contains_key("hello"));
-    assert!(env.names.lex.contains_key("world"));
-    assert!(env.names.lex.contains_key("second"));
-    assert!(env.names.lex.contains_key("level"));
+    assert_eq!(env.names.var.len(), 4);
+    assert!(env.names.var.contains_key("hello"));
+    assert!(env.names.var.contains_key("world"));
+    assert!(env.names.var.contains_key("second"));
+    assert!(env.names.var.contains_key("level"));
 }

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -35,6 +35,12 @@ pub(super) fn check_invalid(js: &str) {
     assert!(Parser::new(js.as_bytes(), false).parse_all().is_err());
 }
 
+/// Checks that the given javascript string does not create a parse error.
+#[track_caller]
+pub(super) fn check_valid(js: &str) {
+    assert!(Parser::new(js.as_bytes(), false).parse_all().is_ok());
+}
+
 /// Should be parsed as `new Class().method()` instead of `new (Class().method())`
 #[test]
 fn check_construct_call_precedence() {

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -353,19 +353,24 @@ fn empty_statement() {
 fn declared_names_test() {
     let mut env = DeclaredNames::default();
 
-    env.push_lex_restore();
     env.insert_lex_name("hello", Position::new(1, 1)).unwrap();
     env.insert_lex_name("world", Position::new(1, 1)).unwrap();
-    env.push_lex_restore();
+    assert_eq!(env.lex.len(), 2);
+    env.push_stack();
+    assert_eq!(env.lex.len(), 0);
     env.insert_lex_name("second", Position::new(1, 1)).unwrap();
     env.insert_lex_name("level", Position::new(1, 1)).unwrap();
-
-    assert_eq!(env.lex.len(), 4);
-
-    assert!(env.pop_lex_restore());
     assert_eq!(env.lex.len(), 2);
-    assert!(env.pop_lex_restore());
+    env.push_stack();
     assert_eq!(env.lex.len(), 0);
-    assert!(!env.pop_lex_restore());
-    assert_eq!(env.lex.len(), 0);
+
+    assert!(env.pop_stack().is_ok());
+    assert_eq!(env.lex.len(), 2);
+    assert!(env.lex.contains_key("second"));
+    assert!(env.lex.contains_key("level"));
+    assert!(env.pop_stack().is_ok());
+    assert_eq!(env.lex.len(), 2);
+    assert!(env.lex.contains_key("hello"));
+    assert!(env.lex.contains_key("world"));
+    // Calling pop again will panic
 }

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -1,13 +1,17 @@
 //! Tests for the parser.
 
-use super::Parser;
-use crate::syntax::ast::{
-    node::{
-        field::GetConstField, ArrowFunctionDecl, Assign, BinOp, Call, Declaration, DeclarationList,
-        FormalParameter, FunctionDecl, Identifier, If, New, Node, Return, StatementList, UnaryOp,
+use super::{DeclaredNames, Parser};
+use crate::syntax::{
+    ast::{
+        node::{
+            field::GetConstField, ArrowFunctionDecl, Assign, BinOp, Call, Declaration,
+            DeclarationList, FormalParameter, FunctionDecl, Identifier, If, New, Node, Return,
+            StatementList, UnaryOp,
+        },
+        op::{self, CompOp, LogOp, NumOp},
+        Const,
     },
-    op::{self, CompOp, LogOp, NumOp},
-    Const,
+    lexer::Position,
 };
 
 /// Checks that the given JavaScript string gives the expected expression.
@@ -337,4 +341,25 @@ fn empty_statement() {
             )),
         ],
     );
+}
+
+#[test]
+fn declared_names_test() {
+    let mut env = DeclaredNames::default();
+
+    env.push_lex_restore();
+    env.insert_lex_name("hello", Position::new(1, 1)).unwrap();
+    env.insert_lex_name("world", Position::new(1, 1)).unwrap();
+    env.push_lex_restore();
+    env.insert_lex_name("second", Position::new(1, 1)).unwrap();
+    env.insert_lex_name("level", Position::new(1, 1)).unwrap();
+
+    assert_eq!(env.lex.len(), 4);
+
+    assert!(env.pop_lex_restore());
+    assert_eq!(env.lex.len(), 2);
+    assert!(env.pop_lex_restore());
+    assert_eq!(env.lex.len(), 0);
+    assert!(!env.pop_lex_restore());
+    assert_eq!(env.lex.len(), 0);
 }

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -355,22 +355,45 @@ fn declared_names_test() {
 
     env.insert_lex_name("hello", Position::new(1, 1)).unwrap();
     env.insert_lex_name("world", Position::new(1, 1)).unwrap();
-    assert_eq!(env.lex.len(), 2);
+    assert_eq!(env.names.lex.len(), 2);
     env.push_stack();
-    assert_eq!(env.lex.len(), 0);
+    assert_eq!(env.names.lex.len(), 0);
     env.insert_lex_name("second", Position::new(1, 1)).unwrap();
     env.insert_lex_name("level", Position::new(1, 1)).unwrap();
-    assert_eq!(env.lex.len(), 2);
+    assert_eq!(env.names.lex.len(), 2);
     env.push_stack();
-    assert_eq!(env.lex.len(), 0);
+    assert_eq!(env.names.lex.len(), 0);
 
     assert!(env.pop_stack().is_ok());
-    assert_eq!(env.lex.len(), 2);
-    assert!(env.lex.contains_key("second"));
-    assert!(env.lex.contains_key("level"));
+    assert_eq!(env.names.lex.len(), 2);
+    assert!(env.names.lex.contains_key("second"));
+    assert!(env.names.lex.contains_key("level"));
     assert!(env.pop_stack().is_ok());
-    assert_eq!(env.lex.len(), 2);
-    assert!(env.lex.contains_key("hello"));
-    assert!(env.lex.contains_key("world"));
+    assert_eq!(env.names.lex.len(), 2);
+    assert!(env.names.lex.contains_key("hello"));
+    assert!(env.names.lex.contains_key("world"));
     // Calling pop again will panic
+    let mut env = DeclaredNames::default();
+
+    env.insert_var_name("hello", Position::new(1, 1)).unwrap();
+    env.insert_var_name("world", Position::new(1, 1)).unwrap();
+    assert_eq!(env.names.lex.len(), 2);
+    env.push_stack();
+    assert_eq!(env.names.lex.len(), 0);
+    env.insert_var_name("second", Position::new(1, 1)).unwrap();
+    env.insert_var_name("level", Position::new(1, 1)).unwrap();
+    assert_eq!(env.names.lex.len(), 2);
+    env.push_stack();
+    assert_eq!(env.names.lex.len(), 0);
+
+    assert!(env.pop_stack().is_ok());
+    assert_eq!(env.names.lex.len(), 2);
+    assert!(env.names.lex.contains_key("second"));
+    assert!(env.names.lex.contains_key("level"));
+    assert!(env.pop_stack().is_ok());
+    assert_eq!(env.names.lex.len(), 4);
+    assert!(env.names.lex.contains_key("hello"));
+    assert!(env.names.lex.contains_key("world"));
+    assert!(env.names.lex.contains_key("second"));
+    assert!(env.names.lex.contains_key("level"));
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Currently, lexically declared names are only partially implemented. During parsing, anything declared with `var`, `let`, `function`, or `class`, should be added to a set of `var_declared_names` and/or `lexically_declared_names`. Currently, there is a simple implementation in the [statement list](https://github.com/boa-dev/boa/blob/e5dc8fc6792dee23dc8fb92cab2cdb8e968a49d8/boa/src/syntax/parser/statement/mod.rs#L293) parser, but this does not handle things like outer scoped variables and nested scope variables.

This PR will fix the above issues by changing the following:
- It will add functions to `Node`, which will be able to generate [lexically declared names](https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames) and [var declared names](https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames) according to the spec.
  - These functions will not end up being used at all. The `var` function recursively iterates through all children nodes, which causes O(n!) or something like that with lots of nested blocks (because for each outer block, you need to loop through all the inner ones again). This function will most likely just be used for checking if things like `arguments` is within a `Node`.
- This adds a new type called `DeclaredNames`, which is the var declared names and lexically declared names. It will be passed as a new argument to `TokenParser`, and is meant to be used like how the [spec](https://tc39.es/ecma262/#sec-block-runtime-semantics-evaluation) uses a lexical environment. This new type will only be used at parsing time, and will never be stored in any `Node` fields.
  - This is the fix to the recursion problem. For every node that is parsed, it will edit the environment depending on what type of node it is. So `VarDeclList` nodes will add all the names they encounter into the environment, while `StatementList` will look at all of those names after parsing all the nested nodes. This will allow the entire system to be fast, and not rely on many levels of recursion.
  - Also, I don't know if this is a very good name. The parameter name is `env`, so I was thinking it should be called `LexicalEnvironment` instead, but that is already used somewhere else. This type should be used to store any state information that the parser will need.
- Most of the [redeclaration](https://github.com/tc39/test262/tree/main/test/language/block-scope/syntax/redeclaration) tests should pass after this, and everything will be great, and all the problems will be solved.