### PR TITLE
Implement switch statement for vm

### DIFF
--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -92,6 +92,8 @@ impl CodeBlock {
             | Opcode::Jump
             | Opcode::JumpIfFalse
             | Opcode::JumpIfTrue
+            | Opcode::Case
+            | Opcode::Default
             | Opcode::LogicalAnd
             | Opcode::LogicalOr
             | Opcode::Coalesce => {

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -59,6 +59,7 @@ impl<'a> Vm<'a> {
     ///
     /// If there is nothing to pop, then this will panic.
     #[inline]
+    #[track_caller]
     pub fn pop(&mut self) -> Value {
         self.stack.pop().unwrap()
     }
@@ -422,6 +423,22 @@ impl<'a> Vm<'a> {
             Opcode::This => {
                 let this = self.context.get_this_binding()?;
                 self.push(this);
+            }
+            Opcode::Case => {
+                let address = self.read::<u32>();
+                let cond = self.pop();
+                let value = self.pop();
+
+                if !value.strict_equals(&cond) {
+                    self.push(value);
+                } else {
+                    self.pc = address as usize;
+                }
+            }
+            Opcode::Default => {
+                let exit = self.read::<u32>();
+                let _ = self.pop();
+                self.pc = exit as usize;
             }
         }
 

--- a/boa/src/vm/opcode.rs
+++ b/boa/src/vm/opcode.rs
@@ -496,7 +496,7 @@ pub enum Opcode {
     ///
     /// Operands: address: `u32`
     ///
-    /// Stack: `value`, `cond` **=>** `cond` (if `cond === value`).
+    /// Stack: `value`, `cond` **=>** `cond` (if `cond !== value`).
     Case,
 
     /// Pops the top of stack and jump to address.

--- a/boa/src/vm/opcode.rs
+++ b/boa/src/vm/opcode.rs
@@ -137,7 +137,7 @@ pub enum Opcode {
     ///
     /// Operands: n: `u32`
     ///
-    /// Stack: v1, v1, ... vn **=>** [v1, v2, ..., vn]    
+    /// Stack: v1, v1, ... vn **=>** [v1, v2, ..., vn]
     PushNewArray,
 
     /// Binary `+` operator.
@@ -235,7 +235,7 @@ pub enum Opcode {
     ///
     /// Operands:
     ///
-    /// Stack: lhs, rhs **=>** (lhs `in` rhs)    
+    /// Stack: lhs, rhs **=>** (lhs `in` rhs)
     In,
 
     /// Binary `==` operator.
@@ -491,6 +491,21 @@ pub enum Opcode {
     /// Stack: **=>** `this`
     This,
 
+    /// Pop the two values of the stack, strict equal compares the two values,
+    /// if true jumps to address, otherwise push the second poped value.
+    ///
+    /// Operands: address: `u32`
+    ///
+    /// Stack: `value`, `cond` **=>** `cond` (if `cond === value`).
+    Case,
+
+    /// Pops the top of stack and jump to address.
+    ///
+    /// Operands: address: `u32`
+    ///
+    /// Stack: `value` **=>**
+    Default,
+
     /// No-operation instruction, does nothing.
     ///
     /// Operands:
@@ -579,6 +594,8 @@ impl Opcode {
             Opcode::Throw => "Throw",
             Opcode::ToBoolean => "ToBoolean",
             Opcode::This => "This",
+            Opcode::Case => "Case",
+            Opcode::Default => "Default",
             Opcode::Nop => "Nop",
         }
     }


### PR DESCRIPTION
It changes the following:
- Implement switch statement with break support.
- Remove `_to_bytes()` free function, use `.to_ne_bytes()` instead.
- Fix use_expr bug for operator assign.
