### PR TITLE
Lazy computed JsString hashes

### DIFF
--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -487,7 +487,7 @@ impl Console {
             None => "default".into(),
         };
 
-        if let Some(t) = context.console_mut().timer_map.remove(label.as_str()) {
+        if let Some(t) = context.console_mut().timer_map.remove(&label) {
             let time = Self::system_time_in_ms();
             logger(
                 LogMessage::Info(format!("{}: {} ms - timer removed", label, time - t)),

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -126,7 +126,7 @@ impl Function {
         // Create binding
         local_env
             // Function parameters can share names in JavaScript...
-            .create_mutable_binding(param.name().to_owned(), false, true, context)
+            .create_mutable_binding(param.name().clone(), false, true, context)
             .expect("Failed to create binding for rest param");
 
         // Set Binding to value
@@ -145,7 +145,7 @@ impl Function {
     ) {
         // Create binding
         local_env
-            .create_mutable_binding(param.name().to_owned(), false, true, context)
+            .create_mutable_binding(param.name().clone(), false, true, context)
             .expect("Failed to create binding");
 
         // Set Binding to value

--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -106,14 +106,14 @@ impl ByteCompiler {
     }
 
     #[inline]
-    fn get_or_insert_name(&mut self, name: JsString) -> u32 {
-        if let Some(index) = self.names_map.get(&name) {
+    fn get_or_insert_name(&mut self, name: &JsString) -> u32 {
+        if let Some(index) = self.names_map.get(name) {
             return *index;
         }
 
         let index = self.code_block.names.len() as u32;
         self.code_block.names.push(name.clone());
-        self.names_map.insert(name, index);
+        self.names_map.insert(name.clone(), index);
         index
     }
 
@@ -282,11 +282,11 @@ impl ByteCompiler {
     fn access_get(&mut self, access: Access<'_>, use_expr: bool) {
         match access {
             Access::Variable { name } => {
-                let index = self.get_or_insert_name(name.as_ref().into());
+                let index = self.get_or_insert_name(name.as_ref());
                 self.emit(Opcode::GetName, &[index]);
             }
             Access::ByName { node } => {
-                let index = self.get_or_insert_name(node.field().into());
+                let index = self.get_or_insert_name(&node.field());
                 self.compile_expr(node.obj(), true);
                 self.emit(Opcode::GetPropertyByName, &[index]);
             }
@@ -317,12 +317,12 @@ impl ByteCompiler {
 
         match access {
             Access::Variable { name } => {
-                let index = self.get_or_insert_name(name.as_ref().into());
+                let index = self.get_or_insert_name(name.as_ref());
                 self.emit(Opcode::SetName, &[index]);
             }
             Access::ByName { node } => {
                 self.compile_expr(node.obj(), true);
-                let index = self.get_or_insert_name(node.field().into());
+                let index = self.get_or_insert_name(&node.field());
                 self.emit(Opcode::SetPropertyByName, &[index]);
             }
             Access::ByValue { node } => {
@@ -575,7 +575,7 @@ impl ByteCompiler {
         match node {
             Node::VarDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name().into());
+                    let index = self.get_or_insert_name(decl.name());
                     self.emit(Opcode::DefVar, &[index]);
 
                     if let Some(expr) = decl.init() {
@@ -586,7 +586,7 @@ impl ByteCompiler {
             }
             Node::LetDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name().into());
+                    let index = self.get_or_insert_name(decl.name());
                     self.emit(Opcode::DefLet, &[index]);
 
                     if let Some(expr) = decl.init() {
@@ -597,7 +597,7 @@ impl ByteCompiler {
             }
             Node::ConstDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name().into());
+                    let index = self.get_or_insert_name(decl.name());
                     self.emit(Opcode::DefConst, &[index]);
 
                     if let Some(expr) = decl.init() {

--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -106,12 +106,11 @@ impl ByteCompiler {
     }
 
     #[inline]
-    fn get_or_insert_name(&mut self, name: &str) -> u32 {
-        if let Some(index) = self.names_map.get(name) {
+    fn get_or_insert_name(&mut self, name: JsString) -> u32 {
+        if let Some(index) = self.names_map.get(&name) {
             return *index;
         }
 
-        let name = JsString::new(name);
         let index = self.code_block.names.len() as u32;
         self.code_block.names.push(name.clone());
         self.names_map.insert(name, index);
@@ -283,11 +282,11 @@ impl ByteCompiler {
     fn access_get(&mut self, access: Access<'_>, use_expr: bool) {
         match access {
             Access::Variable { name } => {
-                let index = self.get_or_insert_name(name.as_ref());
+                let index = self.get_or_insert_name(name.as_ref().into());
                 self.emit(Opcode::GetName, &[index]);
             }
             Access::ByName { node } => {
-                let index = self.get_or_insert_name(node.field());
+                let index = self.get_or_insert_name(node.field().into());
                 self.compile_expr(node.obj(), true);
                 self.emit(Opcode::GetPropertyByName, &[index]);
             }
@@ -318,12 +317,12 @@ impl ByteCompiler {
 
         match access {
             Access::Variable { name } => {
-                let index = self.get_or_insert_name(name.as_ref());
+                let index = self.get_or_insert_name(name.as_ref().into());
                 self.emit(Opcode::SetName, &[index]);
             }
             Access::ByName { node } => {
                 self.compile_expr(node.obj(), true);
-                let index = self.get_or_insert_name(node.field());
+                let index = self.get_or_insert_name(node.field().into());
                 self.emit(Opcode::SetPropertyByName, &[index]);
             }
             Access::ByValue { node } => {
@@ -576,7 +575,7 @@ impl ByteCompiler {
         match node {
             Node::VarDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name());
+                    let index = self.get_or_insert_name(decl.name().into());
                     self.emit(Opcode::DefVar, &[index]);
 
                     if let Some(expr) = decl.init() {
@@ -587,7 +586,7 @@ impl ByteCompiler {
             }
             Node::LetDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name());
+                    let index = self.get_or_insert_name(decl.name().into());
                     self.emit(Opcode::DefLet, &[index]);
 
                     if let Some(expr) = decl.init() {
@@ -598,7 +597,7 @@ impl ByteCompiler {
             }
             Node::ConstDeclList(list) => {
                 for decl in list.as_ref() {
-                    let index = self.get_or_insert_name(decl.name());
+                    let index = self.get_or_insert_name(decl.name().into());
                     self.emit(Opcode::DefConst, &[index]);
 
                     if let Some(expr) = decl.init() {

--- a/boa/src/environment/environment_record_trait.rs
+++ b/boa/src/environment/environment_record_trait.rs
@@ -9,6 +9,7 @@
 //! There are 5 Environment record kinds. They all have methods in common, these are implemented as a the `EnvironmentRecordTrait`
 //!
 
+use crate::JsString;
 use crate::{environment::lexical_environment::VariableScope, object::GcObject};
 use crate::{
     environment::lexical_environment::{Environment, EnvironmentType},
@@ -24,7 +25,7 @@ use std::fmt::Debug;
 pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Determine if an Environment Record has a binding for the String value N.
     /// Return true if it does and false if it does not.
-    fn has_binding(&self, name: &str) -> bool;
+    fn has_binding(&self, name: &JsString) -> bool;
 
     /// Create a new but uninitialized mutable binding in an Environment Record. The String value N is the text of the bound name.
     /// If the Boolean argument deletion is true the binding may be subsequently deleted.
@@ -35,7 +36,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// paraments with the same name.
     fn create_mutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         allow_name_reuse: bool,
         context: &mut Context,
@@ -47,7 +48,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// regardless of the strict mode setting of operations that reference that binding.
     fn create_immutable_binding(
         &self,
-        name: String,
+        name: JsString,
         strict: bool,
         context: &mut Context,
     ) -> Result<()>;
@@ -55,7 +56,12 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Set the value of an already existing but uninitialized binding in an Environment Record.
     /// The String value N is the text of the bound name.
     /// V is the value for the binding and is a value of any ECMAScript language type.
-    fn initialize_binding(&self, name: &str, value: Value, context: &mut Context) -> Result<()>;
+    fn initialize_binding(
+        &self,
+        name: &JsString,
+        value: Value,
+        context: &mut Context,
+    ) -> Result<()>;
 
     /// Set the value of an already existing mutable binding in an Environment Record.
     /// The String value `name` is the text of the bound name.
@@ -63,7 +69,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// If `strict` is true and the binding cannot be set throw a TypeError exception.
     fn set_mutable_binding(
         &self,
-        name: &str,
+        name: &JsString,
         value: Value,
         strict: bool,
         context: &mut Context,
@@ -73,13 +79,18 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// The String value N is the text of the bound name.
     /// S is used to identify references originating in strict mode code or that
     /// otherwise require strict mode reference semantics.
-    fn get_binding_value(&self, name: &str, strict: bool, context: &mut Context) -> Result<Value>;
+    fn get_binding_value(
+        &self,
+        name: &JsString,
+        strict: bool,
+        context: &mut Context,
+    ) -> Result<Value>;
 
     /// Delete a binding from an Environment Record.
     /// The String value name is the text of the bound name.
     /// If a binding for name exists, remove the binding and return true.
     /// If the binding exists but cannot be removed return false. If the binding does not exist return true.
-    fn delete_binding(&self, name: &str) -> bool;
+    fn delete_binding(&self, name: &JsString) -> bool;
 
     /// Determine if an Environment Record establishes a this binding.
     /// Return true if it does and false if it does not.
@@ -123,7 +134,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Create mutable binding while handling outer environments
     fn recursive_create_mutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         scope: VariableScope,
         context: &mut Context,
@@ -140,7 +151,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Create immutable binding while handling outer environments
     fn recursive_create_immutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         scope: VariableScope,
         context: &mut Context,
@@ -157,7 +168,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Set mutable binding while handling outer environments
     fn recursive_set_mutable_binding(
         &self,
-        name: &str,
+        name: &JsString,
         value: Value,
         strict: bool,
         context: &mut Context,
@@ -174,7 +185,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     /// Initialize binding while handling outer environments
     fn recursive_initialize_binding(
         &self,
-        name: &str,
+        name: &JsString,
         value: Value,
         context: &mut Context,
     ) -> Result<()> {
@@ -188,7 +199,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     }
 
     /// Check if a binding exists in current or any outer environment
-    fn recursive_has_binding(&self, name: &str) -> bool {
+    fn recursive_has_binding(&self, name: &JsString) -> bool {
         self.has_binding(name)
             || match self.get_outer_environment_ref() {
                 Some(outer) => outer.recursive_has_binding(name),
@@ -197,7 +208,7 @@ pub trait EnvironmentRecordTrait: Debug + Trace + Finalize {
     }
 
     /// Retrieve binding from current or any outer environment
-    fn recursive_get_binding_value(&self, name: &str, context: &mut Context) -> Result<Value> {
+    fn recursive_get_binding_value(&self, name: &JsString, context: &mut Context) -> Result<Value> {
         if self.has_binding(name) {
             self.get_binding_value(name, false, context)
         } else {

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     gc::{empty_trace, Finalize, Trace},
     object::GcObject,
-    Context, Result, Value,
+    Context, JsString, Result, Value,
 };
 
 /// Different binding status for `this`.
@@ -113,13 +113,13 @@ impl FunctionEnvironmentRecord {
 }
 
 impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
-    fn has_binding(&self, name: &str) -> bool {
+    fn has_binding(&self, name: &JsString) -> bool {
         self.declarative_record.has_binding(name)
     }
 
     fn create_mutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         allow_name_reuse: bool,
         context: &mut Context,
@@ -130,7 +130,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn create_immutable_binding(
         &self,
-        name: String,
+        name: JsString,
         strict: bool,
         context: &mut Context,
     ) -> Result<()> {
@@ -138,14 +138,19 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
             .create_immutable_binding(name, strict, context)
     }
 
-    fn initialize_binding(&self, name: &str, value: Value, context: &mut Context) -> Result<()> {
+    fn initialize_binding(
+        &self,
+        name: &JsString,
+        value: Value,
+        context: &mut Context,
+    ) -> Result<()> {
         self.declarative_record
             .initialize_binding(name, value, context)
     }
 
     fn set_mutable_binding(
         &self,
-        name: &str,
+        name: &JsString,
         value: Value,
         strict: bool,
         context: &mut Context,
@@ -154,12 +159,17 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
             .set_mutable_binding(name, value, strict, context)
     }
 
-    fn get_binding_value(&self, name: &str, strict: bool, context: &mut Context) -> Result<Value> {
+    fn get_binding_value(
+        &self,
+        name: &JsString,
+        strict: bool,
+        context: &mut Context,
+    ) -> Result<Value> {
         self.declarative_record
             .get_binding_value(name, strict, context)
     }
 
-    fn delete_binding(&self, name: &str) -> bool {
+    fn delete_binding(&self, name: &JsString) -> bool {
         self.declarative_record.delete_binding(name)
     }
 
@@ -205,7 +215,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn recursive_create_mutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         _scope: VariableScope,
         context: &mut Context,
@@ -215,7 +225,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn recursive_create_immutable_binding(
         &self,
-        name: String,
+        name: JsString,
         deletion: bool,
         _scope: VariableScope,
         context: &mut Context,

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -8,7 +8,7 @@
 use super::global_environment_record::GlobalEnvironmentRecord;
 use crate::{
     environment::environment_record_trait::EnvironmentRecordTrait, object::GcObject, BoaProfiler,
-    Context, Result, Value,
+    Context, JsString, Result, Value,
 };
 use gc::Gc;
 use std::{collections::VecDeque, error, fmt};
@@ -95,7 +95,7 @@ impl Context {
 
     pub(crate) fn create_mutable_binding(
         &mut self,
-        name: String,
+        name: JsString,
         deletion: bool,
         scope: VariableScope,
     ) -> Result<()> {
@@ -105,7 +105,7 @@ impl Context {
 
     pub(crate) fn create_immutable_binding(
         &mut self,
-        name: String,
+        name: JsString,
         deletion: bool,
         scope: VariableScope,
     ) -> Result<()> {
@@ -115,7 +115,7 @@ impl Context {
 
     pub(crate) fn set_mutable_binding(
         &mut self,
-        name: &str,
+        name: &JsString,
         value: Value,
         strict: bool,
     ) -> Result<()> {
@@ -123,7 +123,7 @@ impl Context {
             .recursive_set_mutable_binding(name, value, strict, self)
     }
 
-    pub(crate) fn initialize_binding(&mut self, name: &str, value: Value) -> Result<()> {
+    pub(crate) fn initialize_binding(&mut self, name: &JsString, value: Value) -> Result<()> {
         self.get_current_environment()
             .recursive_initialize_binding(name, value, self)
     }
@@ -139,11 +139,11 @@ impl Context {
             .clone()
     }
 
-    pub(crate) fn has_binding(&mut self, name: &str) -> bool {
+    pub(crate) fn has_binding(&mut self, name: &JsString) -> bool {
         self.get_current_environment().recursive_has_binding(name)
     }
 
-    pub(crate) fn get_binding_value(&mut self, name: &str) -> Result<Value> {
+    pub(crate) fn get_binding_value(&mut self, name: &JsString) -> Result<Value> {
         self.get_current_environment()
             .recursive_get_binding_value(name, self)
     }

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -17,7 +17,7 @@ use crate::{
     symbol::WellKnownSymbols,
     syntax::ast::node::RcStatementList,
     value::PreferredType,
-    Context, Executable, Result, Value,
+    Context, Executable, JsString, Result, Value,
 };
 use gc::{Finalize, Gc, GcCell, GcCellRef, GcCellRefMut, Trace};
 use serde_json::{map::Map, Value as JSONValue};
@@ -217,18 +217,26 @@ impl GcObject {
                         if !flags.is_lexical_this_mode()
                             && !arguments_in_parameter_names
                             && (has_parameter_expressions
-                                || (!body.lexically_declared_names().contains("arguments")
-                                    && !body.function_declared_names().contains("arguments")))
+                                || (!body
+                                    .lexically_declared_names()
+                                    .contains(&JsString::new("arguments"))
+                                    && !body
+                                        .function_declared_names()
+                                        .contains(&JsString::new("arguments"))))
                         {
                             // Add arguments object
                             let arguments_obj = create_unmapped_arguments_object(args);
                             local_env.create_mutable_binding(
-                                "arguments".to_string(),
+                                "arguments".into(),
                                 false,
                                 true,
                                 context,
                             )?;
-                            local_env.initialize_binding("arguments", arguments_obj, context)?;
+                            local_env.initialize_binding(
+                                &"arguments".into(),
+                                arguments_obj,
+                                context,
+                            )?;
                         }
 
                         // Turn local_env into Environment so it can be cloned

--- a/boa/src/string.rs
+++ b/boa/src/string.rs
@@ -2,12 +2,13 @@ use crate::gc::{empty_trace, Finalize, Trace};
 use std::{
     alloc::{alloc, dealloc, Layout},
     cell::Cell,
-    collections::hash_map::DefaultHasher,
     hash::{Hash, Hasher},
     marker::PhantomData,
     ops::Deref,
     ptr::{copy_nonoverlapping, NonNull},
 };
+
+use rustc_hash::FxHasher;
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
@@ -221,7 +222,7 @@ impl JsString {
             hash
         } else {
             let hash = {
-                let mut hasher = DefaultHasher::new();
+                let mut hasher = FxHasher::default();
                 this.as_str().hash(&mut hasher);
                 hasher.finish()
             };
@@ -396,6 +397,8 @@ mod tests {
     use super::JsString;
     use std::mem::size_of;
 
+    use rustc_hash::FxHasher;
+
     #[test]
     fn empty() {
         let _ = JsString::new("");
@@ -453,7 +456,6 @@ mod tests {
 
     #[test]
     fn hash() {
-        use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
         let s = "Hello, world!";
@@ -463,7 +465,7 @@ mod tests {
 
         assert!(!JsString::has_hash(&x));
 
-        let mut hasher = DefaultHasher::new();
+        let mut hasher = FxHasher::default();
         s.hash(&mut hasher);
         let s_hash = hasher.finish();
 

--- a/boa/src/string.rs
+++ b/boa/src/string.rs
@@ -9,6 +9,9 @@ use std::{
     ptr::{copy_nonoverlapping, NonNull},
 };
 
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
+
 /// The inner representation of a [`JsString`].
 #[repr(C)]
 struct Inner {
@@ -132,6 +135,26 @@ impl Default for JsString {
     #[inline]
     fn default() -> Self {
         Self::new("")
+    }
+}
+
+#[cfg(feature = "deser")]
+impl Serialize for JsString {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.as_str().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "deser")]
+impl<'de> Deserialize<'de> for JsString {
+    fn deserialize<D>(_deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        todo!()
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::{join_nodes, Identifier, Node},
-    Context, Result, Value,
+    Context, JsString, Result, Value,
 };
 use std::fmt;
 
@@ -110,17 +110,17 @@ impl Executable for DeclarationList {
 
             match &self {
                 Const(_) => context.create_immutable_binding(
-                    decl.name().to_owned(),
+                    decl.name().clone(),
                     false,
                     VariableScope::Block,
                 )?,
                 Let(_) => context.create_mutable_binding(
-                    decl.name().to_owned(),
+                    decl.name().clone(),
                     false,
                     VariableScope::Block,
                 )?,
                 Var(_) => context.create_mutable_binding(
-                    decl.name().to_owned(),
+                    decl.name().clone(),
                     false,
                     VariableScope::Function,
                 )?,
@@ -220,7 +220,7 @@ impl Declaration {
     }
 
     /// Gets the name of the variable.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &JsString {
         self.name.as_ref()
     }
 

--- a/boa/src/syntax/ast/node/field/get_const_field/mod.rs
+++ b/boa/src/syntax/ast/node/field/get_const_field/mod.rs
@@ -2,8 +2,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::Node,
-    value::{Type, Value},
-    Context, Result,
+    Context, JsString, Result, Value,
 };
 use std::fmt;
 
@@ -35,7 +34,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct GetConstField {
     obj: Box<Node>,
-    field: Box<str>,
+    field: JsString,
 }
 
 impl GetConstField {
@@ -43,7 +42,7 @@ impl GetConstField {
     pub fn new<V, L>(value: V, label: L) -> Self
     where
         V: Into<Node>,
-        L: Into<Box<str>>,
+        L: Into<JsString>,
     {
         Self {
             obj: Box::new(value.into()),
@@ -57,15 +56,15 @@ impl GetConstField {
     }
 
     /// Gets the name of the field to retrieve.
-    pub fn field(&self) -> &str {
-        &self.field
+    pub fn field(&self) -> JsString {
+        self.field.clone()
     }
 }
 
 impl Executable for GetConstField {
     fn run(&self, context: &mut Context) -> Result<Value> {
         let mut obj = self.obj().run(context)?;
-        if obj.get_type() != Type::Object {
+        if !obj.is_object() {
             obj = Value::Object(obj.to_object(context)?);
         }
 

--- a/boa/src/syntax/ast/node/field/get_field/mod.rs
+++ b/boa/src/syntax/ast/node/field/get_field/mod.rs
@@ -2,8 +2,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::Node,
-    value::{Type, Value},
-    Context, Result,
+    Context, Result, Value,
 };
 use std::fmt;
 
@@ -64,7 +63,7 @@ impl GetField {
 impl Executable for GetField {
     fn run(&self, context: &mut Context) -> Result<Value> {
         let mut obj = self.obj().run(context)?;
-        if obj.get_type() != Type::Object {
+        if !obj.is_object() {
             obj = Value::Object(obj.to_object(context)?);
         }
         let field = self.field().run(context)?;

--- a/boa/src/syntax/ast/node/identifier/mod.rs
+++ b/boa/src/syntax/ast/node/identifier/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::Node,
-    BoaProfiler, Context, Result, Value,
+    BoaProfiler, Context, JsString, Result, Value,
 };
 use std::fmt;
 
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "deser", serde(transparent))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct Identifier {
-    ident: Box<str>,
+    ident: JsString,
 }
 
 impl Executable for Identifier {
@@ -46,15 +46,15 @@ impl fmt::Display for Identifier {
     }
 }
 
-impl AsRef<str> for Identifier {
-    fn as_ref(&self) -> &str {
+impl AsRef<JsString> for Identifier {
+    fn as_ref(&self) -> &JsString {
         &self.ident
     }
 }
 
 impl<T> From<T> for Identifier
 where
-    T: Into<Box<str>>,
+    T: Into<JsString>,
 {
     fn from(stm: T) -> Self {
         Self { ident: stm.into() }

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -115,7 +115,7 @@ impl Executable for ForInLoop {
                         context.set_mutable_binding(name.as_ref(), next_result.clone(), true)?;
                     } else {
                         context.create_mutable_binding(
-                            name.as_ref().to_owned(),
+                            name.as_ref().clone(),
                             true,
                             VariableScope::Function,
                         )?;
@@ -132,7 +132,7 @@ impl Executable for ForInLoop {
                             context.set_mutable_binding(var.name(), next_result, true)?;
                         } else {
                             context.create_mutable_binding(
-                                var.name().to_owned(),
+                                var.name().clone(),
                                 false,
                                 VariableScope::Function,
                             )?;

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -50,7 +50,7 @@ use super::Const;
 use crate::{
     exec::Executable,
     gc::{empty_trace, Finalize, Trace},
-    BoaProfiler, Context, Result, Value,
+    BoaProfiler, Context, JsString, Result, Value,
 };
 use std::{
     cmp::Ordering,
@@ -401,7 +401,7 @@ where
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Trace, Finalize)]
 pub struct FormalParameter {
-    name: Box<str>,
+    name: JsString,
     init: Option<Node>,
     is_rest_param: bool,
 }
@@ -410,7 +410,7 @@ impl FormalParameter {
     /// Creates a new formal parameter.
     pub(in crate::syntax) fn new<N>(name: N, init: Option<Node>, is_rest_param: bool) -> Self
     where
-        N: Into<Box<str>>,
+        N: Into<JsString>,
     {
         Self {
             name: name.into(),
@@ -420,7 +420,7 @@ impl FormalParameter {
     }
 
     /// Gets the name of the formal parameter.
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &JsString {
         &self.name
     }
 

--- a/boa/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa/src/syntax/ast/node/statement_list/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     exec::{Executable, InterpreterState},
     gc::{empty_trace, Finalize, Trace},
     syntax::ast::node::Node,
-    BoaProfiler, Context, Result, Value,
+    BoaProfiler, Context, JsString, Result, Value,
 };
 use std::{collections::HashSet, fmt, ops::Deref, rc::Rc};
 
@@ -52,7 +52,7 @@ impl StatementList {
         Ok(())
     }
 
-    pub fn lexically_declared_names(&self) -> HashSet<&str> {
+    pub fn lexically_declared_names(&self) -> HashSet<&JsString> {
         let mut set = HashSet::new();
         for stmt in self.items() {
             if let Node::LetDeclList(decl_list) | Node::ConstDeclList(decl_list) = stmt {
@@ -68,7 +68,7 @@ impl StatementList {
         set
     }
 
-    pub fn function_declared_names(&self) -> HashSet<&str> {
+    pub fn function_declared_names(&self) -> HashSet<&JsString> {
         let mut set = HashSet::new();
         for stmt in self.items() {
             if let Node::FunctionDecl(decl) = stmt {
@@ -78,7 +78,7 @@ impl StatementList {
         set
     }
 
-    pub fn var_declared_names(&self) -> HashSet<&str> {
+    pub fn var_declared_names(&self) -> HashSet<&JsString> {
         let mut set = HashSet::new();
         for stmt in self.items() {
             if let Node::VarDeclList(decl_list) = stmt {

--- a/boa/src/syntax/ast/node/try_node/mod.rs
+++ b/boa/src/syntax/ast/node/try_node/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     exec::Executable,
     gc::{Finalize, Trace},
     syntax::ast::node::{Block, Identifier, Node},
-    BoaProfiler, Context, Result, Value,
+    BoaProfiler, Context, JsString, Result, Value,
 };
 use std::fmt;
 
@@ -106,7 +106,7 @@ impl Executable for Try {
 
                         if let Some(param) = catch.parameter() {
                             context.create_mutable_binding(
-                                param.to_owned(),
+                                param.clone(),
                                 false,
                                 VariableScope::Block,
                             )?;
@@ -170,7 +170,7 @@ impl Catch {
     }
 
     /// Gets the parameter of the catch block.
-    pub fn parameter(&self) -> Option<&str> {
+    pub fn parameter(&self) -> Option<&JsString> {
         self.parameter.as_ref().map(Identifier::as_ref)
     }
 

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -86,7 +86,7 @@ where
                 return Err(ParseError::general("duplicate parameter name", position));
             }
 
-            param_names.insert(Box::from(next_param.name()));
+            param_names.insert(next_param.name().clone());
             params.push(next_param);
 
             if cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind()

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -293,8 +293,8 @@ where
         // Handle any redeclarations
         // https://tc39.es/ecma262/#sec-block-static-semantics-early-errors
         {
-            let mut lexically_declared_names: HashSet<&str> = HashSet::new();
-            let mut var_declared_names: HashSet<&str> = HashSet::new();
+            let mut lexically_declared_names = HashSet::new();
+            let mut var_declared_names = HashSet::new();
 
             // TODO: Use more helpful positions in errors when spans are added to Nodes
             for item in &items {
@@ -303,7 +303,7 @@ where
                         for decl in decl_list.as_ref() {
                             // if name in VarDeclaredNames or can't be added to
                             // LexicallyDeclaredNames, raise an error
-                            if var_declared_names.contains(decl.name())
+                            if var_declared_names.contains(&decl.name())
                                 || !lexically_declared_names.insert(decl.name())
                             {
                                 return Err(ParseError::lex(LexError::Syntax(
@@ -319,7 +319,7 @@ where
                     Node::VarDeclList(decl_list) => {
                         for decl in decl_list.as_ref() {
                             // if name in LexicallyDeclaredNames, raise an error
-                            if lexically_declared_names.contains(decl.name()) {
+                            if lexically_declared_names.contains(&decl.name()) {
                                 return Err(ParseError::lex(LexError::Syntax(
                                     format!("Redeclaration of variable `{}`", decl.name()).into(),
                                     match cursor.peek(0)? {

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -258,7 +258,7 @@ impl<'a> Vm<'a> {
                 let name = &self.code.names[index as usize];
 
                 self.context.create_mutable_binding(
-                    name.to_string(),
+                    name.clone(),
                     false,
                     VariableScope::Function,
                 )?;
@@ -267,34 +267,28 @@ impl<'a> Vm<'a> {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
-                self.context.create_mutable_binding(
-                    name.to_string(),
-                    false,
-                    VariableScope::Block,
-                )?;
+                self.context
+                    .create_mutable_binding(name.clone(), false, VariableScope::Block)?;
             }
             Opcode::DefConst => {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
-                self.context.create_immutable_binding(
-                    name.to_string(),
-                    false,
-                    VariableScope::Block,
-                )?;
+                self.context
+                    .create_immutable_binding(name.clone(), false, VariableScope::Block)?;
             }
             Opcode::InitLexical => {
                 let index = self.read::<u32>();
                 let value = self.pop();
                 let name = &self.code.names[index as usize];
 
-                self.context.initialize_binding(&name, value)?;
+                self.context.initialize_binding(name, value)?;
             }
             Opcode::GetName => {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
-                let value = self.context.get_binding_value(&name)?;
+                let value = self.context.get_binding_value(name)?;
                 self.push(value);
             }
             Opcode::SetName => {
@@ -302,12 +296,12 @@ impl<'a> Vm<'a> {
                 let value = self.pop();
                 let name = &self.code.names[index as usize];
 
-                if self.context.has_binding(&name) {
+                if self.context.has_binding(name) {
                     // Binding already exists
-                    self.context.set_mutable_binding(&name, value, true)?;
+                    self.context.set_mutable_binding(name, value, true)?;
                 } else {
                     self.context.create_mutable_binding(
-                        name.to_string(),
+                        name.clone(),
                         true,
                         VariableScope::Function,
                     )?;


### PR DESCRIPTION
It changes the following:
- Lazy computed hashes
- Make Environments hold `JsString` instead of `Box<str>`
- Make some nodes hold `JsString`
