### PR TITLE
fix(boa): fixes panic on bigint size

### DIFF
--- a/boa/src/bigint.rs
+++ b/boa/src/bigint.rs
@@ -169,9 +169,9 @@ impl JsBigInt {
             return Err(context.construct_range_error("BigInt negative exponent"));
         };
 
-        let num_bits = (y.to_f64().expect("Unable to convert from BigUInt to f64")
-            * x.inner.bits() as f64)
-            .floor()
+        let num_bits = (x.inner.bits() as f64
+            * y.to_f64().expect("Unable to convert from BigUInt to f64"))
+        .floor()
             + 1f64;
 
         if num_bits > 1_000_000_000f64 {

--- a/boa/src/bigint.rs
+++ b/boa/src/bigint.rs
@@ -169,6 +169,12 @@ impl JsBigInt {
             return Err(context.construct_range_error("BigInt negative exponent"));
         };
 
+        let num_bits= (y.to_f64().expect("Unable to convert from BigUInt to f64") * x.inner.bits() as f64).floor() + 1f64;
+
+        if num_bits > 1_000_000_000f64 {
+            return Err(context.construct_range_error("Maximum BigInt size exceeded"));
+        }
+
         Ok(Self::new(x.inner.as_ref().clone().pow(y)))
     }
 

--- a/boa/src/bigint.rs
+++ b/boa/src/bigint.rs
@@ -169,7 +169,10 @@ impl JsBigInt {
             return Err(context.construct_range_error("BigInt negative exponent"));
         };
 
-        let num_bits= (y.to_f64().expect("Unable to convert from BigUInt to f64") * x.inner.bits() as f64).floor() + 1f64;
+        let num_bits = (y.to_f64().expect("Unable to convert from BigUInt to f64")
+            * x.inner.bits() as f64)
+            .floor()
+            + 1f64;
 
         if num_bits > 1_000_000_000f64 {
             return Err(context.construct_range_error("Maximum BigInt size exceeded"));


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1401.

It changes the following:

- adds crude memory check on bigint bitsize
- throws range error if exceeds 1B bits
