### PR TITLE
Fix DataDescriptor Value to possibly be empty

### DIFF
--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -65,7 +65,8 @@ fn date_this_time_value() {
         .expect("Expected 'message' property")
         .as_data_descriptor()
         .unwrap()
-        .value();
+        .value()
+        .unwrap();
 
     assert_eq!(Value::string("\'this\' is not a Date"), *message_property);
 }

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -230,7 +230,7 @@ impl Json {
                             .get_property(key)
                             .as_ref()
                             .and_then(|p| p.as_data_descriptor())
-                            .map(|d| d.value())
+                            .map(|d| d.value().unwrap_or_else(Value::undefined))
                             .unwrap_or_else(Value::undefined),
                     )
                 }

--- a/boa/src/environment/object_environment_record.rs
+++ b/boa/src/environment/object_environment_record.rs
@@ -112,7 +112,9 @@ impl EnvironmentRecordTrait for ObjectEnvironmentRecord {
     fn get_binding_value(&self, name: &str, strict: bool, context: &mut Context) -> Result<Value> {
         if self.bindings.has_field(name) {
             match self.bindings.get_property(name) {
-                Some(PropertyDescriptor::Data(ref d)) => Ok(d.value()),
+                Some(PropertyDescriptor::Data(ref d)) => {
+                    Ok(d.value().unwrap_or_else(Value::undefined))
+                }
                 _ => Ok(Value::undefined()),
             }
         } else if strict {

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -534,12 +534,14 @@ impl GcObject {
             }
 
             Ok(AccessorDescriptor::new(get, set, attribute).into())
+        } else if let Some(v) = value {
+            Ok(DataDescriptor::new(v, attribute).into())
         } else {
-            Ok(DataDescriptor::new(value.unwrap_or_else(Value::undefined), attribute).into())
+            Ok(DataDescriptor::new_without_value(attribute).into())
         }
     }
 
-    /// Reeturn `true` if it is a native object and the native type is `T`.
+    /// Return `true` if it is a native object and the native type is `T`.
     ///
     /// # Panics
     ///

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -34,7 +34,7 @@ pub use attribute::Attribute;
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct DataDescriptor {
-    pub(crate) value: Value,
+    pub(crate) value: Option<Value>,
     attributes: Attribute,
 }
 
@@ -46,14 +46,23 @@ impl DataDescriptor {
         V: Into<Value>,
     {
         Self {
-            value: value.into(),
+            value: Some(value.into()),
+            attributes,
+        }
+    }
+
+    /// Create a new `DataDescriptor` without a value.
+    #[inline]
+    pub fn new_without_value(attributes: Attribute) -> Self {
+        Self {
+            value: None,
             attributes,
         }
     }
 
     /// Return the `value` of the data descriptor.
     #[inline]
-    pub fn value(&self) -> Value {
+    pub fn value(&self) -> Option<Value> {
         self.value.clone()
     }
 

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -92,7 +92,12 @@ impl Executable for ForInLoop {
         let for_in_iterator = ForInIterator::create_for_in_iterator(context, Value::from(object));
         let next_function = for_in_iterator
             .get_property("next")
-            .map(|p| p.as_data_descriptor().unwrap().value())
+            .map(|p| {
+                p.as_data_descriptor()
+                    .unwrap()
+                    .value()
+                    .unwrap_or_else(Value::undefined)
+            })
             .ok_or_else(|| context.construct_type_error("Could not find property `next`"))?;
         let iterator = IteratorRecord::new(for_in_iterator, next_function);
 

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -52,7 +52,8 @@ macro_rules! print_obj_value {
                 let v = &val
                     .as_data_descriptor()
                     .unwrap()
-                    .value();
+                    .value()
+                    .unwrap_or(Value::undefined());
                 format!(
                     "{:>width$}: {}",
                     key,
@@ -109,6 +110,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                         .as_data_descriptor()
                         .unwrap()
                         .value()
+                        .unwrap_or_else(Value::undefined)
                         .as_number()
                         .map(|n| n as i32)
                         .unwrap_or_default();
@@ -125,7 +127,10 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                 log_string_from(
                                     &v.get_own_property(&i.into())
                                         // FIXME: handle accessor descriptors
-                                        .and_then(|p| p.as_data_descriptor().map(|d| d.value()))
+                                        .and_then(|p| {
+                                            p.as_data_descriptor()
+                                                .map(|d| d.value().unwrap_or_else(Value::undefined))
+                                        })
                                         .unwrap_or_default(),
                                     print_internals,
                                     false,
@@ -205,13 +210,13 @@ pub(crate) fn display_obj(v: &Value, print_internals: bool) -> String {
                 .get_property("name")
                 .as_ref()
                 .and_then(|p| p.as_data_descriptor())
-                .map(|d| d.value())
+                .map(|d| d.value().unwrap_or_else(Value::undefined))
                 .unwrap_or_else(Value::undefined);
             let message = v
                 .get_property("message")
                 .as_ref()
                 .and_then(|p| p.as_data_descriptor())
-                .map(|d| d.value())
+                .map(|d| d.value().unwrap_or_else(Value::undefined))
                 .unwrap_or_else(Value::undefined);
             return format!("{}: {}", name.display(), message.display());
         }

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -286,6 +286,7 @@ fn string_length_is_in_utf16_codeunits() {
             .as_data_descriptor()
             .unwrap()
             .value()
+            .unwrap()
             .to_integer_or_infinity(&mut context)
             .unwrap(),
         IntegerOrInfinity::Integer(2)


### PR DESCRIPTION
This Pull Request fixes/closes #1418.

It changes the following:

Changes `DataDescriptor.value` to be an `Option<Value>` instead of `Value`. This allows to express that a call to `Object.defineProperties` or `Object.defineProperty` may not contain a value.
