### PR TITLE
Refactor internal methods and make some builtins spec compliant

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -123,7 +123,7 @@ impl ArrayIterator {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype
-        let mut array_iterator = context.construct_object();
+        let array_iterator = context.construct_object();
         make_builtin_fn(Self::next, "next", &array_iterator, 0, context);
         array_iterator.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -711,7 +711,7 @@ fn fill() {
 
     assert_eq!(
         forward(&mut context, "a.fill().join()"),
-        String::from("\"undefined,undefined,undefined\"")
+        String::from("\",,\"")
     );
 
     // test object reference

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -69,7 +69,7 @@ impl Boolean {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -35,14 +35,6 @@ pub enum LogMessage {
     Error(String),
 }
 
-/// Helper function that returns the argument at a specified index.
-fn get_arg_at_index<'a, T>(args: &'a [Value], index: usize) -> Option<T>
-where
-    T: From<&'a Value> + Default,
-{
-    args.get(index).map(|s| T::from(s))
-}
-
 /// Helper function for logging messages.
 pub(crate) fn logger(msg: LogMessage, console_state: &Console) {
     let indent = 2 * console_state.groups.len();
@@ -193,7 +185,7 @@ impl Console {
     /// [spec]: https://console.spec.whatwg.org/#assert
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/assert
     pub(crate) fn assert(_: &Value, args: &[Value], context: &mut Context) -> Result<Value> {
-        let assertion = get_arg_at_index::<bool>(args, 0).unwrap_or_default();
+        let assertion = args.get(0).map(Value::to_boolean).unwrap_or(false);
 
         if !assertion {
             let mut args: Vec<Value> = args.iter().skip(1).cloned().collect();

--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -376,13 +376,13 @@ impl Date {
             let prototype = new_target
                 .as_object()
                 .and_then(|obj| {
-                    obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                    obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                         .map(|o| o.as_object())
                         .transpose()
                 })
                 .transpose()?
                 .unwrap_or_else(|| context.standard_objects().object_object().prototype());
-            let mut obj = context.construct_object();
+            let obj = context.construct_object();
             obj.set_prototype_instance(prototype.into());
             let this = obj.into();
             if args.is_empty() {

--- a/boa/src/builtins/error/eval.rs
+++ b/boa/src/builtins/error/eval.rs
@@ -65,13 +65,13 @@ impl EvalError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -81,13 +81,13 @@ impl Error {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -62,13 +62,13 @@ impl RangeError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -61,13 +61,13 @@ impl ReferenceError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -64,13 +64,13 @@ impl SyntaxError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -67,13 +67,13 @@ impl TypeError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/error/uri.rs
+++ b/boa/src/builtins/error/uri.rs
@@ -63,13 +63,13 @@ impl UriError {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or_else(|| context.standard_objects().error_object().prototype());
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
         if let Some(message) = args.get(0) {

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -176,14 +176,14 @@ impl Function {
 /// <https://tc39.es/ecma262/#sec-createunmappedargumentsobject>
 pub fn create_unmapped_arguments_object(arguments_list: &[Value]) -> Value {
     let len = arguments_list.len();
-    let mut obj = GcObject::new(Object::default());
+    let obj = GcObject::new(Object::default());
     // Set length
     let length = DataDescriptor::new(
         len,
         Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
     );
     // Define length as a property
-    obj.ordinary_define_own_property("length", length.into());
+    obj.ordinary_define_own_property("length".into(), length.into());
     let mut index: usize = 0;
     while index < len {
         let val = arguments_list.get(index).expect("Could not get argument");
@@ -258,7 +258,7 @@ impl BuiltInFunctionObject {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -197,7 +197,7 @@ impl Json {
                 .map(|obj| {
                     let object_to_return = Value::object(Object::default());
                     for key in obj.borrow().keys() {
-                        let val = obj.get(&key, obj.clone().into(), context)?;
+                        let val = obj.__get__(&key, obj.clone().into(), context)?;
                         let this_arg = object.clone();
                         object_to_return.set_property(
                             key.to_owned(),

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -149,7 +149,7 @@ impl MapIterator {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype
-        let mut map_iterator = context.construct_object();
+        let map_iterator = context.construct_object();
         make_builtin_fn(Self::next, "next", &map_iterator, 0, context);
         map_iterator.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -118,14 +118,14 @@ impl Map {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or(map_prototype);
 
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = Value::from(obj);
 

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -169,7 +169,7 @@ impl Number {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })

--- a/boa/src/builtins/object/for_in_iterator.rs
+++ b/boa/src/builtins/object/for_in_iterator.rs
@@ -87,7 +87,7 @@ impl ForInIterator {
                     while let Some(r) = iterator.remaining_keys.pop_front() {
                         if !iterator.visited_keys.contains(&r) {
                             if let Some(desc) =
-                                object.get_own_property(&PropertyKey::from(r.clone()))
+                                object.__get_own_property__(&PropertyKey::from(r.clone()))
                             {
                                 iterator.visited_keys.insert(r.clone());
                                 if desc.enumerable() {
@@ -129,7 +129,7 @@ impl ForInIterator {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype
-        let mut for_in_iterator = context.construct_object();
+        let for_in_iterator = context.construct_object();
         make_builtin_fn(Self::next, "next", &for_in_iterator, 0, context);
         for_in_iterator.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa/src/builtins/regexp/regexp_string_iterator.rs
@@ -154,7 +154,7 @@ impl RegExpStringIterator {
         let _timer = BoaProfiler::global().start_event("RegExp String Iterator", "init");
 
         // Create prototype
-        let mut result = context.construct_object();
+        let result = context.construct_object();
         make_builtin_fn(Self::next, "next", &result, 0, context);
         result.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/set/mod.rs
+++ b/boa/src/builtins/set/mod.rs
@@ -128,14 +128,14 @@ impl Set {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
             .transpose()?
             .unwrap_or(set_prototype);
 
-        let mut obj = context.construct_object();
+        let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
 
         let set = Value::from(obj);

--- a/boa/src/builtins/set/set_iterator.rs
+++ b/boa/src/builtins/set/set_iterator.rs
@@ -139,7 +139,7 @@ impl SetIterator {
         let _timer = BoaProfiler::global().start_event(Self::NAME, "init");
 
         // Create prototype
-        let mut set_iterator = context.construct_object();
+        let set_iterator = context.construct_object();
         make_builtin_fn(Self::next, "next", &set_iterator, 0, context);
         set_iterator.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -178,7 +178,7 @@ impl String {
         let prototype = new_target
             .as_object()
             .and_then(|obj| {
-                obj.get(&PROTOTYPE.into(), obj.clone().into(), context)
+                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                     .map(|o| o.as_object())
                     .transpose()
             })
@@ -1156,7 +1156,7 @@ impl String {
     /// `String.prototype.split ( separator, limit )`
     ///
     /// The split() method divides a String into an ordered list of substrings, puts these substrings into an array, and returns the array.
-    /// The division is done by searching for a pattern; where the pattern is provided as the first parameter in the method's call.  
+    /// The division is done by searching for a pattern; where the pattern is provided as the first parameter in the method's call.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -1189,7 +1189,7 @@ impl String {
         let this_str = this.to_string(context)?;
 
         // 4. Let A be ! ArrayCreate(0).
-        let a = Array::array_create(0, None, context);
+        let a = Array::array_create(0, None, context).unwrap();
 
         // 5. Let lengthA be 0.
         let mut length_a = 0;
@@ -1206,16 +1206,17 @@ impl String {
 
         // 8. If lim = 0, return A.
         if lim == 0 {
-            return Ok(a);
+            return Ok(a.into());
         }
 
         // 9. If separator is undefined, then
         if separator.is_undefined() {
             // a. Perform ! CreateDataPropertyOrThrow(A, "0", S).
-            Array::add_to_array_object(&a, &[Value::from(this_str)], context)?;
+            a.create_data_property_or_throw(0, this_str, context)
+                .unwrap();
 
             // b. Return A.
-            return Ok(a);
+            return Ok(a.into());
         }
 
         // 10. Let s be the length of S.
@@ -1226,11 +1227,12 @@ impl String {
             // a. If R is not the empty String, then
             if !separator_str.is_empty() {
                 // i. Perform ! CreateDataPropertyOrThrow(A, "0", S).
-                Array::add_to_array_object(&a, &[Value::from(this_str)], context)?;
+                a.create_data_property_or_throw(0, this_str, context)
+                    .unwrap();
             }
 
             // b. Return A.
-            return Ok(a);
+            return Ok(a.into());
         }
 
         // 12. Let p be 0.
@@ -1264,18 +1266,15 @@ impl String {
                         );
 
                         // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-                        Array::add_to_array_object(
-                            &a,
-                            &[Value::from(this_str_substring)],
-                            context,
-                        )?;
+                        a.create_data_property_or_throw(length_a, this_str_substring, context)
+                            .unwrap();
 
                         // 3. Set lengthA to lengthA + 1.
                         length_a += 1;
 
                         // 4. If lengthA = lim, return A.
                         if length_a == lim {
-                            return Ok(a);
+                            return Ok(a.into());
                         }
 
                         // 5. Set p to e.
@@ -1298,10 +1297,11 @@ impl String {
         );
 
         // 16. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
-        Array::add_to_array_object(&a, &[Value::from(this_str_substring)], context)?;
+        a.create_data_property_or_throw(length_a, this_str_substring, context)
+            .unwrap();
 
         // 17. Return A.
-        Ok(a)
+        Ok(a.into())
     }
 
     /// String.prototype.valueOf()

--- a/boa/src/builtins/string/string_iterator.rs
+++ b/boa/src/builtins/string/string_iterator.rs
@@ -74,7 +74,7 @@ impl StringIterator {
         let _timer = BoaProfiler::global().start_event("String Iterator", "init");
 
         // Create prototype
-        let mut array_iterator = context.construct_object();
+        let array_iterator = context.construct_object();
         make_builtin_fn(Self::next, "next", &array_iterator, 0, context);
         array_iterator.set_prototype_instance(iterator_prototype);
 

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -562,7 +562,7 @@ impl Context {
     #[inline]
     pub(crate) fn has_property(&self, obj: &Value, key: &PropertyKey) -> bool {
         if let Some(obj) = obj.as_object() {
-            obj.has_property(key)
+            obj.__has_property__(key)
         } else {
             false
         }

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -135,7 +135,7 @@ impl GcObject {
         let body = if let Some(function) = self.borrow().as_function() {
             if construct && !function.is_constructable() {
                 let name = self
-                    .get(&"name".into(), self.clone().into(), context)?
+                    .__get__(&"name".into(), self.clone().into(), context)?
                     .display()
                     .to_string();
                 return context.throw_type_error(format!("{} is not a constructor", name));
@@ -161,7 +161,7 @@ impl GcObject {
                             // prototype as prototype for the new object
                             // see <https://tc39.es/ecma262/#sec-ordinarycreatefromconstructor>
                             // see <https://tc39.es/ecma262/#sec-getprototypefromconstructor>
-                            let proto = this_target.as_object().unwrap().get(
+                            let proto = this_target.as_object().unwrap().__get__(
                                 &PROTOTYPE.into(),
                                 this_target.clone(),
                                 context,
@@ -458,50 +458,61 @@ impl GcObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     pub fn to_property_descriptor(&self, context: &mut Context) -> Result<PropertyDescriptor> {
+        // 1. If Type(Obj) is not Object, throw a TypeError exception.
+        // 2. Let desc be a new Property Descriptor that initially has no fields.
+
         let mut attribute = Attribute::empty();
 
-        let enumerable_key = PropertyKey::from("enumerable");
-        if self.has_property(&enumerable_key)
-            && self
-                .get(&enumerable_key, self.clone().into(), context)?
-                .to_boolean()
-        {
+        // 3. Let hasEnumerable be ? HasProperty(Obj, "enumerable").
+        let has_enumerable = self.has_property("enumerable", context)?;
+        // 4. If hasEnumerable is true, then
+        //     a. Let enumerable be ! ToBoolean(? Get(Obj, "enumerable")).
+        //     b. Set desc.[[Enumerable]] to enumerable.
+        if has_enumerable && self.get("enumerable", context)?.to_boolean() {
             attribute |= Attribute::ENUMERABLE;
         }
 
-        let configurable_key = PropertyKey::from("configurable");
-        if self.has_property(&configurable_key)
-            && self
-                .get(&configurable_key, self.clone().into(), context)?
-                .to_boolean()
-        {
+        // 5. Let hasConfigurable be ? HasProperty(Obj, "configurable").
+        let has_configurable = self.has_property("configurable", context)?;
+        // 6. If hasConfigurable is true, then
+        //     a. Let configurable be ! ToBoolean(? Get(Obj, "configurable")).
+        //     b. Set desc.[[Configurable]] to configurable.
+        if has_configurable && self.get("configurable", context)?.to_boolean() {
             attribute |= Attribute::CONFIGURABLE;
         }
 
         let mut value = None;
-        let value_key = PropertyKey::from("value");
-        if self.has_property(&value_key) {
-            value = Some(self.get(&value_key, self.clone().into(), context)?);
+        // 7. Let hasValue be ? HasProperty(Obj, "value").
+        let has_value = self.has_property("value", context)?;
+        // 8. If hasValue is true, then
+        if has_value {
+            // a. Let value be ? Get(Obj, "value").
+            // b. Set desc.[[Value]] to value.
+            value = Some(self.get("value", context)?);
         }
 
-        let mut has_writable = false;
-        let writable_key = PropertyKey::from("writable");
-        if self.has_property(&writable_key) {
-            has_writable = true;
-            if self
-                .get(&writable_key, self.clone().into(), context)?
-                .to_boolean()
-            {
+        // 9. Let hasWritable be ? HasProperty(Obj, ).
+        let has_writable = self.has_property("writable", context)?;
+        // 10. If hasWritable is true, then
+        if has_writable {
+            // a. Let writable be ! ToBoolean(? Get(Obj, "writable")).
+            if self.get("writable", context)?.to_boolean() {
+                // b. Set desc.[[Writable]] to writable.
                 attribute |= Attribute::WRITABLE;
             }
         }
 
+        // 11. Let hasGet be ? HasProperty(Obj, "get").
+        let has_get = self.has_property("get", context)?;
+        // 12. If hasGet is true, then
         let mut get = None;
-        let get_key = PropertyKey::from("get");
-        if self.has_property(&get_key) {
-            let getter = self.get(&get_key, self.clone().into(), context)?;
+        if has_get {
+            // a. Let getter be ? Get(Obj, "get").
+            let getter = self.get("get", context)?;
+            // b. If IsCallable(getter) is false and getter is not undefined, throw a TypeError exception.
             match getter {
                 Value::Object(ref object) if object.is_callable() => {
+                    // c. Set desc.[[Get]] to getter.
                     get = Some(object.clone());
                 }
                 _ => {
@@ -512,12 +523,17 @@ impl GcObject {
             }
         }
 
+        // 13. Let hasSet be ? HasProperty(Obj, "set").
+        let has_set = self.has_property("set", context)?;
+        // 14. If hasSet is true, then
         let mut set = None;
-        let set_key = PropertyKey::from("set");
-        if self.has_property(&set_key) {
-            let setter = self.get(&set_key, self.clone().into(), context)?;
+        if has_set {
+            // 14.a. Let setter be ? Get(Obj, "set").
+            let setter = self.get("set", context)?;
+            // 14.b. If IsCallable(setter) is false and setter is not undefined, throw a TypeError exception.
             match setter {
                 Value::Object(ref object) if object.is_callable() => {
+                    // 14.c. Set desc.[[Set]] to setter.
                     set = Some(object.clone());
                 }
                 _ => {
@@ -528,7 +544,10 @@ impl GcObject {
             };
         }
 
+        // 15. If desc.[[Get]] is present or desc.[[Set]] is present, then
+        // 16. Return desc.
         if get.is_some() || set.is_some() {
+            // 15.a. If desc.[[Value]] is present or desc.[[Writable]] is present, throw a TypeError exception.
             if value.is_some() || has_writable {
                 return Err(context.construct_type_error("Invalid property descriptor. Cannot both specify accessors and a value or writable attribute"));
             }
@@ -612,7 +631,7 @@ impl GcObject {
     /// or if th prototype is not an object or undefined.
     #[inline]
     #[track_caller]
-    pub fn set_prototype_instance(&mut self, prototype: Value) -> bool {
+    pub fn set_prototype_instance(&self, prototype: Value) -> bool {
         self.borrow_mut().set_prototype_instance(prototype)
     }
 
@@ -770,13 +789,17 @@ impl GcObject {
     where
         K: Into<PropertyKey>,
     {
-        let key = key.into();
-        let value = self.get(&key, self.clone().into(), context)?;
+        // 1. Assert: IsPropertyKey(P) is true.
+        // 2. Let func be ? GetV(V, P).
+        let value = self.get(key, context)?;
 
+        // 3. If func is either undefined or null, return undefined.
         if value.is_null_or_undefined() {
             return Ok(None);
         }
 
+        // 4. If IsCallable(func) is false, throw a TypeError exception.
+        // 5. Return func.
         match value.as_object() {
             Some(object) if object.is_callable() => Ok(Some(object)),
             _ => Err(context
@@ -796,25 +819,31 @@ impl GcObject {
         context: &mut Context,
         value: &Value,
     ) -> Result<bool> {
+        // 1. If IsCallable(C) is false, return false.
         if !self.is_callable() {
             return Ok(false);
         }
 
-        // TODO: If C has a [[BoundTargetFunction]] internal slot, then
-        //           Let BC be C.[[BoundTargetFunction]].
-        //           Return ? InstanceofOperator(O, BC).
+        // TODO: 2. If C has a [[BoundTargetFunction]] internal slot, then
+        //         a. Let BC be C.[[BoundTargetFunction]].
+        //         b.  Return ? InstanceofOperator(O, BC).
 
+        // 3. If Type(O) is not Object, return false.
         if let Some(object) = value.as_object() {
-            if let Some(prototype) = self
-                .get(&"prototype".into(), self.clone().into(), context)?
-                .as_object()
-            {
-                let mut object = object.get_prototype_of();
+            // 4. Let P be ? Get(C, "prototype").
+            // 5. If Type(P) is not Object, throw a TypeError exception.
+            if let Some(prototype) = self.get("prototype", context)?.as_object() {
+                // 6. Repeat,
+                //      a. Set O to ? O.[[GetPrototypeOf]]().
+                //      b. If O is null, return false.
+                let mut object = object.__get_prototype_of__();
                 while let Some(object_prototype) = object.as_object() {
+                    //     c. If SameValue(P, O) is true, return true.
                     if GcObject::equals(&prototype, &object_prototype) {
                         return Ok(true);
                     }
-                    object = object_prototype.get_prototype_of();
+                    // a. Set O to ? O.[[GetPrototypeOf]]().
+                    object = object_prototype.__get_prototype_of__();
                 }
 
                 Ok(false)
@@ -824,43 +853,6 @@ impl GcObject {
             }
         } else {
             Ok(false)
-        }
-    }
-    #[inline]
-    #[track_caller]
-    pub fn has_own_property<K>(&self, key: K) -> bool
-    where
-        K: Into<PropertyKey>,
-    {
-        let key = key.into();
-        self.get_own_property(&key).is_some()
-    }
-
-    /// Defines the property or throws a `TypeError` if the operation fails.
-    ///
-    /// More information:
-    /// - [EcmaScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-definepropertyorthrow
-    #[inline]
-    pub(crate) fn define_property_or_throw<K, P>(
-        &mut self,
-        key: K,
-        desc: P,
-        context: &mut Context,
-    ) -> Result<()>
-    where
-        K: Into<PropertyKey>,
-        P: Into<PropertyDescriptor>,
-    {
-        let key = key.into();
-        let desc = desc.into();
-
-        let success = self.define_own_property(key.clone(), desc, context)?;
-        if !success {
-            Err(context.construct_type_error(format!("Cannot redefine property: {}", key)))
-        } else {
-            Ok(())
         }
     }
 
@@ -882,11 +874,7 @@ impl GcObject {
         // 1. Assert: Type(O) is Object.
 
         // 2. Let C be ? Get(O, "constructor").
-        let c = self.clone().get(
-            &PropertyKey::from("constructor"),
-            self.clone().into(),
-            context,
-        )?;
+        let c = self.clone().get("constructor", context)?;
 
         // 3. If C is undefined, return defaultConstructor.
         if c.is_undefined() {

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -434,6 +434,16 @@ impl From<usize> for PropertyKey {
     }
 }
 
+impl From<u64> for PropertyKey {
+    fn from(value: u64) -> Self {
+        if let Ok(index) = u32::try_from(value) {
+            PropertyKey::Index(index)
+        } else {
+            PropertyKey::String(JsString::from(value.to_string()))
+        }
+    }
+}
+
 impl From<isize> for PropertyKey {
     fn from(value: isize) -> Self {
         if let Ok(index) = u32::try_from(value) {

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -94,14 +94,14 @@ impl Executable for UnaryOp {
                         .obj()
                         .run(context)?
                         .to_object(context)?
-                        .delete(&get_const_field.field().into()),
+                        .__delete__(&get_const_field.field().into()),
                 ),
                 Node::GetField(ref get_field) => {
                     let obj = get_field.obj().run(context)?;
                     let field = &get_field.field().run(context)?;
                     let res = obj
                         .to_object(context)?
-                        .delete(&field.to_property_key(context)?);
+                        .__delete__(&field.to_property_key(context)?);
                     return Ok(Value::boolean(res));
                 }
                 Node::Identifier(_) => Value::boolean(false),

--- a/boa/src/value/conversions.rs
+++ b/boa/src/value/conversions.rs
@@ -68,6 +68,7 @@ impl Display for TryFromCharError {
 }
 
 impl From<f64> for Value {
+    #[inline]
     fn from(value: f64) -> Self {
         Self::rational(value)
     }
@@ -85,32 +86,45 @@ impl From<u32> for Value {
 }
 
 impl From<i32> for Value {
+    #[inline]
     fn from(value: i32) -> Value {
         Value::integer(value)
     }
 }
 
 impl From<JsBigInt> for Value {
+    #[inline]
     fn from(value: JsBigInt) -> Self {
         Value::BigInt(value)
     }
 }
 
 impl From<usize> for Value {
+    #[inline]
     fn from(value: usize) -> Value {
-        Value::integer(value as i32)
+        if let Ok(value) = i32::try_from(value) {
+            Value::integer(value)
+        } else {
+            Value::rational(value as f64)
+        }
+    }
+}
+
+impl From<u64> for Value {
+    #[inline]
+    fn from(value: u64) -> Value {
+        if let Ok(value) = i32::try_from(value) {
+            Value::integer(value)
+        } else {
+            Value::rational(value as f64)
+        }
     }
 }
 
 impl From<bool> for Value {
+    #[inline]
     fn from(value: bool) -> Self {
         Value::boolean(value)
-    }
-}
-
-impl From<&Value> for bool {
-    fn from(value: &Value) -> Self {
-        value.to_boolean()
     }
 }
 
@@ -148,6 +162,7 @@ impl From<Object> for Value {
 }
 
 impl From<GcObject> for Value {
+    #[inline]
     fn from(object: GcObject) -> Self {
         let _timer = BoaProfiler::global().start_event("From<GcObject>", "value");
         Value::Object(object)
@@ -158,12 +173,14 @@ impl From<GcObject> for Value {
 pub struct TryFromObjectError;
 
 impl Display for TryFromObjectError {
+    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Could not convert value to an Object type")
     }
 }
 
 impl From<()> for Value {
+    #[inline]
     fn from(_: ()) -> Self {
         Value::null()
     }
@@ -173,6 +190,7 @@ impl<T> From<Option<T>> for Value
 where
     T: Into<Value>,
 {
+    #[inline]
     fn from(value: Option<T>) -> Self {
         match value {
             Some(value) => value.into(),

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -102,7 +102,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                 }
                 ObjectData::Array => {
                     let len = v
-                        .get_own_property(&PropertyKey::from("length"))
+                        .__get_own_property__(&PropertyKey::from("length"))
                         // TODO: do this in a better way `unwrap`
                         .unwrap()
                         // FIXME: handle accessor descriptors
@@ -123,7 +123,7 @@ pub(crate) fn log_string_from(x: &Value, print_internals: bool, print_children: 
                                 // Introduce recursive call to stringify any objects
                                 // which are part of the Array
                                 log_string_from(
-                                    &v.get_own_property(&i.into())
+                                    &v.__get_own_property__(&i.into())
                                         // FIXME: handle accessor descriptors
                                         .and_then(|p| p.as_data_descriptor().map(|d| d.value()))
                                         .unwrap_or_default(),

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -426,9 +426,7 @@ impl Value {
     where
         Key: Into<PropertyKey>,
     {
-        self.as_object()
-            .map(|mut x| x.remove(&key.into()))
-            .is_some()
+        self.as_object().map(|x| x.remove(&key.into())).is_some()
     }
 
     /// Resolve the property in the object.
@@ -442,7 +440,7 @@ impl Value {
         let _timer = BoaProfiler::global().start_event("Value::get_property", "value");
         match self {
             Self::Object(ref object) => {
-                let property = object.get_own_property(&key);
+                let property = object.__get_own_property__(&key);
                 if property.is_some() {
                     return property;
                 }
@@ -461,7 +459,8 @@ impl Value {
     {
         let _timer = BoaProfiler::global().start_event("Value::get_field", "value");
         if let Self::Object(ref obj) = *self {
-            obj.clone().get(&key.into(), obj.clone().into(), context)
+            obj.clone()
+                .__get__(&key.into(), obj.clone().into(), context)
         } else {
             Ok(Value::undefined())
         }
@@ -475,7 +474,7 @@ impl Value {
     {
         let _timer = BoaProfiler::global().start_event("Value::has_field", "value");
         self.as_object()
-            .map(|object| object.has_property(&key.into()))
+            .map(|object| object.__has_property__(&key.into()))
             .unwrap_or(false)
     }
 
@@ -512,7 +511,7 @@ impl Value {
             // 4. Let success be ? O.[[Set]](P, V, O).
             let success = obj
                 .clone()
-                .set(key, value.clone(), obj.clone().into(), context)?;
+                .__set__(key, value.clone(), obj.clone().into(), context)?;
 
             // 5. If success is false and Throw is true, throw a TypeError exception.
             // 6. Return success.
@@ -540,7 +539,7 @@ impl Value {
         K: Into<PropertyKey>,
         P: Into<PropertyDescriptor>,
     {
-        if let Some(mut object) = self.as_object() {
+        if let Some(object) = self.as_object() {
             object.insert(key.into(), property.into());
         }
     }
@@ -699,7 +698,7 @@ impl Value {
             Value::String(ref string) => {
                 let prototype = context.standard_objects().string_object().prototype();
 
-                let mut object = GcObject::new(Object::with_prototype(
+                let object = GcObject::new(Object::with_prototype(
                     prototype.into(),
                     ObjectData::String(string.clone()),
                 ));

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -267,7 +267,7 @@ fn string_length_is_not_enumerable() {
 
     let object = Value::from("foo").to_object(&mut context).unwrap();
     let length_desc = object
-        .get_own_property(&PropertyKey::from("length"))
+        .__get_own_property__(&PropertyKey::from("length"))
         .unwrap();
     assert!(!length_desc.enumerable());
 }
@@ -279,7 +279,7 @@ fn string_length_is_in_utf16_codeunits() {
     // 😀 is one Unicode code point, but 2 UTF-16 code units
     let object = Value::from("😀").to_object(&mut context).unwrap();
     let length_desc = object
-        .get_own_property(&PropertyKey::from("length"))
+        .__get_own_property__(&PropertyKey::from("length"))
         .unwrap();
     assert_eq!(
         length_desc

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -370,7 +370,7 @@ impl<'a> Vm<'a> {
                 };
 
                 let name = self.code.names[index as usize].clone();
-                let result = object.get(&name.into(), value, self.context)?;
+                let result = object.get(name, self.context)?;
 
                 self.push(result)
             }
@@ -384,7 +384,7 @@ impl<'a> Vm<'a> {
                 };
 
                 let key = key.to_property_key(self.context)?;
-                let result = object.get(&key, value, self.context)?;
+                let result = object.get(key, self.context)?;
 
                 self.push(result)
             }
@@ -393,7 +393,7 @@ impl<'a> Vm<'a> {
 
                 let object = self.pop();
                 let value = self.pop();
-                let mut object = if let Some(object) = object.as_object() {
+                let object = if let Some(object) = object.as_object() {
                     object
                 } else {
                     object.to_object(self.context)?
@@ -401,20 +401,20 @@ impl<'a> Vm<'a> {
 
                 let name = self.code.names[index as usize].clone();
 
-                object.set(name.into(), value, object.clone().into(), self.context)?;
+                object.set(name, value, true, self.context)?;
             }
             Opcode::SetPropertyByValue => {
                 let object = self.pop();
                 let key = self.pop();
                 let value = self.pop();
-                let mut object = if let Some(object) = object.as_object() {
+                let object = if let Some(object) = object.as_object() {
                     object
                 } else {
                     object.to_object(self.context)?
                 };
 
                 let key = key.to_property_key(self.context)?;
-                object.set(key, value, object.clone().into(), self.context)?;
+                object.set(key, value, true, self.context)?;
             }
             Opcode::Throw => {
                 let value = self.pop();


### PR DESCRIPTION
We currently have the internal object method such as `set` (which in reality is `[[set]]`) the problem is that we do not differentiate between [`Set`](https://tc39.es/ecma262/#sec-set-o-p-v-throw) and `[[set]]` (same goes for many others `[[get]]`, etc). That's is why in this PR internal method with `[[something]]` are renamed to `__something__`. This makes it very clear that we are calling an internal method using the `[[]]` syntax.

Rename internal object methods:
 - `set` => `__set__`
 - `get` => `__get__`
 - etc

Implement some spec functions:
 - `CreateDataProperty()`
 - `CreateDataPropertyOrThrow()`
 - `Set`
 - `Get`
 - `HasProperty`
 - `IsExtensible`
 - `DeletePropertyOrThrow`
 - `DefineOwnProperty`

The above methods help with implementing other builtin function and are used everywhere in the spec.

Documented/make spec compliant:
 - `Object.prototype.toString`
 - `Object.prototype.assign`
 - `get RegExp.prototype.flags`
 - `Reflect.get`
 - `RegExp` `abstract_builtin_exec` helper function
 - `GcObject::to_property_descriptor`
 - `GcObject::get_method`
 - `Array.prototype.of`
 - `Array.prototype.push`
 - `Array.prototype.pop`
 - `Array.prototype.forEach`
 - `Array.prototype.join`
 - `Array.prototype.toString`
 - `Array.prototype.reverse`
 - `Array.prototype.shift`
 - `Array.prototype.unshift`
 - `Array.prototype.every`
 - `Array.prototype.some`

Misc changes:
 - Made all internal methods take `&self` instead of `&mut self` (this avoids some clones).
 - removed unnecessary `get_arg_at_index()` function in `console` builtin
 - Implement `From<u64>` to `PropertyKey`
