### PR TITLE
Extract `PropertyMap` struct from `Object`

### DIFF
--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -106,7 +106,7 @@ impl Json {
         let value = holder.get_field(key.clone(), context)?;
 
         if let Value::Object(ref object) = value {
-            let keys: Vec<_> = object.borrow().keys().collect();
+            let keys: Vec<_> = object.borrow().properties().keys().collect();
 
             for key in keys {
                 let v = Self::walk(reviver, context, &mut value.clone(), &key);
@@ -196,7 +196,7 @@ impl Json {
                 .as_object()
                 .map(|obj| {
                     let object_to_return = Value::object(Object::default());
-                    for key in obj.borrow().keys() {
+                    for key in obj.borrow().properties().keys() {
                         let val = obj.__get__(&key, obj.clone().into(), context)?;
                         let this_arg = object.clone();
                         object_to_return.set_property(
@@ -222,7 +222,7 @@ impl Json {
         } else if replacer_as_object.is_array() {
             let mut obj_to_return = serde_json::Map::new();
             let replacer_as_object = replacer_as_object.borrow();
-            let fields = replacer_as_object.keys().filter_map(|key| {
+            let fields = replacer_as_object.properties().keys().filter_map(|key| {
                 if key == "length" {
                     None
                 } else {

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -192,7 +192,7 @@ impl Object {
             .to_object(context)?;
         let descriptors = context.construct_object();
 
-        for key in object.borrow().keys() {
+        for key in object.borrow().properties().keys() {
             let descriptor = {
                 let desc = object
                     .__get_own_property__(&key)

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -428,7 +428,12 @@ impl GcObject {
         if rec_limiter.live {
             Err(context.construct_type_error("cyclic object value"))
         } else if self.is_array() {
-            let mut keys: Vec<u32> = self.borrow().index_property_keys().cloned().collect();
+            let mut keys: Vec<u32> = self
+                .borrow()
+                .properties
+                .index_property_keys()
+                .cloned()
+                .collect();
             keys.sort_unstable();
             let mut arr: Vec<JSONValue> = Vec::with_capacity(keys.len());
             let this = Value::from(self.clone());
@@ -444,7 +449,7 @@ impl GcObject {
         } else {
             let mut new_obj = Map::new();
             let this = Value::from(self.clone());
-            let keys: Vec<PropertyKey> = self.borrow().keys().collect();
+            let keys: Vec<PropertyKey> = self.borrow().properties.keys().collect();
             for k in keys {
                 let key = k.clone();
                 let value = this.get_field(k.to_string(), context)?;

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -73,6 +73,7 @@ macro_rules! print_obj_value {
     (impl $v:expr, $f:expr) => {
         $v
             .borrow()
+            .properties()
             .iter()
             .map($f)
             .collect::<Vec<String>>()


### PR DESCRIPTION
Refactors object properties from `Object` by creating a `PropertyMap` struct.

It changes the following:

- Adds the `PropertyMap` struct
- Changes `Object` to contain a `properties` field of type `PropertyMap`
- Adds a `properties() -> &PropertyMap` function to `Object`
- Renames `iter.rs` to `property_map.rs`
