### PR TITLE
Proposal of new `PropertyDescriptor` design 

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, Value},
     gc::{Finalize, Trace},
     object::{GcObject, ObjectData},
-    property::{Attribute, DataDescriptor},
+    property::PropertyDescriptor,
     symbol::WellKnownSymbols,
     BoaProfiler, Context, Result,
 };
@@ -128,10 +128,11 @@ impl ArrayIterator {
         array_iterator.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "Array Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("Array Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         array_iterator.insert(to_string_tag, to_string_tag_property);
         array_iterator
     }

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -1546,5 +1546,5 @@ fn array_length_is_not_enumerable() {
 
     let array = Array::new_array(&context);
     let desc = array.get_property("length").unwrap();
-    assert!(!desc.enumerable());
+    assert!(!desc.expect_enumerable());
 }

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -63,9 +63,8 @@ fn date_this_time_value() {
     let message_property = &error
         .get_property("message")
         .expect("Expected 'message' property")
-        .as_data_descriptor()
-        .unwrap()
-        .value();
+        .expect_value()
+        .clone();
 
     assert_eq!(Value::string("\'this\' is not a Date"), *message_property);
 }

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -1,7 +1,7 @@
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, Value},
     object::{GcObject, ObjectData},
-    property::{Attribute, DataDescriptor},
+    property::PropertyDescriptor,
     symbol::WellKnownSymbols,
     BoaProfiler, Context, Result,
 };
@@ -154,10 +154,11 @@ impl MapIterator {
         map_iterator.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "Map Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("Map Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         map_iterator.insert(to_string_tag, to_string_tag_property);
         map_iterator
     }

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -15,7 +15,7 @@
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, FunctionBuilder, ObjectData, PROTOTYPE},
-    property::{Attribute, DataDescriptor},
+    property::{Attribute, PropertyDescriptor},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, Result, Value,
 };
@@ -217,12 +217,13 @@ impl Map {
 
     /// Helper function to set the size property.
     fn set_size(this: &Value, size: usize) {
-        let size = DataDescriptor::new(
-            size,
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
-        );
+        let size = PropertyDescriptor::builder()
+            .value(size)
+            .writable(false)
+            .enumerable(false)
+            .configurable(false);
 
-        this.set_property("size".to_string(), size);
+        this.set_property("size", size);
     }
 
     /// `Map.prototype.set( key, value )`

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use self::{
     undefined::Undefined,
 };
 use crate::{
-    property::{Attribute, DataDescriptor},
+    property::{Attribute, PropertyDescriptor},
     Context, Value,
 };
 
@@ -104,7 +104,11 @@ pub fn init(context: &mut Context) {
 
     for init in &globals {
         let (name, value, attribute) = init(context);
-        let property = DataDescriptor::new(value, attribute);
+        let property = PropertyDescriptor::builder()
+            .value(value)
+            .writable(attribute.writable())
+            .enumerable(attribute.enumerable())
+            .configurable(attribute.configurable());
         global_object.borrow_mut().insert(name, property);
     }
 }

--- a/boa/src/builtins/object/for_in_iterator.rs
+++ b/boa/src/builtins/object/for_in_iterator.rs
@@ -2,8 +2,8 @@ use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object},
     gc::{Finalize, Trace},
     object::{GcObject, ObjectData},
+    property::PropertyDescriptor,
     property::PropertyKey,
-    property::{Attribute, DataDescriptor},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsString, Result, Value,
 };
@@ -90,7 +90,7 @@ impl ForInIterator {
                                 object.__get_own_property__(&PropertyKey::from(r.clone()))
                             {
                                 iterator.visited_keys.insert(r.clone());
-                                if desc.enumerable() {
+                                if desc.expect_enumerable() {
                                     return Ok(create_iter_result_object(
                                         context,
                                         Value::from(r.to_string()),
@@ -134,10 +134,11 @@ impl ForInIterator {
         for_in_iterator.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "For In Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("For In Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         for_in_iterator.insert(to_string_tag, to_string_tag_property);
         for_in_iterator
     }

--- a/boa/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa/src/builtins/regexp/regexp_string_iterator.rs
@@ -15,7 +15,7 @@ use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, regexp},
     gc::{Finalize, Trace},
     object::{GcObject, ObjectData},
-    property::{Attribute, DataDescriptor},
+    property::PropertyDescriptor,
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsString, Result, Value,
 };
@@ -162,10 +162,11 @@ impl RegExpStringIterator {
         result.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "RegExp String Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("RegExp String Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         result.insert(to_string_tag, to_string_tag_property);
         result
     }

--- a/boa/src/builtins/regexp/tests.rs
+++ b/boa/src/builtins/regexp/tests.rs
@@ -56,7 +56,6 @@ fn species() {
         "\"function\""
     );
     assert_eq!(forward(&mut context, "descriptor.enumerable"), "false");
-    assert_eq!(forward(&mut context, "descriptor.writable"), "false");
     assert_eq!(forward(&mut context, "descriptor.configurable"), "true");
 }
 

--- a/boa/src/builtins/set/mod.rs
+++ b/boa/src/builtins/set/mod.rs
@@ -232,7 +232,7 @@ impl Set {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
     pub(crate) fn clear(this: &Value, _: &[Value], context: &mut Context) -> Result<Value> {
         if let Some(object) = this.as_object() {
-            if object.borrow_mut().is_set() {
+            if object.borrow().is_set() {
                 this.set_data(ObjectData::Set(OrderedSet::new()));
                 Ok(Value::Undefined)
             } else {

--- a/boa/src/builtins/set/set_iterator.rs
+++ b/boa/src/builtins/set/set_iterator.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::Array,
     builtins::Value,
     object::{GcObject, ObjectData},
-    property::{Attribute, DataDescriptor},
+    property::PropertyDescriptor,
     symbol::WellKnownSymbols,
     BoaProfiler, Context, Result,
 };
@@ -144,10 +144,11 @@ impl SetIterator {
         set_iterator.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "Set Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("Set Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         set_iterator.insert(to_string_tag, to_string_tag_property);
         set_iterator
     }

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -15,11 +15,10 @@ mod tests;
 
 use crate::builtins::Symbol;
 use crate::object::PROTOTYPE;
-use crate::property::DataDescriptor;
 use crate::{
     builtins::{string::string_iterator::StringIterator, Array, BuiltIn, RegExp},
     object::{ConstructorBuilder, ObjectData},
-    property::Attribute,
+    property::{Attribute, PropertyDescriptor},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsString, Result, Value,
 };
@@ -191,11 +190,14 @@ impl String {
             .expect("this should be an object")
             .set_prototype_instance(prototype.into());
 
-        let length = DataDescriptor::new(
-            Value::from(string.encode_utf16().count()),
-            Attribute::NON_ENUMERABLE,
+        this.set_property(
+            "length",
+            PropertyDescriptor::builder()
+                .value(string.encode_utf16().count())
+                .writable(false)
+                .enumerable(false)
+                .configurable(false),
         );
-        this.set_property("length", length);
 
         this.set_data(ObjectData::String(string));
 

--- a/boa/src/builtins/string/string_iterator.rs
+++ b/boa/src/builtins/string/string_iterator.rs
@@ -4,7 +4,7 @@ use crate::{
     },
     gc::{Finalize, Trace},
     object::{GcObject, ObjectData},
-    property::{Attribute, DataDescriptor},
+    property::PropertyDescriptor,
     symbol::WellKnownSymbols,
     BoaProfiler, Context, Result, Value,
 };
@@ -79,10 +79,11 @@ impl StringIterator {
         array_iterator.set_prototype_instance(iterator_prototype);
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
-        let to_string_tag_property = DataDescriptor::new(
-            "String Iterator",
-            Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-        );
+        let to_string_tag_property = PropertyDescriptor::builder()
+            .value("String Iterator")
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
         array_iterator.insert(to_string_tag, to_string_tag_property);
         array_iterator
     }

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -74,7 +74,7 @@ pub trait Class: NativeObject + Sized {
     /// The amount of arguments the class `constructor` takes, default is `0`.
     const LENGTH: usize = 0;
     /// The attibutes the class will be binded with, default is `writable`, `enumerable`, `configurable`.
-    const ATTRIBUTE: Attribute = Attribute::all();
+    const ATTRIBUTES: Attribute = Attribute::all();
 
     /// The constructor of the class.
     fn constructor(this: &Value, args: &[Value], context: &mut Context) -> Result<Self>;

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -92,7 +92,9 @@ impl Executable for ForInLoop {
         let for_in_iterator = ForInIterator::create_for_in_iterator(context, Value::from(object));
         let next_function = for_in_iterator
             .get_property("next")
-            .map(|p| p.as_data_descriptor().unwrap().value())
+            .as_ref()
+            .map(|p| p.expect_value())
+            .cloned()
             .ok_or_else(|| context.construct_type_error("Could not find property `next`"))?;
         let iterator = IteratorRecord::new(for_in_iterator, next_function);
 

--- a/boa/src/value/conversions.rs
+++ b/boa/src/value/conversions.rs
@@ -146,7 +146,14 @@ where
     fn from(value: &[T]) -> Self {
         let mut array = Object::default();
         for (i, item) in value.iter().enumerate() {
-            array.insert(i, DataDescriptor::new(item.clone(), Attribute::all()));
+            array.insert(
+                i,
+                PropertyDescriptor::builder()
+                    .value(item.clone())
+                    .writable(true)
+                    .enumerable(true)
+                    .configurable(true),
+            );
         }
         Self::from(array)
     }
@@ -159,7 +166,14 @@ where
     fn from(value: Vec<T>) -> Self {
         let mut array = Object::default();
         for (i, item) in value.into_iter().enumerate() {
-            array.insert(i, DataDescriptor::new(item, Attribute::all()));
+            array.insert(
+                i,
+                PropertyDescriptor::builder()
+                    .value(item)
+                    .writable(true)
+                    .enumerable(true)
+                    .configurable(true),
+            );
         }
         Value::from(array)
     }

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -269,7 +269,7 @@ fn string_length_is_not_enumerable() {
     let length_desc = object
         .__get_own_property__(&PropertyKey::from("length"))
         .unwrap();
-    assert!(!length_desc.enumerable());
+    assert!(!length_desc.expect_enumerable());
 }
 
 #[test]
@@ -283,9 +283,7 @@ fn string_length_is_in_utf16_codeunits() {
         .unwrap();
     assert_eq!(
         length_desc
-            .as_data_descriptor()
-            .unwrap()
-            .value()
+            .expect_value()
             .to_integer_or_infinity(&mut context)
             .unwrap(),
         IntegerOrInfinity::Integer(2)

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -16,7 +16,7 @@ pub(super) fn init(context: &mut Context) -> GcObject {
         // .property("agent", agent, Attribute::default())
         .build();
 
-    context.register_global_property("$262", obj.clone(), Attribute::default());
+    context.register_global_property("$262", obj.clone(), Attribute::empty());
 
     obj
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This PR changes `PropertyDescriptor` to allow for generic descriptors. Opted for a builder pattern because using always `Some(val)` was very tedious. The type system ensures that you cannot create an invalid descriptor, since the builder automatically switches to a valid descriptor type when you specify `[[writable]]`, `[[value]]`, `[[get]]` or `[[set]]`, but we could make it panic instead if needed.

This design follows the spec more closely, so I expected to see a bump on the number of passed tests. Fortunately, running the 262 test suite shows that the number of passed tests increase from 28322 to 29109.

closes #1426