### PR TITLE
Fix clippy errors

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -493,7 +493,7 @@ impl Array {
         // 5. For each element E of items, do
         for item in [Value::from(obj)].iter().chain(args.iter()) {
             // a. Let spreadable be ? IsConcatSpreadable(E).
-            let spreadable = Self::is_concat_spreadable(&item, context)?;
+            let spreadable = Self::is_concat_spreadable(item, context)?;
             // b. If spreadable is true, then
             if spreadable {
                 // item is guaranteed to be an object since is_concat_spreadable checks it,

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -13,8 +13,8 @@ fn construct_and_call() {
     let one = forward_val(&mut context, "one").unwrap();
     let zero = forward_val(&mut context, "zero").unwrap();
 
-    assert_eq!(one.is_object(), true);
-    assert_eq!(zero.is_boolean(), true);
+    assert!(one.is_object());
+    assert!(zero.is_boolean());
 }
 
 #[test]
@@ -34,16 +34,16 @@ fn constructor_gives_true_instance() {
     let true_bool = forward_val(&mut context, "trueBool").expect("value expected");
 
     // Values should all be objects
-    assert_eq!(true_val.is_object(), true);
-    assert_eq!(true_num.is_object(), true);
-    assert_eq!(true_string.is_object(), true);
-    assert_eq!(true_bool.is_object(), true);
+    assert!(true_val.is_object());
+    assert!(true_num.is_object());
+    assert!(true_string.is_object());
+    assert!(true_bool.is_object());
 
     // Values should all be truthy
-    assert_eq!(true_val.to_boolean(), true);
-    assert_eq!(true_num.to_boolean(), true);
-    assert_eq!(true_string.to_boolean(), true);
-    assert_eq!(true_bool.to_boolean(), true);
+    assert!(true_val.to_boolean());
+    assert!(true_num.to_boolean());
+    assert!(true_string.to_boolean());
+    assert!(true_bool.to_boolean());
 }
 
 #[test]

--- a/boa/src/builtins/function/tests.rs
+++ b/boa/src/builtins/function/tests.rs
@@ -15,7 +15,7 @@ fn arguments_object() {
     eprintln!("{}", forward(&mut context, init));
 
     let return_val = forward_val(&mut context, "val").expect("value expected");
-    assert_eq!(return_val.is_integer(), true);
+    assert!(return_val.is_integer());
     assert_eq!(
         return_val
             .to_i32(&mut context)
@@ -35,7 +35,7 @@ fn self_mutating_function_when_calling() {
         "#;
     eprintln!("{}", forward(&mut context, func));
     let y = forward_val(&mut context, "x.y").expect("value expected");
-    assert_eq!(y.is_integer(), true);
+    assert!(y.is_integer());
     assert_eq!(
         y.to_i32(&mut context)
             .expect("Could not convert value to i32"),
@@ -54,7 +54,7 @@ fn self_mutating_function_when_constructing() {
         "#;
     eprintln!("{}", forward(&mut context, func));
     let y = forward_val(&mut context, "x.y").expect("value expected");
-    assert_eq!(y.is_integer(), true);
+    assert!(y.is_integer());
     assert_eq!(
         y.to_i32(&mut context)
             .expect("Could not convert value to i32"),

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -425,14 +425,11 @@ fn json_parse_sets_prototypes() {
         .into();
     let global_array_prototype: Value =
         context.standard_objects().array_object().prototype().into();
-    assert_eq!(
-        Value::same_value(&object_prototype, &global_object_prototype),
-        true
-    );
-    assert_eq!(
-        Value::same_value(&array_prototype, &global_array_prototype),
-        true
-    );
+    assert!(Value::same_value(
+        &object_prototype,
+        &global_object_prototype
+    ));
+    assert!(Value::same_value(&array_prototype, &global_array_prototype));
 }
 
 #[test]

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -1,5 +1,8 @@
 //! Builtins live here, such as Object, String, Math, etc.
 
+// builtins module has a lot of built-in functions that need unnecessary_wraps
+#![allow(clippy::unnecessary_wraps)]
+
 pub mod array;
 pub mod bigint;
 pub mod boolean;

--- a/boa/src/builtins/number/tests.rs
+++ b/boa/src/builtins/number/tests.rs
@@ -434,23 +434,23 @@ fn value_of() {
 
 #[test]
 fn equal() {
-    assert_eq!(Number::equal(0.0, 0.0), true);
-    assert_eq!(Number::equal(-0.0, 0.0), true);
-    assert_eq!(Number::equal(0.0, -0.0), true);
-    assert_eq!(Number::equal(f64::NAN, -0.0), false);
-    assert_eq!(Number::equal(0.0, f64::NAN), false);
+    assert!(Number::equal(0.0, 0.0));
+    assert!(Number::equal(-0.0, 0.0));
+    assert!(Number::equal(0.0, -0.0));
+    assert!(!Number::equal(f64::NAN, -0.0));
+    assert!(!Number::equal(0.0, f64::NAN));
 
-    assert_eq!(Number::equal(1.0, 1.0), true);
+    assert!(Number::equal(1.0, 1.0));
 }
 
 #[test]
 fn same_value() {
-    assert_eq!(Number::same_value(0.0, 0.0), true);
-    assert_eq!(Number::same_value(-0.0, 0.0), false);
-    assert_eq!(Number::same_value(0.0, -0.0), false);
-    assert_eq!(Number::same_value(f64::NAN, -0.0), false);
-    assert_eq!(Number::same_value(0.0, f64::NAN), false);
-    assert_eq!(Number::equal(1.0, 1.0), true);
+    assert!(Number::same_value(0.0, 0.0));
+    assert!(!Number::same_value(-0.0, 0.0));
+    assert!(!Number::same_value(0.0, -0.0));
+    assert!(!Number::same_value(f64::NAN, -0.0));
+    assert!(!Number::same_value(0.0, f64::NAN));
+    assert!(Number::equal(1.0, 1.0));
 }
 
 #[test]
@@ -483,12 +483,12 @@ fn less_than() {
 
 #[test]
 fn same_value_zero() {
-    assert_eq!(Number::same_value_zero(0.0, 0.0), true);
-    assert_eq!(Number::same_value_zero(-0.0, 0.0), true);
-    assert_eq!(Number::same_value_zero(0.0, -0.0), true);
-    assert_eq!(Number::same_value_zero(f64::NAN, -0.0), false);
-    assert_eq!(Number::same_value_zero(0.0, f64::NAN), false);
-    assert_eq!(Number::equal(1.0, 1.0), true);
+    assert!(Number::same_value_zero(0.0, 0.0));
+    assert!(Number::same_value_zero(-0.0, 0.0));
+    assert!(Number::same_value_zero(0.0, -0.0));
+    assert!(!Number::same_value_zero(f64::NAN, -0.0));
+    assert!(!Number::same_value_zero(0.0, f64::NAN));
+    assert!(Number::equal(1.0, 1.0));
 }
 
 #[test]

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -107,8 +107,8 @@ fn construct_and_call() {
     let hello = forward_val(&mut context, "hello").unwrap();
     let world = forward_val(&mut context, "world").unwrap();
 
-    assert_eq!(hello.is_object(), true);
-    assert_eq!(world.is_string(), true);
+    assert!(hello.is_object());
+    assert!(world.is_string());
 }
 
 #[test]

--- a/boa/src/builtins/symbol/tests.rs
+++ b/boa/src/builtins/symbol/tests.rs
@@ -8,7 +8,7 @@ fn call_symbol_and_check_return_type() {
         "#;
     eprintln!("{}", forward(&mut context, init));
     let sym = forward_val(&mut context, "sym").unwrap();
-    assert_eq!(sym.is_symbol(), true);
+    assert!(sym.is_symbol());
 }
 
 #[test]

--- a/boa/src/lib.rs
+++ b/boa/src/lib.rs
@@ -13,7 +13,6 @@ This is an experimental Javascript lexer, parser and compiler written in Rust. C
     html_favicon_url = "https://raw.githubusercontent.com/jasonwilliams/boa/master/assets/logo.svg"
 )]
 #![deny(
-    unused_qualifications,
     clippy::all,
     unused_qualifications,
     unused_import_braces,
@@ -43,8 +42,6 @@ This is an experimental Javascript lexer, parser and compiler written in Rust. C
 )]
 
 pub mod bigint;
-// builtins module has a lot of built-in functions that need unnecessary_wraps
-#[allow(clippy::unnecessary_wraps)]
 pub mod builtins;
 pub mod class;
 pub mod context;
@@ -57,8 +54,6 @@ pub mod property;
 pub mod realm;
 pub mod string;
 pub mod symbol;
-// syntax module has a lot of acronyms
-#[allow(clippy::upper_case_acronyms)]
 pub mod syntax;
 pub mod value;
 

--- a/boa/src/syntax/mod.rs
+++ b/boa/src/syntax/mod.rs
@@ -1,4 +1,6 @@
 //! Syntactical analysis, such as Abstract Syntax Tree (AST), Parsing and Lexing
+// syntax module has a lot of acronyms
+#![allow(clippy::upper_case_acronyms)]
 
 pub mod ast;
 pub mod lexer;

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -10,15 +10,15 @@ use std::hash::{Hash, Hasher};
 fn is_object() {
     let context = Context::new();
     let val = Value::new_object(&context);
-    assert_eq!(val.is_object(), true);
+    assert!(val.is_object());
 }
 
 #[test]
 fn string_to_value() {
     let s = String::from("Hello");
     let v = Value::from(s);
-    assert_eq!(v.is_string(), true);
-    assert_eq!(v.is_null(), false);
+    assert!(v.is_string());
+    assert!(!v.is_null());
 }
 
 #[test]
@@ -46,19 +46,19 @@ fn get_set_field() {
 
 #[test]
 fn integer_is_true() {
-    assert_eq!(Value::from(1).to_boolean(), true);
-    assert_eq!(Value::from(0).to_boolean(), false);
-    assert_eq!(Value::from(-1).to_boolean(), true);
+    assert!(Value::from(1).to_boolean());
+    assert!(!Value::from(0).to_boolean());
+    assert!(Value::from(-1).to_boolean());
 }
 
 #[test]
 fn number_is_true() {
-    assert_eq!(Value::from(1.0).to_boolean(), true);
-    assert_eq!(Value::from(0.1).to_boolean(), true);
-    assert_eq!(Value::from(0.0).to_boolean(), false);
-    assert_eq!(Value::from(-0.0).to_boolean(), false);
-    assert_eq!(Value::from(-1.0).to_boolean(), true);
-    assert_eq!(Value::nan().to_boolean(), false);
+    assert!(Value::from(1.0).to_boolean());
+    assert!(Value::from(0.1).to_boolean());
+    assert!(!Value::from(0.0).to_boolean());
+    assert!(!Value::from(-0.0).to_boolean());
+    assert!(Value::from(-1.0).to_boolean());
+    assert!(!Value::nan().to_boolean());
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness
@@ -757,6 +757,8 @@ mod cyclic_conversions {
 }
 
 mod abstract_relational_comparison {
+    #![allow(clippy::bool_assert_comparison)]
+
     use super::*;
     macro_rules! check_comparison {
         ($context:ident, $string:expr => $expect:expr) => {


### PR DESCRIPTION
This PR fixes clippy lints and makes lints warnings instead of errors. Why do we want this? It's because as clippy becomes "smarter" it's going to detect more, and they all will be errors, breaking our builds. This mostly affects nightly users as they have the latest version of clippy, but it still applies for stable (like now).

Changed CI so clippy lint warnings cause a CI failure
