### PR TITLE
Change StringGetOwnProperty to produce the same strings that the lexer produces

### DIFF
--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -1132,7 +1132,7 @@ fn string_get_property() {
     assert_eq!(forward(&mut context, "'abc'[2]"), "\"c\"");
     assert_eq!(forward(&mut context, "'abc'[3]"), "undefined");
     assert_eq!(forward(&mut context, "'abc'['foo']"), "undefined");
-    assert_eq!(forward(&mut context, "'😀'[0]"), "\"\\ud83d\"");
+    assert_eq!(forward(&mut context, "'😀'[0]"), "\"�\"");
 }
 
 #[test]

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -620,10 +620,10 @@ impl GcObject {
                     return None;
                 }
 
-                let result_str = string.encode_utf16().nth(pos).map(|utf16_val| {
-                    char::from_u32(u32::from(utf16_val))
-                        .map_or_else(|| Value::from(format!("\\u{:x}", utf16_val)), Value::from)
-                })?;
+                let result_str = string
+                    .encode_utf16()
+                    .nth(pos)
+                    .map(|utf16_val| Value::from(String::from_utf16_lossy(&[utf16_val])))?;
 
                 let desc = PropertyDescriptor::builder()
                     .value(result_str)


### PR DESCRIPTION
This Pull Request fixes/closes #1459.

This changes StringGetOwnProperty to use String::from_utf16_lossy. This fixes the issue mentioned, but of course `String::from_utf16_lossy` is only a hack for the missing full UTF16 support. In my opinion it is the best way to go, as writing the codepoint as an escaped string may cause even more unexpected behavior.