### PR TITLE
Feature throw `Error` object

### DIFF
--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -358,6 +358,30 @@ impl Context {
         self.realm.global_object.clone()
     }
 
+    /// Constructs a `Error` with the specified message.
+    #[inline]
+    pub fn construct_error<M>(&mut self, message: M) -> JsValue
+    where
+        M: Into<Box<str>>,
+    {
+        // Runs a `new RangeError(message)`.
+        New::from(Call::new(
+            Identifier::from("Error"),
+            vec![Const::from(message.into()).into()],
+        ))
+        .run(self)
+        .expect("Into<String> used as message")
+    }
+
+    /// Throws a `Error` with the specified message.
+    #[inline]
+    pub fn throw_error<M>(&mut self, message: M) -> Result<JsValue>
+    where
+        M: Into<Box<str>>,
+    {
+        Err(self.construct_error(message))
+    }
+
     /// Constructs a `RangeError` with the specified message.
     #[inline]
     pub fn construct_range_error<M>(&mut self, message: M) -> JsValue

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -364,7 +364,7 @@ impl Context {
     where
         M: Into<Box<str>>,
     {
-        // Runs a `new RangeError(message)`.
+        // Runs a `new Error(message)`.
         New::from(Call::new(
             Identifier::from("Error"),
             vec![Const::from(message.into()).into()],


### PR DESCRIPTION
It changes the following:
- Implement `Context::construct_error()`
- Implement `Context::throw_error()`
