### PR TITLE
Implement `String.prototype.replaceAll`

### DIFF
--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -1598,7 +1598,11 @@ impl RegExp {
         let splitter = constructor
             .as_object()
             .expect("SpeciesConstructor returned non Object")
-            .construct(&[JsValue::from(rx), new_flags.into()], &constructor, context)?;
+            .construct(
+                &[JsValue::from(rx), new_flags.into()],
+                &constructor,
+                context,
+            )?;
 
         // 11. Let A be ! ArrayCreate(0).
         let a = Array::array_create(0, None, context).unwrap();

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -855,7 +855,7 @@ impl String {
             // d. If replacer is not undefined, then
             if let Some(replacer) = replacer {
                 // i. Return ? Call(replacer, searchValue, « O, replaceValue »).
-                return context.call(&replacer.into(), &search_value, &[o.into(), replace_value]);
+                return replacer.call(&search_value, &[o.into(), replace_value], context);
             }
         }
 


### PR DESCRIPTION
This Pull Request relates to #13.

It changes the following:

- Implement String.prototype.replaceAll
- Implement StringIndexOf on JsString
- Fix some utf16 related bugs in GetSubstitution

Not all tests in the `built-ins/String/prototype/replaceAll` suite pass. I checked all failing tests and each one can be attributed to some other bug/missing feature. I will open issues for those who have none.