### PR TITLE
Implement `Object.keys` and `Object.entries`

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -64,6 +64,7 @@ impl BuiltIn for Object {
         .static_method(Self::assign, "assign", 2)
         .static_method(Self::is, "is", 2)
         .static_method(Self::keys, "keys", 1)
+        .static_method(Self::entries, "entries", 1)
         .static_method(
             Self::get_own_property_descriptor,
             "getOwnPropertyDescriptor",

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -638,7 +638,7 @@ impl Object {
             obj.enumerable_own_property_names(PropertyNameKind::KeyAndValue, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        let result = Array::create_array_from_list(name_list.into_iter(), context);
+        let result = Array::create_array_from_list(name_list, context);
 
         Ok(result.into())
     }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     object::{
         ConstructorBuilder, Object as BuiltinObject, ObjectData, ObjectInitializer, PROTOTYPE,
     },
-    property::{Attribute, DescriptorKind, PropertyDescriptor},
+    property::{Attribute, DescriptorKind, PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
     value::{JsValue, Type},
     BoaProfiler, Context, Result,
@@ -608,7 +608,7 @@ impl Object {
             .to_object(context)?;
 
         // 2. Let nameList be ? EnumerableOwnPropertyNames(obj, key).
-        let name_list = obj.enumerable_own_property_names(true, false, context)?;
+        let name_list = obj.enumerable_own_property_names(PropertyNameKind::Key, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
         // TODO: Implement https://tc39.es/ecma262/#sec-createarrayfromlist

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -611,4 +611,34 @@ impl Object {
 
         Ok(result.into())
     }
+
+    /// `Object.entries( target )`
+    ///
+    /// This method returns an array of a given object's own enumerable string-keyed property [key, value] pairs.
+    /// This is the same as iterating with a for...in loop,
+    /// except that a for...in loop enumerates properties in the prototype chain as well).
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-object.entries
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
+    pub fn entries(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
+        // 1. Let obj be ? ToObject(target).
+        let obj = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_object(context)?;
+
+        // 2. Let nameList be ? EnumerableOwnPropertyNames(obj, key+value).
+        let name_list =
+            obj.enumerable_own_property_names(PropertyNameKind::KeyAndValue, context)?;
+
+        // 3. Return CreateArrayFromList(nameList).
+        let result = Array::create_array_from_list(name_list.into_iter(), context);
+
+        Ok(result.into())
+    }
 }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -544,8 +544,6 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-object.assign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
     pub fn assign(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        //
-        //
         // 1. Let to be ? ToObject(target).
         let to = args
             .get(0)
@@ -598,8 +596,6 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-object.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
     pub fn keys(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        //
-        //
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -611,12 +607,8 @@ impl Object {
         let name_list = obj.enumerable_own_property_names(PropertyNameKind::Key, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        // TODO: Implement https://tc39.es/ecma262/#sec-createarrayfromlist
-        let result = Array::array_create(name_list.len(), None, context)?;
-        for (index, name) in name_list.iter().enumerate() {
-            result.set(index, name, false, context)?;
-        }
+        let result = Array::create_array_from_list(name_list.into_iter(), context);
 
-        Ok(JsValue::Object(result))
+        Ok(result.into())
     }
 }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -24,6 +24,8 @@ use crate::{
     BoaProfiler, Context, Result,
 };
 
+use super::Array;
+
 pub mod for_in_iterator;
 #[cfg(test)]
 mod tests;
@@ -61,6 +63,7 @@ impl BuiltIn for Object {
         .static_method(Self::define_properties, "defineProperties", 2)
         .static_method(Self::assign, "assign", 2)
         .static_method(Self::is, "is", 2)
+        .static_method(Self::keys, "keys", 1)
         .static_method(
             Self::get_own_property_descriptor,
             "getOwnPropertyDescriptor",
@@ -581,5 +584,39 @@ impl Object {
 
         // 4. Return to.
         Ok(to.into())
+    }
+
+    /// `Object.keys( target )`
+    ///
+    /// This method returns an array of a given object's own enumerable
+    /// property names, iterated in the same order that a normal loop would.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-object.keys
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+    pub fn keys(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
+        //
+        //
+        // 1. Let obj be ? ToObject(target).
+        let obj = args
+            .get(0)
+            .cloned()
+            .unwrap_or_default()
+            .to_object(context)?;
+
+        // 2. Let nameList be ? EnumerableOwnPropertyNames(obj, key).
+        let name_list = obj.enumerable_own_property_names(true, false, context)?;
+
+        // 3. Return CreateArrayFromList(nameList).
+        // TODO: Implement https://tc39.es/ecma262/#sec-createarrayfromlist
+        let result = Array::array_create(name_list.len(), None, context)?;
+        for (index, name) in name_list.iter().enumerate() {
+            result.set(index, name, false, context)?;
+        }
+
+        Ok(JsValue::Object(result))
     }
 }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -608,7 +608,7 @@ impl Object {
         let name_list = obj.enumerable_own_property_names(PropertyNameKind::Key, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        let result = Array::create_array_from_list(name_list.into_iter(), context);
+        let result = Array::create_array_from_list(name_list, context);
 
         Ok(result.into())
     }

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -1598,7 +1598,7 @@ impl RegExp {
         let splitter = constructor
             .as_object()
             .expect("SpeciesConstructor returned non Object")
-            .construct(&[Value::from(rx), new_flags.into()], &constructor, context)?;
+            .construct(&[JsValue::from(rx), new_flags.into()], &constructor, context)?;
 
         // 11. Let A be ! ArrayCreate(0).
         let a = Array::array_create(0, None, context).unwrap();

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -7,7 +7,7 @@
 
 use crate::{
     object::{GcObject, Object, ObjectData},
-    property::{DescriptorKind, PropertyDescriptor, PropertyKey},
+    property::{DescriptorKind, PropertyDescriptor, PropertyKey, PropertyNameKind},
     value::{JsValue, Type},
     BoaProfiler, Context, Result,
 };
@@ -889,8 +889,7 @@ impl GcObject {
     /// [spec]: https://tc39.es/ecma262/#sec-enumerableownpropertynames
     pub(crate) fn enumerable_own_property_names(
         &self,
-        kind_key: bool,
-        kind_value: bool,
+        kind: PropertyNameKind,
         context: &mut Context,
     ) -> Result<Vec<JsValue>> {
         // 1. Assert: Type(O) is Object.
@@ -909,7 +908,7 @@ impl GcObject {
                 if let Some(desc) = desc {
                     if desc.expect_enumerable() {
                         // 1. If kind is key, append key to properties.
-                        if kind_key && kind_value == false {
+                        if let PropertyNameKind::Key = kind {
                             properties.push(JsValue::String(key_str.clone()))
                         }
                         // 2. Else,
@@ -917,7 +916,7 @@ impl GcObject {
                             // a. Let value be ? Get(O, key).
                             let value = self.get(key.clone(), context)?;
                             // b. If kind is value, append value to properties.
-                            if kind_value && kind_key == false {
+                            if let PropertyNameKind::Value = kind {
                                 properties.push(value)
                             }
                             // c. Else,

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -924,7 +924,7 @@ impl GcObject {
                             else {
                                 // i. Assert: kind is key+value.
                                 // ii. Let entry be ! CreateArrayFromList(« key, value »).
-                                let key_val = JsValue::String(key_str.clone());
+                                let key_val = key_str.clone().into();
                                 let entry =
                                     Array::create_array_from_list([key_val, value], context);
 

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -924,14 +924,12 @@ impl GcObject {
                             else {
                                 // i. Assert: kind is key+value.
                                 // ii. Let entry be ! CreateArrayFromList(« key, value »).
-                                // TODO: Implement https://tc39.es/ecma262/#sec-createarrayfromlist
-                                let entry = JsValue::new_object(context);
                                 let key_val = JsValue::String(key_str.clone());
-                                entry.add(&key_val, context)?;
-                                entry.add(&value, context)?;
+                                let entry =
+                                    Array::create_array_from_list([key_val, value], context);
 
                                 // iii. Append entry to properties.
-                                properties.push(entry);
+                                properties.push(entry.into());
                             }
                         }
                     }

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -6,6 +6,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots
 
 use crate::{
+    builtins::Array,
     object::{GcObject, Object, ObjectData},
     property::{DescriptorKind, PropertyDescriptor, PropertyKey, PropertyNameKind},
     value::{JsValue, Type},
@@ -909,7 +910,7 @@ impl GcObject {
                     if desc.expect_enumerable() {
                         // 1. If kind is key, append key to properties.
                         if let PropertyNameKind::Key = kind {
-                            properties.push(JsValue::String(key_str.clone()))
+                            properties.push(key_str.clone().into())
                         }
                         // 2. Else,
                         else {

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -662,3 +662,10 @@ impl PartialEq<&str> for PropertyKey {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub enum PropertyNameKind {
+    Key,
+    Value,
+    KeyValue,
+}

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -667,5 +667,5 @@ impl PartialEq<&str> for PropertyKey {
 pub(crate) enum PropertyNameKind {
     Key,
     Value,
-    KeyValue,
+    KeyAndValue,
 }

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -664,7 +664,7 @@ impl PartialEq<&str> for PropertyKey {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub enum PropertyNameKind {
+pub(crate) enum PropertyNameKind {
     Key,
     Value,
     KeyValue,


### PR DESCRIPTION
This Pull Request adds the `Object.keys(...)` function.

It's my first contribution, sorry if something is missing, incorrect or dirty, I tried to implement it to-spec.