### PR TITLE
Implement abstract operation `CreateArrayFromList`

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -105,12 +105,9 @@ impl ArrayIterator {
                     }
                     ArrayIterationKind::KeyAndValue => {
                         let element_value = array_iterator.array.get_field(index, context)?;
-                        let result = Array::constructor(
-                            &JsValue::new_object(context),
-                            &[index.into(), element_value],
-                            context,
-                        )?;
-                        Ok(create_iter_result_object(context, result, false))
+                        let result =
+                            Array::create_array_from_list([index.into(), element_value], context);
+                        Ok(create_iter_result_object(context, result.into(), false))
                     }
                 }
             } else {

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -233,7 +233,7 @@ impl Array {
         array.ordinary_define_own_property(
             "length".into(),
             PropertyDescriptor::builder()
-                .value(length as f64)
+                .value(length)
                 .writable(true)
                 .enumerable(false)
                 .configurable(false)
@@ -288,47 +288,6 @@ impl Array {
                 .build(),
         );
         array
-    }
-
-    /// Utility function for creating array objects.
-    ///
-    /// `array_obj` can be any array with prototype already set (it will be wiped and
-    /// recreated from `array_contents`)
-    pub(crate) fn construct_array(
-        array_obj: &JsValue,
-        array_contents: &[JsValue],
-        context: &mut Context,
-    ) -> Result<JsValue> {
-        let array_obj_ptr = array_obj.clone();
-
-        // Wipe existing contents of the array object
-        let orig_length = array_obj.get_field("length", context)?.to_length(context)?;
-        for n in 0..orig_length {
-            array_obj_ptr.remove_property(n);
-        }
-
-        // Create length
-        array_obj_ptr.set_property(
-            "length".to_string(),
-            PropertyDescriptor::builder()
-                .value(array_contents.len())
-                .writable(true)
-                .enumerable(false)
-                .configurable(false)
-                .build(),
-        );
-
-        for (n, value) in array_contents.iter().enumerate() {
-            array_obj_ptr.set_property(
-                n,
-                PropertyDescriptor::builder()
-                    .value(value)
-                    .configurable(true)
-                    .enumerable(true)
-                    .writable(true),
-            );
-        }
-        Ok(array_obj_ptr)
     }
 
     /// Utility function for concatenating array objects.

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -243,6 +243,33 @@ impl Array {
         Ok(array)
     }
 
+    /// Utility for constructing `Array` objects from an iterator of `JsValue`s.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-createarrayfromlist
+    pub(crate) fn create_array_from_list<I>(elements: I, context: &mut Context) -> GcObject
+    where
+        I: IntoIterator<Item = JsValue>,
+    {
+        // 1. Assert: elements is a List whose elements are all ECMAScript language values.
+        // 2. Let array be ! ArrayCreate(0).
+        let array = Self::array_create(0, None, context)
+            .expect("creating an empty array with the default prototype must not fail");
+        // 3. Let n be 0.
+        // 4. For each element e of elements, do
+        for (i, elem) in elements.into_iter().enumerate() {
+            // a. Perform ! CreateDataPropertyOrThrow(array, ! ToString(𝔽(n)), e).
+            array
+                .create_data_property_or_throw(i, elem, context)
+                .expect("new array must be extensible");
+            // b. Set n to n + 1.
+        }
+        // 5. Return array.
+        array
+    }
+
     /// Creates a new `Array` instance.
     pub(crate) fn new_array(context: &Context) -> JsValue {
         let array = JsValue::new_object(context);

--- a/boa/src/builtins/map/map_iterator.rs
+++ b/boa/src/builtins/map/map_iterator.rs
@@ -114,13 +114,14 @@ impl MapIterator {
                                         ));
                                     }
                                     MapIterationKind::KeyAndValue => {
-                                        let result = Array::construct_array(
-                                            &Array::new_array(context),
-                                            &[key.clone(), value.clone()],
+                                        let result = Array::create_array_from_list(
+                                            [key.clone(), value.clone()],
                                             context,
-                                        )?;
+                                        );
                                         return Ok(create_iter_result_object(
-                                            context, result, false,
+                                            context,
+                                            result.into(),
+                                            false,
                                         ));
                                     }
                                 }

--- a/boa/src/builtins/set/set_iterator.rs
+++ b/boa/src/builtins/set/set_iterator.rs
@@ -104,13 +104,14 @@ impl SetIterator {
                                         ));
                                     }
                                     SetIterationKind::KeyAndValue => {
-                                        let result = Array::construct_array(
-                                            &Array::new_array(context),
-                                            &[value.clone(), value.clone()],
+                                        let result = Array::create_array_from_list(
+                                            [value.clone(), value.clone()],
                                             context,
-                                        )?;
+                                        );
                                         return Ok(create_iter_result_object(
-                                            context, result, false,
+                                            context,
+                                            result.into(),
+                                            false,
                                         ));
                                     }
                                 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request implements the abstract operation `CreateArrayFromList`.

It changes the following:

- Creates new function `Array::create_array_from_list`
- Replaces calls to other functions with calls to the above.
- Removes the function `Array::construct_array`, as it is equivalent to `create_array_from_list`
