### PR TITLE
Date refactor

### DIFF
--- a/boa/src/builtins/date/mod.rs
+++ b/boa/src/builtins/date/mod.rs
@@ -523,19 +523,15 @@ impl Date {
             return context.throw_type_error("Date.prototype[@@toPrimitive] called on non object");
         };
 
-        let hint = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_string(context)?;
+        let hint = args.get(0).cloned().unwrap_or_default();
 
-        let try_first = match hint.as_str() {
+        let try_first = match hint.as_string().map(|s| s.as_str()) {
             // 3. If hint is "string" or "default", then
             // a. Let tryFirst be string.
-            "string" | "default" => PreferredType::String,
+            Some("string") | Some("default") => PreferredType::String,
             // 4. Else if hint is "number", then
             // a. Let tryFirst be number.
-            "number" => PreferredType::Number,
+            Some("number") => PreferredType::Number,
             // 5. Else, throw a TypeError exception.
             _ => {
                 return context
@@ -723,7 +719,7 @@ impl Date {
         }
 
         // 3. Return (t - LocalTime(t)) / msPerMinute.
-        Ok(JsValue::Rational(
+        Ok(JsValue::new(
             -Local::now().offset().local_minus_utc() as f64 / 60f64,
         ))
     }

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -408,7 +408,7 @@ fn date_proto_get_timezone_offset() -> Result<(), Box<dyn std::error::Error>> {
 
     let actual = forward_val(
         &mut context,
-        "new Date('August 19, 1975 23:15:30 GMT+07:00').getTimezoneOffset() === new Date('August 19, 1975 23:15:30 GMT-02:00').getTimezoneOffset()",
+        "new Date('1975-08-19T23:15:30+07:00').getTimezoneOffset() === new Date('1975-08-19T23:15:30-02:00').getTimezoneOffset()",
     );
 
     // NB: Host Settings, not TZ specified in the DateTime.
@@ -416,17 +416,17 @@ fn date_proto_get_timezone_offset() -> Result<(), Box<dyn std::error::Error>> {
 
     let actual = forward_val(
         &mut context,
-        "new Date('August 19, 1975 23:15:30 GMT+07:00').getTimezoneOffset()",
+        "new Date('1975-08-19T23:15:30+07:00').getTimezoneOffset()",
     );
 
     // The value of now().offset() depends on the host machine, so we have to replicate the method code here.
     let offset_seconds = chrono::Local::now().offset().local_minus_utc() as f64;
-    let offset_minutes = offset_seconds / 60f64;
+    let offset_minutes = -offset_seconds / 60f64;
     assert_eq!(Ok(JsValue::new(offset_minutes)), actual);
 
     let actual = forward_val(
         &mut context,
-        "new Date(1/0, 06, 08, 09, 16, 15, 779).getTimezoneOffset()",
+        "new Date('1975-08-19T23:15:30+07:00').getTimezoneOffset()",
     );
     assert_eq!(Ok(JsValue::new(offset_minutes)), actual);
     Ok(())
@@ -1282,7 +1282,7 @@ fn date_proto_to_string() -> Result<(), Box<dyn std::error::Error>> {
                 ))
                 .earliest()
                 .unwrap()
-                .format("Wed Jul 08 2020 09:16:15 GMT%:z")
+                .format("Wed Jul 08 2020 09:16:15 GMT%z")
                 .to_string()
         )),
         actual
@@ -1310,7 +1310,7 @@ fn date_proto_to_time_string() -> Result<(), Box<dyn std::error::Error>> {
                 ))
                 .earliest()
                 .unwrap()
-                .format("09:16:15 GMT%:z")
+                .format("09:16:15 GMT%z")
                 .to_string()
         )),
         actual


### PR DESCRIPTION
It changes the following:

- Handle high and negative values in `new Date()`
- Refactor `Date` setter methods
- Refactor some `Date` getter methods
- Implement `Date.prototype[Symbol.toPrimitive]` method
