### PR TITLE
Implement new `get_or_undefined` method for `[JsValue]` (`Cow` version)

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -25,6 +25,8 @@ use crate::{
 };
 use std::cmp::{max, min};
 
+use super::JsArgs;
+
 /// JavaScript `Array` built-in implementation.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Array;
@@ -680,7 +682,7 @@ impl Array {
                 // i. Let kValue be ? Get(O, Pk).
                 let k_value = o.get(pk, context)?;
                 // ii. Perform ? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »).
-                let this_arg = args.get(1).cloned().unwrap_or_else(JsValue::undefined);
+                let this_arg = args.get_or_undefined(1);
                 callback.call(&this_arg, &[k_value, k.into(), o.clone().into()], context)?;
             }
             // d. Set k to k + 1.
@@ -1007,7 +1009,7 @@ impl Array {
             return context.throw_type_error("Array.prototype.every: callback is not callable");
         };
 
-        let this_arg = args.get(1).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(1);
 
         // 4. Let k be 0.
         // 5. Repeat, while k < len,
@@ -1051,7 +1053,7 @@ impl Array {
         // 2. Let len be ? LengthOfArrayLike(O).
         let len = o.length_of_array_like(context)?;
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
-        let callback = args.get(0).cloned().unwrap_or_default();
+        let callback = args.get_or_undefined(0);
         if !callback.is_function() {
             return context.throw_type_error("Array.prototype.map: Callbackfn is not callable");
         }
@@ -1059,7 +1061,7 @@ impl Array {
         // 4. Let A be ? ArraySpeciesCreate(O, len).
         let a = Self::array_species_create(&o, len, context)?;
 
-        let this_arg = args.get(1).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(1);
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -1137,7 +1139,7 @@ impl Array {
             }
         };
 
-        let search_element = args.get(0).cloned().unwrap_or_default();
+        let search_element = args.get_or_undefined(0);
 
         // 10. Repeat, while k < len,
         while k < len {
@@ -1213,7 +1215,7 @@ impl Array {
             IntegerOrInfinity::Integer(n) => len + n,
         };
 
-        let search_element = args.get(0).cloned().unwrap_or_default();
+        let search_element = args.get_or_undefined(0);
 
         // 8. Repeat, while k ≥ 0,
         while k >= 0 {
@@ -1263,7 +1265,7 @@ impl Array {
             }
         };
 
-        let this_arg = args.get(1).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(1);
 
         // 4. Let k be 0.
         let mut k = 0;
@@ -1324,7 +1326,7 @@ impl Array {
             }
         };
 
-        let this_arg = args.get(1).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(1);
 
         // 4. Let k be 0.
         let mut k = 0;
@@ -1424,7 +1426,7 @@ impl Array {
         let source_len = o.length_of_array_like(context)?;
 
         // 3. If ! IsCallable(mapperFunction) is false, throw a TypeError exception.
-        let mapper_function = args.get(0).cloned().unwrap_or_default();
+        let mapper_function = args.get_or_undefined(0);
         if !mapper_function.is_function() {
             return context.throw_type_error("flatMap mapper function is not callable");
         }
@@ -1440,7 +1442,7 @@ impl Array {
             0,
             1,
             Some(mapper_function.as_object().unwrap()),
-            &args.get(1).cloned().unwrap_or_default(),
+            &args.get_or_undefined(1),
             context,
         )?;
 
@@ -1591,7 +1593,7 @@ impl Array {
         // 10. Else, let final be min(relativeEnd, len).
         let final_ = Self::get_relative_end(context, args.get(2), len)?;
 
-        let value = args.get(0).cloned().unwrap_or_default();
+        let value = args.get_or_undefined(0).into_owned();
 
         // 11. Repeat, while k < final,
         while k < final_ {
@@ -1662,7 +1664,7 @@ impl Array {
             }
         }
 
-        let search_element = args.get(0).cloned().unwrap_or_default();
+        let search_element = args.get_or_undefined(0);
 
         // 10. Repeat, while k < len,
         while k < len {
@@ -1782,7 +1784,7 @@ impl Array {
                     "missing argument 0 when calling function Array.prototype.filter",
                 )
             })?;
-        let this_val = args.get(1).cloned().unwrap_or_else(JsValue::undefined);
+        let this_val = args.get_or_undefined(1);
 
         if !callback.is_callable() {
             return context.throw_type_error("the callback must be callable");
@@ -1864,7 +1866,7 @@ impl Array {
                 // i. Let kValue be ? Get(O, Pk).
                 let k_value = o.get(k, context)?;
                 // ii. Let testResult be ! ToBoolean(? Call(callbackfn, thisArg, « kValue, 𝔽(k), O »)).
-                let this_arg = args.get(1).cloned().unwrap_or_default();
+                let this_arg = args.get_or_undefined(1);
                 let test_result = callback
                     .call(&this_arg, &[k_value, k.into(), o.clone().into()], context)?
                     .to_boolean();

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -13,7 +13,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     object::{ConstructorBuilder, ObjectData},
     property::Attribute,
     symbol::WellKnownSymbols,
@@ -214,10 +214,8 @@ impl BigInt {
     fn calculate_as_uint_n(args: &[JsValue], context: &mut Context) -> Result<(JsBigInt, u32)> {
         use std::convert::TryFrom;
 
-        let undefined_value = JsValue::undefined();
-
-        let bits_arg = args.get(0).unwrap_or(&undefined_value);
-        let bigint_arg = args.get(1).unwrap_or(&undefined_value);
+        let bits_arg = args.get_or_undefined(0);
+        let bigint_arg = args.get_or_undefined(1);
 
         let bits = bits_arg.to_index(context)?;
         let bits = u32::try_from(bits).unwrap_or(u32::MAX);

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -17,7 +17,7 @@
 mod tests;
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     object::ObjectInitializer,
     property::Attribute,
     value::{display::display_obj, JsValue},
@@ -90,7 +90,7 @@ pub fn formatter(data: &[JsValue], context: &mut Context) -> Result<String> {
                         }
                         /* object, FIXME: how to render this properly? */
                         'o' | 'O' => {
-                            let arg = data.get(arg_index).cloned().unwrap_or_default();
+                            let arg = data.get_or_undefined(arg_index);
                             formatted.push_str(&format!("{}", arg.display()));
                             arg_index += 1
                         }
@@ -556,9 +556,8 @@ impl Console {
     /// [spec]: https://console.spec.whatwg.org/#dir
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/dir
     pub(crate) fn dir(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        let undefined = JsValue::undefined();
         logger(
-            LogMessage::Info(display_obj(args.get(0).unwrap_or(&undefined), true)),
+            LogMessage::Info(display_obj(&args.get_or_undefined(0), true)),
             context.console(),
         );
 

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -25,6 +25,8 @@ use bitflags::bitflags;
 use std::fmt::{self, Debug};
 use std::rc::Rc;
 
+use super::JsArgs;
+
 #[cfg(test)]
 mod tests;
 
@@ -309,7 +311,7 @@ impl BuiltInFunctionObject {
         if !this.is_function() {
             return context.throw_type_error(format!("{} is not a function", this.display()));
         }
-        let this_arg: JsValue = args.get(0).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(0);
         // TODO?: 3. Perform PrepareForTailCall
         let start = if !args.is_empty() { 1 } else { 0 };
         context.call(this, &this_arg, &args[start..])
@@ -330,8 +332,8 @@ impl BuiltInFunctionObject {
         if !this.is_function() {
             return context.throw_type_error(format!("{} is not a function", this.display()));
         }
-        let this_arg = args.get(0).cloned().unwrap_or_default();
-        let arg_array = args.get(1).cloned().unwrap_or_default();
+        let this_arg = args.get_or_undefined(0);
+        let arg_array = args.get_or_undefined(1);
         if arg_array.is_null_or_undefined() {
             // TODO?: 3.a. PrepareForTailCall
             return context.call(this, &this_arg, &[]);

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -26,6 +26,8 @@ use map_iterator::{MapIterationKind, MapIterator};
 
 use self::ordered_map::MapLock;
 
+use super::JsArgs;
+
 pub mod ordered_map;
 #[cfg(test)]
 mod tests;
@@ -273,7 +275,7 @@ impl Map {
         args: &[JsValue],
         context: &mut Context,
     ) -> Result<JsValue> {
-        let key = args.get(0).cloned().unwrap_or_default();
+        let key = args.get_or_undefined(0);
 
         let (deleted, size) = if let Some(object) = this.as_object() {
             if let Some(map) = object.borrow_mut().as_map_mut() {
@@ -300,7 +302,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
     pub(crate) fn get(this: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        let key = args.get(0).cloned().unwrap_or_default();
+        let key = args.get_or_undefined(0);
 
         if let JsValue::Object(ref object) = this {
             let object = object.borrow();
@@ -345,7 +347,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
     pub(crate) fn has(this: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        let key = args.get(0).cloned().unwrap_or_default();
+        let key = args.get_or_undefined(0);
 
         if let JsValue::Object(ref object) = this {
             let object = object.borrow();
@@ -377,7 +379,7 @@ impl Map {
         }
 
         let callback_arg = &args[0];
-        let this_arg = args.get(1).cloned().unwrap_or_else(JsValue::undefined);
+        let this_arg = args.get_or_undefined(1);
 
         let mut index = 0;
 

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -118,3 +118,12 @@ pub fn init(context: &mut Context) {
 pub(crate) trait JsArgs {
     fn get_or_undefined(&self, index: usize) -> Cow<'_, JsValue>;
 }
+
+
+impl JsArgs for [JsValue] {
+    fn get_or_undefined(&self, index: usize) -> Cow<'_, JsValue> {
+        self.get(index)
+            .map(|v| Cow::Borrowed(v))
+            .unwrap_or(Cow::Owned(JsValue::Undefined))
+    }
+}

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -27,6 +27,8 @@ pub mod string;
 pub mod symbol;
 pub mod undefined;
 
+use std::borrow::Cow;
+
 pub(crate) use self::{
     array::{array_iterator::ArrayIterator, Array},
     bigint::BigInt,
@@ -111,4 +113,8 @@ pub fn init(context: &mut Context) {
             .configurable(attribute.configurable());
         global_object.borrow_mut().insert(name, property);
     }
+}
+
+pub(crate) trait JsArgs {
+    fn get_or_undefined(&self, index: usize) -> Cow<'_, JsValue>;
 }

--- a/boa/src/builtins/mod.rs
+++ b/boa/src/builtins/mod.rs
@@ -115,10 +115,9 @@ pub fn init(context: &mut Context) {
     }
 }
 
-pub(crate) trait JsArgs {
+pub trait JsArgs {
     fn get_or_undefined(&self, index: usize) -> Cow<'_, JsValue>;
 }
-
 
 impl JsArgs for [JsValue] {
     fn get_or_undefined(&self, index: usize) -> Cow<'_, JsValue> {

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -13,8 +13,8 @@
 //! [spec]: https://tc39.es/ecma262/#sec-number-object
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number
 
-use super::function::make_builtin_fn;
 use super::string::is_trimmable_whitespace;
+use super::{function::make_builtin_fn, JsArgs};
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, ObjectData, PROTOTYPE},
@@ -392,12 +392,12 @@ impl Number {
         args: &[JsValue],
         context: &mut Context,
     ) -> Result<JsValue> {
-        let precision = args.get(0).cloned().unwrap_or_default();
+        let precision = args.get_or_undefined(0);
 
         // 1 & 6
         let mut this_num = Self::this_number_value(this, context)?;
         // 2
-        if precision == JsValue::undefined() {
+        if precision.is_undefined() {
             return Self::to_string(this, &[], context);
         }
 
@@ -720,7 +720,7 @@ impl Number {
         args: &[JsValue],
         context: &mut Context,
     ) -> Result<JsValue> {
-        if let (Some(val), radix) = (args.get(0), args.get(1)) {
+        if let (Some(val), radix) = (args.get(0), args.get_or_undefined(1)) {
             // 1. Let inputString be ? ToString(string).
             let input_string = val.to_string(context)?;
 
@@ -745,7 +745,7 @@ impl Number {
             }
 
             // 6. Let R be ℝ(? ToInt32(radix)).
-            let mut var_r = radix.cloned().unwrap_or_default().to_i32(context)?;
+            let mut var_r = radix.to_i32(context)?;
 
             // 7. Let stripPrefix be true.
             let mut strip_prefix = true;

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -31,6 +31,8 @@ use std::cell::RefCell;
 
 use rustc_hash::FxHashMap;
 
+use super::JsArgs;
+
 thread_local! {
     static GLOBAL_SYMBOL_REGISTRY: RefCell<GlobalSymbolRegistry> = RefCell::new(GlobalSymbolRegistry::new());
 }
@@ -272,7 +274,7 @@ impl Symbol {
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.keyfor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
     pub(crate) fn key_for(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue> {
-        let sym = args.get(0).cloned().unwrap_or_default();
+        let sym = args.get_or_undefined(0);
         // 1. If Type(sym) is not Symbol, throw a TypeError exception.
         if let Some(sym) = sym.as_symbol() {
             // 2. For each element e of the GlobalSymbolRegistry List (see 20.4.2.2), do

--- a/boa/src/class.rs
+++ b/boa/src/class.rs
@@ -7,6 +7,7 @@
 //!#    class::{Class, ClassBuilder},
 //!#    gc::{Finalize, Trace},
 //!#    Context, Result, JsValue,
+//!#    builtins::JsArgs
 //!# };
 //!#
 //! // This does not have to be an enum it can also be a struct.
@@ -27,7 +28,7 @@
 //!     // This is what is called when we do `new Animal()`
 //!     fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context) -> Result<Self> {
 //!         // This is equivalent to `String(arg)`.
-//!         let kind = args.get(0).cloned().unwrap_or_default().to_string(context)?;
+//!         let kind = args.get_or_undefined(0).to_string(context)?;
 //!
 //!         let animal = match kind.as_str() {
 //!             "cat" => Self::Cat,


### PR DESCRIPTION
This Pull Request fixes/closes #1490.

It changes the following:

- Adds a new trait `JsArgs` to add new methods to `[JsValue]`
- Implements a new method `get_or_undefined` for `[JsValue]`
- Replaces calls to `args.get(n).cloned().unwrap_or_default()` with `args.get_or_undefined()`

This should improve the usability of the api by not having to `unwrap_or_default` everytime we want an argument inside a builtin function.

I'm opening two pull requests for benchmarking purposes; one PR (this one) will use `Cow` as the return type of `get_or_undefined` and another one will directly return `args.get(n).cloned().unwrap_or_default()`. I'll close the one with worse performance.
