### PR TITLE
Reuse `PropertyNameKind` for all iterators

### DIFF
--- a/boa/src/builtins/array/array_iterator.rs
+++ b/boa/src/builtins/array/array_iterator.rs
@@ -2,17 +2,10 @@ use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, JsValue},
     gc::{Finalize, Trace},
     object::{GcObject, ObjectData},
-    property::PropertyDescriptor,
+    property::{PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsResult,
 };
-
-#[derive(Debug, Clone, Finalize, Trace)]
-pub enum ArrayIterationKind {
-    Key,
-    Value,
-    KeyAndValue,
-}
 
 /// The Array Iterator object represents an iteration over an array. It implements the iterator protocol.
 ///
@@ -24,13 +17,13 @@ pub enum ArrayIterationKind {
 pub struct ArrayIterator {
     array: JsValue,
     next_index: u32,
-    kind: ArrayIterationKind,
+    kind: PropertyNameKind,
 }
 
 impl ArrayIterator {
     pub(crate) const NAME: &'static str = "ArrayIterator";
 
-    fn new(array: JsValue, kind: ArrayIterationKind) -> Self {
+    fn new(array: JsValue, kind: PropertyNameKind) -> Self {
         ArrayIterator {
             array,
             kind,
@@ -49,7 +42,7 @@ impl ArrayIterator {
     pub(crate) fn create_array_iterator(
         context: &Context,
         array: JsValue,
-        kind: ArrayIterationKind,
+        kind: PropertyNameKind,
     ) -> JsValue {
         let array_iterator = JsValue::new_object(context);
         array_iterator.set_data(ObjectData::ArrayIterator(Self::new(array, kind)));
@@ -96,14 +89,14 @@ impl ArrayIterator {
                 }
                 array_iterator.next_index = index + 1;
                 match array_iterator.kind {
-                    ArrayIterationKind::Key => {
+                    PropertyNameKind::Key => {
                         Ok(create_iter_result_object(context, index.into(), false))
                     }
-                    ArrayIterationKind::Value => {
+                    PropertyNameKind::Value => {
                         let element_value = array_iterator.array.get_field(index, context)?;
                         Ok(create_iter_result_object(context, element_value, false))
                     }
-                    ArrayIterationKind::KeyAndValue => {
+                    PropertyNameKind::KeyAndValue => {
                         let element_value = array_iterator.array.get_field(index, context)?;
                         let result =
                             Array::create_array_from_list([index.into(), element_value], context);

--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -14,11 +14,11 @@ pub mod array_iterator;
 mod tests;
 
 use crate::{
-    builtins::array::array_iterator::{ArrayIterationKind, ArrayIterator},
+    builtins::array::array_iterator::ArrayIterator,
     builtins::BuiltIn,
     builtins::Number,
     object::{ConstructorBuilder, FunctionBuilder, GcObject, ObjectData, PROTOTYPE},
-    property::{Attribute, PropertyDescriptor},
+    property::{Attribute, PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
     value::{IntegerOrInfinity, JsValue},
     BoaProfiler, Context, JsResult, JsString,
@@ -2350,7 +2350,7 @@ impl Array {
         Ok(ArrayIterator::create_array_iterator(
             context,
             this.clone(),
-            ArrayIterationKind::Value,
+            PropertyNameKind::Value,
         ))
     }
 
@@ -2368,7 +2368,7 @@ impl Array {
         Ok(ArrayIterator::create_array_iterator(
             context,
             this.clone(),
-            ArrayIterationKind::Key,
+            PropertyNameKind::Key,
         ))
     }
 
@@ -2390,7 +2390,7 @@ impl Array {
         Ok(ArrayIterator::create_array_iterator(
             context,
             this.clone(),
-            ArrayIterationKind::KeyAndValue,
+            PropertyNameKind::KeyAndValue,
         ))
     }
 

--- a/boa/src/builtins/map/mod.rs
+++ b/boa/src/builtins/map/mod.rs
@@ -15,14 +15,14 @@
 use crate::{
     builtins::BuiltIn,
     object::{ConstructorBuilder, FunctionBuilder, ObjectData, PROTOTYPE},
-    property::{Attribute, PropertyDescriptor},
+    property::{Attribute, PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsResult, JsValue,
 };
 use ordered_map::OrderedMap;
 
 pub mod map_iterator;
-use map_iterator::{MapIterationKind, MapIterator};
+use map_iterator::MapIterator;
 
 use self::ordered_map::MapLock;
 
@@ -202,7 +202,7 @@ impl Map {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::KeyAndValue)
+        MapIterator::create_map_iterator(context, this.clone(), PropertyNameKind::KeyAndValue)
     }
 
     /// `Map.prototype.keys()`
@@ -216,7 +216,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
     pub(crate) fn keys(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Key)
+        MapIterator::create_map_iterator(context, this.clone(), PropertyNameKind::Key)
     }
 
     /// Helper function to set the size property.
@@ -470,7 +470,7 @@ impl Map {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        MapIterator::create_map_iterator(context, this.clone(), MapIterationKind::Value)
+        MapIterator::create_map_iterator(context, this.clone(), PropertyNameKind::Value)
     }
 
     /// Helper function to get a key-value pair from an array.

--- a/boa/src/builtins/set/mod.rs
+++ b/boa/src/builtins/set/mod.rs
@@ -13,14 +13,14 @@
 use crate::{
     builtins::{iterable::get_iterator, BuiltIn},
     object::{ConstructorBuilder, FunctionBuilder, ObjectData, PROTOTYPE},
-    property::Attribute,
+    property::{Attribute, PropertyNameKind},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsResult, JsValue,
 };
 use ordered_set::OrderedSet;
 
 pub mod set_iterator;
-use set_iterator::{SetIterationKind, SetIterator};
+use set_iterator::SetIterator;
 
 pub mod ordered_set;
 #[cfg(test)]
@@ -308,7 +308,7 @@ impl Set {
         Ok(SetIterator::create_set_iterator(
             context,
             this.clone(),
-            SetIterationKind::KeyAndValue,
+            PropertyNameKind::KeyAndValue,
         ))
     }
 
@@ -422,7 +422,7 @@ impl Set {
         Ok(SetIterator::create_set_iterator(
             context,
             this.clone(),
-            SetIterationKind::Value,
+            PropertyNameKind::Value,
         ))
     }
 

--- a/boa/src/property/mod.rs
+++ b/boa/src/property/mod.rs
@@ -22,6 +22,7 @@ use std::{convert::TryFrom, fmt};
 
 mod attribute;
 pub use attribute::Attribute;
+use gc::unsafe_empty_trace;
 
 /// This represents a JavaScript Property AKA The Property Descriptor.
 ///
@@ -663,9 +664,13 @@ impl PartialEq<&str> for PropertyKey {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Finalize)]
 pub(crate) enum PropertyNameKind {
     Key,
     Value,
     KeyAndValue,
+}
+
+unsafe impl Trace for PropertyNameKind {
+    unsafe_empty_trace!();
 }


### PR DESCRIPTION
This Pull Request changes the following:

- Removes all enums of `PropertyNameKind` likes and replaces them with `PropertyNameKind`

Specifically, with #1471 I realized there were several enums akin to `PropertyNameKind` (`ArrayIterationKind`, `SetIterationKind` and `MapIterationKind`), meaning we could just unify them in a single type to avoid repetition.