### PR TITLE
Fix panic on example `classes.rs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -212,10 +212,16 @@ jobs:
             ~/.cargo/git
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-examples-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
+      - name: Build examples
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --examples -v
+      - name: Run example classes
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example classes
 
   doc:
     name: Documentation check

--- a/boa/examples/classes.rs
+++ b/boa/examples/classes.rs
@@ -1,3 +1,5 @@
+// NOTE: this example requires the `console` feature to run correctly.
+
 use boa::{
     class::{Class, ClassBuilder},
     gc::{Finalize, Trace},
@@ -7,11 +9,11 @@ use boa::{
 
 // We create a new struct that is going to represent a person.
 //
-// We derive `Debug`, `Trace` and `Finalize`, It automatically implements `NativeObject`
-// so we can pass it an object in JavaScript.
+// We derive `Debug`, `Trace` and `Finalize`, it automatically implements `NativeObject`
+// so we can pass it as an object in Javascript.
 //
-// The fields of the struct are not accessible by JavaScript unless accessors are created for them.
-/// This  Represents a Person.
+// The fields of the struct are not accessible by Javascript unless we create accessors for them.
+/// Represents a `Person` object.
 #[derive(Debug, Trace, Finalize)]
 struct Person {
     /// The name of the person.
@@ -20,45 +22,46 @@ struct Person {
     age: u32,
 }
 
-// Here we implement a static method for Person that matches the `NativeFunction` signiture.
+// Here we implement a static method for Person that matches the `NativeFunction` signature.
 //
-// NOTE: The function does not have to be implemented of Person it can be a free function,
-// or any function that matches that signature.
+// NOTE: The function does not have to be implemented inside Person, it can be a free function,
+// or any function that matches the required signature.
 impl Person {
-    /// This function says hello
+    /// Says hello if `this` is a `Person`
     fn say_hello(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // We check if this is an object.
         if let Some(object) = this.as_object() {
             // If it is we downcast the type to type `Person`.
             if let Some(person) = object.downcast_ref::<Person>() {
-                // we print the message to stdout.
+                // and print a message to stdout.
                 println!(
                     "Hello my name is {}, I'm {} years old",
                     person.name,
-                    person.age // Here we can access the native rust fields of Person struct.
+                    person.age // Here we can access the native rust fields of the struct.
                 );
                 return Ok(JsValue::undefined());
             }
         }
-        // If `this` was not an object or the type was not an native object `Person`,
+        // If `this` was not an object or the type of `this` was not a native object `Person`,
         // we throw a `TypeError`.
         context.throw_type_error("'this' is not a Person object")
     }
 }
 
 impl Class for Person {
-    // we set the binging name of this function to be `"Person"`.
-    // It does not have to be `"Person"` it can be any string.
+    // We set the binding name of this function to `"Person"`.
+    // It does not have to be `"Person"`, it can be any string.
     const NAME: &'static str = "Person";
     // We set the length to `2` since we accept 2 arguments in the constructor.
     //
     // This is the same as `Object.length`.
-    // NOTE: If this is not defiend that the default is `0`.
+    // NOTE: The default value of `LENGTH` is `0`.
     const LENGTH: usize = 2;
 
-    // This is what is called when we do `new Person()`
+    // This is what is called when we construct a `Person` with the expression `new Person()`.
     fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<Self> {
-        // We get the first argument. If it is unavailable we get `undefined`. And, then call `to_string()`.
+        // We get the first argument. If it is unavailable we default to `undefined`,
+        // and then we call `to_string()`.
         //
         // This is equivalent to `String(arg)`.
         let name = args
@@ -66,12 +69,13 @@ impl Class for Person {
             .cloned()
             .unwrap_or_default()
             .to_string(context)?;
-        // We get the second argument. If it is unavailable we get `undefined`. And, then call `to_u32`.
+        // We get the second argument. If it is unavailable we default to `undefined`,
+        // and then we call `to_u32`.
         //
         // This is equivalent to `arg | 0`.
         let age = args.get(1).cloned().unwrap_or_default().to_u32(context)?;
 
-        // we construct the native struct `Person`
+        // We construct a new native struct `Person`
         let person = Person {
             name: name.to_string(),
             age,
@@ -80,34 +84,35 @@ impl Class for Person {
         Ok(person) // and we return it.
     }
 
-    /// This is where the object is intitialized.
+    /// Here is where the class is initialized.
     fn init(class: &mut ClassBuilder) -> JsResult<()> {
-        // we add a inheritable method `sayHello` with length `0` the amount of args it takes.
+        // We add a inheritable method `sayHello` with `0` arguments of length.
         //
-        // This function is added to `Person.prototype.sayHello()`
+        // This function is added to the `Person` prototype.
         class.method("sayHello", 0, Self::say_hello);
-        // we add a static mathod `is`, and here we use a closure, but it must be convertible
-        // to a NativeFunction. it must not contain state, if it does it will give a compilation error.
+        // We add a static method `is` using a closure, but it must be convertible
+        // to a NativeFunction.
+        // This means it must not contain state, or the code won't compile.
         //
-        // This function is added to `Person.is()`
+        // This function is added to the `Person` class.
         class.static_method("is", 1, |_this, args, _ctx| {
             if let Some(arg) = args.get(0) {
                 if let Some(object) = arg.as_object() {
+                    // We check if the type of `args[0]` is `Person`
                     if object.is::<Person>() {
-                        // we check if the object type is `Person`
-                        return Ok(true.into()); // return `true`.
+                        return Ok(true.into()); // and return `true` if it is.
                     }
                 }
             }
-            Ok(false.into()) // otherwise `false`.
+            Ok(false.into()) // Otherwise we return `false`.
         });
 
-        // Add a inherited property with the value `10`, with default attribute.
-        // (`READONLY, NON_ENUMERABLE, PERMANENT).
+        // We add an `"inheritedProperty"` property to the prototype of `Person` with
+        // a value of `10` and default attribute flags `READONLY`, `NON_ENUMERABLE` and `PERMANENT`.
         class.property("inheritedProperty", 10, Attribute::default());
 
-        // Add a static property with the value `"Im a static property"`, with default attribute.
-        // (`WRITABLE, ENUMERABLE, PERMANENT`).
+        // Finally, we add a `"staticProperty"` property to `Person` with a value
+        // of `"Im a static property"` and attribute flags `WRITABLE`, `ENUMERABLE` and `PERMANENT`.
         class.static_property(
             "staticProperty",
             "Im a static property",
@@ -119,11 +124,14 @@ impl Class for Person {
 }
 
 fn main() {
+    // First we need to create a Javascript context.
     let mut context = Context::new();
 
-    // we register the global class `Person`.
+    // Then we need to register the global class `Person` inside `context`.
     context.register_global_class::<Person>().unwrap();
 
+    // Having done all of that, we can execute Javascript code with `eval`,
+    // and access the `Person` class defined in Rust!
     context
         .eval(
             r"


### PR DESCRIPTION
This Pull Request fixes/closes #1262.

It changes the following:

- Initializes the prototype of a new `ClassBuilder` to `Object object`.
- Improves the documentation of the example `classes.rs`.
