### PR TITLE
Adjust `EnumerableOwnPropertyNames` to use all `String` type property keys

### DIFF
--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -902,12 +902,10 @@ impl GcObject {
         // 4. For each element key of ownKeys, do
         for key in own_keys {
             // a. If Type(key) is String, then
-            let key_str = if let PropertyKey::Index(index) = &key {
-                Some(index.to_string().into())
-            } else if let PropertyKey::String(key_str) = &key {
-                Some(key_str.clone())
-            } else {
-                None
+            let key_str = match &key {
+                PropertyKey::String(s) => Some(s.clone()),
+                PropertyKey::Index(i) => Some(i.to_string().into()),
+                _ => None,
             };
 
             if let Some(key_str) = key_str {

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -902,7 +902,15 @@ impl GcObject {
         // 4. For each element key of ownKeys, do
         for key in own_keys {
             // a. If Type(key) is String, then
-            if let PropertyKey::String(key_str) = &key {
+            let key_str = if let PropertyKey::Index(index) = &key {
+                Some(index.to_string().into())
+            } else if let PropertyKey::String(key_str) = &key {
+                Some(key_str.clone())
+            } else {
+                None
+            };
+
+            if let Some(key_str) = key_str {
                 // i. Let desc be ? O.[[GetOwnProperty]](key).
                 let desc = self.__get_own_property__(&key);
                 // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
@@ -910,7 +918,7 @@ impl GcObject {
                     if desc.expect_enumerable() {
                         // 1. If kind is key, append key to properties.
                         if let PropertyNameKind::Key = kind {
-                            properties.push(key_str.clone().into())
+                            properties.push(key_str.into())
                         }
                         // 2. Else,
                         else {
@@ -924,7 +932,7 @@ impl GcObject {
                             else {
                                 // i. Assert: kind is key+value.
                                 // ii. Let entry be ! CreateArrayFromList(« key, value »).
-                                let key_val = key_str.clone().into();
+                                let key_val = key_str.into();
                                 let entry =
                                     Array::create_array_from_list([key_val, value], context);
 

--- a/boa/src/object/internal_methods.rs
+++ b/boa/src/object/internal_methods.rs
@@ -914,29 +914,26 @@ impl GcObject {
                 // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
                 if let Some(desc) = desc {
                     if desc.expect_enumerable() {
-                        // 1. If kind is key, append key to properties.
-                        if let PropertyNameKind::Key = kind {
-                            properties.push(key_str.into())
-                        }
-                        // 2. Else,
-                        else {
+                        match kind {
+                            // 1. If kind is key, append key to properties.
+                            PropertyNameKind::Key => properties.push(key_str.into()),
+                            // 2. Else,
                             // a. Let value be ? Get(O, key).
-                            let value = self.get(key.clone(), context)?;
                             // b. If kind is value, append value to properties.
-                            if let PropertyNameKind::Value = kind {
-                                properties.push(value)
+                            PropertyNameKind::Value => {
+                                properties.push(self.get(key.clone(), context)?)
                             }
                             // c. Else,
-                            else {
-                                // i. Assert: kind is key+value.
-                                // ii. Let entry be ! CreateArrayFromList(« key, value »).
-                                let key_val = key_str.into();
-                                let entry =
-                                    Array::create_array_from_list([key_val, value], context);
-
-                                // iii. Append entry to properties.
-                                properties.push(entry.into());
-                            }
+                            // i. Assert: kind is key+value.
+                            // ii. Let entry be ! CreateArrayFromList(« key, value »).
+                            // iii. Append entry to properties.
+                            PropertyNameKind::KeyAndValue => properties.push(
+                                Array::create_array_from_list(
+                                    [key_str.into(), self.get(key.clone(), context)?],
+                                    context,
+                                )
+                                .into(),
+                            ),
                         }
                     }
                 }


### PR DESCRIPTION
This Pull Request fixes/closes #1501.

It changes the following:

- Adjust `EnumerableOwnPropertyNames` to use all `String` type property keys

This looks different from the [spec](https://tc39.es/ecma262/#sec-enumerableownpropertynames), because the meaning of `String` in `4.a: If Type(key) is String, then` is different than our internal `PropertyKey` enum types `String`, `Symbol` and `Index`. Our internal `Index` type is a `String` type in the context of the spec.
This PR is only a fix for this specific function. We should change our `[[OwnPropertyKeys]]` to be spec compliant, but I think we should wait with that until #1354 is merged, because `[[OwnPropertyKeys]]` is defined multiple times for different object types.
