### PR TITLE
Allow `NewExpression` without arguments

### DIFF
--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -77,7 +77,7 @@ impl Executable for ArrowFunctionDecl {
             "",
             self.params().to_vec(),
             self.body().to_vec(),
-            FunctionFlags::CONSTRUCTABLE | FunctionFlags::LEXICAL_THIS_MODE,
+            FunctionFlags::LEXICAL_THIS_MODE,
         )
     }
 }

--- a/boa/src/syntax/parser/expression/left_hand_side/member.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/member.rs
@@ -69,7 +69,12 @@ where
         {
             let _ = cursor.next().expect("new keyword disappeared");
             let lhs = self.parse(cursor)?;
-            let args = Arguments::new(self.allow_yield, self.allow_await).parse(cursor)?;
+            let args = match cursor.peek(0)? {
+                Some(next) if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) => {
+                    Arguments::new(self.allow_yield, self.allow_await).parse(cursor)?
+                }
+                _ => Box::new([]),
+            };
             let call_node = Call::new(lhs, args);
 
             Node::from(New::from(call_node))


### PR DESCRIPTION
This Pull Request fixes/closes #1429.

It changes the following:

- Allow `NewExpression` without arguments
- Fix arrow functions to not be constructable

