### PR TITLE
Fixed tests compilation

### DIFF
--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -758,7 +758,7 @@ mod in_operator {
         "#;
 
         check_output(&[TestAction::TestEq(
-            &scenario,
+            scenario,
             "Uncaught \"TypeError\": \"a is not a constructor\"",
         )]);
     }

--- a/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -214,11 +214,15 @@ fn check_object_shorthand_property_names() {
         ",
         vec![
             DeclarationList::Const(
-                vec![Declaration::new("a", Some(Const::from(true).into()))].into(),
+                vec![Declaration::new_with_identifier(
+                    "a",
+                    Some(Const::from(true).into()),
+                )]
+                .into(),
             )
             .into(),
             DeclarationList::Const(
-                vec![Declaration::new(
+                vec![Declaration::new_with_identifier(
                     "x",
                     Some(Object::from(object_properties).into()),
                 )]
@@ -243,15 +247,23 @@ fn check_object_shorthand_multiple_properties() {
         ",
         vec![
             DeclarationList::Const(
-                vec![Declaration::new("a", Some(Const::from(true).into()))].into(),
+                vec![Declaration::new_with_identifier(
+                    "a",
+                    Some(Const::from(true).into()),
+                )]
+                .into(),
             )
             .into(),
             DeclarationList::Const(
-                vec![Declaration::new("b", Some(Const::from(false).into()))].into(),
+                vec![Declaration::new_with_identifier(
+                    "b",
+                    Some(Const::from(false).into()),
+                )]
+                .into(),
             )
             .into(),
             DeclarationList::Const(
-                vec![Declaration::new(
+                vec![Declaration::new_with_identifier(
                     "x",
                     Some(Object::from(object_properties).into()),
                 )]


### PR DESCRIPTION
After merging #1324, which was a bit outdated but didn't have merge conflicts, the compilation of the tests was failing. This fixes it by updating the syntax.