### PR TITLE
Restrict `ClosureFunction` to only `Copy` closures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "boa_unicode",
  "chrono",
  "criterion",
+ "dyn-clone",
  "fast-float",
  "float-cmp",
  "gc",
@@ -357,6 +358,12 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "either"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -37,6 +37,7 @@ ryu-js = "0.2.1"
 chrono = "0.4.19"
 fast-float = "0.2.0"
 unicode-normalization = "0.1.19"
+dyn-clone = "1.0.4"
 
 # Optional Dependencies
 measureme = { version = "9.1.2", optional = true }

--- a/boa/examples/closures.rs
+++ b/boa/examples/closures.rs
@@ -1,14 +1,15 @@
-use boa::{Context, JsString, JsValue};
+use boa::{Context, JsValue};
 
 fn main() -> Result<(), JsValue> {
     let mut context = Context::new();
 
-    let variable = JsString::new("I am a captured variable");
+    let variable = "I am a captured variable";
 
     // We register a global closure function that has the name 'closure' with length 0.
     context.register_global_closure("closure", 0, move |_, _, _| {
         // This value is captured from main function.
-        Ok(variable.clone().into())
+        println!("variable = {}", variable);
+        Ok(JsValue::new(variable))
     })?;
 
     assert_eq!(

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -635,7 +635,7 @@ impl Context {
     #[inline]
     pub fn register_global_closure<F>(&mut self, name: &str, length: usize, body: F) -> JsResult<()>
     where
-        F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + 'static,
+        F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
     {
         let function = FunctionBuilder::closure(self, body)
             .name(name)

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -25,7 +25,6 @@ use std::{
     collections::HashMap,
     error::Error,
     fmt::{self, Debug, Display},
-    rc::Rc,
     result::Result as StdResult,
 };
 
@@ -46,7 +45,7 @@ pub struct JsObject(Gc<GcCell<Object>>);
 enum FunctionBody {
     BuiltInFunction(NativeFunction),
     BuiltInConstructor(NativeFunction),
-    Closure(Rc<ClosureFunction>),
+    Closure(Box<dyn ClosureFunction>),
     Ordinary(RcStatementList),
 }
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -15,13 +15,12 @@ use crate::{
     context::StandardConstructor,
     gc::{Finalize, Trace},
     property::{Attribute, PropertyDescriptor, PropertyKey},
-    BoaProfiler, Context, JsBigInt, JsString, JsSymbol, JsValue,
+    BoaProfiler, Context, JsBigInt, JsResult, JsString, JsSymbol, JsValue,
 };
 use std::{
     any::Any,
     fmt::{self, Debug, Display},
     ops::{Deref, DerefMut},
-    rc::Rc,
 };
 
 #[cfg(test)]
@@ -1108,12 +1107,12 @@ impl<'context> FunctionBuilder<'context> {
     #[inline]
     pub fn closure<F>(context: &'context mut Context, function: F) -> Self
     where
-        F: Fn(&JsValue, &[JsValue], &mut Context) -> Result<JsValue, JsValue> + 'static,
+        F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
     {
         Self {
             context,
             function: Some(Function::Closure {
-                function: Rc::new(function),
+                function: Box::new(function),
                 constructable: false,
             }),
             name: JsString::default(),


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1515.

It changes the following:

- Refactors `ClosureFunction` into a proper trait, with an additional `Copy` bound.
- Replaces `Rc<ClosureFunction>` with `Box<dyn ClosureFunction>` inside `Function`.
- Documents parts of the `function` module.
