### PR TITLE
Fixed Array.of panic with a non-conforming type error

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -465,7 +465,9 @@ impl Array {
             Some(object) if object.is_constructable() => object
                 .construct(&[len.into()], this, context)?
                 .as_object()
-                .unwrap(),
+                .ok_or_else(|| {
+                    context.construct_type_error("object constructor didn't return an object")
+                })?,
             _ => Array::array_create(len, None, context)?,
         };
 


### PR DESCRIPTION
This Pull Request closes #1517.

It changes the following:

- `Array.of` will no longer panic if the object constructor doesn't return an object.
- `Array.of` will throw a `TypeError` when this happens, which is not spec-compliant, but as we mentioned in #1517, we cannot implement a proper function constructor just yet.
