### PR TITLE
Allow moving `NativeObject` variables into closures as external captures

### DIFF
--- a/boa/examples/closures.rs
+++ b/boa/examples/closures.rs
@@ -1,21 +1,110 @@
-use boa::{Context, JsValue};
+// This example goes into the details on how to pass closures as functions
+// inside Rust and call them from Javascript.
+
+use boa::{
+    gc::{Finalize, Trace},
+    object::{FunctionBuilder, JsObject},
+    property::{Attribute, PropertyDescriptor},
+    Context, JsString, JsValue,
+};
 
 fn main() -> Result<(), JsValue> {
+    // We create a new `Context` to create a new Javascript executor.
     let mut context = Context::new();
 
-    let variable = "I am a captured variable";
+    // We make some operations in Rust that return a `Copy` value that we want
+    // to pass to a Javascript function.
+    let variable = 128 + 64 + 32 + 16 + 8 + 4 + 2 + 1;
 
     // We register a global closure function that has the name 'closure' with length 0.
     context.register_global_closure("closure", 0, move |_, _, _| {
-        // This value is captured from main function.
+        println!("Called `closure`");
+        // `variable` is captured from the main function.
         println!("variable = {}", variable);
+
+        // We return the moved variable as a `JsValue`.
         Ok(JsValue::new(variable))
     })?;
 
-    assert_eq!(
-        context.eval("closure()")?,
-        "I am a captured variable".into()
+    assert_eq!(context.eval("closure()")?, 255.into());
+
+    // We have created a closure with moved variables and executed that closure
+    // inside Javascript!
+
+    // This struct is passed to a closure as a capture.
+    #[derive(Debug, Clone, Trace, Finalize)]
+    struct BigStruct {
+        greeting: JsString,
+        object: JsObject,
+    }
+
+    // We create a new `JsObject` with some data
+    let object = context.construct_object();
+    object.define_property_or_throw(
+        "name",
+        PropertyDescriptor::builder()
+            .value("Boa dev")
+            .writable(false)
+            .enumerable(false)
+            .configurable(false),
+        &mut context,
+    )?;
+
+    // Now, we execute some operations that return a `Clone` type
+    let clone_variable = BigStruct {
+        greeting: JsString::from("Hello from Javascript!"),
+        object,
+    };
+
+    // We can use `FunctionBuilder` to define a closure with additional
+    // captures.
+    let js_function = FunctionBuilder::closure_with_captures(
+        &mut context,
+        |_, _, context, captures| {
+            println!("Called `createMessage`");
+            // We obtain the `name` property of `captures.object`
+            let name = captures.object.get("name", context)?;
+
+            // We create a new message from our captured variable.
+            let message = JsString::concat_array(&[
+                "message from `",
+                name.to_string(context)?.as_str(),
+                "`: ",
+                captures.greeting.as_str(),
+            ]);
+
+            println!("{}", message);
+
+            // We convert `message` into `Jsvalue` to be able to return it.
+            Ok(message.into())
+        },
+        // Here is where we move `clone_variable` into the closure.
+        clone_variable,
+    )
+    // And here we assign `createMessage` to the `name` property of the closure.
+    .name("createMessage")
+    // By default all `FunctionBuilder`s set the `length` property to `0` and
+    // the `constructable` property to `false`.
+    .build();
+
+    // We bind the newly constructed closure as a global property in Javascript.
+    context.register_global_property(
+        // We set the key to access the function the same as its name for
+        // consistency, but it may be different if needed.
+        "createMessage",
+        // We pass `js_function` as a property value.
+        js_function,
+        // We assign to the "createMessage" property the desired attributes.
+        Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
     );
+
+    assert_eq!(
+        context.eval("createMessage()")?,
+        "message from `Boa dev`: Hello from Javascript!".into()
+    );
+
+    // We have moved `Clone` variables into a closure and executed that closure
+    // inside Javascript!
 
     Ok(())
 }

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -25,6 +25,7 @@ use crate::{
 };
 use bitflags::bitflags;
 use dyn_clone::DynClone;
+
 use sealed::Sealed;
 use std::fmt::{self, Debug};
 
@@ -55,13 +56,16 @@ pub type NativeFunction = fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsV
 /// be callable from Javascript, but most of the time the compiler
 /// is smart enough to correctly infer the types.
 pub trait ClosureFunction:
-    Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + DynCopy + DynClone + 'static
+    Fn(&JsValue, &[JsValue], &mut Context, &mut JsObject) -> JsResult<JsValue>
+    + DynCopy
+    + DynClone
+    + 'static
 {
 }
 
 // The `Copy` bound automatically infers `DynCopy` and `DynClone`
 impl<T> ClosureFunction for T where
-    T: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static
+    T: Fn(&JsValue, &[JsValue], &mut Context, &mut JsObject) -> JsResult<JsValue> + Copy + 'static
 {
 }
 
@@ -126,6 +130,7 @@ pub enum Function {
         #[unsafe_ignore_trace]
         function: Box<dyn ClosureFunction>,
         constructable: bool,
+        captures: JsObject,
     },
     Ordinary {
         flags: FunctionFlags,

--- a/boa/src/builtins/function/tests.rs
+++ b/boa/src/builtins/function/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     forward, forward_val,
-    object::{FunctionBuilder, JsObject},
+    object::FunctionBuilder,
     property::{Attribute, PropertyDescriptor},
     Context, JsString,
 };
@@ -239,9 +239,7 @@ fn closure_capture_clone() {
     let func = FunctionBuilder::closure_with_captures(
         &mut context,
         |_, _, context, captures| {
-            let data = captures.try_downcast_ref::<(JsString, JsObject)>(context)?;
-            let string = &data.0;
-            let object = &data.1;
+            let (string, object) = &captures;
 
             let hw = JsString::concat(
                 string,

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -673,11 +673,20 @@ impl Context {
     /// The function will be bound to the global object with `writable`, `non-enumerable`
     /// and `configurable` attributes. The same as when you create a function in JavaScript.
     ///
-    /// # Note
+    /// # Note #1
     ///
     /// If you want to make a function only `constructable`, or wish to bind it differently
     /// to the global object, you can create the function object with [`FunctionBuilder`](crate::object::FunctionBuilder::closure).
     /// And bind it to the global object with [`Context::register_global_property`](Context::register_global_property) method.
+    ///
+    /// # Note #2
+    ///
+    /// This function will only accept `Copy` closures, meaning you cannot
+    /// move `Clone` types, just `Copy` types. If you need to move `Clone` types
+    /// as captures, see [`FunctionBuilder::closure_with_captures`].
+    ///
+    /// See <https://github.com/boa-dev/boa/issues/1515> for an explanation on
+    /// why we need to restrict the set of accepted closures.
     #[inline]
     pub fn register_global_closure<F>(&mut self, name: &str, length: usize, body: F) -> JsResult<()>
     where

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -45,7 +45,10 @@ pub struct JsObject(Gc<GcCell<Object>>);
 enum FunctionBody {
     BuiltInFunction(NativeFunction),
     BuiltInConstructor(NativeFunction),
-    Closure(Box<dyn ClosureFunction>),
+    Closure {
+        function: Box<dyn ClosureFunction>,
+        captures: JsObject,
+    },
     Ordinary(RcStatementList),
 }
 
@@ -151,7 +154,12 @@ impl JsObject {
                             FunctionBody::BuiltInFunction(function.0)
                         }
                     }
-                    Function::Closure { function, .. } => FunctionBody::Closure(function.clone()),
+                    Function::Closure {
+                        function, captures, ..
+                    } => FunctionBody::Closure {
+                        function: function.clone(),
+                        captures: captures.clone(),
+                    },
                     Function::Ordinary {
                         body,
                         params,
@@ -297,7 +305,10 @@ impl JsObject {
                 function(&JsValue::undefined(), args, context)
             }
             FunctionBody::BuiltInFunction(function) => function(this_target, args, context),
-            FunctionBody::Closure(function) => (function)(this_target, args, context),
+            FunctionBody::Closure {
+                function,
+                mut captures,
+            } => (function)(this_target, args, context, &mut captures),
             FunctionBody::Ordinary(body) => {
                 let result = body.run(context);
                 let this = context.get_this_binding();

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -5,7 +5,7 @@
 use super::{NativeObject, Object, PROTOTYPE};
 use crate::{
     builtins::function::{
-        create_unmapped_arguments_object, ClosureFunction, Function, NativeFunction,
+        create_unmapped_arguments_object, Captures, ClosureFunction, Function, NativeFunction,
     },
     environment::{
         environment_record_trait::EnvironmentRecordTrait,
@@ -47,7 +47,7 @@ enum FunctionBody {
     BuiltInConstructor(NativeFunction),
     Closure {
         function: Box<dyn ClosureFunction>,
-        captures: JsObject,
+        captures: Captures,
     },
     Ordinary(RcStatementList),
 }
@@ -305,10 +305,9 @@ impl JsObject {
                 function(&JsValue::undefined(), args, context)
             }
             FunctionBody::BuiltInFunction(function) => function(this_target, args, context),
-            FunctionBody::Closure {
-                function,
-                mut captures,
-            } => (function)(this_target, args, context, &mut captures),
+            FunctionBody::Closure { function, captures } => {
+                (function)(this_target, args, context, captures)
+            }
             FunctionBody::Ordinary(body) => {
                 let result = body.run(context);
                 let this = context.get_this_binding();

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -1132,11 +1132,33 @@ impl<'context> FunctionBuilder<'context> {
     where
         F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
     {
+        Self::closure_with_captures(
+            context,
+            move |this, args, context, _| function(this, args, context),
+            (),
+        )
+    }
+
+    /// Create a new `FunctionBuilder` for creating a closure function with additional captures.
+    #[inline]
+    pub fn closure_with_captures<F, C>(
+        context: &'context mut Context,
+        function: F,
+        captures: C,
+    ) -> Self
+    where
+        F: Fn(&JsValue, &[JsValue], &mut Context, &mut JsObject) -> JsResult<JsValue>
+            + Copy
+            + 'static,
+        C: NativeObject,
+    {
+        let captures = JsObject::new(Object::native_object(captures));
         Self {
             context,
             function: Some(Function::Closure {
                 function: Box::new(function),
                 constructable: false,
+                captures,
             }),
             name: JsString::default(),
             length: 0,

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -3,7 +3,7 @@
 use crate::{
     builtins::{
         array::array_iterator::ArrayIterator,
-        function::{Function, NativeFunction},
+        function::{Captures, Function, NativeFunction},
         map::map_iterator::MapIterator,
         map::ordered_map::OrderedMap,
         regexp::regexp_string_iterator::RegExpStringIterator,
@@ -1147,18 +1147,15 @@ impl<'context> FunctionBuilder<'context> {
         captures: C,
     ) -> Self
     where
-        F: Fn(&JsValue, &[JsValue], &mut Context, &mut JsObject) -> JsResult<JsValue>
-            + Copy
-            + 'static,
-        C: NativeObject,
+        F: Fn(&JsValue, &[JsValue], &mut Context, Captures) -> JsResult<JsValue> + Copy + 'static,
+        C: NativeObject + Clone,
     {
-        let captures = JsObject::new(Object::native_object(captures));
         Self {
             context,
             function: Some(Function::Closure {
                 function: Box::new(function),
                 constructable: false,
-                captures,
+                captures: Captures::new(captures),
             }),
             name: JsString::default(),
             length: 0,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request follows from #1518.

It changes the following:

- Allows moving any `NativeObject + Clone` type as a parameter into any closure
- Adds test for the new feature

This unblocks the implementation of arguments exotic objects.
The new test is a good example of how this new feature works:
```Rust
let js_function = FunctionBuilder::closure_with_captures(
        &mut context,
        |_, _, context, captures| {
            println!("Called `createMessage`");
            // We obtain the `name` property of `captures.object`
            let name = captures.object.get("name", context)?;

            // We create a new message from our captured variable.
            let message = JsString::concat_array(&[
                "message from `",
                name.to_string(context)?.as_str(),
                "`: ",
                captures.greeting.as_str(),
            ]);

            println!("{}", message);

            // We convert `message` into `Jsvalue` to be able to return it.
            Ok(message.into())
        },
        // Here is where we move `clone_variable` into the closure.
        clone_variable,
    )
```