### PR TITLE
Use lock for set iteration.

### DIFF
--- a/boa/src/builtins/set/tests.rs
+++ b/boa/src/builtins/set/tests.rs
@@ -246,3 +246,49 @@ fn not_a_function() {
         "\"TypeError: calling a builtin Set constructor without new is forbidden\""
     );
 }
+
+#[test]
+fn for_each_delete() {
+    let mut context = Context::new();
+    let init = r#"
+        let set = new Set(["a", "b", "c"]);
+        let result = [];
+        let i = 0;
+        set.forEach(function(value) {
+            if (i === 0) {
+                set.delete("a");
+                set.add("d");
+            }
+            i++;
+            result.push(value);
+        })
+    "#;
+    forward(&mut context, init);
+    assert_eq!(forward(&mut context, "result[0]"), "\"a\"");
+    assert_eq!(forward(&mut context, "result[1]"), "\"b\"");
+    assert_eq!(forward(&mut context, "result[2]"), "\"c\"");
+    assert_eq!(forward(&mut context, "result[3]"), "\"d\"");
+}
+
+#[test]
+fn for_of_delete() {
+    let mut context = Context::new();
+    let init = r#"
+        let set = new Set(["a", "b", "c"]);
+        let result = [];
+        let i = 0;
+        for (a of set) {
+            if (i === 0) {
+                set.delete("a");
+                set.add("d");
+            }
+            i++;
+            result.push(a);
+        }
+    "#;
+    forward(&mut context, init);
+    assert_eq!(forward(&mut context, "result[0]"), "\"a\"");
+    assert_eq!(forward(&mut context, "result[1]"), "\"b\"");
+    assert_eq!(forward(&mut context, "result[2]"), "\"c\"");
+    assert_eq!(forward(&mut context, "result[3]"), "\"d\"");
+}

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -100,7 +100,7 @@ pub enum ObjectKind {
     Boolean(bool),
     ForInIterator(ForInIterator),
     Function(Function),
-    Set(OrderedSet<JsValue>),
+    Set(OrderedSet),
     SetIterator(SetIterator),
     String(JsString),
     StringIterator(StringIterator),
@@ -195,7 +195,7 @@ impl ObjectData {
     }
 
     /// Create the `Set` object data
-    pub fn set(set: OrderedSet<JsValue>) -> Self {
+    pub fn set(set: OrderedSet) -> Self {
         Self {
             kind: ObjectKind::Set(set),
             internal_methods: &ORDINARY_INTERNAL_METHODS,
@@ -626,7 +626,7 @@ impl Object {
     }
 
     #[inline]
-    pub fn as_set_ref(&self) -> Option<&OrderedSet<JsValue>> {
+    pub fn as_set_ref(&self) -> Option<&OrderedSet> {
         match self.data {
             ObjectData {
                 kind: ObjectKind::Set(ref set),
@@ -637,7 +637,7 @@ impl Object {
     }
 
     #[inline]
-    pub fn as_set_mut(&mut self) -> Option<&mut OrderedSet<JsValue>> {
+    pub fn as_set_mut(&mut self) -> Option<&mut OrderedSet> {
         match &mut self.data {
             ObjectData {
                 kind: ObjectKind::Set(set),

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -162,7 +162,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                     }
                 }
                 ObjectKind::Set(ref set) => {
-                    let size = set.size();
+                    let size = set.len();
 
                     if size == 0 {
                         return String::from("Set(0)");


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes the issue of concurrent modification of a set during iteration, similar to that in map in #1092.

It changes the following:

- Changes the key of OrderedSet to a SetKey, which contains either a JsValue or an empty value.
- Allows locking a set to allow safe iteration.
- When an entry is deleted while the set is locked, it replaces the entry with an empty value to maintain the indexes.
- When the set is unlocked any empty entries are deleted.
- Locks are implemented as a guard object so that they are released even if an error occurs.

This implementation is very similar to that of #1366, and so should not present any additional issues.