### PR TITLE
Always return `undefined` from functions that do not `return`

### DIFF
--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -336,8 +336,9 @@ fn json_parse_array_with_reviver() {
             if (typeof v == 'number') {
                 return v * 2;
             } else {
-                v
-        }})"#,
+                return v;
+            }
+        })"#,
     )
     .unwrap();
     assert_eq!(

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -327,8 +327,11 @@ impl JsObject {
 
                     // 14. Return ? constructorEnv.GetThisBinding().
                     this
-                } else {
+                } else if context.executor().get_current_state() == &InterpreterState::Return {
                     result
+                } else {
+                    result?;
+                    Ok(JsValue::undefined())
                 }
             }
         }


### PR DESCRIPTION
This Pull Request fixes/closes #672.

It changes the following:

- Always return `undefined` from functions that do not `return`
- Fix `JSON.parse` test