### PR TITLE
Add strict mode flag to `Context`

### DIFF
--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -565,7 +565,7 @@ impl Context {
         &mut self,
         name: N,
         params: P,
-        body: StatementList,
+        mut body: StatementList,
         flags: FunctionFlags,
     ) -> JsResult<JsValue>
     where
@@ -578,6 +578,11 @@ impl Context {
 
         // Every new function has a prototype property pre-made
         let prototype = self.construct_object();
+
+        // If a function is defined within a strict context, it is strict.
+        if self.strict() {
+            body.set_strict(true);
+        }
 
         let params = params.into();
         let params_len = params.len();

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -273,6 +273,9 @@ pub struct Context {
 
     /// Whether or not to show trace of instructions being ran
     pub trace: bool,
+
+    /// Whether or not strict mode is active.
+    pub strict: bool,
 }
 
 impl Default for Context {
@@ -287,6 +290,7 @@ impl Default for Context {
             iterator_prototypes: IteratorPrototypes::default(),
             standard_objects: Default::default(),
             trace: false,
+            strict: false,
         };
 
         // Add new builtIns to Context Realm
@@ -519,17 +523,16 @@ impl Context {
     }
 
     /// Utility to create a function Value for Function Declarations, Arrow Functions or Function Expressions
-    pub(crate) fn create_function<N, P, B>(
+    pub(crate) fn create_function<N, P>(
         &mut self,
         name: N,
         params: P,
-        body: B,
+        body: StatementList,
         flags: FunctionFlags,
     ) -> JsResult<JsValue>
     where
         N: Into<JsString>,
         P: Into<Box<[FormalParameter]>>,
-        B: Into<StatementList>,
     {
         let name = name.into();
         let function_prototype: JsValue =
@@ -542,7 +545,7 @@ impl Context {
         let params_len = params.len();
         let func = Function::Ordinary {
             flags,
-            body: RcStatementList::from(body.into()),
+            body: RcStatementList::from(body),
             params,
             environment: self.get_current_environment().clone(),
         };

--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -49,8 +49,8 @@ impl ArrowFunctionDecl {
     }
 
     /// Gets the body of the arrow function.
-    pub(crate) fn body(&self) -> &[Node] {
-        self.body.items()
+    pub(crate) fn body(&self) -> &StatementList {
+        &self.body
     }
 
     /// Implements the display formatting with indentation.
@@ -61,7 +61,7 @@ impl ArrowFunctionDecl {
     ) -> fmt::Result {
         write!(f, "(")?;
         join_nodes(f, &self.params)?;
-        if self.body().is_empty() {
+        if self.body().items().is_empty() {
             f.write_str(") => {}")
         } else {
             f.write_str(") => {\n")?;
@@ -76,7 +76,7 @@ impl Executable for ArrowFunctionDecl {
         context.create_function(
             "",
             self.params().to_vec(),
-            self.body().to_vec(),
+            self.body().clone(),
             FunctionFlags::LEXICAL_THIS_MODE,
         )
     }

--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -63,8 +63,8 @@ impl FunctionDecl {
     }
 
     /// Gets the body of the function declaration.
-    pub fn body(&self) -> &[Node] {
-        self.body.items()
+    pub fn body(&self) -> &StatementList {
+        &self.body
     }
 
     /// Implements the display formatting with indentation.
@@ -75,7 +75,7 @@ impl FunctionDecl {
     ) -> fmt::Result {
         write!(f, "function {}(", self.name)?;
         join_nodes(f, &self.parameters)?;
-        if self.body().is_empty() {
+        if self.body().items().is_empty() {
             f.write_str(") {}")
         } else {
             f.write_str(") {\n")?;
@@ -91,7 +91,7 @@ impl Executable for FunctionDecl {
         let val = context.create_function(
             self.name(),
             self.parameters().to_vec(),
-            self.body().to_vec(),
+            self.body().clone(),
             FunctionFlags::CONSTRUCTABLE,
         )?;
 

--- a/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -60,8 +60,8 @@ impl FunctionExpr {
     }
 
     /// Gets the body of the function declaration.
-    pub fn body(&self) -> &[Node] {
-        self.body.items()
+    pub fn body(&self) -> &StatementList {
+        &self.body
     }
 
     /// Implements the display formatting with indentation.
@@ -87,7 +87,7 @@ impl FunctionExpr {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
-        if self.body().is_empty() {
+        if self.body().items().is_empty() {
             f.write_str("{}")
         } else {
             f.write_str("{\n")?;
@@ -102,7 +102,7 @@ impl Executable for FunctionExpr {
         let val = context.create_function(
             self.name().unwrap_or(""),
             self.parameters().to_vec(),
-            self.body().to_vec(),
+            self.body().clone(),
             FunctionFlags::CONSTRUCTABLE,
         )?;
 

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -90,13 +90,19 @@ impl Executable for UnaryOp {
                 JsValue::undefined()
             }
             op::UnaryOp::Delete => match *self.target() {
-                Node::GetConstField(ref get_const_field) => JsValue::new(
-                    get_const_field
+                Node::GetConstField(ref get_const_field) => {
+                    let delete_status = get_const_field
                         .obj()
                         .run(context)?
                         .to_object(context)?
-                        .__delete__(&get_const_field.field().into(), context)?,
-                ),
+                        .__delete__(&get_const_field.field().into(), context)?;
+
+                    if !delete_status && context.strict {
+                        return context.throw_type_error("Cannot delete property");
+                    } else {
+                        JsValue::new(delete_status)
+                    }
+                }
                 Node::GetField(ref get_field) => {
                     let obj = get_field.obj().run(context)?;
                     let field = &get_field.field().run(context)?;

--- a/boa/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -97,7 +97,7 @@ impl Executable for UnaryOp {
                         .to_object(context)?
                         .__delete__(&get_const_field.field().into(), context)?;
 
-                    if !delete_status && context.strict {
+                    if !delete_status && context.strict() {
                         return context.throw_type_error("Cannot delete property");
                     } else {
                         JsValue::new(delete_status)

--- a/boa/src/syntax/ast/node/statement_list/tests.rs
+++ b/boa/src/syntax/ast/node/statement_list/tests.rs
@@ -53,3 +53,22 @@ fn strict_mode_function_after() {
 
     assert_eq!(&exec(scenario), "false");
 }
+
+#[test]
+fn strict_mode_global_active_in_function() {
+    let scenario = r#"
+        'use strict'
+        let throws = false;
+        function a(){
+            try {
+                delete Boolean.prototype;
+            } catch (e) {
+                throws = true;
+            }
+        }
+        a();
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "true");
+}

--- a/boa/src/syntax/ast/node/statement_list/tests.rs
+++ b/boa/src/syntax/ast/node/statement_list/tests.rs
@@ -1,0 +1,55 @@
+use crate::exec;
+
+#[test]
+fn strict_mode_global() {
+    let scenario = r#"
+        'use strict';
+        let throws = false;
+        try {
+            delete Boolean.prototype;
+        } catch (e) {
+            throws = true;
+        }
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "true");
+}
+
+#[test]
+fn strict_mode_function() {
+    let scenario = r#"
+        let throws = false;
+        function t() {
+            'use strict';
+            try {
+                delete Boolean.prototype;
+            } catch (e) {
+                throws = true;
+            }
+        }
+        t()
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "true");
+}
+
+#[test]
+fn strict_mode_function_after() {
+    let scenario = r#"
+        function t() {
+            'use strict';
+        }
+        t()
+        let throws = false;
+        try {
+            delete Boolean.prototype;
+        } catch (e) {
+            throws = true;
+        }
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "false");
+}

--- a/boa/src/syntax/ast/node/statement_list/tests.rs
+++ b/boa/src/syntax/ast/node/statement_list/tests.rs
@@ -94,3 +94,25 @@ fn strict_mode_function_in_function() {
 
     assert_eq!(&exec(scenario), "false");
 }
+
+#[test]
+fn strict_mode_function_return() {
+    let scenario = r#"
+        let throws = false;
+        function a() {
+            'use strict';
+        
+            return function () {
+                try {
+                    delete Boolean.prototype;
+                } catch (e) {
+                    throws = true;
+                }
+            }
+        }
+        a()();
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "true");
+}

--- a/boa/src/syntax/ast/node/statement_list/tests.rs
+++ b/boa/src/syntax/ast/node/statement_list/tests.rs
@@ -72,3 +72,25 @@ fn strict_mode_global_active_in_function() {
 
     assert_eq!(&exec(scenario), "true");
 }
+
+#[test]
+fn strict_mode_function_in_function() {
+    let scenario = r#"
+        let throws = false;
+        function a(){
+            try {
+                delete Boolean.prototype;
+            } catch (e) {
+                throws = true;
+            }
+        }
+        function b(){
+            'use strict';
+            a();
+        }
+        b();
+        throws
+    "#;
+
+    assert_eq!(&exec(scenario), "false");
+}

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -267,6 +267,8 @@ where
         let _timer = BoaProfiler::global().start_event("FunctionStatementList", "Parsing");
 
         let global_strict_mode = cursor.strict_mode();
+        let mut strict = false;
+
         if let Some(tk) = cursor.peek(0)? {
             match tk.kind() {
                 TokenKind::Punctuator(Punctuator::CloseBlock) => {
@@ -274,12 +276,13 @@ where
                 }
                 TokenKind::StringLiteral(string) if string.as_ref() == "use strict" => {
                     cursor.set_strict_mode(true);
+                    strict = true;
                 }
                 _ => {}
             }
         }
 
-        let stmlist = StatementList::new(
+        let statement_list = StatementList::new(
             self.allow_yield,
             self.allow_await,
             true,
@@ -290,6 +293,9 @@ where
 
         // Reset strict mode back to the global scope.
         cursor.set_strict_mode(global_strict_mode);
-        stmlist
+
+        let mut statement_list = statement_list?;
+        statement_list.set_strict_mode(strict);
+        Ok(statement_list)
     }
 }

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -295,7 +295,7 @@ where
         cursor.set_strict_mode(global_strict_mode);
 
         let mut statement_list = statement_list?;
-        statement_list.set_strict_mode(strict);
+        statement_list.set_strict(strict);
         Ok(statement_list)
     }
 }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -124,13 +124,17 @@ where
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         match cursor.peek(0)? {
             Some(tok) => {
+                let mut strict = false;
                 match tok.kind() {
                     TokenKind::StringLiteral(string) if string.as_ref() == "use strict" => {
                         cursor.set_strict_mode(true);
+                        strict = true;
                     }
                     _ => {}
                 }
-                ScriptBody.parse(cursor)
+                let mut statement_list = ScriptBody.parse(cursor)?;
+                statement_list.set_strict_mode(strict);
+                Ok(statement_list)
             }
             None => Ok(StatementList::from(Vec::new())),
         }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -133,7 +133,7 @@ where
                     _ => {}
                 }
                 let mut statement_list = ScriptBody.parse(cursor)?;
-                statement_list.set_strict_mode(strict);
+                statement_list.set_strict(strict);
                 Ok(statement_list)
             }
             None => Ok(StatementList::from(Vec::new())),

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -139,6 +139,7 @@ impl Test {
 
                     match self.set_up_env(harness, strict) {
                         Ok(mut context) => {
+                            context.strict = strict;
                             let res = context.eval(&self.content.as_ref());
 
                             let passed = res.is_ok();
@@ -184,15 +185,18 @@ impl Test {
                         (false, format!("Uncaught {}", e))
                     } else {
                         match self.set_up_env(harness, strict) {
-                            Ok(mut context) => match context.eval(&self.content.as_ref()) {
-                                Ok(res) => (false, format!("{}", res.display())),
-                                Err(e) => {
-                                    let passed =
-                                        e.display().to_string().contains(error_type.as_ref());
+                            Ok(mut context) => {
+                                context.strict = strict;
+                                match context.eval(&self.content.as_ref()) {
+                                    Ok(res) => (false, format!("{}", res.display())),
+                                    Err(e) => {
+                                        let passed =
+                                            e.display().to_string().contains(error_type.as_ref());
 
-                                    (passed, format!("Uncaught {}", e.display()))
+                                        (passed, format!("Uncaught {}", e.display()))
+                                    }
                                 }
-                            },
+                            }
                             Err(e) => (false, e),
                         }
                     }

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -139,7 +139,9 @@ impl Test {
 
                     match self.set_up_env(harness, strict) {
                         Ok(mut context) => {
-                            context.strict = strict;
+                            if strict {
+                                context.set_strict_mode_global();
+                            }
                             let res = context.eval(&self.content.as_ref());
 
                             let passed = res.is_ok();
@@ -186,7 +188,9 @@ impl Test {
                     } else {
                         match self.set_up_env(harness, strict) {
                             Ok(mut context) => {
-                                context.strict = strict;
+                                if strict {
+                                    context.set_strict_mode_global();
+                                }
                                 match context.eval(&self.content.as_ref()) {
                                     Ok(res) => (false, format!("{}", res.display())),
                                     Err(e) => {


### PR DESCRIPTION
This Pull Request fixes/closes #1504.

It changes the following:

- Add strict mode flag to `Context`
- Add strict mode detection to `StatementList` parsing
- Add strict mode handling of `delete`
