### PR TITLE
Implement abstract operation `GetPrototypeFromConstructor`

### DIFF
--- a/boa/src/builtins/array/mod.rs
+++ b/boa/src/builtins/array/mod.rs
@@ -17,7 +17,11 @@ use crate::{
     builtins::array::array_iterator::ArrayIterator,
     builtins::BuiltIn,
     builtins::Number,
-    object::{ConstructorBuilder, FunctionBuilder, JsObject, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{
+        internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
+        JsObject, ObjectData,
+    },
     property::{Attribute, PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
     value::{IntegerOrInfinity, JsValue},
@@ -130,15 +134,8 @@ impl Array {
     ) -> JsResult<JsValue> {
         // If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let proto be ? GetPrototypeFromConstructor(newTarget, "%Array.prototype%").
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().array_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::array_object, context)?;
 
         // 3. Let numberOfArgs be the number of elements in values.
         let number_of_args = args.len();

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -68,7 +68,7 @@ impl Boolean {
             return Ok(JsValue::new(data));
         }
         let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
+            get_prototype_from_constructor(new_target, StandardObjects::boolean_object, context)?;
         let boolean = JsValue::new_object(context);
 
         boolean

--- a/boa/src/builtins/boolean/mod.rs
+++ b/boa/src/builtins/boolean/mod.rs
@@ -14,7 +14,8 @@ mod tests;
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     property::Attribute,
     BoaProfiler, Context, JsResult, JsValue,
 };
@@ -66,15 +67,8 @@ impl Boolean {
         if new_target.is_undefined() {
             return Ok(JsValue::new(data));
         }
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().object_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
         let boolean = JsValue::new_object(context);
 
         boolean

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -12,7 +12,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
     property::Attribute,
     Context, JsResult, JsValue,
@@ -78,15 +79,8 @@ impl Error {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -11,7 +11,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
     property::Attribute,
     Context, JsResult, JsValue,
@@ -59,15 +60,8 @@ impl RangeError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -11,7 +11,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
     property::Attribute,
     Context, JsResult, JsValue,
@@ -58,15 +59,8 @@ impl ReferenceError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -13,7 +13,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
     property::Attribute,
     Context, JsResult, JsValue,
@@ -61,15 +62,8 @@ impl SyntaxError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -17,7 +17,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     property::Attribute,
     BoaProfiler, Context, JsResult, JsValue,
 };
@@ -64,15 +65,8 @@ impl TypeError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/error/uri.rs
+++ b/boa/src/builtins/error/uri.rs
@@ -12,7 +12,8 @@
 
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     profiler::BoaProfiler,
     property::Attribute,
     Context, JsResult, JsValue,
@@ -60,15 +61,8 @@ impl UriError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().error_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());
         let this = JsValue::new(obj);

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -305,7 +305,7 @@ impl BuiltInFunctionObject {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
+            get_prototype_from_constructor(new_target, StandardObjects::function_object, context)?;
         let this = JsValue::new_object(context);
 
         this.as_object()

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -11,7 +11,9 @@
 //! [spec]: https://tc39.es/ecma262/#sec-function-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function
 
-use crate::object::PROTOTYPE;
+use crate::context::StandardObjects;
+use crate::object::internal_methods::get_prototype_from_constructor;
+
 use crate::{
     builtins::{Array, BuiltIn},
     environment::lexical_environment::Environment,
@@ -302,15 +304,8 @@ impl BuiltInFunctionObject {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().object_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
         let this = JsValue::new_object(context);
 
         this.as_object()

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -15,9 +15,10 @@
 
 use super::string::is_trimmable_whitespace;
 use super::{function::make_builtin_fn, JsArgs};
+use crate::context::StandardObjects;
 use crate::{
     builtins::BuiltIn,
-    object::{ConstructorBuilder, ObjectData, PROTOTYPE},
+    object::{internal_methods::get_prototype_from_constructor, ConstructorBuilder, ObjectData},
     property::Attribute,
     value::{AbstractRelation, IntegerOrInfinity, JsValue},
     BoaProfiler, Context, JsResult,
@@ -166,15 +167,8 @@ impl Number {
         if new_target.is_undefined() {
             return Ok(JsValue::new(data));
         }
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().object_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
         let this = JsValue::new_object(context);
         this.as_object()
             .expect("this should be an object")

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -168,7 +168,7 @@ impl Number {
             return Ok(JsValue::new(data));
         }
         let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
+            get_prototype_from_constructor(new_target, StandardObjects::number_object, context)?;
         let this = JsValue::new_object(context);
         this.as_object()
             .expect("this should be an object")

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -15,9 +15,10 @@
 
 use crate::{
     builtins::{BuiltIn, JsArgs},
+    context::StandardObjects,
     object::{
-        ConstructorBuilder, IntegrityLevel, JsObject, Object as BuiltinObject, ObjectData,
-        ObjectInitializer, ObjectKind, PROTOTYPE,
+        internal_methods::get_prototype_from_constructor, ConstructorBuilder, IntegrityLevel,
+        JsObject, Object as BuiltinObject, ObjectData, ObjectInitializer, ObjectKind,
     },
     property::{Attribute, DescriptorKind, PropertyDescriptor, PropertyKey, PropertyNameKind},
     symbol::WellKnownSymbols,
@@ -99,15 +100,11 @@ impl Object {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         if !new_target.is_undefined() {
-            let prototype = new_target
-                .as_object()
-                .and_then(|obj| {
-                    obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                        .map(|o| o.as_object())
-                        .transpose()
-                })
-                .transpose()?
-                .unwrap_or_else(|| context.standard_objects().object_object().prototype());
+            let prototype = get_prototype_from_constructor(
+                new_target,
+                StandardObjects::object_object,
+                context,
+            )?;
             let object = JsValue::new_object(context);
 
             object

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -13,8 +13,12 @@ pub mod regexp_string_iterator;
 
 use crate::{
     builtins::{array::Array, string, BuiltIn},
+    context::StandardObjects,
     gc::{empty_trace, Finalize, Trace},
-    object::{ConstructorBuilder, FunctionBuilder, JsObject, Object, ObjectData, PROTOTYPE},
+    object::{
+        internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
+        JsObject, Object, ObjectData,
+    },
     property::Attribute,
     symbol::WellKnownSymbols,
     value::{IntegerOrInfinity, JsValue},
@@ -257,17 +261,9 @@ impl RegExp {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexpalloc
     fn alloc(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let proto = if let Some(obj) = this.as_object() {
-            obj.get(PROTOTYPE, context)?
-        } else {
-            context
-                .standard_objects()
-                .regexp_object()
-                .prototype()
-                .into()
-        };
+        let proto = get_prototype_from_constructor(this, StandardObjects::regexp_object, context)?;
 
-        Ok(JsObject::new(Object::create(proto)).into())
+        Ok(JsObject::new(Object::create(proto.into())).into())
     }
 
     /// `22.2.3.2.2 RegExpInitialize ( obj, pattern, flags )`

--- a/boa/src/builtins/set/mod.rs
+++ b/boa/src/builtins/set/mod.rs
@@ -12,7 +12,11 @@
 
 use crate::{
     builtins::{iterable::get_iterator, BuiltIn},
-    object::{ConstructorBuilder, FunctionBuilder, ObjectData, PROTOTYPE},
+    context::StandardObjects,
+    object::{
+        internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
+        ObjectData,
+    },
     property::{Attribute, PropertyNameKind},
     symbol::WellKnownSymbols,
     BoaProfiler, Context, JsResult, JsValue,
@@ -123,16 +127,8 @@ impl Set {
         }
 
         // 2
-        let set_prototype = context.standard_objects().set_object().prototype();
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or(set_prototype);
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::set_object, context)?;
 
         let obj = context.construct_object();
         obj.set_prototype_instance(prototype.into());

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -182,7 +182,7 @@ impl String {
         }
 
         let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
+            get_prototype_from_constructor(new_target, StandardObjects::string_object, context)?;
         Ok(Self::string_create(string, prototype, context).into())
     }
 

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -14,7 +14,9 @@ pub mod string_iterator;
 mod tests;
 
 use crate::builtins::Symbol;
-use crate::object::{JsObject, PROTOTYPE};
+use crate::context::StandardObjects;
+use crate::object::internal_methods::get_prototype_from_constructor;
+use crate::object::JsObject;
 use crate::{
     builtins::{string::string_iterator::StringIterator, Array, BuiltIn, RegExp},
     object::{ConstructorBuilder, ObjectData},
@@ -179,16 +181,8 @@ impl String {
             return Ok(string.into());
         }
 
-        // todo: extract `GetPrototypeFromConstructor` function
-        let prototype = new_target
-            .as_object()
-            .and_then(|obj| {
-                obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
-                    .map(|o| o.as_object())
-                    .transpose()
-            })
-            .transpose()?
-            .unwrap_or_else(|| context.standard_objects().object_object().prototype());
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardObjects::object_object, context)?;
         Ok(Self::string_create(string, prototype, context).into())
     }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request reduces the repetition on constructors when obtaining the default prototype of an object.
Extracted the pattern from #1552, thanks to @Razican :)

It changes the following:

- Implements the abstract operation `GetPrototypeFromConstructor`

- Replaces the pattern:
```Rust
let proto = new_target
        .as_object()
        .and_then(|obj| {
            obj.__get__(&PROTOTYPE.into(), obj.clone().into(), context)
                .map(|o| o.as_object())
                .transpose()
        })
        .transpose()?
        .unwrap_or_else(default_proto);
```
with
```Rust
let proto = get_prototype_from_constructor(
                new_target,
                |intrinsics| intrinsics.object_object().prototype(),
                context,
            )?;
```
This also allows for an easy replacement of  `intrinsics` with the intrinsic objects of a `realm` when we eventually implement multiple realms.