### PR TITLE
Refactor `EnvironmentRecordTrait` functions

### DIFF
--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -159,7 +159,7 @@ impl Function {
         // Create binding
         local_env
             // Function parameters can share names in JavaScript...
-            .create_mutable_binding(param.name().to_owned(), false, true, context)
+            .create_mutable_binding(param.name(), false, true, context)
             .expect("Failed to create binding for rest param");
 
         // Set Binding to value
@@ -178,7 +178,7 @@ impl Function {
     ) {
         // Create binding
         local_env
-            .create_mutable_binding(param.name().to_owned(), false, true, context)
+            .create_mutable_binding(param.name(), false, true, context)
             .expect("Failed to create binding");
 
         // Set Binding to value

--- a/boa/src/environment/declarative_environment_record.rs
+++ b/boa/src/environment/declarative_environment_record.rs
@@ -49,27 +49,44 @@ impl DeclarativeEnvironmentRecord {
 }
 
 impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
-    fn has_binding(&self, name: &str) -> bool {
-        self.env_rec.borrow().contains_key(name)
+    /// `9.1.1.1.1 HasBinding ( N )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-hasbinding-n
+    fn has_binding(&self, name: &str, _context: &mut Context) -> JsResult<bool> {
+        // 1. If envRec has a binding for the name that is the value of N, return true.
+        // 2. Return false.
+        Ok(self.env_rec.borrow().contains_key(name))
     }
 
+    /// `9.1.1.1.2 CreateMutableBinding ( N, D )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-createmutablebinding-n-d
     fn create_mutable_binding(
         &self,
-        name: String,
+        name: &str,
         deletion: bool,
         allow_name_reuse: bool,
         _context: &mut Context,
     ) -> JsResult<()> {
+        // 1. Assert: envRec does not already have a binding for N.
         if !allow_name_reuse {
             assert!(
-                !self.env_rec.borrow().contains_key(name.as_str()),
+                !self.env_rec.borrow().contains_key(name),
                 "Identifier {} has already been declared",
                 name
             );
         }
 
+        // 2. Create a mutable binding in envRec for N and record that it is uninitialized.
+        //    If D is true, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
         self.env_rec.borrow_mut().insert(
-            name.into_boxed_str(),
+            name.into(),
             DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: deletion,
@@ -77,23 +94,34 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
                 strict: false,
             },
         );
+
+        // 3. Return NormalCompletion(empty).
         Ok(())
     }
 
+    /// `9.1.1.1.3 CreateImmutableBinding ( N, S )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-createimmutablebinding-n-s
     fn create_immutable_binding(
         &self,
-        name: String,
+        name: &str,
         strict: bool,
         _context: &mut Context,
     ) -> JsResult<()> {
+        // 1. Assert: envRec does not already have a binding for N.
         assert!(
-            !self.env_rec.borrow().contains_key(name.as_str()),
+            !self.env_rec.borrow().contains_key(name),
             "Identifier {} has already been declared",
             name
         );
 
+        // 2. Create an immutable binding in envRec for N and record that it is uninitialized.
+        //    If S is true, record that the newly created binding is a strict binding.
         self.env_rec.borrow_mut().insert(
-            name.into_boxed_str(),
+            name.into(),
             DeclarativeEnvironmentRecordBinding {
                 value: None,
                 can_delete: true,
@@ -101,9 +129,17 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
                 strict,
             },
         );
+
+        // 3. Return NormalCompletion(empty).
         Ok(())
     }
 
+    /// `9.1.1.1.4 InitializeBinding ( N, V )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-initializebinding-n-v
     fn initialize_binding(
         &self,
         name: &str,
@@ -112,13 +148,25 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
     ) -> JsResult<()> {
         if let Some(ref mut record) = self.env_rec.borrow_mut().get_mut(name) {
             if record.value.is_none() {
+                // 2. Set the bound value for N in envRec to V.
+                // 3. Record that the binding for N in envRec has been initialized.
                 record.value = Some(value);
+
+                // 4. Return NormalCompletion(empty).
                 return Ok(());
             }
         }
+
+        // 1. Assert: envRec must have an uninitialized binding for N.
         panic!("record must have binding for {}", name);
     }
 
+    /// `9.1.1.1.5 SetMutableBinding ( N, V, S )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-setmutablebinding-n-v-s
     #[allow(clippy::else_if_without_else)]
     fn set_mutable_binding(
         &self,
@@ -127,49 +175,70 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
         mut strict: bool,
         context: &mut Context,
     ) -> JsResult<()> {
+        // 1. If envRec does not have a binding for N, then
         if self.env_rec.borrow().get(name).is_none() {
+            // a. If S is true, throw a ReferenceError exception.
             if strict {
                 return Err(context.construct_reference_error(format!("{} not found", name)));
             }
 
-            self.create_mutable_binding(name.to_owned(), true, false, context)?;
+            // b. Perform envRec.CreateMutableBinding(N, true).
+            self.create_mutable_binding(name, true, false, context)?;
+            // c. Perform envRec.InitializeBinding(N, V).
             self.initialize_binding(name, value, context)?;
+
+            // d. Return NormalCompletion(empty).
             return Ok(());
         }
 
-        let (record_strict, record_has_no_value, record_mutable) = {
+        let (binding_strict, binding_value_is_none, binding_mutable) = {
             let env_rec = self.env_rec.borrow();
-            let record = env_rec.get(name).unwrap();
-            (record.strict, record.value.is_none(), record.mutable)
+            let binding = env_rec.get(name).unwrap();
+            (binding.strict, binding.value.is_none(), binding.mutable)
         };
-        if record_strict {
-            strict = true
+
+        // 2. If the binding for N in envRec is a strict binding, set S to true.
+        if binding_strict {
+            strict = true;
         }
-        if record_has_no_value {
+
+        // 3. If the binding for N in envRec has not yet been initialized, throw a ReferenceError exception.
+        if binding_value_is_none {
             return Err(
                 context.construct_reference_error(format!("{} has not been initialized", name))
             );
-        }
-        if record_mutable {
+        // 4. Else if the binding for N in envRec is a mutable binding, change its bound value to V.
+        } else if binding_mutable {
             let mut env_rec = self.env_rec.borrow_mut();
-            let record = env_rec.get_mut(name).unwrap();
-            record.value = Some(value);
+            let binding = env_rec.get_mut(name).unwrap();
+            binding.value = Some(value);
+        // 5. Else,
+        // a. Assert: This is an attempt to change the value of an immutable binding.
+        // b. If S is true, throw a TypeError exception.
         } else if strict {
-            return Err(context.construct_reference_error(format!(
-                "Cannot mutate an immutable binding {}",
-                name
-            )));
+            return Err(context
+                .construct_type_error(format!("Cannot mutate an immutable binding {}", name)));
         }
 
+        // 6. Return NormalCompletion(empty).
         Ok(())
     }
 
+    /// `9.1.1.1.6 GetBindingValue ( N, S )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-getbindingvalue-n-s
     fn get_binding_value(
         &self,
         name: &str,
         _strict: bool,
         context: &mut Context,
     ) -> JsResult<JsValue> {
+        // 1. Assert: envRec has a binding for N.
+        // 2. If the binding for N in envRec is an uninitialized binding, throw a ReferenceError exception.
+        // 3. Return the value currently bound to N in envRec.
         if let Some(binding) = self.env_rec.borrow().get(name) {
             if let Some(ref val) = binding.value {
                 Ok(val.clone())
@@ -181,21 +250,38 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
         }
     }
 
-    fn delete_binding(&self, name: &str) -> bool {
+    /// `9.1.1.1.7 DeleteBinding ( N )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-deletebinding-n
+    fn delete_binding(&self, name: &str, _context: &mut Context) -> JsResult<bool> {
+        // 1. Assert: envRec has a binding for the name that is the value of N.
+        // 2. If the binding for N in envRec cannot be deleted, return false.
+        // 3. Remove the binding for N from envRec.
+        // 4. Return true.
         match self.env_rec.borrow().get(name) {
             Some(binding) => {
                 if binding.can_delete {
                     self.env_rec.borrow_mut().remove(name);
-                    true
+                    Ok(true)
                 } else {
-                    false
+                    Ok(false)
                 }
             }
             None => panic!("env_rec has no binding for {}", name),
         }
     }
 
+    /// `9.1.1.1.8 HasThisBinding ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-hasthisbinding
     fn has_this_binding(&self) -> bool {
+        // 1. Return false.
         false
     }
 
@@ -203,10 +289,23 @@ impl EnvironmentRecordTrait for DeclarativeEnvironmentRecord {
         Ok(JsValue::undefined())
     }
 
+    /// `9.1.1.1.9 HasSuperBinding ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-hassuperbinding
     fn has_super_binding(&self) -> bool {
+        // 1. Return false.
         false
     }
 
+    /// `9.1.1.1.10 WithBaseObject ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-declarative-environment-records-withbaseobject
     fn with_base_object(&self) -> Option<JsObject> {
         None
     }

--- a/boa/src/environment/function_environment_record.rs
+++ b/boa/src/environment/function_environment_record.rs
@@ -64,7 +64,8 @@ impl FunctionEnvironmentRecord {
         outer: Option<Environment>,
         binding_status: BindingStatus,
         new_target: JsValue,
-    ) -> FunctionEnvironmentRecord {
+        context: &mut Context,
+    ) -> JsResult<FunctionEnvironmentRecord> {
         let mut func_env = FunctionEnvironmentRecord {
             declarative_record: DeclarativeEnvironmentRecord::new(outer), // the outer environment will come from Environment set as a private property of F - https://tc39.es/ecma262/#sec-ecmascript-function-objects
             function: f,
@@ -75,36 +76,56 @@ impl FunctionEnvironmentRecord {
         };
         // If a `this` value has been passed, bind it to the environment
         if let Some(v) = this {
-            func_env.bind_this_value(v).unwrap();
+            func_env.bind_this_value(v, context)?;
         }
-        func_env
+        Ok(func_env)
     }
 
-    pub fn bind_this_value(&mut self, value: JsValue) -> JsResult<JsValue> {
+    /// `9.1.1.3.1 BindThisValue ( V )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-bindthisvalue
+    pub fn bind_this_value(&mut self, value: JsValue, context: &mut Context) -> JsResult<JsValue> {
         match self.this_binding_status {
-            // You can not bind an arrow function, their `this` value comes from the lexical scope above
+            // 1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
             BindingStatus::Lexical => {
                 panic!("Cannot bind to an arrow function!");
             }
-            // You can not bind a function twice
+            // 2. If envRec.[[ThisBindingStatus]] is initialized, throw a ReferenceError exception.
             BindingStatus::Initialized => {
-                todo!();
-                // context.throw_reference_error("Cannot bind to an initialised function!")
+                context.throw_reference_error("Cannot bind to an initialized function!")
             }
             BindingStatus::Uninitialized => {
+                // 3. Set envRec.[[ThisValue]] to V.
                 self.this_value = value.clone();
+                // 4. Set envRec.[[ThisBindingStatus]] to initialized.
                 self.this_binding_status = BindingStatus::Initialized;
+                // 5. Return V.
                 Ok(value)
             }
         }
     }
 
+    /// `9.1.1.3.5 GetSuperBase ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-getsuperbase
     pub fn get_super_base(&self) -> JsValue {
+        // 1. Let home be envRec.[[FunctionObject]].[[HomeObject]].
         let home = &self.home_object;
+
+        // 2. If home has the value undefined, return undefined.
         if home.is_undefined() {
             JsValue::undefined()
         } else {
+            // 3. Assert: Type(home) is Object.
             assert!(home.is_object());
+
+            // 4. Return ? home.[[GetPrototypeOf]]().
             home.as_object()
                 .expect("home_object must be an Object")
                 .prototype_instance()
@@ -113,13 +134,13 @@ impl FunctionEnvironmentRecord {
 }
 
 impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
-    fn has_binding(&self, name: &str) -> bool {
-        self.declarative_record.has_binding(name)
+    fn has_binding(&self, name: &str, context: &mut Context) -> JsResult<bool> {
+        self.declarative_record.has_binding(name, context)
     }
 
     fn create_mutable_binding(
         &self,
-        name: String,
+        name: &str,
         deletion: bool,
         allow_name_reuse: bool,
         context: &mut Context,
@@ -130,7 +151,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn create_immutable_binding(
         &self,
-        name: String,
+        name: &str,
         strict: bool,
         context: &mut Context,
     ) -> JsResult<()> {
@@ -169,31 +190,55 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
             .get_binding_value(name, strict, context)
     }
 
-    fn delete_binding(&self, name: &str) -> bool {
-        self.declarative_record.delete_binding(name)
+    fn delete_binding(&self, name: &str, context: &mut Context) -> JsResult<bool> {
+        self.declarative_record.delete_binding(name, context)
     }
 
+    /// `9.1.1.3.2 HasThisBinding ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hasthisbinding
     fn has_this_binding(&self) -> bool {
+        // 1. If envRec.[[ThisBindingStatus]] is lexical, return false; otherwise, return true.
         !matches!(self.this_binding_status, BindingStatus::Lexical)
     }
 
-    fn get_this_binding(&self, context: &mut Context) -> JsResult<JsValue> {
-        match self.this_binding_status {
-            BindingStatus::Lexical => {
-                panic!("There is no this for a lexical function record");
-            }
-            BindingStatus::Uninitialized => {
-                context.throw_reference_error("Uninitialised binding for this function")
-            }
-            BindingStatus::Initialized => Ok(self.this_value.clone()),
-        }
-    }
-
+    /// `9.1.1.3.3 HasSuperBinding ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hassuperbinding
     fn has_super_binding(&self) -> bool {
+        // 1. If envRec.[[ThisBindingStatus]] is lexical, return false.
+        // 2. If envRec.[[FunctionObject]].[[HomeObject]] has the value undefined, return false; otherwise, return true.
         if let BindingStatus::Lexical = self.this_binding_status {
             false
         } else {
             !self.home_object.is_undefined()
+        }
+    }
+
+    /// `9.1.1.3.4 GetThisBinding ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+    fn get_this_binding(&self, context: &mut Context) -> JsResult<JsValue> {
+        match self.this_binding_status {
+            // 1. Assert: envRec.[[ThisBindingStatus]] is not lexical.
+            BindingStatus::Lexical => {
+                panic!("There is no this for a lexical function record");
+            }
+            // 2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError exception.
+            BindingStatus::Uninitialized => {
+                context.throw_reference_error("Uninitialized binding for this function")
+            }
+            // 3. Return envRec.[[ThisValue]].
+            BindingStatus::Initialized => Ok(self.this_value.clone()),
         }
     }
 
@@ -215,7 +260,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn recursive_create_mutable_binding(
         &self,
-        name: String,
+        name: &str,
         deletion: bool,
         _scope: VariableScope,
         context: &mut Context,
@@ -225,7 +270,7 @@ impl EnvironmentRecordTrait for FunctionEnvironmentRecord {
 
     fn recursive_create_immutable_binding(
         &self,
-        name: String,
+        name: &str,
         deletion: bool,
         _scope: VariableScope,
         context: &mut Context,

--- a/boa/src/environment/lexical_environment.rs
+++ b/boa/src/environment/lexical_environment.rs
@@ -95,7 +95,7 @@ impl Context {
 
     pub(crate) fn create_mutable_binding(
         &mut self,
-        name: String,
+        name: &str,
         deletion: bool,
         scope: VariableScope,
     ) -> JsResult<()> {
@@ -105,7 +105,7 @@ impl Context {
 
     pub(crate) fn create_immutable_binding(
         &mut self,
-        name: String,
+        name: &str,
         deletion: bool,
         scope: VariableScope,
     ) -> JsResult<()> {
@@ -139,8 +139,9 @@ impl Context {
             .clone()
     }
 
-    pub(crate) fn has_binding(&mut self, name: &str) -> bool {
-        self.get_current_environment().recursive_has_binding(name)
+    pub(crate) fn has_binding(&mut self, name: &str) -> JsResult<bool> {
+        self.get_current_environment()
+            .recursive_has_binding(name, self)
     }
 
     pub(crate) fn get_binding_value(&mut self, name: &str) -> JsResult<JsValue> {

--- a/boa/src/object/gcobject.rs
+++ b/boa/src/object/gcobject.rs
@@ -199,7 +199,8 @@ impl JsObject {
                                 BindingStatus::Uninitialized
                             },
                             JsValue::undefined(),
-                        );
+                            context,
+                        )?;
 
                         let mut arguments_in_parameter_names = false;
 
@@ -224,12 +225,7 @@ impl JsObject {
                         {
                             // Add arguments object
                             let arguments_obj = create_unmapped_arguments_object(args, context)?;
-                            local_env.create_mutable_binding(
-                                "arguments".to_string(),
-                                false,
-                                true,
-                                context,
-                            )?;
+                            local_env.create_mutable_binding("arguments", false, true, context)?;
                             local_env.initialize_binding("arguments", arguments_obj, context)?;
                         }
 
@@ -280,7 +276,8 @@ impl JsObject {
                                     BindingStatus::Uninitialized
                                 },
                                 JsValue::undefined(),
-                            );
+                                context,
+                            )?;
                             context.push_environment(second_env);
                         }
 

--- a/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -95,14 +95,10 @@ impl Executable for FunctionDecl {
             FunctionFlags::CONSTRUCTABLE,
         )?;
 
-        if context.has_binding(self.name()) {
-            context.set_mutable_binding(self.name(), val, true)?;
+        if context.has_binding(self.name())? {
+            context.set_mutable_binding(self.name(), val, context.strict())?;
         } else {
-            context.create_mutable_binding(
-                self.name().to_owned(),
-                false,
-                VariableScope::Function,
-            )?;
+            context.create_mutable_binding(self.name(), false, VariableScope::Function)?;
 
             context.initialize_binding(self.name(), val)?;
         }

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -104,26 +104,26 @@ impl Executable for DeclarationList {
 
             match &decl {
                 Declaration::Identifier { ident, init } => {
-                    if self.is_var() && context.has_binding(ident.as_ref()) {
+                    if self.is_var() && context.has_binding(ident.as_ref())? {
                         if init.is_some() {
-                            context.set_mutable_binding(ident.as_ref(), val, true)?;
+                            context.set_mutable_binding(ident.as_ref(), val, context.strict())?;
                         }
                         continue;
                     }
 
                     match &self {
                         Const(_) => context.create_immutable_binding(
-                            ident.to_string(),
+                            ident.as_ref(),
                             false,
                             VariableScope::Block,
                         )?,
                         Let(_) => context.create_mutable_binding(
-                            ident.to_string(),
+                            ident.as_ref(),
                             false,
                             VariableScope::Block,
                         )?,
                         Var(_) => context.create_mutable_binding(
-                            ident.to_string(),
+                            ident.as_ref(),
                             false,
                             VariableScope::Function,
                         )?,
@@ -133,26 +133,30 @@ impl Executable for DeclarationList {
                 }
                 Declaration::Pattern(p) => {
                     for (ident, value) in p.run(None, context)? {
-                        if self.is_var() && context.has_binding(ident.as_ref()) {
+                        if self.is_var() && context.has_binding(ident.as_ref())? {
                             if !value.is_undefined() {
-                                context.set_mutable_binding(ident.as_ref(), value, true)?;
+                                context.set_mutable_binding(
+                                    ident.as_ref(),
+                                    value,
+                                    context.strict(),
+                                )?;
                             }
                             continue;
                         }
 
                         match &self {
                             Const(_) => context.create_immutable_binding(
-                                ident.to_string(),
+                                ident.as_ref(),
                                 false,
                                 VariableScope::Block,
                             )?,
                             Let(_) => context.create_mutable_binding(
-                                ident.to_string(),
+                                ident.as_ref(),
                                 false,
                                 VariableScope::Block,
                             )?,
                             Var(_) => context.create_mutable_binding(
-                                ident.to_string(),
+                                ident.as_ref(),
                                 false,
                                 VariableScope::Function,
                             )?,

--- a/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -112,12 +112,16 @@ impl Executable for ForInLoop {
 
             match self.variable() {
                 Node::Identifier(ref name) => {
-                    if context.has_binding(name.as_ref()) {
+                    if context.has_binding(name.as_ref())? {
                         // Binding already exists
-                        context.set_mutable_binding(name.as_ref(), next_result, true)?;
+                        context.set_mutable_binding(
+                            name.as_ref(),
+                            next_result.clone(),
+                            context.strict(),
+                        )?;
                     } else {
                         context.create_mutable_binding(
-                            name.as_ref().to_owned(),
+                            name.as_ref(),
                             true,
                             VariableScope::Function,
                         )?;
@@ -132,15 +136,15 @@ impl Executable for ForInLoop {
 
                         match &var {
                             Declaration::Identifier { ident, .. } => {
-                                if context.has_binding(ident.as_ref()) {
+                                if context.has_binding(ident.as_ref())? {
                                     context.set_mutable_binding(
                                         ident.as_ref(),
                                         next_result,
-                                        true,
+                                        context.strict(),
                                     )?;
                                 } else {
                                     context.create_mutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Function,
                                     )?;
@@ -149,11 +153,15 @@ impl Executable for ForInLoop {
                             }
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
-                                    if context.has_binding(ident.as_ref()) {
-                                        context.set_mutable_binding(ident.as_ref(), value, true)?;
+                                    if context.has_binding(ident.as_ref())? {
+                                        context.set_mutable_binding(
+                                            ident.as_ref(),
+                                            value,
+                                            context.strict(),
+                                        )?;
                                     } else {
                                         context.create_mutable_binding(
-                                            ident.to_string(),
+                                            ident.as_ref(),
                                             false,
                                             VariableScope::Function,
                                         )?;
@@ -178,7 +186,7 @@ impl Executable for ForInLoop {
                         match &var {
                             Declaration::Identifier { ident, .. } => {
                                 context.create_mutable_binding(
-                                    ident.to_string(),
+                                    ident.as_ref(),
                                     false,
                                     VariableScope::Block,
                                 )?;
@@ -187,7 +195,7 @@ impl Executable for ForInLoop {
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
                                     context.create_mutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Block,
                                     )?;
@@ -211,7 +219,7 @@ impl Executable for ForInLoop {
                         match &var {
                             Declaration::Identifier { ident, .. } => {
                                 context.create_immutable_binding(
-                                    ident.to_string(),
+                                    ident.as_ref(),
                                     false,
                                     VariableScope::Block,
                                 )?;
@@ -220,7 +228,7 @@ impl Executable for ForInLoop {
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
                                     context.create_immutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Block,
                                     )?;

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -100,12 +100,16 @@ impl Executable for ForOfLoop {
 
             match self.variable() {
                 Node::Identifier(ref name) => {
-                    if context.has_binding(name.as_ref()) {
+                    if context.has_binding(name.as_ref())? {
                         // Binding already exists
-                        context.set_mutable_binding(name.as_ref(), next_result, true)?;
+                        context.set_mutable_binding(
+                            name.as_ref(),
+                            next_result.clone(),
+                            context.strict(),
+                        )?;
                     } else {
                         context.create_mutable_binding(
-                            name.as_ref().to_owned(),
+                            name.as_ref(),
                             true,
                             VariableScope::Function,
                         )?;
@@ -120,15 +124,15 @@ impl Executable for ForOfLoop {
 
                         match &var {
                             Declaration::Identifier { ident, .. } => {
-                                if context.has_binding(ident.as_ref()) {
+                                if context.has_binding(ident.as_ref())? {
                                     context.set_mutable_binding(
                                         ident.as_ref(),
                                         next_result,
-                                        true,
+                                        context.strict(),
                                     )?;
                                 } else {
                                     context.create_mutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Function,
                                     )?;
@@ -137,11 +141,15 @@ impl Executable for ForOfLoop {
                             }
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
-                                    if context.has_binding(ident.as_ref()) {
-                                        context.set_mutable_binding(ident.as_ref(), value, true)?;
+                                    if context.has_binding(ident.as_ref())? {
+                                        context.set_mutable_binding(
+                                            ident.as_ref(),
+                                            value,
+                                            context.strict(),
+                                        )?;
                                     } else {
                                         context.create_mutable_binding(
-                                            ident.to_string(),
+                                            ident.as_ref(),
                                             false,
                                             VariableScope::Function,
                                         )?;
@@ -166,7 +174,7 @@ impl Executable for ForOfLoop {
                         match &var {
                             Declaration::Identifier { ident, .. } => {
                                 context.create_mutable_binding(
-                                    ident.to_string(),
+                                    ident.as_ref(),
                                     false,
                                     VariableScope::Block,
                                 )?;
@@ -175,7 +183,7 @@ impl Executable for ForOfLoop {
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
                                     context.create_mutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Block,
                                     )?;
@@ -199,7 +207,7 @@ impl Executable for ForOfLoop {
                         match &var {
                             Declaration::Identifier { ident, .. } => {
                                 context.create_immutable_binding(
-                                    ident.to_string(),
+                                    ident.as_ref(),
                                     false,
                                     VariableScope::Block,
                                 )?;
@@ -208,7 +216,7 @@ impl Executable for ForOfLoop {
                             Declaration::Pattern(p) => {
                                 for (ident, value) in p.run(Some(next_result), context)? {
                                     context.create_immutable_binding(
-                                        ident.to_string(),
+                                        ident.as_ref(),
                                         false,
                                         VariableScope::Block,
                                     )?;

--- a/boa/src/syntax/ast/node/operator/assign/mod.rs
+++ b/boa/src/syntax/ast/node/operator/assign/mod.rs
@@ -58,15 +58,11 @@ impl Executable for Assign {
         let val = self.rhs().run(context)?;
         match self.lhs() {
             Node::Identifier(ref name) => {
-                if context.has_binding(name.as_ref()) {
+                if context.has_binding(name.as_ref())? {
                     // Binding already exists
-                    context.set_mutable_binding(name.as_ref(), val.clone(), true)?;
+                    context.set_mutable_binding(name.as_ref(), val.clone(), context.strict())?;
                 } else {
-                    context.create_mutable_binding(
-                        name.as_ref().to_owned(),
-                        true,
-                        VariableScope::Function,
-                    )?;
+                    context.create_mutable_binding(name.as_ref(), true, VariableScope::Function)?;
                     context.initialize_binding(name.as_ref(), val.clone())?;
                 }
             }

--- a/boa/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -203,7 +203,7 @@ impl Executable for BinOp {
                     let v_a = context.get_binding_value(name.as_ref())?;
 
                     let value = Self::run_assign(op, v_a, self.rhs(), context)?;
-                    context.set_mutable_binding(name.as_ref(), value.clone(), true)?;
+                    context.set_mutable_binding(name.as_ref(), value.clone(), context.strict())?;
                     Ok(value)
                 }
                 Node::GetConstField(ref get_const_field) => {

--- a/boa/src/syntax/ast/node/try_node/mod.rs
+++ b/boa/src/syntax/ast/node/try_node/mod.rs
@@ -105,11 +105,7 @@ impl Executable for Try {
                         context.push_environment(DeclarativeEnvironmentRecord::new(Some(env)));
 
                         if let Some(param) = catch.parameter() {
-                            context.create_mutable_binding(
-                                param.to_owned(),
-                                false,
-                                VariableScope::Block,
-                            )?;
+                            context.create_mutable_binding(param, false, VariableScope::Block)?;
                             context.initialize_binding(param, err)?;
                         }
                     }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -154,19 +154,6 @@ impl JsValue {
         }
     }
 
-    /// This will tell us if we can exten an object or not, not properly implemented yet
-    ///
-    /// For now always returns true.
-    ///
-    /// For scalar types it should be false, for objects check the private field for extensibilaty.
-    /// By default true.
-    ///
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal> would turn `extensible` to `false`
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze> would also turn `extensible` to `false`
-    pub(crate) fn is_extensible(&self) -> bool {
-        true
-    }
-
     /// Returns true if the value is an object
     #[inline]
     pub fn is_object(&self) -> bool {
@@ -363,19 +350,6 @@ impl JsValue {
         } else {
             Ok(JsValue::undefined())
         }
-    }
-
-    /// Check to see if the Value has the field, mainly used by environment records.
-    #[inline]
-    pub(crate) fn has_field<K>(&self, key: K) -> bool
-    where
-        K: Into<PropertyKey>,
-    {
-        let _timer = BoaProfiler::global().start_event("Value::has_field", "value");
-        // todo: call `__has_property__` instead of directly getting from object
-        self.as_object()
-            .map(|object| object.borrow().properties().contains_key(&key.into()))
-            .unwrap_or(false)
     }
 
     /// Set the field in the value

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -259,28 +259,22 @@ impl<'a> Vm<'a> {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
-                self.context.create_mutable_binding(
-                    name.to_string(),
-                    false,
-                    VariableScope::Function,
-                )?;
+                self.context
+                    .create_mutable_binding(name, false, VariableScope::Function)?;
             }
             Opcode::DefLet => {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
-                self.context.create_mutable_binding(
-                    name.to_string(),
-                    false,
-                    VariableScope::Block,
-                )?;
+                self.context
+                    .create_mutable_binding(name, false, VariableScope::Block)?;
             }
             Opcode::DefConst => {
                 let index = self.read::<u32>();
                 let name = &self.code.names[index as usize];
 
                 self.context.create_immutable_binding(
-                    name.to_string(),
+                    name.as_ref(),
                     false,
                     VariableScope::Block,
                 )?;
@@ -304,15 +298,13 @@ impl<'a> Vm<'a> {
                 let value = self.pop();
                 let name = &self.code.names[index as usize];
 
-                if self.context.has_binding(name) {
+                if self.context.has_binding(name)? {
                     // Binding already exists
-                    self.context.set_mutable_binding(name, value, true)?;
+                    self.context
+                        .set_mutable_binding(name, value, self.context.strict())?;
                 } else {
-                    self.context.create_mutable_binding(
-                        name.to_string(),
-                        true,
-                        VariableScope::Function,
-                    )?;
+                    self.context
+                        .create_mutable_binding(name, true, VariableScope::Function)?;
                     self.context.initialize_binding(name, value)?;
                 }
             }


### PR DESCRIPTION
It changes the following:

- Refactor some `EnvironmentRecordTrait` function implementations for spec compliance.
- Change some `EnvironmentRecordTrait` functions to take `&str` instead of `String` to avoid allocations.
- Change some `EnvironmentRecordTrait` functions to use accept `Context` and return `JsResult` for some spec compliant error handling.
- Add documentation for `EnvironmentRecordTrait` function implementations.
- Change `ObjectEnvironmentRecord.bindings` from `Jsvalue` to `JsObject`
- Remove now unused `JsValue.is_extensible` and `JsValue.has_field` functions.
- Replace the static `strict = true` in some `Context.set_mutable_binding` calls with the current strict value of `Context`.
