### PR TITLE
Implement Generator parsing

### DIFF
--- a/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct AsyncFunctionDecl {
-    name: Option<Box<str>>,
+    name: Box<str>,
     parameters: Box<[FormalParameter]>,
     body: StatementList,
 }
@@ -31,7 +31,7 @@ impl AsyncFunctionDecl {
     /// Creates a new async function declaration.
     pub(in crate::syntax) fn new<N, P, B>(name: N, parameters: P, body: B) -> Self
     where
-        N: Into<Option<Box<str>>>,
+        N: Into<Box<str>>,
         P: Into<Box<[FormalParameter]>>,
         B: Into<StatementList>,
     {
@@ -43,8 +43,8 @@ impl AsyncFunctionDecl {
     }
 
     /// Gets the name of the async function declaration.
-    pub fn name(&self) -> Option<&str> {
-        self.name.as_deref()
+    pub fn name(&self) -> &str {
+        &self.name
     }
 
     /// Gets the list of parameters of the async function declaration.
@@ -63,10 +63,7 @@ impl AsyncFunctionDecl {
         f: &mut fmt::Formatter<'_>,
         indentation: usize,
     ) -> fmt::Result {
-        match &self.name {
-            Some(name) => write!(f, "async function {}(", name)?,
-            None => write!(f, "async function (")?,
-        }
+        write!(f, "async function {}(", self.name())?;
         join_nodes(f, &self.parameters)?;
         if self.body().is_empty() {
             f.write_str(") {}")

--- a/boa/src/syntax/ast/node/declaration/generator_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/generator_decl/mod.rs
@@ -1,0 +1,96 @@
+use crate::{
+    exec::Executable,
+    gc::{Finalize, Trace},
+    syntax::ast::node::{join_nodes, FormalParameter, Node, StatementList},
+    BoaProfiler, Context, JsResult, JsValue,
+};
+use std::fmt;
+
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
+
+/// The `function*` declaration (`function` keyword followed by an asterisk) defines a generator function,
+/// which returns a `Generator` object.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-GeneratorDeclaration
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
+#[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+pub struct GeneratorDecl {
+    name: Box<str>,
+    parameters: Box<[FormalParameter]>,
+    body: StatementList,
+}
+
+impl GeneratorDecl {
+    /// Creates a new generator declaration.
+    pub(in crate::syntax) fn new<N, P, B>(name: N, parameters: P, body: B) -> Self
+    where
+        N: Into<Box<str>>,
+        P: Into<Box<[FormalParameter]>>,
+        B: Into<StatementList>,
+    {
+        Self {
+            name: name.into(),
+            parameters: parameters.into(),
+            body: body.into(),
+        }
+    }
+
+    /// Gets the name of the generator declaration.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Gets the list of parameters of the generator declaration.
+    pub fn parameters(&self) -> &[FormalParameter] {
+        &self.parameters
+    }
+
+    /// Gets the body of the generator declaration.
+    pub fn body(&self) -> &[Node] {
+        self.body.items()
+    }
+
+    /// Implements the display formatting with indentation.
+    pub(in crate::syntax::ast::node) fn display(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        indentation: usize,
+    ) -> fmt::Result {
+        write!(f, "function* {}(", self.name)?;
+        join_nodes(f, &self.parameters)?;
+        if self.body().is_empty() {
+            f.write_str(") {}")
+        } else {
+            f.write_str(") {\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
+    }
+}
+
+impl Executable for GeneratorDecl {
+    fn run(&self, _context: &mut Context) -> JsResult<JsValue> {
+        let _timer = BoaProfiler::global().start_event("GeneratorDecl", "exec");
+        // TODO: Implement GeneratorFunction
+        // https://tc39.es/ecma262/#sec-generatorfunction-objects
+        Ok(JsValue::undefined())
+    }
+}
+
+impl From<GeneratorDecl> for Node {
+    fn from(decl: GeneratorDecl) -> Self {
+        Self::GeneratorDecl(decl)
+    }
+}
+
+impl fmt::Display for GeneratorDecl {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display(f, 0)
+    }
+}

--- a/boa/src/syntax/ast/node/declaration/generator_expr/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/generator_expr/mod.rs
@@ -1,0 +1,109 @@
+use crate::{
+    exec::Executable,
+    gc::{Finalize, Trace},
+    syntax::ast::node::{join_nodes, FormalParameter, Node, StatementList},
+    Context, JsResult, JsValue,
+};
+use std::fmt;
+
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
+
+/// The `function*` keyword can be used to define a generator function inside an expression.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-GeneratorExpression
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function*
+#[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+pub struct GeneratorExpr {
+    name: Option<Box<str>>,
+    parameters: Box<[FormalParameter]>,
+    body: StatementList,
+}
+
+impl GeneratorExpr {
+    /// Creates a new generator expression
+    pub(in crate::syntax) fn new<N, P, B>(name: N, parameters: P, body: B) -> Self
+    where
+        N: Into<Option<Box<str>>>,
+        P: Into<Box<[FormalParameter]>>,
+        B: Into<StatementList>,
+    {
+        Self {
+            name: name.into(),
+            parameters: parameters.into(),
+            body: body.into(),
+        }
+    }
+
+    /// Gets the name of the generator declaration.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_ref().map(Box::as_ref)
+    }
+
+    /// Gets the list of parameters of the generator declaration.
+    pub fn parameters(&self) -> &[FormalParameter] {
+        &self.parameters
+    }
+
+    /// Gets the body of the generator declaration.
+    pub fn body(&self) -> &StatementList {
+        &self.body
+    }
+
+    /// Implements the display formatting with indentation.
+    pub(in crate::syntax::ast::node) fn display(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        indentation: usize,
+    ) -> fmt::Result {
+        f.write_str("function*")?;
+        if let Some(ref name) = self.name {
+            write!(f, " {}", name)?;
+        }
+        f.write_str("(")?;
+        join_nodes(f, &self.parameters)?;
+        f.write_str(") ")?;
+        self.display_block(f, indentation)
+    }
+
+    /// Displays the generator's body. This includes the curly braces at the start and end.
+    /// This will not indent the first brace, but will indent the last brace.
+    pub(in crate::syntax::ast::node) fn display_block(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        indentation: usize,
+    ) -> fmt::Result {
+        if self.body().items().is_empty() {
+            f.write_str("{}")
+        } else {
+            f.write_str("{\n")?;
+            self.body.display(f, indentation + 1)?;
+            write!(f, "{}}}", "    ".repeat(indentation))
+        }
+    }
+}
+
+impl Executable for GeneratorExpr {
+    fn run(&self, _context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Implement GeneratorFunction
+        // https://tc39.es/ecma262/#sec-generatorfunction-objects
+        Ok(JsValue::undefined())
+    }
+}
+
+impl fmt::Display for GeneratorExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display(f, 0)
+    }
+}
+
+impl From<GeneratorExpr> for Node {
+    fn from(expr: GeneratorExpr) -> Self {
+        Self::GeneratorExpr(expr)
+    }
+}

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -17,6 +17,8 @@ pub mod async_function_decl;
 pub mod async_function_expr;
 pub mod function_decl;
 pub mod function_expr;
+pub mod generator_decl;
+pub mod generator_expr;
 
 pub use self::{
     arrow_function_decl::ArrowFunctionDecl, async_function_decl::AsyncFunctionDecl,

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -20,6 +20,7 @@ pub mod switch;
 pub mod template;
 pub mod throw;
 pub mod try_node;
+pub mod r#yield;
 
 pub use self::{
     array::ArrayDecl,
@@ -29,8 +30,9 @@ pub use self::{
     call::Call,
     conditional::{ConditionalOp, If},
     declaration::{
-        ArrowFunctionDecl, AsyncFunctionDecl, AsyncFunctionExpr, Declaration, DeclarationList,
-        FunctionDecl, FunctionExpr,
+        generator_decl::GeneratorDecl, generator_expr::GeneratorExpr, ArrowFunctionDecl,
+        AsyncFunctionDecl, AsyncFunctionExpr, Declaration, DeclarationList, FunctionDecl,
+        FunctionExpr,
     },
     field::{GetConstField, GetField},
     identifier::Identifier,
@@ -38,6 +40,7 @@ pub use self::{
     new::New,
     object::Object,
     operator::{Assign, BinOp, UnaryOp},
+    r#yield::Yield,
     return_smt::Return,
     spread::Spread,
     statement_list::{RcStatementList, StatementList},
@@ -209,6 +212,15 @@ pub enum Node {
     /// [spec]: https://tc39.es/ecma262/#prod-EmptyStatement
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/Empty
     Empty,
+
+    /// A `yield` node. [More information](./yield/struct.Yield.html).
+    Yield(Yield),
+
+    /// A generator function declaration node. [More information](./declaration/struct.GeneratorDecl.html).
+    GeneratorDecl(GeneratorDecl),
+
+    /// A generator function expression node. [More information](./declaration/struct.GeneratorExpr.html).
+    GeneratorExpr(GeneratorExpr),
 }
 
 impl Display for Node {
@@ -302,6 +314,9 @@ impl Node {
             Self::AsyncFunctionExpr(ref expr) => expr.display(f, indentation),
             Self::AwaitExpr(ref expr) => Display::fmt(expr, f),
             Self::Empty => write!(f, ";"),
+            Self::Yield(ref y) => Display::fmt(y, f),
+            Self::GeneratorDecl(ref decl) => Display::fmt(decl, f),
+            Self::GeneratorExpr(ref expr) => expr.display(f, indentation),
         }
     }
 }
@@ -363,6 +378,9 @@ impl Executable for Node {
             Node::Break(ref break_node) => break_node.run(context),
             Node::Continue(ref continue_node) => continue_node.run(context),
             Node::Empty => Ok(JsValue::undefined()),
+            Node::Yield(ref y) => y.run(context),
+            Node::GeneratorDecl(ref decl) => decl.run(context),
+            Node::GeneratorExpr(ref expr) => expr.run(context),
         }
     }
 }
@@ -597,7 +615,16 @@ pub enum MethodDefinitionKind {
     /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#Method_definition_syntax
     Ordinary,
-    // TODO: support other method definition kinds, like `Generator`.
+
+    /// Starting with ECMAScript 2015, you are able to define own methods in a shorter syntax, similar to the getters and setters.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions#generator_methods
+    Generator,
 }
 
 unsafe impl Trace for MethodDefinitionKind {

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -72,7 +72,7 @@ impl Object {
                     match &kind {
                         MethodDefinitionKind::Get => write!(f, "get ")?,
                         MethodDefinitionKind::Set => write!(f, "set ")?,
-                        MethodDefinitionKind::Ordinary => (),
+                        MethodDefinitionKind::Ordinary | MethodDefinitionKind::Generator => (),
                     }
                     write!(f, "{}(", key)?;
                     join_nodes(f, node.parameters())?;
@@ -165,6 +165,17 @@ impl Executable for Object {
                                     .build(),
                                 context,
                             )?;
+                        }
+                        &MethodDefinitionKind::Generator => {
+                            // TODO: Implement generator method definition execution.
+                            obj.set_property(
+                                name,
+                                PropertyDescriptor::builder()
+                                    .value(JsValue::undefined())
+                                    .writable(true)
+                                    .enumerable(true)
+                                    .configurable(true),
+                            );
                         }
                     }
                 }

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -168,14 +168,16 @@ impl Executable for Object {
                         }
                         &MethodDefinitionKind::Generator => {
                             // TODO: Implement generator method definition execution.
-                            obj.set_property(
+                            obj.__define_own_property__(
                                 name,
                                 PropertyDescriptor::builder()
                                     .value(JsValue::undefined())
                                     .writable(true)
                                     .enumerable(true)
-                                    .configurable(true),
-                            );
+                                    .configurable(true)
+                                    .build(),
+                                context,
+                            )?;
                         }
                     }
                 }

--- a/boa/src/syntax/ast/node/yield/mod.rs
+++ b/boa/src/syntax/ast/node/yield/mod.rs
@@ -1,0 +1,70 @@
+use crate::{
+    exec::Executable,
+    gc::{Finalize, Trace},
+    syntax::ast::node::Node,
+    Context, JsResult, JsValue,
+};
+use std::fmt;
+
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
+
+/// The `yield` keyword is used to pause and resume a generator function
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-YieldExpression
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield
+#[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+pub struct Yield {
+    expr: Option<Box<Node>>,
+    delegate: bool,
+}
+
+impl Yield {
+    pub fn expr(&self) -> Option<&Node> {
+        self.expr.as_ref().map(Box::as_ref)
+    }
+
+    pub fn delegate(&self) -> bool {
+        self.delegate
+    }
+
+    /// Creates a `Yield` AST node.
+    pub fn new<E, OE>(expr: OE, delegate: bool) -> Self
+    where
+        E: Into<Node>,
+        OE: Into<Option<E>>,
+    {
+        Self {
+            expr: expr.into().map(E::into).map(Box::new),
+            delegate,
+        }
+    }
+}
+
+impl Executable for Yield {
+    fn run(&self, _context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Implement Generator execution
+        Ok(JsValue::undefined())
+    }
+}
+
+impl From<Yield> for Node {
+    fn from(r#yield: Yield) -> Node {
+        Node::Yield(r#yield)
+    }
+}
+
+impl fmt::Display for Yield {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let y = if self.delegate { "yield*" } else { "yield" };
+        match self.expr() {
+            Some(ex) => write!(f, "{} {}", y, ex),
+            None => write!(f, "{}", y),
+        }
+    }
+}

--- a/boa/src/syntax/parser/error.rs
+++ b/boa/src/syntax/parser/error.rs
@@ -92,6 +92,14 @@ impl ParseError {
         Self::General { message, position }
     }
 
+    /// Creates a "general" parsing error with the specific error message for a wrong function declaration in non-strict mode.
+    pub(super) fn wrong_function_declaration_non_strict(position: Position) -> Self {
+        Self::General {
+            message: "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.",
+            position
+        }
+    }
+
     /// Creates a parsing error from a lexing error.
     pub(super) fn lex(e: LexError) -> Self {
         Self::Lex { err: e }

--- a/boa/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -17,7 +17,7 @@ use crate::{
         lexer::{Error as LexError, Position, TokenKind},
         parser::{
             error::{ErrorContext, ParseError, ParseResult},
-            function::{FormalParameters, FunctionBody},
+            function::{FormalParameterList, FormalParameters, FunctionBody},
             statement::BindingIdentifier,
             AllowAwait, AllowIn, AllowYield, Cursor, TokenParser,
         },
@@ -72,18 +72,31 @@ where
         let _timer = BoaProfiler::global().start_event("ArrowFunction", "Parsing");
         let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
 
-        let params = if let TokenKind::Punctuator(Punctuator::OpenParen) = &next_token.kind() {
+        let (params, params_start_position) = if let TokenKind::Punctuator(Punctuator::OpenParen) =
+            &next_token.kind()
+        {
             // CoverParenthesizedExpressionAndArrowParameterList
-            cursor.expect(Punctuator::OpenParen, "arrow function")?;
+            let params_start_position = cursor
+                .expect(Punctuator::OpenParen, "arrow function")?
+                .span()
+                .end();
 
             let params = FormalParameters::new(self.allow_yield, self.allow_await).parse(cursor)?;
             cursor.expect(Punctuator::CloseParen, "arrow function")?;
-            params
+            (params, params_start_position)
         } else {
+            let params_start_position = next_token.span().start();
             let param = BindingIdentifier::new(self.allow_yield, self.allow_await)
                 .parse(cursor)
                 .context("arrow function")?;
-            Box::new([FormalParameter::new(param, None, false)])
+            (
+                FormalParameterList {
+                    parameters: Box::new([FormalParameter::new(param, None, false)]),
+                    is_simple: true,
+                    has_duplicates: false,
+                },
+                params_start_position,
+            )
         };
 
         cursor.peek_expect_no_lineterminator(0, "arrow function")?;
@@ -91,12 +104,29 @@ where
         cursor.expect(TokenKind::Punctuator(Punctuator::Arrow), "arrow function")?;
         let body = ConciseBody::new(self.allow_in).parse(cursor)?;
 
+        // Early Error: ArrowFormalParameters are UniqueFormalParameters.
+        if params.has_duplicates {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Duplicate parameter name not allowed in this context".into(),
+                params_start_position,
+            )));
+        }
+
+        // Early Error: It is a Syntax Error if ConciseBodyContainsUseStrict of ConciseBody is true
+        // and IsSimpleParameterList of ArrowParameters is false.
+        if body.strict() && !params.is_simple {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of ArrowParameters
         // also occurs in the LexicallyDeclaredNames of ConciseBody.
         // https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-early-errors
         {
             let lexically_declared_names = body.lexically_declared_names();
-            for param in params.as_ref() {
+            for param in params.parameters.as_ref() {
                 if lexically_declared_names.contains(param.name()) {
                     return Err(ParseError::lex(LexError::Syntax(
                         format!("Redeclaration of formal parameter `{}`", param.name()).into(),
@@ -109,7 +139,7 @@ where
             }
         }
 
-        Ok(ArrowFunctionDecl::new(params, body))
+        Ok(ArrowFunctionDecl::new(params.parameters, body))
     }
 }
 

--- a/boa/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa/src/syntax/parser/expression/assignment/yield.rs
@@ -1,0 +1,93 @@
+//! YieldExpression parsing.
+//!
+//! More information:
+//!  - [MDN documentation][mdn]
+//!  - [ECMAScript specification][spec]
+//!
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield
+//! [spec]: https://tc39.es/ecma262/#prod-YieldExpression
+
+use crate::{
+    syntax::{
+        ast::{
+            node::{Node, Yield},
+            Keyword, Punctuator,
+        },
+        lexer::TokenKind,
+        parser::{cursor::SemicolonResult, AllowAwait, AllowIn, Cursor, ParseResult, TokenParser},
+    },
+    BoaProfiler,
+};
+
+use std::io::Read;
+
+use super::AssignmentExpression;
+
+/// YieldExpression parsing.
+///
+/// More information:
+///  - [MDN documentation][mdn]
+///  - [ECMAScript specification][spec]
+///
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield
+/// [spec]: https://tc39.es/ecma262/#prod-YieldExpression
+#[derive(Debug, Clone, Copy)]
+pub(in crate::syntax::parser) struct YieldExpression {
+    allow_in: AllowIn,
+    allow_await: AllowAwait,
+}
+
+impl YieldExpression {
+    /// Creates a new `YieldExpression` parser.
+    pub(in crate::syntax::parser) fn new<I, A>(allow_in: I, allow_await: A) -> Self
+    where
+        I: Into<AllowIn>,
+        A: Into<AllowAwait>,
+    {
+        Self {
+            allow_in: allow_in.into(),
+            allow_await: allow_await.into(),
+        }
+    }
+}
+
+impl<R> TokenParser<R> for YieldExpression
+where
+    R: Read,
+{
+    type Output = Node;
+
+    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+        let _timer = BoaProfiler::global().start_event("YieldExpression", "Parsing");
+
+        cursor.expect(TokenKind::Keyword(Keyword::Yield), "yield expression")?;
+
+        let mut expr = None;
+        let mut delegate = false;
+
+        if let SemicolonResult::Found(_) = cursor.peek_semicolon()? {
+            cursor.expect(
+                TokenKind::Punctuator(Punctuator::Semicolon),
+                "token disappeared",
+            )?;
+        } else if let Ok(next_token) = cursor.peek_expect_no_lineterminator(0, "yield expression") {
+            if let TokenKind::Punctuator(Punctuator::Mul) = next_token.kind() {
+                cursor.expect(TokenKind::Punctuator(Punctuator::Mul), "token disappeared")?;
+                delegate = true;
+                expr = Some(
+                    AssignmentExpression::new(self.allow_in, true, self.allow_await)
+                        .parse(cursor)?,
+                );
+            } else {
+                expr = Some(
+                    AssignmentExpression::new(self.allow_in, true, self.allow_await)
+                        .parse(cursor)?,
+                );
+            }
+        }
+
+        Ok(Node::Yield(Yield::new::<Node, Option<Node>>(
+            expr, delegate,
+        )))
+    }
+}

--- a/boa/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -63,7 +63,24 @@ where
             return Err(ParseError::AbruptEnd);
         };
 
-        cursor.expect(Punctuator::OpenParen, "async function expression")?;
+        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+        if let Some(name) = &name {
+            if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
+                return Err(ParseError::lex(LexError::Syntax(
+                    "Unexpected eval or arguments in strict mode".into(),
+                    match cursor.peek(0)? {
+                        Some(token) => token.span().end(),
+                        None => Position::new(1, 1),
+                    },
+                )));
+            }
+        }
+
+        let params_start_position = cursor
+            .expect(Punctuator::OpenParen, "async function expression")?
+            .span()
+            .end();
 
         let params = FormalParameters::new(false, true).parse(cursor)?;
 
@@ -74,12 +91,30 @@ where
 
         cursor.expect(Punctuator::CloseBlock, "async function expression")?;
 
+        // Early Error: If the source code matching FormalParameters is strict mode code,
+        // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
+        if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Duplicate parameter name not allowed in this context".into(),
+                params_start_position,
+            )));
+        }
+
+        // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true
+        // and IsSimpleParameterList of FormalParameters is false.
+        if body.strict() && !params.is_simple {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         {
             let lexically_declared_names = body.lexically_declared_names();
-            for param in params.as_ref() {
+            for param in params.parameters.as_ref() {
                 if lexically_declared_names.contains(param.name()) {
                     return Err(ParseError::lex(LexError::Syntax(
                         format!("Redeclaration of formal parameter `{}`", param.name()).into(),
@@ -92,6 +127,6 @@ where
             }
         }
 
-        Ok(AsyncFunctionExpr::new(name, params, body))
+        Ok(AsyncFunctionExpr::new(name, params.parameters, body))
     }
 }

--- a/boa/src/syntax/parser/expression/primary/generator_expression/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/generator_expression/tests.rs
@@ -1,0 +1,57 @@
+use crate::syntax::{
+    ast::{
+        node::{Declaration, DeclarationList, GeneratorExpr, StatementList, Yield},
+        Const,
+    },
+    parser::tests::check_parser,
+};
+
+#[test]
+fn check_generator_function_expression() {
+    check_parser(
+        "const gen = function*() {
+            yield 1;
+        };
+        ",
+        vec![DeclarationList::Const(
+            vec![Declaration::new_with_identifier(
+                "gen",
+                Some(
+                    GeneratorExpr::new::<Option<Box<str>>, _, StatementList>(
+                        None,
+                        [],
+                        vec![Yield::new(Const::from(1), false).into()].into(),
+                    )
+                    .into(),
+                ),
+            )]
+            .into(),
+        )
+        .into()],
+    );
+}
+
+#[test]
+fn check_generator_function_delegate_yield_expression() {
+    check_parser(
+        "const gen = function*() {
+            yield* 1;
+        };
+        ",
+        vec![DeclarationList::Const(
+            vec![Declaration::new_with_identifier(
+                "gen",
+                Some(
+                    GeneratorExpr::new::<Option<Box<str>>, _, StatementList>(
+                        None,
+                        [],
+                        vec![Yield::new(Const::from(1), true).into()].into(),
+                    )
+                    .into(),
+                ),
+            )]
+            .into(),
+        )
+        .into()],
+    );
+}

--- a/boa/src/syntax/parser/expression/primary/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/mod.rs
@@ -130,7 +130,7 @@ where
                 }
                 Ok(Identifier::from("yield").into())
             }
-            TokenKind::Keyword(Keyword::Await) if self.allow_yield.0 => {
+            TokenKind::Keyword(Keyword::Await) if self.allow_await.0 => {
                 // Early Error: It is a Syntax Error if this production has an [Await] parameter and StringValue of Identifier is "await".
                 Err(ParseError::general(
                     "Unexpected identifier",

--- a/boa/src/syntax/parser/expression/primary/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/mod.rs
@@ -10,6 +10,7 @@
 mod array_initializer;
 mod async_function_expression;
 mod function_expression;
+mod generator_expression;
 mod object_initializer;
 mod template;
 #[cfg(test)]
@@ -17,7 +18,8 @@ mod tests;
 
 use self::{
     array_initializer::ArrayLiteral, async_function_expression::AsyncFunctionExpression,
-    function_expression::FunctionExpression, object_initializer::ObjectLiteral,
+    function_expression::FunctionExpression, generator_expression::GeneratorExpression,
+    object_initializer::ObjectLiteral,
 };
 use super::Expression;
 use crate::{
@@ -80,7 +82,12 @@ where
         match tok.kind() {
             TokenKind::Keyword(Keyword::This) => Ok(Node::This),
             TokenKind::Keyword(Keyword::Function) => {
-                FunctionExpression.parse(cursor).map(Node::from)
+                let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+                if next_token.kind() == &TokenKind::Punctuator(Punctuator::Mul) {
+                    GeneratorExpression.parse(cursor).map(Node::from)
+                } else {
+                    FunctionExpression.parse(cursor).map(Node::from)
+                }
             }
             TokenKind::Keyword(Keyword::Async) => AsyncFunctionExpression::new(self.allow_yield)
                 .parse(cursor)
@@ -106,7 +113,39 @@ where
             }
             TokenKind::BooleanLiteral(boolean) => Ok(Const::from(*boolean).into()),
             TokenKind::NullLiteral => Ok(Const::Null.into()),
-            TokenKind::Identifier(ident) => Ok(Identifier::from(ident.as_ref()).into()), // TODO: IdentifierReference
+            TokenKind::Identifier(ident) => Ok(Identifier::from(ident.as_ref()).into()),
+            TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
+                // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".
+                Err(ParseError::general(
+                    "Unexpected identifier",
+                    tok.span().start(),
+                ))
+            }
+            TokenKind::Keyword(Keyword::Yield) if !self.allow_yield.0 => {
+                if cursor.strict_mode() {
+                    return Err(ParseError::general(
+                        "Unexpected strict mode reserved word",
+                        tok.span().start(),
+                    ));
+                }
+                Ok(Identifier::from("yield").into())
+            }
+            TokenKind::Keyword(Keyword::Await) if self.allow_yield.0 => {
+                // Early Error: It is a Syntax Error if this production has an [Await] parameter and StringValue of Identifier is "await".
+                Err(ParseError::general(
+                    "Unexpected identifier",
+                    tok.span().start(),
+                ))
+            }
+            TokenKind::Keyword(Keyword::Await) if !self.allow_await.0 => {
+                if cursor.strict_mode() {
+                    return Err(ParseError::general(
+                        "Unexpected strict mode reserved word",
+                        tok.span().start(),
+                    ));
+                }
+                Ok(Identifier::from("await").into())
+            }
             TokenKind::StringLiteral(s) => Ok(Const::from(s.as_ref()).into()),
             TokenKind::TemplateNoSubstitution(template_string) => {
                 Ok(Const::from(template_string.to_owned_cooked().map_err(ParseError::lex)?).into())

--- a/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -267,12 +267,12 @@ where
             return Ok(node::PropertyDefinition::property(property_name, value));
         }
 
-        let ordinary = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind()
+        let ordinary_method = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind()
             == &TokenKind::Punctuator(Punctuator::OpenParen);
 
         match property_name {
             // MethodDefinition[?Yield, ?Await] -> get ClassElementName[?Yield, ?Await] ( ) { FunctionBody[~Yield, ~Await] }
-            node::PropertyName::Literal(str) if str.as_ref() == "get" && !ordinary => {
+            node::PropertyName::Literal(str) if str.as_ref() == "get" && !ordinary_method => {
                 property_name =
                     PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
 
@@ -302,7 +302,7 @@ where
                 ))
             }
             // MethodDefinition[?Yield, ?Await] -> set ClassElementName[?Yield, ?Await] ( PropertySetParameterList ) { FunctionBody[~Yield, ~Await] }
-            node::PropertyName::Literal(str) if str.as_ref() == "set" && !ordinary => {
+            node::PropertyName::Literal(str) if str.as_ref() == "set" && !ordinary_method => {
                 property_name =
                     PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
 

--- a/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -9,14 +9,13 @@
 
 #[cfg(test)]
 mod tests;
-use crate::syntax::ast::node::{Identifier, PropertyName};
-use crate::syntax::lexer::TokenKind;
 use crate::{
     syntax::{
         ast::{
-            node::{self, FunctionExpr, MethodDefinitionKind, Node, Object},
-            Punctuator,
+            node::{self, FunctionExpr, Identifier, MethodDefinitionKind, Node, Object},
+            Keyword, Punctuator,
         },
+        lexer::{Error as LexError, Position, TokenKind},
         parser::{
             expression::AssignmentExpression,
             function::{FormalParameters, FunctionBody},
@@ -129,226 +128,331 @@ where
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("PropertyDefinition", "Parsing");
 
+        // IdentifierReference[?Yield, ?Await]
+        if let Some(next_token) = cursor.peek(1)? {
+            match next_token.kind() {
+                TokenKind::Punctuator(Punctuator::CloseBlock)
+                | TokenKind::Punctuator(Punctuator::Comma) => {
+                    let token = cursor.next()?.ok_or(ParseError::AbruptEnd)?;
+                    let ident = match token.kind() {
+                        TokenKind::Identifier(ident) => Identifier::from(ident.as_ref()),
+                        TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
+                            // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".
+                            return Err(ParseError::general(
+                                "Unexpected identifier",
+                                token.span().start(),
+                            ));
+                        }
+                        TokenKind::Keyword(Keyword::Yield) if !self.allow_yield.0 => {
+                            if cursor.strict_mode() {
+                                // Early Error: It is a Syntax Error if the code matched by this production is contained in strict mode code.
+                                return Err(ParseError::general(
+                                    "Unexpected strict mode reserved word",
+                                    token.span().start(),
+                                ));
+                            }
+                            Identifier::from("yield")
+                        }
+                        TokenKind::Keyword(Keyword::Await) if self.allow_await.0 => {
+                            // Early Error: It is a Syntax Error if this production has an [Await] parameter and StringValue of Identifier is "await".
+                            return Err(ParseError::general(
+                                "Unexpected identifier",
+                                token.span().start(),
+                            ));
+                        }
+                        TokenKind::Keyword(Keyword::Await) if !self.allow_await.0 => {
+                            if cursor.strict_mode() {
+                                // Early Error: It is a Syntax Error if the code matched by this production is contained in strict mode code.
+                                return Err(ParseError::general(
+                                    "Unexpected strict mode reserved word",
+                                    token.span().start(),
+                                ));
+                            }
+                            Identifier::from("yield")
+                        }
+                        _ => {
+                            return Err(ParseError::unexpected(
+                                token.clone(),
+                                "expected IdentifierReference",
+                            ));
+                        }
+                    };
+                    return Ok(node::PropertyDefinition::property(
+                        ident.clone().as_ref(),
+                        ident,
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        //  ... AssignmentExpression[+In, ?Yield, ?Await]
         if cursor.next_if(Punctuator::Spread)?.is_some() {
             let node = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
                 .parse(cursor)?;
             return Ok(node::PropertyDefinition::SpreadObject(node));
         }
 
-        // ComputedPropertyName
-        // https://tc39.es/ecma262/#prod-ComputedPropertyName
-        if cursor.next_if(Punctuator::OpenBracket)?.is_some() {
-            let node = AssignmentExpression::new(false, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
-            cursor.expect(Punctuator::CloseBracket, "expected token ']'")?;
-            let next_token = cursor.next()?.ok_or(ParseError::AbruptEnd)?;
-            match next_token.kind() {
-                TokenKind::Punctuator(Punctuator::Colon) => {
-                    let val = AssignmentExpression::new(false, self.allow_yield, self.allow_await)
-                        .parse(cursor)?;
-                    return Ok(node::PropertyDefinition::property(node, val));
-                }
-                TokenKind::Punctuator(Punctuator::OpenParen) => {
-                    return MethodDefinition::new(self.allow_yield, self.allow_await, node)
-                        .parse(cursor);
-                }
-                _ => {
-                    return Err(ParseError::unexpected(
-                        next_token,
-                        "expected AssignmentExpression or MethodDefinition",
-                    ))
-                }
-            }
-        }
+        // MethodDefinition[?Yield, ?Await] -> GeneratorMethod[?Yield, ?Await]
+        if cursor.next_if(Punctuator::Mul)?.is_some() {
+            let property_name =
+                PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
 
-        // Peek for '}' or ',' to indicate shorthand property name
-        if let Some(next_token) = cursor.peek(1)? {
-            match next_token.kind() {
-                TokenKind::Punctuator(Punctuator::CloseBlock)
-                | TokenKind::Punctuator(Punctuator::Comma) => {
-                    let token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
-                    if let TokenKind::Identifier(ident) = token.kind() {
-                        // ident is both the name and value in a shorthand property
-                        let name = ident.to_string();
-                        let value = Identifier::from(ident.to_owned());
-                        cursor.next()?.expect("token vanished"); // Consume the token.
-                        return Ok(node::PropertyDefinition::property(name, value));
-                    } else {
-                        // Anything besides an identifier is a syntax error
-                        return Err(ParseError::unexpected(token.clone(), "object literal"));
+            let params_start_position = cursor
+                .expect(Punctuator::OpenParen, "generator method definition")?
+                .span()
+                .start();
+            let params = FormalParameters::new(false, false).parse(cursor)?;
+            cursor.expect(Punctuator::CloseParen, "generator method definition")?;
+
+            // Early Error: UniqueFormalParameters : FormalParameters
+            if params.has_duplicates {
+                return Err(ParseError::lex(LexError::Syntax(
+                    "Duplicate parameter name not allowed in this context".into(),
+                    params_start_position,
+                )));
+            }
+
+            cursor.expect(
+                TokenKind::Punctuator(Punctuator::OpenBlock),
+                "generator method definition",
+            )?;
+            let body = FunctionBody::new(true, false).parse(cursor)?;
+            cursor.expect(
+                TokenKind::Punctuator(Punctuator::CloseBlock),
+                "generator method definition",
+            )?;
+
+            // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
+            // and IsSimpleParameterList of UniqueFormalParameters is false.
+            if body.strict() && !params.is_simple {
+                return Err(ParseError::lex(LexError::Syntax(
+                    "Illegal 'use strict' directive in function with non-simple parameter list"
+                        .into(),
+                    params_start_position,
+                )));
+            }
+
+            // Early Error: It is a Syntax Error if any element of the BoundNames of UniqueFormalParameters also
+            // occurs in the LexicallyDeclaredNames of GeneratorBody.
+            {
+                let lexically_declared_names = body.lexically_declared_names();
+                for param in params.parameters.as_ref() {
+                    if lexically_declared_names.contains(param.name()) {
+                        return Err(ParseError::lex(LexError::Syntax(
+                            format!("Redeclaration of formal parameter `{}`", param.name()).into(),
+                            match cursor.peek(0)? {
+                                Some(token) => token.span().end(),
+                                None => Position::new(1, 1),
+                            },
+                        )));
                     }
                 }
-                _ => {}
+            }
+
+            return Ok(node::PropertyDefinition::method_definition(
+                MethodDefinitionKind::Generator,
+                property_name,
+                FunctionExpr::new(None, params.parameters, body),
+            ));
+        }
+
+        let mut property_name =
+            PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+
+        //  PropertyName[?Yield, ?Await] : AssignmentExpression[+In, ?Yield, ?Await]
+        if cursor.next_if(Punctuator::Colon)?.is_some() {
+            let value = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
+                .parse(cursor)?;
+            return Ok(node::PropertyDefinition::property(property_name, value));
+        }
+
+        let ordinary = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind()
+            == &TokenKind::Punctuator(Punctuator::OpenParen);
+
+        match property_name {
+            // MethodDefinition[?Yield, ?Await] -> get ClassElementName[?Yield, ?Await] ( ) { FunctionBody[~Yield, ~Await] }
+            node::PropertyName::Literal(str) if str.as_ref() == "get" && !ordinary => {
+                property_name =
+                    PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::OpenParen),
+                    "get method definition",
+                )?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseParen),
+                    "get method definition",
+                )?;
+
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::OpenBlock),
+                    "get method definition",
+                )?;
+                let body = FunctionBody::new(false, false).parse(cursor)?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseBlock),
+                    "get method definition",
+                )?;
+
+                Ok(node::PropertyDefinition::method_definition(
+                    MethodDefinitionKind::Get,
+                    property_name,
+                    FunctionExpr::new(None, [], body),
+                ))
+            }
+            // MethodDefinition[?Yield, ?Await] -> set ClassElementName[?Yield, ?Await] ( PropertySetParameterList ) { FunctionBody[~Yield, ~Await] }
+            node::PropertyName::Literal(str) if str.as_ref() == "set" && !ordinary => {
+                property_name =
+                    PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+
+                let params_start_position = cursor
+                    .expect(
+                        TokenKind::Punctuator(Punctuator::OpenParen),
+                        "set method definition",
+                    )?
+                    .span()
+                    .end();
+                let params = FormalParameters::new(false, false).parse(cursor)?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseParen),
+                    "set method definition",
+                )?;
+                if params.parameters.len() != 1 {
+                    return Err(ParseError::general(
+                        "set method definition must have one parameter",
+                        params_start_position,
+                    ));
+                }
+
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::OpenBlock),
+                    "set method definition",
+                )?;
+                let body = FunctionBody::new(false, false).parse(cursor)?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseBlock),
+                    "set method definition",
+                )?;
+
+                // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
+                // and IsSimpleParameterList of PropertySetParameterList is false.
+                if body.strict() && !params.is_simple {
+                    return Err(ParseError::lex(LexError::Syntax(
+                        "Illegal 'use strict' directive in function with non-simple parameter list"
+                            .into(),
+                        params_start_position,
+                    )));
+                }
+
+                Ok(node::PropertyDefinition::method_definition(
+                    MethodDefinitionKind::Set,
+                    property_name,
+                    FunctionExpr::new(None, params.parameters, body),
+                ))
+            }
+            // MethodDefinition[?Yield, ?Await] -> ClassElementName[?Yield, ?Await] ( UniqueFormalParameters[~Yield, ~Await] ) { FunctionBody[~Yield, ~Await] }
+            _ => {
+                let params_start_position = cursor
+                    .expect(
+                        TokenKind::Punctuator(Punctuator::OpenParen),
+                        "method definition",
+                    )?
+                    .span()
+                    .end();
+                let params = FormalParameters::new(false, false).parse(cursor)?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseParen),
+                    "method definition",
+                )?;
+
+                // Early Error: UniqueFormalParameters : FormalParameters
+                if params.has_duplicates {
+                    return Err(ParseError::lex(LexError::Syntax(
+                        "Duplicate parameter name not allowed in this context".into(),
+                        params_start_position,
+                    )));
+                }
+
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::OpenBlock),
+                    "method definition",
+                )?;
+                let body = FunctionBody::new(false, false).parse(cursor)?;
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseBlock),
+                    "method definition",
+                )?;
+
+                // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
+                // and IsSimpleParameterList of UniqueFormalParameters is false.
+                if body.strict() && !params.is_simple {
+                    return Err(ParseError::lex(LexError::Syntax(
+                        "Illegal 'use strict' directive in function with non-simple parameter list"
+                            .into(),
+                        params_start_position,
+                    )));
+                }
+
+                Ok(node::PropertyDefinition::method_definition(
+                    MethodDefinitionKind::Ordinary,
+                    property_name,
+                    FunctionExpr::new(None, params.parameters, body),
+                ))
             }
         }
-
-        let prop_name = cursor.next()?.ok_or(ParseError::AbruptEnd)?.to_string();
-        if cursor.next_if(Punctuator::Colon)?.is_some() {
-            let val = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
-            return Ok(node::PropertyDefinition::property(prop_name, val));
-        }
-
-        // TODO GeneratorMethod
-        // https://tc39.es/ecma262/#prod-GeneratorMethod
-
-        if prop_name.as_str() == "async" {
-            // TODO - AsyncMethod.
-            // https://tc39.es/ecma262/#prod-AsyncMethod
-
-            // TODO - AsyncGeneratorMethod
-            // https://tc39.es/ecma262/#prod-AsyncGeneratorMethod
-        }
-
-        if cursor
-            .next_if(TokenKind::Punctuator(Punctuator::OpenParen))?
-            .is_some()
-            || ["get", "set"].contains(&prop_name.as_str())
-        {
-            return MethodDefinition::new(self.allow_yield, self.allow_await, prop_name)
-                .parse(cursor);
-        }
-
-        let pos = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.span().start();
-        Err(ParseError::general("expected property definition", pos))
     }
 }
 
-/// Parses a method definition.
+/// Parses a property name.
 ///
 /// More information:
 ///  - [ECMAScript specification][spec]
 ///
-/// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
+/// [spec]: https://tc39.es/ecma262/#prod-PropertyName
 #[derive(Debug, Clone)]
-struct MethodDefinition {
+struct PropertyName {
     allow_yield: AllowYield,
     allow_await: AllowAwait,
-    identifier: PropertyName,
 }
 
-impl MethodDefinition {
-    /// Creates a new `MethodDefinition` parser.
-    fn new<Y, A, I>(allow_yield: Y, allow_await: A, identifier: I) -> Self
+impl PropertyName {
+    /// Creates a new `PropertyName` parser.
+    fn new<Y, A>(allow_yield: Y, allow_await: A) -> Self
     where
         Y: Into<AllowYield>,
         A: Into<AllowAwait>,
-        I: Into<PropertyName>,
     {
         Self {
             allow_yield: allow_yield.into(),
             allow_await: allow_await.into(),
-            identifier: identifier.into(),
         }
     }
 }
 
-impl<R> TokenParser<R> for MethodDefinition
+impl<R> TokenParser<R> for PropertyName
 where
     R: Read,
 {
-    type Output = node::PropertyDefinition;
+    type Output = node::PropertyName;
 
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        let _timer = BoaProfiler::global().start_event("MethodDefinition", "Parsing");
+        let _timer = BoaProfiler::global().start_event("PropertyName", "Parsing");
 
-        let (method_kind, prop_name, params) = match self.identifier {
-            PropertyName::Literal(ident)
-                if ["get", "set"].contains(&ident.as_ref())
-                    && matches!(
-                        cursor.peek(0)?.map(|t| t.kind()),
-                        Some(&TokenKind::Identifier(_))
-                            | Some(&TokenKind::Keyword(_))
-                            | Some(&TokenKind::BooleanLiteral(_))
-                            | Some(&TokenKind::NullLiteral)
-                            | Some(&TokenKind::NumericLiteral(_))
-                    ) =>
-            {
-                let prop_name = cursor.next()?.ok_or(ParseError::AbruptEnd)?.to_string();
-                cursor.expect(
-                    TokenKind::Punctuator(Punctuator::OpenParen),
-                    "property method definition",
-                )?;
-                let first_param = cursor.peek(0)?.expect("current token disappeared").clone();
-                let params = FormalParameters::new(false, false).parse(cursor)?;
-                cursor.expect(Punctuator::CloseParen, "method definition")?;
-                if ident.as_ref() == "get" {
-                    if !params.is_empty() {
-                        return Err(ParseError::unexpected(
-                            first_param,
-                            "getter functions must have no arguments",
-                        ));
-                    }
-                    (MethodDefinitionKind::Get, prop_name.into(), params)
-                } else {
-                    if params.len() != 1 {
-                        return Err(ParseError::unexpected(
-                            first_param,
-                            "setter functions must have one argument",
-                        ));
-                    }
-                    (MethodDefinitionKind::Set, prop_name.into(), params)
-                }
-            }
-            PropertyName::Literal(ident)
-                if ["get", "set"].contains(&ident.as_ref())
-                    && matches!(
-                        cursor.peek(0)?.map(|t| t.kind()),
-                        Some(&TokenKind::Punctuator(Punctuator::OpenBracket))
-                    ) =>
-            {
-                cursor.expect(Punctuator::OpenBracket, "token vanished")?;
-                let prop_name =
-                    AssignmentExpression::new(false, self.allow_yield, self.allow_await)
-                        .parse(cursor)?;
-                cursor.expect(Punctuator::CloseBracket, "expected token ']'")?;
-                cursor.expect(
-                    TokenKind::Punctuator(Punctuator::OpenParen),
-                    "property method definition",
-                )?;
-                let first_param = cursor.peek(0)?.expect("current token disappeared").clone();
-                let params = FormalParameters::new(false, false).parse(cursor)?;
-                cursor.expect(Punctuator::CloseParen, "method definition")?;
-                if ident.as_ref() == "get" {
-                    if !params.is_empty() {
-                        return Err(ParseError::unexpected(
-                            first_param,
-                            "getter functions must have no arguments",
-                        ));
-                    }
-                    (MethodDefinitionKind::Get, prop_name.into(), params)
-                } else {
-                    if params.len() != 1 {
-                        return Err(ParseError::unexpected(
-                            first_param,
-                            "setter functions must have one argument",
-                        ));
-                    }
-                    (MethodDefinitionKind::Set, prop_name.into(), params)
-                }
-            }
-            prop_name => {
-                let params = FormalParameters::new(false, false).parse(cursor)?;
-                cursor.expect(Punctuator::CloseParen, "method definition")?;
-                (MethodDefinitionKind::Ordinary, prop_name, params)
-            }
-        };
+        // ComputedPropertyName[?Yield, ?Await] -> [ AssignmentExpression[+In, ?Yield, ?Await] ]
+        if cursor.next_if(Punctuator::OpenBracket)?.is_some() {
+            let node = AssignmentExpression::new(false, self.allow_yield, self.allow_await)
+                .parse(cursor)?;
+            cursor.expect(Punctuator::CloseBracket, "expected token ']'")?;
+            return Ok(node.into());
+        }
 
-        cursor.expect(
-            TokenKind::Punctuator(Punctuator::OpenBlock),
-            "property method definition",
-        )?;
-        let body = FunctionBody::new(false, false).parse(cursor)?;
-        cursor.expect(
-            TokenKind::Punctuator(Punctuator::CloseBlock),
-            "property method definition",
-        )?;
-
-        Ok(node::PropertyDefinition::method_definition(
-            method_kind,
-            prop_name,
-            FunctionExpr::new(None, params, body),
-        ))
+        // LiteralPropertyName
+        Ok(cursor
+            .next()?
+            .ok_or(ParseError::AbruptEnd)?
+            .to_string()
+            .into())
     }
 }
 

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -22,7 +22,8 @@ use crate::{
     },
     BoaProfiler,
 };
-use std::{collections::HashSet, io::Read};
+use rustc_hash::FxHashSet;
+use std::io::Read;
 
 /// Intermediate type for a list of FormalParameters with some meta information.
 pub(in crate::syntax::parser) struct FormalParameterList {
@@ -83,7 +84,7 @@ where
         }
         let start_position = next_token.span().start();
 
-        let mut parameter_names = HashSet::new();
+        let mut parameter_names = FxHashSet::default();
 
         loop {
             let mut rest_param = false;

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -21,10 +21,27 @@ fn check_basic() {
     );
 }
 
-/// Checks for duplicate parameter names.
+/// Checks if duplicate parameter names are allowed with strict mode off.
 #[test]
-fn check_duplicates() {
-    let js = "function foo(a, a) {}";
+fn check_duplicates_strict_off() {
+    check_parser(
+        "function foo(a, a) { return a; }",
+        vec![FunctionDecl::new(
+            Box::from("foo"),
+            vec![
+                FormalParameter::new("a", None, false),
+                FormalParameter::new("a", None, false),
+            ],
+            vec![Return::new(Identifier::from("a"), None).into()],
+        )
+        .into()],
+    );
+}
+
+/// Checks if duplicate parameter names are an error with strict mode on.
+#[test]
+fn check_duplicates_strict_on() {
+    let js = "'use strict'; function foo(a, a) {}";
 
     let res = Parser::new(js.as_bytes(), false).parse_all();
     dbg!(&res);

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -75,7 +75,24 @@ where
             return Err(ParseError::AbruptEnd);
         };
 
-        cursor.expect(Punctuator::OpenParen, "async function declaration")?;
+        if let Some(name) = &name {
+            // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+            // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+            if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
+                return Err(ParseError::lex(LexError::Syntax(
+                    "Unexpected eval or arguments in strict mode".into(),
+                    match cursor.peek(0)? {
+                        Some(token) => token.span().end(),
+                        None => Position::new(1, 1),
+                    },
+                )));
+            }
+        }
+
+        let params_start_position = cursor
+            .expect(Punctuator::OpenParen, "async function declaration")?
+            .span()
+            .end();
 
         let params = FormalParameters::new(false, true).parse(cursor)?;
 
@@ -86,12 +103,30 @@ where
 
         cursor.expect(Punctuator::CloseBlock, "async function declaration")?;
 
+        // Early Error: If the source code matching FormalParameters is strict mode code,
+        // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
+        if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Duplicate parameter name not allowed in this context".into(),
+                params_start_position,
+            )));
+        }
+
+        // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true
+        // and IsSimpleParameterList of FormalParameters is false.
+        if body.strict() && !params.is_simple {
+            return Err(ParseError::lex(LexError::Syntax(
+                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         {
             let lexically_declared_names = body.lexically_declared_names();
-            for param in params.as_ref() {
+            for param in params.parameters.as_ref() {
                 if lexically_declared_names.contains(param.name()) {
                     return Err(ParseError::lex(LexError::Syntax(
                         format!("Redeclaration of formal parameter `{}`", param.name()).into(),
@@ -104,6 +139,6 @@ where
             }
         }
 
-        Ok(AsyncFunctionDecl::new(name, params, body))
+        Ok(AsyncFunctionDecl::new(name, params.parameters, body))
     }
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -2,13 +2,10 @@
 mod tests;
 
 use crate::syntax::{
-    ast::{node::AsyncFunctionDecl, Keyword, Punctuator},
-    lexer::TokenKind,
+    ast::{node::AsyncFunctionDecl, Keyword},
     parser::{
-        function::FormalParameters,
-        function::FunctionBody,
-        statement::{BindingIdentifier, LexError, Position},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        statement::declaration::hoistable::parse_function_like_declaration, AllowAwait,
+        AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
     },
 };
 use std::io::Read;
@@ -54,91 +51,19 @@ where
         cursor.expect(Keyword::Async, "async function declaration")?;
         cursor.peek_expect_no_lineterminator(0, "async function declaration")?;
         cursor.expect(Keyword::Function, "async function declaration")?;
-        let tok = cursor.peek(0)?;
 
-        let name = if let Some(token) = tok {
-            match token.kind() {
-                TokenKind::Punctuator(Punctuator::OpenParen) => {
-                    if !self.is_default.0 {
-                        return Err(ParseError::unexpected(
-                            token.clone(),
-                            " in async function declaration",
-                        ));
-                    }
-                    None
-                }
-                _ => {
-                    Some(BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?)
-                }
-            }
-        } else {
-            return Err(ParseError::AbruptEnd);
-        };
+        let result = parse_function_like_declaration(
+            "async function declaration",
+            self.is_default.0,
+            self.allow_yield.0,
+            self.allow_await.0,
+            false,
+            true,
+            false,
+            true,
+            cursor,
+        )?;
 
-        if let Some(name) = &name {
-            // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
-            // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-            if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
-                return Err(ParseError::lex(LexError::Syntax(
-                    "Unexpected eval or arguments in strict mode".into(),
-                    match cursor.peek(0)? {
-                        Some(token) => token.span().end(),
-                        None => Position::new(1, 1),
-                    },
-                )));
-            }
-        }
-
-        let params_start_position = cursor
-            .expect(Punctuator::OpenParen, "async function declaration")?
-            .span()
-            .end();
-
-        let params = FormalParameters::new(false, true).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseParen, "async function declaration")?;
-        cursor.expect(Punctuator::OpenBlock, "async function declaration")?;
-
-        let body = FunctionBody::new(false, true).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseBlock, "async function declaration")?;
-
-        // Early Error: If the source code matching FormalParameters is strict mode code,
-        // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Duplicate parameter name not allowed in this context".into(),
-                params_start_position,
-            )));
-        }
-
-        // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of AsyncFunctionBody is true
-        // and IsSimpleParameterList of FormalParameters is false.
-        if body.strict() && !params.is_simple {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
-                params_start_position,
-            )));
-        }
-
-        // It is a Syntax Error if any element of the BoundNames of FormalParameters
-        // also occurs in the LexicallyDeclaredNames of FunctionBody.
-        // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
-        {
-            let lexically_declared_names = body.lexically_declared_names();
-            for param in params.parameters.as_ref() {
-                if lexically_declared_names.contains(param.name()) {
-                    return Err(ParseError::lex(LexError::Syntax(
-                        format!("Redeclaration of formal parameter `{}`", param.name()).into(),
-                        match cursor.peek(0)? {
-                            Some(token) => token.span().end(),
-                            None => Position::new(1, 1),
-                        },
-                    )));
-                }
-            }
-        }
-
-        Ok(AsyncFunctionDecl::new(name, params.parameters, body))
+        Ok(AsyncFunctionDecl::new(result.0, result.1, result.2))
     }
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -4,8 +4,8 @@ mod tests;
 use crate::syntax::{
     ast::{node::AsyncFunctionDecl, Keyword},
     parser::{
-        statement::declaration::hoistable::parse_function_like_declaration, AllowAwait,
-        AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
     },
 };
 use std::io::Read;
@@ -41,6 +41,33 @@ impl AsyncFunctionDeclaration {
     }
 }
 
+impl CallableDeclaration for AsyncFunctionDeclaration {
+    fn error_context(&self) -> &'static str {
+        "async function declaration"
+    }
+    fn is_default(&self) -> bool {
+        self.is_default.0
+    }
+    fn name_allow_yield(&self) -> bool {
+        self.allow_yield.0
+    }
+    fn name_allow_await(&self) -> bool {
+        self.allow_await.0
+    }
+    fn parameters_allow_yield(&self) -> bool {
+        false
+    }
+    fn parameters_allow_await(&self) -> bool {
+        true
+    }
+    fn body_allow_yield(&self) -> bool {
+        false
+    }
+    fn body_allow_await(&self) -> bool {
+        true
+    }
+}
+
 impl<R> TokenParser<R> for AsyncFunctionDeclaration
 where
     R: Read,
@@ -52,17 +79,7 @@ where
         cursor.peek_expect_no_lineterminator(0, "async function declaration")?;
         cursor.expect(Keyword::Function, "async function declaration")?;
 
-        let result = parse_function_like_declaration(
-            "async function declaration",
-            self.is_default.0,
-            self.allow_yield.0,
-            self.allow_await.0,
-            false,
-            true,
-            false,
-            true,
-            cursor,
-        )?;
+        let result = parse_callable_declaration(&self, cursor)?;
 
         Ok(AsyncFunctionDecl::new(result.0, result.1, result.2))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -2,12 +2,10 @@
 mod tests;
 
 use crate::syntax::{
-    ast::{node::FunctionDecl, Keyword, Punctuator},
+    ast::{node::FunctionDecl, Keyword},
     parser::{
-        function::FormalParameters,
-        function::FunctionBody,
-        statement::{BindingIdentifier, LexError, Position},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        statement::declaration::hoistable::parse_function_like_declaration, AllowAwait,
+        AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
     },
 };
 use std::io::Read;
@@ -57,71 +55,18 @@ where
     fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
         cursor.expect(Keyword::Function, "function declaration")?;
 
-        // TODO: If self.is_default, then this can be empty.
-        let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let result = parse_function_like_declaration(
+            "function declaration",
+            self.is_default.0,
+            self.allow_yield.0,
+            self.allow_await.0,
+            false,
+            false,
+            self.allow_yield.0,
+            self.allow_await.0,
+            cursor,
+        )?;
 
-        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
-        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Unexpected eval or arguments in strict mode".into(),
-                match cursor.peek(0)? {
-                    Some(token) => token.span().end(),
-                    None => Position::new(1, 1),
-                },
-            )));
-        }
-
-        let params_start_position = cursor
-            .expect(Punctuator::OpenParen, "generator declaration")?
-            .span()
-            .end();
-
-        let params = FormalParameters::new(false, false).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseParen, "function declaration")?;
-        cursor.expect(Punctuator::OpenBlock, "function declaration")?;
-
-        let body = FunctionBody::new(self.allow_yield, self.allow_await).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseBlock, "function declaration")?;
-
-        // Early Error: If the source code matching FormalParameters is strict mode code,
-        // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Duplicate parameter name not allowed in this context".into(),
-                params_start_position,
-            )));
-        }
-
-        // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
-        // and IsSimpleParameterList of FormalParameters is false.
-        if body.strict() && !params.is_simple {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
-                params_start_position,
-            )));
-        }
-
-        // It is a Syntax Error if any element of the BoundNames of FormalParameters
-        // also occurs in the LexicallyDeclaredNames of FunctionBody.
-        // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
-        {
-            let lexically_declared_names = body.lexically_declared_names();
-            for param in params.parameters.as_ref() {
-                if lexically_declared_names.contains(param.name()) {
-                    return Err(ParseError::lex(LexError::Syntax(
-                        format!("Redeclaration of formal parameter `{}`", param.name()).into(),
-                        match cursor.peek(0)? {
-                            Some(token) => token.span().end(),
-                            None => Position::new(1, 1),
-                        },
-                    )));
-                }
-            }
-        }
-
-        Ok(FunctionDecl::new(name, params.parameters, body))
+        Ok(FunctionDecl::new(result.0, result.1, result.2))
     }
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -4,10 +4,8 @@ mod tests;
 use crate::syntax::{
     ast::{node::declaration::generator_decl::GeneratorDecl, Keyword, Punctuator},
     parser::{
-        function::FormalParameters,
-        function::FunctionBody,
-        statement::{BindingIdentifier, LexError, Position},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        statement::declaration::hoistable::parse_function_like_declaration, AllowAwait,
+        AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
     },
 };
 use std::io::Read;
@@ -53,70 +51,18 @@ where
         cursor.expect(Keyword::Function, "generator declaration")?;
         cursor.expect(Punctuator::Mul, "generator declaration")?;
 
-        // TODO: If self.is_default, then this can be empty.
-        let name = BindingIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
+        let result = parse_function_like_declaration(
+            "generator declaration",
+            self.is_default.0,
+            self.allow_yield.0,
+            self.allow_await.0,
+            true,
+            false,
+            true,
+            false,
+            cursor,
+        )?;
 
-        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
-        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Unexpected eval or arguments in strict mode".into(),
-                match cursor.peek(0)? {
-                    Some(token) => token.span().end(),
-                    None => Position::new(1, 1),
-                },
-            )));
-        }
-
-        let params_start_position = cursor
-            .expect(Punctuator::OpenParen, "generator declaration")?
-            .span()
-            .end();
-
-        let params = FormalParameters::new(true, false).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseParen, "generator declaration")?;
-        cursor.expect(Punctuator::OpenBlock, "generator declaration")?;
-
-        let body = FunctionBody::new(true, false).parse(cursor)?;
-
-        cursor.expect(Punctuator::CloseBlock, "generator declaration")?;
-
-        // Early Error: If the source code matching FormalParameters is strict mode code,
-        // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Duplicate parameter name not allowed in this context".into(),
-                params_start_position,
-            )));
-        }
-
-        // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of GeneratorBody is true
-        // and IsSimpleParameterList of FormalParameters is false.
-        if body.strict() && !params.is_simple {
-            return Err(ParseError::lex(LexError::Syntax(
-                "Illegal 'use strict' directive in function with non-simple parameter list".into(),
-                params_start_position,
-            )));
-        }
-
-        // Early Error: It is a Syntax Error if any element of the BoundNames of FormalParameters
-        // also occurs in the LexicallyDeclaredNames of GeneratorBody.
-        {
-            let lexically_declared_names = body.lexically_declared_names();
-            for param in params.parameters.as_ref() {
-                if lexically_declared_names.contains(param.name()) {
-                    return Err(ParseError::lex(LexError::Syntax(
-                        format!("Redeclaration of formal parameter `{}`", param.name()).into(),
-                        match cursor.peek(0)? {
-                            Some(token) => token.span().end(),
-                            None => Position::new(1, 1),
-                        },
-                    )));
-                }
-            }
-        }
-
-        Ok(GeneratorDecl::new(name, params.parameters, body))
+        Ok(GeneratorDecl::new(result.0, result.1, result.2))
     }
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
@@ -1,0 +1,9 @@
+use crate::syntax::{ast::node::GeneratorDecl, parser::tests::check_parser};
+
+#[test]
+fn generator_function_declaration() {
+    check_parser(
+        "function* gen() {}",
+        vec![GeneratorDecl::new(Box::from("gen"), vec![], vec![]).into()],
+    );
+}

--- a/boa/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -18,9 +18,12 @@ use generator_decl::GeneratorDeclaration;
 
 use crate::{
     syntax::{
+        ast::node::{FormalParameter, StatementList},
         ast::{Keyword, Node, Punctuator},
-        lexer::TokenKind,
+        lexer::{Position, TokenKind},
         parser::{
+            function::{FormalParameters, FunctionBody},
+            statement::{BindingIdentifier, LexError},
             AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
         },
     },
@@ -88,4 +91,99 @@ where
             _ => unreachable!("unknown token found: {:?}", tok),
         }
     }
+}
+
+// This is a helper function to not duplicate code in the individual hoistable deceleration parser functions.
+#[inline]
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
+fn parse_function_like_declaration<R: Read>(
+    error_context: &'static str,
+    is_default: bool,
+    name_allow_yield: bool,
+    name_allow_await: bool,
+    parameters_allow_yield: bool,
+    parameters_allow_await: bool,
+    body_allow_yield: bool,
+    body_allow_await: bool,
+    cursor: &mut Cursor<R>,
+) -> Result<(Box<str>, Box<[FormalParameter]>, StatementList), ParseError> {
+    let next_token = cursor.peek(0)?;
+    let name = if let Some(token) = next_token {
+        match token.kind() {
+            TokenKind::Punctuator(Punctuator::OpenParen) => {
+                if !is_default {
+                    return Err(ParseError::unexpected(token.clone(), error_context));
+                }
+                "default".into()
+            }
+            _ => BindingIdentifier::new(name_allow_yield, name_allow_await).parse(cursor)?,
+        }
+    } else {
+        return Err(ParseError::AbruptEnd);
+    };
+
+    // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+    // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+    if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
+        return Err(ParseError::lex(LexError::Syntax(
+            "Unexpected eval or arguments in strict mode".into(),
+            match cursor.peek(0)? {
+                Some(token) => token.span().end(),
+                None => Position::new(1, 1),
+            },
+        )));
+    }
+
+    let params_start_position = cursor
+        .expect(Punctuator::OpenParen, error_context)?
+        .span()
+        .end();
+
+    let params =
+        FormalParameters::new(parameters_allow_yield, parameters_allow_await).parse(cursor)?;
+
+    cursor.expect(Punctuator::CloseParen, error_context)?;
+    cursor.expect(Punctuator::OpenBlock, error_context)?;
+
+    let body = FunctionBody::new(body_allow_yield, body_allow_await).parse(cursor)?;
+
+    cursor.expect(Punctuator::CloseBlock, error_context)?;
+
+    // Early Error: If the source code matching FormalParameters is strict mode code,
+    // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
+    if (cursor.strict_mode() || body.strict()) && params.has_duplicates {
+        return Err(ParseError::lex(LexError::Syntax(
+            "Duplicate parameter name not allowed in this context".into(),
+            params_start_position,
+        )));
+    }
+
+    // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
+    // and IsSimpleParameterList of FormalParameters is false.
+    if body.strict() && !params.is_simple {
+        return Err(ParseError::lex(LexError::Syntax(
+            "Illegal 'use strict' directive in function with non-simple parameter list".into(),
+            params_start_position,
+        )));
+    }
+
+    // It is a Syntax Error if any element of the BoundNames of FormalParameters
+    // also occurs in the LexicallyDeclaredNames of FunctionBody.
+    // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
+    {
+        let lexically_declared_names = body.lexically_declared_names();
+        for param in params.parameters.as_ref() {
+            if lexically_declared_names.contains(param.name()) {
+                return Err(ParseError::lex(LexError::Syntax(
+                    format!("Redeclaration of formal parameter `{}`", param.name()).into(),
+                    match cursor.peek(0)? {
+                        Some(token) => token.span().end(),
+                        None => Position::new(1, 1),
+                    },
+                )));
+            }
+        }
+    }
+
+    Ok((name, params.parameters, body))
 }

--- a/boa/src/syntax/parser/statement/declaration/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/mod.rs
@@ -7,7 +7,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements#Declarations
 //! [spec]:https://tc39.es/ecma262/#sec-declarations-and-the-variable-statement
 
-mod hoistable;
+pub(in crate::syntax::parser) mod hoistable;
 mod lexical;
 #[cfg(test)]
 mod tests;

--- a/boa/src/syntax/parser/statement/expression/mod.rs
+++ b/boa/src/syntax/parser/statement/expression/mod.rs
@@ -1,8 +1,9 @@
 use super::super::{expression::Expression, ParseResult};
 use crate::{
     syntax::{
-        ast::node::Node,
-        parser::{AllowAwait, AllowYield, Cursor, TokenParser},
+        ast::{node::Node, Keyword, Punctuator},
+        lexer::TokenKind,
+        parser::{AllowAwait, AllowYield, Cursor, ParseError, TokenParser},
     },
     BoaProfiler,
 };
@@ -42,7 +43,36 @@ where
 
     fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("ExpressionStatement", "Parsing");
-        // TODO: lookahead
+
+        let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+        match next_token.kind() {
+            TokenKind::Keyword(Keyword::Function) | TokenKind::Keyword(Keyword::Class) => {
+                return Err(ParseError::general(
+                    "expected statement",
+                    next_token.span().start(),
+                ));
+            }
+            TokenKind::Keyword(Keyword::Async) => {
+                let next_token = cursor.peek(1)?.ok_or(ParseError::AbruptEnd)?;
+                if next_token.kind() == &TokenKind::Keyword(Keyword::Function) {
+                    return Err(ParseError::general(
+                        "expected statement",
+                        next_token.span().start(),
+                    ));
+                }
+            }
+            TokenKind::Keyword(Keyword::Let) => {
+                let next_token = cursor.peek(1)?.ok_or(ParseError::AbruptEnd)?;
+                if next_token.kind() == &TokenKind::Punctuator(Punctuator::OpenBracket) {
+                    return Err(ParseError::general(
+                        "expected statement",
+                        next_token.span().start(),
+                    ));
+                }
+            }
+            _ => {}
+        }
+
         let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
 
         cursor.expect_semicolon("expression statement")?;

--- a/boa/src/syntax/parser/statement/if_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/if_stm/mod.rs
@@ -82,10 +82,7 @@ where
 
             // Early Error: It is a Syntax Error if IsLabelledFunction(the first Statement) is true.
             if let Node::FunctionDecl(_) = node {
-                return Err(ParseError::general(
-                    "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.",
-                    position
-                ));
+                return Err(ParseError::wrong_function_declaration_non_strict(position));
             }
 
             node
@@ -111,10 +108,7 @@ where
 
                 // Early Error: It is a Syntax Error if IsLabelledFunction(the second Statement) is true.
                 if let Node::FunctionDecl(_) = node {
-                    return Err(ParseError::general(
-                        "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.",
-                        position
-                    ));
+                    return Err(ParseError::wrong_function_declaration_non_strict(position));
                 }
 
                 Some(node)

--- a/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
@@ -74,7 +74,7 @@ where
 
         // Early Error: It is a Syntax Error if IsLabelledFunction(Statement) is true.
         if let Node::FunctionDecl(_) = body {
-            return Err(ParseError::general("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.", position));
+            return Err(ParseError::wrong_function_declaration_non_strict(position));
         }
 
         let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;

--- a/boa/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/for_statement.rs
@@ -104,7 +104,7 @@ where
 
                 // Early Error: It is a Syntax Error if IsLabelledFunction(the first Statement) is true.
                 if let Node::FunctionDecl(_) = body {
-                    return Err(ParseError::general("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.", position));
+                    return Err(ParseError::wrong_function_declaration_non_strict(position));
                 }
 
                 return Ok(ForInLoop::new(init.unwrap(), expr, body).into());
@@ -124,7 +124,7 @@ where
 
                 // Early Error: It is a Syntax Error if IsLabelledFunction(the first Statement) is true.
                 if let Node::FunctionDecl(_) = body {
-                    return Err(ParseError::general("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.", position));
+                    return Err(ParseError::wrong_function_declaration_non_strict(position));
                 }
 
                 return Ok(ForOfLoop::new(init.unwrap(), iterable, body).into());
@@ -160,7 +160,7 @@ where
 
         // Early Error: It is a Syntax Error if IsLabelledFunction(the first Statement) is true.
         if let Node::FunctionDecl(_) = body {
-            return Err(ParseError::general("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.", position));
+            return Err(ParseError::wrong_function_declaration_non_strict(position));
         }
 
         // TODO: do not encapsulate the `for` in a block just to have an inner scope.

--- a/boa/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/while_statement.rs
@@ -70,7 +70,7 @@ where
 
         // Early Error: It is a Syntax Error if IsLabelledFunction(Statement) is true.
         if let Node::FunctionDecl(_) = body {
-            return Err(ParseError::general("In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.", position));
+            return Err(ParseError::wrong_function_declaration_non_strict(position));
         }
 
         Ok(WhileLoop::new(cond, body))

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -537,7 +537,7 @@ where
                     Ok("yield".into())
                 }
             }
-            TokenKind::Keyword(Keyword::Await) if self.allow_yield.0 => {
+            TokenKind::Keyword(Keyword::Await) if self.allow_await.0 => {
                 // Early Error: It is a Syntax Error if this production has an [Await] parameter and StringValue of Identifier is "await".
                 Err(ParseError::general(
                     "Unexpected identifier",


### PR DESCRIPTION
I know this diff is pretty large, but a good amount is pasting early error handling and pretty trivial code. A big chunk of this is actually implementing lots of early error handling. Without that generator parsing only produces more failed tests. There are some new errors, but those are either related to #1391 or will be fixed with some more early error handling that I did not want to do here.
If it seems to much for one PR, I can split this.

This Pull Request fixes/closes #1557,  #1527.

It changes the following:

- Implement GeneratorMethod parsing
- Implement GeneratorDeclaration parsing
- Implement GeneratorExpression parsing
- Implement YieldExpression parsing
- Implement early error handling for duplicate function parameters
- Implement early error handling for for simple function parameters
- Implement early error handling for function identifiers not being `eval` or `arguments`
- Implement `IdentifierReference` parsing in `PrimaryExpression`
- Implement early errors for `BindingIdentifier`
- Implement early errors for `LabelledItem`
- Implement annexB syntax for `IfStatement`
- Implement the lookahead in `ExpressionStatement`
- Refactor the `MethodDefinition` parser (Note: I have removed the `MethodDefinition` and moved the parsing into the `PropertyDefinition` parser. This is done, because we cannot differentiate between `PropertyName : AssignmentExpression` and `MethodDefinition`, if we encounter a `ComputedPropertyName`, without parsing the `ComputedPropertyName`. The only other place `MethodDefinition` is used is in classes. I think we can live with implementing that parser two times. The other benefit is, that the parser is now way cleaner. Adjusting it for the classes use-case would make it even worse.)