### PR TITLE
Implement Object.getOwnPropertyNames and Object.getOwnPropertySymbols

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -827,7 +827,14 @@ impl Object {
         }
     }
 
-    /// TODO: Documentation
+    /// `Object.getOwnPropertyNames( object )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-object.getownpropertynames
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyNames
     pub fn get_own_property_names(
         _: &JsValue,
         args: &[JsValue],
@@ -837,7 +844,14 @@ impl Object {
         get_own_property_keys(o, GetOwnPropertyKeysType::String, context)
     }
 
-    /// TODO: Documentation
+    /// `Object.getOwnPropertySymbols( object )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-object.getownpropertysymbols
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols
     pub fn get_own_property_symbols(
         _: &JsValue,
         args: &[JsValue],
@@ -900,14 +914,19 @@ fn object_define_properties(
     Ok(())
 }
 
-/// TODO: Docs
+/// Type enum used in the abstract operation GetOwnPropertyKeys
 #[derive(Debug, Copy, Clone)]
 enum GetOwnPropertyKeysType {
     String,
     Symbol,
 }
 
-/// TODO: Docs
+/// The abstract operation GetOwnPropertyKeys
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-getownpropertykeys
 fn get_own_property_keys(
     o: &JsValue,
     r#type: GetOwnPropertyKeysType,

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -945,10 +945,10 @@ fn get_own_property_keys(
     let name_list = keys.iter().filter_map(|next_key| {
         // a. If Type(nextKey) is Symbol and type is symbol or Type(nextKey) is String and type is string, then
         // i. Append nextKey as the last element of nameList.
-        match (r#type, next_key) {
-            (PropertyKeyType::String, PropertyKey::String(key)) => Some(key.clone().into()),
+        match (r#type, &next_key) {
+            (PropertyKeyType::String, PropertyKey::String(_)) => Some(next_key.into()),
             (PropertyKeyType::String, PropertyKey::Index(index)) => Some(index.to_string().into()),
-            (PropertyKeyType::Symbol, PropertyKey::Symbol(symbol)) => Some(symbol.clone().into()),
+            (PropertyKeyType::Symbol, PropertyKey::Symbol(_)) => Some(next_key.into()),
             _ => None,
         }
     });

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -289,3 +289,51 @@ fn object_is_prototype_of() {
 
     assert_eq!(context.eval(init).unwrap(), JsValue::new(true));
 }
+
+#[test]
+fn object_get_own_property_names_invalid_args() {
+    let mut context = Context::new();
+
+    let error_message = r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#;
+
+    assert_eq!(
+        forward(&mut context, r#"Object.getOwnPropertyNames()"#),
+        error_message
+    );
+    assert_eq!(
+        forward(&mut context, r#"Object.getOwnPropertyNames(null)"#),
+        error_message
+    );
+    assert_eq!(
+        forward(&mut context, r#"Object.getOwnPropertyNames(undefined)"#),
+        error_message
+    );
+}
+
+#[test]
+fn object_get_own_property_names() {
+    let mut context = Context::new();
+
+    let init = r#"
+        const a = Object.getOwnPropertyNames(0);
+        const b = Object.getOwnPropertyNames(false);
+        const c = Object.getOwnPropertyNames(Symbol("a"));
+        const d = Object.getOwnPropertyNames({});
+        const e = Object.getOwnPropertyNames(NaN);
+
+        const f = Object.getOwnPropertyNames("abc");
+        const g = Object.getOwnPropertyNames([1, 2, 3]);
+        const h = Object.getOwnPropertyNames({ "a": 1, "b": 2, [ Symbol("c") ]: 3 });
+    "#;
+    forward(&mut context, init);
+
+    assert_eq!(forward(&mut context, "a"), "[]");
+    assert_eq!(forward(&mut context, "b"), "[]");
+    assert_eq!(forward(&mut context, "c"), "[]");
+    assert_eq!(forward(&mut context, "d"), "[]");
+    assert_eq!(forward(&mut context, "e"), "[]");
+
+    assert_eq!(forward(&mut context, "f"), r#"[ "0", "1", "2", "length" ]"#);
+    assert_eq!(forward(&mut context, "g"), r#"[ "0", "1", "2", "length" ]"#);
+    assert_eq!(forward(&mut context, "h"), r#"[ "a", "b" ]"#);
+}

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -303,30 +303,25 @@ fn object_get_own_property_names_invalid_args() {
 
 #[test]
 fn object_get_own_property_names() {
-    let scenario = r#"
-        const a = Object.getOwnPropertyNames(0);
-        const b = Object.getOwnPropertyNames(false);
-        const c = Object.getOwnPropertyNames(Symbol("a"));
-        const d = Object.getOwnPropertyNames({});
-        const e = Object.getOwnPropertyNames(NaN);
-        const f = Object.getOwnPropertyNames([1, 2, 3]);
-        const g = Object.getOwnPropertyNames({
-            "a": 1,
-            "b": 2,
-            [ Symbol("c") ]: 3,
-            [ Symbol("d") ]: 4,
-        });
-    "#;
-
     check_output(&[
-        TestAction::Execute(scenario),
-        TestAction::TestEq("a", "[]"),
-        TestAction::TestEq("b", "[]"),
-        TestAction::TestEq("c", "[]"),
-        TestAction::TestEq("d", "[]"),
-        TestAction::TestEq("e", "[]"),
-        TestAction::TestEq("f", r#"[ "0", "1", "2", "length" ]"#),
-        TestAction::TestEq("g", r#"[ "a", "b" ]"#),
+        TestAction::TestEq("Object.getOwnPropertyNames(0)", "[]"),
+        TestAction::TestEq("Object.getOwnPropertyNames(false)", "[]"),
+        TestAction::TestEq(r#"Object.getOwnPropertyNames(Symbol("a"))"#, "[]"),
+        TestAction::TestEq("Object.getOwnPropertyNames({})", "[]"),
+        TestAction::TestEq("Object.getOwnPropertyNames(NaN)", "[]"),
+        TestAction::TestEq(
+            "Object.getOwnPropertyNames([1, 2, 3])",
+            r#"[ "0", "1", "2", "length" ]"#,
+        ),
+        TestAction::TestEq(
+            r#"Object.getOwnPropertyNames({
+                "a": 1,
+                "b": 2,
+                [ Symbol("c") ]: 3,
+                [ Symbol("d") ]: 4,
+            })"#,
+            r#"[ "a", "b" ]"#,
+        ),
     ]);
 }
 
@@ -343,29 +338,22 @@ fn object_get_own_property_symbols_invalid_args() {
 
 #[test]
 fn object_get_own_property_symbols() {
-    let scenario = r#"
-        const a = Object.getOwnPropertySymbols(0);
-        const b = Object.getOwnPropertySymbols(false);
-        const c = Object.getOwnPropertySymbols(Symbol("a"));
-        const d = Object.getOwnPropertySymbols({});
-        const e = Object.getOwnPropertySymbols(NaN);
-        const f = Object.getOwnPropertySymbols([1, 2, 3]);
-        const g = Object.getOwnPropertySymbols({
-            "a": 1,
-            "b": 2,
-            [ Symbol("c") ]: 3,
-            [ Symbol("d") ]: 4,
-        });
-    "#;
-
     check_output(&[
-        TestAction::Execute(scenario),
-        TestAction::TestEq("a", "[]"),
-        TestAction::TestEq("b", "[]"),
-        TestAction::TestEq("c", "[]"),
-        TestAction::TestEq("d", "[]"),
-        TestAction::TestEq("e", "[]"),
-        TestAction::TestEq("f", "[]"),
-        TestAction::TestEq("g", "[ Symbol(c), Symbol(d) ]"),
+        TestAction::TestEq("Object.getOwnPropertySymbols(0)", "[]"),
+        TestAction::TestEq("Object.getOwnPropertySymbols(false)", "[]"),
+        TestAction::TestEq(r#"Object.getOwnPropertySymbols(Symbol("a"))"#, "[]"),
+        TestAction::TestEq("Object.getOwnPropertySymbols({})", "[]"),
+        TestAction::TestEq("Object.getOwnPropertySymbols(NaN)", "[]"),
+        TestAction::TestEq("Object.getOwnPropertySymbols([1, 2, 3])", "[]"),
+        TestAction::TestEq(
+            r#"
+            Object.getOwnPropertySymbols({
+                "a": 1,
+                "b": 2,
+                [ Symbol("c") ]: 3,
+                [ Symbol("d") ]: 4,
+            })"#,
+            "[ Symbol(c), Symbol(d) ]",
+        ),
     ]);
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -309,9 +309,13 @@ fn object_get_own_property_names() {
         const c = Object.getOwnPropertyNames(Symbol("a"));
         const d = Object.getOwnPropertyNames({});
         const e = Object.getOwnPropertyNames(NaN);
-        const f = Object.getOwnPropertyNames("abc");
-        const g = Object.getOwnPropertyNames([1, 2, 3]);
-        const h = Object.getOwnPropertyNames({ "a": 1, "b": 2, [ Symbol("c") ]: 3 });
+        const f = Object.getOwnPropertyNames([1, 2, 3]);
+        const g = Object.getOwnPropertyNames({
+            "a": 1,
+            "b": 2,
+            [ Symbol("c") ]: 3,
+            [ Symbol("d") ]: 4,
+        });
     "#;
 
     check_output(&[
@@ -322,7 +326,46 @@ fn object_get_own_property_names() {
         TestAction::TestEq("d", "[]"),
         TestAction::TestEq("e", "[]"),
         TestAction::TestEq("f", r#"[ "0", "1", "2", "length" ]"#),
-        TestAction::TestEq("g", r#"[ "0", "1", "2", "length" ]"#),
-        TestAction::TestEq("h", r#"[ "a", "b" ]"#),
+        TestAction::TestEq("g", r#"[ "a", "b" ]"#),
+    ]);
+}
+
+#[test]
+fn object_get_own_property_symbols_invalid_args() {
+    let error_message = r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#;
+
+    check_output(&[
+        TestAction::TestEq("Object.getOwnPropertySymbols()", error_message),
+        TestAction::TestEq("Object.getOwnPropertySymbols(null)", error_message),
+        TestAction::TestEq("Object.getOwnPropertySymbols(undefined)", error_message),
+    ]);
+}
+
+#[test]
+fn object_get_own_property_symbols() {
+    let scenario = r#"
+        const a = Object.getOwnPropertySymbols(0);
+        const b = Object.getOwnPropertySymbols(false);
+        const c = Object.getOwnPropertySymbols(Symbol("a"));
+        const d = Object.getOwnPropertySymbols({});
+        const e = Object.getOwnPropertySymbols(NaN);
+        const f = Object.getOwnPropertySymbols([1, 2, 3]);
+        const g = Object.getOwnPropertySymbols({
+            "a": 1,
+            "b": 2,
+            [ Symbol("c") ]: 3,
+            [ Symbol("d") ]: 4,
+        });
+    "#;
+
+    check_output(&[
+        TestAction::Execute(scenario),
+        TestAction::TestEq("a", "[]"),
+        TestAction::TestEq("b", "[]"),
+        TestAction::TestEq("c", "[]"),
+        TestAction::TestEq("d", "[]"),
+        TestAction::TestEq("e", "[]"),
+        TestAction::TestEq("f", "[]"),
+        TestAction::TestEq("g", "[ Symbol(c), Symbol(d) ]"),
     ]);
 }

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -292,48 +292,34 @@ fn object_is_prototype_of() {
 
 #[test]
 fn object_get_own_property_names_invalid_args() {
-    let mut context = Context::new();
+    let args = vec!["", "null", "undefined"];
 
-    let error_message = r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#;
-
-    assert_eq!(
-        forward(&mut context, r#"Object.getOwnPropertyNames()"#),
-        error_message
-    );
-    assert_eq!(
-        forward(&mut context, r#"Object.getOwnPropertyNames(null)"#),
-        error_message
-    );
-    assert_eq!(
-        forward(&mut context, r#"Object.getOwnPropertyNames(undefined)"#),
-        error_message
-    );
+    for arg in args {
+        let mut context = Context::new();
+        let init = format!("Object.getOwnPropertyNames({})", arg);
+        assert_eq!(
+            forward(&mut context, init),
+            r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#
+        );
+    }
 }
 
 #[test]
 fn object_get_own_property_names() {
-    let mut context = Context::new();
+    let tests = vec![
+        ("0", "[]"),
+        ("NaN", "[]"),
+        ("false", "[]"),
+        ("{}", "[]"),
+        ("Symbol(\"a\")", "[]"),
+        ("\"abc\"", r#"[ "0", "1", "2", "length" ]"#),
+        ("[ 1, 2, 3 ]", r#"[ "0", "1", "2", "length" ]"#),
+        (r#"{ "a": 1, "b": 2, [Symbol("c")]: 3 }"#, r#"[ "a", "b" ]"#),
+    ];
 
-    let init = r#"
-        const a = Object.getOwnPropertyNames(0);
-        const b = Object.getOwnPropertyNames(false);
-        const c = Object.getOwnPropertyNames(Symbol("a"));
-        const d = Object.getOwnPropertyNames({});
-        const e = Object.getOwnPropertyNames(NaN);
-
-        const f = Object.getOwnPropertyNames("abc");
-        const g = Object.getOwnPropertyNames([1, 2, 3]);
-        const h = Object.getOwnPropertyNames({ "a": 1, "b": 2, [ Symbol("c") ]: 3 });
-    "#;
-    forward(&mut context, init);
-
-    assert_eq!(forward(&mut context, "a"), "[]");
-    assert_eq!(forward(&mut context, "b"), "[]");
-    assert_eq!(forward(&mut context, "c"), "[]");
-    assert_eq!(forward(&mut context, "d"), "[]");
-    assert_eq!(forward(&mut context, "e"), "[]");
-
-    assert_eq!(forward(&mut context, "f"), r#"[ "0", "1", "2", "length" ]"#);
-    assert_eq!(forward(&mut context, "g"), r#"[ "0", "1", "2", "length" ]"#);
-    assert_eq!(forward(&mut context, "h"), r#"[ "a", "b" ]"#);
+    for (arg, expected) in tests {
+        let mut context = Context::new();
+        let init = format!("Object.getOwnPropertyNames({})", arg);
+        assert_eq!(forward(&mut context, init), expected);
+    }
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

## Scope

This Pull Request *partially* fixes/closes #1580.

In this PR, I implemented `Object.getOwnPropertyNames` and `Object.getOwnPropertySymbols`. Originally I planned to open separate PRs for each of the missing method listed in #1580, but ended up implementing these two methods in one PR since they are very much alike.

I still plan to work on `Object.fromEntries` and `Object.hasOwn` in separate PRs, though. Please let me know in case it's preferred to have the implementation of these four methods in this PR instead!

## Testing

There are several failing conformance tests, which are due to the following:
- `Proxy` not defined (I'm guessing it's not implemented yet?)
- `Object.getOwnPropertyNames(this)` returning slightly different set of properties from expected:
   - Expected: `Array,Boolean,Date,Date,Error,EvalError,Function,Infinity,JSON,Math,NaN,Number,Object,RangeError,ReferenceError,RegExp,String,SyntaxError,TypeError,URIError,decodeURI,decodeURIComponent,encodeURI,encodeURIComponent,eval,isFinite,isNaN,parseFloat,parseInt,undefined`
   - Returned: `Array,BigInt,Boolean,Date,Error,EvalError,Function,Infinity,JSON,Map,Math,NaN,Number,Object,RangeError,ReferenceError,Reflect,RegExp,Set,String,Symbol,SyntaxError,TypeError,URIError,console,globalThis,isFinite,isNaN,parseFloat,parseInt,undefined`
- `test/built-ins/Object/getOwnPropertySymbols/order-after-define-property.js` failing with `Uncaught "TypeError": "can't convert symbol to string"`. I think this has something to do with calling `[Symbol("a")].toString()`, but I'm not exactly sure. Anyhow, I tried editing the test such that no string conversion happens, and the test passed.

On another note, should I also write some custom tests in the `builtins/object/tests.rs` file?