### PR TITLE
Fix broken structure links in documentation

### DIFF
--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -3,7 +3,7 @@
 //! This module contains the Boa lexer or tokenizer implementation.
 //!
 //! The Lexer splits its input source code into a sequence of input elements called tokens,
-//! represented by the [Token](../ast/token/struct.Token.html) structure. It also removes
+//! represented by the [Token] structure. It also removes
 //! whitespace and comments and attaches them to the next token.
 //!
 //! This is tightly coupled with the parser due to the javascript goal-symbol requirements

--- a/boa/src/syntax/lexer/token.rs
+++ b/boa/src/syntax/lexer/token.rs
@@ -107,8 +107,6 @@ pub enum TokenKind {
     Identifier(Box<str>),
 
     /// A keyword.
-    ///
-    /// see: [`Keyword`](../keyword/enum.Keyword.html)
     Keyword(Keyword),
 
     /// A `null` literal.
@@ -118,8 +116,6 @@ pub enum TokenKind {
     NumericLiteral(Numeric),
 
     /// A piece of punctuation
-    ///
-    /// see: [`Punctuator`](../punc/enum.Punctuator.html)
     Punctuator(Punctuator),
 
     /// A string literal.


### PR DESCRIPTION
Found some broken links to some structures when perusing the documentation of Lexer and Parser.
