### PR TITLE
Fix integer parsing

### DIFF
--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -10,7 +10,6 @@ use crate::{
     JsBigInt,
 };
 use std::io::Read;
-use std::num::IntErrorKind;
 use std::str;
 
 /// Number literal lexing.
@@ -399,13 +398,8 @@ impl<R> Tokenizer<R> for NumberLiteral {
                 if let Ok(num) = i32::from_str_radix(num_str, base) {
                     Numeric::Integer(num)
                 } else {
-                    let num = i128::from_str_radix(num_str, base)
-                        .unwrap_or_else(|e| match e.kind() {
-                            IntErrorKind::PosOverflow => i128::MAX,
-                            IntErrorKind::NegOverflow => i128::MIN,
-                            _ => unreachable!("Failed to parse integer after checks")
-                        });
-                    Numeric::Rational(num as f64)
+                    let num = JsBigInt::from_string_radix(num_str, base).expect("Failed to parse integer after checks");
+                    Numeric::Rational(num.to_f64())
                 }
             }
         };

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -10,8 +10,8 @@ use crate::{
     JsBigInt,
 };
 use std::io::Read;
-use std::str;
 use std::num::IntErrorKind;
+use std::str;
 
 /// Number literal lexing.
 ///


### PR DESCRIPTION
This Pull Request makes it possible to continue with #1602 and also fixes some errors with parsing integers.

It changes the following:

- Instead of manually parsing and adding each character I use i128::from_str_radix, which is then converted to f64

~~Unanswered questions:~~

~~- What does the spec say about even larger numbers? I've tested NodeJS and Firefox and you can more or less get unlimited range, albeit anything that's larger than `Number.MAX_SAFE_INTEGER` is not represented exactly. With this solution, however, numbers get clamped to -1.7e+38 and 1.7e+38. I'm assuming fixing this would most likely require an overhaul of the number representation and parsing code.~~