### PR TITLE
Implement `Symbol.prototype.valueOf`

### DIFF
--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -228,7 +228,7 @@ impl Symbol {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        // valueOf a symbol is itself
+        // 1. Return ? thisSymbolValue(this value).
         let symbol = Self::this_symbol_value(this, context)?;
         Ok(JsValue::Symbol(symbol))
     }

--- a/boa/src/builtins/symbol/mod.rs
+++ b/boa/src/builtins/symbol/mod.rs
@@ -127,6 +127,7 @@ impl BuiltIn for Symbol {
         .static_property("toStringTag", symbol_to_string_tag.clone(), attribute)
         .static_property("unscopables", symbol_unscopables, attribute)
         .method(Self::to_string, "toString", 0)
+        .method(Self::value_of, "valueOf", 0)
         .accessor(
             "description",
             Some(get_description),
@@ -210,6 +211,26 @@ impl Symbol {
     ) -> JsResult<JsValue> {
         let symbol = Self::this_symbol_value(this, context)?;
         Ok(symbol.to_string().into())
+    }
+
+    /// `Symbol.prototype.valueOf()`
+    ///
+    /// This method returns a `Symbol` that is the primitive value of the specified `Symbol` object.
+    ///
+    /// More information:
+    /// - [MDN documentation][mdn]
+    /// - [ECMAScript reference][spec]
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
+    /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.valueof
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // valueOf a symbol is itself
+        let symbol = Self::this_symbol_value(this, context)?;
+        Ok(JsValue::Symbol(symbol))
     }
 
     /// `get Symbol.prototype.description`


### PR DESCRIPTION
Signed-off-by: hle0 <91701075+hle0@users.noreply.github.com>

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1617 .

It changes the following:

- `valueOf` is defined differently for `Symbol` so that `Symbol('s').valueOf() == Symbol('s')`, as per the spec.
