### PR TITLE
Fix `Number.toExponential` and `Number.toFixed`

### DIFF
--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -1164,7 +1164,7 @@ fn f64_to_exponential(n: f64) -> String {
 }
 
 /// Helper function that formats a float as a ES6-style exponential number string with a given precision.
-// We can't use the same approach as in `num_to_exponential`
+// We can't use the same approach as in `f64_to_exponential`
 // because in cases like (0.999).toExponential(0) the result will be 1e0.
 // Instead we get the index of 'e', and if the next character is not '-' we insert the plus sign
 fn f64_to_exponential_with_precision(n: f64, prec: usize) -> String {

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -257,10 +257,9 @@ impl Number {
         // Get rid of the '-' sign for -0.0
         let this_num = if this_num == 0. { 0. } else { this_num };
         let this_str_num = if let Some(precision) = precision {
-            if precision < 0 || precision > 100 {
-                return Err(context.construct_range_error(
-                    "toExponential() argument must be between 0 and 100",
-                ));
+            if !(0..=100).contains(&precision) {
+                return Err(context
+                    .construct_range_error("toExponential() argument must be between 0 and 100"));
             }
             Self::num_to_exponential_with_precision(this_num, precision as usize)
         } else {

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -1158,7 +1158,7 @@ impl Number {
 /// Helper function that formats a float as a ES6-style exponential number string.
 fn f64_to_exponential(n: f64) -> String {
     match n.abs() {
-        x if x > 1.0 || x == 0.0 => format!("{:e}", n).replace("e", "e+"),
+        x if x >= 1.0 || x == 0.0 => format!("{:e}", n).replace("e", "e+"),
         _ => format!("{:e}", n),
     }
 }


### PR DESCRIPTION
This Pull Request closes #1602.

It makes `toExponential` and `toFixed` methods on `Number` compliant with the specification.

One of the tests in `toExponential` currently fails. This is something that's blocked by https://github.com/rust-lang/rust/issues/89493, unless we were to implement the exponential string algorithm ourselves. 