### PR TITLE
Add limited console.trace implementation

### DIFF
--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -299,6 +299,24 @@ impl Console {
         Ok(JsValue::undefined())
     }
 
+    #[cfg(feature = "vm")]
+    fn get_stack_trace(context: &mut Context) -> Vec<String> {
+        let mut stack_trace: Vec<String> = vec![];
+        let mut prev_frame = context.vm.frame.as_ref();
+
+        while let Some(frame) = prev_frame {
+            stack_trace.push(frame.code.name.to_string());
+            prev_frame = frame.prev.as_ref();
+        }
+
+        stack_trace
+    }
+
+    #[cfg(not(feature = "vm"))]
+    fn get_stack_trace(_: &mut Context) -> Vec<String> {
+        vec![]
+    }
+
     /// `console.trace(...data)`
     ///
     /// Prints a stack trace with "trace" logLevel, optionally labelled by data.
@@ -316,11 +334,8 @@ impl Console {
                 context.console(),
             );
 
-            /* TODO: get and print stack trace */
-            logger(
-                LogMessage::Log("Not implemented: <stack trace>".to_string()),
-                context.console(),
-            )
+            let stack_trace_dump = Self::get_stack_trace(context).join("\n");
+            logger(LogMessage::Log(stack_trace_dump), context.console())
         }
 
         Ok(JsValue::undefined())


### PR DESCRIPTION
This Pull Request partially fixes #307.

It changes the following:

- Implements limited `console.trace` functionality by dumping stack trace. Since `console.trace`'s output is supposed to be implementation-specific according to the technical specification, it should be technically correct 😀 Any hints about potential improvements are welcome!