### PR TITLE
Fix Math tests #1559

### DIFF
--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -631,8 +631,8 @@ impl Math {
             } else if num.is_nan() {
                 // a. If number is NaN, return NaN.
                 f64::NAN
-            } else if (highest - num).signum() == 1.0 {
-                // We use the sign of the difference of the numbers because it's more robust then f64::min when it comes to -0.0
+            } else if ((highest - num).signum() - 1.0).abs() < f64::EPSILON {
+                // We use the sign of the difference of the numbers because it's more robust then f64::max when it comes to -0.0
                 // b. If the sign of the difference is negative,  return highest.
                 highest
             } else {
@@ -669,7 +669,7 @@ impl Math {
             } else if num.is_nan() {
                 // a. If number is NaN, return NaN.
                 f64::NAN
-            } else if (lowest - num).signum() == -1.0 {
+            } else if ((lowest - num).signum() - -1.0).abs() < f64::EPSILON {
                 // We use the sign of the difference of the numbers because it's more robust then f64::min when it comes to -0.0
                 // b. If the sign of the difference is negative,  return lowest.
                 lowest

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -64,7 +64,7 @@ impl BuiltIn for Math {
             .function(Self::floor, "floor", 1)
             .function(Self::fround, "fround", 1)
             .function(Self::hypot, "hypot", 2)
-            .function(Self::imul, "imul", 1)
+            .function(Self::imul, "imul", 2)
             .function(Self::log, "log", 1)
             .function(Self::log1p, "log1p", 1)
             .function(Self::log10, "log10", 1)

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -631,10 +631,13 @@ impl Math {
             } else if num.is_nan() {
                 // a. If number is NaN, return NaN.
                 f64::NAN
+            } else if (highest - num).signum() == 1.0 {
+                // We use the sign of the difference of the numbers because it's more robust then f64::min when it comes to -0.0
+                // b. If the sign of the difference is negative,  return highest.
+                highest
             } else {
-                // b. If number is +0𝔽 and highest is -0𝔽, set highest to +0𝔽.
-                // c. If number > highest, set highest to number.
-                highest.max(num)
+                // c. If the sign of the difference is positive,  return num.
+                num
             };
         }
         // 5. Return highest.

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -698,7 +698,7 @@ impl Math {
         let y = args.get_or_undefined(1).to_number(context)?;
 
         // 3. If |x| = 1 and the exponent is infinite, return NaN.
-        if f64::abs(x) == 1.0 && y.is_infinite() {
+        if (f64::abs(x) - 1.0).abs() < f64::EPSILON && y.is_infinite() {
             return Ok(f64::NAN.into())
         }
 
@@ -728,16 +728,21 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     pub(crate) fn round(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        Ok(args
+        let num = args
             .get_or_undefined(0)
             //1. Let n be ? ToNumber(x).
-            .to_number(context)?
+            .to_number(context)?;
+
             //2. If n is NaN, +∞𝔽, -∞𝔽, or an integral Number, return n.
             //3. If n < 0.5𝔽 and n > +0𝔽, return +0𝔽.
             //4. If n < +0𝔽 and n ≥ -0.5𝔽, return -0𝔽.
             //5. Return the integral Number closest to n, preferring the Number closer to +∞ in the case of a tie.
-            .round()
-            .into())
+
+            if num.fract() == -0.5 {
+                Ok(num.ceil().into())
+            } else {
+                Ok(num.round().into())
+            }
     }
 
     /// Get the sign of a number.

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -697,7 +697,12 @@ impl Math {
         // 2. Set exponent to ? ToNumber(exponent).
         let y = args.get_or_undefined(1).to_number(context)?;
 
-        // 3. Return ! Number::exponentiate(base, exponent).
+        // 3. If |x| = 1 and the exponent is infinite, return NaN.
+        if f64::abs(x) == 1.0 && y.is_infinite() {
+            return Ok(f64::NAN.into())
+        }
+
+        // 4. Return ! Number::exponentiate(base, exponent).
         Ok(x.powf(y).into())
     }
 

--- a/boa/src/builtins/math/mod.rs
+++ b/boa/src/builtins/math/mod.rs
@@ -666,10 +666,13 @@ impl Math {
             } else if num.is_nan() {
                 // a. If number is NaN, return NaN.
                 f64::NAN
+            } else if (lowest - num).signum() == -1.0 {
+                // We use the sign of the difference of the numbers because it's more robust then f64::min when it comes to -0.0
+                // b. If the sign of the difference is negative,  return lowest.
+                lowest
             } else {
-                // b. If number is -0𝔽 and lowest is +0𝔽, set lowest to -0𝔽.
-                // c. If number < lowest, set lowest to number.
-                lowest.min(num)
+                // c. If the sign of the difference is positive,  return num.
+                num
             };
         }
         // 5. Return lowest.


### PR DESCRIPTION
This Pull Request closes #1599.

Things changed:
- Instead of using f64::min, we use the sign of the difference of the numbers to compare. There is certainly a more efficient way to do this.
- imul's length was changed to the right one
- pow now returns NaN when the exponent is infinite and the base is 1 or -1
- round now ceils for negative numbers with a fractionnal part of 0.5 instead of flooring

It's my first pull request on a repo, I'd love so me feedback.