### PR TITLE
Allow destructuring in catch parameter

### DIFF
--- a/boa/src/syntax/ast/node/block/mod.rs
+++ b/boa/src/syntax/ast/node/block/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     gc::{Finalize, Trace},
     BoaProfiler, Context, JsResult, JsValue,
 };
-use std::fmt;
+use std::{collections::HashSet, fmt};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
@@ -43,6 +43,14 @@ impl Block {
     /// Gets the list of statements and declarations in this block.
     pub(crate) fn items(&self) -> &[Node] {
         self.statements.items()
+    }
+
+    pub(crate) fn lexically_declared_names(&self) -> HashSet<&str> {
+        self.statements.lexically_declared_names()
+    }
+
+    pub(crate) fn var_declared_named(&self) -> HashSet<&str> {
+        self.statements.var_declared_names()
     }
 
     /// Implements the display formatting with indentation.

--- a/boa/src/syntax/ast/node/try_node/tests.rs
+++ b/boa/src/syntax/ast/node/try_node/tests.rs
@@ -78,6 +78,38 @@ fn catch_binding() {
 }
 
 #[test]
+fn catch_binding_pattern_object() {
+    let scenario = r#"
+        let a = 10;
+        try {
+            throw {
+                n: 30,
+            };
+        } catch ({ n }) {
+            a = n;
+        }
+
+        a;
+    "#;
+    assert_eq!(&exec(scenario), "30");
+}
+
+#[test]
+fn catch_binding_pattern_array() {
+    let scenario = r#"
+        let a = 10;
+        try {
+            throw [20, 30];
+        } catch ([, n]) {
+            a = n;
+        }
+
+        a;
+    "#;
+    assert_eq!(&exec(scenario), "30");
+}
+
+#[test]
 fn catch_binding_finally() {
     let scenario = r#"
         let a = 10;

--- a/boa/src/syntax/parser/statement/try_stm/catch.rs
+++ b/boa/src/syntax/parser/statement/try_stm/catch.rs
@@ -15,7 +15,8 @@ use crate::{
     BoaProfiler,
 };
 
-use std::{collections::HashSet, io::Read};
+use rustc_hash::FxHashSet;
+use std::io::Read;
 
 /// Catch parsing
 ///
@@ -67,7 +68,7 @@ where
             None
         };
 
-        let mut set = HashSet::new();
+        let mut set = FxHashSet::default();
         let idents = match &catch_param {
             Some(node::Declaration::Identifier { ident, .. }) => vec![ident.as_ref()],
             Some(node::Declaration::Pattern(p)) => p.idents(),

--- a/boa/src/syntax/parser/statement/try_stm/catch.rs
+++ b/boa/src/syntax/parser/statement/try_stm/catch.rs
@@ -2,7 +2,7 @@ use crate::{
     syntax::{
         ast::{
             node::{self, Identifier},
-            Keyword, Punctuator,
+            Keyword, Position, Punctuator,
         },
         lexer::TokenKind,
         parser::{
@@ -15,7 +15,7 @@ use crate::{
     BoaProfiler,
 };
 
-use std::io::Read;
+use std::{collections::HashSet, io::Read};
 
 /// Catch parsing
 ///
@@ -60,17 +60,63 @@ where
         let catch_param = if cursor.next_if(Punctuator::OpenParen)?.is_some() {
             let catch_param =
                 CatchParameter::new(self.allow_yield, self.allow_await).parse(cursor)?;
+
             cursor.expect(Punctuator::CloseParen, "catch in try statement")?;
             Some(catch_param)
         } else {
             None
         };
 
+        let mut set = HashSet::new();
+        let idents = match &catch_param {
+            Some(node::Declaration::Identifier { ident, .. }) => vec![ident.as_ref()],
+            Some(node::Declaration::Pattern(p)) => p.idents(),
+            _ => vec![],
+        };
+
+        // It is a Syntax Error if BoundNames of CatchParameter contains any duplicate elements.
+        // https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks
+        for ident in idents {
+            if !set.insert(ident) {
+                // FIXME: pass correct position once #1295 lands
+                return Err(ParseError::general(
+                    "duplicate identifier",
+                    Position::new(1, 1),
+                ));
+            }
+        }
+
         // Catch block
-        Ok(node::Catch::new::<_, node::Declaration, _>(
-            catch_param,
-            Block::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?,
-        ))
+        let catch_block =
+            Block::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?;
+
+        // It is a Syntax Error if any element of the BoundNames of CatchParameter also occurs in the LexicallyDeclaredNames of Block.
+        // It is a Syntax Error if any element of the BoundNames of CatchParameter also occurs in the VarDeclaredNames of Block.
+        // https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors
+
+        // FIXME: `lexically_declared_names` only holds part of LexicallyDeclaredNames of the
+        // Block e.g. function names are *not* included but should be.
+        let lexically_declared_names = catch_block.lexically_declared_names();
+        let var_declared_names = catch_block.var_declared_named();
+
+        for ident in set {
+            // FIXME: pass correct position once #1295 lands
+            if lexically_declared_names.contains(ident) {
+                return Err(ParseError::general(
+                    "identifier redeclared",
+                    Position::new(1, 1),
+                ));
+            }
+            if var_declared_names.contains(ident) {
+                return Err(ParseError::general(
+                    "identifier redeclared",
+                    Position::new(1, 1),
+                ));
+            }
+        }
+
+        let catch_node = node::Catch::new::<_, node::Declaration, _>(catch_param, catch_block);
+        Ok(catch_node)
     }
 }
 
@@ -115,6 +161,7 @@ where
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
                 let pat = ObjectBindingPattern::new(true, self.allow_yield, self.allow_await)
                     .parse(cursor)?;
+
                 Ok(node::Declaration::new_with_object_pattern(pat, None))
             }
             TokenKind::Punctuator(Punctuator::OpenBracket) => {

--- a/boa/src/syntax/parser/statement/try_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/try_stm/tests.rs
@@ -227,3 +227,18 @@ fn check_invalid_try_no_catch_finally() {
 fn check_invalid_catch_with_empty_paren() {
     check_invalid("try {} catch() {}");
 }
+
+#[test]
+fn check_invalid_catch_with_duplicate_params() {
+    check_invalid("try {} catch({ a, b: a }) {}");
+}
+
+#[test]
+fn check_invalid_catch_with_lexical_redeclaration() {
+    check_invalid("try {} catch(e) { let e = 'oh' }");
+}
+
+#[test]
+fn check_invalid_catch_with_var_redeclaration() {
+    check_invalid("try {} catch(e) { var e = 'oh' }");
+}

--- a/boa/src/syntax/parser/statement/try_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/try_stm/tests.rs
@@ -1,6 +1,9 @@
 use crate::syntax::{
     ast::{
-        node::{Block, Catch, Declaration, DeclarationList, Finally, Identifier, Try},
+        node::{
+            declaration::{BindingPatternTypeArray, BindingPatternTypeObject},
+            Block, Catch, Declaration, DeclarationList, Finally, Try,
+        },
         Const,
     },
     parser::tests::{check_invalid, check_parser},
@@ -10,7 +13,15 @@ use crate::syntax::{
 fn check_inline_with_empty_try_catch() {
     check_parser(
         "try { } catch(e) {}",
-        vec![Try::new(vec![], Some(Catch::new("e", vec![])), None).into()],
+        vec![Try::new(
+            vec![],
+            Some(Catch::new(
+                Declaration::new_with_identifier("e", None),
+                vec![],
+            )),
+            None,
+        )
+        .into()],
     );
 }
 
@@ -27,7 +38,10 @@ fn check_inline_with_var_decl_inside_try() {
                 .into(),
             )
             .into()],
-            Some(Catch::new("e", vec![])),
+            Some(Catch::new(
+                Declaration::new_with_identifier("e", None),
+                vec![],
+            )),
             None,
         )
         .into()],
@@ -48,7 +62,7 @@ fn check_inline_with_var_decl_inside_catch() {
             )
             .into()],
             Some(Catch::new(
-                "e",
+                Declaration::new_with_identifier("e", None),
                 vec![DeclarationList::Var(
                     vec![Declaration::new_with_identifier(
                         "x",
@@ -70,7 +84,10 @@ fn check_inline_with_empty_try_catch_finally() {
         "try {} catch(e) {} finally {}",
         vec![Try::new(
             vec![],
-            Some(Catch::new("e", vec![])),
+            Some(Catch::new(
+                Declaration::new_with_identifier("e", None),
+                vec![],
+            )),
             Some(Finally::from(vec![])),
         )
         .into()],
@@ -111,7 +128,7 @@ fn check_inline_empty_try_paramless_catch() {
         "try {} catch { var x = 1; }",
         vec![Try::new(
             Block::from(vec![]),
-            Some(Catch::new::<_, Identifier, _>(
+            Some(Catch::new::<_, Declaration, _>(
                 None,
                 vec![DeclarationList::Var(
                     vec![Declaration::new_with_identifier(
@@ -121,6 +138,64 @@ fn check_inline_empty_try_paramless_catch() {
                     .into(),
                 )
                 .into()],
+            )),
+            None,
+        )
+        .into()],
+    );
+}
+
+#[test]
+fn check_inline_with_binding_pattern_object() {
+    check_parser(
+        "try {} catch ({ a, b: c }) {}",
+        vec![Try::new(
+            Block::from(vec![]),
+            Some(Catch::new::<_, Declaration, _>(
+                Some(Declaration::new_with_object_pattern(
+                    vec![
+                        BindingPatternTypeObject::SingleName {
+                            ident: "a".into(),
+                            property_name: "a".into(),
+                            default_init: None,
+                        },
+                        BindingPatternTypeObject::SingleName {
+                            ident: "c".into(),
+                            property_name: "b".into(),
+                            default_init: None,
+                        },
+                    ],
+                    None,
+                )),
+                vec![],
+            )),
+            None,
+        )
+        .into()],
+    );
+}
+
+#[test]
+fn check_inline_with_binding_pattern_array() {
+    check_parser(
+        "try {} catch ([a, b]) {}",
+        vec![Try::new(
+            Block::from(vec![]),
+            Some(Catch::new::<_, Declaration, _>(
+                Some(Declaration::new_with_array_pattern(
+                    vec![
+                        BindingPatternTypeArray::SingleName {
+                            ident: "a".into(),
+                            default_init: None,
+                        },
+                        BindingPatternTypeArray::SingleName {
+                            ident: "b".into(),
+                            default_init: None,
+                        },
+                    ],
+                    None,
+                )),
+                vec![],
             )),
             None,
         )
@@ -144,6 +219,11 @@ fn check_inline_invalid_catch_parameter() {
 }
 
 #[test]
-fn check_invalide_try_no_catch_finally() {
+fn check_invalid_try_no_catch_finally() {
     check_invalid("try {} let a = 10;");
+}
+
+#[test]
+fn check_invalid_catch_with_empty_paren() {
+    check_invalid("try {} catch() {}");
 }


### PR DESCRIPTION
This Pull Request closes #1600.

It changes the following:

- Allows `ObjectBindingPattern`s and `ArrayBindingPattern`s as `CatchParameter`
- Checks early errors for Catch production as defined in [14.15.1](https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors)
  - If this is out of scope of the issue and should be in separate PR, let me know.

Some design decisions that may need revised:

- I used `node::Declaration` as `CatchParameter` ([code](https://github.com/boa-dev/boa/commit/acb7c766dd3a15f80bc49374d19ee5ecb14bc297#diff-657e67b4643202187d8f6e2ff6783a4ce07c5ea20e2836ccfd3d06a1a6f1e01bL150-R170)) since they are almost identical, the only difference being that `CatchParameter` won't have initialization. Should I define distinct struct for `CatchParameter`?
- I adopted [14.5.1](https://tc39.es/ecma262/#sec-try-statement-static-semantics-early-errors) for early errors rather than its counterpart [Annex B.3.4](https://tc39.es/ecma262/#sec-variablestatements-in-catch-blocks), which most widely used JS engines adopt.