### PR TITLE
Badge updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Currently, it has support for some of the language.
 
 [![Build Status][build_badge]][build_link]
 [![codecov](https://codecov.io/gh/boa-dev/boa/branch/main/graph/badge.svg)](https://codecov.io/gh/boa-dev/boa)
-[![](http://meritbadge.herokuapp.com/boa)](https://crates.io/crates/boa)
+[![](https://img.shields.io/crates/v/Boa.svg)](https://crates.io/crates/Boa)
 [![](https://docs.rs/Boa/badge.svg)](https://docs.rs/Boa/)
-![Discord](https://img.shields.io/discord/595323158140158003?logo=discord)
+[![Discord](https://img.shields.io/discord/595323158140158003?logo=discord)](https://discord.gg/tUFFk9Y)
 
 [build_badge]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fboa-dev%2Fboa%2Fbadge&style=flat
 [build_link]: https://actions-badge.atrox.dev/boa-dev/boa/goto


### PR DESCRIPTION
It changes the following:

- Fix crates.io badge and link Discord badge to the Discord page