### PR TITLE
Implement Object.hasOwn and improve Object.prototype.hasOwnProperty

### DIFF
--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -54,7 +54,7 @@ impl BuiltIn for Object {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(JsValue::null())
-        .method(Self::has_own_property, "hasOwnProperty", 0)
+        .method(Self::has_own_property, "hasOwnProperty", 1)
         .method(Self::property_is_enumerable, "propertyIsEnumerable", 0)
         .method(Self::to_string, "toString", 0)
         .method(Self::value_of, "valueOf", 0)
@@ -87,7 +87,7 @@ impl BuiltIn for Object {
         )
         .static_method(Self::get_own_property_names, "getOwnPropertyNames", 1)
         .static_method(Self::get_own_property_symbols, "getOwnPropertySymbols", 1)
-        .static_method(Self::has_own, "hasOwn", 1)
+        .static_method(Self::has_own, "hasOwn", 2)
         .build();
 
         object.into()

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -93,6 +93,7 @@ fn object_is() {
     assert_eq!(forward(&mut context, "Object.is(undefined)"), "true");
     assert!(context.global_object().is_global());
 }
+
 #[test]
 fn object_has_own_property() {
     let mut context = Context::new();
@@ -117,6 +118,33 @@ fn object_has_own_property() {
         forward(&mut context, "x.hasOwnProperty('hasOwnProperty')"),
         "false"
     );
+}
+
+#[test]
+fn object_has_own() {
+    let scenario = r#"
+        let sym = Symbol('a');
+
+        let x = {
+            undefinedProp: undefined,
+            nullProp: null,
+            someProp: 1,
+            [sym]: 2,
+        };
+
+        let y = [1, 2, 3];
+    "#;
+
+    check_output(&[
+        TestAction::Execute(scenario),
+        TestAction::TestEq("Object.hasOwn(x, 'hasOwnProperty')", "false"),
+        TestAction::TestEq("Object.hasOwn(x, 'undefinedProp')", "true"),
+        TestAction::TestEq("Object.hasOwn(x, 'nullProp')", "true"),
+        TestAction::TestEq("Object.hasOwn(x, 'someProp')", "true"),
+        TestAction::TestEq("Object.hasOwn(x, sym)", "true"),
+        TestAction::TestEq("Object.hasOwn(y, 3)", "false"),
+        TestAction::TestEq("Object.hasOwn(y, 1)", "true"),
+    ]);
 }
 
 #[test]

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -96,43 +96,45 @@ fn object_is() {
 
 #[test]
 fn object_has_own_property() {
-    let mut context = Context::new();
-    let init = r#"
-        let x = { someProp: 1, undefinedProp: undefined, nullProp: null };
-    "#;
-
-    eprintln!("{}", forward(&mut context, init));
-    assert_eq!(
-        forward(&mut context, "x.hasOwnProperty('someProp')"),
-        "true"
-    );
-    assert_eq!(
-        forward(&mut context, "x.hasOwnProperty('undefinedProp')"),
-        "true"
-    );
-    assert_eq!(
-        forward(&mut context, "x.hasOwnProperty('nullProp')"),
-        "true"
-    );
-    assert_eq!(
-        forward(&mut context, "x.hasOwnProperty('hasOwnProperty')"),
-        "false"
-    );
-}
-
-#[test]
-fn object_has_own() {
     let scenario = r#"
-        let sym = Symbol('a');
+        let symA = Symbol('a');
+        let symB = Symbol('b');
 
         let x = {
             undefinedProp: undefined,
             nullProp: null,
             someProp: 1,
-            [sym]: 2,
+            [symA]: 2,
+            100: 3,
         };
+    "#;
 
-        let y = [1, 2, 3];
+    check_output(&[
+        TestAction::Execute(scenario),
+        TestAction::TestEq("x.hasOwnProperty('hasOwnProperty')", "false"),
+        TestAction::TestEq("x.hasOwnProperty('undefinedProp')", "true"),
+        TestAction::TestEq("x.hasOwnProperty('nullProp')", "true"),
+        TestAction::TestEq("x.hasOwnProperty('someProp')", "true"),
+        TestAction::TestEq("x.hasOwnProperty(symB)", "false"),
+        TestAction::TestEq("x.hasOwnProperty(symA)", "true"),
+        TestAction::TestEq("x.hasOwnProperty(1000)", "false"),
+        TestAction::TestEq("x.hasOwnProperty(100)", "true"),
+    ]);
+}
+
+#[test]
+fn object_has_own() {
+    let scenario = r#"
+        let symA = Symbol('a');
+        let symB = Symbol('b');
+
+        let x = {
+            undefinedProp: undefined,
+            nullProp: null,
+            someProp: 1,
+            [symA]: 2,
+            100: 3,
+        };
     "#;
 
     check_output(&[
@@ -141,9 +143,10 @@ fn object_has_own() {
         TestAction::TestEq("Object.hasOwn(x, 'undefinedProp')", "true"),
         TestAction::TestEq("Object.hasOwn(x, 'nullProp')", "true"),
         TestAction::TestEq("Object.hasOwn(x, 'someProp')", "true"),
-        TestAction::TestEq("Object.hasOwn(x, sym)", "true"),
-        TestAction::TestEq("Object.hasOwn(y, 3)", "false"),
-        TestAction::TestEq("Object.hasOwn(y, 1)", "true"),
+        TestAction::TestEq("Object.hasOwn(x, symB)", "false"),
+        TestAction::TestEq("Object.hasOwn(x, symA)", "true"),
+        TestAction::TestEq("Object.hasOwn(x, 1000)", "false"),
+        TestAction::TestEq("Object.hasOwn(x, 100)", "true"),
     ]);
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request *partially* fixes/closes #1580. The last unimplemented method from #1580, i.e. `Object.fromEntries`, will be implemented in a separate PR.

In addition to implementing `Object.hasOwn`, I decided to also make some changes to *hopefully* improve the existing `Object.prototype.hasOwnProperty` implementation (in the same PR since it is nearly identical to `Object.hasOwn`).

It changes the following:
- Added implementation for `Object.hasOwn`.
- Added tests for `Object.hasOwn`.
- Fix docs typo and add more docs for `Object.prototype.hasOwnProperty`.
- More tests for `Object.prototype.hasOwnProperty`.
- Small bugfix regarding `Object.prototype.hasOwnProperty`'s `'length'` property.