### PR TITLE
Change type of prototypes of objects to `Option<JsObject>`

### DIFF
--- a/boa/src/builtins/array_buffer/mod.rs
+++ b/boa/src/builtins/array_buffer/mod.rs
@@ -307,7 +307,7 @@ impl ArrayBuffer {
             context,
         )?;
         let obj = context.construct_object();
-        obj.set_prototype_instance(prototype.into());
+        obj.set_prototype(prototype.into());
 
         // 2. Let block be ? CreateByteDataBlock(byteLength).
         // TODO: for now just a arbitrary limit to not OOM.

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -1,4 +1,4 @@
-use crate::{forward, forward_val, Context, JsValue};
+use crate::{forward, forward_val, Context};
 
 /// Test the correct type is returned from call and construct
 #[allow(clippy::unwrap_used)]
@@ -58,8 +58,8 @@ fn instances_have_correct_proto_set() {
     let bool_instance = forward_val(&mut context, "boolInstance").expect("value expected");
     let bool_prototype = forward_val(&mut context, "boolProto").expect("value expected");
 
-    assert!(JsValue::same_value(
-        &bool_instance.as_object().unwrap().prototype_instance(),
-        &bool_prototype
-    ));
+    assert_eq!(
+        &*bool_instance.as_object().unwrap().prototype(),
+        &bool_prototype.as_object()
+    );
 }

--- a/boa/src/builtins/console/mod.rs
+++ b/boa/src/builtins/console/mod.rs
@@ -568,7 +568,6 @@ impl Console {
             LogMessage::Info(display_obj(args.get_or_undefined(0), true)),
             context.console(),
         );
-
         Ok(JsValue::undefined())
     }
 }

--- a/boa/src/builtins/error/eval.rs
+++ b/boa/src/builtins/error/eval.rs
@@ -46,7 +46,7 @@ impl BuiltIn for EvalError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/error/range.rs
+++ b/boa/src/builtins/error/range.rs
@@ -43,7 +43,7 @@ impl BuiltIn for RangeError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/error/reference.rs
+++ b/boa/src/builtins/error/reference.rs
@@ -42,7 +42,7 @@ impl BuiltIn for ReferenceError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/error/syntax.rs
+++ b/boa/src/builtins/error/syntax.rs
@@ -45,7 +45,7 @@ impl BuiltIn for SyntaxError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/error/type.rs
+++ b/boa/src/builtins/error/type.rs
@@ -48,7 +48,7 @@ impl BuiltIn for TypeError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/error/uri.rs
+++ b/boa/src/builtins/error/uri.rs
@@ -44,7 +44,7 @@ impl BuiltIn for UriError {
         )
         .name(Self::NAME)
         .length(Self::LENGTH)
-        .inherit(error_prototype.into())
+        .inherit(error_prototype)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -1,4 +1,4 @@
-use crate::{forward, forward_val, Context, JsValue};
+use crate::{forward, forward_val, Context};
 
 #[test]
 fn json_sanity() {
@@ -413,27 +413,22 @@ fn json_parse_sets_prototypes() {
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype_instance();
+        .prototype()
+        .clone();
     let array_prototype = forward_val(&mut context, r#"jsonObj.arr"#)
         .unwrap()
         .as_object()
         .unwrap()
-        .prototype_instance();
-    let global_object_prototype: JsValue = context
+        .prototype()
+        .clone();
+    let global_object_prototype = context
         .standard_objects()
         .object_object()
         .prototype()
         .into();
-    let global_array_prototype: JsValue =
-        context.standard_objects().array_object().prototype().into();
-    assert!(JsValue::same_value(
-        &object_prototype,
-        &global_object_prototype
-    ));
-    assert!(JsValue::same_value(
-        &array_prototype,
-        &global_array_prototype
-    ));
+    let global_array_prototype = context.standard_objects().array_object().prototype().into();
+    assert_eq!(object_prototype, global_object_prototype);
+    assert_eq!(array_prototype, global_array_prototype);
 }
 
 #[test]

--- a/boa/src/builtins/object/for_in_iterator.rs
+++ b/boa/src/builtins/object/for_in_iterator.rs
@@ -98,8 +98,9 @@ impl ForInIterator {
                             }
                         }
                     }
-                    match object.prototype_instance().to_object(context) {
-                        Ok(o) => {
+                    let proto = object.prototype().clone();
+                    match proto {
+                        Some(o) => {
                             object = o;
                         }
                         _ => {

--- a/boa/src/builtins/typed_array/integer_indexed_object.rs
+++ b/boa/src/builtins/typed_array/integer_indexed_object.rs
@@ -77,7 +77,7 @@ impl IntegerIndexed {
         a.borrow_mut().data = ObjectData::integer_indexed(data);
 
         // 10. Set A.[[Prototype]] to prototype.
-        a.set_prototype_instance(prototype.into());
+        a.set_prototype(prototype.into());
 
         // 11. Return A.
         a

--- a/boa/src/builtins/typed_array/mod.rs
+++ b/boa/src/builtins/typed_array/mod.rs
@@ -82,8 +82,8 @@ macro_rules! typed_array {
                     TypedArrayName::$ty.element_size(),
                     Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
                 )
-                .custom_prototype(typed_array_constructor.into())
-                .inherit(typed_array_constructor_proto.into())
+                .custom_prototype(typed_array_constructor)
+                .inherit(typed_array_constructor_proto)
                 .build()
                 .into()
             }

--- a/boa/src/exec/tests.rs
+++ b/boa/src/exec/tests.rs
@@ -791,9 +791,12 @@ mod in_operator {
         let bar_val = forward_val(&mut context, "bar").unwrap();
         let bar_obj = bar_val.as_object().unwrap();
         let foo_val = forward_val(&mut context, "Foo").unwrap();
-        assert!(bar_obj
-            .prototype_instance()
-            .strict_equals(&foo_val.get_field("prototype", &mut context).unwrap()));
+        assert_eq!(
+            &*bar_obj.prototype(),
+            &foo_val
+                .as_object()
+                .and_then(|obj| obj.get("prototype", &mut context).unwrap().as_object())
+        );
     }
 }
 

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -31,18 +31,18 @@ macro_rules! print_obj_value {
     (internals of $obj:expr, $display_fn:ident, $indent:expr, $encounters:expr) => {
         {
             let object = $obj.borrow();
-            if object.prototype_instance().is_object() {
+            if let Some(object) = object.prototype() {
                 vec![format!(
                     "{:>width$}: {}",
                     "__proto__",
-                    $display_fn(object.prototype_instance(), $encounters, $indent.wrapping_add(4), true),
+                    $display_fn(&object.clone().into(), $encounters, $indent.wrapping_add(4), true),
                     width = $indent,
                 )]
             } else {
                 vec![format!(
                     "{:>width$}: {}",
                     "__proto__",
-                    object.prototype_instance().display(),
+                    JsValue::Null.display(),
                     width = $indent,
                 )]
             }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -290,7 +290,11 @@ impl JsValue {
                     return property;
                 }
 
-                object.borrow().prototype_instance().get_property(key)
+                object
+                    .prototype()
+                    .as_ref()
+                    .map_or(JsValue::Null, |obj| obj.clone().into())
+                    .get_property(key)
             }
             _ => None,
         }


### PR DESCRIPTION
The objective of this PR is to try to make use of the [null pointer optimization](https://rust-lang.github.io/unsafe-code-guidelines/layout/enums.html#discriminant-elision-on-option-like-enums) of the [`Option`](https://doc.rust-lang.org/std/option/#representation) type, theoretically optimizing the access of the prototype of an object.

It changes the following:

- Changes the type of prototype of objects from `JsValue` to `JsObject`
- Creates a new type alias `ObjectPrototype` to avoid having to read `Option<Option<JsObject>>` in some places.  (name subject to change, maybe? I was thinking of using plain `Prototype` but there's already a `PROTOTYPE` constant, and `ObjectPrototype` doesn't sound as good because it could be confused with the intrinsic prototypes of constructor objects. I'd like to hear your suggestions on this)
