### PR TITLE
Added version history to Test262 conformance page

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -17,14 +17,14 @@
 
       body {
         color: #4a4a4a;
-        background-color: #FFF;
+        background-color: #fff;
         padding: 8px;
         font-size: 1em;
         font-weight: 400;
       }
 
       body.dark {
-        color: #FFF;
+        color: #fff;
         background-color: #0f1419;
       }
 
@@ -51,7 +51,7 @@
       }
 
       body.dark a:hover {
-        color: #FFF;
+        color: #fff;
       }
 
       button {
@@ -103,7 +103,7 @@
         font-size: 1.5rem;
       }
 
-      .dark-mode-toggle input[type=checkbox] {
+      .dark-mode-toggle input[type="checkbox"] {
         display: none;
       }
 
@@ -173,7 +173,7 @@
         <a id="repository-link" rel="noopener"></a>
       </div>
       <label class="dark-mode-toggle" for="checkbox">
-        <input type="checkbox" id="checkbox">
+        <input type="checkbox" id="checkbox" />
         <span>&#9728;</span>
         <div class="slot">
           <div class="handle"></div>
@@ -197,7 +197,7 @@
 
     <script
       src="https://cdn.jsdelivr.net/npm/chart.js@3.4.1/dist/chart.min.js"
-      integrity="sha256-GMN9UIJeUeOsn/Uq4xDheGItEeSpI5Hcfp/63GclDZk=" 
+      integrity="sha256-GMN9UIJeUeOsn/Uq4xDheGItEeSpI5Hcfp/63GclDZk="
       crossorigin="anonymous"
     ></script>
     <script src="https://cdn.jsdelivr.net/npm/mathjs@9.4.0/lib/browser/math.min.js"></script>
@@ -217,12 +217,12 @@
           _: "#333333",
         };
 
-        Chart.defaults.color = toolColors._
+        Chart.defaults.color = toolColors._;
 
-        const lightTextColor = Chart.defaults.color
-        const darkTextColor = '#CCC'
-        const lightGridColor = 'rgba(0, 0, 0, 0.1)'
-        const darkGridColor = 'rgba(255, 255, 255, 0.1)'
+        const lightTextColor = Chart.defaults.color;
+        const darkTextColor = "#CCC";
+        const lightGridColor = "rgba(0, 0, 0, 0.1)";
+        const darkGridColor = "rgba(255, 255, 255, 0.1)";
 
         function isNumeric(n) {
           return !isNaN(parseFloat(n)) && isFinite(n);
@@ -379,7 +379,7 @@
                   }),
                   borderColor: color,
                   backgroundColor: color + "60", // Add alpha for #rrggbbaa
-                  fill: true
+                  fill: true,
                 },
               ],
             };
@@ -391,8 +391,8 @@
                     text: "Commit",
                   },
                   grid: {
-                    color: lightGridColor
-                  }
+                    color: lightGridColor,
+                  },
                 },
                 y: {
                   title: {
@@ -403,8 +403,8 @@
                     beginAtZero: true,
                   },
                   grid: {
-                    color: lightGridColor
-                  }
+                    color: lightGridColor,
+                  },
                 },
               },
               tooltips: {
@@ -468,37 +468,47 @@
             graphsElem.className = "benchmark-graphs";
             setElem.appendChild(graphsElem);
 
-            const charts = []
+            const charts = [];
             for (const [benchName, benches] of benchSet.entries()) {
               const benchUnit = unit.get(benchName);
-              charts.push(renderGraph(graphsElem, benchName, benchUnit, benches))
+              charts.push(
+                renderGraph(graphsElem, benchName, benchUnit, benches)
+              );
             }
-            return charts
+            return charts;
           }
 
-          const allCharts = []
+          const allCharts = [];
           const main = document.getElementById("main");
           for (const { name, dataSet, unit } of dataSets) {
             allCharts.push(...renderBenchSet(name, dataSet, unit, main));
           }
 
-          const darkModeCheckbox = document.querySelector('.dark-mode-toggle input[type=checkbox]')
-          const darkModeHandle = document.querySelector('.dark-mode-toggle .handle')
-          darkModeCheckbox.addEventListener('change', async (e) => {
-            document.body.classList.toggle('dark')
-            const chartTextColor = e.target.checked ? darkTextColor : lightTextColor
-            const chartGridColor = e.target.checked ? darkGridColor : lightGridColor
+          const darkModeCheckbox = document.querySelector(
+            ".dark-mode-toggle input[type=checkbox]"
+          );
+          const darkModeHandle = document.querySelector(
+            ".dark-mode-toggle .handle"
+          );
+          darkModeCheckbox.addEventListener("change", async (e) => {
+            document.body.classList.toggle("dark");
+            const chartTextColor = e.target.checked
+              ? darkTextColor
+              : lightTextColor;
+            const chartGridColor = e.target.checked
+              ? darkGridColor
+              : lightGridColor;
             for (const chart of allCharts) {
-              chart.options.color = chartTextColor
-              chart.options.scales.x.title.color = chartTextColor
-              chart.options.scales.x.ticks.color = chartTextColor
-              chart.options.scales.x.grid.color = chartGridColor
-              chart.options.scales.y.title.color = chartTextColor
-              chart.options.scales.y.ticks.color = chartTextColor
-              chart.options.scales.y.grid.color = chartGridColor
-              chart.update()
+              chart.options.color = chartTextColor;
+              chart.options.scales.x.title.color = chartTextColor;
+              chart.options.scales.x.ticks.color = chartTextColor;
+              chart.options.scales.x.grid.color = chartGridColor;
+              chart.options.scales.y.title.color = chartTextColor;
+              chart.options.scales.y.ticks.color = chartTextColor;
+              chart.options.scales.y.grid.color = chartGridColor;
+              chart.update();
             }
-          })
+          });
         }
 
         renderAllChars(init()); // Start

--- a/test262/index.html
+++ b/test262/index.html
@@ -37,6 +37,10 @@
         font-size: 2em;
       }
 
+      .info-link a {
+        cursor: pointer;
+      }
+
       .card.test {
         width: 2em;
         height: 2em;
@@ -52,6 +56,15 @@
 
       .small {
         font-size: 0.75rem;
+      }
+
+      #old-versions li {
+        padding: 1.5em;
+      }
+
+      #old-versions ul {
+        max-height: 18em;
+        overflow-y: auto;
       }
     </style>
   </head>
@@ -95,9 +108,7 @@
         <div class="modal-dialog modal-xl">
           <div class="modal-content">
             <div class="modal-header">
-              <h5 class="modal-title" id="modalTitle">
-                Main branch progress
-              </h5>
+              <h5 class="modal-title" id="modalTitle">Main branch progress</h5>
               <button
                 type="button"
                 class="btn-close"
@@ -116,13 +127,13 @@
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4"
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.min.js"
+      integrity="sha256-cMPWkL3FzjuaFSfEYESYmjF25hCIL6mfRSPnW8OVvM4="
       crossorigin="anonymous"
     ></script>
     <script
-      src="https://cdn.jsdelivr.net/npm/chart.js@3.2.1/dist/chart.min.js"
-      integrity="sha256-uVEHWRIr846/vAdLJeybWxjPNStREzOlqLMXjW/Saeo="
+      src="https://cdn.jsdelivr.net/npm/chart.js@3.5.1/dist/chart.min.js"
+      integrity="sha256-bC3LCZCwKeehY6T4fFi9VfOU0gztUa+S4cnkIhVPZ5E="
       crossorigin="anonymous"
     ></script>
     <script src="./results.js"></script>

--- a/test262/results.js
+++ b/test262/results.js
@@ -1,4 +1,5 @@
 "use strict";
+
 (function () {
   let latest = {};
   let mainData = [];
@@ -36,6 +37,7 @@
   fetch("https://api.github.com/repos/boa-dev/boa/releases")
     .then((response) => response.json())
     .then((data) => {
+      data.sort((a, b) => compareVersions(a.tag_name, b.tag_name) * -1);
       let latestTag = data[0].tag_name;
 
       // We set the latest version.
@@ -47,7 +49,7 @@
             .append(createGeneralInfo(data));
 
           if (typeof latest[latestTag] !== "undefined") {
-            innerContainer.append(infoLink(latestTag, data));
+            innerContainer.append(infoLink(latestTag));
           }
 
           $("#version-latest")
@@ -76,7 +78,9 @@
               return;
             }
 
-            let dataHTML = `<span class="text-success">${formatter.format(
+            let dataHTML =
+              '<span class="position-absolute top-50 start-50 translate-middle">';
+            dataHTML += `<span class="text-success">${formatter.format(
               reldata.r.o
             )}</span>`;
             dataHTML += ` / <span class="text-warning">${formatter.format(
@@ -84,15 +88,29 @@
             )}</span>`;
             dataHTML += ` / <span class="text-danger">${formatter.format(
               reldata.r.c - reldata.r.o - reldata.r.i
-            )}${reldata.r.p !== 0
-              ? ` (${formatter.format(
-                reldata.r.p
-              )} <i class="bi-exclamation-triangle"></i>)`
-              : ""
-              }</span>`;
+            )}${
+              reldata.r.p !== 0
+                ? ` (${formatter.format(
+                    reldata.r.p
+                  )} <i class="bi-exclamation-triangle"></i>)`
+                : ""
+            }</span>`;
+            console.log(reldata.r);
+            dataHTML += ` / <b>${formatter.format(
+              Math.round((10000 * reldata.r.o) / reldata.r.c) / 100
+            )}%</b></span>`;
 
-            let html = $(`<li class="list-group-item"><b>${tag}</b> ${dataHTML}</li>`);
-            html.append(infoLink(rel.tag_name, reldata));
+            var tagHTML = `<b class="position-absolute top-50 start-0 translate-middle-y">${tag}</b>`;
+
+            let html = $(
+              `<li class="list-group-item position-relative">${tagHTML}${dataHTML}</li>`
+            );
+            html.append(
+              infoLink(
+                rel.tag_name,
+                "position-absolute top-50 end-0 translate-middle-y"
+              )
+            );
             versionList.push({ tag, html });
             //   .append(createGeneralInfo(data));
 
@@ -101,18 +119,23 @@
             // }
 
             if (versionList.length === data.length - 11) {
-              versionList.sort((a, b) => a.tag > b.tag ? -1 : 1);
+              versionList.sort((a, b) => compareVersions(a.tag, b.tag) * -1);
 
-              let versionListHTML = $('<ul class="list-group list-group-flush"></ul>');
+              let versionListHTML = $(
+                '<ul class="list-group list-group-flush"></ul>'
+              );
               for (version of versionList) {
                 versionListHTML.append(version.html);
               }
 
               $("#old-versions")
-                .append($('<div class="card"></div>')
-                  .append($('<div class="card-body"></div>')
-                    .append($(`<h2>Older versions</h2>`))
-                    .append(versionListHTML)))
+                .append(
+                  $('<div class="card"></div>').append(
+                    $('<div class="card-body"></div>')
+                      .append($(`<h2>Older versions</h2>`))
+                      .append(versionListHTML)
+                  )
+                )
                 .show();
             }
           });
@@ -120,17 +143,19 @@
     });
 
   // Creates a link to show the information about a particular tag / branch
-  function infoLink(tag, data) {
-    let container = $('<div class="info-link"></div>');
+  function infoLink(tag, extraClass) {
+    let container = $(
+      `<div class="info-link${extraClass ? " " + extraClass : ""}"></div>`
+    );
 
     if (tag === "main") {
       container.append(createHistoricalGraph());
     }
 
     container.append(
-      $('<a class="card-link" href="#"></a>')
+      $('<a class="card-link"></a>')
         .append($('<i class="bi-info-square"></i>'))
-        .click((e) => {
+        .on("click", (e) => {
           let data = latest[tag];
           showData(data, e.target);
         })
@@ -142,7 +167,7 @@
   // Shows the full test data.
   function showData(data, infoIcon) {
     let infoContainer = $("#info");
-    $(infoIcon).attr("class", "spinner-border text-primary small")
+    $(infoIcon).attr("class", "spinner-border text-primary small");
 
     setTimeout(
       function () {
@@ -199,7 +224,7 @@
           addSuite(infoContainer, suite, "info", "test/" + suite.n, data.u);
         }
         infoContainer.collapse("show");
-        $(infoIcon).attr("class", "bi-info-square")
+        $(infoIcon).attr("class", "bi-info-square");
       },
       infoContainer.hasClass("show") ? 500 : 0
     );
@@ -231,12 +256,13 @@
       )}</span>`;
       dataHTML += ` / <span class="text-danger">${formatter.format(
         suite.c - suite.o - suite.i
-      )}${suite.p !== 0
-        ? ` (${formatter.format(
-          suite.p
-        )} <i class="bi-exclamation-triangle"></i>)`
-        : ""
-        }</span>`;
+      )}${
+        suite.p !== 0
+          ? ` (${formatter.format(
+              suite.p
+            )} <i class="bi-exclamation-triangle"></i>)`
+          : ""
+      }</span>`;
       dataHTML += ` / <span>${formatter.format(suite.c)}</span>`;
       info.append($('<span class="data-overview"></span>').html(dataHTML));
 
@@ -340,17 +366,19 @@
         $('<li class="list-group-item"></li>').html(
           `Failed tests: <span class="text-danger">${formatter.format(
             latest.t - latest.o - latest.i
-          )}${latest.p !== 0
-            ? ` (${formatter.format(
-              latest.p
-            )} <i class="bi-exclamation-triangle"></i>)`
-            : ""
+          )}${
+            latest.p !== 0
+              ? ` (${formatter.format(
+                  latest.p
+                )} <i class="bi-exclamation-triangle"></i>)`
+              : ""
           }</span>`
         )
       )
       .append(
         $('<li class="list-group-item"></li>').html(
-          `Conformance: <b>${Math.round((10000 * latest.o) / latest.t) / 100
+          `Conformance: <b>${
+            Math.round((10000 * latest.o) / latest.t) / 100
           }%</b>`
         )
       );
@@ -458,3 +486,39 @@
     return [version, tag];
   }
 })();
+
+function compareVersions(a, b) {
+  a = splitVersion(a);
+  b = splitVersion(b);
+
+  if (a[0] > b[0]) {
+    return 1;
+  } else if (b[0] > a[0]) {
+    return -1;
+  } else if (a[1] > b[1]) {
+    return 1;
+  } else if (b[1] > a[1]) {
+    return -1;
+  } else if (a[2] > b[2]) {
+    return 1;
+  } else if (b[2] > a[2]) {
+    return -1;
+  } else {
+    return 0;
+  }
+}
+
+function splitVersion(ver) {
+  ver = ver[0] === "v" ? ver.slice(1) : ver;
+  ver = ver.split(".").map((x) => parseInt(x));
+
+  if (ver.length === 1) {
+    ver.push(0);
+  }
+
+  if (ver.length === 2) {
+    ver.push(0);
+  }
+
+  return ver;
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request closes one of the points in #820.

It adds a third column to the ECMAScript results to include all the information of previous Boa version conformance:

![Screenshot from 2021-10-18 17-04-44](https://user-images.githubusercontent.com/597469/137757862-e1c49400-a1b7-4a4e-b4b6-c3d9d03584a1.png)

I also took the opportunity to remove a deprecated call to jQuery's `click()` function and to update all dependencies.