### PR TITLE
[Merged by Bors] - Implement missing vm operations

### DIFF
--- a/boa/src/builtins/iterable/mod.rs
+++ b/boa/src/builtins/iterable/mod.rs
@@ -195,6 +195,16 @@ impl IteratorRecord {
         }
     }
 
+    #[cfg(feature = "vm")]
+    pub(crate) fn iterator_object(&self) -> &JsValue {
+        &self.iterator_object
+    }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn next_function(&self) -> &JsValue {
+        &self.next_function
+    }
+
     /// Get the next value in the iterator
     ///
     /// More information:

--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -4,6 +4,9 @@ use crate::{
     builtins::function::ThisMode,
     syntax::ast::{
         node::{
+            declaration::{BindingPatternTypeArray, BindingPatternTypeObject, DeclarationPattern},
+            iteration::IterableLoopInitializer,
+            template::TemplateElement,
             Declaration, GetConstField, GetField, MethodDefinitionKind, PropertyDefinition,
             PropertyName, StatementList,
         },
@@ -31,8 +34,15 @@ struct Label {
 struct JumpControlInfo {
     label: Option<Box<str>>,
     start_address: u32,
-    is_loop: bool,
+    kind: JumpControlInfoKind,
     breaks: Vec<Label>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum JumpControlInfoKind {
+    Loop,
+    Switch,
+    Try,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -231,7 +241,7 @@ impl ByteCompiler {
         self.jump_info.push(JumpControlInfo {
             label,
             start_address,
-            is_loop: true,
+            kind: JumpControlInfoKind::Loop,
             breaks: Vec::new(),
         })
     }
@@ -240,7 +250,7 @@ impl ByteCompiler {
     fn pop_loop_control_info(&mut self) {
         let loop_info = self.jump_info.pop().unwrap();
 
-        assert!(loop_info.is_loop);
+        assert!(loop_info.kind == JumpControlInfoKind::Loop);
 
         for label in loop_info.breaks {
             self.patch_jump(label);
@@ -252,7 +262,7 @@ impl ByteCompiler {
         self.jump_info.push(JumpControlInfo {
             label,
             start_address,
-            is_loop: false,
+            kind: JumpControlInfoKind::Switch,
             breaks: Vec::new(),
         })
     }
@@ -261,10 +271,45 @@ impl ByteCompiler {
     fn pop_switch_control_info(&mut self) {
         let info = self.jump_info.pop().unwrap();
 
-        assert!(!info.is_loop);
+        assert!(info.kind == JumpControlInfoKind::Switch);
 
         for label in info.breaks {
             self.patch_jump(label);
+        }
+    }
+
+    #[inline]
+    fn push_try_control_info(&mut self) {
+        self.jump_info.push(JumpControlInfo {
+            label: None,
+            start_address: u32::MAX,
+            kind: JumpControlInfoKind::Try,
+            breaks: Vec::new(),
+        })
+    }
+
+    #[inline]
+    fn pop_try_control_info(&mut self, finally_start_address: Option<u32>) {
+        let mut info = self.jump_info.pop().unwrap();
+
+        assert!(info.kind == JumpControlInfoKind::Try);
+
+        if let Some(finally_start_address) = finally_start_address {
+            let mut breaks = Vec::with_capacity(info.breaks.len());
+            let finally_end = self.jump_with_custom_opcode(Opcode::FinallyJump);
+            for label in info.breaks {
+                if label.index < finally_start_address {
+                    self.patch_jump_with_target(label, finally_start_address);
+                    breaks.push(finally_end);
+                } else {
+                    breaks.push(label);
+                }
+            }
+            if let Some(jump_info) = self.jump_info.last_mut() {
+                jump_info.breaks.append(&mut breaks);
+            }
+        } else if let Some(jump_info) = self.jump_info.last_mut() {
+            jump_info.breaks.append(&mut info.breaks);
         }
     }
 
@@ -374,7 +419,7 @@ impl ByteCompiler {
                         self.emit(Opcode::Inc, &[]);
 
                         let access = self.compile_access(unary.target());
-                        self.access_set(access, None, use_expr);
+                        self.access_set(access, None, true);
                         None
                     }
                     UnaryOp::DecrementPre => {
@@ -382,7 +427,7 @@ impl ByteCompiler {
                         self.emit(Opcode::Dec, &[]);
 
                         let access = self.compile_access(unary.target());
-                        self.access_set(access, None, use_expr);
+                        self.access_set(access, None, true);
                         None
                     }
                     UnaryOp::IncrementPost => {
@@ -392,10 +437,6 @@ impl ByteCompiler {
                         let access = self.compile_access(unary.target());
                         self.access_set(access, None, false);
 
-                        if !use_expr {
-                            self.emit(Opcode::Pop, &[]);
-                        }
-
                         None
                     }
                     UnaryOp::DecrementPost => {
@@ -404,10 +445,6 @@ impl ByteCompiler {
                         self.emit(Opcode::Dec, &[]);
                         let access = self.compile_access(unary.target());
                         self.access_set(access, None, false);
-
-                        if !use_expr {
-                            self.emit(Opcode::Pop, &[]);
-                        }
 
                         None
                     }
@@ -706,8 +743,12 @@ impl ByteCompiler {
                                 }
                             }
                         }
-                        // TODO: Spread Object
-                        PropertyDefinition::SpreadObject(_) => todo!(),
+                        PropertyDefinition::SpreadObject(expr) => {
+                            self.compile_expr(expr, true);
+                            self.emit_opcode(Opcode::Swap);
+                            self.emit(Opcode::CopyDataProperties, &[0]);
+                            self.emit_opcode(Opcode::Pop);
+                        }
                     }
                 }
 
@@ -746,16 +787,17 @@ impl ByteCompiler {
                 }
             }
             Node::ArrayDecl(array) => {
-                let mut count = 0;
+                self.emit_opcode(Opcode::PushNewArray);
+
                 for element in array.as_ref().iter().rev() {
+                    self.compile_expr(element, true);
                     if let Node::Spread(_) = element {
-                        todo!("array with spread element");
+                        self.emit_opcode(Opcode::InitIterator);
+                        self.emit_opcode(Opcode::PushIteratorToArray);
                     } else {
-                        self.compile_expr(element, true);
+                        self.emit_opcode(Opcode::PushValueToArray);
                     }
-                    count += 1;
                 }
-                self.emit(Opcode::PushNewArray, &[count]);
 
                 if !use_expr {
                     self.emit(Opcode::Pop, &[]);
@@ -764,13 +806,74 @@ impl ByteCompiler {
             Node::This => {
                 self.access_get(Access::This, use_expr);
             }
+            Node::Spread(spread) => self.compile_expr(spread.val(), true),
             Node::FunctionExpr(_function) => self.function(expr, use_expr),
             Node::ArrowFunctionDecl(_function) => self.function(expr, use_expr),
-            Node::Call(call) => {
-                for arg in call.args().iter().rev() {
-                    self.compile_expr(arg, true);
+            Node::Call(_) => self.call(expr, use_expr),
+            Node::New(_) => self.call(expr, use_expr),
+            Node::TemplateLit(template_literal) => {
+                for element in template_literal.elements() {
+                    match element {
+                        TemplateElement::String(s) => {
+                            self.emit_push_literal(Literal::String(s.as_ref().into()))
+                        }
+                        TemplateElement::Expr(expr) => {
+                            self.compile_expr(expr, true);
+                        }
+                    }
                 }
-                match call.expr() {
+
+                self.emit(
+                    Opcode::ConcatToString,
+                    &[template_literal.elements().len() as u32],
+                );
+
+                if !use_expr {
+                    self.emit(Opcode::Pop, &[]);
+                }
+            }
+            // TODO: implement AsyncFunctionExpr
+            Node::AsyncFunctionExpr(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
+            }
+            // TODO: implement AwaitExpr
+            Node::AwaitExpr(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
+            }
+            // TODO: implement GeneratorExpr
+            Node::GeneratorExpr(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
+            }
+            // TODO: implement Yield
+            Node::Yield(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
+            }
+            Node::TaggedTemplate(template) => {
+                for expr in template.exprs().iter().rev() {
+                    self.compile_expr(expr, true);
+                }
+
+                self.emit_opcode(Opcode::PushNewArray);
+                for raw in template.raws() {
+                    self.emit_push_literal(Literal::String(raw.as_ref().into()));
+                    self.emit_opcode(Opcode::PushValueToArray);
+                }
+
+                self.emit_opcode(Opcode::PushNewArray);
+                for cooked in template.cookeds() {
+                    if let Some(cooked) = cooked {
+                        self.emit_push_literal(Literal::String(cooked.as_ref().into()));
+                    } else {
+                        self.emit_opcode(Opcode::PushUndefined);
+                    }
+                    self.emit_opcode(Opcode::PushValueToArray);
+                }
+
+                self.emit_opcode(Opcode::Dup);
+                let index = self.get_or_insert_name("raw");
+                self.emit(Opcode::SetPropertyByName, &[index]);
+
+                match template.tag() {
                     Node::GetConstField(field) => {
                         self.compile_expr(field.obj(), true);
                         self.emit(Opcode::Dup, &[]);
@@ -789,13 +892,10 @@ impl ByteCompiler {
                         self.compile_expr(expr, true);
                     }
                 }
-                self.emit(Opcode::Call, &[call.args().len() as u32]);
 
-                if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
-                }
+                self.emit(Opcode::Call, &[(template.exprs().len() + 1) as u32]);
             }
-            expr => todo!("TODO compile: {}", expr),
+            _ => unreachable!(),
         }
     }
 
@@ -807,23 +907,22 @@ impl ByteCompiler {
                     match decl {
                         Declaration::Identifier { ident, .. } => {
                             let index = self.get_or_insert_name(ident.as_ref());
-                            self.emit(Opcode::DefVar, &[index]);
 
                             if let Some(expr) = decl.init() {
                                 self.compile_expr(expr, true);
-                                self.emit(Opcode::InitLexical, &[index]);
-                            };
+                                self.emit(Opcode::DefInitVar, &[index]);
+                            } else {
+                                self.emit(Opcode::DefVar, &[index]);
+                            }
                         }
                         Declaration::Pattern(pattern) => {
-                            for ident in pattern.idents() {
-                                let index = self.get_or_insert_name(ident);
-                                self.emit(Opcode::DefVar, &[index]);
+                            if let Some(init) = decl.init() {
+                                self.compile_expr(init, true);
+                            } else {
+                                self.emit_opcode(Opcode::PushUndefined);
+                            };
 
-                                if let Some(expr) = decl.init() {
-                                    self.compile_expr(expr, true);
-                                    self.emit(Opcode::InitLexical, &[index]);
-                                };
-                            }
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitVar);
                         }
                     }
                 }
@@ -833,23 +932,22 @@ impl ByteCompiler {
                     match decl {
                         Declaration::Identifier { ident, .. } => {
                             let index = self.get_or_insert_name(ident.as_ref());
-                            self.emit(Opcode::DefLet, &[index]);
 
                             if let Some(expr) = decl.init() {
                                 self.compile_expr(expr, true);
-                                self.emit(Opcode::InitLexical, &[index]);
-                            };
+                                self.emit(Opcode::DefInitLet, &[index]);
+                            } else {
+                                self.emit(Opcode::DefLet, &[index]);
+                            }
                         }
                         Declaration::Pattern(pattern) => {
-                            for ident in pattern.idents() {
-                                let index = self.get_or_insert_name(ident);
-                                self.emit(Opcode::DefLet, &[index]);
+                            if let Some(init) = decl.init() {
+                                self.compile_expr(init, true);
+                            } else {
+                                self.emit_opcode(Opcode::PushUndefined);
+                            };
 
-                                if let Some(expr) = decl.init() {
-                                    self.compile_expr(expr, true);
-                                    self.emit(Opcode::InitLexical, &[index]);
-                                };
-                            }
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitLet);
                         }
                     }
                 }
@@ -859,23 +957,22 @@ impl ByteCompiler {
                     match decl {
                         Declaration::Identifier { ident, .. } => {
                             let index = self.get_or_insert_name(ident.as_ref());
-                            self.emit(Opcode::DefConst, &[index]);
 
                             if let Some(expr) = decl.init() {
                                 self.compile_expr(expr, true);
-                                self.emit(Opcode::InitLexical, &[index]);
-                            };
+                                self.emit(Opcode::DefInitConst, &[index]);
+                            } else {
+                                self.emit(Opcode::DefConst, &[index]);
+                            }
                         }
                         Declaration::Pattern(pattern) => {
-                            for ident in pattern.idents() {
-                                let index = self.get_or_insert_name(ident);
-                                self.emit(Opcode::DefConst, &[index]);
+                            if let Some(init) = decl.init() {
+                                self.compile_expr(init, true);
+                            } else {
+                                self.emit_opcode(Opcode::PushUndefined);
+                            };
 
-                                if let Some(expr) = decl.init() {
-                                    self.compile_expr(expr, true);
-                                    self.emit(Opcode::InitLexical, &[index]);
-                                };
-                            }
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitConst);
                         }
                     }
                 }
@@ -898,6 +995,147 @@ impl ByteCompiler {
                     }
                 }
             }
+            Node::ForLoop(for_loop) => {
+                self.emit_opcode(Opcode::PushDeclarativeEnvironment);
+
+                if let Some(init) = for_loop.init() {
+                    self.compile_stmt(init, false);
+                }
+
+                let initial_jump = self.jump();
+
+                let start_address = self.next_opcode_location();
+                self.push_loop_control_info(for_loop.label().map(Into::into), start_address);
+
+                if let Some(final_expr) = for_loop.final_expr() {
+                    self.compile_expr(final_expr, true);
+                }
+
+                self.patch_jump(initial_jump);
+
+                if let Some(condition) = for_loop.condition() {
+                    self.compile_expr(condition, true);
+                } else {
+                    self.emit_opcode(Opcode::PushTrue);
+                }
+                let exit = self.jump_if_false();
+
+                self.compile_stmt(for_loop.body(), false);
+
+                self.emit(Opcode::Jump, &[start_address]);
+
+                self.patch_jump(exit);
+                self.pop_loop_control_info();
+
+                self.emit_opcode(Opcode::PopEnvironment);
+            }
+            Node::ForInLoop(for_in_loop) => {
+                self.compile_expr(for_in_loop.expr(), true);
+                let early_exit = self.jump_with_custom_opcode(Opcode::ForInLoopInitIterator);
+
+                let start_address = self.next_opcode_location();
+                self.push_loop_control_info(for_in_loop.label().map(Into::into), start_address);
+
+                self.emit_opcode(Opcode::PushDeclarativeEnvironment);
+                let exit = self.jump_with_custom_opcode(Opcode::ForInLoopNext);
+
+                match for_in_loop.init() {
+                    IterableLoopInitializer::Identifier(ref ident) => {
+                        let index = self.get_or_insert_name(ident.as_ref());
+                        self.emit(Opcode::SetName, &[index]);
+                    }
+                    IterableLoopInitializer::Var(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitVar);
+                        }
+                    },
+                    IterableLoopInitializer::Let(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitLet);
+                        }
+                    },
+                    IterableLoopInitializer::Const(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitConst);
+                        }
+                    },
+                }
+
+                self.compile_stmt(for_in_loop.body(), false);
+                self.emit_opcode(Opcode::PopEnvironment);
+
+                self.emit(Opcode::Jump, &[start_address]);
+
+                self.patch_jump(exit);
+                self.patch_jump(early_exit);
+
+                self.pop_loop_control_info();
+            }
+            Node::ForOfLoop(for_of_loop) => {
+                self.compile_expr(for_of_loop.iterable(), true);
+                self.emit_opcode(Opcode::InitIterator);
+
+                let start_address = self.next_opcode_location();
+                self.push_loop_control_info(for_of_loop.label().map(Into::into), start_address);
+
+                self.emit_opcode(Opcode::PushDeclarativeEnvironment);
+                let exit = self.jump_with_custom_opcode(Opcode::ForInLoopNext);
+
+                match for_of_loop.init() {
+                    IterableLoopInitializer::Identifier(ref ident) => {
+                        let index = self.get_or_insert_name(ident.as_ref());
+                        self.emit(Opcode::SetName, &[index]);
+                    }
+                    IterableLoopInitializer::Var(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitVar);
+                        }
+                    },
+                    IterableLoopInitializer::Let(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitLet);
+                        }
+                    },
+                    IterableLoopInitializer::Const(declaration) => match declaration {
+                        Declaration::Identifier { ident, .. } => {
+                            let index = self.get_or_insert_name(ident.as_ref());
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Declaration::Pattern(pattern) => {
+                            self.compile_declaration_pattern(pattern, Opcode::DefInitConst);
+                        }
+                    },
+                }
+
+                self.compile_stmt(for_of_loop.body(), false);
+                self.emit_opcode(Opcode::PopEnvironment);
+
+                self.emit(Opcode::Jump, &[start_address]);
+
+                self.patch_jump(exit);
+
+                self.pop_loop_control_info();
+            }
             Node::WhileLoop(while_) => {
                 let start_address = self.next_opcode_location();
                 self.push_loop_control_info(while_.label().map(Into::into), start_address);
@@ -911,19 +1149,31 @@ impl ByteCompiler {
                 self.pop_loop_control_info();
             }
             Node::DoWhileLoop(do_while) => {
+                let initial_label = self.jump();
+
                 let start_address = self.next_opcode_location();
                 self.push_loop_control_info(do_while.label().map(Into::into), start_address);
 
-                self.compile_stmt(do_while.body(), false);
-
+                let condition_label_address = self.next_opcode_location();
                 self.compile_expr(do_while.cond(), true);
-                self.emit(Opcode::JumpIfTrue, &[start_address]);
+                let exit = self.jump_if_false();
+
+                self.patch_jump(initial_label);
+
+                self.compile_stmt(do_while.body(), false);
+                self.emit(Opcode::Jump, &[condition_label_address]);
 
                 self.pop_loop_control_info();
+
+                self.patch_jump(exit);
             }
             Node::Continue(node) => {
                 let label = self.jump();
-                let mut items = self.jump_info.iter_mut().rev().filter(|info| info.is_loop);
+                let mut items = self
+                    .jump_info
+                    .iter_mut()
+                    .rev()
+                    .filter(|info| info.kind == JumpControlInfoKind::Loop);
                 let target = if node.label().is_none() {
                     items.next()
                 } else {
@@ -948,9 +1198,11 @@ impl ByteCompiler {
                 }
             }
             Node::Block(block) => {
+                self.emit_opcode(Opcode::PushDeclarativeEnvironment);
                 for node in block.items() {
                     self.compile_stmt(node, false);
                 }
+                self.emit_opcode(Opcode::PopEnvironment);
             }
             Node::Throw(throw) => {
                 self.compile_expr(throw.expr(), true);
@@ -991,6 +1243,70 @@ impl ByteCompiler {
                     self.emit(Opcode::PushUndefined, &[]);
                 }
                 self.emit(Opcode::Return, &[]);
+            }
+            Node::Try(t) => {
+                self.push_try_control_info();
+
+                let try_start = self.jump_with_custom_opcode(Opcode::TryStart);
+
+                self.emit_opcode(Opcode::PushDeclarativeEnvironment);
+                for node in t.block().items() {
+                    self.compile_stmt(node, false);
+                }
+                self.emit_opcode(Opcode::PopEnvironment);
+
+                self.emit_opcode(Opcode::TryEnd);
+                let finally = self.jump();
+
+                self.patch_jump(try_start);
+                if let Some(catch) = t.catch() {
+                    self.emit_opcode(Opcode::PushDeclarativeEnvironment);
+                    if let Some(decl) = catch.parameter() {
+                        match decl {
+                            Declaration::Identifier { ident, .. } => {
+                                let index = self.get_or_insert_name(ident.as_ref());
+                                self.emit(Opcode::DefInitLet, &[index]);
+                            }
+                            Declaration::Pattern(pattern) => {
+                                let idents = pattern.idents();
+                                for (i, ident) in idents.iter().enumerate() {
+                                    if i < idents.len() {
+                                        self.emit_opcode(Opcode::Dup);
+                                    }
+                                    let index = self.get_or_insert_name(ident);
+                                    self.emit(Opcode::DefInitLet, &[index]);
+                                }
+                            }
+                        }
+                    }
+                    for node in catch.block().items() {
+                        self.compile_stmt(node, false);
+                    }
+                    self.emit_opcode(Opcode::PopEnvironment);
+                    self.emit_opcode(Opcode::TryEnd);
+                }
+
+                self.patch_jump(finally);
+                if let Some(finally) = t.finally() {
+                    self.emit_opcode(Opcode::FinallyStart);
+                    let finally_start_address = self.next_opcode_location();
+
+                    for node in finally.items() {
+                        self.compile_stmt(node, false);
+                    }
+                    self.emit_opcode(Opcode::FinallyEnd);
+                    self.pop_try_control_info(Some(finally_start_address));
+                } else {
+                    self.pop_try_control_info(None);
+                }
+            }
+            // TODO: implement AsyncFunctionDecl
+            Node::AsyncFunctionDecl(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
+            }
+            // TODO: implement GeneratorDecl
+            Node::GeneratorDecl(_) => {
+                self.emit_opcode(Opcode::PushUndefined);
             }
             Node::Empty => {}
             expr => self.compile_expr(expr, use_expr),
@@ -1075,8 +1391,202 @@ impl ByteCompiler {
         }
     }
 
+    pub(crate) fn call(&mut self, node: &Node, use_expr: bool) {
+        #[derive(PartialEq)]
+        enum CallKind {
+            Call,
+            New,
+        }
+
+        let (call, kind) = match node {
+            Node::Call(call) => (call, CallKind::Call),
+            Node::New(new) => (new.call(), CallKind::New),
+            _ => unreachable!(),
+        };
+
+        for arg in call.args().iter().rev() {
+            self.compile_expr(arg, true);
+        }
+        match call.expr() {
+            Node::GetConstField(field) => {
+                self.compile_expr(field.obj(), true);
+                self.emit(Opcode::Dup, &[]);
+                let index = self.get_or_insert_name(field.field());
+                self.emit(Opcode::GetPropertyByName, &[index]);
+            }
+            Node::GetField(field) => {
+                self.compile_expr(field.obj(), true);
+                self.emit(Opcode::Dup, &[]);
+                self.compile_expr(field.field(), true);
+                self.emit(Opcode::Swap, &[]);
+                self.emit(Opcode::GetPropertyByValue, &[]);
+            }
+            expr => {
+                if kind == CallKind::Call {
+                    self.emit(Opcode::This, &[]);
+                }
+                self.compile_expr(expr, true);
+            }
+        }
+
+        match kind {
+            CallKind::Call => self.emit(Opcode::Call, &[call.args().len() as u32]),
+            CallKind::New => self.emit(Opcode::New, &[call.args().len() as u32]),
+        }
+
+        if !use_expr {
+            self.emit(Opcode::Pop, &[]);
+        }
+    }
+
     #[inline]
     pub fn finish(self) -> CodeBlock {
         self.code_block
+    }
+
+    #[inline]
+    fn compile_declaration_pattern(&mut self, pattern: &DeclarationPattern, def: Opcode) {
+        match pattern {
+            DeclarationPattern::Object(pattern) => {
+                let skip_init = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
+                if let Some(init) = pattern.init() {
+                    self.compile_expr(init, true);
+                } else {
+                    self.emit_opcode(Opcode::PushUndefined);
+                }
+                self.patch_jump(skip_init);
+                self.emit_opcode(Opcode::ValueNotNullOrUndefined);
+
+                self.emit_opcode(Opcode::RequireObjectCoercible);
+
+                for binding in pattern.bindings() {
+                    use BindingPatternTypeObject::*;
+
+                    match binding {
+                        // ObjectBindingPattern : { }
+                        Empty => {}
+                        //  SingleNameBinding : BindingIdentifier Initializer[opt]
+                        SingleName {
+                            ident,
+                            property_name,
+                            default_init,
+                        } => {
+                            self.emit_opcode(Opcode::Dup);
+                            let index = self.get_or_insert_name(property_name);
+                            self.emit(Opcode::GetPropertyByName, &[index]);
+
+                            if let Some(init) = default_init {
+                                let skip = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
+                                self.emit_opcode(Opcode::Pop);
+                                self.compile_expr(init, true);
+                                self.patch_jump(skip);
+                            }
+
+                            let index = self.get_or_insert_name(ident);
+                            self.emit(def, &[index]);
+                        }
+                        //  BindingRestProperty : ... BindingIdentifier
+                        RestProperty {
+                            ident,
+                            excluded_keys,
+                        } => {
+                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::PushEmptyObject);
+
+                            for key in excluded_keys {
+                                self.emit_push_literal(Literal::String(key.as_ref().into()));
+                            }
+
+                            self.emit(Opcode::CopyDataProperties, &[excluded_keys.len() as u32]);
+
+                            let index = self.get_or_insert_name(ident);
+                            self.emit(def, &[index]);
+                        }
+                        BindingPattern {
+                            ident,
+                            pattern,
+                            default_init,
+                        } => {
+                            self.emit_opcode(Opcode::Dup);
+                            let index = self.get_or_insert_name(ident);
+                            self.emit(Opcode::GetPropertyByName, &[index]);
+
+                            if let Some(init) = default_init {
+                                let skip = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
+                                self.emit_opcode(Opcode::Pop);
+                                self.compile_expr(init, true);
+                                self.patch_jump(skip);
+                            } else {
+                                self.emit_opcode(Opcode::PushUndefined);
+                            }
+
+                            self.compile_declaration_pattern(pattern, def);
+                        }
+                    }
+                }
+
+                self.emit_opcode(Opcode::Pop);
+            }
+            DeclarationPattern::Array(pattern) => {
+                let skip_init = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
+                if let Some(init) = pattern.init() {
+                    self.compile_expr(init, true);
+                } else {
+                    self.emit_opcode(Opcode::PushUndefined);
+                }
+                self.patch_jump(skip_init);
+                self.emit_opcode(Opcode::ValueNotNullOrUndefined);
+                self.emit_opcode(Opcode::InitIterator);
+
+                for binding in pattern.bindings() {
+                    use BindingPatternTypeArray::*;
+
+                    match binding {
+                        // ArrayBindingPattern : [ ]
+                        Empty => {}
+                        // ArrayBindingPattern : [ Elision ]
+                        Elision => {
+                            self.emit_opcode(Opcode::IteratorNext);
+                            self.emit_opcode(Opcode::Pop);
+                        }
+                        // SingleNameBinding : BindingIdentifier Initializer[opt]
+                        SingleName {
+                            ident,
+                            default_init,
+                        } => {
+                            self.emit_opcode(Opcode::IteratorNext);
+                            if let Some(init) = default_init {
+                                let skip = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
+                                self.emit_opcode(Opcode::Pop);
+                                self.compile_expr(init, true);
+                                self.patch_jump(skip);
+                            }
+
+                            let index = self.get_or_insert_name(ident);
+                            self.emit(def, &[index]);
+                        }
+                        // BindingElement : BindingPattern Initializer[opt]
+                        BindingPattern { pattern } => {
+                            self.emit_opcode(Opcode::IteratorNext);
+                            self.compile_declaration_pattern(pattern, def)
+                        }
+                        // BindingRestElement : ... BindingIdentifier
+                        SingleNameRest { ident } => {
+                            self.emit_opcode(Opcode::IteratorToArray);
+
+                            let index = self.get_or_insert_name(ident);
+                            self.emit(def, &[index]);
+                        }
+                        // BindingRestElement : ... BindingPattern
+                        BindingPatternRest { pattern } => {
+                            self.emit_opcode(Opcode::IteratorToArray);
+                            self.compile_declaration_pattern(pattern, def);
+                        }
+                    }
+                }
+
+                self.emit_opcode(Opcode::Pop);
+            }
+        }
     }
 }

--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -985,13 +985,11 @@ impl ByteCompiler {
                             }
 
                             let index = self.get_or_insert_name(ident.as_ref());
-
-                            if let Some(expr) = decl.init() {
-                                self.compile_expr(expr, true);
-                                self.emit(Opcode::DefInitConst, &[index]);
-                            } else {
-                                self.emit(Opcode::DefConst, &[index]);
-                            }
+                            let init = decl
+                                .init()
+                                .expect("const declaration must have initializer");
+                            self.compile_expr(init, true);
+                            self.emit(Opcode::DefInitConst, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
                             if pattern.idents().contains(&"arguments") {

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -1050,8 +1050,10 @@ impl Context {
             this: global_object,
             pc: 0,
             fp,
-            exit_on_return: true,
             environment,
+            catch: None,
+            pop_env_on_return: 0,
+            finally_no_jump: false,
         });
         let result = self.run();
 

--- a/boa/src/object/operations.rs
+++ b/boa/src/object/operations.rs
@@ -259,7 +259,6 @@ impl JsObject {
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
     #[track_caller]
     #[inline]
-    #[cfg(not(feature = "vm"))]
     pub fn call(
         &self,
         this: &JsValue,
@@ -283,7 +282,6 @@ impl JsObject {
     // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
     #[track_caller]
     #[inline]
-    #[cfg(not(feature = "vm"))]
     pub fn construct(
         &self,
         args: &[JsValue],

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -437,8 +437,15 @@ impl DeclarationPatternObject {
 
     /// Gets the initialization node for the object binding pattern, if any.
     #[inline]
-    pub(in crate::syntax) fn init(&self) -> Option<&Node> {
+    pub(crate) fn init(&self) -> Option<&Node> {
         self.init.as_ref()
+    }
+
+    /// Gets the bindings for the object binding pattern.
+    #[inline]
+    #[cfg(feature = "vm")]
+    pub(crate) fn bindings(&self) -> &Vec<BindingPatternTypeObject> {
+        &self.bindings
     }
 
     /// Initialize the values of an object binding pattern.
@@ -560,7 +567,7 @@ impl DeclarationPatternObject {
 
     /// Gets the list of identifiers declared by the object binding pattern.
     #[inline]
-    pub(in crate::syntax) fn idents(&self) -> Vec<&str> {
+    pub(crate) fn idents(&self) -> Vec<&str> {
         let mut idents = Vec::new();
 
         for binding in &self.bindings {
@@ -645,8 +652,15 @@ impl DeclarationPatternArray {
 
     /// Gets the initialization node for the array binding pattern, if any.
     #[inline]
-    pub(in crate::syntax) fn init(&self) -> Option<&Node> {
+    pub(crate) fn init(&self) -> Option<&Node> {
         self.init.as_ref()
+    }
+
+    /// Gets the bindings for the array binding pattern.
+    #[inline]
+    #[cfg(feature = "vm")]
+    pub(crate) fn bindings(&self) -> &Vec<BindingPatternTypeArray> {
+        &self.bindings
     }
 
     /// Initialize the values of an array binding pattern.
@@ -847,7 +861,7 @@ impl DeclarationPatternArray {
 
     /// Gets the list of identifiers declared by the array binding pattern.
     #[inline]
-    pub(in crate::syntax) fn idents(&self) -> Vec<&str> {
+    pub(crate) fn idents(&self) -> Vec<&str> {
         let mut idents = Vec::new();
 
         for binding in &self.bindings {

--- a/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     exec::{Executable, InterpreterState},
     gc::{Finalize, Trace},
-    syntax::ast::node::{Declaration, Node},
+    syntax::ast::node::{iteration::IterableLoopInitializer, Declaration, Node},
     BoaProfiler, Context, JsResult, JsValue,
 };
 use std::fmt;
@@ -16,29 +16,28 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct ForOfLoop {
-    variable: Box<Node>,
+    init: Box<IterableLoopInitializer>,
     iterable: Box<Node>,
     body: Box<Node>,
     label: Option<Box<str>>,
 }
 
 impl ForOfLoop {
-    pub fn new<V, I, B>(variable: V, iterable: I, body: B) -> Self
+    pub fn new<I, B>(init: IterableLoopInitializer, iterable: I, body: B) -> Self
     where
-        V: Into<Node>,
         I: Into<Node>,
         B: Into<Node>,
     {
         Self {
-            variable: Box::new(variable.into()),
+            init: Box::new(init),
             iterable: Box::new(iterable.into()),
             body: Box::new(body.into()),
             label: None,
         }
     }
 
-    pub fn variable(&self) -> &Node {
-        &self.variable
+    pub fn init(&self) -> &IterableLoopInitializer {
+        &self.init
     }
 
     pub fn iterable(&self) -> &Node {
@@ -61,7 +60,7 @@ impl ForOfLoop {
         if let Some(ref label) = self.label {
             write!(f, "{}: ", label)?;
         }
-        write!(f, "for ({} of {}) ", self.variable, self.iterable)?;
+        write!(f, "for ({} of {}) ", self.init, self.iterable)?;
         self.body().display(f, indentation)
     }
 }
@@ -97,8 +96,8 @@ impl Executable for ForOfLoop {
             }
             let next_result = iterator_result.value;
 
-            match self.variable() {
-                Node::Identifier(ref name) => {
+            match self.init() {
+                IterableLoopInitializer::Identifier(ref name) => {
                     if context.has_binding(name.as_ref())? {
                         // Binding already exists
                         context.set_mutable_binding(
@@ -115,130 +114,82 @@ impl Executable for ForOfLoop {
                         context.initialize_binding(name.as_ref(), next_result)?;
                     }
                 }
-                Node::VarDeclList(ref list) => match list.as_ref() {
-                    [var] => {
-                        if var.init().is_some() {
-                            return context.throw_syntax_error("a declaration in the head of a for-of loop can't have an initializer");
-                        }
-
-                        match &var {
-                            Declaration::Identifier { ident, .. } => {
-                                if context.has_binding(ident.as_ref())? {
-                                    context.set_mutable_binding(
-                                        ident.as_ref(),
-                                        next_result,
-                                        context.strict(),
-                                    )?;
-                                } else {
-                                    context.create_mutable_binding(
-                                        ident.as_ref(),
-                                        false,
-                                        VariableScope::Function,
-                                    )?;
-                                    context.initialize_binding(ident.as_ref(), next_result)?;
-                                }
-                            }
-                            Declaration::Pattern(p) => {
-                                for (ident, value) in p.run(Some(next_result), context)? {
-                                    if context.has_binding(ident.as_ref())? {
-                                        context.set_mutable_binding(
-                                            ident.as_ref(),
-                                            value,
-                                            context.strict(),
-                                        )?;
-                                    } else {
-                                        context.create_mutable_binding(
-                                            ident.as_ref(),
-                                            false,
-                                            VariableScope::Function,
-                                        )?;
-                                        context.initialize_binding(ident.as_ref(), value)?;
-                                    }
-                                }
-                            }
+                IterableLoopInitializer::Var(declaration) => match declaration {
+                    Declaration::Identifier { ident, .. } => {
+                        if context.has_binding(ident.as_ref())? {
+                            context.set_mutable_binding(
+                                ident.as_ref(),
+                                next_result,
+                                context.strict(),
+                            )?;
+                        } else {
+                            context.create_mutable_binding(
+                                ident.as_ref(),
+                                false,
+                                VariableScope::Function,
+                            )?;
+                            context.initialize_binding(ident.as_ref(), next_result)?;
                         }
                     }
-                    _ => {
-                        return context.throw_syntax_error(
-                            "only one variable can be declared in the head of a for-of loop",
-                        )
-                    }
-                },
-                Node::LetDeclList(ref list) => match list.as_ref() {
-                    [var] => {
-                        if var.init().is_some() {
-                            return context.throw_syntax_error("a declaration in the head of a for-of loop can't have an initializer");
-                        }
-
-                        match &var {
-                            Declaration::Identifier { ident, .. } => {
+                    Declaration::Pattern(p) => {
+                        for (ident, value) in p.run(Some(next_result), context)? {
+                            if context.has_binding(ident.as_ref())? {
+                                context.set_mutable_binding(
+                                    ident.as_ref(),
+                                    value,
+                                    context.strict(),
+                                )?;
+                            } else {
                                 context.create_mutable_binding(
                                     ident.as_ref(),
                                     false,
-                                    VariableScope::Block,
+                                    VariableScope::Function,
                                 )?;
-                                context.initialize_binding(ident.as_ref(), next_result)?;
-                            }
-                            Declaration::Pattern(p) => {
-                                for (ident, value) in p.run(Some(next_result), context)? {
-                                    context.create_mutable_binding(
-                                        ident.as_ref(),
-                                        false,
-                                        VariableScope::Block,
-                                    )?;
-                                    context.initialize_binding(ident.as_ref(), value)?;
-                                }
+                                context.initialize_binding(ident.as_ref(), value)?;
                             }
                         }
-                    }
-                    _ => {
-                        return context.throw_syntax_error(
-                            "only one variable can be declared in the head of a for-of loop",
-                        )
                     }
                 },
-                Node::ConstDeclList(ref list) => match list.as_ref() {
-                    [var] => {
-                        if var.init().is_some() {
-                            return context.throw_syntax_error("a declaration in the head of a for-of loop can't have an initializer");
-                        }
-
-                        match &var {
-                            Declaration::Identifier { ident, .. } => {
-                                context.create_immutable_binding(
-                                    ident.as_ref(),
-                                    false,
-                                    VariableScope::Block,
-                                )?;
-                                context.initialize_binding(ident.as_ref(), next_result)?;
-                            }
-                            Declaration::Pattern(p) => {
-                                for (ident, value) in p.run(Some(next_result), context)? {
-                                    context.create_immutable_binding(
-                                        ident.as_ref(),
-                                        false,
-                                        VariableScope::Block,
-                                    )?;
-                                    context.initialize_binding(ident.as_ref(), value)?;
-                                }
-                            }
-                        }
+                IterableLoopInitializer::Let(declaration) => match declaration {
+                    Declaration::Identifier { ident, .. } => {
+                        context.create_mutable_binding(
+                            ident.as_ref(),
+                            false,
+                            VariableScope::Block,
+                        )?;
+                        context.initialize_binding(ident.as_ref(), next_result)?;
                     }
-                    _ => {
-                        return context.throw_syntax_error(
-                            "only one variable can be declared in the head of a for-of loop",
-                        )
+                    Declaration::Pattern(p) => {
+                        for (ident, value) in p.run(Some(next_result), context)? {
+                            context.create_mutable_binding(
+                                ident.as_ref(),
+                                false,
+                                VariableScope::Block,
+                            )?;
+                            context.initialize_binding(ident.as_ref(), value)?;
+                        }
                     }
                 },
-                Node::Assign(_) => {
-                    return context.throw_syntax_error(
-                        "a declaration in the head of a for-of loop can't have an initializer",
-                    );
-                }
-                _ => {
-                    return context
-                        .throw_syntax_error("unknown left hand side in head of for-of loop")
-                }
+                IterableLoopInitializer::Const(declaration) => match declaration {
+                    Declaration::Identifier { ident, .. } => {
+                        context.create_immutable_binding(
+                            ident.as_ref(),
+                            false,
+                            VariableScope::Block,
+                        )?;
+                        context.initialize_binding(ident.as_ref(), next_result)?;
+                    }
+                    Declaration::Pattern(p) => {
+                        for (ident, value) in p.run(Some(next_result), context)? {
+                            context.create_immutable_binding(
+                                ident.as_ref(),
+                                false,
+                                VariableScope::Block,
+                            )?;
+                            context.initialize_binding(ident.as_ref(), value)?;
+                        }
+                    }
+                },
             }
 
             result = self.body().run(context)?;

--- a/boa/src/syntax/ast/node/iteration/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/mod.rs
@@ -4,6 +4,14 @@ pub use self::{
     continue_node::Continue, do_while_loop::DoWhileLoop, for_in_loop::ForInLoop, for_loop::ForLoop,
     for_of_loop::ForOfLoop, while_loop::WhileLoop,
 };
+use crate::{
+    gc::{Finalize, Trace},
+    syntax::ast::node::{declaration::Declaration, identifier::Identifier},
+};
+use std::fmt;
+
+#[cfg(feature = "deser")]
+use serde::{Deserialize, Serialize};
 
 #[cfg(test)]
 mod tests;
@@ -27,6 +35,26 @@ macro_rules! handle_state_with_labels {
             .executor()
             .set_current_state(InterpreterState::Executing);
     }};
+}
+
+#[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+pub enum IterableLoopInitializer {
+    Identifier(Identifier),
+    Var(Declaration),
+    Let(Declaration),
+    Const(Declaration),
+}
+
+impl fmt::Display for IterableLoopInitializer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            IterableLoopInitializer::Identifier(identifier) => write!(f, "{}: ", identifier),
+            IterableLoopInitializer::Var(declaration) => write!(f, "{}: ", declaration),
+            IterableLoopInitializer::Let(declaration) => write!(f, "{}: ", declaration),
+            IterableLoopInitializer::Const(declaration) => write!(f, "{}: ", declaration),
+        }
+    }
 }
 
 pub mod continue_node;

--- a/boa/src/syntax/ast/node/iteration/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/mod.rs
@@ -49,10 +49,10 @@ pub enum IterableLoopInitializer {
 impl fmt::Display for IterableLoopInitializer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            IterableLoopInitializer::Identifier(identifier) => write!(f, "{}: ", identifier),
-            IterableLoopInitializer::Var(declaration) => write!(f, "{}: ", declaration),
-            IterableLoopInitializer::Let(declaration) => write!(f, "{}: ", declaration),
-            IterableLoopInitializer::Const(declaration) => write!(f, "{}: ", declaration),
+            IterableLoopInitializer::Identifier(identifier) => write!(f, "{}", identifier),
+            IterableLoopInitializer::Var(declaration) => write!(f, "var {}", declaration),
+            IterableLoopInitializer::Let(declaration) => write!(f, "let {}", declaration),
+            IterableLoopInitializer::Const(declaration) => write!(f, "const {}", declaration),
         }
     }
 }

--- a/boa/src/syntax/ast/node/new/mod.rs
+++ b/boa/src/syntax/ast/node/new/mod.rs
@@ -44,6 +44,12 @@ impl New {
     pub fn args(&self) -> &[Node] {
         self.call.args()
     }
+
+    /// Returns the inner call
+    #[cfg(feature = "vm")]
+    pub(crate) fn call(&self) -> &Call {
+        &self.call
+    }
 }
 
 impl Executable for New {

--- a/boa/src/syntax/ast/node/template/mod.rs
+++ b/boa/src/syntax/ast/node/template/mod.rs
@@ -29,6 +29,11 @@ impl TemplateLit {
     pub fn new(elements: Vec<TemplateElement>) -> Self {
         TemplateLit { elements }
     }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn elements(&self) -> &Vec<TemplateElement> {
+        &self.elements
+    }
 }
 
 impl Executable for TemplateLit {
@@ -86,6 +91,26 @@ impl TaggedTemplate {
             cookeds,
             exprs,
         }
+    }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn tag(&self) -> &Node {
+        &self.tag
+    }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn raws(&self) -> &Vec<Box<str>> {
+        &self.raws
+    }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn cookeds(&self) -> &Vec<Option<Box<str>>> {
+        &self.cookeds
+    }
+
+    #[cfg(feature = "vm")]
+    pub(crate) fn exprs(&self) -> &Vec<Node> {
+        &self.exprs
     }
 }
 

--- a/boa/src/vm/call_frame.rs
+++ b/boa/src/vm/call_frame.rs
@@ -11,7 +11,9 @@ pub struct CallFrame {
     pub(crate) code: Gc<CodeBlock>,
     pub(crate) pc: usize,
     pub(crate) fp: usize,
-    pub(crate) exit_on_return: bool,
     pub(crate) this: JsValue,
     pub(crate) environment: Environment,
+    pub(crate) catch: Option<u32>,
+    pub(crate) pop_env_on_return: usize,
+    pub(crate) finally_no_jump: bool,
 }

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -167,7 +167,6 @@ impl CodeBlock {
             | Opcode::DefInitVar
             | Opcode::DefLet
             | Opcode::DefInitLet
-            | Opcode::DefConst
             | Opcode::DefInitConst
             | Opcode::GetName
             | Opcode::SetName

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -253,20 +253,31 @@ impl CodeBlock {
 
 impl std::fmt::Display for CodeBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.name != "<main>" {
+            f.write_char('\n')?;
+        }
+
         writeln!(
             f,
-            "----------------- name '{}' (length: {}) ------------------",
-            self.name, self.length
+            "{:-^width$}",
+            format!("Compiled Output: '{}'", self.name),
+            width = 70
         )?;
 
-        writeln!(f, "    Location  Count   Opcode              Operands")?;
+        writeln!(
+            f,
+            "    Location  Count   Opcode                     Operands"
+        )?;
+
+        f.write_char('\n')?;
+
         let mut pc = 0;
         let mut count = 0;
         while pc < self.code.len() {
             let opcode: Opcode = self.code[pc].try_into().unwrap();
             write!(
                 f,
-                "    {:06}    {:04}    {:<20}",
+                "    {:06}    {:04}    {:<27}",
                 pc,
                 count,
                 opcode.as_str()

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -684,9 +684,11 @@ impl JsObject {
 
                 let _result = context.run()?;
 
+                let result = context.get_this_binding();
+
                 context.pop_environment();
 
-                context.get_this_binding()
+                result
             }
         }
     }

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -467,7 +467,7 @@ impl JsObject {
                 for param in code.params.iter() {
                     has_parameter_expressions = has_parameter_expressions || param.init().is_some();
                     arguments_in_parameter_names =
-                        arguments_in_parameter_names || param.name() == "arguments";
+                        arguments_in_parameter_names || param.names().contains(&"arguments");
                     is_simple_parameter_list =
                         is_simple_parameter_list && !param.is_rest_param() && param.init().is_none()
                 }
@@ -621,7 +621,7 @@ impl JsObject {
                 for param in code.params.iter() {
                     has_parameter_expressions = has_parameter_expressions || param.init().is_some();
                     arguments_in_parameter_names =
-                        arguments_in_parameter_names || param.name() == "arguments";
+                        arguments_in_parameter_names || param.names().contains(&"arguments");
                     is_simple_parameter_list =
                         is_simple_parameter_list && !param.is_rest_param() && param.init().is_none()
                 }

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -327,13 +327,6 @@ impl Context {
                 self.create_mutable_binding(name.as_ref(), false, VariableScope::Block)?;
                 self.initialize_binding(name.as_ref(), value)?;
             }
-            Opcode::DefConst => {
-                let index = self.vm.read::<u32>();
-                let name = self.vm.frame().code.variables[index as usize].clone();
-
-                self.create_immutable_binding(name.as_ref(), true, VariableScope::Block)?;
-                self.initialize_binding(name.as_ref(), JsValue::Undefined)?;
-            }
             Opcode::DefInitConst => {
                 let index = self.vm.read::<u32>();
                 let name = self.vm.frame().code.variables[index as usize].clone();
@@ -378,7 +371,7 @@ impl Context {
                 if !value.is_undefined() {
                     self.vm.frame_mut().pc = address as usize;
                 }
-                self.vm.push(value)
+                self.vm.push(value);
             }
             Opcode::LogicalAnd => {
                 let exit = self.vm.read::<u32>();

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -820,9 +820,13 @@ impl Context {
         const OPERAND_COLUMN_WIDTH: usize = COLUMN_WIDTH;
         const NUMBER_OF_COLUMNS: usize = 4;
 
-        let msg = " VM Start";
-
         if self.vm.trace {
+            let msg = if self.vm.frame().prev.is_some() {
+                " Call Frame "
+            } else {
+                " VM Start "
+            };
+
             println!("{}\n", self.vm.frame().code);
             println!(
                 "{:-^width$}",

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -869,7 +869,7 @@ impl Context {
     pub(crate) fn run(&mut self) -> JsResult<JsValue> {
         let _timer = BoaProfiler::global().start_event("run", "vm");
 
-        const COLUMN_WIDTH: usize = 24;
+        const COLUMN_WIDTH: usize = 26;
         const TIME_COLUMN_WIDTH: usize = COLUMN_WIDTH / 2;
         const OPCODE_COLUMN_WIDTH: usize = COLUMN_WIDTH;
         const OPERAND_COLUMN_WIDTH: usize = COLUMN_WIDTH;
@@ -889,7 +889,7 @@ impl Context {
                 width = COLUMN_WIDTH * NUMBER_OF_COLUMNS - 10
             );
             println!(
-                "{:<time_width$} {:<opcode_width$} {:<operand_width$} Top Of Stack",
+                "{:<time_width$} {:<opcode_width$} {:<operand_width$} Top Of Stack\n",
                 "Time",
                 "Opcode",
                 "Operands",

--- a/boa/src/vm/opcode.rs
+++ b/boa/src/vm/opcode.rs
@@ -414,13 +414,6 @@ pub enum Opcode {
     /// Stack: value **=>**
     DefInitLet,
 
-    /// Declare `const` type variable.
-    ///
-    /// Operands: name_index: `u32`
-    ///
-    /// Stack: **=>**
-    DefConst,
-
     /// Declare and initialize `const` type variable.
     ///
     /// Operands: name_index: `u32`
@@ -791,7 +784,6 @@ impl Opcode {
             Opcode::DefInitVar => "DefInitVar",
             Opcode::DefLet => "DefLet",
             Opcode::DefInitLet => "DefInitLet",
-            Opcode::DefConst => "DefConst",
             Opcode::DefInitConst => "DefInitConst",
             Opcode::GetName => "GetName",
             Opcode::SetName => "SetName",

--- a/boa/src/vm/opcode.rs
+++ b/boa/src/vm/opcode.rs
@@ -133,12 +133,20 @@ pub enum Opcode {
     /// Stack: **=>** object
     PushEmptyObject,
 
-    /// Push array object `{}` value on the stack.
+    /// Push an empty array value on the stack.
     ///
-    /// Operands: n: `u32`
-    ///
-    /// Stack: v1, v1, ... vn **=>** [v1, v2, ..., vn]
+    /// Stack: **=>** `array`
     PushNewArray,
+
+    /// Push a value to an array.
+    ///
+    /// Stack: `array`, `value` **=>** `array`
+    PushValueToArray,
+
+    /// Push all iterator values to an array.
+    ///
+    /// Stack: `array`, `iterator`, `next_function` **=>** `array`
+    PushIteratorToArray,
 
     /// Binary `+` operator.
     ///
@@ -378,33 +386,47 @@ pub enum Opcode {
     /// Stack: value **=>** (value - 1)
     Dec,
 
-    /// Declate `var` type variable.
+    /// Declare `var` type variable.
     ///
     /// Operands: name_index: `u32`
     ///
     /// Stack: **=>**
     DefVar,
 
-    /// Declate `let` type variable.
+    /// Declare and initialize `var` type variable.
+    ///
+    /// Operands: name_index: `u32`
+    ///
+    /// Stack: value **=>**
+    DefInitVar,
+
+    /// Declare `let` type variable.
     ///
     /// Operands: name_index: `u32`
     ///
     /// Stack: **=>**
     DefLet,
 
-    /// Declate `const` type variable.
+    /// Declare and initialize `let` type variable.
+    ///
+    /// Operands: name_index: `u32`
+    ///
+    /// Stack: value **=>**
+    DefInitLet,
+
+    /// Declare `const` type variable.
     ///
     /// Operands: name_index: `u32`
     ///
     /// Stack: **=>**
     DefConst,
 
-    /// Initialize a lexical binding.
+    /// Declare and initialize `const` type variable.
     ///
     /// Operands: name_index: `u32`
     ///
-    /// Stack: **=>**
-    InitLexical,
+    /// Stack: value **=>**
+    DefInitConst,
 
     /// Find a binding on the environment chain and push its value.
     ///
@@ -510,13 +532,21 @@ pub enum Opcode {
     /// Stack: key, object **=>**
     DeletePropertyByValue,
 
+    /// Copy all properties of one object to another object.
+    ///
+    /// Operands: number of excluded keys: `u32`
+    ///
+    /// Stack: object, rest_object, excluded_key_0 ... excluded_key_n **=>** object
+    CopyDataProperties,
+
     /// Unconditional jump to address.
     ///
     /// Operands: address: `u32`
+    ///
     /// Stack: **=>**
     Jump,
 
-    /// Constional jump to address.
+    /// Conditional jump to address.
     ///
     /// If the value popped is [`falsy`][falsy] then jump to `address`.
     ///
@@ -527,16 +557,14 @@ pub enum Opcode {
     /// [falsy]: https://developer.mozilla.org/en-US/docs/Glossary/Falsy
     JumpIfFalse,
 
-    /// Constional jump to address.
+    /// Conditional jump to address.
     ///
-    /// If the value popped is [`truthy`][truthy] then jump to `address`.
+    /// If the value popped is not undefined jump to `address`.
     ///
     /// Operands: address: `u32`
     ///
-    /// Stack: cond **=>**
-    ///
-    /// [truthy]: https://developer.mozilla.org/en-US/docs/Glossary/Truthy
-    JumpIfTrue,
+    /// Stack: value **=>** value
+    JumpIfNotUndefined,
 
     /// Throw exception
     ///
@@ -544,6 +572,25 @@ pub enum Opcode {
     ///
     /// Stack: `exc` **=>**
     Throw,
+
+    /// Start of a try block.
+    ///
+    /// Operands: address: `u32`
+    TryStart,
+
+    /// End of a try block.
+    TryEnd,
+
+    /// Start of a finally block.
+    FinallyStart,
+
+    /// End of a finally block.
+    FinallyEnd,
+
+    /// Jump if the finally block was entered trough a break statement.
+    ///
+    /// Operands: address: `u32`
+    FinallyJump,
 
     /// Pops value converts it to boolean and pushes it back.
     ///
@@ -588,8 +635,67 @@ pub enum Opcode {
     /// Stack: `func`, `this`, `arg1`, `arg2`,...`argn` **=>**
     Call,
 
+    /// Call construct on a function.
+    ///
+    /// Operands: argc: `u32`
+    ///
+    /// Stack: `func`, `arg1`, `arg2`,...`argn` **=>**
+    New,
+
     /// Return from a function.
     Return,
+
+    /// Push a declarative environment.
+    PushDeclarativeEnvironment,
+
+    /// Pop the current environment.
+    PopEnvironment,
+
+    /// Initialize the iterator for a for..in loop or jump to after the loop if object is null or undefined.
+    ///
+    /// Operands: address: `u32`
+    ///
+    /// Stack: `object` **=>** `for_in_iterator`, `next_function`
+    ForInLoopInitIterator,
+
+    /// Initialize an iterator.
+    ///
+    /// Stack: `object` **=>** `iterator`, `next_function`
+    InitIterator,
+
+    /// Advance the iterator by one and put the value on the stack.
+    ///
+    /// Stack: `iterator`, `next_function` **=>** `for_of_iterator`, `next_function`, `next_value`
+    IteratorNext,
+
+    /// Consume the iterator and construct and array with all the values.
+    ///
+    /// Stack: `iterator`, `next_function` **=>** `for_of_iterator`, `next_function`, `array`
+    IteratorToArray,
+
+    /// Move to the next value in a for..in loop or jump to exit of the loop if done.
+    ///
+    /// Operands: address: `u32`
+    ///
+    /// Stack: `for_in_iterator`, `next_function` **=>** `for_in_iterator`, `next_function`, `next_result` (if not done)
+    ForInLoopNext,
+
+    /// Concat multiple stack objects into a string.
+    ///
+    /// Operands: number of stack objects: `u32`
+    ///
+    /// Stack: `value1`,...`valuen` **=>** `string`
+    ConcatToString,
+
+    /// Call RequireObjectCoercible on the stack value.
+    ///
+    /// Stack: `value` **=>** `value`
+    RequireObjectCoercible,
+
+    /// Require the stack value to be neither null nor undefined.
+    ///
+    /// Stack: `value` **=>** `value`
+    ValueNotNullOrUndefined,
 
     /// No-operation instruction, does nothing.
     ///
@@ -632,6 +738,8 @@ impl Opcode {
             Opcode::PushLiteral => "PushLiteral",
             Opcode::PushEmptyObject => "PushEmptyObject",
             Opcode::PushNewArray => "PushNewArray",
+            Opcode::PushValueToArray => "PushValueToArray",
+            Opcode::PushIteratorToArray => "PushIteratorToArray",
             Opcode::Add => "Add",
             Opcode::Sub => "Sub",
             Opcode::Div => "Div",
@@ -666,9 +774,11 @@ impl Opcode {
             Opcode::Inc => "Inc",
             Opcode::Dec => "Dec",
             Opcode::DefVar => "DefVar",
+            Opcode::DefInitVar => "DefInitVar",
             Opcode::DefLet => "DefLet",
+            Opcode::DefInitLet => "DefInitLet",
             Opcode::DefConst => "DefConst",
-            Opcode::InitLexical => "InitLexical",
+            Opcode::DefInitConst => "DefInitConst",
             Opcode::GetName => "GetName",
             Opcode::SetName => "SetName",
             Opcode::GetPropertyByName => "GetPropertyByName",
@@ -681,17 +791,34 @@ impl Opcode {
             Opcode::SetPropertySetterByValue => "SetPropertySetterByValue",
             Opcode::DeletePropertyByName => "DeletePropertyByName",
             Opcode::DeletePropertyByValue => "DeletePropertyByValue",
+            Opcode::CopyDataProperties => "CopyDataProperties",
             Opcode::Jump => "Jump",
             Opcode::JumpIfFalse => "JumpIfFalse",
-            Opcode::JumpIfTrue => "JumpIfTrue",
+            Opcode::JumpIfNotUndefined => "JumpIfNotUndefined",
             Opcode::Throw => "Throw",
+            Opcode::TryStart => "TryStart",
+            Opcode::TryEnd => "TryEnd",
+            Opcode::FinallyStart => "FinallyStart",
+            Opcode::FinallyEnd => "FinallyEnd",
+            Opcode::FinallyJump => "FinallyJump",
             Opcode::ToBoolean => "ToBoolean",
             Opcode::This => "This",
             Opcode::Case => "Case",
             Opcode::Default => "Default",
             Opcode::GetFunction => "GetFunction",
             Opcode::Call => "Call",
+            Opcode::New => "New",
             Opcode::Return => "Return",
+            Opcode::PushDeclarativeEnvironment => "PushDeclarativeEnvironment",
+            Opcode::PopEnvironment => "PopEnvironment",
+            Opcode::ForInLoopInitIterator => "ForInLoopInitIterator",
+            Opcode::InitIterator => "InitIterator",
+            Opcode::IteratorNext => "IteratorNext",
+            Opcode::IteratorToArray => "IteratorToArray",
+            Opcode::ForInLoopNext => "ForInLoopNext",
+            Opcode::ConcatToString => "ConcatToString",
+            Opcode::RequireObjectCoercible => "RequireObjectCoercible",
+            Opcode::ValueNotNullOrUndefined => "ValueNotNullOrUndefined",
             Opcode::Nop => "Nop",
         }
     }

--- a/boa/src/vm/opcode.rs
+++ b/boa/src/vm/opcode.rs
@@ -635,12 +635,26 @@ pub enum Opcode {
     /// Stack: `func`, `this`, `arg1`, `arg2`,...`argn` **=>**
     Call,
 
+    /// Call a function where the last argument is a rest parameter.
+    ///
+    /// Operands: argc: `u32`
+    ///
+    /// Stack: `func`, `this`, `arg1`, `arg2`,...`argn` **=>**
+    CallWithRest,
+
     /// Call construct on a function.
     ///
     /// Operands: argc: `u32`
     ///
     /// Stack: `func`, `arg1`, `arg2`,...`argn` **=>**
     New,
+
+    /// Call construct on a function where the last argument is a rest parameter.
+    ///
+    /// Operands: argc: `u32`
+    ///
+    /// Stack: `func`, `arg1`, `arg2`,...`argn` **=>**
+    NewWithRest,
 
     /// Return from a function.
     Return,
@@ -807,7 +821,9 @@ impl Opcode {
             Opcode::Default => "Default",
             Opcode::GetFunction => "GetFunction",
             Opcode::Call => "Call",
+            Opcode::CallWithRest => "CallWithRest",
             Opcode::New => "New",
+            Opcode::NewWithRest => "NewWithRest",
             Opcode::Return => "Return",
             Opcode::PushDeclarativeEnvironment => "PushDeclarativeEnvironment",
             Opcode::PopEnvironment => "PopEnvironment",


### PR DESCRIPTION
This implements most of the missing vm operations and fixes most of the panics.

The early errors for declarations in `for in` and `for of` loops are moved to the parser. The content of those `Node`s is changed accordingly.