### PR TITLE
[Merged by Bors] - Small test ux improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ for debugging purposes by setting up the verbose flag twice, for example `-vv`. 
 each test that is executed, you can use the triple verbose (`-vvv`) flag.
 
 Finally, if you want to only run one sub-suite or even one test (to just check if you fixed/broke something specific),
-you can do it with the `-s` parameter, and then passing the path to the sub-suite or test that you want to run.
+you can do it with the `-s` parameter, and then passing the path to the sub-suite or test that you want to run. Note
+that the `-s` parameter value should be a path relative to the `test262` directory. For example, to run the number
+type tests, use `-s test/language/types/number`.
 
 ## Communication
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,10 +92,17 @@ You can get some more verbose information that tells you the exact name of each 
 for debugging purposes by setting up the verbose flag twice, for example `-vv`. If you want to know the output of
 each test that is executed, you can use the triple verbose (`-vvv`) flag.
 
-Finally, if you want to only run one sub-suite or even one test (to just check if you fixed/broke something specific),
+If you want to only run one sub-suite or even one test (to just check if you fixed/broke something specific),
 you can do it with the `-s` parameter, and then passing the path to the sub-suite or test that you want to run. Note
 that the `-s` parameter value should be a path relative to the `test262` directory. For example, to run the number
 type tests, use `-s test/language/types/number`.
+
+Finally, if you're using the verbose flag and running a sub suite with a small number of tests, then the output will
+be more readable if you disable parallelism with the `-d` flag. All together it might look something like:
+
+```
+cargo run --release --bin boa_tester -- run -vv -d -s test/language/types/number 2> error.log
+```
 
 ## Communication
 

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -13,23 +13,36 @@ use std::panic;
 
 impl TestSuite {
     /// Runs the test suite.
-    pub(crate) fn run(&self, harness: &Harness, verbose: u8) -> SuiteResult {
+    pub(crate) fn run(&self, harness: &Harness, verbose: u8, parallel: bool) -> SuiteResult {
         if verbose != 0 {
             println!("Suite {}:", self.name);
         }
 
-        let suites: Vec<_> = self
-            .suites
-            .par_iter()
-            .map(|suite| suite.run(harness, verbose))
-            .collect();
+        let suites: Vec<_> = if parallel {
+            self.suites
+                .par_iter()
+                .map(|suite| suite.run(harness, verbose, parallel))
+                .collect()
+        } else {
+            self.suites
+                .iter()
+                .map(|suite| suite.run(harness, verbose, parallel))
+                .collect()
+        };
 
-        let tests: Vec<_> = self
-            .tests
-            .par_iter()
-            .map(|test| test.run(harness, verbose))
-            .flatten()
-            .collect();
+        let tests: Vec<_> = if parallel {
+            self.tests
+                .par_iter()
+                .map(|test| test.run(harness, verbose))
+                .flatten()
+                .collect()
+        } else {
+            self.tests
+                .iter()
+                .map(|test| test.run(harness, verbose))
+                .flatten()
+                .collect()
+        };
 
         if verbose != 0 {
             println!();

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -102,7 +102,7 @@ impl Test {
     fn run_once(&self, harness: &Harness, strict: bool, verbose: u8) -> TestResult {
         if verbose > 1 {
             println!(
-                "Starting `{}`{}",
+                "`{}`{}: starting",
                 self.name,
                 if strict { " (strict mode)" } else { "" }
             );
@@ -222,7 +222,9 @@ impl Test {
 
             if verbose > 1 {
                 println!(
-                    "Result: {}",
+                    "`{}`{}: {}",
+                    self.name,
+                    if strict { " (strict mode)" } else { "" },
                     if matches!(result, (TestOutcomeResult::Passed, _)) {
                         "Passed".green()
                     } else if matches!(result, (TestOutcomeResult::Failed, _)) {
@@ -245,7 +247,12 @@ impl Test {
             result
         } else {
             if verbose > 1 {
-                println!("Result: {}", "Ignored".yellow());
+                println!(
+                    "`{}`{}: {}",
+                    self.name,
+                    if strict { " (strict mode)" } else { "" },
+                    "Ignored".yellow()
+                );
             } else {
                 print!("{}", ".".yellow());
             }
@@ -253,7 +260,11 @@ impl Test {
         };
 
         if verbose > 2 {
-            println!("Result text:");
+            println!(
+                "`{}`{}: result text",
+                self.name,
+                if strict { " (strict mode)" } else { "" },
+            );
             println!("{}", result_text);
             println!();
         }

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -180,6 +180,10 @@ enum Cli {
         /// Optional output folder for the full results information.
         #[structopt(short, long, parse(from_os_str))]
         output: Option<PathBuf>,
+
+        /// Execute tests serially
+        #[structopt(short, long)]
+        disable_parallelism: bool,
     },
     Compare {
         /// Base results of the suite.
@@ -204,9 +208,11 @@ fn main() {
             test262_path,
             suite,
             output,
+            disable_parallelism,
         } => {
             run_test_suite(
                 verbose,
+                !disable_parallelism,
                 test262_path.as_path(),
                 suite.as_path(),
                 output.as_deref(),
@@ -221,7 +227,13 @@ fn main() {
 }
 
 /// Runs the full test suite.
-fn run_test_suite(verbose: u8, test262_path: &Path, suite: &Path, output: Option<&Path>) {
+fn run_test_suite(
+    verbose: u8,
+    parallel: bool,
+    test262_path: &Path,
+    suite: &Path,
+    output: Option<&Path>,
+) {
     if let Some(path) = output {
         if path.exists() {
             if !path.is_dir() {
@@ -254,7 +266,7 @@ fn run_test_suite(verbose: u8, test262_path: &Path, suite: &Path, output: Option
         if verbose != 0 {
             println!("Test suite loaded, starting tests...");
         }
-        let results = suite.run(&harness, verbose);
+        let results = suite.run(&harness, verbose, parallel);
 
         println!();
         println!("Results:");

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -173,7 +173,7 @@ enum Cli {
         #[structopt(long, parse(from_os_str), default_value = "./test262")]
         test262_path: PathBuf,
 
-        /// Which specific test or test suite to run.
+        /// Which specific test or test suite to run. Should be a path relative to the Test262 directory: e.g. "test/language/types/number"
         #[structopt(short, long, parse(from_os_str), default_value = "test")]
         suite: PathBuf,
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

Hi, first time contributor :)

I was playing with getting the test262 test runner working and found a couple small things that I thought would've made my life a bit easier. I've split them into separate commits. Just let me know if you disagree with any and we can drop that commit. And of course, let me know of any changes you'd like to see :)

The changes are:
- Adds details to the documentation on the `--suite` command to `boa_tester`. I was trying to pass a path starting with `./test262/` for a bit before I looked at the code and saw what it was doing.
- Changes the individual test output when verbosity is > 1. Because the tests are run in parallel, the "Result" line for a given test was frequently not immediately after the "Started" line. This made it hard to determine which test had failed. The new output includes the test name in the result line, and also changes the format of all the individual-test-output lines to begin with the test name.
- Adds a `--disable-parallelism` flag. Even with the adjustments to the test output, it was still a bit hard to follow. Running serially for small sub-suites produces output that can be more easily scanned IMO. I added this as a "disable" flag (as opposed to "enable parallelism") in order to maintain the current default of running in parallel.
