### PR TITLE
[Merged by Bors] - Added fallible allocation to data blocks

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -75,7 +75,7 @@ jobs:
         shell: bash
         run: |
           cd boa
-          comment="$(./target/release/boa_tester compare ../gh-pages/test262/refs/heads/main/vm-latest.json ../results/test262/vm/pull/latest.json -m)"
+          comment="$(./target/release/boa_tester compare ../gh-pages/test262/vm/refs/heads/main/latest.json ../results/test262/vm/pull/latest.json -m)"
           comment="${comment//'%'/'%25'}"
           comment="${comment//$'\n'/'%0A'}"
           comment="${comment//$'\r'/'%0D'}"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["parser-implementations", "wasm"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.57"
 
 [features]
 profiler = ["measureme"]

--- a/boa/src/builtins/array_buffer/mod.rs
+++ b/boa/src/builtins/array_buffer/mod.rs
@@ -767,12 +767,6 @@ fn copy_data_block_bytes(
     mut count: usize,
 ) {
     // 1. Assert: fromBlock and toBlock are distinct values.
-    assert_ne!(
-        from_block.as_ptr(),
-        to_block.as_ptr(),
-        "fromBlock and toBlock were not distinct"
-    );
-
     // 2. Let fromSize be the number of bytes in fromBlock.
     let from_size = from_block.len();
 

--- a/boa/src/builtins/array_buffer/mod.rs
+++ b/boa/src/builtins/array_buffer/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use crate::{
     builtins::{typed_array::TypedArrayName, BuiltIn, JsArgs},
     context::StandardObjects,
@@ -313,11 +316,7 @@ impl ArrayBuffer {
         obj.set_prototype(prototype.into());
 
         // 2. Let block be ? CreateByteDataBlock(byteLength).
-        // TODO: for now just a arbitrary limit to not OOM.
-        if byte_length > 8589934592 {
-            return Err(context.construct_range_error("ArrayBuffer allocation failed"));
-        }
-        let block = vec![0; byte_length];
+        let block = create_byte_data_block(byte_length, context)?;
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
@@ -733,6 +732,27 @@ impl ArrayBuffer {
     }
 }
 
+/// `CreateByteDataBlock ( size )` abstract operation.
+///
+/// The abstract operation `CreateByteDataBlock` takes argument `size` (a non-negative
+/// integer). For more information, check the [spec][spec].
+///
+/// [spec]: https://tc39.es/ecma262/#sec-createbytedatablock
+pub fn create_byte_data_block(size: usize, context: &mut Context) -> JsResult<Vec<u8>> {
+    // 1. Let db be a new Data Block value consisting of size bytes. If it is impossible to
+    //    create such a Data Block, throw a RangeError exception.
+    let mut data_block = Vec::new();
+    data_block.try_reserve(size).map_err(|e| {
+        context.construct_range_error(format!("couldn't allocate the data block: {}", e))
+    })?;
+
+    // 2. Set all of the bytes of db to 0.
+    data_block.resize(size, 0);
+
+    // 3. Return db.
+    Ok(data_block)
+}
+
 /// `6.2.8.3 CopyDataBlockBytes ( toBlock, toIndex, fromBlock, fromIndex, count )`
 ///
 /// More information:
@@ -747,6 +767,12 @@ fn copy_data_block_bytes(
     mut count: usize,
 ) {
     // 1. Assert: fromBlock and toBlock are distinct values.
+    assert_ne!(
+        from_block.as_ptr(),
+        to_block.as_ptr(),
+        "fromBlock and toBlock were not distinct"
+    );
+
     // 2. Let fromSize be the number of bytes in fromBlock.
     let from_size = from_block.len();
 

--- a/boa/src/builtins/array_buffer/tests.rs
+++ b/boa/src/builtins/array_buffer/tests.rs
@@ -1,7 +1,14 @@
 use super::*;
 
 #[test]
-fn ut_check_failed_allocation() {
+fn ut_sunnyy_day_create_byte_data_block() {
+    let mut context = Context::new();
+
+    assert!(create_byte_data_block(100, &mut context).is_ok())
+}
+
+#[test]
+fn ut_rainy_day_create_byte_data_block() {
     let mut context = Context::new();
 
     assert!(create_byte_data_block(usize::MAX, &mut context).is_err())

--- a/boa/src/builtins/array_buffer/tests.rs
+++ b/boa/src/builtins/array_buffer/tests.rs
@@ -1,0 +1,8 @@
+use super::*;
+
+#[test]
+fn ut_check_failed_allocation() {
+    let mut context = Context::new();
+
+    assert!(create_byte_data_block(usize::MAX, &mut context).is_err())
+}

--- a/boa/src/builtins/typed_array/integer_indexed_object.rs
+++ b/boa/src/builtins/typed_array/integer_indexed_object.rs
@@ -12,7 +12,7 @@ use crate::{
     builtins::typed_array::TypedArrayName,
     gc::{empty_trace, Finalize, Trace},
     object::{JsObject, ObjectData},
-    Context, JsResult,
+    Context,
 };
 
 /// Type of the array content.
@@ -145,40 +145,5 @@ impl IntegerIndexed {
     /// Set the integer indexed object's array length.
     pub(crate) fn set_array_length(&mut self, array_length: usize) {
         self.array_length = array_length;
-    }
-}
-
-/// A Data Block
-///
-/// The Data Block specification type is used to describe a distinct and mutable sequence of
-/// byte-sized (8 bit) numeric values. A byte value is an integer value in the range `0` through
-/// `255`, inclusive. A Data Block value is created with a fixed number of bytes that each have
-/// the initial value `0`.
-///
-/// For more information, check the [spec][spec].
-///
-/// [spec]: https://tc39.es/ecma262/#sec-data-blocks
-#[derive(Debug, Clone, Default, Trace, Finalize)]
-pub struct DataBlock {
-    inner: Vec<u8>,
-}
-
-impl DataBlock {
-    /// `CreateByteDataBlock ( size )` abstract operation.
-    ///
-    /// The abstract operation `CreateByteDataBlock` takes argument `size` (a non-negative
-    /// integer). For more information, check the [spec][spec].
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-createbytedatablock
-    pub fn create_byte_data_block(size: usize) -> JsResult<Self> {
-        // 1. Let db be a new Data Block value consisting of size bytes. If it is impossible to
-        //    create such a Data Block, throw a RangeError exception.
-        // 2. Set all of the bytes of db to 0.
-        // 3. Return db.
-        // TODO: waiting on <https://github.com/rust-lang/rust/issues/48043> for having fallible
-        // allocation.
-        Ok(Self {
-            inner: vec![0u8; size],
-        })
     }
 }


### PR DESCRIPTION
This Pull Request uses the new fallible allocation API in Rust 1.57 to follow the JavaScript specification for data blocks: https://tc39.es/ecma262/#sec-createbytedatablock

It changes the following:

- Creating a new DataBlock for an ArrayBuffer will no longer fail with an arbitrary byte length, it will now actually call the allocator and try to reserve the needed space, and fail if it can't.
- Added sunny and rainy day unit tests that check if the API works as expected.
- Bumped the minimum Rust version to Rust 1.57 for the Boa crate.
- Removed the unused `DataBlock` implementation in IntegerIndexedObjects.
