### PR TITLE
Cleaning-up benchmarks

### DIFF
--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -195,11 +195,7 @@
       </div>
     </footer>
 
-    <script
-      src="https://cdn.jsdelivr.net/npm/chart.js@3.6.1/dist/chart.min.js"
-      integrity="sha256-bj8JMRF/ShthPyTNKaHVG4LwnGL/KNnJ5CAASgZE99I="
-      crossorigin="anonymous"
-    ></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.6.2/dist/chart.min.js" integrity="sha256-D2tkh/3EROq+XuDEmgxOLW1oNxf0rLNlOwsPIUX+co4=" crossorigin="anonymous"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/mathjs@10.0.0/lib/browser/math.js"
       integrity="sha256-FZa3VNf8tvhGe+DknMtysLfXXqZtwjbaL4QPMPHufmU="

--- a/dev/bench/index.html
+++ b/dev/bench/index.html
@@ -195,7 +195,11 @@
       </div>
     </footer>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.6.2/dist/chart.min.js" integrity="sha256-D2tkh/3EROq+XuDEmgxOLW1oNxf0rLNlOwsPIUX+co4=" crossorigin="anonymous"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@3.6.2/dist/chart.min.js"
+      integrity="sha256-D2tkh/3EROq+XuDEmgxOLW1oNxf0rLNlOwsPIUX+co4="
+      crossorigin="anonymous"
+    ></script>
     <script
       src="https://cdn.jsdelivr.net/npm/mathjs@10.0.0/lib/browser/math.js"
       integrity="sha256-FZa3VNf8tvhGe+DknMtysLfXXqZtwjbaL4QPMPHufmU="

--- a/dev/process.py
+++ b/dev/process.py
@@ -1,5 +1,3 @@
-#! /opt/homebrew/bin/python3
-
 import json
 from datetime import datetime, timezone
 

--- a/dev/process.py
+++ b/dev/process.py
@@ -1,0 +1,24 @@
+#! /opt/homebrew/bin/python3
+
+import json
+from datetime import datetime, timezone
+
+def new_bench(bench):
+    date = datetime.strptime(bench["commit"]["timestamp"], "%Y-%m-%dT%H:%M:%S%z")
+    date_diff = now - date
+    diff_years = (date_diff.days + date_diff.seconds/86400)/365.2425
+
+    return diff_years < 1
+
+with open('./dev/bench/data.json') as input_f:
+    data = json.load(input_f)
+    benches = data["entries"]["Boa Benchmarks"]
+
+    now = datetime.now(timezone.utc)
+    total = len(benches)
+    print("Benches: ", total)
+
+    data["entries"]["Boa Benchmarks"] = list(filter(new_bench, benches))
+
+    with open('./dev/bench/data_processed.json', 'w') as output_f:
+        json.dump(data, output_f)


### PR DESCRIPTION
This Pull Request does some clean-up in the benchmarks:

- Updates the Chart.js dependency
- Removes benchmark data older than 1 year
- Adds a Python script to automatically remove this data (if executed)
- Minimised the benchmark data

This is a short term solution while we improve our benchmarking.
