### PR TITLE
Using upstream benchmark action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,12 +43,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run benchmark
-        run: cargo bench -p Boa | tee output.txt
+        run: cargo bench -p Boa -- --output-format bencher | tee output.txt
       - name: Store benchmark result
-        uses: jasonwilliams/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@v1.11.1
         with:
           name: Boa Benchmarks
-          tool: "criterion"
+          tool: "cargo"
           output-file-path: output.txt
           auto-push: true
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Run benchmark
         run: cargo bench -p Boa -- --output-format bencher | tee output.txt
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.11.1
+        uses: benchmark-action/github-action-benchmark@v1.11.2
         with:
           name: Boa Benchmarks
           tool: "cargo"


### PR DESCRIPTION
This Pull Request stops using our GitHub action fork, and starts using the upstream GitHub action for benchmarks. This follows this example:
https://github.com/benchmark-action/github-action-benchmark/tree/master/examples/criterion-rs

This is blocked, though, until https://github.com/benchmark-action/github-action-benchmark/pull/94 gets merged, since our benchmarks have spaces in their names.