### PR TITLE
[Merged by Bors] - auto generate release notes based on labels

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,16 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Feature Enhancements
+      labels:
+        - enhancement
+    - title: Bug Fixes
+      labels:
+        - bug
+    - title: Internal Improvements
+      labels:
+        - internal


### PR DESCRIPTION
This should help with the process of making the changelogs on releases.
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes