### PR TITLE
[Merged by Bors] - Lexer string interning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,6 +7,7 @@ name = "Boa"
 version = "0.13.0"
 dependencies = [
  "bitflags",
+ "boa_interner",
  "boa_unicode",
  "chrono",
  "criterion",
@@ -29,6 +30,17 @@ dependencies = [
  "serde",
  "serde_json",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
 ]
 
 [[package]]
@@ -94,6 +106,14 @@ dependencies = [
  "rustyline-derive",
  "serde_json",
  "structopt",
+]
+
+[[package]]
+name = "boa_interner"
+version = "0.13.0"
+dependencies = [
+ "serde",
+ "string-interner",
 ]
 
 [[package]]
@@ -493,6 +513,9 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -914,9 +937,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -944,18 +967,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1103,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.1.1"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c38cfbd0a4d7df7aab7cf53732d5d43449d0300358fd15cd4e8c8468a956aca"
+checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1234,6 +1257,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
+name = "string-interner"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e2531d8525b29b514d25e275a43581320d587b86db302b9a7e464bac579648"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "serde",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1265,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1402,9 +1436,9 @@ checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1509,9 +1509,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1534,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1557,15 +1557,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.2.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8340083d28acb43451166543b98c838299b7e0863621be53a338adceea0ed"
+checksum = "1951fb8aa063a2ee18b4b4d217e4aa2ec9cc4f2430482983f607fa10cd36d7aa"
 dependencies = [
  "error-code",
  "str-buf",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -310,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -323,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -393,10 +393,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "error-code"
-version = "2.3.0"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
 dependencies = [
  "libc",
  "str-buf",
@@ -410,12 +431,12 @@ checksum = "95765f67b4b18863968b4a1bd5bb576f732b29a4a28c7cd84c09fa3e2875f33c"
 
 [[package]]
 name = "fd-lock"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16910e685088843d53132b04e0f10a571fdb193224fc589685b3ba1ce4cb03d"
+checksum = "fcef756dea9cf3db5ce73759cf0467330427a786b47711b8d6c97620d718ceb9"
 dependencies = [
  "cfg-if",
- "libc",
+ "rustix",
  "windows-sys",
 ]
 
@@ -572,6 +593,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ef6787e7f0faedc040f95716bdd0e62bcfcf4ba93da053b62dea2691c13864"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -639,9 +669,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libgit2-sys"
@@ -688,6 +718,12 @@ name = "linked-hash-map"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f5690fef754d905294c56f7ac815836f2513af966aa47f2e07ac79be07827f"
 
 [[package]]
 name = "lock_api"
@@ -844,9 +880,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -976,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -1125,6 +1161,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cee647393af53c750e15dcbf7781cdd2e550b246bde76e46c326e7ea3c73773"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustyline"
 version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,9 +1243,9 @@ checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "96b3c34c1690edf8174f5b289a336ab03f568a4460d8c6df75f2f3a692b3bc6a"
 dependencies = [
  "serde_derive",
 ]
@@ -1212,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "784ed1fbfa13fe191077537b0d70ec8ad1e903cfe04831da608aa36457cb653d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1246,9 +1296,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "str-buf"
@@ -1299,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1513,9 +1563,9 @@ checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1554,9 +1604,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82ca39602d5cbfa692c4b67e3bcbb2751477355141c1ed434c94da4186836ff6"
+checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -1567,33 +1617,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52695a41e536859d5308cc613b4a022261a274390b25bd29dfff4bf08505f3c2"
+checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54725ac23affef038fecb177de6c9bf065787c2f432f79e3c373da92f3e1d8a"
+checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d5158a43cc43623c0729d1ad6647e62fa384a3d135fd15108d37c683461f64"
+checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc31f409f565611535130cfe7ee8e6655d3fa99c1c61013981e491921b5ce954"
+checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.28.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2b8c7cbd3bfdddd9ab98769f9746a7fad1bca236554cd032b78d768bc0e89f"
+checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "boa_wasm",
     "boa_tester",
     "boa_unicode",
+    "boa_interner",
 ]
 
 # The release profile, used for `cargo build --release`.

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -13,13 +13,14 @@ rust-version = "1.57"
 
 [features]
 profiler = ["measureme"]
-deser = []
+deser = ["boa_interner/serde"]
 
 # Enable Boa's WHATWG console object implementation.
 console = []
 
 [dependencies]
 boa_unicode = { path = "../boa_unicode", version = "0.13.0" }
+boa_interner = { path = "../boa_interner", version = "0.13.0" }
 gc = { version = "0.4.1", features = ["derive"] }
 serde = { version = "1.0.132", features = ["derive", "rc"] }
 serde_json = "1.0.75"

--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -22,7 +22,7 @@ console = []
 boa_unicode = { path = "../boa_unicode", version = "0.13.0" }
 boa_interner = { path = "../boa_interner", version = "0.13.0" }
 gc = { version = "0.4.1", features = ["derive"] }
-serde = { version = "1.0.132", features = ["derive", "rc"] }
+serde = { version = "1.0.134", features = ["derive", "rc"] }
 serde_json = "1.0.75"
 rand = "0.8.4"
 num-traits = "0.2.14"

--- a/boa/examples/classes.rs
+++ b/boa/examples/classes.rs
@@ -125,7 +125,7 @@ impl Class for Person {
 
 fn main() {
     // First we need to create a Javascript context.
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // Then we need to register the global class `Person` inside `context`.
     context.register_global_class::<Person>().unwrap();

--- a/boa/examples/closures.rs
+++ b/boa/examples/closures.rs
@@ -10,7 +10,7 @@ use boa::{
 
 fn main() -> Result<(), JsValue> {
     // We create a new `Context` to create a new Javascript executor.
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // We make some operations in Rust that return a `Copy` value that we want
     // to pass to a Javascript function.

--- a/boa/src/builtins/array/tests.rs
+++ b/boa/src/builtins/array/tests.rs
@@ -4,7 +4,7 @@ use crate::{forward, Context, JsValue};
 
 #[test]
 fn is_array() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [];
         var new_arr = new Array();
@@ -70,7 +70,7 @@ fn is_array() {
 
 #[test]
 fn of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         context
             .eval("Array.of(1, 2, 3)")
@@ -120,7 +120,7 @@ fn of() {
 #[ignore]
 #[test]
 fn concat() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
     var empty = [];
     var one = [1];
@@ -158,7 +158,7 @@ fn concat() {
 
 #[test]
 fn copy_within() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let target = forward(&mut context, "[1,2,3,4,5].copyWithin(-2).join('.')");
     assert_eq!(target, String::from("\"1.2.3.1.2\""));
@@ -175,7 +175,7 @@ fn copy_within() {
 
 #[test]
 fn join() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = ["a"];
@@ -195,7 +195,7 @@ fn join() {
 
 #[test]
 fn to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = ["a"];
@@ -215,7 +215,7 @@ fn to_string() {
 
 #[test]
 fn every() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every
     let init = r#"
         var empty = [];
@@ -259,7 +259,7 @@ fn every() {
 
 #[test]
 fn find() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         function comp(a) {
             return a == "a";
@@ -273,7 +273,7 @@ fn find() {
 
 #[test]
 fn find_index() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         function comp(item) {
@@ -298,7 +298,7 @@ fn find_index() {
 
 #[test]
 fn flat() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         var depth1 = ['a', ['b', 'c']];
@@ -323,7 +323,7 @@ fn flat() {
 
 #[test]
 fn flat_empty() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         var empty = [[]];
@@ -336,7 +336,7 @@ fn flat_empty() {
 
 #[test]
 fn flat_infinity() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         var arr = [[[[[['a']]]]]];
@@ -350,7 +350,7 @@ fn flat_infinity() {
 
 #[test]
 fn flat_map() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         var double = [1, 2, 3];
@@ -375,7 +375,7 @@ fn flat_map() {
 
 #[test]
 fn flat_map_with_hole() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         var arr = [0, 1, 2];
@@ -391,7 +391,7 @@ fn flat_map_with_hole() {
 
 #[test]
 fn flat_map_not_callable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let code = r#"
         try {
@@ -407,7 +407,7 @@ fn flat_map_not_callable() {
 
 #[test]
 fn push() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var arr = [1, 2];
         "#;
@@ -421,7 +421,7 @@ fn push() {
 
 #[test]
 fn pop() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = [1];
@@ -442,7 +442,7 @@ fn pop() {
 
 #[test]
 fn shift() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = [1];
@@ -463,7 +463,7 @@ fn shift() {
 
 #[test]
 fn unshift() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var arr = [3, 4];
         "#;
@@ -477,7 +477,7 @@ fn unshift() {
 
 #[test]
 fn reverse() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var arr = [1, 2];
         var reversed = arr.reverse();
@@ -491,7 +491,7 @@ fn reverse() {
 
 #[test]
 fn index_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = ["a"];
@@ -554,7 +554,7 @@ fn index_of() {
 
 #[test]
 fn last_index_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = ["a"];
@@ -617,7 +617,7 @@ fn last_index_of() {
 
 #[test]
 fn fill_obj_ref() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // test object reference
     forward(&mut context, "a = (new Array(3)).fill({});");
@@ -627,7 +627,7 @@ fn fill_obj_ref() {
 
 #[test]
 fn fill() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     forward(&mut context, "var a = [1, 2, 3];");
     assert_eq!(
@@ -722,7 +722,7 @@ fn fill() {
 
 #[test]
 fn includes_value() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ];
         var one = ["a"];
@@ -760,7 +760,7 @@ fn includes_value() {
 
 #[test]
 fn map() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let js = r#"
         var empty = [];
@@ -824,7 +824,7 @@ fn map() {
 
 #[test]
 fn slice() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [ ].slice();
         var one = ["a"].slice();
@@ -847,7 +847,7 @@ fn slice() {
 
 #[test]
 fn for_each() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = [2, 3, 4, 5];
         var sum = 0;
@@ -869,7 +869,7 @@ fn for_each() {
 
 #[test]
 fn for_each_push_value() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = [1, 2, 3, 4];
         function callingCallback(item, index, list) {
@@ -889,7 +889,7 @@ fn for_each_push_value() {
 
 #[test]
 fn filter() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let js = r#"
         var empty = [];
@@ -958,7 +958,7 @@ fn filter() {
 
 #[test]
 fn some() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = [];
 
@@ -1006,7 +1006,7 @@ fn some() {
 
 #[test]
 fn reduce() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var arr = [1, 2, 3, 4];
@@ -1118,7 +1118,7 @@ fn reduce() {
 
 #[test]
 fn reduce_right() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var arr = [1, 2, 3, 4];
@@ -1243,7 +1243,7 @@ fn reduce_right() {
 
 #[test]
 fn call_array_constructor_with_one_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new Array(0);
 
@@ -1264,7 +1264,7 @@ fn call_array_constructor_with_one_argument() {
 
 #[test]
 fn array_values_simple() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [1, 2, 3].values();
         var next = iterator.next();
@@ -1285,7 +1285,7 @@ fn array_values_simple() {
 
 #[test]
 fn array_keys_simple() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [1, 2, 3].keys();
         var next = iterator.next();
@@ -1306,7 +1306,7 @@ fn array_keys_simple() {
 
 #[test]
 fn array_entries_simple() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [1, 2, 3].entries();
         var next = iterator.next();
@@ -1327,7 +1327,7 @@ fn array_entries_simple() {
 
 #[test]
 fn array_values_empty() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [].values();
         var next = iterator.next();
@@ -1339,7 +1339,7 @@ fn array_values_empty() {
 
 #[test]
 fn array_values_sparse() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var array = Array();
         array[3] = 5;
@@ -1365,7 +1365,7 @@ fn array_values_sparse() {
 
 #[test]
 fn array_symbol_iterator() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [1, 2, 3][Symbol.iterator]();
         var next = iterator.next();
@@ -1386,7 +1386,7 @@ fn array_symbol_iterator() {
 
 #[test]
 fn array_values_symbol_iterator() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var iterator = [1, 2, 3].values();
         iterator === iterator[Symbol.iterator]();
@@ -1396,7 +1396,7 @@ fn array_values_symbol_iterator() {
 
 #[test]
 fn array_spread_arrays() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const array1 = [2, 3];
         const array2 = [1, ...array1];
@@ -1407,7 +1407,7 @@ fn array_spread_arrays() {
 
 #[test]
 fn array_spread_non_iterable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         try {
             const array2 = [...5];
@@ -1420,7 +1420,7 @@ fn array_spread_non_iterable() {
 
 #[test]
 fn get_relative_start() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(Array::get_relative_start(&mut context, None, 10), Ok(0));
     assert_eq!(
@@ -1481,7 +1481,7 @@ fn get_relative_start() {
 
 #[test]
 fn get_relative_end() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(Array::get_relative_end(&mut context, None, 10), Ok(10));
     assert_eq!(
@@ -1542,7 +1542,7 @@ fn get_relative_end() {
 
 #[test]
 fn array_length_is_not_enumerable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let array = Array::new_array(&mut context);
     let desc = array.get_property("length").unwrap();
@@ -1551,7 +1551,7 @@ fn array_length_is_not_enumerable() {
 
 #[test]
 fn array_sort() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let arr = ['80', '9', '700', 40, 1, 5, 200];
 

--- a/boa/src/builtins/array_buffer/tests.rs
+++ b/boa/src/builtins/array_buffer/tests.rs
@@ -2,14 +2,14 @@ use super::*;
 
 #[test]
 fn ut_sunnyy_day_create_byte_data_block() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(create_byte_data_block(100, &mut context).is_ok())
 }
 
 #[test]
 fn ut_rainy_day_create_byte_data_block() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(create_byte_data_block(usize::MAX, &mut context).is_err())
 }

--- a/boa/src/builtins/bigint/tests.rs
+++ b/boa/src/builtins/bigint/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn equality() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "0n == 0n"), "true");
     assert_eq!(forward(&mut context, "1n == 0n"), "false");
@@ -55,7 +55,7 @@ fn equality() {
 
 #[test]
 fn bigint_function_conversion_from_integer() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "BigInt(1000)"), "1000n");
     assert_eq!(
@@ -70,7 +70,7 @@ fn bigint_function_conversion_from_integer() {
 
 #[test]
 fn bigint_function_conversion_from_rational() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "BigInt(0.0)"), "0n");
     assert_eq!(forward(&mut context, "BigInt(1.0)"), "1n");
@@ -79,7 +79,7 @@ fn bigint_function_conversion_from_rational() {
 
 #[test]
 fn bigint_function_conversion_from_rational_with_fractional_part() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -96,7 +96,7 @@ fn bigint_function_conversion_from_rational_with_fractional_part() {
 
 #[test]
 fn bigint_function_conversion_from_null() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -113,7 +113,7 @@ fn bigint_function_conversion_from_null() {
 
 #[test]
 fn bigint_function_conversion_from_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -130,7 +130,7 @@ fn bigint_function_conversion_from_undefined() {
 
 #[test]
 fn bigint_function_conversion_from_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "BigInt('')"), "0n");
     assert_eq!(forward(&mut context, "BigInt('   ')"), "0n");
@@ -149,21 +149,21 @@ fn bigint_function_conversion_from_string() {
 
 #[test]
 fn add() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "10000n + 1000n"), "11000n");
 }
 
 #[test]
 fn sub() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "10000n - 1000n"), "9000n");
 }
 
 #[test]
 fn mul() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(&mut context, "123456789n * 102030n"),
@@ -173,28 +173,28 @@ fn mul() {
 
 #[test]
 fn div() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "15000n / 50n"), "300n");
 }
 
 #[test]
 fn div_with_truncation() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "15001n / 50n"), "300n");
 }
 
 #[test]
 fn r#mod() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "15007n % 10n"), "7n");
 }
 
 #[test]
 fn pow() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(&mut context, "100n ** 10n"),
@@ -204,42 +204,42 @@ fn pow() {
 
 #[test]
 fn pow_negative_exponent() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "10n ** (-10n)", "RangeError");
 }
 
 #[test]
 fn shl() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "8n << 2n"), "32n");
 }
 
 #[test]
 fn shl_out_of_range() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "1000n << 1000000000000000n", "RangeError");
 }
 
 #[test]
 fn shr() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "8n >> 2n"), "2n");
 }
 
 #[test]
 fn shr_out_of_range() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "1000n >> 1000000000000000n", "RangeError");
 }
 
 #[test]
 fn to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "1000n.toString()"), "\"1000\"");
     assert_eq!(forward(&mut context, "1000n.toString(2)"), "\"1111101000\"");
@@ -249,7 +249,7 @@ fn to_string() {
 
 #[test]
 fn to_string_invalid_radix() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "10n.toString(null)", "RangeError");
     assert_throws(&mut context, "10n.toString(-1)", "RangeError");
@@ -258,7 +258,7 @@ fn to_string_invalid_radix() {
 
 #[test]
 fn as_int_n() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "BigInt.asIntN(0, 1n)"), "0n");
     assert_eq!(forward(&mut context, "BigInt.asIntN(1, 1n)"), "-1n");
@@ -318,7 +318,7 @@ fn as_int_n() {
 
 #[test]
 fn as_int_n_errors() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "BigInt.asIntN(-1, 0n)", "RangeError");
     assert_throws(&mut context, "BigInt.asIntN(-2.5, 0n)", "RangeError");
@@ -332,7 +332,7 @@ fn as_int_n_errors() {
 
 #[test]
 fn as_uint_n() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "BigInt.asUintN(0, -2n)"), "0n");
     assert_eq!(forward(&mut context, "BigInt.asUintN(0, -1n)"), "0n");
@@ -383,7 +383,7 @@ fn as_uint_n() {
 
 #[test]
 fn as_uint_n_errors() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_throws(&mut context, "BigInt.asUintN(-1, 0n)", "RangeError");
     assert_throws(&mut context, "BigInt.asUintN(-2.5, 0n)", "RangeError");
@@ -402,12 +402,12 @@ fn assert_throws(context: &mut Context, src: &str, error_type: &str) {
 
 #[test]
 fn division_by_zero() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_throws(&mut context, "1n/0n", "RangeError");
 }
 
 #[test]
 fn remainder_by_zero() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_throws(&mut context, "1n % 0n", "RangeError");
 }

--- a/boa/src/builtins/boolean/tests.rs
+++ b/boa/src/builtins/boolean/tests.rs
@@ -4,7 +4,7 @@ use crate::{forward, forward_val, Context};
 #[allow(clippy::unwrap_used)]
 #[test]
 fn construct_and_call() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var one = new Boolean(1);
         var zero = Boolean(0);
@@ -19,7 +19,7 @@ fn construct_and_call() {
 
 #[test]
 fn constructor_gives_true_instance() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var trueVal = new Boolean(true);
         var trueNum = new Boolean(1);
@@ -48,7 +48,7 @@ fn constructor_gives_true_instance() {
 
 #[test]
 fn instances_have_correct_proto_set() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var boolInstance = new Boolean(true);
         var boolProto = Boolean.prototype;

--- a/boa/src/builtins/console/tests.rs
+++ b/boa/src/builtins/console/tests.rs
@@ -2,20 +2,20 @@ use crate::{builtins::console::formatter, Context, JsValue};
 
 #[test]
 fn formatter_no_args_is_empty_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(formatter(&[], &mut context).unwrap(), "");
 }
 
 #[test]
 fn formatter_empty_format_string_is_empty_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let val = JsValue::new("");
     assert_eq!(formatter(&[val], &mut context).unwrap(), "");
 }
 
 #[test]
 fn formatter_format_without_args_renders_verbatim() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let val = [JsValue::new("%d %s %% %f")];
     let res = formatter(&val, &mut context).unwrap();
     assert_eq!(res, "%d %s %% %f");
@@ -23,7 +23,7 @@ fn formatter_format_without_args_renders_verbatim() {
 
 #[test]
 fn formatter_empty_format_string_concatenates_rest_of_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let val = [
         JsValue::new(""),
@@ -36,7 +36,7 @@ fn formatter_empty_format_string_concatenates_rest_of_args() {
 
 #[test]
 fn formatter_utf_8_checks() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let val = [
         JsValue::new("Są takie chwile %dą %są tu%sów %привет%ź".to_string()),
@@ -50,7 +50,7 @@ fn formatter_utf_8_checks() {
 
 #[test]
 fn formatter_trailing_format_leader_renders() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let val = [JsValue::new("%%%%%"), JsValue::new("|")];
     let res = formatter(&val, &mut context).unwrap();
@@ -60,7 +60,7 @@ fn formatter_trailing_format_leader_renders() {
 #[test]
 #[allow(clippy::approx_constant)]
 fn formatter_float_format_works() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let val = [JsValue::new("%f"), JsValue::new(3.1415)];
     let res = formatter(&val, &mut context).unwrap();

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -53,7 +53,7 @@ fn date_display() {
 
 #[test]
 fn date_this_time_value() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let error = forward_val(
         &mut context,
@@ -71,7 +71,7 @@ fn date_this_time_value() {
 
 #[test]
 fn date_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let dt1 = forward(&mut context, "Date()");
 
@@ -85,7 +85,7 @@ fn date_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let dt1 = forward_dt_local(&mut context, "new Date()");
 
@@ -99,7 +99,7 @@ fn date_ctor_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_utc(&mut context, "new Date('2020-06-08T09:16:15.779-06:30')");
 
@@ -113,7 +113,7 @@ fn date_ctor_call_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_string_invalid() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_local(&mut context, "new Date('nope')");
     assert_eq!(None, date_time);
@@ -122,7 +122,7 @@ fn date_ctor_call_string_invalid() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_number() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_utc(&mut context, "new Date(1594199775779)");
     assert_eq!(
@@ -134,7 +134,7 @@ fn date_ctor_call_number() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_date() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_utc(&mut context, "new Date(new Date(1594199775779))");
 
@@ -147,7 +147,7 @@ fn date_ctor_call_date() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_multiple() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_local(&mut context, "new Date(2020, 06, 08, 09, 16, 15, 779)");
 
@@ -160,7 +160,7 @@ fn date_ctor_call_multiple() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_call_multiple_90s() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_dt_local(&mut context, "new Date(99, 06, 08, 09, 16, 15, 779)");
 
@@ -174,7 +174,7 @@ fn date_ctor_call_multiple_90s() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn date_ctor_call_multiple_nan() -> Result<(), Box<dyn std::error::Error>> {
     fn check(src: &str) {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let date_time = forward_dt_local(&mut context, src);
         assert_eq!(None, date_time);
     }
@@ -192,7 +192,7 @@ fn date_ctor_call_multiple_nan() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_now_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward(&mut context, "Date.now()");
     let dt1 = date_time.parse::<u64>()?;
@@ -208,7 +208,7 @@ fn date_ctor_now_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_parse_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_val(&mut context, "Date.parse('2020-06-08T09:16:15.779-07:30')");
 
@@ -218,7 +218,7 @@ fn date_ctor_parse_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_ctor_utc_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let date_time = forward_val(&mut context, "Date.UTC(2020, 06, 08, 09, 16, 15, 779)");
 
@@ -229,7 +229,7 @@ fn date_ctor_utc_call() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn date_ctor_utc_call_nan() -> Result<(), Box<dyn std::error::Error>> {
     fn check(src: &str) {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let date_time = forward_val(&mut context, src).expect("Expected Success");
         assert_eq!(JsValue::nan(), date_time);
     }
@@ -247,7 +247,7 @@ fn date_ctor_utc_call_nan() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_date_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -263,7 +263,7 @@ fn date_proto_get_date_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_day_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -278,7 +278,7 @@ fn date_proto_get_day_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_full_year_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -293,7 +293,7 @@ fn date_proto_get_full_year_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_hours_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -308,7 +308,7 @@ fn date_proto_get_hours_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_milliseconds_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -323,7 +323,7 @@ fn date_proto_get_milliseconds_call() -> Result<(), Box<dyn std::error::Error>> 
 
 #[test]
 fn date_proto_get_minutes_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -338,7 +338,7 @@ fn date_proto_get_minutes_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_month() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -354,7 +354,7 @@ fn date_proto_get_month() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_seconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -369,7 +369,7 @@ fn date_proto_get_seconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_time() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -389,7 +389,7 @@ fn date_proto_get_time() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_year() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -404,7 +404,7 @@ fn date_proto_get_year() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_timezone_offset() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -434,7 +434,7 @@ fn date_proto_get_timezone_offset() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_date_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -450,7 +450,7 @@ fn date_proto_get_utc_date_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_day_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -465,7 +465,7 @@ fn date_proto_get_utc_day_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_full_year_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -480,7 +480,7 @@ fn date_proto_get_utc_full_year_call() -> Result<(), Box<dyn std::error::Error>>
 
 #[test]
 fn date_proto_get_utc_hours_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -495,7 +495,7 @@ fn date_proto_get_utc_hours_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_milliseconds_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -510,7 +510,7 @@ fn date_proto_get_utc_milliseconds_call() -> Result<(), Box<dyn std::error::Erro
 
 #[test]
 fn date_proto_get_utc_minutes_call() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -525,7 +525,7 @@ fn date_proto_get_utc_minutes_call() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_month() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -541,7 +541,7 @@ fn date_proto_get_utc_month() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_get_utc_seconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -556,7 +556,7 @@ fn date_proto_get_utc_seconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_date() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -588,7 +588,7 @@ fn date_proto_set_date() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_full_year() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -660,7 +660,7 @@ fn date_proto_set_full_year() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_hours() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -714,7 +714,7 @@ fn date_proto_set_hours() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_milliseconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -742,7 +742,7 @@ fn date_proto_set_milliseconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_minutes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -788,7 +788,7 @@ fn date_proto_set_minutes() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_month() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -825,7 +825,7 @@ fn date_proto_set_month() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_seconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -862,7 +862,7 @@ fn date_proto_set_seconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn set_year() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -887,7 +887,7 @@ fn set_year() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_time() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_local(
         &mut context,
@@ -903,7 +903,7 @@ fn date_proto_set_time() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_date() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -935,7 +935,7 @@ fn date_proto_set_utc_date() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_full_year() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1007,7 +1007,7 @@ fn date_proto_set_utc_full_year() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_hours() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1061,7 +1061,7 @@ fn date_proto_set_utc_hours() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_milliseconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1089,7 +1089,7 @@ fn date_proto_set_utc_milliseconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_minutes() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1135,7 +1135,7 @@ fn date_proto_set_utc_minutes() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_month() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1172,7 +1172,7 @@ fn date_proto_set_utc_month() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_set_utc_seconds() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_dt_utc(
         &mut context,
@@ -1209,7 +1209,7 @@ fn date_proto_set_utc_seconds() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_date_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1223,7 +1223,7 @@ fn date_proto_to_date_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_gmt_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1237,7 +1237,7 @@ fn date_proto_to_gmt_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_iso_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1251,7 +1251,7 @@ fn date_proto_to_iso_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_json() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1265,7 +1265,7 @@ fn date_proto_to_json() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1293,7 +1293,7 @@ fn date_proto_to_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_time_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1321,7 +1321,7 @@ fn date_proto_to_time_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_to_utc_string() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1335,7 +1335,7 @@ fn date_proto_to_utc_string() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_proto_value_of() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1349,7 +1349,7 @@ fn date_proto_value_of() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_neg() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,
@@ -1363,7 +1363,7 @@ fn date_neg() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn date_json() -> Result<(), Box<dyn std::error::Error>> {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward_val(
         &mut context,

--- a/boa/src/builtins/error/tests.rs
+++ b/boa/src/builtins/error/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn error_to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let e = new Error('1');
         let name = new Error();
@@ -37,19 +37,19 @@ fn error_to_string() {
 
 #[test]
 fn eval_error_name() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "EvalError.name"), "\"EvalError\"");
 }
 
 #[test]
 fn eval_error_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "EvalError.length"), "1");
 }
 
 #[test]
 fn eval_error_to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         forward(&mut context, "new EvalError('hello').toString()"),
         "\"EvalError: hello\""
@@ -62,19 +62,19 @@ fn eval_error_to_string() {
 
 #[test]
 fn uri_error_name() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "URIError.name"), "\"URIError\"");
 }
 
 #[test]
 fn uri_error_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "URIError.length"), "1");
 }
 
 #[test]
 fn uri_error_to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         forward(&mut context, "new URIError('hello').toString()"),
         "\"URIError: hello\""

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -346,7 +346,7 @@ impl BuiltInFunctionObject {
         })?;
 
         let this_arg = args.get_or_undefined(0).clone();
-        let bound_args = args.get(1..).unwrap_or_else(|| &[]).to_vec();
+        let bound_args = args.get(1..).unwrap_or(&[]).to_vec();
         let arg_count = bound_args.len() as i64;
 
         // 3. Let F be ? BoundFunctionCreate(Target, thisArg, args).

--- a/boa/src/builtins/function/tests.rs
+++ b/boa/src/builtins/function/tests.rs
@@ -8,7 +8,7 @@ use crate::{
 #[allow(clippy::float_cmp)]
 #[test]
 fn arguments_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         function jason(a, b) {
@@ -31,7 +31,7 @@ fn arguments_object() {
 
 #[test]
 fn self_mutating_function_when_calling() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         function x() {
 	        x.y = 3;
@@ -50,7 +50,7 @@ fn self_mutating_function_when_calling() {
 
 #[test]
 fn self_mutating_function_when_constructing() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         function x() {
             x.y = 3;
@@ -69,7 +69,7 @@ fn self_mutating_function_when_constructing() {
 
 #[test]
 fn call_function_prototype() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         Function.prototype()
         "#;
@@ -79,7 +79,7 @@ fn call_function_prototype() {
 
 #[test]
 fn call_function_prototype_with_arguments() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         Function.prototype(1, "", new String(""))
         "#;
@@ -89,7 +89,7 @@ fn call_function_prototype_with_arguments() {
 
 #[test]
 fn call_function_prototype_with_new() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         new Function.prototype()
         "#;
@@ -99,7 +99,7 @@ fn call_function_prototype_with_new() {
 
 #[test]
 fn function_prototype_name() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         Function.prototype.name
         "#;
@@ -111,7 +111,7 @@ fn function_prototype_name() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn function_prototype_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         Function.prototype.length
         "#;
@@ -122,7 +122,7 @@ fn function_prototype_length() {
 
 #[test]
 fn function_prototype_call() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let func = r#"
         let e = new Error()
         Object.prototype.toString.call(e)
@@ -134,7 +134,7 @@ fn function_prototype_call() {
 
 #[test]
 fn function_prototype_call_throw() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let throw = r#"
         let call = Function.prototype.call;
         call(call)
@@ -147,7 +147,7 @@ fn function_prototype_call_throw() {
 
 #[test]
 fn function_prototype_call_multiple_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         function f(a, b) {
             this.a = a;
@@ -171,7 +171,7 @@ fn function_prototype_call_multiple_args() {
 
 #[test]
 fn function_prototype_apply() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const numbers = [6, 7, 3, 4, 2];
         const max = Math.max.apply(null, numbers);
@@ -194,7 +194,7 @@ fn function_prototype_apply() {
 
 #[test]
 fn function_prototype_apply_on_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         function f(a, b) {
             this.a = a;
@@ -220,7 +220,7 @@ fn function_prototype_apply_on_object() {
 
 #[test]
 fn closure_capture_clone() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let string = JsString::from("Hello");
     let object = context.construct_object();

--- a/boa/src/builtins/json/tests.rs
+++ b/boa/src/builtins/json/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, forward_val, Context};
 
 #[test]
 fn json_sanity() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         forward(&mut context, r#"JSON.parse('{"aaa":"bbb"}').aaa == 'bbb'"#),
         "true"
@@ -18,7 +18,7 @@ fn json_sanity() {
 
 #[test]
 fn json_stringify_remove_undefined_values_from_objects() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -31,7 +31,7 @@ fn json_stringify_remove_undefined_values_from_objects() {
 
 #[test]
 fn json_stringify_remove_function_values_from_objects() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -44,7 +44,7 @@ fn json_stringify_remove_function_values_from_objects() {
 
 #[test]
 fn json_stringify_remove_symbols_from_objects() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -57,7 +57,7 @@ fn json_stringify_remove_symbols_from_objects() {
 
 #[test]
 fn json_stringify_replacer_array_strings() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(
         &mut context,
         r#"JSON.stringify({aaa: 'bbb', bbb: 'ccc', ccc: 'ddd'}, ['aaa', 'bbb'])"#,
@@ -68,7 +68,7 @@ fn json_stringify_replacer_array_strings() {
 
 #[test]
 fn json_stringify_replacer_array_numbers() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(
         &mut context,
         r#"JSON.stringify({ 0: 'aaa', 1: 'bbb', 2: 'ccc'}, [1, 2])"#,
@@ -79,7 +79,7 @@ fn json_stringify_replacer_array_numbers() {
 
 #[test]
 fn json_stringify_replacer_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(
         &mut context,
         r#"JSON.stringify({ aaa: 1, bbb: 2}, (key, value) => {
@@ -96,7 +96,7 @@ fn json_stringify_replacer_function() {
 
 #[test]
 fn json_stringify_arrays() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(&mut context, r#"JSON.stringify(['a', 'b'])"#);
     let expected = forward(&mut context, r#"'["a","b"]'"#);
 
@@ -105,7 +105,7 @@ fn json_stringify_arrays() {
 
 #[test]
 fn json_stringify_object_array() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(&mut context, r#"JSON.stringify([{a: 'b'}, {b: 'c'}])"#);
     let expected = forward(&mut context, r#"'[{"a":"b"},{"b":"c"}]'"#);
 
@@ -114,7 +114,7 @@ fn json_stringify_object_array() {
 
 #[test]
 fn json_stringify_array_converts_undefined_to_null() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(&mut context, r#"JSON.stringify([undefined])"#);
     let expected = forward(&mut context, r#"'[null]'"#);
 
@@ -123,7 +123,7 @@ fn json_stringify_array_converts_undefined_to_null() {
 
 #[test]
 fn json_stringify_array_converts_function_to_null() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(&mut context, r#"JSON.stringify([() => {}])"#);
     let expected = forward(&mut context, r#"'[null]'"#);
 
@@ -132,7 +132,7 @@ fn json_stringify_array_converts_function_to_null() {
 
 #[test]
 fn json_stringify_array_converts_symbol_to_null() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual = forward(&mut context, r#"JSON.stringify([Symbol()])"#);
     let expected = forward(&mut context, r#"'[null]'"#);
 
@@ -140,7 +140,7 @@ fn json_stringify_array_converts_symbol_to_null() {
 }
 #[test]
 fn json_stringify_function_replacer_propogate_error() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -161,7 +161,7 @@ fn json_stringify_function_replacer_propogate_error() {
 
 #[test]
 fn json_stringify_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual_function = forward(&mut context, r#"JSON.stringify(() => {})"#);
     let expected = forward(&mut context, r#"undefined"#);
@@ -171,7 +171,7 @@ fn json_stringify_function() {
 
 #[test]
 fn json_stringify_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual_undefined = forward(&mut context, r#"JSON.stringify(undefined)"#);
     let expected = forward(&mut context, r#"undefined"#);
 
@@ -180,7 +180,7 @@ fn json_stringify_undefined() {
 
 #[test]
 fn json_stringify_symbol() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual_symbol = forward(&mut context, r#"JSON.stringify(Symbol())"#);
     let expected = forward(&mut context, r#"undefined"#);
@@ -190,7 +190,7 @@ fn json_stringify_symbol() {
 
 #[test]
 fn json_stringify_no_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual_no_args = forward(&mut context, r#"JSON.stringify()"#);
     let expected = forward(&mut context, r#"undefined"#);
@@ -200,7 +200,7 @@ fn json_stringify_no_args() {
 
 #[test]
 fn json_stringify_fractional_numbers() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(&mut context, r#"JSON.stringify(Math.round(1.0))"#);
     let expected = forward(&mut context, r#""1""#);
@@ -209,7 +209,7 @@ fn json_stringify_fractional_numbers() {
 
 #[test]
 fn json_stringify_pretty_print() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -227,7 +227,7 @@ fn json_stringify_pretty_print() {
 
 #[test]
 fn json_stringify_pretty_print_four_spaces() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -245,7 +245,7 @@ fn json_stringify_pretty_print_four_spaces() {
 
 #[test]
 fn json_stringify_pretty_print_twenty_spaces() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -263,7 +263,7 @@ fn json_stringify_pretty_print_twenty_spaces() {
 
 #[test]
 fn json_stringify_pretty_print_with_number_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -281,7 +281,7 @@ fn json_stringify_pretty_print_with_number_object() {
 
 #[test]
 fn json_stringify_pretty_print_bad_space_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -293,7 +293,7 @@ fn json_stringify_pretty_print_bad_space_argument() {
 
 #[test]
 fn json_stringify_pretty_print_with_too_long_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -311,7 +311,7 @@ fn json_stringify_pretty_print_with_too_long_string() {
 
 #[test]
 fn json_stringify_pretty_print_with_string_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let actual = forward(
         &mut context,
@@ -329,7 +329,7 @@ fn json_stringify_pretty_print_with_string_object() {
 
 #[test]
 fn json_parse_array_with_reviver() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let result = forward_val(
         &mut context,
         r#"JSON.parse('[1,2,3,4]', function(k, v){
@@ -377,7 +377,7 @@ fn json_parse_array_with_reviver() {
 
 #[test]
 fn json_parse_object_with_reviver() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let result = forward(
         &mut context,
         r#"
@@ -403,7 +403,7 @@ fn json_parse_object_with_reviver() {
 
 #[test]
 fn json_parse_sets_prototypes() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const jsonString = "{\"ob\":{\"ject\":1},\"arr\": [0,1]}";
         const jsonObj = JSON.parse(jsonString);
@@ -433,7 +433,7 @@ fn json_parse_sets_prototypes() {
 
 #[test]
 fn json_fields_should_be_enumerable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let actual_object = forward(
         &mut context,
         r#"
@@ -456,7 +456,7 @@ fn json_fields_should_be_enumerable() {
 
 #[test]
 fn json_parse_with_no_args_throws_syntax_error() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let result = forward(&mut context, "JSON.parse();");
     assert!(result.contains("SyntaxError"));
 }

--- a/boa/src/builtins/map/ordered_map.rs
+++ b/boa/src/builtins/map/ordered_map.rs
@@ -155,7 +155,7 @@ impl<V> OrderedMap<V> {
     ///
     /// Computes in **O(1)** time (average).
     pub fn get(&self, key: &JsValue) -> Option<&V> {
-        self.map.get(key).map(Option::as_ref).flatten()
+        self.map.get(key).and_then(Option::as_ref)
     }
 
     /// Get a key-value pair by index.

--- a/boa/src/builtins/map/tests.rs
+++ b/boa/src/builtins/map/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn construct_empty() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new Map();
         "#;
@@ -13,7 +13,7 @@ fn construct_empty() {
 
 #[test]
 fn construct_from_array() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([["1", "one"], ["2", "two"]]);
         "#;
@@ -24,7 +24,7 @@ fn construct_from_array() {
 
 #[test]
 fn clone() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let original = new Map([["1", "one"], ["2", "two"]]);
         let clone = new Map(original);
@@ -45,7 +45,7 @@ fn clone() {
 
 #[test]
 fn symbol_iterator() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const map1 = new Map();
         map1.set('0', 'foo');
@@ -81,7 +81,7 @@ fn symbol_iterator() {
 // Should behave the same as symbol_iterator
 #[test]
 fn entries() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const map1 = new Map();
         map1.set('0', 'foo');
@@ -116,7 +116,7 @@ fn entries() {
 
 #[test]
 fn merge() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let first = new Map([["1", "one"], ["2", "two"]]);
         let second = new Map([["2", "second two"], ["3", "three"]]);
@@ -135,7 +135,7 @@ fn merge() {
 
 #[test]
 fn get() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([["1", "one"], ["2", "two"]]);
         "#;
@@ -152,7 +152,7 @@ fn get() {
 
 #[test]
 fn set() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map();
         "#;
@@ -170,7 +170,7 @@ fn set() {
 
 #[test]
 fn clear() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([["1", "one"], ["2", "two"]]);
         map.clear();
@@ -182,7 +182,7 @@ fn clear() {
 
 #[test]
 fn delete() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([["1", "one"], ["2", "two"]]);
         "#;
@@ -197,7 +197,7 @@ fn delete() {
 
 #[test]
 fn has() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([["1", "one"]]);
         "#;
@@ -212,7 +212,7 @@ fn has() {
 
 #[test]
 fn keys() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const map1 = new Map();
         map1.set('0', 'foo');
@@ -239,7 +239,7 @@ fn keys() {
 
 #[test]
 fn for_each() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([[1, 5], [2, 10], [3, 15]]);
         let valueSum = 0;
@@ -260,7 +260,7 @@ fn for_each() {
 
 #[test]
 fn values() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const map1 = new Map();
         map1.set('0', 'foo');
@@ -287,7 +287,7 @@ fn values() {
 
 #[test]
 fn modify_key() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let obj = new Object();
         let map = new Map([[obj, "one"]]);
@@ -300,7 +300,7 @@ fn modify_key() {
 
 #[test]
 fn order() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([[1, "one"]]);
         map.set(2, "two");
@@ -326,7 +326,7 @@ fn order() {
 
 #[test]
 fn recursive_display() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map();
         let array = new Array([map]);
@@ -341,7 +341,7 @@ fn recursive_display() {
 
 #[test]
 fn not_a_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r"
         try {
             let map = Map()
@@ -357,7 +357,7 @@ fn not_a_function() {
 
 #[test]
 fn for_each_delete() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([[0, "a"], [1, "b"], [2, "c"]]);
         let result = [];
@@ -382,7 +382,7 @@ fn for_each_delete() {
 
 #[test]
 fn for_of_delete() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let map = new Map([[0, "a"], [1, "b"], [2, "c"]]);
         let result = [];

--- a/boa/src/builtins/math/tests.rs
+++ b/boa/src/builtins/math/tests.rs
@@ -5,7 +5,7 @@ use std::f64;
 
 #[test]
 fn abs() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.abs(3 - 5);
         var b = Math.abs(1.23456 - 7.89012);
@@ -22,7 +22,7 @@ fn abs() {
 
 #[test]
 fn acos() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.acos(8 / 10);
         var b = Math.acos(5 / 3);
@@ -45,7 +45,7 @@ fn acos() {
 
 #[test]
 fn acosh() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.acosh(2);
         var b = Math.acosh(-1);
@@ -65,7 +65,7 @@ fn acosh() {
 
 #[test]
 fn asin() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.asin(6 / 10);
         var b = Math.asin(5 / 3);
@@ -82,7 +82,7 @@ fn asin() {
 
 #[test]
 fn asinh() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.asinh(1);
         var b = Math.asinh(0);
@@ -99,7 +99,7 @@ fn asinh() {
 
 #[test]
 fn atan() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.atan(1);
         var b = Math.atan(0);
@@ -119,7 +119,7 @@ fn atan() {
 
 #[test]
 fn atan2() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.atan2(90, 15);
         var b = Math.atan2(15, 90);
@@ -136,7 +136,7 @@ fn atan2() {
 
 #[test]
 fn cbrt() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.cbrt(64);
         var b = Math.cbrt(-1);
@@ -156,7 +156,7 @@ fn cbrt() {
 
 #[test]
 fn ceil() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.ceil(1.95);
         var b = Math.ceil(4);
@@ -177,7 +177,7 @@ fn ceil() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn clz32() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.clz32();
         var b = Math.clz32({});
@@ -212,7 +212,7 @@ fn clz32() {
 
 #[test]
 fn cos() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.cos(0);
         var b = Math.cos(1);
@@ -229,7 +229,7 @@ fn cos() {
 
 #[test]
 fn cosh() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.cosh(0);
         var b = Math.cosh(1);
@@ -249,7 +249,7 @@ fn cosh() {
 
 #[test]
 fn exp() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.exp(0);
         var b = Math.exp(-1);
@@ -270,7 +270,7 @@ fn exp() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn expm1() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.expm1();
         var b = Math.expm1({});
@@ -315,7 +315,7 @@ fn expm1() {
 
 #[test]
 fn floor() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.floor(1.95);
         var b = Math.floor(-3.01);
@@ -336,7 +336,7 @@ fn floor() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn fround() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.fround(NaN);
         var b = Math.fround(Infinity);
@@ -369,7 +369,7 @@ fn fround() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn hypot() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.hypot();
         var b = Math.hypot(3, 4);
@@ -402,7 +402,7 @@ fn hypot() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn imul() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.imul(3, 4);
         var b = Math.imul(-5, 12);
@@ -431,7 +431,7 @@ fn imul() {
 
 #[test]
 fn log() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.log(1);
         var b = Math.log(10);
@@ -452,7 +452,7 @@ fn log() {
 #[test]
 #[allow(clippy::many_single_char_names)]
 fn log1p() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.log1p(1);
         var b = Math.log1p(0);
@@ -484,7 +484,7 @@ fn log1p() {
 
 #[test]
 fn log10() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.log10(2);
         var b = Math.log10(1);
@@ -504,7 +504,7 @@ fn log10() {
 
 #[test]
 fn log2() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.log2(3);
         var b = Math.log2(1);
@@ -524,7 +524,7 @@ fn log2() {
 
 #[test]
 fn max() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.max(10, 20);
         var b = Math.max(-10, -20);
@@ -544,7 +544,7 @@ fn max() {
 
 #[test]
 fn min() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.min(10, 20);
         var b = Math.min(-10, -20);
@@ -564,7 +564,7 @@ fn min() {
 
 #[test]
 fn pow() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.pow(2, 10);
         var b = Math.pow(-7, 2);
@@ -587,7 +587,7 @@ fn pow() {
 
 #[test]
 fn round() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.round(20.5);
         var b = Math.round(-20.3);
@@ -604,7 +604,7 @@ fn round() {
 
 #[test]
 fn sign() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.sign(3);
         var b = Math.sign(-3);
@@ -624,7 +624,7 @@ fn sign() {
 
 #[test]
 fn sin() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.sin(0);
         var b = Math.sin(1);
@@ -641,7 +641,7 @@ fn sin() {
 
 #[test]
 fn sinh() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.sinh(0);
         var b = Math.sinh(1);
@@ -658,7 +658,7 @@ fn sinh() {
 
 #[test]
 fn sqrt() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.sqrt(0);
         var b = Math.sqrt(2);
@@ -678,7 +678,7 @@ fn sqrt() {
 
 #[test]
 fn tan() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.tan(1.1);
         "#;
@@ -696,7 +696,7 @@ fn tan() {
 
 #[test]
 fn tanh() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.tanh(1);
         var b = Math.tanh(0);
@@ -713,7 +713,7 @@ fn tanh() {
 
 #[test]
 fn trunc() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = Math.trunc(13.37);
         var b = Math.trunc(0.123);

--- a/boa/src/builtins/number/mod.rs
+++ b/boa/src/builtins/number/mod.rs
@@ -1141,7 +1141,7 @@ impl Number {
 /// Helper function that formats a float as a ES6-style exponential number string.
 fn f64_to_exponential(n: f64) -> String {
     match n.abs() {
-        x if x >= 1.0 || x == 0.0 => format!("{:e}", n).replace("e", "e+"),
+        x if x >= 1.0 || x == 0.0 => format!("{:e}", n).replace('e', "e+"),
         _ => format!("{:e}", n),
     }
 }

--- a/boa/src/builtins/number/tests.rs
+++ b/boa/src/builtins/number/tests.rs
@@ -4,7 +4,7 @@ use crate::{builtins::Number, forward, forward_val, value::AbstractRelation, Con
 
 #[test]
 fn integer_number_primitive_to_number_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         (100).toString() === "100"
@@ -15,7 +15,7 @@ fn integer_number_primitive_to_number_object() {
 
 #[test]
 fn call_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var default_zero = Number();
         var int_one = Number(1);
@@ -49,7 +49,7 @@ fn call_number() {
 
 #[test]
 fn to_exponential() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var default_exp = Number().toExponential();
         var int_exp = Number(5).toExponential();
@@ -77,7 +77,7 @@ fn to_exponential() {
 
 #[test]
 fn to_fixed() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var default_fixed = Number().toFixed();
         var pos_fixed = Number("3.456e+4").toFixed();
@@ -102,7 +102,7 @@ fn to_fixed() {
 
 #[test]
 fn to_locale_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var default_locale = Number().toLocaleString();
         var small_locale = Number(5).toLocaleString();
@@ -127,7 +127,7 @@ fn to_locale_string() {
 
 #[test]
 fn to_precision() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var infinity = (1/0).toPrecision(3);
         var default_precision = Number().toPrecision();
@@ -185,7 +185,7 @@ fn to_precision() {
 
 #[test]
 fn to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("\"NaN\"", &forward(&mut context, "Number(NaN).toString()"));
     assert_eq!(
@@ -369,7 +369,7 @@ fn to_string() {
 
 #[test]
 fn num_to_string_exponential() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("\"0\"", forward(&mut context, "(0).toString()"));
     assert_eq!("\"0\"", forward(&mut context, "(-0).toString()"));
@@ -407,7 +407,7 @@ fn num_to_string_exponential() {
 
 #[test]
 fn value_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     // TODO: In addition to parsing numbers from strings, parse them bare As of October 2019
     // the parser does not understand scientific e.g., Xe+Y or -Xe-Y notation.
     let init = r#"
@@ -493,7 +493,7 @@ fn same_value_zero() {
 
 #[test]
 fn from_bigint() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "Number(0n)"), "0",);
     assert_eq!(&forward(&mut context, "Number(100000n)"), "100000",);
@@ -503,7 +503,7 @@ fn from_bigint() {
 
 #[test]
 fn number_constants() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(!forward_val(&mut context, "Number.EPSILON")
         .unwrap()
@@ -530,42 +530,42 @@ fn number_constants() {
 
 #[test]
 fn parse_int_simple() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"6\")"), "6");
 }
 
 #[test]
 fn parse_int_negative() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"-9\")"), "-9");
 }
 
 #[test]
 fn parse_int_already_int() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(100)"), "100");
 }
 
 #[test]
 fn parse_int_float() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(100.5)"), "100");
 }
 
 #[test]
 fn parse_int_float_str() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"100.5\")"), "100");
 }
 
 #[test]
 fn parse_int_inferred_hex() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"0xA\")"), "10");
 }
@@ -574,14 +574,14 @@ fn parse_int_inferred_hex() {
 /// a radix 10 if no radix is specified. Some alternative implementations default to a radix of 8.
 #[test]
 fn parse_int_zero_start() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"018\")"), "18");
 }
 
 #[test]
 fn parse_int_varying_radix() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let base_str = "1000";
 
@@ -600,7 +600,7 @@ fn parse_int_varying_radix() {
 
 #[test]
 fn parse_int_negative_varying_radix() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let base_str = "-1000";
 
@@ -619,14 +619,14 @@ fn parse_int_negative_varying_radix() {
 
 #[test]
 fn parse_int_malformed_str() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"hello\")"), "NaN");
 }
 
 #[test]
 fn parse_int_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(undefined)"), "NaN");
 }
@@ -635,7 +635,7 @@ fn parse_int_undefined() {
 /// passed as the first argument.
 #[test]
 fn parse_int_no_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt()"), "NaN");
 }
@@ -643,56 +643,56 @@ fn parse_int_no_args() {
 /// Shows that extra arguments to parseInt are ignored.
 #[test]
 fn parse_int_too_many_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseInt(\"100\", 10, 10)"), "100");
 }
 
 #[test]
 fn parse_float_simple() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(\"6.5\")"), "6.5");
 }
 
 #[test]
 fn parse_float_int() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(10)"), "10");
 }
 
 #[test]
 fn parse_float_int_str() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(\"8\")"), "8");
 }
 
 #[test]
 fn parse_float_already_float() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(17.5)"), "17.5");
 }
 
 #[test]
 fn parse_float_negative() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(\"-99.7\")"), "-99.7");
 }
 
 #[test]
 fn parse_float_malformed_str() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(\"hello\")"), "NaN");
 }
 
 #[test]
 fn parse_float_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(undefined)"), "NaN");
 }
@@ -700,7 +700,7 @@ fn parse_float_undefined() {
 /// No arguments to parseFloat is treated the same as passing undefined as the first argument.
 #[test]
 fn parse_float_no_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat()"), "NaN");
 }
@@ -708,14 +708,14 @@ fn parse_float_no_args() {
 /// Shows that the parseFloat function ignores extra arguments.
 #[test]
 fn parse_float_too_many_args() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(&forward(&mut context, "parseFloat(\"100.5\", 10)"), "100.5");
 }
 
 #[test]
 fn global_is_finite() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("false", &forward(&mut context, "isFinite(Infinity)"));
     assert_eq!("false", &forward(&mut context, "isFinite(NaN)"));
@@ -730,7 +730,7 @@ fn global_is_finite() {
 
 #[test]
 fn global_is_nan() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("true", &forward(&mut context, "isNaN(NaN)"));
     assert_eq!("true", &forward(&mut context, "isNaN('NaN')"));
@@ -751,7 +751,7 @@ fn global_is_nan() {
 
 #[test]
 fn number_is_finite() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("false", &forward(&mut context, "Number.isFinite(Infinity)"));
     assert_eq!("false", &forward(&mut context, "Number.isFinite(NaN)"));
@@ -783,7 +783,7 @@ fn number_is_finite() {
 
 #[test]
 fn number_is_integer() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("true", &forward(&mut context, "Number.isInteger(0)"));
     assert_eq!("true", &forward(&mut context, "Number.isInteger(1)"));
@@ -833,7 +833,7 @@ fn number_is_integer() {
 
 #[test]
 fn number_is_nan() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("true", &forward(&mut context, "Number.isNaN(NaN)"));
     assert_eq!("true", &forward(&mut context, "Number.isNaN(Number.NaN)"));
@@ -866,7 +866,7 @@ fn number_is_nan() {
 
 #[test]
 fn number_is_safe_integer() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!("true", &forward(&mut context, "Number.isSafeInteger(3)"));
     assert_eq!(

--- a/boa/src/builtins/object/tests.rs
+++ b/boa/src/builtins/object/tests.rs
@@ -2,7 +2,7 @@ use crate::{check_output, forward, Context, JsValue, TestAction};
 
 #[test]
 fn object_create_with_regular_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         const foo = { a: 5 };
@@ -17,7 +17,7 @@ fn object_create_with_regular_object() {
 
 #[test]
 fn object_create_with_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         try {
@@ -36,7 +36,7 @@ fn object_create_with_undefined() {
 
 #[test]
 fn object_create_with_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         try {
@@ -57,7 +57,7 @@ fn object_create_with_number() {
 #[ignore]
 // TODO: to test on __proto__ somehow. __proto__ getter is not working as expected currently
 fn object_create_with_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         const x = function (){};
@@ -71,7 +71,7 @@ fn object_create_with_function() {
 
 #[test]
 fn object_is() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var foo = { a: 1};
@@ -152,7 +152,7 @@ fn object_has_own() {
 
 #[test]
 fn object_property_is_enumerable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let x = { enumerableProp: 'yes' };
     "#;
@@ -177,7 +177,7 @@ fn object_property_is_enumerable() {
 
 #[test]
 fn object_to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let u = undefined;
         let n = null;
@@ -230,7 +230,7 @@ fn object_to_string() {
 
 #[test]
 fn define_symbol_property() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = {};
@@ -244,7 +244,7 @@ fn define_symbol_property() {
 
 #[test]
 fn get_own_property_descriptor_1_arg_returns_undefined() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let code = r#"
         let obj = {a: 2};
         Object.getOwnPropertyDescriptor(obj)
@@ -254,7 +254,7 @@ fn get_own_property_descriptor_1_arg_returns_undefined() {
 
 #[test]
 fn get_own_property_descriptor() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     forward(
         &mut context,
         r#"
@@ -271,7 +271,7 @@ fn get_own_property_descriptor() {
 
 #[test]
 fn get_own_property_descriptors() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     forward(
         &mut context,
         r#"
@@ -293,7 +293,7 @@ fn get_own_property_descriptors() {
 
 #[test]
 fn object_define_properties() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         const obj = {};
@@ -312,7 +312,7 @@ fn object_define_properties() {
 
 #[test]
 fn object_is_prototype_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         Object.prototype.isPrototypeOf(String.prototype)

--- a/boa/src/builtins/reflect/tests.rs
+++ b/boa/src/builtins/reflect/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn apply() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var called = {};
@@ -17,7 +17,7 @@ fn apply() {
 
 #[test]
 fn construct() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var called = {};
@@ -32,7 +32,7 @@ fn construct() {
 
 #[test]
 fn define_property() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = {};
@@ -46,7 +46,7 @@ fn define_property() {
 
 #[test]
 fn delete_property() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -61,7 +61,7 @@ fn delete_property() {
 
 #[test]
 fn get() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 }
@@ -75,7 +75,7 @@ fn get() {
 
 #[test]
 fn get_own_property_descriptor() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -89,7 +89,7 @@ fn get_own_property_descriptor() {
 
 #[test]
 fn get_prototype_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         function F() { this.p = 42 };
@@ -104,7 +104,7 @@ fn get_prototype_of() {
 
 #[test]
 fn has() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -120,7 +120,7 @@ fn has() {
 
 #[test]
 fn is_extensible() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -134,7 +134,7 @@ fn is_extensible() {
 
 #[test]
 fn own_keys() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -148,7 +148,7 @@ fn own_keys() {
 
 #[test]
 fn prevent_extensions() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = { p: 42 };
@@ -162,7 +162,7 @@ fn prevent_extensions() {
 
 #[test]
 fn set() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         let obj = {};
@@ -176,7 +176,7 @@ fn set() {
 
 #[test]
 fn set_prototype_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         function F() { this.p = 42 };

--- a/boa/src/builtins/regexp/tests.rs
+++ b/boa/src/builtins/regexp/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn constructors() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var constructed = new RegExp("[0-9]+(\\.[0-9]+)?");
         var literal = /[0-9]+(\.[0-9]+)?/;
@@ -17,7 +17,7 @@ fn constructors() {
 
 #[test]
 fn species() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let init = r#"
         var descriptor = Object.getOwnPropertyDescriptor(RegExp, Symbol.species);
@@ -63,7 +63,7 @@ fn species() {
 
 //    #[test]
 //    fn flags() {
-//        let mut context = Context::new();
+//        let mut context = Context::default();
 //        let init = r#"
 //                var re_gi = /test/gi;
 //                var re_sm = /test/sm;
@@ -89,7 +89,7 @@ fn species() {
 
 #[test]
 fn last_index() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var regex = /[0-9]+(\.[0-9]+)?/g;
         "#;
@@ -104,7 +104,7 @@ fn last_index() {
 
 #[test]
 fn exec() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var re = /quick\s(brown).+?(jumps)/ig;
         var result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
@@ -126,7 +126,7 @@ fn exec() {
 
 #[test]
 fn to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(&mut context, "(new RegExp('a+b+c')).toString()"),
@@ -145,7 +145,7 @@ fn to_string() {
 
 #[test]
 fn no_panic_on_invalid_character_escape() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // This used to panic, we now return an error
     // The line below should not cause Boa to panic
@@ -154,7 +154,7 @@ fn no_panic_on_invalid_character_escape() {
 
 #[test]
 fn search() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // coerce-string
     assert_eq!(

--- a/boa/src/builtins/set/tests.rs
+++ b/boa/src/builtins/set/tests.rs
@@ -2,7 +2,7 @@ use crate::{forward, Context};
 
 #[test]
 fn construct_empty() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new Set();
         "#;
@@ -13,7 +13,7 @@ fn construct_empty() {
 
 #[test]
 fn construct_from_array() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set(["one", "two"]);
         "#;
@@ -24,7 +24,7 @@ fn construct_from_array() {
 
 #[test]
 fn clone() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let original = new Set(["one", "two"]);
         let clone = new Set(original);
@@ -45,7 +45,7 @@ fn clone() {
 
 #[test]
 fn symbol_iterator() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const set1 = new Set();
         set1.add('foo');
@@ -72,7 +72,7 @@ fn symbol_iterator() {
 
 #[test]
 fn entries() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const set1 = new Set();
         set1.add('foo');
@@ -107,7 +107,7 @@ fn entries() {
 
 #[test]
 fn merge() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let first = new Set(["one", "two"]);
         let second = new Set(["three", "four"]);
@@ -124,7 +124,7 @@ fn merge() {
 
 #[test]
 fn clear() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set(["one", "two"]);
         set.clear();
@@ -136,7 +136,7 @@ fn clear() {
 
 #[test]
 fn delete() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set(["one", "two"]);
         "#;
@@ -151,7 +151,7 @@ fn delete() {
 
 #[test]
 fn has() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set(["one", "two"]);
         "#;
@@ -168,7 +168,7 @@ fn has() {
 
 #[test]
 fn values_and_keys() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         const set1 = new Set();
         set1.add('foo');
@@ -197,7 +197,7 @@ fn values_and_keys() {
 
 #[test]
 fn for_each() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set([5, 10, 15]);
         let value1Sum = 0;
@@ -218,7 +218,7 @@ fn for_each() {
 
 #[test]
 fn recursive_display() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let set = new Set();
         let array = new Array([set]);
@@ -233,7 +233,7 @@ fn recursive_display() {
 
 #[test]
 fn not_a_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r"
         try {
             let set = Set()

--- a/boa/src/builtins/string/tests.rs
+++ b/boa/src/builtins/string/tests.rs
@@ -3,7 +3,7 @@ use crate::{forward, forward_val, Context};
 #[test]
 fn length() {
     //TEST262: https://github.com/tc39/test262/blob/master/test/built-ins/String/length.js
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
     const a = new String(' ');
     const b = new String('\ud834\udf06');
@@ -26,7 +26,7 @@ fn length() {
 
 #[test]
 fn new_string_has_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let a = new String("1234");
         a
@@ -38,7 +38,7 @@ fn new_string_has_length() {
 
 #[test]
 fn new_string_has_length_not_enumerable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let a = new String("1234");
         "#;
@@ -52,7 +52,7 @@ fn new_string_has_length_not_enumerable() {
 
 #[test]
 fn new_utf8_string_has_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let a = new String("中文");
         a
@@ -64,7 +64,7 @@ fn new_utf8_string_has_length() {
 
 #[test]
 fn concat() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var hello = new String('Hello, ');
         var world = new String('world! ');
@@ -81,7 +81,7 @@ fn concat() {
 
 #[test]
 fn generic_concat() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         Number.prototype.concat = String.prototype.concat;
         let number = new Number(100);
@@ -96,7 +96,7 @@ fn generic_concat() {
 #[test]
 /// Test the correct type is returned from call and construct
 fn construct_and_call() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var hello = new String('Hello');
         var world = String('world');
@@ -113,7 +113,7 @@ fn construct_and_call() {
 
 #[test]
 fn repeat() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new String('');
         var en = new String('english');
@@ -134,7 +134,7 @@ fn repeat() {
 
 #[test]
 fn repeat_throws_when_count_is_negative() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(
@@ -153,7 +153,7 @@ fn repeat_throws_when_count_is_negative() {
 
 #[test]
 fn repeat_throws_when_count_is_infinity() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(
@@ -172,7 +172,7 @@ fn repeat_throws_when_count_is_infinity() {
 
 #[test]
 fn repeat_throws_when_count_overflows_max_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward(
@@ -191,7 +191,7 @@ fn repeat_throws_when_count_overflows_max_length() {
 
 #[test]
 fn repeat_generic() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = "Number.prototype.repeat = String.prototype.repeat;";
 
     forward(&mut context, init);
@@ -205,7 +205,7 @@ fn repeat_generic() {
 
 #[test]
 fn replace() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = "abc";
         a = a.replace("a", "2");
@@ -219,7 +219,7 @@ fn replace() {
 
 #[test]
 fn replace_no_match() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = "abc";
         a = a.replace(/d/, "$&$&");
@@ -232,7 +232,7 @@ fn replace_no_match() {
 
 #[test]
 fn replace_with_capture_groups() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var re = /(\w+)\s(\w+)/;
         var a = "John Smith";
@@ -247,7 +247,7 @@ fn replace_with_capture_groups() {
 
 #[test]
 fn replace_with_tenth_capture_group() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var re = /(\d)(\d)(\d)(\d)(\d)(\d)(\d)(\d)(\d)(\d)/;
         var a = "0123456789";
@@ -261,7 +261,7 @@ fn replace_with_tenth_capture_group() {
 
 #[test]
 fn replace_substitutions() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var re = / two /;
         var a = "one two three";
@@ -283,7 +283,7 @@ fn replace_substitutions() {
 
 #[test]
 fn replace_with_function() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var a = "ecmascript is cool";
         var p1, p2, p3, length;
@@ -311,7 +311,7 @@ fn replace_with_function() {
 
 #[test]
 fn starts_with() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new String('');
         var en = new String('english');
@@ -335,7 +335,7 @@ fn starts_with() {
 
 #[test]
 fn starts_with_with_regex_arg() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -355,7 +355,7 @@ fn starts_with_with_regex_arg() {
 
 #[test]
 fn ends_with() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new String('');
         var en = new String('english');
@@ -379,7 +379,7 @@ fn ends_with() {
 
 #[test]
 fn ends_with_with_regex_arg() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -399,7 +399,7 @@ fn ends_with_with_regex_arg() {
 
 #[test]
 fn includes() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var empty = new String('');
         var en = new String('english');
@@ -423,7 +423,7 @@ fn includes() {
 
 #[test]
 fn includes_with_regex_arg() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let scenario = r#"
         try {
@@ -443,7 +443,7 @@ fn includes_with_regex_arg() {
 
 #[test]
 fn match_all() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     forward(
         &mut context,
@@ -518,7 +518,7 @@ fn match_all() {
 
 #[test]
 fn test_match() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var str = new String('The Quick Brown Fox Jumps Over The Lazy Dog');
         var result1 = str.match(/quick\s(brown).+?(jumps)/i);
@@ -562,7 +562,7 @@ fn test_match() {
 
 #[test]
 fn trim() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, r#"'Hello'.trim()"#), "\"Hello\"");
     assert_eq!(forward(&mut context, r#"' \nHello'.trim()"#), "\"Hello\"");
     assert_eq!(forward(&mut context, r#"'Hello \n\r'.trim()"#), "\"Hello\"");
@@ -571,7 +571,7 @@ fn trim() {
 
 #[test]
 fn trim_start() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, r#"'Hello'.trimStart()"#), "\"Hello\"");
     assert_eq!(
         forward(&mut context, r#"' \nHello'.trimStart()"#),
@@ -589,7 +589,7 @@ fn trim_start() {
 
 #[test]
 fn trim_end() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, r#"'Hello'.trimEnd()"#), "\"Hello\"");
     assert_eq!(
         forward(&mut context, r#"' \nHello'.trimEnd()"#),
@@ -607,7 +607,7 @@ fn trim_end() {
 
 #[test]
 fn split() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         forward(&mut context, "'Hello'.split()"),
         forward(&mut context, "['Hello']")
@@ -689,7 +689,7 @@ fn split() {
 fn split_with_symbol_split_method() {
     assert_eq!(
         forward(
-            &mut Context::new(),
+            &mut Context::default(),
             r#"
             let sep = {};
             sep[Symbol.split] = function(s, limit) { return s + limit.toString(); };
@@ -701,7 +701,7 @@ fn split_with_symbol_split_method() {
 
     assert_eq!(
         forward(
-            &mut Context::new(),
+            &mut Context::default(),
             r#"
             let sep = {};
             sep[Symbol.split] = undefined;
@@ -713,7 +713,7 @@ fn split_with_symbol_split_method() {
 
     assert_eq!(
         forward(
-            &mut Context::new(),
+            &mut Context::default(),
             r#"
             try {
                 let sep = {};
@@ -730,7 +730,7 @@ fn split_with_symbol_split_method() {
 
 #[test]
 fn index_of_with_no_arguments() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.indexOf()"), "-1");
     assert_eq!(forward(&mut context, "'undefined'.indexOf()"), "0");
     assert_eq!(forward(&mut context, "'a1undefined'.indexOf()"), "2");
@@ -741,7 +741,7 @@ fn index_of_with_no_arguments() {
 
 #[test]
 fn index_of_with_string_search_string_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.indexOf('hello')"), "-1");
     assert_eq!(
         forward(&mut context, "'undefined'.indexOf('undefined')"),
@@ -767,7 +767,7 @@ fn index_of_with_string_search_string_argument() {
 
 #[test]
 fn index_of_with_non_string_search_string_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.indexOf(1)"), "-1");
     assert_eq!(forward(&mut context, "'1'.indexOf(1)"), "0");
     assert_eq!(forward(&mut context, "'true'.indexOf(true)"), "0");
@@ -778,7 +778,7 @@ fn index_of_with_non_string_search_string_argument() {
 
 #[test]
 fn index_of_with_from_index_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.indexOf('x', 2)"), "-1");
     assert_eq!(forward(&mut context, "'x'.indexOf('x', 2)"), "-1");
     assert_eq!(forward(&mut context, "'abcx'.indexOf('x', 2)"), "3");
@@ -793,7 +793,7 @@ fn index_of_with_from_index_argument() {
 
 #[test]
 fn generic_index_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     forward_val(
         &mut context,
         "Number.prototype.indexOf = String.prototype.indexOf",
@@ -807,7 +807,7 @@ fn generic_index_of() {
 
 #[test]
 fn index_of_empty_search_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "''.indexOf('')"), "0");
     assert_eq!(forward(&mut context, "''.indexOf('', 10)"), "0");
@@ -818,7 +818,7 @@ fn index_of_empty_search_string() {
 
 #[test]
 fn last_index_of_with_no_arguments() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.lastIndexOf()"), "-1");
     assert_eq!(forward(&mut context, "'undefined'.lastIndexOf()"), "0");
     assert_eq!(forward(&mut context, "'a1undefined'.lastIndexOf()"), "2");
@@ -838,7 +838,7 @@ fn last_index_of_with_no_arguments() {
 
 #[test]
 fn last_index_of_with_string_search_string_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.lastIndexOf('hello')"), "-1");
     assert_eq!(
         forward(&mut context, "'undefined'.lastIndexOf('undefined')"),
@@ -873,7 +873,7 @@ fn last_index_of_with_string_search_string_argument() {
 
 #[test]
 fn last_index_of_with_non_string_search_string_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.lastIndexOf(1)"), "-1");
     assert_eq!(forward(&mut context, "'1'.lastIndexOf(1)"), "0");
     assert_eq!(forward(&mut context, "'11'.lastIndexOf(1)"), "1");
@@ -888,7 +888,7 @@ fn last_index_of_with_non_string_search_string_argument() {
 
 #[test]
 fn last_index_of_with_from_index_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.lastIndexOf('x', 2)"), "-1");
     assert_eq!(forward(&mut context, "'x'.lastIndexOf('x', 2)"), "-1");
     assert_eq!(forward(&mut context, "'abcxx'.lastIndexOf('x', 2)"), "4");
@@ -903,7 +903,7 @@ fn last_index_of_with_from_index_argument() {
 
 #[test]
 fn last_index_with_empty_search_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "''.lastIndexOf('')"), "0");
     assert_eq!(forward(&mut context, "'x'.lastIndexOf('', 2)"), "1");
     assert_eq!(forward(&mut context, "'abcxx'.lastIndexOf('', 4)"), "4");
@@ -917,7 +917,7 @@ fn last_index_with_empty_search_string() {
 
 #[test]
 fn generic_last_index_of() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     forward_val(
         &mut context,
         "Number.prototype.lastIndexOf = String.prototype.lastIndexOf",
@@ -931,7 +931,7 @@ fn generic_last_index_of() {
 
 #[test]
 fn last_index_non_integer_position_argument() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(
         forward(&mut context, "''.lastIndexOf('x', new Number(4))"),
         "-1"
@@ -953,7 +953,7 @@ fn last_index_non_integer_position_argument() {
 
 #[test]
 fn char_at() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "'abc'.charAt(-1)"), "\"\"");
     assert_eq!(forward(&mut context, "'abc'.charAt(1)"), "\"b\"");
     assert_eq!(forward(&mut context, "'abc'.charAt(9)"), "\"\"");
@@ -964,7 +964,7 @@ fn char_at() {
 
 #[test]
 fn char_code_at() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "'abc'.charCodeAt(-1)"), "NaN");
     assert_eq!(forward(&mut context, "'abc'.charCodeAt(1)"), "98");
     assert_eq!(forward(&mut context, "'abc'.charCodeAt(9)"), "NaN");
@@ -975,7 +975,7 @@ fn char_code_at() {
 
 #[test]
 fn code_point_at() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "'abc'.codePointAt(-1)"), "undefined");
     assert_eq!(forward(&mut context, "'abc'.codePointAt(1)"), "98");
     assert_eq!(forward(&mut context, "'abc'.codePointAt(9)"), "undefined");
@@ -1017,7 +1017,7 @@ fn code_point_at() {
 
 #[test]
 fn slice() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "'abc'.slice()"), "\"abc\"");
     assert_eq!(forward(&mut context, "'abc'.slice(1)"), "\"bc\"");
     assert_eq!(forward(&mut context, "'abc'.slice(-1)"), "\"c\"");
@@ -1027,7 +1027,7 @@ fn slice() {
 
 #[test]
 fn empty_iter() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let iter = new String()[Symbol.iterator]();
         let next = iter.next();
@@ -1039,7 +1039,7 @@ fn empty_iter() {
 
 #[test]
 fn ascii_iter() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let iter = new String("Hello World")[Symbol.iterator]();
         let next = iter.next();
@@ -1084,7 +1084,7 @@ fn ascii_iter() {
 
 #[test]
 fn unicode_iter() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         let iter = new String("C🙂🙂l W🙂rld")[Symbol.iterator]();
         let next = iter.next();
@@ -1126,7 +1126,7 @@ fn unicode_iter() {
 
 #[test]
 fn string_get_property() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     assert_eq!(forward(&mut context, "'abc'[-1]"), "undefined");
     assert_eq!(forward(&mut context, "'abc'[1]"), "\"b\"");
     assert_eq!(forward(&mut context, "'abc'[2]"), "\"c\"");
@@ -1137,7 +1137,7 @@ fn string_get_property() {
 
 #[test]
 fn search() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(forward(&mut context, "'aa'.search(/b/)"), "-1");
     assert_eq!(forward(&mut context, "'aa'.search(/a/)"), "0");

--- a/boa/src/builtins/symbol/tests.rs
+++ b/boa/src/builtins/symbol/tests.rs
@@ -2,7 +2,7 @@ use crate::{check_output, forward, forward_val, Context, TestAction};
 
 #[test]
 fn call_symbol_and_check_return_type() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var sym = Symbol();
         "#;
@@ -13,7 +13,7 @@ fn call_symbol_and_check_return_type() {
 
 #[test]
 fn print_symbol_expect_description() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var sym = Symbol("Hello");
         "#;

--- a/boa/src/builtins/typed_array/mod.rs
+++ b/boa/src/builtins/typed_array/mod.rs
@@ -2794,12 +2794,11 @@ impl TypedArray {
         // 6. Return name.
         Ok(this
             .as_object()
-            .map(|obj| {
+            .and_then(|obj| {
                 obj.borrow()
                     .as_typed_array()
                     .map(|o| o.typed_array_name().name().into())
             })
-            .flatten()
             .unwrap_or(JsValue::Undefined))
     }
 

--- a/boa/src/object/mod.rs
+++ b/boa/src/object/mod.rs
@@ -1387,7 +1387,7 @@ impl<'context> FunctionBuilder<'context> {
 ///
 /// ```
 /// # use boa::{Context, JsValue, object::ObjectInitializer, property::Attribute};
-/// let mut context = Context::new();
+/// let mut context = Context::default();
 /// let object = ObjectInitializer::new(&mut context)
 ///     .property(
 ///         "hello",

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -667,6 +667,8 @@ unsafe impl Trace for PropertyName {
 /// level.
 #[cfg(test)]
 fn test_formatting(source: &'static str) {
+    use crate::{syntax::Parser, Interner};
+
     // Remove preceding newline.
     let source = &source[1..];
 
@@ -680,7 +682,13 @@ fn test_formatting(source: &'static str) {
         .map(|l| &l[characters_to_remove..]) // Remove preceding whitespace from each line
         .collect::<Vec<&'static str>>()
         .join("\n");
-    let result = format!("{}", crate::parse(&scenario, false).unwrap());
+    let mut interner = Interner::new();
+    let result = format!(
+        "{}",
+        Parser::new(scenario.as_bytes(), false)
+            .parse_all(&mut interner)
+            .expect("parsing failed")
+    );
     if scenario != result {
         eprint!("========= Expected:\n{}", scenario);
         eprint!("========= Got:\n{}", result);

--- a/boa/src/syntax/lexer/comment.rs
+++ b/boa/src/syntax/lexer/comment.rs
@@ -7,6 +7,7 @@ use crate::{
         ast::{Position, Span},
         lexer::{Token, TokenKind},
     },
+    Interner,
 };
 use core::convert::TryFrom;
 use std::io::Read;
@@ -24,7 +25,12 @@ use std::io::Read;
 pub(super) struct SingleLineComment;
 
 impl<R> Tokenizer<R> for SingleLineComment {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -59,7 +65,12 @@ impl<R> Tokenizer<R> for SingleLineComment {
 pub(super) struct MultiLineComment;
 
 impl<R> Tokenizer<R> for MultiLineComment {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -103,7 +114,12 @@ impl<R> Tokenizer<R> for MultiLineComment {
 pub(super) struct HashbangComment;
 
 impl<R> Tokenizer<R> for HashbangComment {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {

--- a/boa/src/syntax/lexer/identifier.rs
+++ b/boa/src/syntax/lexer/identifier.rs
@@ -7,6 +7,7 @@ use crate::{
         ast::{Keyword, Position, Span},
         lexer::{StringLiteral, Token, TokenKind},
     },
+    Interner,
 };
 use boa_unicode::UnicodeProperties;
 use core::convert::TryFrom;
@@ -80,7 +81,12 @@ impl Identifier {
 }
 
 impl<R> Tokenizer<R> for Identifier {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -123,7 +129,7 @@ impl<R> Tokenizer<R> for Identifier {
                     start_pos,
                 ));
             }
-            TokenKind::identifier(identifier_name.into_boxed_str())
+            TokenKind::identifier(interner.get_or_intern(identifier_name))
         };
 
         Ok(Token::new(token_kind, Span::new(start_pos, cursor.pos())))

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -40,8 +40,11 @@ use self::{
     string::StringLiteral,
     template::TemplateLiteral,
 };
-use crate::syntax::ast::{Punctuator, Span};
 pub use crate::{profiler::BoaProfiler, syntax::ast::Position};
+use crate::{
+    syntax::ast::{Punctuator, Span},
+    Interner,
+};
 use core::convert::TryFrom;
 pub use error::Error;
 use std::io::Read;
@@ -49,7 +52,12 @@ pub use token::{Token, TokenKind};
 
 trait Tokenizer<R> {
     /// Lexes the next token.
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read;
 }
@@ -120,7 +128,11 @@ impl<R> Lexer<R> {
     // that means it could be multiple different tokens depending on the input token.
     //
     // As per https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar
-    pub(crate) fn lex_slash_token(&mut self, start: Position) -> Result<Token, Error>
+    pub(crate) fn lex_slash_token(
+        &mut self,
+        start: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -130,11 +142,11 @@ impl<R> Lexer<R> {
             match c {
                 b'/' => {
                     self.cursor.next_byte()?.expect("/ token vanished"); // Consume the '/'
-                    SingleLineComment.lex(&mut self.cursor, start)
+                    SingleLineComment.lex(&mut self.cursor, start, interner)
                 }
                 b'*' => {
                     self.cursor.next_byte()?.expect("* token vanished"); // Consume the '*'
-                    MultiLineComment.lex(&mut self.cursor, start)
+                    MultiLineComment.lex(&mut self.cursor, start, interner)
                 }
                 ch => {
                     match self.get_goal() {
@@ -157,7 +169,7 @@ impl<R> Lexer<R> {
                         }
                         InputElement::RegExp => {
                             // Can be a regular expression.
-                            RegexLiteral.lex(&mut self.cursor, start)
+                            RegexLiteral.lex(&mut self.cursor, start, interner)
                         }
                     }
                 }
@@ -173,7 +185,7 @@ impl<R> Lexer<R> {
     /// Retrieves the next token from the lexer.
     // We intentionally don't implement Iterator trait as Result<Option> is cleaner to handle.
     #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> Result<Option<Token>, Error>
+    pub fn next(&mut self, interner: &mut Interner) -> Result<Option<Token>, Error>
     where
         R: Read,
     {
@@ -196,8 +208,8 @@ impl<R> Lexer<R> {
         if start.column_number() == 1 && start.line_number() == 1 && next_ch == 0x23 {
             if let Some(hashbang_peek) = self.cursor.peek()? {
                 if hashbang_peek == 0x21 {
-                    let _token = HashbangComment.lex(&mut self.cursor, start);
-                    return self.next();
+                    let _token = HashbangComment.lex(&mut self.cursor, start, interner);
+                    return self.next(interner);
                 }
             }
         };
@@ -208,8 +220,8 @@ impl<R> Lexer<R> {
                     TokenKind::LineTerminator,
                     Span::new(start, self.cursor.pos()),
                 )),
-                '"' | '\'' => StringLiteral::new(c).lex(&mut self.cursor, start),
-                '`' => TemplateLiteral.lex(&mut self.cursor, start),
+                '"' | '\'' => StringLiteral::new(c).lex(&mut self.cursor, start, interner),
+                '`' => TemplateLiteral.lex(&mut self.cursor, start, interner),
                 ';' => Ok(Token::new(
                     Punctuator::Semicolon.into(),
                     Span::new(start, self.cursor.pos()),
@@ -220,9 +232,9 @@ impl<R> Lexer<R> {
                 )),
                 '.' => {
                     if self.cursor.peek()?.map(|c| (b'0'..=b'9').contains(&c)) == Some(true) {
-                        NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start)
+                        NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start, interner)
                     } else {
-                        SpreadLiteral::new().lex(&mut self.cursor, start)
+                        SpreadLiteral::new().lex(&mut self.cursor, start, interner)
                     }
                 }
                 '(' => Ok(Token::new(
@@ -253,18 +265,18 @@ impl<R> Lexer<R> {
                     Punctuator::CloseBracket.into(),
                     Span::new(start, self.cursor.pos()),
                 )),
-                '/' => self.lex_slash_token(start),
+                '/' => self.lex_slash_token(start, interner),
                 '=' | '*' | '+' | '-' | '%' | '|' | '&' | '^' | '<' | '>' | '!' | '~' | '?' => {
-                    Operator::new(next_ch as u8).lex(&mut self.cursor, start)
+                    Operator::new(next_ch as u8).lex(&mut self.cursor, start, interner)
                 }
                 '\\' if self.cursor.peek()? == Some(b'u') => {
-                    Identifier::new(c).lex(&mut self.cursor, start)
+                    Identifier::new(c).lex(&mut self.cursor, start, interner)
                 }
                 _ if Identifier::is_identifier_start(c as u32) => {
-                    Identifier::new(c).lex(&mut self.cursor, start)
+                    Identifier::new(c).lex(&mut self.cursor, start, interner)
                 }
                 _ if c.is_digit(10) => {
-                    NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start)
+                    NumberLiteral::new(next_ch as u8).lex(&mut self.cursor, start, interner)
                 }
                 _ => {
                     let details = format!(
@@ -279,7 +291,7 @@ impl<R> Lexer<R> {
 
             if token.kind() == &TokenKind::Comment {
                 // Skip comment
-                self.next()
+                self.next(interner)
             } else {
                 Ok(Some(token))
             }
@@ -296,11 +308,16 @@ impl<R> Lexer<R> {
         }
     }
 
-    pub(crate) fn lex_template(&mut self, start: Position) -> Result<Token, Error>
+    /// Performs the lexing of a template literal.
+    pub(crate) fn lex_template(
+        &mut self,
+        start: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
-        TemplateLiteral.lex(&mut self.cursor, start)
+        TemplateLiteral.lex(&mut self.cursor, start, interner)
     }
 }
 

--- a/boa/src/syntax/lexer/number.rs
+++ b/boa/src/syntax/lexer/number.rs
@@ -7,7 +7,7 @@ use crate::{
         ast::{Position, Span},
         lexer::{token::Numeric, Token},
     },
-    JsBigInt,
+    Interner, JsBigInt,
 };
 use std::io::Read;
 use std::str;
@@ -178,7 +178,12 @@ where
 }
 
 impl<R> Tokenizer<R> for NumberLiteral {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {

--- a/boa/src/syntax/lexer/operator.rs
+++ b/boa/src/syntax/lexer/operator.rs
@@ -2,6 +2,7 @@
 
 use super::{Cursor, Error, Tokenizer};
 use crate::syntax::lexer::TokenKind;
+use crate::Interner;
 use crate::{
     profiler::BoaProfiler,
     syntax::{
@@ -94,7 +95,12 @@ impl Operator {
 }
 
 impl<R> Tokenizer<R> for Operator {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {

--- a/boa/src/syntax/lexer/regex.rs
+++ b/boa/src/syntax/lexer/regex.rs
@@ -7,6 +7,7 @@ use crate::{
         ast::Position,
         lexer::{Token, TokenKind},
     },
+    Interner,
 };
 use bitflags::bitflags;
 use std::io::{self, ErrorKind};
@@ -35,7 +36,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 pub(super) struct RegexLiteral;
 
 impl<R> Tokenizer<R> for RegexLiteral {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -115,7 +121,7 @@ impl<R> Tokenizer<R> for RegexLiteral {
         if let Ok(body_str) = str::from_utf8(body.as_slice()) {
             Ok(Token::new(
                 TokenKind::regular_expression_literal(
-                    body_str,
+                    interner.get_or_intern(body_str),
                     parse_regex_flags(flags_str, flags_start)?,
                 ),
                 Span::new(start_pos, cursor.pos()),

--- a/boa/src/syntax/lexer/spread.rs
+++ b/boa/src/syntax/lexer/spread.rs
@@ -7,6 +7,7 @@ use crate::{
         ast::{Position, Punctuator, Span},
         lexer::Token,
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -31,7 +32,12 @@ impl SpreadLiteral {
 }
 
 impl<R> Tokenizer<R> for SpreadLiteral {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        _interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {

--- a/boa/src/syntax/lexer/string.rs
+++ b/boa/src/syntax/lexer/string.rs
@@ -7,6 +7,7 @@ use crate::{
         ast::{Position, Span},
         lexer::{Token, TokenKind},
     },
+    Interner,
 };
 use std::{
     io::{self, ErrorKind, Read},
@@ -77,7 +78,12 @@ impl UTF16CodeUnitsBuffer for Vec<u16> {
 }
 
 impl<R> Tokenizer<R> for StringLiteral {
-    fn lex(&mut self, cursor: &mut Cursor<R>, start_pos: Position) -> Result<Token, Error>
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
     where
         R: Read,
     {
@@ -86,7 +92,10 @@ impl<R> Tokenizer<R> for StringLiteral {
         let (lit, span) =
             Self::take_string_characters(cursor, start_pos, self.terminator, cursor.strict_mode())?;
 
-        Ok(Token::new(TokenKind::string_literal(lit), span))
+        Ok(Token::new(
+            TokenKind::string_literal(interner.get_or_intern(lit)),
+            span,
+        ))
     }
 }
 

--- a/boa/src/syntax/lexer/tests.rs
+++ b/boa/src/syntax/lexer/tests.rs
@@ -13,16 +13,16 @@ fn span(start: (u32, u32), end: (u32, u32)) -> Span {
     Span::new(Position::new(start.0, start.1), Position::new(end.0, end.1))
 }
 
-fn expect_tokens<R>(lexer: &mut Lexer<R>, expected: &[TokenKind])
+fn expect_tokens<R>(lexer: &mut Lexer<R>, expected: &[TokenKind], interner: &mut Interner)
 where
     R: Read,
 {
     for expect in expected.iter() {
-        assert_eq!(&lexer.next().unwrap().unwrap().kind(), &expect);
+        assert_eq!(&lexer.next(interner).unwrap().unwrap().kind(), &expect);
     }
 
     assert!(
-        lexer.next().unwrap().is_none(),
+        lexer.next(interner).unwrap().is_none(),
         "Unexpected extra token lexed at end of input"
     );
 }
@@ -31,6 +31,7 @@ where
 fn check_single_line_comment() {
     let s1 = "var \n//This is a comment\ntrue";
     let mut lexer = Lexer::new(s1.as_bytes());
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::Keyword(Keyword::Var),
@@ -39,13 +40,14 @@ fn check_single_line_comment() {
         TokenKind::BooleanLiteral(true),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn check_single_line_comment_with_crlf_ending() {
     let s1 = "var \r\n//This is a comment\r\ntrue";
     let mut lexer = Lexer::new(s1.as_bytes());
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::Keyword(Keyword::Var),
@@ -54,44 +56,47 @@ fn check_single_line_comment_with_crlf_ending() {
         TokenKind::BooleanLiteral(true),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn check_multi_line_comment() {
     let s = "var /* await \n break \n*/ x";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
+    let sym = interner.get_or_intern_static("x");
     let expected = [
         TokenKind::Keyword(Keyword::Var),
         TokenKind::LineTerminator,
-        TokenKind::identifier("x"),
+        TokenKind::identifier(sym),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn check_identifier() {
     let s = "x x1 _x $x __ $$ Ѐ ЀЀ x\u{200C}\u{200D} \\u0078 \\u0078\\u0078 \\u{0078}x\\u{0078}";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     let expected = [
-        TokenKind::identifier("x"),
-        TokenKind::identifier("x1"),
-        TokenKind::identifier("_x"),
-        TokenKind::identifier("$x"),
-        TokenKind::identifier("__"),
-        TokenKind::identifier("$$"),
-        TokenKind::identifier("Ѐ"),
-        TokenKind::identifier("ЀЀ"),
-        TokenKind::identifier("x\u{200C}\u{200D}"),
-        TokenKind::identifier("x"),
-        TokenKind::identifier("xx"),
-        TokenKind::identifier("xxx"),
+        TokenKind::identifier(interner.get_or_intern_static("x")),
+        TokenKind::identifier(interner.get_or_intern_static("x1")),
+        TokenKind::identifier(interner.get_or_intern_static("_x")),
+        TokenKind::identifier(interner.get_or_intern_static("$x")),
+        TokenKind::identifier(interner.get_or_intern_static("__")),
+        TokenKind::identifier(interner.get_or_intern_static("$$")),
+        TokenKind::identifier(interner.get_or_intern_static("Ѐ")),
+        TokenKind::identifier(interner.get_or_intern_static("ЀЀ")),
+        TokenKind::identifier(interner.get_or_intern_static("x\u{200C}\u{200D}")),
+        TokenKind::identifier(interner.get_or_intern_static("x")),
+        TokenKind::identifier(interner.get_or_intern_static("xx")),
+        TokenKind::identifier(interner.get_or_intern_static("xxx")),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -100,8 +105,9 @@ fn check_invalid_identifier_start() {
 
     for s in invalid_identifier_starts.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
         lexer
-            .next()
+            .next(&mut interner)
             .expect_err("Invalid identifier start not rejected as expected");
     }
 }
@@ -109,13 +115,16 @@ fn check_invalid_identifier_start() {
 #[test]
 fn check_invalid_identifier_part() {
     let invalid_identifier_parts = [" ", "\n", ".", "*", "😀", "\u{007F}"];
+    let mut interner = Interner::new();
 
+    let sym = interner.get_or_intern_static("x");
     for part in invalid_identifier_parts.iter() {
         let s = String::from("x") + part;
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
         assert_eq!(
-            lexer.next().unwrap().unwrap().kind(),
-            &TokenKind::identifier("x")
+            lexer.next(&mut interner).unwrap().unwrap().kind(),
+            &TokenKind::identifier(sym)
         );
     }
 }
@@ -124,26 +133,29 @@ fn check_invalid_identifier_part() {
 fn check_string() {
     let s = "'aaa' \"bbb\"";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
+    let a_sym = interner.get_or_intern_static("aaa");
+    let b_sym = interner.get_or_intern_static("bbb");
     let expected = [
-        TokenKind::string_literal("aaa"),
-        TokenKind::string_literal("bbb"),
+        TokenKind::string_literal(a_sym),
+        TokenKind::string_literal(b_sym),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn check_template_literal_simple() {
     let s = "`I'm a template literal`";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
+
+    let sym = interner.get_or_intern_static("I'm a template literal");
 
     assert_eq!(
-        lexer.next().unwrap().unwrap().kind(),
-        &TokenKind::template_no_substitution(TemplateString::new(
-            "I'm a template literal",
-            Position::new(1, 1)
-        ))
+        lexer.next(&mut interner).unwrap().unwrap().kind(),
+        &TokenKind::template_no_substitution(TemplateString::new(sym, Position::new(1, 1)))
     );
 }
 
@@ -151,9 +163,10 @@ fn check_template_literal_simple() {
 fn check_template_literal_unterminated() {
     let s = "`I'm a template";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     lexer
-        .next()
+        .next(&mut interner)
         .expect_err("Lexer did not handle unterminated literal with error");
 }
 
@@ -164,6 +177,7 @@ fn check_punctuators() {
              + - * % -- << >> >>> & | ^ ! ~ && || ? : \
              = += -= *= &= **= ++ ** <<= >>= >>>= &= |= ^= => ?? ??= &&= ||=";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::Punctuator(Punctuator::OpenBlock),
@@ -221,7 +235,7 @@ fn check_punctuators() {
         TokenKind::Punctuator(Punctuator::AssignBoolOr),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -232,6 +246,7 @@ fn check_keywords() {
              new return super switch this throw try typeof var void while with yield";
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::Keyword(Keyword::Await),
@@ -270,23 +285,26 @@ fn check_keywords() {
         TokenKind::Keyword(Keyword::Yield),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn check_variable_definition_tokens() {
     let s = "let a = 'hello';";
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
+    let a_sym = interner.get_or_intern_static("a");
+    let hello_sym = interner.get_or_intern_static("hello");
     let expected = [
         TokenKind::Keyword(Keyword::Let),
-        TokenKind::identifier("a"),
+        TokenKind::identifier(a_sym),
         TokenKind::Punctuator(Punctuator::Assign),
-        TokenKind::string_literal("hello"),
+        TokenKind::string_literal(hello_sym),
         TokenKind::Punctuator(Punctuator::Semicolon),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -294,37 +312,47 @@ fn check_positions() {
     let s = r#"console.log("hello world"); // Test"#;
     // --------123456789
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     // The first column is 1 (not zero indexed)
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 1), (1, 8)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 1), (1, 8))
+    );
 
     // Dot Token starts on column 8
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 8), (1, 9)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 8), (1, 9))
+    );
 
     // Log Token starts on column 9
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 9), (1, 12)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 9), (1, 12))
+    );
 
     // Open parenthesis token starts on column 12
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 12), (1, 13))
     );
 
     // String token starts on column 13
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 13), (1, 26))
     );
 
     // Close parenthesis token starts on column 26.
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 26), (1, 27))
     );
 
     // Semi Colon token starts on column 35
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 27), (1, 28))
     );
 }
@@ -334,37 +362,47 @@ fn check_positions_codepoint() {
     let s = r#"console.log("hello world\u{2764}"); // Test"#;
     // --------123456789
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
     // The first column is 1 (not zero indexed)
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 1), (1, 8)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 1), (1, 8))
+    );
 
     // Dot Token starts on column 8
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 8), (1, 9)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 8), (1, 9))
+    );
 
     // Log Token starts on column 9
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 9), (1, 12)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 9), (1, 12))
+    );
 
     // Open parenthesis token starts on column 12
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 12), (1, 13))
     );
 
     // String token starts on column 13
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 13), (1, 34))
     );
 
     // Close parenthesis token starts on column 34
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 34), (1, 35))
     );
 
     // Semi Colon token starts on column 35
     assert_eq!(
-        lexer.next().unwrap().unwrap().span(),
+        lexer.next(&mut interner).unwrap().unwrap().span(),
         span((1, 35), (1, 36))
     );
 }
@@ -374,11 +412,24 @@ fn check_line_numbers() {
     let s = "x\ny\n";
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 1), (1, 2)));
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((1, 2), (2, 1)));
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((2, 1), (2, 2)));
-    assert_eq!(lexer.next().unwrap().unwrap().span(), span((2, 2), (3, 1)));
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 1), (1, 2))
+    );
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((1, 2), (2, 1))
+    );
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((2, 1), (2, 2))
+    );
+    assert_eq!(
+        lexer.next(&mut interner).unwrap().unwrap().span(),
+        span((2, 2), (3, 1))
+    );
 }
 
 // Increment/Decrement
@@ -386,20 +437,21 @@ fn check_line_numbers() {
 fn check_decrement_advances_lexer_2_places() {
     // Here we want an example of decrementing an integer
     let mut lexer = Lexer::new(&b"let a = b--;"[..]);
+    let mut interner = Interner::new();
 
     for _ in 0..4 {
-        lexer.next().unwrap();
+        lexer.next(&mut interner).unwrap();
     }
 
     assert_eq!(
-        lexer.next().unwrap().unwrap().kind(),
+        lexer.next(&mut interner).unwrap().unwrap().kind(),
         &TokenKind::Punctuator(Punctuator::Dec)
     );
     // Decrementing means adding 2 characters '--', the lexer should consume it as a single token
     // and move the curser forward by 2, meaning the next token should be a semicolon
 
     assert_eq!(
-        lexer.next().unwrap().unwrap().kind(),
+        lexer.next(&mut interner).unwrap().unwrap().kind(),
         &TokenKind::Punctuator(Punctuator::Semicolon)
     );
 }
@@ -407,10 +459,11 @@ fn check_decrement_advances_lexer_2_places() {
 #[test]
 fn single_int() {
     let mut lexer = Lexer::new(&b"52"[..]);
+    let mut interner = Interner::new();
 
     let expected = [TokenKind::numeric_literal(52)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -419,6 +472,7 @@ fn numbers() {
         "1 2 0x34 056 7.89 42. 5e3 5e+3 5e-3 0b10 0O123 0999 1.0e1 1.0e-1 1.0E1 1E1 0.0 0.12 -32"
             .as_bytes(),
     );
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
@@ -443,7 +497,7 @@ fn numbers() {
         TokenKind::numeric_literal(32),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -451,6 +505,7 @@ fn numbers_with_separators() {
     let mut lexer = Lexer::new(
         "1_0 2_0 0x3_4 056 7.8_9 4_2. 5_0e2 5_0e+2 5_0e-4 0b1_0 1_0.0_0e2 1.0E-0_1 -3_2".as_bytes(),
     );
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(10),
@@ -469,7 +524,7 @@ fn numbers_with_separators() {
         TokenKind::numeric_literal(32),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -480,13 +535,15 @@ fn numbers_with_bad_separators() {
 
     for n in numbers.iter() {
         let mut lexer = Lexer::new(n.as_bytes());
-        assert!(lexer.next().is_err());
+        let mut interner = Interner::new();
+        assert!(lexer.next(&mut interner).is_err());
     }
 }
 
 #[test]
 fn big_exp_numbers() {
     let mut lexer = Lexer::new(&b"1.0e25 1.0e36 9.0e50"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(10000000000000000000000000.0),
@@ -494,22 +551,24 @@ fn big_exp_numbers() {
         TokenKind::numeric_literal(900000000000000000000000000000000000000000000000000.0),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 #[ignore]
 fn big_literal_numbers() {
     let mut lexer = Lexer::new(&b"10000000000000000000000000"[..]);
+    let mut interner = Interner::new();
 
     let expected = [TokenKind::numeric_literal(10000000000000000000000000.0)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn implicit_octal_edge_case() {
     let mut lexer = Lexer::new(&b"044.5 094.5"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(36),
@@ -517,27 +576,31 @@ fn implicit_octal_edge_case() {
         TokenKind::numeric_literal(94.5),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn hexadecimal_edge_case() {
     let mut lexer = Lexer::new(&b"0xffff.ff 0xffffff"[..]);
+    let mut interner = Interner::new();
 
+    let sym = interner.get_or_intern_static("ff");
     let expected = [
         TokenKind::numeric_literal(0xffff),
         TokenKind::Punctuator(Punctuator::Dot),
-        TokenKind::identifier("ff"),
+        TokenKind::identifier(sym),
         TokenKind::numeric_literal(0x00ff_ffff),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn single_number_without_semicolon() {
     let mut lexer = Lexer::new(&b"1"[..]);
-    if let Some(x) = lexer.next().unwrap() {
+    let mut interner = Interner::new();
+
+    if let Some(x) = lexer.next(&mut interner).unwrap() {
         assert_eq!(x.kind(), &TokenKind::numeric_literal(Numeric::Integer(1)));
     } else {
         panic!("Failed to lex 1 without semicolon");
@@ -547,47 +610,50 @@ fn single_number_without_semicolon() {
 #[test]
 fn number_followed_by_dot() {
     let mut lexer = Lexer::new(&b"1.."[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
         TokenKind::Punctuator(Punctuator::Dot),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn regex_literal() {
     let mut lexer = Lexer::new(&b"/(?:)/"[..]);
+    let mut interner = Interner::new();
 
+    let sym = interner.get_or_intern_static("(?:)");
     let expected = [TokenKind::regular_expression_literal(
-        "(?:)",
+        sym,
         RegExpFlags::default(),
     )];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn regex_literal_flags() {
     let mut lexer = Lexer::new(&br"/\/[^\/]*\/*/gmi"[..]);
+    let mut interner = Interner::new();
 
     let mut flags = RegExpFlags::default();
     flags.insert(RegExpFlags::GLOBAL);
     flags.insert(RegExpFlags::MULTILINE);
     flags.insert(RegExpFlags::IGNORE_CASE);
 
-    let expected = [TokenKind::regular_expression_literal(
-        "\\/[^\\/]*\\/*",
-        flags,
-    )];
+    let sym = interner.get_or_intern_static("\\/[^\\/]*\\/*");
+    let expected = [TokenKind::regular_expression_literal(sym, flags)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces() {
     let mut lexer = Lexer::new(&b"1+1"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
@@ -595,12 +661,13 @@ fn addition_no_spaces() {
         TokenKind::numeric_literal(1),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces_left_side() {
     let mut lexer = Lexer::new(&b"1+ 1"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
@@ -608,12 +675,13 @@ fn addition_no_spaces_left_side() {
         TokenKind::numeric_literal(1),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces_right_side() {
     let mut lexer = Lexer::new(&b"1 +1"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
@@ -621,12 +689,13 @@ fn addition_no_spaces_right_side() {
         TokenKind::numeric_literal(1),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces_e_number_left_side() {
     let mut lexer = Lexer::new(&b"1e2+ 1"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(100),
@@ -634,12 +703,13 @@ fn addition_no_spaces_e_number_left_side() {
         TokenKind::numeric_literal(1),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces_e_number_right_side() {
     let mut lexer = Lexer::new(&b"1 +1e3"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1),
@@ -647,12 +717,13 @@ fn addition_no_spaces_e_number_right_side() {
         TokenKind::numeric_literal(1000),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn addition_no_spaces_e_number() {
     let mut lexer = Lexer::new(&b"1e3+1e11"[..]);
+    let mut interner = Interner::new();
 
     let expected = [
         TokenKind::numeric_literal(1000),
@@ -660,7 +731,7 @@ fn addition_no_spaces_e_number() {
         TokenKind::numeric_literal(100_000_000_000.0),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -769,8 +840,10 @@ fn illegal_following_numeric_literal() {
 
     // Decimal Digit
     let mut lexer = Lexer::new(&b"11.6n3"[..]);
+    let mut interner = Interner::new();
+
     let err = lexer
-        .next()
+        .next(&mut interner)
         .expect_err("DecimalDigit following NumericLiteral not rejected as expected");
     if let Error::Syntax(_, pos) = err {
         assert_eq!(pos, Position::new(1, 5))
@@ -780,8 +853,10 @@ fn illegal_following_numeric_literal() {
 
     // Identifier Start
     let mut lexer = Lexer::new(&b"17.4$"[..]);
+    let mut interner = Interner::new();
+
     if let Error::Syntax(_, pos) = lexer
-        .next()
+        .next(&mut interner)
         .expect_err("IdentifierStart '$' following NumericLiteral not rejected as expected")
     {
         assert_eq!(pos, Position::new(1, 5));
@@ -790,8 +865,10 @@ fn illegal_following_numeric_literal() {
     }
 
     let mut lexer = Lexer::new(&b"17.4_"[..]);
+    let mut interner = Interner::new();
+
     if let Error::Syntax(_, pos) = lexer
-        .next()
+        .next(&mut interner)
         .expect_err("IdentifierStart '_' following NumericLiteral not rejected as expected")
     {
         assert_eq!(pos, Position::new(1, 5));
@@ -803,7 +880,9 @@ fn illegal_following_numeric_literal() {
 #[test]
 fn string_codepoint_with_no_braces() {
     let mut lexer = Lexer::new(&br#""test\uD38Dtest""#[..]);
-    assert!(lexer.next().is_ok());
+    let mut interner = Interner::new();
+
+    assert!(lexer.next(&mut interner).is_ok());
 }
 
 #[test]
@@ -812,8 +891,10 @@ fn illegal_code_point_following_numeric_literal() {
     // Checks as per https://tc39.es/ecma262/#sec-literals-numeric-literals that a NumericLiteral cannot
     // be immediately followed by an IdentifierStart where the IdentifierStart
     let mut lexer = Lexer::new(&br#"17.4\u{2764}"#[..]);
+    let mut interner = Interner::new();
+
     assert!(
-        lexer.next().is_err(),
+        lexer.next(&mut interner).is_err(),
         "{}",
         r#"IdentifierStart \u{2764} following NumericLiteral not rejected as expected"#
     );
@@ -824,27 +905,31 @@ fn string_unicode() {
     let s = r#"'中文';"#;
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
+    let sym = interner.get_or_intern_static("中文");
     let expected = [
-        TokenKind::StringLiteral("中文".into()),
+        TokenKind::StringLiteral(sym),
         TokenKind::Punctuator(Punctuator::Semicolon),
     ];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
 fn string_unicode_escape_with_braces() {
     let mut lexer = Lexer::new(&br#"'{\u{20ac}\u{a0}\u{a0}}'"#[..]);
+    let mut interner = Interner::new();
 
-    let expected = [TokenKind::StringLiteral("{\u{20ac}\u{a0}\u{a0}}".into())];
+    let sym = interner.get_or_intern_static("{\u{20ac}\u{a0}\u{a0}}");
+    let expected = [TokenKind::StringLiteral(sym)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 
     lexer = Lexer::new(&br#"\u{{a0}"#[..]);
 
     if let Error::Syntax(_, pos) = lexer
-        .next()
+        .next(&mut interner)
         .expect_err("Malformed Unicode character sequence expected")
     {
         assert_eq!(pos, Position::new(1, 1));
@@ -855,7 +940,7 @@ fn string_unicode_escape_with_braces() {
     lexer = Lexer::new(&br#"\u{{a0}}"#[..]);
 
     if let Error::Syntax(_, pos) = lexer
-        .next()
+        .next(&mut interner)
         .expect_err("Malformed Unicode character sequence expected")
     {
         assert_eq!(pos, Position::new(1, 1));
@@ -869,10 +954,12 @@ fn string_unicode_escape_with_braces_2() {
     let s = r#"'\u{20ac}\u{a0}\u{a0}'"#;
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
-    let expected = [TokenKind::StringLiteral("\u{20ac}\u{a0}\u{a0}".into())];
+    let sym = interner.get_or_intern_static("\u{20ac}\u{a0}\u{a0}");
+    let expected = [TokenKind::StringLiteral(sym)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -880,10 +967,12 @@ fn string_with_single_escape() {
     let s = r#"'\Б'"#;
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
-    let expected = [TokenKind::StringLiteral("Б".into())];
+    let sym = interner.get_or_intern_static("Б");
+    let expected = [TokenKind::StringLiteral(sym)];
 
-    expect_tokens(&mut lexer, &expected);
+    expect_tokens(&mut lexer, &expected, &mut interner);
 }
 
 #[test]
@@ -900,18 +989,21 @@ fn string_legacy_octal_escape() {
 
     for (s, expected) in test_cases.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
 
-        let expected_tokens = [TokenKind::StringLiteral((*expected).into())];
+        let sym = interner.get_or_intern(expected);
+        let expected_tokens = [TokenKind::StringLiteral(sym)];
 
-        expect_tokens(&mut lexer, &expected_tokens);
+        expect_tokens(&mut lexer, &expected_tokens, &mut interner);
     }
 
     for (s, _) in test_cases.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
         lexer.set_strict_mode(true);
 
         if let Error::Syntax(_, pos) = lexer
-            .next()
+            .next(&mut interner)
             .expect_err("Octal-escape in strict mode not rejected as expected")
         {
             assert_eq!(pos, Position::new(1, 2));
@@ -927,10 +1019,12 @@ fn string_zero_escape() {
 
     for (s, expected) in test_cases.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
 
-        let expected_tokens = [TokenKind::StringLiteral((*expected).into())];
+        let sym = interner.get_or_intern(expected);
+        let expected_tokens = [TokenKind::StringLiteral(sym)];
 
-        expect_tokens(&mut lexer, &expected_tokens);
+        expect_tokens(&mut lexer, &expected_tokens, &mut interner);
     }
 }
 
@@ -940,18 +1034,21 @@ fn string_non_octal_decimal_escape() {
 
     for (s, expected) in test_cases.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
 
-        let expected_tokens = [TokenKind::StringLiteral((*expected).into())];
+        let sym = interner.get_or_intern(expected);
+        let expected_tokens = [TokenKind::StringLiteral(sym)];
 
-        expect_tokens(&mut lexer, &expected_tokens);
+        expect_tokens(&mut lexer, &expected_tokens, &mut interner);
     }
 
     for (s, _) in test_cases.iter() {
         let mut lexer = Lexer::new(s.as_bytes());
+        let mut interner = Interner::new();
         lexer.set_strict_mode(true);
 
         if let Error::Syntax(_, pos) = lexer
-            .next()
+            .next(&mut interner)
             .expect_err("Non-octal-decimal-escape in strict mode not rejected as expected")
         {
             assert_eq!(pos, Position::new(1, 2));
@@ -966,10 +1063,12 @@ fn string_line_continuation() {
     let s = "'hello \\\nworld'";
 
     let mut lexer = Lexer::new(s.as_bytes());
+    let mut interner = Interner::new();
 
-    let expected_tokens = [TokenKind::StringLiteral("hello world".into())];
+    let sym = interner.get_or_intern_static("hello world");
+    let expected_tokens = [TokenKind::StringLiteral(sym)];
 
-    expect_tokens(&mut lexer, &expected_tokens);
+    expect_tokens(&mut lexer, &expected_tokens, &mut interner);
 }
 
 mod carriage_return {
@@ -977,6 +1076,7 @@ mod carriage_return {
 
     fn expect_tokens_with_lines(lines: usize, src: &str) {
         let mut lexer = Lexer::new(src.as_bytes());
+        let mut interner = Interner::new();
 
         let mut expected = Vec::with_capacity(lines + 2);
         expected.push(TokenKind::Punctuator(Punctuator::Sub));
@@ -985,7 +1085,7 @@ mod carriage_return {
         }
         expected.push(TokenKind::NumericLiteral(Numeric::Integer(3)));
 
-        expect_tokens(&mut lexer, &expected);
+        expect_tokens(&mut lexer, &expected, &mut interner);
     }
 
     #[test]

--- a/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
@@ -1,199 +1,206 @@
 use super::BufferedLexer;
-use crate::syntax::lexer::{Token, TokenKind};
+use crate::{
+    syntax::lexer::{Token, TokenKind},
+    Interner,
+};
 
 #[test]
 fn peek_skip_accending() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
+    let mut interner = Interner::new();
 
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("b")
+        TokenKind::identifier(interner.get_or_intern_static("b"))
     );
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("b")
+        TokenKind::identifier(interner.get_or_intern_static("b"))
     );
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
 }
 
 #[test]
 fn peek_skip_next() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
+    let mut interner = Interner::new();
 
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("b")
+        TokenKind::identifier(interner.get_or_intern_static("b"))
     );
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("b")
+        TokenKind::identifier(interner.get_or_intern_static("b"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("d")
+        TokenKind::identifier(interner.get_or_intern_static("d"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("e")
+        TokenKind::identifier(interner.get_or_intern_static("e"))
     );
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("f")
+        TokenKind::identifier(interner.get_or_intern_static("f"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("g")
+        TokenKind::identifier(interner.get_or_intern_static("g"))
     );
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("h")
+        TokenKind::identifier(interner.get_or_intern_static("h"))
     );
 }
 
 #[test]
 fn peek_skip_next_alternating() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
+    let mut interner = Interner::new();
 
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("a")
+        TokenKind::identifier(interner.get_or_intern_static("a"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("b")
+        TokenKind::identifier(interner.get_or_intern_static("b"))
     );
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("d")
+        TokenKind::identifier(interner.get_or_intern_static("d"))
     );
     assert_eq!(
-        *cur.next(false)
+        *cur.next(false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("c")
+        TokenKind::identifier(interner.get_or_intern_static("c"))
     );
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("f")
+        TokenKind::identifier(interner.get_or_intern_static("f"))
     );
 }
 
 #[test]
 fn peek_next_till_end() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
+    let mut interner = Interner::new();
 
     loop {
-        let peek = cur.peek(0, false).unwrap().cloned();
-        let next = cur.next(false).unwrap();
+        let peek = cur.peek(0, false, &mut interner).unwrap().cloned();
+        let next = cur.next(false, &mut interner).unwrap();
 
         assert_eq!(peek, next);
 
@@ -206,17 +213,18 @@ fn peek_next_till_end() {
 #[test]
 fn peek_skip_next_till_end() {
     let mut cur = BufferedLexer::from(&b"a b c d e f g h i"[..]);
+    let mut interner = Interner::new();
 
     let mut peeked: [Option<Token>; super::MAX_PEEK_SKIP + 1] =
         [None::<Token>, None::<Token>, None::<Token>, None::<Token>];
 
     loop {
         for (i, peek) in peeked.iter_mut().enumerate() {
-            *peek = cur.peek(i, false).unwrap().cloned();
+            *peek = cur.peek(i, false, &mut interner).unwrap().cloned();
         }
 
         for peek in &peeked {
-            assert_eq!(&cur.next(false).unwrap(), peek);
+            assert_eq!(&cur.next(false, &mut interner).unwrap(), peek);
         }
 
         if peeked[super::MAX_PEEK_SKIP - 1].is_none() {
@@ -228,43 +236,45 @@ fn peek_skip_next_till_end() {
 #[test]
 fn skip_peeked_terminators() {
     let mut cur = BufferedLexer::from(&b"A \n B"[..]);
+    let mut interner = Interner::new();
+
     assert_eq!(
-        *cur.peek(0, false)
+        *cur.peek(0, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("A")
+        TokenKind::identifier(interner.get_or_intern_static("A"))
     );
     assert_eq!(
-        *cur.peek(0, true)
+        *cur.peek(0, true, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("A")
+        TokenKind::identifier(interner.get_or_intern_static("A"))
     );
 
     assert_eq!(
-        *cur.peek(1, false)
+        *cur.peek(1, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
         TokenKind::LineTerminator,
     );
     assert_eq!(
-        *cur.peek(1, true)
+        *cur.peek(1, true, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("B") // This value is after the line terminator
+        TokenKind::identifier(interner.get_or_intern_static("B")) // This value is after the line terminator
     );
 
     assert_eq!(
-        *cur.peek(2, false)
+        *cur.peek(2, false, &mut interner)
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier("B")
+        TokenKind::identifier(interner.get_or_intern_static("B"))
     );
     // End of stream
-    assert!(cur.peek(2, true).unwrap().is_none());
+    assert!(cur.peek(2, true, &mut interner).unwrap().is_none());
 }

--- a/boa/src/syntax/parser/cursor/mod.rs
+++ b/boa/src/syntax/parser/cursor/mod.rs
@@ -2,9 +2,12 @@
 mod buffered_lexer;
 
 use super::ParseError;
-use crate::syntax::{
-    ast::Punctuator,
-    lexer::{InputElement, Lexer, Position, Token, TokenKind},
+use crate::{
+    syntax::{
+        ast::Punctuator,
+        lexer::{InputElement, Lexer, Position, Token, TokenKind},
+    },
+    Interner,
 };
 use buffered_lexer::BufferedLexer;
 use std::io::Read;
@@ -42,23 +45,35 @@ where
     }
 
     #[inline]
-    pub(super) fn lex_regex(&mut self, start: Position) -> Result<Token, ParseError> {
-        self.buffered_lexer.lex_regex(start)
+    pub(super) fn lex_regex(
+        &mut self,
+        start: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, ParseError> {
+        self.buffered_lexer.lex_regex(start, interner)
     }
 
     #[inline]
-    pub(super) fn lex_template(&mut self, start: Position) -> Result<Token, ParseError> {
-        self.buffered_lexer.lex_template(start)
+    pub(super) fn lex_template(
+        &mut self,
+        start: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, ParseError> {
+        self.buffered_lexer.lex_template(start, interner)
     }
 
     #[inline]
-    pub(super) fn next(&mut self) -> Result<Option<Token>, ParseError> {
-        self.buffered_lexer.next(true)
+    pub(super) fn next(&mut self, interner: &mut Interner) -> Result<Option<Token>, ParseError> {
+        self.buffered_lexer.next(true, interner)
     }
 
     #[inline]
-    pub(super) fn peek(&mut self, skip_n: usize) -> Result<Option<&Token>, ParseError> {
-        self.buffered_lexer.peek(skip_n, true)
+    pub(super) fn peek(
+        &mut self,
+        skip_n: usize,
+        interner: &mut Interner,
+    ) -> Result<Option<&Token>, ParseError> {
+        self.buffered_lexer.peek(skip_n, true, interner)
     }
 
     #[inline]
@@ -73,17 +88,27 @@ where
 
     /// Returns an error if the next token is not of kind `kind`.
     #[inline]
-    pub(super) fn expect<K>(&mut self, kind: K, context: &'static str) -> Result<Token, ParseError>
+    pub(super) fn expect<K>(
+        &mut self,
+        kind: K,
+        context: &'static str,
+        interner: &mut Interner,
+    ) -> Result<Token, ParseError>
     where
         K: Into<TokenKind>,
     {
-        let next_token = self.next()?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = self.next(interner)?.ok_or(ParseError::AbruptEnd)?;
         let kind = kind.into();
 
         if next_token.kind() == &kind {
             Ok(next_token)
         } else {
-            Err(ParseError::expected(vec![kind], next_token, context))
+            Err(ParseError::expected(
+                [kind.to_string(interner)],
+                next_token.to_string(interner),
+                next_token.span(),
+                context,
+            ))
         }
     }
 
@@ -93,8 +118,11 @@ where
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
     #[inline]
-    pub(super) fn peek_semicolon(&mut self) -> Result<SemicolonResult<'_>, ParseError> {
-        match self.buffered_lexer.peek(0, false)? {
+    pub(super) fn peek_semicolon(
+        &mut self,
+        interner: &mut Interner,
+    ) -> Result<SemicolonResult<'_>, ParseError> {
+        match self.buffered_lexer.peek(0, false, interner)? {
             Some(tk) => match tk.kind() {
                 TokenKind::Punctuator(Punctuator::Semicolon)
                 | TokenKind::LineTerminator
@@ -113,19 +141,24 @@ where
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
     #[inline]
-    pub(super) fn expect_semicolon(&mut self, context: &'static str) -> Result<(), ParseError> {
-        match self.peek_semicolon()? {
+    pub(super) fn expect_semicolon(
+        &mut self,
+        context: &'static str,
+        interner: &mut Interner,
+    ) -> Result<(), ParseError> {
+        match self.peek_semicolon(interner)? {
             SemicolonResult::Found(Some(tk)) => match *tk.kind() {
                 TokenKind::Punctuator(Punctuator::Semicolon) | TokenKind::LineTerminator => {
-                    let _ = self.buffered_lexer.next(false)?;
+                    let _ = self.buffered_lexer.next(false, interner)?;
                     Ok(())
                 }
                 _ => Ok(()),
             },
             SemicolonResult::Found(None) => Ok(()),
             SemicolonResult::NotFound(tk) => Err(ParseError::expected(
-                vec![TokenKind::Punctuator(Punctuator::Semicolon)],
-                tk.clone(),
+                [";".to_owned()],
+                tk.to_string(interner),
+                tk.span(),
                 context,
             )),
         }
@@ -141,10 +174,15 @@ where
         &mut self,
         skip_n: usize,
         context: &'static str,
+        interner: &mut Interner,
     ) -> Result<&Token, ParseError> {
-        if let Some(t) = self.buffered_lexer.peek(skip_n, false)? {
+        if let Some(t) = self.buffered_lexer.peek(skip_n, false, interner)? {
             if t.kind() == &TokenKind::LineTerminator {
-                Err(ParseError::unexpected(t.clone(), context))
+                Err(ParseError::unexpected(
+                    t.to_string(interner),
+                    t.span(),
+                    context,
+                ))
             } else {
                 Ok(t)
             }
@@ -159,13 +197,17 @@ where
     ///
     /// No next token also returns None.
     #[inline]
-    pub(super) fn next_if<K>(&mut self, kind: K) -> Result<Option<Token>, ParseError>
+    pub(super) fn next_if<K>(
+        &mut self,
+        kind: K,
+        interner: &mut Interner,
+    ) -> Result<Option<Token>, ParseError>
     where
         K: Into<TokenKind>,
     {
-        Ok(if let Some(token) = self.peek(0)? {
+        Ok(if let Some(token) = self.peek(0, interner)? {
             if token.kind() == &kind.into() {
-                self.next()?
+                self.next(interner)?
             } else {
                 None
             }

--- a/boa/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -25,7 +25,7 @@ use crate::{
             AllowAwait, AllowIn, AllowYield, Cursor, TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 
 use std::io::Read;
@@ -71,44 +71,52 @@ where
 {
     type Output = ArrowFunctionDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ArrowFunction", "Parsing");
-        let next_token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
-        let (params, params_start_position) = if let TokenKind::Punctuator(Punctuator::OpenParen) =
-            &next_token.kind()
-        {
-            // CoverParenthesizedExpressionAndArrowParameterList
-            let params_start_position = cursor
-                .expect(Punctuator::OpenParen, "arrow function")?
-                .span()
-                .end();
+        let (params, params_start_position) =
+            if let TokenKind::Punctuator(Punctuator::OpenParen) = &next_token.kind() {
+                // CoverParenthesizedExpressionAndArrowParameterList
+                let params_start_position = cursor
+                    .expect(Punctuator::OpenParen, "arrow function", interner)?
+                    .span()
+                    .end();
 
-            let params = FormalParameters::new(self.allow_yield, self.allow_await).parse(cursor)?;
-            cursor.expect(Punctuator::CloseParen, "arrow function")?;
-            (params, params_start_position)
-        } else {
-            let params_start_position = next_token.span().start();
-            let param = BindingIdentifier::new(self.allow_yield, self.allow_await)
-                .parse(cursor)
-                .context("arrow function")?;
-            (
-                FormalParameterList {
-                    parameters: Box::new([FormalParameter::new(
-                        Declaration::new_with_identifier(param, None),
-                        false,
-                    )]),
-                    is_simple: true,
-                    has_duplicates: false,
-                },
-                params_start_position,
-            )
-        };
+                let params = FormalParameters::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
+                cursor.expect(Punctuator::CloseParen, "arrow function", interner)?;
+                (params, params_start_position)
+            } else {
+                let params_start_position = next_token.span().start();
+                let param = BindingIdentifier::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)
+                    .context("arrow function")?;
+                (
+                    FormalParameterList {
+                        parameters: Box::new([FormalParameter::new(
+                            Declaration::new_with_identifier(param, None),
+                            false,
+                        )]),
+                        is_simple: true,
+                        has_duplicates: false,
+                    },
+                    params_start_position,
+                )
+            };
 
-        cursor.peek_expect_no_lineterminator(0, "arrow function")?;
+        cursor.peek_expect_no_lineterminator(0, "arrow function", interner)?;
 
-        cursor.expect(TokenKind::Punctuator(Punctuator::Arrow), "arrow function")?;
-        let body = ConciseBody::new(self.allow_in).parse(cursor)?;
+        cursor.expect(
+            TokenKind::Punctuator(Punctuator::Arrow),
+            "arrow function",
+            interner,
+        )?;
+        let body = ConciseBody::new(self.allow_in).parse(cursor, interner)?;
 
         // Early Error: ArrowFormalParameters are UniqueFormalParameters.
         if params.has_duplicates {
@@ -137,7 +145,7 @@ where
                     if lexically_declared_names.contains(param_name) {
                         return Err(ParseError::lex(LexError::Syntax(
                             format!("Redeclaration of formal parameter `{}`", param_name).into(),
-                            match cursor.peek(0)? {
+                            match cursor.peek(0, interner)? {
                                 Some(token) => token.span().end(),
                                 None => Position::new(1, 1),
                             },
@@ -175,16 +183,24 @@ where
 {
     type Output = StatementList;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        match cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind() {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        match cursor
+            .peek(0, interner)?
+            .ok_or(ParseError::AbruptEnd)?
+            .kind()
+        {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                let _ = cursor.next();
-                let body = FunctionBody::new(false, false).parse(cursor)?;
-                cursor.expect(Punctuator::CloseBlock, "arrow function")?;
+                let _ = cursor.next(interner)?;
+                let body = FunctionBody::new(false, false).parse(cursor, interner)?;
+                cursor.expect(Punctuator::CloseBlock, "arrow function", interner)?;
                 Ok(body)
             }
             _ => Ok(StatementList::from(vec![Return::new(
-                ExpressionBody::new(self.allow_in, false).parse(cursor)?,
+                ExpressionBody::new(self.allow_in, false).parse(cursor, interner)?,
                 None,
             )
             .into()])),
@@ -219,7 +235,7 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
-        AssignmentExpression::new(self.allow_in, false, self.allow_await).parse(cursor)
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
+        AssignmentExpression::new(self.allow_in, false, self.allow_await).parse(cursor, interner)
     }
 }

--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -15,6 +15,7 @@ mod r#yield;
 use self::r#yield::YieldExpression;
 use self::{arrow_function::ArrowFunction, conditional::ConditionalExpression};
 use crate::syntax::lexer::{Error as LexError, InputElement, TokenKind};
+use crate::Interner;
 use crate::{
     syntax::{
         ast::{
@@ -80,46 +81,53 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("AssignmentExpression", "Parsing");
         cursor.set_goal(InputElement::Div);
 
-        match cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind() {
+        match cursor
+            .peek(0, interner)?
+            .ok_or(ParseError::AbruptEnd)?
+            .kind()
+        {
             // [+Yield]YieldExpression[?In, ?Await]
             TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
-                return YieldExpression::new(self.allow_in, self.allow_await).parse(cursor)
+                return YieldExpression::new(self.allow_in, self.allow_await)
+                    .parse(cursor, interner)
             }
             // ArrowFunction[?In, ?Yield, ?Await] -> ArrowParameters[?Yield, ?Await] -> BindingIdentifier[?Yield, ?Await]
             TokenKind::Identifier(_)
             | TokenKind::Keyword(Keyword::Yield)
             | TokenKind::Keyword(Keyword::Await) => {
-                if let Ok(tok) = cursor.peek_expect_no_lineterminator(1, "assignment expression") {
+                if let Ok(tok) =
+                    cursor.peek_expect_no_lineterminator(1, "assignment expression", interner)
+                {
                     if tok.kind() == &TokenKind::Punctuator(Punctuator::Arrow) {
                         return ArrowFunction::new(
                             self.allow_in,
                             self.allow_yield,
                             self.allow_await,
                         )
-                        .parse(cursor)
+                        .parse(cursor, interner)
                         .map(Node::ArrowFunctionDecl);
                     }
                 }
             }
             // ArrowFunction[?In, ?Yield, ?Await] -> ArrowParameters[?Yield, ?Await] -> CoverParenthesizedExpressionAndArrowParameterList[?Yield, ?Await]
             TokenKind::Punctuator(Punctuator::OpenParen) => {
-                if let Some(next_token) = cursor.peek(1)? {
+                if let Some(next_token) = cursor.peek(1, interner)? {
                     match *next_token.kind() {
                         TokenKind::Punctuator(Punctuator::CloseParen) => {
                             // Need to check if the token after the close paren is an arrow, if so then this is an ArrowFunction
                             // otherwise it is an expression of the form (b).
-                            if let Some(t) = cursor.peek(2)? {
+                            if let Some(t) = cursor.peek(2, interner)? {
                                 if t.kind() == &TokenKind::Punctuator(Punctuator::Arrow) {
                                     return ArrowFunction::new(
                                         self.allow_in,
                                         self.allow_yield,
                                         self.allow_await,
                                     )
-                                    .parse(cursor)
+                                    .parse(cursor, interner)
                                     .map(Node::ArrowFunctionDecl);
                                 }
                             }
@@ -130,11 +138,11 @@ where
                                 self.allow_yield,
                                 self.allow_await,
                             )
-                            .parse(cursor)
+                            .parse(cursor, interner)
                             .map(Node::ArrowFunctionDecl);
                         }
                         TokenKind::Identifier(_) => {
-                            if let Some(t) = cursor.peek(2)? {
+                            if let Some(t) = cursor.peek(2, interner)? {
                                 match *t.kind() {
                                     TokenKind::Punctuator(Punctuator::Comma) => {
                                         // This must be an argument list and therefore (a, b) => {}
@@ -143,13 +151,13 @@ where
                                             self.allow_yield,
                                             self.allow_await,
                                         )
-                                        .parse(cursor)
+                                        .parse(cursor, interner)
                                         .map(Node::ArrowFunctionDecl);
                                     }
                                     TokenKind::Punctuator(Punctuator::CloseParen) => {
                                         // Need to check if the token after the close paren is an arrow, if so then this is an ArrowFunction
                                         // otherwise it is an expression of the form (b).
-                                        if let Some(t) = cursor.peek(3)? {
+                                        if let Some(t) = cursor.peek(3, interner)? {
                                             if t.kind() == &TokenKind::Punctuator(Punctuator::Arrow)
                                             {
                                                 return ArrowFunction::new(
@@ -157,7 +165,7 @@ where
                                                     self.allow_yield,
                                                     self.allow_await,
                                                 )
-                                                .parse(cursor)
+                                                .parse(cursor, interner)
                                                 .map(Node::ArrowFunctionDecl);
                                             }
                                         }
@@ -177,16 +185,16 @@ where
         cursor.set_goal(InputElement::Div);
 
         let mut lhs = ConditionalExpression::new(self.allow_in, self.allow_yield, self.allow_await)
-            .parse(cursor)?;
+            .parse(cursor, interner)?;
 
         // Review if we are trying to assign to an invalid left hand side expression.
         // TODO: can we avoid cloning?
-        if let Some(tok) = cursor.peek(0)?.cloned() {
+        if let Some(tok) = cursor.peek(0, interner)?.cloned() {
             match tok.kind() {
                 TokenKind::Punctuator(Punctuator::Assign) => {
-                    cursor.next()?.expect("= token vanished"); // Consume the token.
+                    cursor.next(interner)?.expect("= token vanished"); // Consume the token.
                     if is_assignable(&lhs) {
-                        lhs = Assign::new(lhs, self.parse(cursor)?).into();
+                        lhs = Assign::new(lhs, self.parse(cursor, interner)?).into();
                     } else {
                         return Err(ParseError::lex(LexError::Syntax(
                             "Invalid left-hand side in assignment".into(),
@@ -195,10 +203,10 @@ where
                     }
                 }
                 TokenKind::Punctuator(p) if p.as_binop().is_some() && p != &Punctuator::Comma => {
-                    cursor.next()?.expect("token vanished"); // Consume the token.
+                    cursor.next(interner)?.expect("token vanished"); // Consume the token.
                     if is_assignable(&lhs) {
                         let binop = p.as_binop().expect("binop disappeared");
-                        let expr = self.parse(cursor)?;
+                        let expr = self.parse(cursor, interner)?;
 
                         lhs = BinOp::new(binop, lhs, expr).into();
                     } else {

--- a/boa/src/syntax/parser/expression/await_expr.rs
+++ b/boa/src/syntax/parser/expression/await_expr.rs
@@ -9,10 +9,13 @@
 
 use super::unary::UnaryExpression;
 
-use crate::syntax::{
-    ast::{node::AwaitExpr, Keyword},
-    lexer::TokenKind,
-    parser::{AllowYield, Cursor, ParseError, TokenParser},
+use crate::{
+    syntax::{
+        ast::{node::AwaitExpr, Keyword},
+        lexer::TokenKind,
+        parser::{AllowYield, Cursor, ParseError, TokenParser},
+    },
+    Interner,
 };
 use std::io::Read;
 
@@ -47,12 +50,17 @@ where
 {
     type Output = AwaitExpr;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         cursor.expect(
             TokenKind::Keyword(Keyword::Await),
             "Await expression parsing",
+            interner,
         )?;
-        let expr = UnaryExpression::new(self.allow_yield, true).parse(cursor)?;
+        let expr = UnaryExpression::new(self.allow_yield, true).parse(cursor, interner)?;
         Ok(expr.into())
     }
 }

--- a/boa/src/syntax/parser/expression/left_hand_side/call.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/call.rs
@@ -23,7 +23,7 @@ use crate::{
             AllowAwait, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 
 use std::io::Read;
@@ -62,54 +62,65 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("CallExpression", "Parsing");
 
-        let token = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+        let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         let mut lhs = if token.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
-            let args = Arguments::new(self.allow_yield, self.allow_await).parse(cursor)?;
+            let args =
+                Arguments::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
             Node::from(Call::new(self.first_member_expr, args))
         } else {
-            let next_token = cursor.next()?.expect("token vanished");
+            let next_token = cursor.next(interner)?.expect("token vanished");
             return Err(ParseError::expected(
-                vec![TokenKind::Punctuator(Punctuator::OpenParen)],
-                next_token,
+                ["(".to_owned()],
+                next_token.to_string(interner),
+                next_token.span(),
                 "call expression",
             ));
         };
 
-        while let Some(tok) = cursor.peek(0)? {
+        while let Some(tok) = cursor.peek(0, interner)? {
             let token = tok.clone();
             match token.kind() {
                 TokenKind::Punctuator(Punctuator::OpenParen) => {
-                    let args = Arguments::new(self.allow_yield, self.allow_await).parse(cursor)?;
+                    let args = Arguments::new(self.allow_yield, self.allow_await)
+                        .parse(cursor, interner)?;
                     lhs = Node::from(Call::new(lhs, args));
                 }
                 TokenKind::Punctuator(Punctuator::Dot) => {
-                    cursor.next()?.ok_or(ParseError::AbruptEnd)?; // We move the parser forward.
+                    cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?; // We move the parser forward.
 
-                    match &cursor.next()?.ok_or(ParseError::AbruptEnd)?.kind() {
+                    match &cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?.kind() {
                         TokenKind::Identifier(name) => {
-                            lhs = GetConstField::new(lhs, name.clone()).into();
+                            lhs = GetConstField::new(
+                                lhs,
+                                interner
+                                    .resolve(*name)
+                                    .expect("string disappeared")
+                                    .to_owned(),
+                            )
+                            .into();
                         }
                         TokenKind::Keyword(kw) => {
                             lhs = GetConstField::new(lhs, kw.to_string()).into();
                         }
                         _ => {
                             return Err(ParseError::expected(
-                                vec![TokenKind::identifier("identifier")],
-                                token,
+                                ["identifier".to_owned()],
+                                token.to_string(interner),
+                                token.span(),
                                 "call expression",
                             ));
                         }
                     }
                 }
                 TokenKind::Punctuator(Punctuator::OpenBracket) => {
-                    let _ = cursor.next()?.ok_or(ParseError::AbruptEnd)?; // We move the parser.
-                    let idx =
-                        Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
-                    cursor.expect(Punctuator::CloseBracket, "call expression")?;
+                    let _ = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?; // We move the parser.
+                    let idx = Expression::new(true, self.allow_yield, self.allow_await)
+                        .parse(cursor, interner)?;
+                    cursor.expect(Punctuator::CloseBracket, "call expression", interner)?;
                     lhs = GetField::new(lhs, idx).into();
                 }
                 TokenKind::TemplateNoSubstitution { .. } | TokenKind::TemplateMiddle { .. } => {
@@ -119,7 +130,7 @@ where
                         tok.span().start(),
                         lhs,
                     )
-                    .parse(cursor)?;
+                    .parse(cursor, interner)?;
                 }
                 _ => break,
             }

--- a/boa/src/syntax/parser/expression/primary/array_initializer/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/array_initializer/tests.rs
@@ -1,28 +1,35 @@
 // ! Tests for array initializer parsing.
 
-use crate::syntax::{
-    ast::{node::ArrayDecl, Const},
-    parser::tests::check_parser,
+use crate::{
+    syntax::{
+        ast::{node::ArrayDecl, Const},
+        parser::tests::check_parser,
+    },
+    Interner,
 };
 
 /// Checks an empty array.
 #[test]
 fn check_empty() {
-    check_parser("[]", vec![ArrayDecl::from(vec![]).into()]);
+    let mut interner = Interner::new();
+    check_parser("[]", vec![ArrayDecl::from(vec![]).into()], &mut interner);
 }
 
 /// Checks an array with empty slot.
 #[test]
 fn check_empty_slot() {
+    let mut interner = Interner::new();
     check_parser(
         "[,]",
         vec![ArrayDecl::from(vec![Const::Undefined.into()]).into()],
+        &mut interner,
     );
 }
 
 /// Checks a numeric array.
 #[test]
 fn check_numeric_array() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, 2, 3]",
         vec![ArrayDecl::from(vec![
@@ -31,12 +38,14 @@ fn check_numeric_array() {
             Const::from(3).into(),
         ])
         .into()],
+        &mut interner,
     );
 }
 
 // Checks a numeric array with trailing comma
 #[test]
 fn check_numeric_array_trailing() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, 2, 3,]",
         vec![ArrayDecl::from(vec![
@@ -45,12 +54,14 @@ fn check_numeric_array_trailing() {
             Const::from(3).into(),
         ])
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks a numeric array with an elision.
 #[test]
 fn check_numeric_array_elision() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, 2, , 3]",
         vec![ArrayDecl::from(vec![
@@ -60,12 +71,14 @@ fn check_numeric_array_elision() {
             Const::from(3).into(),
         ])
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks a numeric array with repeated elisions.
 #[test]
 fn check_numeric_array_repeated_elision() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, 2, ,, 3]",
         vec![ArrayDecl::from(vec![
@@ -76,12 +89,14 @@ fn check_numeric_array_repeated_elision() {
             Const::from(3).into(),
         ])
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks a combined array.
 #[test]
 fn check_combined() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, \"a\", 2]",
         vec![ArrayDecl::from(vec![
@@ -90,12 +105,14 @@ fn check_combined() {
             Const::from(2).into(),
         ])
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks a combined array with an empty string
 #[test]
 fn check_combined_empty_str() {
+    let mut interner = Interner::new();
     check_parser(
         "[1, \"\", 2]",
         vec![ArrayDecl::from(vec![
@@ -104,5 +121,6 @@ fn check_combined_empty_str() {
             Const::from(2).into(),
         ])
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/expression/primary/async_function_expression/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/async_function_expression/tests.rs
@@ -1,14 +1,18 @@
-use crate::syntax::{
-    ast::{
-        node::{AsyncFunctionExpr, Declaration, DeclarationList, Return, StatementList},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{AsyncFunctionExpr, Declaration, DeclarationList, Return, StatementList},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 /// Checks async expression parsing.
 #[test]
 fn check_async_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const add = async function() {
             return 1;
@@ -30,11 +34,13 @@ fn check_async_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_nested_async_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const a = async function() {
             const b = async function() {
@@ -77,5 +83,6 @@ fn check_nested_async_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/expression/primary/async_generator_expression/test.rs
+++ b/boa/src/syntax/parser/expression/primary/async_generator_expression/test.rs
@@ -1,15 +1,19 @@
-use crate::syntax::{
-    ast::{
-        node::{AsyncGeneratorExpr, Declaration, DeclarationList, Return, StatementList},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{AsyncGeneratorExpr, Declaration, DeclarationList, Return, StatementList},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 ///checks async generator expression parsing
 
 #[test]
 fn check_async_generator_expr() {
+    let mut interner = Interner::new();
     check_parser(
         "const add = async function*(){
             return 1;
@@ -31,11 +35,13 @@ fn check_async_generator_expr() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_nested_async_generator_expr() {
+    let mut interner = Interner::new();
     check_parser(
         "const a = async function*() {
             const b = async function*() {
@@ -78,5 +84,6 @@ fn check_nested_async_generator_expr() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -20,7 +20,7 @@ use crate::{
             Cursor, ParseError, TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 
 use std::io::Read;
@@ -42,15 +42,19 @@ where
 {
     type Output = FunctionExpr;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("FunctionExpression", "Parsing");
 
-        let name = if let Some(token) = cursor.peek(0)? {
+        let name = if let Some(token) = cursor.peek(0, interner)? {
             match token.kind() {
                 TokenKind::Identifier(_)
                 | TokenKind::Keyword(Keyword::Yield)
                 | TokenKind::Keyword(Keyword::Await) => {
-                    Some(BindingIdentifier::new(false, false).parse(cursor)?)
+                    Some(BindingIdentifier::new(false, false).parse(cursor, interner)?)
                 }
                 _ => None,
             }
@@ -64,7 +68,7 @@ where
             if cursor.strict_mode() && ["eval", "arguments"].contains(&name.as_ref()) {
                 return Err(ParseError::lex(LexError::Syntax(
                     "Unexpected eval or arguments in strict mode".into(),
-                    match cursor.peek(0)? {
+                    match cursor.peek(0, interner)? {
                         Some(token) => token.span().end(),
                         None => Position::new(1, 1),
                     },
@@ -73,18 +77,18 @@ where
         }
 
         let params_start_position = cursor
-            .expect(Punctuator::OpenParen, "function expression")?
+            .expect(Punctuator::OpenParen, "function expression", interner)?
             .span()
             .end();
 
-        let params = FormalParameters::new(false, false).parse(cursor)?;
+        let params = FormalParameters::new(false, false).parse(cursor, interner)?;
 
-        cursor.expect(Punctuator::CloseParen, "function expression")?;
-        cursor.expect(Punctuator::OpenBlock, "function expression")?;
+        cursor.expect(Punctuator::CloseParen, "function expression", interner)?;
+        cursor.expect(Punctuator::OpenBlock, "function expression", interner)?;
 
-        let body = FunctionBody::new(false, false).parse(cursor)?;
+        let body = FunctionBody::new(false, false).parse(cursor, interner)?;
 
-        cursor.expect(Punctuator::CloseBlock, "function expression")?;
+        cursor.expect(Punctuator::CloseBlock, "function expression", interner)?;
 
         // Early Error: If the source code matching FormalParameters is strict mode code,
         // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
@@ -114,7 +118,7 @@ where
                     if lexically_declared_names.contains(param_name) {
                         return Err(ParseError::lex(LexError::Syntax(
                             format!("Redeclaration of formal parameter `{}`", param_name).into(),
-                            match cursor.peek(0)? {
+                            match cursor.peek(0, interner)? {
                                 Some(token) => token.span().end(),
                                 None => Position::new(1, 1),
                             },

--- a/boa/src/syntax/parser/expression/primary/function_expression/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/function_expression/tests.rs
@@ -1,14 +1,18 @@
-use crate::syntax::{
-    ast::{
-        node::{Declaration, DeclarationList, FunctionExpr, Return, StatementList},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Declaration, DeclarationList, FunctionExpr, Return, StatementList},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 /// Checks async expression parsing.
 #[test]
 fn check_function_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const add = function() {
             return 1;
@@ -30,11 +34,13 @@ fn check_function_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_nested_function_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const a = function() {
             const b = function() {
@@ -77,5 +83,6 @@ fn check_nested_function_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/expression/primary/generator_expression/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/generator_expression/tests.rs
@@ -1,13 +1,17 @@
-use crate::syntax::{
-    ast::{
-        node::{Declaration, DeclarationList, GeneratorExpr, StatementList, Yield},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Declaration, DeclarationList, GeneratorExpr, StatementList, Yield},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 #[test]
 fn check_generator_function_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const gen = function*() {
             yield 1;
@@ -28,11 +32,13 @@ fn check_generator_function_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_generator_function_delegate_yield_expression() {
+    let mut interner = Interner::new();
     check_parser(
         "const gen = function*() {
             yield* 1;
@@ -53,5 +59,6 @@ fn check_generator_function_delegate_yield_expression() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -22,7 +22,7 @@ use crate::{
             AllowAwait, AllowIn, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 use std::io::Read;
 
@@ -60,30 +60,34 @@ where
 {
     type Output = Object;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ObjectLiteral", "Parsing");
         let mut elements = Vec::new();
 
         loop {
-            if cursor.next_if(Punctuator::CloseBlock)?.is_some() {
+            if cursor.next_if(Punctuator::CloseBlock, interner)?.is_some() {
                 break;
             }
 
-            elements
-                .push(PropertyDefinition::new(self.allow_yield, self.allow_await).parse(cursor)?);
+            elements.push(
+                PropertyDefinition::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?,
+            );
 
-            if cursor.next_if(Punctuator::CloseBlock)?.is_some() {
+            if cursor.next_if(Punctuator::CloseBlock, interner)?.is_some() {
                 break;
             }
 
-            if cursor.next_if(Punctuator::Comma)?.is_none() {
-                let next_token = cursor.next()?.ok_or(ParseError::AbruptEnd)?;
+            if cursor.next_if(Punctuator::Comma, interner)?.is_none() {
+                let next_token = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
                 return Err(ParseError::expected(
-                    vec![
-                        TokenKind::Punctuator(Punctuator::Comma),
-                        TokenKind::Punctuator(Punctuator::CloseBlock),
-                    ],
-                    next_token,
+                    [",".to_owned(), "}".to_owned()],
+                    next_token.to_string(interner),
+                    next_token.span(),
                     "object literal",
                 ));
             }
@@ -125,17 +129,23 @@ where
 {
     type Output = node::PropertyDefinition;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("PropertyDefinition", "Parsing");
 
         // IdentifierReference[?Yield, ?Await]
-        if let Some(next_token) = cursor.peek(1)? {
+        if let Some(next_token) = cursor.peek(1, interner)? {
             match next_token.kind() {
                 TokenKind::Punctuator(Punctuator::CloseBlock)
                 | TokenKind::Punctuator(Punctuator::Comma) => {
-                    let token = cursor.next()?.ok_or(ParseError::AbruptEnd)?;
+                    let token = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
                     let ident = match token.kind() {
-                        TokenKind::Identifier(ident) => Identifier::from(ident.as_ref()),
+                        TokenKind::Identifier(ident) => {
+                            Identifier::from(interner.resolve(*ident).expect("string disappeared"))
+                        }
                         TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
                             // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".
                             return Err(ParseError::general(
@@ -172,7 +182,8 @@ where
                         }
                         _ => {
                             return Err(ParseError::unexpected(
-                                token.clone(),
+                                token.to_string(interner),
+                                token.span(),
                                 "expected IdentifierReference",
                             ));
                         }
@@ -187,29 +198,37 @@ where
         }
 
         //  ... AssignmentExpression[+In, ?Yield, ?Await]
-        if cursor.next_if(Punctuator::Spread)?.is_some() {
+        if cursor.next_if(Punctuator::Spread, interner)?.is_some() {
             let node = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
+                .parse(cursor, interner)?;
             return Ok(node::PropertyDefinition::SpreadObject(node));
         }
 
         //Async [AsyncMethod, AsyncGeneratorMethod] object methods
-        if cursor.next_if(Keyword::Async)?.is_some() {
-            cursor.peek_expect_no_lineterminator(0, "Async object methods")?;
+        if cursor.next_if(Keyword::Async, interner)?.is_some() {
+            cursor.peek_expect_no_lineterminator(0, "Async object methods", interner)?;
 
-            let mul_check = cursor.next_if(Punctuator::Mul)?;
+            let mul_check = cursor.next_if(Punctuator::Mul, interner)?;
             let property_name =
-                PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+                PropertyName::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
             if mul_check.is_some() {
                 // MethodDefinition[?Yield, ?Await] -> AsyncGeneratorMethod[?Yield, ?Await]
 
                 let params_start_position = cursor
-                    .expect(Punctuator::OpenParen, "async generator method definition")?
+                    .expect(
+                        Punctuator::OpenParen,
+                        "async generator method definition",
+                        interner,
+                    )?
                     .span()
                     .start();
-                let params = FormalParameters::new(true, true).parse(cursor)?;
-                cursor.expect(Punctuator::CloseParen, "async generator method definition")?;
+                let params = FormalParameters::new(true, true).parse(cursor, interner)?;
+                cursor.expect(
+                    Punctuator::CloseParen,
+                    "async generator method definition",
+                    interner,
+                )?;
 
                 // Early Error: UniqueFormalParameters : FormalParameters
                 // NOTE: does not appear to formally be in ECMAScript specs for method
@@ -223,11 +242,13 @@ where
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenBlock),
                     "async generator method definition",
+                    interner,
                 )?;
-                let body = FunctionBody::new(true, true).parse(cursor)?;
+                let body = FunctionBody::new(true, true).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseBlock),
                     "async generator method definition",
+                    interner,
                 )?;
 
                 // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
@@ -250,7 +271,7 @@ where
                                 return Err(ParseError::lex(LexError::Syntax(
                                     format!("Redeclaration of formal parameter `{}`", param_name)
                                         .into(),
-                                    match cursor.peek(0)? {
+                                    match cursor.peek(0, interner)? {
                                         Some(token) => token.span().end(),
                                         None => Position::new(1, 1),
                                     },
@@ -269,11 +290,11 @@ where
                 // MethodDefinition[?Yield, ?Await] -> AsyncMethod[?Yield, ?Await]
 
                 let params_start_position = cursor
-                    .expect(Punctuator::OpenParen, "async method definition")?
+                    .expect(Punctuator::OpenParen, "async method definition", interner)?
                     .span()
                     .start();
-                let params = FormalParameters::new(false, true).parse(cursor)?;
-                cursor.expect(Punctuator::CloseParen, "async method definition")?;
+                let params = FormalParameters::new(false, true).parse(cursor, interner)?;
+                cursor.expect(Punctuator::CloseParen, "async method definition", interner)?;
 
                 // Early Error: UniqueFormalParameters : FormalParameters
                 // NOTE: does not appear to be in ECMAScript specs
@@ -287,11 +308,13 @@ where
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenBlock),
                     "async method definition",
+                    interner,
                 )?;
-                let body = FunctionBody::new(true, true).parse(cursor)?;
+                let body = FunctionBody::new(true, true).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseBlock),
                     "async method definition",
+                    interner,
                 )?;
 
                 // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
@@ -314,7 +337,7 @@ where
                                 return Err(ParseError::lex(LexError::Syntax(
                                     format!("Redeclaration of formal parameter `{}`", param_name)
                                         .into(),
-                                    match cursor.peek(0)? {
+                                    match cursor.peek(0, interner)? {
                                         Some(token) => token.span().end(),
                                         None => Position::new(1, 1),
                                     },
@@ -332,16 +355,24 @@ where
         }
 
         // MethodDefinition[?Yield, ?Await] -> GeneratorMethod[?Yield, ?Await]
-        if cursor.next_if(Punctuator::Mul)?.is_some() {
+        if cursor.next_if(Punctuator::Mul, interner)?.is_some() {
             let property_name =
-                PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+                PropertyName::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
             let params_start_position = cursor
-                .expect(Punctuator::OpenParen, "generator method definition")?
+                .expect(
+                    Punctuator::OpenParen,
+                    "generator method definition",
+                    interner,
+                )?
                 .span()
                 .start();
-            let params = FormalParameters::new(false, false).parse(cursor)?;
-            cursor.expect(Punctuator::CloseParen, "generator method definition")?;
+            let params = FormalParameters::new(false, false).parse(cursor, interner)?;
+            cursor.expect(
+                Punctuator::CloseParen,
+                "generator method definition",
+                interner,
+            )?;
 
             // Early Error: UniqueFormalParameters : FormalParameters
             // NOTE: does not appear to be in ECMAScript specs for GeneratorMethod
@@ -355,11 +386,13 @@ where
             cursor.expect(
                 TokenKind::Punctuator(Punctuator::OpenBlock),
                 "generator method definition",
+                interner,
             )?;
-            let body = FunctionBody::new(true, false).parse(cursor)?;
+            let body = FunctionBody::new(true, false).parse(cursor, interner)?;
             cursor.expect(
                 TokenKind::Punctuator(Punctuator::CloseBlock),
                 "generator method definition",
+                interner,
             )?;
 
             // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
@@ -382,7 +415,7 @@ where
                             return Err(ParseError::lex(LexError::Syntax(
                                 format!("Redeclaration of formal parameter `{}`", param_name)
                                     .into(),
-                                match cursor.peek(0)? {
+                                match cursor.peek(0, interner)? {
                                     Some(token) => token.span().end(),
                                     None => Position::new(1, 1),
                                 },
@@ -400,41 +433,48 @@ where
         }
 
         let mut property_name =
-            PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+            PropertyName::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
         //  PropertyName[?Yield, ?Await] : AssignmentExpression[+In, ?Yield, ?Await]
-        if cursor.next_if(Punctuator::Colon)?.is_some() {
+        if cursor.next_if(Punctuator::Colon, interner)?.is_some() {
             let value = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
+                .parse(cursor, interner)?;
             return Ok(node::PropertyDefinition::property(property_name, value));
         }
 
-        let ordinary_method = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?.kind()
+        let ordinary_method = cursor
+            .peek(0, interner)?
+            .ok_or(ParseError::AbruptEnd)?
+            .kind()
             == &TokenKind::Punctuator(Punctuator::OpenParen);
 
         match property_name {
             // MethodDefinition[?Yield, ?Await] -> get ClassElementName[?Yield, ?Await] ( ) { FunctionBody[~Yield, ~Await] }
             node::PropertyName::Literal(str) if str.as_ref() == "get" && !ordinary_method => {
-                property_name =
-                    PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+                property_name = PropertyName::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenParen),
                     "get method definition",
+                    interner,
                 )?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseParen),
                     "get method definition",
+                    interner,
                 )?;
 
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenBlock),
                     "get method definition",
+                    interner,
                 )?;
-                let body = FunctionBody::new(false, false).parse(cursor)?;
+                let body = FunctionBody::new(false, false).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseBlock),
                     "get method definition",
+                    interner,
                 )?;
 
                 Ok(node::PropertyDefinition::method_definition(
@@ -445,20 +485,22 @@ where
             }
             // MethodDefinition[?Yield, ?Await] -> set ClassElementName[?Yield, ?Await] ( PropertySetParameterList ) { FunctionBody[~Yield, ~Await] }
             node::PropertyName::Literal(str) if str.as_ref() == "set" && !ordinary_method => {
-                property_name =
-                    PropertyName::new(self.allow_yield, self.allow_await).parse(cursor)?;
+                property_name = PropertyName::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 let params_start_position = cursor
                     .expect(
                         TokenKind::Punctuator(Punctuator::OpenParen),
                         "set method definition",
+                        interner,
                     )?
                     .span()
                     .end();
-                let params = FormalParameters::new(false, false).parse(cursor)?;
+                let params = FormalParameters::new(false, false).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseParen),
                     "set method definition",
+                    interner,
                 )?;
                 if params.parameters.len() != 1 {
                     return Err(ParseError::general(
@@ -470,11 +512,13 @@ where
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenBlock),
                     "set method definition",
+                    interner,
                 )?;
-                let body = FunctionBody::new(false, false).parse(cursor)?;
+                let body = FunctionBody::new(false, false).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseBlock),
                     "set method definition",
+                    interner,
                 )?;
 
                 // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
@@ -499,13 +543,15 @@ where
                     .expect(
                         TokenKind::Punctuator(Punctuator::OpenParen),
                         "method definition",
+                        interner,
                     )?
                     .span()
                     .end();
-                let params = FormalParameters::new(false, false).parse(cursor)?;
+                let params = FormalParameters::new(false, false).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseParen),
                     "method definition",
+                    interner,
                 )?;
 
                 // Early Error: UniqueFormalParameters : FormalParameters
@@ -519,11 +565,13 @@ where
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::OpenBlock),
                     "method definition",
+                    interner,
                 )?;
-                let body = FunctionBody::new(false, false).parse(cursor)?;
+                let body = FunctionBody::new(false, false).parse(cursor, interner)?;
                 cursor.expect(
                     TokenKind::Punctuator(Punctuator::CloseBlock),
                     "method definition",
+                    interner,
                 )?;
 
                 // Early Error: It is a Syntax Error if FunctionBodyContainsUseStrict of FunctionBody is true
@@ -578,22 +626,26 @@ where
 {
     type Output = node::PropertyName;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("PropertyName", "Parsing");
 
         // ComputedPropertyName[?Yield, ?Await] -> [ AssignmentExpression[+In, ?Yield, ?Await] ]
-        if cursor.next_if(Punctuator::OpenBracket)?.is_some() {
+        if cursor.next_if(Punctuator::OpenBracket, interner)?.is_some() {
             let node = AssignmentExpression::new(false, self.allow_yield, self.allow_await)
-                .parse(cursor)?;
-            cursor.expect(Punctuator::CloseBracket, "expected token ']'")?;
+                .parse(cursor, interner)?;
+            cursor.expect(Punctuator::CloseBracket, "expected token ']'", interner)?;
             return Ok(node.into());
         }
 
         // LiteralPropertyName
         Ok(cursor
-            .next()?
+            .next(interner)?
             .ok_or(ParseError::AbruptEnd)?
-            .to_string()
+            .to_string(interner)
             .into())
     }
 }
@@ -637,10 +689,11 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("Initializer", "Parsing");
 
-        cursor.expect(Punctuator::Assign, "initializer")?;
-        AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await).parse(cursor)
+        cursor.expect(Punctuator::Assign, "initializer", interner)?;
+        AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)
     }
 }

--- a/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -1,12 +1,15 @@
-use crate::syntax::{
-    ast::{
-        node::{
-            Declaration, DeclarationList, FormalParameter, FunctionExpr, Identifier,
-            MethodDefinitionKind, Object, PropertyDefinition,
+use crate::{
+    syntax::{
+        ast::{
+            node::{
+                Declaration, DeclarationList, FormalParameter, FunctionExpr, Identifier,
+                MethodDefinitionKind, Object, PropertyDefinition,
+            },
+            Const,
         },
-        Const,
+        parser::tests::{check_invalid, check_parser},
     },
-    parser::tests::{check_invalid, check_parser},
+    Interner,
 };
 
 /// Checks object literal parsing.
@@ -17,6 +20,7 @@ fn check_object_literal() {
         PropertyDefinition::property("b", Const::from(false)),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             a: true,
@@ -31,6 +35,7 @@ fn check_object_literal() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -46,6 +51,7 @@ fn check_object_short_function() {
         ),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             a: true,
@@ -60,6 +66,7 @@ fn check_object_short_function() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -82,6 +89,7 @@ fn check_object_short_function_arguments() {
         ),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             a: true,
@@ -96,6 +104,7 @@ fn check_object_short_function_arguments() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -110,6 +119,7 @@ fn check_object_getter() {
         ),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             a: true,
@@ -124,6 +134,7 @@ fn check_object_getter() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -145,6 +156,7 @@ fn check_object_setter() {
         ),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             a: true,
@@ -159,6 +171,7 @@ fn check_object_setter() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -170,6 +183,7 @@ fn check_object_short_function_get() {
         FunctionExpr::new(None, vec![], vec![]),
     )];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             get() {}
@@ -183,6 +197,7 @@ fn check_object_short_function_get() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -194,6 +209,7 @@ fn check_object_short_function_set() {
         FunctionExpr::new(None, vec![], vec![]),
     )];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             set() {}
@@ -207,6 +223,7 @@ fn check_object_short_function_set() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -214,6 +231,7 @@ fn check_object_short_function_set() {
 fn check_object_shorthand_property_names() {
     let object_properties = vec![PropertyDefinition::property("a", Identifier::from("a"))];
 
+    let mut interner = Interner::new();
     check_parser(
         "const a = true;
             const x = { a };
@@ -236,6 +254,7 @@ fn check_object_shorthand_property_names() {
             )
             .into(),
         ],
+        &mut interner,
     );
 }
 
@@ -246,6 +265,7 @@ fn check_object_shorthand_multiple_properties() {
         PropertyDefinition::property("b", Identifier::from("b")),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const a = true;
             const b = false;
@@ -277,6 +297,7 @@ fn check_object_shorthand_multiple_properties() {
             )
             .into(),
         ],
+        &mut interner,
     );
 }
 
@@ -287,6 +308,7 @@ fn check_object_spread() {
         PropertyDefinition::spread_object(Identifier::from("b")),
     ];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = { a: 1, ...b };
         ",
@@ -298,6 +320,7 @@ fn check_object_spread() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -309,6 +332,7 @@ fn check_async_method() {
         FunctionExpr::new(None, vec![], vec![]),
     )];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             async dive() {}
@@ -322,6 +346,7 @@ fn check_async_method() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -333,6 +358,7 @@ fn check_async_generator_method() {
         FunctionExpr::new(None, vec![], vec![]),
     )];
 
+    let mut interner = Interner::new();
     check_parser(
         "const x = {
             async* vroom() {}
@@ -346,6 +372,7 @@ fn check_async_generator_method() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 

--- a/boa/src/syntax/parser/expression/primary/tests.rs
+++ b/boa/src/syntax/parser/expression/primary/tests.rs
@@ -1,10 +1,19 @@
-use crate::syntax::{ast::Const, parser::tests::check_parser};
+use crate::{
+    syntax::{ast::Const, parser::tests::check_parser},
+    Interner,
+};
 
 #[test]
 fn check_string() {
     // Check empty string
-    check_parser("\"\"", vec![Const::from("").into()]);
+    let mut interner = Interner::new();
+    check_parser("\"\"", vec![Const::from("").into()], &mut interner);
 
     // Check non-empty string
-    check_parser("\"hello\"", vec![Const::from("hello").into()]);
+    let mut interner = Interner::new();
+    check_parser(
+        "\"hello\"",
+        vec![Const::from("hello").into()],
+        &mut interner,
+    );
 }

--- a/boa/src/syntax/parser/expression/tests.rs
+++ b/boa/src/syntax/parser/expression/tests.rs
@@ -1,68 +1,107 @@
-use crate::syntax::{
-    ast::op::{AssignOp, BitOp, CompOp, LogOp, NumOp},
-    ast::{
-        node::{BinOp, Identifier},
-        Const,
+use crate::{
+    syntax::{
+        ast::op::{AssignOp, BitOp, CompOp, LogOp, NumOp},
+        ast::{
+            node::{BinOp, Identifier},
+            Const,
+        },
+        parser::tests::{check_invalid, check_parser},
     },
-    parser::tests::{check_invalid, check_parser},
+    Interner,
 };
 
 /// Checks numeric operations
 #[test]
 fn check_numeric_operations() {
+    let mut interner = Interner::new();
     check_parser(
         "a + b",
         vec![BinOp::new(NumOp::Add, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a+1",
         vec![BinOp::new(NumOp::Add, Identifier::from("a"), Const::from(1)).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a - b",
         vec![BinOp::new(NumOp::Sub, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a-1",
         vec![BinOp::new(NumOp::Sub, Identifier::from("a"), Const::from(1)).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a / b",
         vec![BinOp::new(NumOp::Div, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a/2",
         vec![BinOp::new(NumOp::Div, Identifier::from("a"), Const::from(2)).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a * b",
         vec![BinOp::new(NumOp::Mul, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a*2",
         vec![BinOp::new(NumOp::Mul, Identifier::from("a"), Const::from(2)).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a ** b",
         vec![BinOp::new(NumOp::Exp, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a**2",
         vec![BinOp::new(NumOp::Exp, Identifier::from("a"), Const::from(2)).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a % b",
         vec![BinOp::new(NumOp::Mod, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a%2",
         vec![BinOp::new(NumOp::Mod, Identifier::from("a"), Const::from(2)).into()],
+        &mut interner,
     );
 }
 
 // Checks complex numeric operations.
 #[test]
 fn check_complex_numeric_operations() {
+    let mut interner = Interner::new();
     check_parser(
         "a + d*(b-3)+1",
         vec![BinOp::new(
@@ -79,109 +118,172 @@ fn check_complex_numeric_operations() {
             Const::from(1),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks bitwise operations.
 #[test]
 fn check_bitwise_operations() {
+    let mut interner = Interner::new();
     check_parser(
         "a & b",
         vec![BinOp::new(BitOp::And, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a&b",
         vec![BinOp::new(BitOp::And, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "a | b",
         vec![BinOp::new(BitOp::Or, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a|b",
         vec![BinOp::new(BitOp::Or, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "a ^ b",
         vec![BinOp::new(BitOp::Xor, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a^b",
         vec![BinOp::new(BitOp::Xor, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "a << b",
         vec![BinOp::new(BitOp::Shl, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a<<b",
         vec![BinOp::new(BitOp::Shl, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "a >> b",
         vec![BinOp::new(BitOp::Shr, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a>>b",
         vec![BinOp::new(BitOp::Shr, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
 }
 
 /// Checks assignment operations.
 #[test]
 fn check_assign_operations() {
+    let mut interner = Interner::new();
     check_parser(
         "a += b",
         vec![BinOp::new(AssignOp::Add, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a -= b",
         vec![BinOp::new(AssignOp::Sub, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a *= b",
         vec![BinOp::new(AssignOp::Mul, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a **= b",
         vec![BinOp::new(AssignOp::Exp, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a /= b",
         vec![BinOp::new(AssignOp::Div, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a %= b",
         vec![BinOp::new(AssignOp::Mod, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a &= b",
         vec![BinOp::new(AssignOp::And, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a |= b",
         vec![BinOp::new(AssignOp::Or, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a ^= b",
         vec![BinOp::new(AssignOp::Xor, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a <<= b",
         vec![BinOp::new(AssignOp::Shl, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a >>= b",
         vec![BinOp::new(AssignOp::Shr, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a >>>= b",
         vec![BinOp::new(AssignOp::Ushr, Identifier::from("a"), Identifier::from("b")).into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a %= 10 / 2",
         vec![BinOp::new(
@@ -190,7 +292,10 @@ fn check_assign_operations() {
             BinOp::new(NumOp::Div, Const::from(10), Const::from(2)),
         )
         .into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a ??= b",
         vec![BinOp::new(
@@ -199,11 +304,13 @@ fn check_assign_operations() {
             Identifier::from("b"),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_relational_operations() {
+    let mut interner = Interner::new();
     check_parser(
         "a < b",
         vec![BinOp::new(
@@ -212,7 +319,10 @@ fn check_relational_operations() {
             Identifier::from("b"),
         )
         .into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a > b",
         vec![BinOp::new(
@@ -221,7 +331,10 @@ fn check_relational_operations() {
             Identifier::from("b"),
         )
         .into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a <= b",
         vec![BinOp::new(
@@ -230,7 +343,10 @@ fn check_relational_operations() {
             Identifier::from("b"),
         )
         .into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "a >= b",
         vec![BinOp::new(
@@ -239,15 +355,20 @@ fn check_relational_operations() {
             Identifier::from("b"),
         )
         .into()],
+        &mut interner,
     );
+
+    let mut interner = Interner::new();
     check_parser(
         "p in o",
         vec![BinOp::new(CompOp::In, Identifier::from("p"), Identifier::from("o")).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_logical_expressions() {
+    let mut interner = Interner::new();
     check_parser(
         "a && b || c && d || e",
         vec![BinOp::new(
@@ -260,8 +381,10 @@ fn check_logical_expressions() {
             ),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "a ?? b ?? c",
         vec![BinOp::new(
@@ -274,6 +397,7 @@ fn check_logical_expressions() {
             Identifier::from("c"),
         )
         .into()],
+        &mut interner,
     );
 
     check_invalid("a ?? b && c");

--- a/boa/src/syntax/parser/expression/unary.rs
+++ b/boa/src/syntax/parser/expression/unary.rs
@@ -21,6 +21,7 @@ use crate::{
             ParseResult, TokenParser,
         },
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -58,15 +59,15 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> ParseResult {
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
         let _timer = BoaProfiler::global().start_event("UnaryExpression", "Parsing");
 
-        let tok = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+        let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         let token_start = tok.span().start();
         match tok.kind() {
             TokenKind::Keyword(Keyword::Delete) => {
-                cursor.next()?.expect("Delete keyword vanished"); // Consume the token.
-                let val = self.parse(cursor)?;
+                cursor.next(interner)?.expect("Delete keyword vanished"); // Consume the token.
+                let val = self.parse(cursor, interner)?;
 
                 if cursor.strict_mode() {
                     if let Node::Identifier(_) = val {
@@ -80,30 +81,30 @@ where
                 Ok(node::UnaryOp::new(UnaryOp::Delete, val).into())
             }
             TokenKind::Keyword(Keyword::Void) => {
-                cursor.next()?.expect("Void keyword vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::Void, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("Void keyword vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::Void, self.parse(cursor, interner)?).into())
             }
             TokenKind::Keyword(Keyword::TypeOf) => {
-                cursor.next()?.expect("TypeOf keyword vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::TypeOf, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("TypeOf keyword vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::TypeOf, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Add) => {
-                cursor.next()?.expect("+ token vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::Plus, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("+ token vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::Plus, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Sub) => {
-                cursor.next()?.expect("- token vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::Minus, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("- token vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::Minus, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Neg) => {
-                cursor.next()?.expect("~ token vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::Tilde, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("~ token vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::Tilde, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Not) => {
-                cursor.next()?.expect("! token vanished"); // Consume the token.
-                Ok(node::UnaryOp::new(UnaryOp::Not, self.parse(cursor)?).into())
+                cursor.next(interner)?.expect("! token vanished"); // Consume the token.
+                Ok(node::UnaryOp::new(UnaryOp::Not, self.parse(cursor, interner)?).into())
             }
-            _ => UpdateExpression::new(self.allow_yield, self.allow_await).parse(cursor),
+            _ => UpdateExpression::new(self.allow_yield, self.allow_await).parse(cursor, interner),
         }
     }
 }

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -1,15 +1,19 @@
-use crate::syntax::{
-    ast::node::{
-        ArrowFunctionDecl, BinOp, Declaration, DeclarationList, FormalParameter, FunctionDecl,
-        Identifier, Node, Return,
+use crate::{
+    syntax::{
+        ast::node::{
+            ArrowFunctionDecl, BinOp, Declaration, DeclarationList, FormalParameter, FunctionDecl,
+            Identifier, Node, Return,
+        },
+        ast::op::NumOp,
+        parser::{tests::check_parser, Parser},
     },
-    ast::op::NumOp,
-    parser::{tests::check_parser, Parser},
+    Interner,
 };
 
 /// Checks basic function declaration parsing.
 #[test]
 fn check_basic() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a) { return a; }",
         vec![FunctionDecl::new(
@@ -21,12 +25,14 @@ fn check_basic() {
             vec![Return::new(Identifier::from("a"), None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks if duplicate parameter names are allowed with strict mode off.
 #[test]
 fn check_duplicates_strict_off() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a, a) { return a; }",
         vec![FunctionDecl::new(
@@ -38,6 +44,7 @@ fn check_duplicates_strict_off() {
             vec![Return::new(Identifier::from("a"), None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -45,8 +52,9 @@ fn check_duplicates_strict_off() {
 #[test]
 fn check_duplicates_strict_on() {
     let js = "'use strict'; function foo(a, a) {}";
+    let mut interner = Interner::new();
 
-    let res = Parser::new(js.as_bytes(), false).parse_all();
+    let res = Parser::new(js.as_bytes(), false).parse_all(&mut interner);
     dbg!(&res);
     assert!(res.is_err());
 }
@@ -54,6 +62,7 @@ fn check_duplicates_strict_on() {
 /// Checks basic function declaration parsing with automatic semicolon insertion.
 #[test]
 fn check_basic_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a) { return a }",
         vec![FunctionDecl::new(
@@ -65,12 +74,14 @@ fn check_basic_semicolon_insertion() {
             vec![Return::new(Identifier::from("a"), None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks functions with empty returns.
 #[test]
 fn check_empty_return() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a) { return; }",
         vec![FunctionDecl::new(
@@ -82,12 +93,14 @@ fn check_empty_return() {
             vec![Return::new::<Node, Option<Node>, Option<_>>(None, None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks functions with empty returns without semicolon
 #[test]
 fn check_empty_return_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a) { return }",
         vec![FunctionDecl::new(
@@ -99,12 +112,14 @@ fn check_empty_return_semicolon_insertion() {
             vec![Return::new::<Node, Option<Node>, Option<_>>(None, None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks rest operator parsing.
 #[test]
 fn check_rest_operator() {
+    let mut interner = Interner::new();
     check_parser(
         "function foo(a, ...b) {}",
         vec![FunctionDecl::new(
@@ -116,12 +131,14 @@ fn check_rest_operator() {
             vec![],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks an arrow function with only a rest parameter.
 #[test]
 fn check_arrow_only_rest() {
+    let mut interner = Interner::new();
     check_parser(
         "(...a) => {}",
         vec![ArrowFunctionDecl::new(
@@ -132,12 +149,14 @@ fn check_arrow_only_rest() {
             vec![],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks an arrow function with a rest parameter.
 #[test]
 fn check_arrow_rest() {
+    let mut interner = Interner::new();
     check_parser(
         "(a, b, ...c) => {}",
         vec![ArrowFunctionDecl::new(
@@ -149,12 +168,14 @@ fn check_arrow_rest() {
             vec![],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks an arrow function with expression return.
 #[test]
 fn check_arrow() {
+    let mut interner = Interner::new();
     check_parser(
         "(a, b) => { return a + b; }",
         vec![ArrowFunctionDecl::new(
@@ -169,12 +190,14 @@ fn check_arrow() {
             .into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks an arrow function with expression return and automatic semicolon insertion
 #[test]
 fn check_arrow_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "(a, b) => { return a + b }",
         vec![ArrowFunctionDecl::new(
@@ -189,12 +212,14 @@ fn check_arrow_semicolon_insertion() {
             .into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks arrow function with empty return
 #[test]
 fn check_arrow_epty_return() {
+    let mut interner = Interner::new();
     check_parser(
         "(a, b) => { return; }",
         vec![ArrowFunctionDecl::new(
@@ -205,12 +230,14 @@ fn check_arrow_epty_return() {
             vec![Return::new::<Node, Option<_>, Option<_>>(None, None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks an arrow function with empty return, with automatic semicolon insertion.
 #[test]
 fn check_arrow_empty_return_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "(a, b) => { return }",
         vec![ArrowFunctionDecl::new(
@@ -221,11 +248,13 @@ fn check_arrow_empty_return_semicolon_insertion() {
             vec![Return::new::<Node, Option<_>, Option<_>>(None, None).into()],
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a) => { return a };",
         vec![DeclarationList::Let(
@@ -249,11 +278,13 @@ fn check_arrow_assignment() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_nobrackets() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a) => a;",
         vec![DeclarationList::Let(
@@ -277,11 +308,13 @@ fn check_arrow_assignment_nobrackets() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_noparenthesis() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = a => { return a };",
         vec![DeclarationList::Let(
@@ -305,11 +338,13 @@ fn check_arrow_assignment_noparenthesis() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_noparenthesis_nobrackets() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = a => a;",
         vec![DeclarationList::Let(
@@ -333,11 +368,13 @@ fn check_arrow_assignment_noparenthesis_nobrackets() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_2arg() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a, b) => { return a };",
         vec![DeclarationList::Let(
@@ -367,11 +404,13 @@ fn check_arrow_assignment_2arg() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_2arg_nobrackets() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a, b) => a;",
         vec![DeclarationList::Let(
@@ -401,11 +440,13 @@ fn check_arrow_assignment_2arg_nobrackets() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_3arg() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a, b, c) => { return a };",
         vec![DeclarationList::Let(
@@ -439,11 +480,13 @@ fn check_arrow_assignment_3arg() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_arrow_assignment_3arg_nobrackets() {
+    let mut interner = Interner::new();
     check_parser(
         "let foo = (a, b, c) => a;",
         vec![DeclarationList::Let(
@@ -477,5 +520,6 @@ fn check_arrow_assignment_3arg_nobrackets() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/mod.rs
+++ b/boa/src/syntax/parser/mod.rs
@@ -9,7 +9,10 @@ mod statement;
 mod tests;
 
 pub use self::error::{ParseError, ParseResult};
-use crate::syntax::{ast::node::StatementList, lexer::TokenKind};
+use crate::{
+    syntax::{ast::node::StatementList, lexer::TokenKind},
+    Interner,
+};
 
 use cursor::Cursor;
 
@@ -28,7 +31,11 @@ where
     /// Parses the token stream using the current parser.
     ///
     /// This method needs to be provided by the implementor type.
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError>;
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError>;
 }
 
 /// Boolean representing if the parser should allow a `yield` keyword.
@@ -98,11 +105,11 @@ impl<R> Parser<R> {
         Self { cursor }
     }
 
-    pub fn parse_all(&mut self) -> Result<StatementList, ParseError>
+    pub fn parse_all(&mut self, interner: &mut Interner) -> Result<StatementList, ParseError>
     where
         R: Read,
     {
-        Script.parse(&mut self.cursor)
+        Script.parse(&mut self.cursor, interner)
     }
 }
 
@@ -121,18 +128,26 @@ where
 {
     type Output = StatementList;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        match cursor.peek(0)? {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        match cursor.peek(0, interner)? {
             Some(tok) => {
                 let mut strict = false;
                 match tok.kind() {
-                    TokenKind::StringLiteral(string) if string.as_ref() == "use strict" => {
+                    // Set the strict mode
+                    TokenKind::StringLiteral(string)
+                        if interner.resolve(*string).expect("string disappeared")
+                            == "use strict" =>
+                    {
                         cursor.set_strict_mode(true);
                         strict = true;
                     }
                     _ => {}
                 }
-                let mut statement_list = ScriptBody.parse(cursor)?;
+                let mut statement_list = ScriptBody.parse(cursor, interner)?;
                 statement_list.set_strict(strict);
                 Ok(statement_list)
             }
@@ -156,7 +171,11 @@ where
 {
     type Output = StatementList;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        self::statement::StatementList::new(false, false, false, false, &[]).parse(cursor)
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        self::statement::StatementList::new(false, false, false, false, &[]).parse(cursor, interner)
     }
 }

--- a/boa/src/syntax/parser/statement/block/mod.rs
+++ b/boa/src/syntax/parser/statement/block/mod.rs
@@ -11,14 +11,14 @@
 mod tests;
 
 use super::StatementList;
-
-use crate::syntax::lexer::TokenKind;
 use crate::{
     profiler::BoaProfiler,
     syntax::{
         ast::{node, Punctuator},
+        lexer::TokenKind,
         parser::{AllowAwait, AllowReturn, AllowYield, Cursor, ParseError, TokenParser},
     },
+    Interner,
 };
 
 use std::io::Read;
@@ -71,12 +71,16 @@ where
 {
     type Output = node::Block;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Block", "Parsing");
-        cursor.expect(Punctuator::OpenBlock, "block")?;
-        if let Some(tk) = cursor.peek(0)? {
+        cursor.expect(Punctuator::OpenBlock, "block", interner)?;
+        if let Some(tk) = cursor.peek(0, interner)? {
             if tk.kind() == &TokenKind::Punctuator(Punctuator::CloseBlock) {
-                cursor.next()?.expect("} token vanished");
+                cursor.next(interner)?.expect("} token vanished");
                 return Ok(node::Block::from(vec![]));
             }
         }
@@ -88,9 +92,9 @@ where
             true,
             &BLOCK_BREAK_TOKENS,
         )
-        .parse(cursor)
+        .parse(cursor, interner)
         .map(node::Block::from)?;
-        cursor.expect(Punctuator::CloseBlock, "block")?;
+        cursor.expect(Punctuator::CloseBlock, "block", interner)?;
 
         Ok(statement_list)
     }

--- a/boa/src/syntax/parser/statement/break_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/break_stm/tests.rs
@@ -1,13 +1,17 @@
-use crate::syntax::{
-    ast::{
-        node::{Block, Break, Node, WhileLoop},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Block, Break, Node, WhileLoop},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 #[test]
 fn inline() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) break;",
         vec![WhileLoop::new(
@@ -15,20 +19,24 @@ fn inline() {
             Node::Break(Break::new::<_, Box<str>>(None)),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true)
             break;",
         vec![WhileLoop::new(Const::from(true), Break::new::<_, Box<str>>(None)).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn inline_block_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {break}",
         vec![WhileLoop::new(
@@ -36,11 +44,13 @@ fn inline_block_semicolon_insertion() {
             Block::from(vec![Break::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break test
@@ -50,11 +60,13 @@ fn new_line_semicolon_insertion() {
             Block::from(vec![Break::new("test").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn inline_block() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {break;}",
         vec![WhileLoop::new(
@@ -62,11 +74,13 @@ fn inline_block() {
             Block::from(vec![Break::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break test;
@@ -76,11 +90,13 @@ fn new_line_block() {
             Block::from(vec![Break::new("test").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn reserved_label() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break await;
@@ -90,8 +106,10 @@ fn reserved_label() {
             Block::from(vec![Break::new("await").into()]),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break yield;
@@ -101,11 +119,13 @@ fn reserved_label() {
             Block::from(vec![Break::new("yield").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block_empty() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break;
@@ -115,11 +135,13 @@ fn new_line_block_empty() {
             Block::from(vec![Break::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block_empty_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             break
@@ -129,5 +151,6 @@ fn new_line_block_empty_semicolon_insertion() {
             Block::from(vec![Break::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/continue_stm/mod.rs
@@ -11,6 +11,7 @@
 mod tests;
 
 use crate::syntax::lexer::TokenKind;
+use crate::Interner;
 use crate::{
     syntax::{
         ast::{node::Continue, Keyword, Punctuator},
@@ -59,22 +60,27 @@ where
 {
     type Output = Continue;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ContinueStatement", "Parsing");
-        cursor.expect(Keyword::Continue, "continue statement")?;
+        cursor.expect(Keyword::Continue, "continue statement", interner)?;
 
-        let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon()? {
+        let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {
                 Some(tok) if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
-                    let _ = cursor.next();
+                    let _ = cursor.next(interner)?;
                 }
                 _ => {}
             }
 
             None
         } else {
-            let label = LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor)?;
-            cursor.expect_semicolon("continue statement")?;
+            let label =
+                LabelIdentifier::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
+            cursor.expect_semicolon("continue statement", interner)?;
 
             Some(label)
         };

--- a/boa/src/syntax/parser/statement/continue_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/continue_stm/tests.rs
@@ -1,30 +1,38 @@
-use crate::syntax::{
-    ast::{
-        node::{Block, Continue, WhileLoop},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Block, Continue, WhileLoop},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 #[test]
 fn inline() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) continue;",
         vec![WhileLoop::new(Const::from(true), Continue::new::<_, Box<str>>(None)).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true)
             continue;",
         vec![WhileLoop::new(Const::from(true), Continue::new::<_, Box<str>>(None)).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn inline_block_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {continue}",
         vec![WhileLoop::new(
@@ -32,11 +40,13 @@ fn inline_block_semicolon_insertion() {
             Block::from(vec![Continue::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue test
@@ -46,11 +56,13 @@ fn new_line_semicolon_insertion() {
             Block::from(vec![Continue::new("test").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn inline_block() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {continue;}",
         vec![WhileLoop::new(
@@ -58,11 +70,13 @@ fn inline_block() {
             Block::from(vec![Continue::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue test;
@@ -72,11 +86,13 @@ fn new_line_block() {
             Block::from(vec![Continue::new("test").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn reserved_label() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue await;
@@ -86,8 +102,10 @@ fn reserved_label() {
             Block::from(vec![Continue::new("await").into()]),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue yield;
@@ -97,11 +115,13 @@ fn reserved_label() {
             Block::from(vec![Continue::new("yield").into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block_empty() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue;
@@ -111,11 +131,13 @@ fn new_line_block_empty() {
             Block::from(vec![Continue::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn new_line_block_empty_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         "while (true) {
             continue
@@ -125,5 +147,6 @@ fn new_line_block_empty_semicolon_insertion() {
             Block::from(vec![Continue::new::<_, Box<str>>(None).into()]),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::syntax::{
-    ast::{node::AsyncFunctionDecl, Keyword},
-    parser::{
-        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+use crate::{
+    syntax::{
+        ast::{node::AsyncFunctionDecl, Keyword},
+        parser::{
+            statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+            AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        },
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -74,12 +77,16 @@ where
 {
     type Output = AsyncFunctionDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Async, "async hoistable declaration")?;
-        cursor.peek_expect_no_lineterminator(0, "async hoistable declaration")?;
-        cursor.expect(Keyword::Function, "async hoistable declaration")?;
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        cursor.expect(Keyword::Async, "async function declaration", interner)?;
+        cursor.peek_expect_no_lineterminator(0, "async function declaration", interner)?;
+        cursor.expect(Keyword::Function, "async function declaration", interner)?;
 
-        let result = parse_callable_declaration(&self, cursor)?;
+        let result = parse_callable_declaration(&self, cursor, interner)?;
 
         Ok(AsyncFunctionDecl::new(result.0, result.1, result.2))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_function_decl/tests.rs
@@ -1,24 +1,33 @@
-use crate::syntax::{ast::node::AsyncFunctionDecl, parser::tests::check_parser};
+use crate::{
+    syntax::{ast::node::AsyncFunctionDecl, parser::tests::check_parser},
+    Interner,
+};
 
 /// Async function declaration parsing.
 #[test]
 fn async_function_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "async function hello() {}",
         vec![AsyncFunctionDecl::new(Box::from("hello"), vec![], vec![]).into()],
+        &mut interner,
     );
 }
 
 /// Async function declaration parsing with keywords.
 #[test]
 fn async_function_declaration_keywords() {
+    let mut interner = Interner::new();
     check_parser(
         "async function yield() {}",
         vec![AsyncFunctionDecl::new(Box::from("yield"), vec![], vec![]).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "async function await() {}",
         vec![AsyncFunctionDecl::new(Box::from("await"), vec![], vec![]).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -6,12 +6,15 @@
 
 #[cfg(test)]
 mod tests;
-use crate::syntax::{
-    ast::{node::AsyncGeneratorDecl, Keyword, Punctuator},
-    parser::{
-        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+use crate::{
+    syntax::{
+        ast::{node::AsyncGeneratorDecl, Keyword, Punctuator},
+        parser::{
+            statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+            AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        },
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -92,13 +95,17 @@ where
 {
     type Output = AsyncGeneratorDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Async, "async hoistable declaration")?;
-        cursor.peek_expect_no_lineterminator(0, "async hoistable declaration")?;
-        cursor.expect(Keyword::Function, "async hoistable declaration")?;
-        cursor.expect(Punctuator::Mul, "async generator declaration")?;
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        cursor.expect(Keyword::Async, "async generator declaration", interner)?;
+        cursor.peek_expect_no_lineterminator(0, "async generator declaration", interner)?;
+        cursor.expect(Keyword::Function, "async generator declaration", interner)?;
+        cursor.expect(Punctuator::Mul, "async generator declaration", interner)?;
 
-        let result = parse_callable_declaration(&self, cursor)?;
+        let result = parse_callable_declaration(&self, cursor, interner)?;
 
         Ok(AsyncGeneratorDecl::new(result.0, result.1, result.2))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
@@ -1,9 +1,14 @@
-use crate::syntax::{ast::node::AsyncGeneratorDecl, parser::tests::check_parser};
+use crate::{
+    syntax::{ast::node::AsyncGeneratorDecl, parser::tests::check_parser},
+    Interner,
+};
 
 #[test]
 fn async_generator_function_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "async function* gen() {}",
         vec![AsyncGeneratorDecl::new(Box::from("gen"), vec![], vec![]).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::syntax::{
-    ast::{node::FunctionDecl, Keyword},
-    parser::{
-        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+use crate::{
+    syntax::{
+        ast::{node::FunctionDecl, Keyword},
+        parser::{
+            statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+            AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        },
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -79,10 +82,14 @@ where
 {
     type Output = FunctionDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Function, "function declaration")?;
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        cursor.expect(Keyword::Function, "function declaration", interner)?;
 
-        let result = parse_callable_declaration(&self, cursor)?;
+        let result = parse_callable_declaration(&self, cursor, interner)?;
 
         Ok(FunctionDecl::new(result.0, result.1, result.2))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/function_decl/tests.rs
@@ -1,24 +1,33 @@
-use crate::syntax::{ast::node::FunctionDecl, parser::tests::check_parser};
+use crate::{
+    syntax::{ast::node::FunctionDecl, parser::tests::check_parser},
+    Interner,
+};
 
 /// Function declaration parsing.
 #[test]
 fn function_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "function hello() {}",
         vec![FunctionDecl::new(Box::from("hello"), vec![], vec![]).into()],
+        &mut interner,
     );
 }
 
 /// Function declaration parsing with keywords.
 #[test]
 fn function_declaration_keywords() {
+    let mut interner = Interner::new();
     check_parser(
         "function yield() {}",
         vec![FunctionDecl::new(Box::from("yield"), vec![], vec![]).into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "function await() {}",
         vec![FunctionDecl::new(Box::from("await"), vec![], vec![]).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -1,12 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::syntax::{
-    ast::{node::declaration::generator_decl::GeneratorDecl, Keyword, Punctuator},
-    parser::{
-        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-        AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+use crate::{
+    syntax::{
+        ast::{node::declaration::generator_decl::GeneratorDecl, Keyword, Punctuator},
+        parser::{
+            statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+            AllowAwait, AllowDefault, AllowYield, Cursor, ParseError, TokenParser,
+        },
     },
+    Interner,
 };
 use std::io::Read;
 
@@ -74,11 +77,15 @@ where
 {
     type Output = GeneratorDecl;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Function, "generator declaration")?;
-        cursor.expect(Punctuator::Mul, "generator declaration")?;
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
+        cursor.expect(Keyword::Function, "generator declaration", interner)?;
+        cursor.expect(Punctuator::Mul, "generator declaration", interner)?;
 
-        let result = parse_callable_declaration(&self, cursor)?;
+        let result = parse_callable_declaration(&self, cursor, interner)?;
 
         Ok(GeneratorDecl::new(result.0, result.1, result.2))
     }

--- a/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
@@ -1,9 +1,14 @@
-use crate::syntax::{ast::node::GeneratorDecl, parser::tests::check_parser};
+use crate::{
+    syntax::{ast::node::GeneratorDecl, parser::tests::check_parser},
+    Interner,
+};
 
 #[test]
 fn generator_function_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "function* gen() {}",
         vec![GeneratorDecl::new(Box::from("gen"), vec![], vec![]).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/declaration/mod.rs
+++ b/boa/src/syntax/parser/statement/declaration/mod.rs
@@ -15,6 +15,7 @@ mod tests;
 use self::{hoistable::HoistableDeclaration, lexical::LexicalDeclaration};
 
 use crate::syntax::lexer::TokenKind;
+use crate::Interner;
 use crate::{
     syntax::{
         ast::{Keyword, Node},
@@ -58,13 +59,18 @@ where
 {
     type Output = Node;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Declaration", "Parsing");
-        let tok = cursor.peek(0)?.ok_or(ParseError::AbruptEnd)?;
+        let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
             TokenKind::Keyword(Keyword::Function) | TokenKind::Keyword(Keyword::Async) => {
-                HoistableDeclaration::new(self.allow_yield, self.allow_await, false).parse(cursor)
+                HoistableDeclaration::new(self.allow_yield, self.allow_await, false)
+                    .parse(cursor, interner)
             }
             TokenKind::Keyword(Keyword::Const) | TokenKind::Keyword(Keyword::Let) => {
                 LexicalDeclaration::new(
@@ -73,7 +79,7 @@ where
                     self.allow_await,
                     self.const_init_required,
                 )
-                .parse(cursor)
+                .parse(cursor, interner)
             }
             _ => unreachable!("unknown token found: {:?}", tok),
         }

--- a/boa/src/syntax/parser/statement/declaration/tests.rs
+++ b/boa/src/syntax/parser/statement/declaration/tests.rs
@@ -1,14 +1,18 @@
-use crate::syntax::{
-    ast::{
-        node::{Declaration, DeclarationList, Node},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Declaration, DeclarationList, Node},
+            Const,
+        },
+        parser::tests::{check_invalid, check_parser},
     },
-    parser::tests::{check_invalid, check_parser},
+    Interner,
 };
 
 /// Checks `var` declaration parsing.
 #[test]
 fn var_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "var a = 5;",
         vec![DeclarationList::Var(
@@ -19,12 +23,14 @@ fn var_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `var` declaration parsing with reserved words.
 #[test]
 fn var_declaration_keywords() {
+    let mut interner = Interner::new();
     check_parser(
         "var yield = 5;",
         vec![DeclarationList::Var(
@@ -35,8 +41,10 @@ fn var_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "var await = 5;",
         vec![DeclarationList::Var(
@@ -47,12 +55,14 @@ fn var_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `var` declaration parsing with no spaces.
 #[test]
 fn var_declaration_no_spaces() {
+    let mut interner = Interner::new();
     check_parser(
         "var a=5;",
         vec![DeclarationList::Var(
@@ -63,21 +73,25 @@ fn var_declaration_no_spaces() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks empty `var` declaration parsing.
 #[test]
 fn empty_var_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "var a;",
         vec![DeclarationList::Var(vec![Declaration::new_with_identifier("a", None)].into()).into()],
+        &mut interner,
     );
 }
 
 /// Checks multiple `var` declarations.
 #[test]
 fn multiple_var_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "var a = 5, b, c = 6;",
         vec![DeclarationList::Var(
@@ -89,12 +103,14 @@ fn multiple_var_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `let` declaration parsing.
 #[test]
 fn let_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "let a = 5;",
         vec![DeclarationList::Let(
@@ -105,12 +121,14 @@ fn let_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `let` declaration parsing with reserved words.
 #[test]
 fn let_declaration_keywords() {
+    let mut interner = Interner::new();
     check_parser(
         "let yield = 5;",
         vec![DeclarationList::Let(
@@ -121,8 +139,10 @@ fn let_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "let await = 5;",
         vec![DeclarationList::Let(
@@ -133,12 +153,14 @@ fn let_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `let` declaration parsing with no spaces.
 #[test]
 fn let_declaration_no_spaces() {
+    let mut interner = Interner::new();
     check_parser(
         "let a=5;",
         vec![DeclarationList::Let(
@@ -149,21 +171,25 @@ fn let_declaration_no_spaces() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks empty `let` declaration parsing.
 #[test]
 fn empty_let_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "let a;",
         vec![DeclarationList::Let(vec![Declaration::new_with_identifier("a", None)].into()).into()],
+        &mut interner,
     );
 }
 
 /// Checks multiple `let` declarations.
 #[test]
 fn multiple_let_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "let a = 5, b, c = 6;",
         vec![DeclarationList::Let(
@@ -175,12 +201,14 @@ fn multiple_let_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `const` declaration parsing.
 #[test]
 fn const_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "const a = 5;",
         vec![DeclarationList::Const(
@@ -191,12 +219,14 @@ fn const_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `const` declaration parsing with reserved words.
 #[test]
 fn const_declaration_keywords() {
+    let mut interner = Interner::new();
     check_parser(
         "const yield = 5;",
         vec![DeclarationList::Const(
@@ -207,8 +237,10 @@ fn const_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 
+    let mut interner = Interner::new();
     check_parser(
         "const await = 5;",
         vec![DeclarationList::Const(
@@ -219,12 +251,14 @@ fn const_declaration_keywords() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
 /// Checks `const` declaration parsing with no spaces.
 #[test]
 fn const_declaration_no_spaces() {
+    let mut interner = Interner::new();
     check_parser(
         "const a=5;",
         vec![DeclarationList::Const(
@@ -235,6 +269,7 @@ fn const_declaration_no_spaces() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }
 
@@ -247,6 +282,7 @@ fn empty_const_declaration() {
 /// Checks multiple `const` declarations.
 #[test]
 fn multiple_const_declaration() {
+    let mut interner = Interner::new();
     check_parser(
         "const a = 5, c = 6;",
         vec![DeclarationList::Const(
@@ -257,5 +293,6 @@ fn multiple_const_declaration() {
             .into(),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/if_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/if_stm/tests.rs
@@ -1,23 +1,30 @@
-use crate::syntax::{
-    ast::{
-        node::{Block, If, Node},
-        Const,
+use crate::{
+    syntax::{
+        ast::{
+            node::{Block, If, Node},
+            Const,
+        },
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 #[test]
 fn if_without_else_block() {
+    let mut interner = Interner::new();
     check_parser(
         "if (true) {}",
         vec![If::new::<_, _, Node, _>(Const::from(true), Block::from(Vec::new()), None).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn if_without_else_block_with_trailing_newline() {
+    let mut interner = Interner::new();
     check_parser(
         "if (true) {}\n",
         vec![If::new::<_, _, Node, _>(Const::from(true), Block::from(Vec::new()), None).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/iteration/tests.rs
+++ b/boa/src/syntax/parser/statement/iteration/tests.rs
@@ -1,18 +1,22 @@
-use crate::syntax::{
-    ast::{
-        node::{
-            field::GetConstField, BinOp, Block, Break, Call, Declaration, DeclarationList,
-            DoWhileLoop, Identifier, UnaryOp, WhileLoop,
+use crate::{
+    syntax::{
+        ast::{
+            node::{
+                field::GetConstField, BinOp, Block, Break, Call, Declaration, DeclarationList,
+                DoWhileLoop, Identifier, UnaryOp, WhileLoop,
+            },
+            op::{self, AssignOp, CompOp},
+            Const,
         },
-        op::{self, AssignOp, CompOp},
-        Const,
+        parser::tests::check_parser,
     },
-    parser::tests::check_parser,
+    Interner,
 };
 
 /// Checks do-while statement parsing.
 #[test]
 fn check_do_while() {
+    let mut interner = Interner::new();
     check_parser(
         r#"do {
             a += 1;
@@ -27,12 +31,14 @@ fn check_do_while() {
             Const::from(true),
         )
         .into()],
+        &mut interner,
     );
 }
 
 // Checks automatic semicolon insertion after do-while.
 #[test]
 fn check_do_while_semicolon_insertion() {
+    let mut interner = Interner::new();
     check_parser(
         r#"var i = 0;
         do {console.log("hello");} while(i++ < 10) console.log("end");"#,
@@ -64,6 +70,7 @@ fn check_do_while_semicolon_insertion() {
             )
             .into(),
         ],
+        &mut interner,
     );
 }
 
@@ -71,6 +78,7 @@ fn check_do_while_semicolon_insertion() {
 // and next statement.
 #[test]
 fn check_do_while_semicolon_insertion_no_space() {
+    let mut interner = Interner::new();
     check_parser(
         r#"var i = 0;
         do {console.log("hello");} while(i++ < 10)console.log("end");"#,
@@ -102,12 +110,14 @@ fn check_do_while_semicolon_insertion_no_space() {
             )
             .into(),
         ],
+        &mut interner,
     );
 }
 
 /// Checks parsing of a while statement which is seperated out with line terminators.
 #[test]
 fn while_spaces() {
+    let mut interner = Interner::new();
     check_parser(
         r#"
 
@@ -123,12 +133,14 @@ fn while_spaces() {
 
         "#,
         vec![WhileLoop::new(Const::from(true), Break::new::<_, Box<str>>(None)).into()],
+        &mut interner,
     );
 }
 
 /// Checks parsing of a while statement which is seperated out with line terminators.
 #[test]
 fn do_while_spaces() {
+    let mut interner = Interner::new();
     check_parser(
         r#"
 
@@ -148,5 +160,6 @@ fn do_while_spaces() {
             Const::Bool(true),
         )
         .into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/while_statement.rs
@@ -6,7 +6,7 @@ use crate::{
             Cursor, ParseError, TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 
 use std::io::Read;
@@ -52,21 +52,26 @@ where
 {
     type Output = WhileLoop;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("WhileStatement", "Parsing");
-        cursor.expect(Keyword::While, "while statement")?;
+        cursor.expect(Keyword::While, "while statement", interner)?;
 
-        cursor.expect(Punctuator::OpenParen, "while statement")?;
+        cursor.expect(Punctuator::OpenParen, "while statement", interner)?;
 
-        let cond = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
+        let cond =
+            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
         let position = cursor
-            .expect(Punctuator::CloseParen, "while statement")?
+            .expect(Punctuator::CloseParen, "while statement", interner)?
             .span()
             .end();
 
-        let body =
-            Statement::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor)?;
+        let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+            .parse(cursor, interner)?;
 
         // Early Error: It is a Syntax Error if IsLabelledFunction(Statement) is true.
         if let Node::FunctionDecl(_) = body {

--- a/boa/src/syntax/parser/statement/switch/tests.rs
+++ b/boa/src/syntax/parser/statement/switch/tests.rs
@@ -1,12 +1,15 @@
-use crate::syntax::{
-    ast::{
-        node::{
-            Break, Call, Case, Declaration, DeclarationList, GetConstField, Identifier, Node,
-            Switch,
+use crate::{
+    syntax::{
+        ast::{
+            node::{
+                Break, Call, Case, Declaration, DeclarationList, GetConstField, Identifier, Node,
+                Switch,
+            },
+            Const,
         },
-        Const,
+        parser::tests::{check_invalid, check_parser},
     },
-    parser::tests::{check_invalid, check_parser},
+    Interner,
 };
 
 /// Checks parsing malformed switch with no closeblock.
@@ -148,6 +151,7 @@ fn check_seperated_switch() {
         }
         "#;
 
+    let mut interner = Interner::new();
     check_parser(
         s,
         vec![
@@ -193,5 +197,6 @@ fn check_seperated_switch() {
             )
             .into(),
         ],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/throw/mod.rs
+++ b/boa/src/syntax/parser/statement/throw/mod.rs
@@ -2,6 +2,7 @@
 mod tests;
 
 use crate::syntax::lexer::TokenKind;
+use crate::Interner;
 use crate::{
     syntax::{
         ast::{node::Throw, Keyword, Punctuator},
@@ -46,16 +47,21 @@ where
 {
     type Output = Throw;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("ThrowStatement", "Parsing");
-        cursor.expect(Keyword::Throw, "throw statement")?;
+        cursor.expect(Keyword::Throw, "throw statement", interner)?;
 
-        cursor.peek_expect_no_lineterminator(0, "throw statement")?;
+        cursor.peek_expect_no_lineterminator(0, "throw statement", interner)?;
 
-        let expr = Expression::new(true, self.allow_yield, self.allow_await).parse(cursor)?;
-        if let Some(tok) = cursor.peek(0)? {
+        let expr =
+            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
-                let _ = cursor.next();
+                let _ = cursor.next(interner).expect("token disappeared");
             }
         }
 

--- a/boa/src/syntax/parser/statement/throw/tests.rs
+++ b/boa/src/syntax/parser/statement/throw/tests.rs
@@ -1,12 +1,17 @@
-use crate::syntax::{
-    ast::{node::Throw, Const},
-    parser::tests::check_parser,
+use crate::{
+    syntax::{
+        ast::{node::Throw, Const},
+        parser::tests::check_parser,
+    },
+    Interner,
 };
 
 #[test]
 fn check_throw_parsing() {
+    let mut interner = Interner::new();
     check_parser(
         "throw 'error';",
         vec![Throw::new(Const::from("error")).into()],
+        &mut interner,
     );
 }

--- a/boa/src/syntax/parser/statement/try_stm/finally.rs
+++ b/boa/src/syntax/parser/statement/try_stm/finally.rs
@@ -6,7 +6,7 @@ use crate::{
             TokenParser,
         },
     },
-    BoaProfiler,
+    BoaProfiler, Interner,
 };
 
 use std::io::Read;
@@ -48,12 +48,16 @@ where
 {
     type Output = node::Finally;
 
-    fn parse(self, cursor: &mut Cursor<R>) -> Result<Self::Output, ParseError> {
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> Result<Self::Output, ParseError> {
         let _timer = BoaProfiler::global().start_event("Finally", "Parsing");
-        cursor.expect(Keyword::Finally, "try statement")?;
+        cursor.expect(Keyword::Finally, "try statement", interner)?;
         Ok(
             Block::new(self.allow_yield, self.allow_await, self.allow_return)
-                .parse(cursor)?
+                .parse(cursor, interner)?
                 .into(),
         )
     }

--- a/boa/src/syntax/parser/statement/try_stm/tests.rs
+++ b/boa/src/syntax/parser/statement/try_stm/tests.rs
@@ -1,16 +1,20 @@
-use crate::syntax::{
-    ast::{
-        node::{
-            declaration::{BindingPatternTypeArray, BindingPatternTypeObject},
-            Block, Catch, Declaration, DeclarationList, Finally, Try,
+use crate::{
+    syntax::{
+        ast::{
+            node::{
+                declaration::{BindingPatternTypeArray, BindingPatternTypeObject},
+                Block, Catch, Declaration, DeclarationList, Finally, Try,
+            },
+            Const,
         },
-        Const,
+        parser::tests::{check_invalid, check_parser},
     },
-    parser::tests::{check_invalid, check_parser},
+    Interner,
 };
 
 #[test]
 fn check_inline_with_empty_try_catch() {
+    let mut interner = Interner::new();
     check_parser(
         "try { } catch(e) {}",
         vec![Try::new(
@@ -22,11 +26,13 @@ fn check_inline_with_empty_try_catch() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_var_decl_inside_try() {
+    let mut interner = Interner::new();
     check_parser(
         "try { var x = 1; } catch(e) {}",
         vec![Try::new(
@@ -45,11 +51,13 @@ fn check_inline_with_var_decl_inside_try() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_var_decl_inside_catch() {
+    let mut interner = Interner::new();
     check_parser(
         "try { var x = 1; } catch(e) { var x = 1; }",
         vec![Try::new(
@@ -75,11 +83,13 @@ fn check_inline_with_var_decl_inside_catch() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_empty_try_catch_finally() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} catch(e) {} finally {}",
         vec![Try::new(
@@ -91,19 +101,23 @@ fn check_inline_with_empty_try_catch_finally() {
             Some(Finally::from(vec![])),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_empty_try_finally() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} finally {}",
         vec![Try::new(vec![], None, Some(Finally::from(vec![]))).into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_empty_try_var_decl_in_finally() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} finally { var x = 1; }",
         vec![Try::new(
@@ -119,11 +133,13 @@ fn check_inline_with_empty_try_var_decl_in_finally() {
             .into()])),
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_empty_try_paramless_catch() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} catch { var x = 1; }",
         vec![Try::new(
@@ -142,11 +158,13 @@ fn check_inline_empty_try_paramless_catch() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_binding_pattern_object() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} catch ({ a, b: c }) {}",
         vec![Try::new(
@@ -172,11 +190,13 @@ fn check_inline_with_binding_pattern_object() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 
 #[test]
 fn check_inline_with_binding_pattern_array() {
+    let mut interner = Interner::new();
     check_parser(
         "try {} catch ([a, b]) {}",
         vec![Try::new(
@@ -200,6 +220,7 @@ fn check_inline_with_binding_pattern_array() {
             None,
         )
         .into()],
+        &mut interner,
     );
 }
 

--- a/boa/src/tests.rs
+++ b/boa/src/tests.rs
@@ -781,7 +781,7 @@ mod in_operator {
     #[test]
     fn new_instance_should_point_to_prototype() {
         // A new instance should point to a prototype object created with the constructor function
-        let mut context = Context::new();
+        let mut context = Context::default();
 
         let scenario = r#"
             function Foo() {}
@@ -913,7 +913,7 @@ fn function_decl_hoisting() {
 
 #[test]
 fn to_bigint() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(JsValue::null().to_bigint(&mut context).is_err());
     assert!(JsValue::undefined().to_bigint(&mut context).is_err());
@@ -924,7 +924,7 @@ fn to_bigint() {
 
 #[test]
 fn to_index() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(JsValue::undefined().to_index(&mut context).unwrap(), 0);
     assert!(JsValue::new(-1).to_index(&mut context).is_err());
@@ -932,7 +932,7 @@ fn to_index() {
 
 #[test]
 fn to_integer() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(Number::equal(
         JsValue::nan().to_integer(&mut context).unwrap(),
@@ -969,7 +969,7 @@ fn to_integer() {
 
 #[test]
 fn to_length() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(JsValue::new(f64::NAN).to_length(&mut context).unwrap(), 0);
     assert_eq!(
@@ -1000,7 +1000,7 @@ fn to_length() {
 
 #[test]
 fn to_int32() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     macro_rules! check_to_int32 {
         ($from:expr => $to:expr) => {
@@ -1113,7 +1113,7 @@ fn to_int32() {
 
 #[test]
 fn to_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(JsValue::null().to_string(&mut context).unwrap(), "null");
     assert_eq!(
@@ -1130,7 +1130,7 @@ fn to_string() {
 
 #[test]
 fn calling_function_with_unspecified_arguments() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let scenario = r#"
         function test(a, b) {
             return b;
@@ -1144,7 +1144,7 @@ fn calling_function_with_unspecified_arguments() {
 
 #[test]
 fn to_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert!(JsValue::undefined()
         .to_object(&mut context)
@@ -1158,7 +1158,7 @@ fn to_object() {
 
 #[test]
 fn check_this_binding_in_object_literal() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         var foo = {
             a: 3,
@@ -1173,7 +1173,7 @@ fn check_this_binding_in_object_literal() {
 
 #[test]
 fn array_creation_benchmark() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
         (function(){
             let testArr = [];
@@ -1190,7 +1190,7 @@ fn array_creation_benchmark() {
 
 #[test]
 fn array_pop_benchmark() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
     (function(){
         let testArray = [83, 93, 27, 29, 2828, 234, 23, 56, 32, 56, 67, 77, 32,
@@ -1223,7 +1223,7 @@ fn array_pop_benchmark() {
 
 #[test]
 fn number_object_access_benchmark() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let init = r#"
     new Number(
         new Number(
@@ -1296,7 +1296,7 @@ fn comma_operator() {
 fn assignment_to_non_assignable() {
     // Relates to the behaviour described at
     // https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // Tests all assignment operators as per [spec] and [mdn]
     //
@@ -1318,7 +1318,7 @@ fn assignment_to_non_assignable() {
 fn multicharacter_assignment_to_non_assignable() {
     // Relates to the behaviour described at
     // https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let test_cases = ["3 **= 5", "3 <<= 5", "3 >>= 5"];
 
@@ -1333,7 +1333,7 @@ fn multicharacter_assignment_to_non_assignable() {
 #[test]
 #[ignore]
 fn multicharacter_bitwise_assignment_to_non_assignable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // Disabled - awaiting implementation.
     let test_cases = ["3 >>>= 5", "3 &&= 5", "3 ||= 5", "3 ??= 5"];
@@ -1358,7 +1358,7 @@ fn assign_to_array_decl() {
 
 #[test]
 fn assign_to_object_decl() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     const ERR_MSG: &str =
         "Uncaught \"SyntaxError\": \"unexpected token '=', primary expression at line 1, col 8\"";
@@ -1479,7 +1479,7 @@ fn test_strict_mode_reserved_name() {
     ];
 
     for case in test_cases.iter() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let scenario = format!("'use strict'; \n {}", case);
 
         let string = dbg!(forward(&mut context, &scenario));

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -23,7 +23,7 @@ fn undefined() {
 
 #[test]
 fn get_set_field() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let obj = &context.construct_object();
     // Create string and convert it to a Value
     let s = JsValue::new("bar");
@@ -145,7 +145,7 @@ fn hash_object() {
 
 #[test]
 fn get_types() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         forward_val(&mut context, "undefined").unwrap().get_type(),
@@ -235,7 +235,7 @@ fn to_string() {
 
 #[test]
 fn string_length_is_not_enumerable() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let object = JsValue::new("foo").to_object(&mut context).unwrap();
     let length_desc = object
@@ -247,7 +247,7 @@ fn string_length_is_not_enumerable() {
 
 #[test]
 fn string_length_is_in_utf16_codeunits() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // 😀 is one Unicode code point, but 2 UTF-16 code units
     let object = JsValue::new("😀").to_object(&mut context).unwrap();
@@ -266,7 +266,7 @@ fn string_length_is_in_utf16_codeunits() {
 
 #[test]
 fn add_number_and_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "1 + 2").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -275,7 +275,7 @@ fn add_number_and_number() {
 
 #[test]
 fn add_number_and_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "1 + \" + 2 = 3\"").unwrap();
     let value = value.to_string(&mut context).unwrap();
@@ -284,7 +284,7 @@ fn add_number_and_string() {
 
 #[test]
 fn add_string_and_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "\"Hello\" + \", world\"").unwrap();
     let value = value.to_string(&mut context).unwrap();
@@ -293,7 +293,7 @@ fn add_string_and_string() {
 
 #[test]
 fn add_number_object_and_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "new Number(10) + 6").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -302,7 +302,7 @@ fn add_number_object_and_number() {
 
 #[test]
 fn add_number_object_and_string_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "new Number(10) + new String(\"0\")").unwrap();
     let value = value.to_string(&mut context).unwrap();
@@ -311,7 +311,7 @@ fn add_number_object_and_string_object() {
 
 #[test]
 fn sub_number_and_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "1 - 999").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -320,7 +320,7 @@ fn sub_number_and_number() {
 
 #[test]
 fn sub_number_object_and_number_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "new Number(1) - new Number(999)").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -329,7 +329,7 @@ fn sub_number_object_and_number_object() {
 
 #[test]
 fn sub_string_and_number_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "'Hello' - new Number(999)").unwrap();
     let value = value.to_number(&mut context).unwrap();
@@ -338,7 +338,7 @@ fn sub_string_and_number_object() {
 
 #[test]
 fn div_by_zero() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "1 / 0").unwrap();
     let value = value.to_number(&mut context).unwrap();
@@ -347,7 +347,7 @@ fn div_by_zero() {
 
 #[test]
 fn rem_by_zero() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "1 % 0").unwrap();
     let value = value.to_number(&mut context).unwrap();
@@ -356,7 +356,7 @@ fn rem_by_zero() {
 
 #[test]
 fn bitand_integer_and_integer() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "0xFFFF & 0xFF").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -365,7 +365,7 @@ fn bitand_integer_and_integer() {
 
 #[test]
 fn bitand_integer_and_rational() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "0xFFFF & 255.5").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -374,7 +374,7 @@ fn bitand_integer_and_rational() {
 
 #[test]
 fn bitand_rational_and_rational() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "255.772 & 255.5").unwrap();
     let value = value.to_i32(&mut context).unwrap();
@@ -384,7 +384,7 @@ fn bitand_rational_and_rational() {
 #[test]
 #[allow(clippy::float_cmp)]
 fn pow_number_and_number() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "3 ** 3").unwrap();
     let value = value.to_number(&mut context).unwrap();
@@ -393,7 +393,7 @@ fn pow_number_and_number() {
 
 #[test]
 fn pow_number_and_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "3 ** 'Hello'").unwrap();
     let value = value.to_number(&mut context).unwrap();
@@ -402,7 +402,7 @@ fn pow_number_and_string() {
 
 #[test]
 fn assign_pow_number_and_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(
         &mut context,
@@ -426,7 +426,7 @@ fn display_string() {
 
 #[test]
 fn display_array_string() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     let value = forward_val(&mut context, "[\"Hello\"]").unwrap();
     assert_eq!(value.display().to_string(), "[ \"Hello\" ]");
@@ -434,7 +434,7 @@ fn display_array_string() {
 
 #[test]
 fn display_boolean_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let d_obj = r#"
         let bool = new Boolean(0);
         bool
@@ -445,7 +445,7 @@ fn display_boolean_object() {
 
 #[test]
 fn display_number_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let d_obj = r#"
         let num = new Number(3.14);
         num
@@ -456,7 +456,7 @@ fn display_number_object() {
 
 #[test]
 fn display_negative_zero_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let d_obj = r#"
         let num = new Number(-0);
         num
@@ -467,7 +467,7 @@ fn display_negative_zero_object() {
 
 #[test]
 fn debug_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let value = forward_val(&mut context, "new Array([new Date()])").unwrap();
 
     // We don't care about the contents of the debug display (it is *debug* after all). In the commit that this test was
@@ -481,7 +481,7 @@ fn debug_object() {
 #[test]
 #[ignore] // TODO: Once objects are printed in a simpler way this test can be simplified and used
 fn display_object() {
-    let mut context = Context::new();
+    let mut context = Context::default();
     let d_obj = r#"
         let o = {a: 'a'};
         o
@@ -534,7 +534,7 @@ toString: {
 
 #[test]
 fn to_integer_or_infinity() {
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     assert_eq!(
         JsValue::undefined().to_integer_or_infinity(&mut context),
@@ -617,7 +617,7 @@ mod cyclic_conversions {
 
     #[test]
     fn to_json_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -632,7 +632,7 @@ mod cyclic_conversions {
 
     #[test]
     fn to_json_noncyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let b = [];
             let a = [b, b];
@@ -647,7 +647,7 @@ mod cyclic_conversions {
     // These tests don't throw errors. Instead we mirror Chrome / Firefox behavior for these conversions
     #[test]
     fn to_string_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -661,7 +661,7 @@ mod cyclic_conversions {
 
     #[test]
     fn to_number_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -676,7 +676,7 @@ mod cyclic_conversions {
     #[test]
     fn to_boolean_cyclic() {
         // this already worked before the mitigation, but we don't want to cause a regression
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -690,7 +690,7 @@ mod cyclic_conversions {
 
     #[test]
     fn to_bigint_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -704,7 +704,7 @@ mod cyclic_conversions {
 
     #[test]
     fn to_u32_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [];
             a[0] = a;
@@ -718,7 +718,7 @@ mod cyclic_conversions {
 
     #[test]
     fn console_log_cyclic() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         let src = r#"
             let a = [1];
             a[1] = a;
@@ -745,7 +745,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 < 2" => true);
         check_comparison!(context, "2 < 2" => false);
         check_comparison!(context, "3 < 2" => false);
@@ -755,7 +755,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1' < 2" => true);
         check_comparison!(context, "'2' < 2" => false);
         check_comparison!(context, "'3' < 2" => false);
@@ -765,7 +765,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 < '2'" => true);
         check_comparison!(context, "2 < '2'" => false);
         check_comparison!(context, "3 < '2'" => false);
@@ -775,7 +775,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_less_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) < '2'" => true);
         check_comparison!(context, "new Number(2) < '2'" => false);
         check_comparison!(context, "new Number(3) < '2'" => false);
@@ -785,7 +785,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_less_than_number_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) < new Number(2)" => true);
         check_comparison!(context, "new Number(2) < new Number(2)" => false);
         check_comparison!(context, "new Number(3) < new Number(2)" => false);
@@ -795,7 +795,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'hello' < 'hello'" => false);
         check_comparison!(context, "'hell' < 'hello'" => true);
         check_comparison!(context, "'hello, world' < 'world'" => true);
@@ -804,7 +804,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_less_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') < 'hello'" => false);
         check_comparison!(context, "new String('hell') < 'hello'" => true);
         check_comparison!(context, "new String('hello, world') < 'world'" => true);
@@ -813,7 +813,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_less_than_string_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') < new String('hello')" => false);
         check_comparison!(context, "new String('hell') < new String('hello')" => true);
         check_comparison!(context, "new String('hello, world') < new String('world')" => true);
@@ -822,7 +822,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn bigint_less_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1n < 10" => true);
         check_comparison!(context, "10n < 10" => false);
         check_comparison!(context, "100n < 10" => false);
@@ -831,7 +831,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "10 < 1n" => false);
         check_comparison!(context, "1 < 1n" => false);
         check_comparison!(context, "-1 < -1n" => false);
@@ -840,35 +840,35 @@ mod abstract_relational_comparison {
 
     #[test]
     fn negative_infnity_less_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "-Infinity < -10000000000n" => true);
         check_comparison!(context, "-Infinity < (-1n << 100n)" => true);
     }
 
     #[test]
     fn bigint_less_than_infinity() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n < NaN" => false);
         check_comparison!(context, "(1n << 100n) < NaN" => false);
     }
 
     #[test]
     fn nan_less_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "NaN < -10000000000n" => false);
         check_comparison!(context, "NaN < (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_less_than_nan() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n < Infinity" => true);
         check_comparison!(context, "(1n << 100n) < Infinity" => true);
     }
 
     #[test]
     fn bigint_less_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n < '1000'" => false);
         check_comparison!(context, "1000n < '2000'" => true);
         check_comparison!(context, "1n < '-1'" => false);
@@ -878,7 +878,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1000' < 1000n" => false);
         check_comparison!(context, "'2000' < 1000n" => false);
         check_comparison!(context, "'500' < 1000n" => true);
@@ -891,7 +891,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 <= 2" => true);
         check_comparison!(context, "2 <= 2" => true);
         check_comparison!(context, "3 <= 2" => false);
@@ -901,7 +901,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1' <= 2" => true);
         check_comparison!(context, "'2' <= 2" => true);
         check_comparison!(context, "'3' <= 2" => false);
@@ -911,7 +911,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 <= '2'" => true);
         check_comparison!(context, "2 <= '2'" => true);
         check_comparison!(context, "3 <= '2'" => false);
@@ -921,7 +921,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_less_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) <= '2'" => true);
         check_comparison!(context, "new Number(2) <= '2'" => true);
         check_comparison!(context, "new Number(3) <= '2'" => false);
@@ -931,7 +931,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_less_than_number_or_equal_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) <= new Number(2)" => true);
         check_comparison!(context, "new Number(2) <= new Number(2)" => true);
         check_comparison!(context, "new Number(3) <= new Number(2)" => false);
@@ -941,7 +941,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'hello' <= 'hello'" => true);
         check_comparison!(context, "'hell' <= 'hello'" => true);
         check_comparison!(context, "'hello, world' <= 'world'" => true);
@@ -950,7 +950,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_less_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') <= 'hello'" => true);
         check_comparison!(context, "new String('hell') <= 'hello'" => true);
         check_comparison!(context, "new String('hello, world') <= 'world'" => true);
@@ -959,7 +959,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_less_than_string_or_equal_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') <= new String('hello')" => true);
         check_comparison!(context, "new String('hell') <= new String('hello')" => true);
         check_comparison!(context, "new String('hello, world') <= new String('world')" => true);
@@ -968,7 +968,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn bigint_less_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1n <= 10" => true);
         check_comparison!(context, "10n <= 10" => true);
         check_comparison!(context, "100n <= 10" => false);
@@ -977,7 +977,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "10 <= 1n" => false);
         check_comparison!(context, "1 <= 1n" => true);
         check_comparison!(context, "-1 <= -1n" => true);
@@ -986,35 +986,35 @@ mod abstract_relational_comparison {
 
     #[test]
     fn negative_infnity_less_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "-Infinity <= -10000000000n" => true);
         check_comparison!(context, "-Infinity <= (-1n << 100n)" => true);
     }
 
     #[test]
     fn bigint_less_than_or_equal_infinity() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n <= NaN" => false);
         check_comparison!(context, "(1n << 100n) <= NaN" => false);
     }
 
     #[test]
     fn nan_less_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "NaN <= -10000000000n" => false);
         check_comparison!(context, "NaN <= (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_less_than_or_equal_nan() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n <= Infinity" => true);
         check_comparison!(context, "(1n << 100n) <= Infinity" => true);
     }
 
     #[test]
     fn bigint_less_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n <= '1000'" => true);
         check_comparison!(context, "1000n <= '2000'" => true);
         check_comparison!(context, "1n <= '-1'" => false);
@@ -1024,7 +1024,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_less_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1000' <= 1000n" => true);
         check_comparison!(context, "'2000' <= 1000n" => false);
         check_comparison!(context, "'500' <= 1000n" => true);
@@ -1037,7 +1037,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_greater_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 > 2" => false);
         check_comparison!(context, "2 > 2" => false);
         check_comparison!(context, "3 > 2" => true);
@@ -1047,7 +1047,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1' > 2" => false);
         check_comparison!(context, "'2' > 2" => false);
         check_comparison!(context, "'3' > 2" => true);
@@ -1057,7 +1057,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_greater_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 > '2'" => false);
         check_comparison!(context, "2 > '2'" => false);
         check_comparison!(context, "3 > '2'" => true);
@@ -1067,7 +1067,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_greater_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) > '2'" => false);
         check_comparison!(context, "new Number(2) > '2'" => false);
         check_comparison!(context, "new Number(3) > '2'" => true);
@@ -1077,7 +1077,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_greater_than_number_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) > new Number(2)" => false);
         check_comparison!(context, "new Number(2) > new Number(2)" => false);
         check_comparison!(context, "new Number(3) > new Number(2)" => true);
@@ -1087,7 +1087,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'hello' > 'hello'" => false);
         check_comparison!(context, "'hell' > 'hello'" => false);
         check_comparison!(context, "'hello, world' > 'world'" => false);
@@ -1097,7 +1097,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_greater_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') > 'hello'" => false);
         check_comparison!(context, "new String('hell') > 'hello'" => false);
         check_comparison!(context, "new String('hello, world') > 'world'" => false);
@@ -1107,7 +1107,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_greater_than_string_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') > new String('hello')" => false);
         check_comparison!(context, "new String('hell') > new String('hello')" => false);
         check_comparison!(context, "new String('hello, world') > new String('world')" => false);
@@ -1117,7 +1117,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn bigint_greater_than_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1n > 10" => false);
         check_comparison!(context, "10n > 10" => false);
         check_comparison!(context, "100n > 10" => true);
@@ -1126,7 +1126,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_greater_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "10 > 1n" => true);
         check_comparison!(context, "1 > 1n" => false);
         check_comparison!(context, "-1 > -1n" => false);
@@ -1135,35 +1135,35 @@ mod abstract_relational_comparison {
 
     #[test]
     fn negative_infnity_greater_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "-Infinity > -10000000000n" => false);
         check_comparison!(context, "-Infinity > (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_greater_than_infinity() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n > NaN" => false);
         check_comparison!(context, "(1n << 100n) > NaN" => false);
     }
 
     #[test]
     fn nan_greater_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "NaN > -10000000000n" => false);
         check_comparison!(context, "NaN > (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_greater_than_nan() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n > Infinity" => false);
         check_comparison!(context, "(1n << 100n) > Infinity" => false);
     }
 
     #[test]
     fn bigint_greater_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n > '1000'" => false);
         check_comparison!(context, "1000n > '2000'" => false);
         check_comparison!(context, "1n > '-1'" => true);
@@ -1173,7 +1173,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1000' > 1000n" => false);
         check_comparison!(context, "'2000' > 1000n" => true);
         check_comparison!(context, "'500' > 1000n" => false);
@@ -1186,7 +1186,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_greater_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 >= 2" => false);
         check_comparison!(context, "2 >= 2" => true);
         check_comparison!(context, "3 >= 2" => true);
@@ -1196,7 +1196,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1' >= 2" => false);
         check_comparison!(context, "'2' >= 2" => true);
         check_comparison!(context, "'3' >= 2" => true);
@@ -1206,7 +1206,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_less_greater_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1 >= '2'" => false);
         check_comparison!(context, "2 >= '2'" => true);
         check_comparison!(context, "3 >= '2'" => true);
@@ -1216,7 +1216,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_greater_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) >= '2'" => false);
         check_comparison!(context, "new Number(2) >= '2'" => true);
         check_comparison!(context, "new Number(3) >= '2'" => true);
@@ -1226,7 +1226,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_object_greater_than_or_equal_number_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new Number(1) >= new Number(2)" => false);
         check_comparison!(context, "new Number(2) >= new Number(2)" => true);
         check_comparison!(context, "new Number(3) >= new Number(2)" => true);
@@ -1236,7 +1236,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'hello' >= 'hello'" => true);
         check_comparison!(context, "'hell' >= 'hello'" => false);
         check_comparison!(context, "'hello, world' >= 'world'" => false);
@@ -1246,7 +1246,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_greater_or_equal_than_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') >= 'hello'" => true);
         check_comparison!(context, "new String('hell') >= 'hello'" => false);
         check_comparison!(context, "new String('hello, world') >= 'world'" => false);
@@ -1256,7 +1256,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_object_greater_than_or_equal_string_object() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "new String('hello') >= new String('hello')" => true);
         check_comparison!(context, "new String('hell') >= new String('hello')" => false);
         check_comparison!(context, "new String('hello, world') >= new String('world')" => false);
@@ -1266,7 +1266,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn bigint_greater_than_or_equal_number() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1n >= 10" => false);
         check_comparison!(context, "10n >= 10" => true);
         check_comparison!(context, "100n >= 10" => true);
@@ -1275,7 +1275,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn number_greater_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "10 >= 1n" => true);
         check_comparison!(context, "1 >= 1n" => true);
         check_comparison!(context, "-1 >= -1n" => true);
@@ -1284,35 +1284,35 @@ mod abstract_relational_comparison {
 
     #[test]
     fn negative_infnity_greater_or_equal_than_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "-Infinity >= -10000000000n" => false);
         check_comparison!(context, "-Infinity >= (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_greater_than_or_equal_infinity() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n >= NaN" => false);
         check_comparison!(context, "(1n << 100n) >= NaN" => false);
     }
 
     #[test]
     fn nan_greater_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "NaN >= -10000000000n" => false);
         check_comparison!(context, "NaN >= (-1n << 100n)" => false);
     }
 
     #[test]
     fn bigint_greater_than_or_equal_nan() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n >= Infinity" => false);
         check_comparison!(context, "(1n << 100n) >= Infinity" => false);
     }
 
     #[test]
     fn bigint_greater_than_or_equal_string() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "1000n >= '1000'" => true);
         check_comparison!(context, "1000n >= '2000'" => false);
         check_comparison!(context, "1n >= '-1'" => true);
@@ -1322,7 +1322,7 @@ mod abstract_relational_comparison {
 
     #[test]
     fn string_greater_than_or_equal_bigint() {
-        let mut context = Context::new();
+        let mut context = Context::default();
         check_comparison!(context, "'1000' >= 1000n" => true);
         check_comparison!(context, "'2000' >= 1000n" => true);
         check_comparison!(context, "'500' >= 1000n" => false);

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -14,7 +14,7 @@ default-run = "boa"
 
 [dependencies]
 Boa = { path = "../boa", features = ["deser", "console"] }
-rustyline = "9.1.1"
+rustyline = "9.1.2"
 rustyline-derive = "0.6.0"
 structopt = "0.3.26"
 serde_json = "1.0.75"

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "boa_interner"
+version = "0.13.0"
+authors = ["boa-dev"]
+description = "String interner used in Boa."
+repository = "https://github.com/boa-dev/boa"
+license = "Unlicense/MIT"
+exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
+edition = "2021"
+rust-version = "1.56"
+
+[dependencies]
+string-interner = "0.14.0"
+serde = { version = "1.0.132", features = ["derive"], optional = true }

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -11,4 +11,4 @@ rust-version = "1.56"
 
 [dependencies]
 string-interner = "0.14.0"
-serde = { version = "1.0.132", features = ["derive"], optional = true }
+serde = { version = "1.0.134", features = ["derive"], optional = true }

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -1,0 +1,76 @@
+//! String interner for Boa.
+//!
+//! The idea behind using a string interner is that in most of the code, strings such as
+//! identifiers and literals are often repeated. This causes extra burden when comparing them and
+//! storing them. A string interner stores a unique `usize` symbol for each string, making sure
+//! that there are no duplicates. This makes it much easier to compare, since it's just comparing
+//! to `usize`, and also it's easier to store, since instead of a heap-allocated string, you only
+//! need to store a `usize`. This reduces memory consumption and improves performance in the
+//! compiler.
+
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
+#![deny(
+    clippy::all,
+    unused_qualifications,
+    unused_import_braces,
+    unused_lifetimes,
+    unreachable_pub,
+    trivial_numeric_casts,
+    // rustdoc,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    deprecated_in_future,
+    meta_variable_misuse,
+    non_ascii_idents,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style,
+)]
+#![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    clippy::cognitive_complexity,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::as_conversions,
+    clippy::let_unit_value,
+    rustdoc::missing_doc_code_examples
+)]
+
+use std::num::NonZeroUsize;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+use string_interner::{backend::BucketBackend, StringInterner, Symbol};
+
+/// The string interner for Boa.
+///
+/// This is a type alias that makes it easier to reference it in the code.
+pub type Interner = StringInterner<BucketBackend<Sym>>;
+
+/// The string symbol type for Boa.
+///
+/// This symbol type is internally a `NonZeroUsize`, which makes it pointer-width in size and it's
+/// optimized so that it can ocupy 1 pointer width even in an `Option` type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+pub struct Sym {
+    value: NonZeroUsize,
+}
+
+impl Symbol for Sym {
+    #[inline]
+    fn try_from_usize(index: usize) -> Option<Self> {
+        NonZeroUsize::new(index.wrapping_add(1)).map(|value| Self { value })
+    }
+
+    #[inline]
+    fn to_usize(self) -> usize {
+        self.value.get() - 1
+    }
+}

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.56"
 [dependencies]
 Boa = { path = "../boa" }
 structopt = "0.3.26"
-serde = { version = "1.0.132", features = ["derive"] }
+serde = { version = "1.0.134", features = ["derive"] }
 serde_yaml = "0.8.23"
 serde_json = "1.0.75"
 bitflags = "1.3.2"

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -29,7 +29,7 @@ pub(super) fn init(context: &mut Context) -> JsObject {
 fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
     // eprintln!("called $262.createRealm()");
 
-    let mut context = Context::new();
+    let mut context = Context::default();
 
     // add the $262 object.
     let js_262 = init(&mut context);
@@ -84,7 +84,7 @@ fn detach_array_buffer(
 /// Accepts a string value as its first argument and executes it as an ECMAScript script.
 fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     if let Some(source_text) = args.get(0).and_then(|val| val.as_string()) {
-        match boa::parse(source_text.as_str(), false) {
+        match context.parse(source_text.as_str()) {
             // TODO: check strict
             Err(e) => context.throw_type_error(format!("Uncaught Syntax Error: {}", e)),
             // Calling eval here parses the code a second time.

--- a/boa_unicode/src/lib.rs
+++ b/boa_unicode/src/lib.rs
@@ -6,6 +6,39 @@
 //!
 //! [uax31]: http://unicode.org/reports/tr31
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
+#![deny(
+    clippy::all,
+    unused_qualifications,
+    unused_import_braces,
+    unused_lifetimes,
+    unreachable_pub,
+    trivial_numeric_casts,
+    // rustdoc,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    deprecated_in_future,
+    meta_variable_misuse,
+    non_ascii_idents,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style,
+)]
+#![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    clippy::cognitive_complexity,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::as_conversions,
+    clippy::let_unit_value,
+    rustdoc::missing_doc_code_examples
+)]
+
 mod tables;
 #[cfg(test)]
 mod tests;

--- a/boa_unicode/src/tables.rs
+++ b/boa_unicode/src/tables.rs
@@ -8,7 +8,7 @@
 //!
 //! [uax44]: http://unicode.org/reports/tr44
 
-pub static PATTERN_SYNTAX: &[char] = &[
+pub(crate) static PATTERN_SYNTAX: &[char] = &[
     '\u{0021}', '\u{0022}', '\u{0023}', '\u{0024}', '\u{0025}', '\u{0026}', '\u{0027}', '\u{0028}',
     '\u{0029}', '\u{002A}', '\u{002B}', '\u{002C}', '\u{002D}', '\u{002E}', '\u{002F}', '\u{003A}',
     '\u{003B}', '\u{003C}', '\u{003D}', '\u{003E}', '\u{003F}', '\u{0040}', '\u{005B}', '\u{005C}',
@@ -356,16 +356,16 @@ pub static PATTERN_SYNTAX: &[char] = &[
     '\u{301E}', '\u{301F}', '\u{3020}', '\u{3030}', '\u{FD3E}', '\u{FD3F}', '\u{FE45}', '\u{FE46}',
 ];
 
-pub static OTHER_ID_CONTINUE: &[char] = &[
+pub(crate) static OTHER_ID_CONTINUE: &[char] = &[
     '\u{00B7}', '\u{0387}', '\u{1369}', '\u{136A}', '\u{136B}', '\u{136C}', '\u{136D}', '\u{136E}',
     '\u{136F}', '\u{1370}', '\u{1371}', '\u{19DA}',
 ];
 
-pub static OTHER_ID_START: &[char] = &[
+pub(crate) static OTHER_ID_START: &[char] = &[
     '\u{1885}', '\u{1886}', '\u{2118}', '\u{212E}', '\u{309B}', '\u{309C}',
 ];
 
-pub static PATTERN_WHITE_SPACE: &[char] = &[
+pub(crate) static PATTERN_WHITE_SPACE: &[char] = &[
     '\u{0009}', '\u{000A}', '\u{000B}', '\u{000C}', '\u{000D}', '\u{0020}', '\u{0085}', '\u{200E}',
     '\u{200F}', '\u{2028}', '\u{2029}',
 ];

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.56"
 
 [dependencies]
 Boa = { path = "../boa", features = ["console"] }
-wasm-bindgen = "0.2.79"
+wasm-bindgen = "=0.2.78"
 getrandom = { version = "0.2.4", features = ["js"] }
 
 [lib]

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -1,10 +1,43 @@
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
+#![deny(
+    clippy::all,
+    unused_qualifications,
+    unused_import_braces,
+    unused_lifetimes,
+    unreachable_pub,
+    trivial_numeric_casts,
+    // rustdoc,
+    missing_debug_implementations,
+    missing_copy_implementations,
+    deprecated_in_future,
+    meta_variable_misuse,
+    non_ascii_idents,
+    rust_2018_compatibility,
+    rust_2018_idioms,
+    future_incompatible,
+    nonstandard_style,
+)]
+#![warn(clippy::perf, clippy::single_match_else, clippy::dbg_macro)]
+#![allow(
+    clippy::missing_inline_in_public_items,
+    clippy::cognitive_complexity,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc,
+    clippy::as_conversions,
+    clippy::let_unit_value,
+    rustdoc::missing_doc_code_examples
+)]
+
 use boa::Context;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn evaluate(src: &str) -> Result<String, JsValue> {
     // Setup executor
-    Context::new()
+    Context::default()
         .eval(src)
         .map_err(|e| JsValue::from(format!("Uncaught {}", e.display())))
         .map(|v| v.display().to_string())

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,17 +59,17 @@
     "@types/node" "*"
 
 "@types/eslint-scope@^3.7.0":
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.2.tgz#11e96a868c67acf65bf6f11d10bb89ea71d5e473"
-  integrity sha512-TzgYCWoPiTeRg6RQYgtuW7iODtVoKu3RVL72k3WohqhjfaOLK5Mg2T4Tg1o2bSfu0vPkoI48wdQFv5b/Xe04wQ==
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.3.tgz#125b88504b61e3c8bc6f870882003253005c3224"
+  integrity sha512-PB3ldyrcnAicT35TWPs5IcwKD8S333HMaa2VVv4+wdvebJkjWuW/xESoB8IwRcog8HYVYamb1g/R31Qv5Bx03g==
   dependencies:
     "@types/eslint" "*"
     "@types/estree" "*"
 
 "@types/eslint@*":
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.2.1.tgz#13f3d69bac93c2ae008019c28783868d0a1d6605"
-  integrity sha512-UP9rzNn/XyGwb5RQ2fok+DzcIRIYwc16qTXse5+Smsy8MOIccCChT15KAwnsgQx4PzJkaMq4myFyZ4CL5TjhIQ==
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.0.tgz#95712d5b32fd99a0d9493c31c6197ea7471c3ba6"
+  integrity sha512-JUYa/5JwoqikCy7O7jKtuNe9Z4ZZt615G+1EKfaDGSNEpzaA2OwbV/G1v08Oa7fd1XzlFoSCvt9ePl9/6FyAug==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"
@@ -80,9 +80,9 @@
   integrity sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==
 
 "@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
-  version "4.17.27"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.27.tgz#7a776191e47295d2a05962ecbb3a4ce97e38b401"
-  integrity sha512-e/sVallzUTPdyOTiqi8O8pMdBBphscvI6E4JYaKlja4Lm+zh7UFSSdW5VMkRbhDtmrONqOUHOXRguPsDckzxNA==
+  version "4.17.28"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.28.tgz#c47def9f34ec81dc6328d0b1b5303d1ec98d86b8"
+  integrity sha512-P1BJAEAW3E2DJUlkgq4tOL3RyMunoWXqbSCygWo5ZIWTjUgN1YnaXWW4VWl/oc8vs/XoYibEGBKP0uZyF4AHig==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -134,9 +134,9 @@
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
 
 "@types/node@*":
-  version "17.0.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.4.tgz#fec0ce0526abb6062fd206d72a642811b887a111"
-  integrity sha512-6xwbrW4JJiJLgF+zNypN5wr2ykM9/jHcL7rQ8fZe2vuftggjzZeRSM4OwRc6Xk8qWjwJ99qVHo/JgOGmomWRog==
+  version "17.0.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.10.tgz#616f16e9d3a2a3d618136b1be244315d95bd7cab"
+  integrity sha512-S/3xB4KzyFxYGCppyDt68yzBU9ysL88lSdIah4D6cptdcltc4NCPCAMc0+PCpg/lLIyC7IPvj2Z52OJWeIUkog==
 
 "@types/qs@*":
   version "6.9.7"
@@ -354,9 +354,9 @@ acorn-import-assertions@^1.7.6:
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
 acorn@^8.4.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
-  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 aggregate-error@^3.0.0:
   version "3.1.0"
@@ -396,9 +396,9 @@ ajv@^6.12.5:
     uri-js "^4.2.2"
 
 ajv@^8.0.0, ajv@^8.8.0:
-  version "8.8.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.8.2.tgz#01b4fef2007a28bf75f0b7fc009f62679de4abbb"
-  integrity sha512-x9VuX+R/jcFj1DHo/fCp99esgGDWiHENrKxaCENuCxpoMCmAt/COCGVDwA7kleEpEzJjDnvh3yGoOuLu0Dtllw==
+  version "8.9.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.9.0.tgz#738019146638824dea25edcf299dcba1b0e7eb18"
+  integrity sha512-qOKJyNj/h+OWx7s5DePL6Zu1KeM9jPZhwBqs+7DzP6bGOvqzVCSf0xueYmVuaC/oQ/VtS2zLMLHdQFbkka+XDQ==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
@@ -595,9 +595,9 @@ camel-case@^4.1.2:
     tslib "^2.0.3"
 
 caniuse-lite@^1.0.30001286:
-  version "1.0.30001292"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz#4a55f61c06abc9595965cfd77897dc7bc1cdc456"
-  integrity sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==
+  version "1.0.30001301"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz#ebc9086026534cab0dab99425d9c3b4425e5f450"
+  integrity sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==
 
 chalk@^2.4.1:
   version "2.4.2"
@@ -609,9 +609,9 @@ chalk@^2.4.1:
     supports-color "^5.3.0"
 
 chokidar@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -746,9 +746,9 @@ cookie@0.4.1:
   integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
 
 copy-webpack-plugin@^10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-10.2.0.tgz#24c2d256953a55400a1ec66be4e0eccd1c4ae958"
-  integrity sha512-my6iXII95c78w14HzYCNya5TlJYa44lOppAge5GSTMM1SyDxNsVGCJvhP4/ld6snm8lzjn3XOonMZD6s1L86Og==
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-10.2.1.tgz#115a41f913070ac236a1b576066204cbf35341a1"
+  integrity sha512-nr81NhCAIpAWXGCK5thrKmfCQ6GDY0L5RN0U+BnIn/7Us55+UCex5ANNsNKmIVtDRnk0Ecf+/kzp9SUVrrBMLg==
   dependencies:
     fast-glob "^3.2.7"
     glob-parent "^6.0.1"
@@ -786,9 +786,9 @@ css-loader@^6.5.1:
     semver "^7.3.5"
 
 css-select@^4.1.3:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.0.tgz#ab28276d3afb00cc05e818bd33eb030f14f57895"
-  integrity sha512-6YVG6hsH9yIb/si3Th/is8Pex7qnVHO6t7q7U6TIUnkQASGbS8tnUDBftnPynLNnuUl/r2+PTd0ekiiq7R0zJw==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-4.2.1.tgz#9e665d6ae4c7f9d65dbe69d0316e3221fb274cdd"
+  integrity sha512-/aUslKhzkTNCQUB2qTX84lVmfia9NyjP3WpDGtj/WxhwBzWBYUV3DgUpurHTme8UTPcPlAD1DJ+b0nN/t50zDQ==
   dependencies:
     boolbase "^1.0.0"
     css-what "^5.1.0"
@@ -978,9 +978,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.4.17:
-  version "1.4.28"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.28.tgz#fef0e92e281df6d568f482d8d53c34ca5374de48"
-  integrity sha512-Gzbf0wUtKfyPaqf0Plz+Ctinf9eQIzxEqBHwSvbGfeOm9GMNdLxyu1dNiCUfM+x6r4BE0xUJNh3Nmg9gfAtTmg==
+  version "1.4.51"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.51.tgz#a432f5a5d983ace79278a33057300cf949627e63"
+  integrity sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ==
 
 emojis-list@^3.0.0:
   version "3.0.0"
@@ -1126,10 +1126,10 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.1.1, fast-glob@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+fast-glob@^3.2.7, fast-glob@^3.2.9:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1278,26 +1278,26 @@ glob@^7.0.3, glob@^7.1.3:
     path-is-absolute "^1.0.0"
 
 globby@^11.0.1:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
   dependencies:
     array-union "^2.1.0"
     dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 globby@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-12.0.2.tgz#53788b2adf235602ed4cabfea5c70a1139e1ab11"
-  integrity sha512-lAsmb/5Lww4r7MM9nCCliDZVIKbZTavrsunAsHLr9oHthrZP1qi7/gAnHOsUs9bLvEt2vKVJhHmxuL7QbDuPdQ==
+  version "12.2.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-12.2.0.tgz#2ab8046b4fba4ff6eede835b29f678f90e3d3c22"
+  integrity sha512-wiSuFQLZ+urS9x2gGPl1H5drc5twabmm4m2gTR27XDFyjUHJUNsS8o/2aKyIF6IoBaR630atdher0XJ5g6OMmA==
   dependencies:
     array-union "^3.0.1"
     dir-glob "^3.0.1"
     fast-glob "^3.2.7"
-    ignore "^5.1.8"
+    ignore "^5.1.9"
     merge2 "^1.4.1"
     slash "^4.0.0"
 
@@ -1473,15 +1473,15 @@ icss-utils@^5.0.0, icss-utils@^5.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-5.1.0.tgz#c6be6858abd013d768e98366ae47e25d5887b1ae"
   integrity sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==
 
-ignore@^5.1.4, ignore@^5.1.8:
+ignore@^5.1.9, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
 
 import-local@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.0.3.tgz#4d51c2c495ca9393da259ec66b62e022920211e0"
-  integrity sha512-bE9iaUY3CXH8Cwfan/abDKAxe1KGT9kyGsBPqf6DMK/z0a2OzAsrukeYNgIH6cH5Xr452jb1TUL8rSfCLjZ9uA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4"
+  integrity sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
@@ -1544,10 +1544,10 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-core-module@^2.2.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.0.tgz#0321336c3d0925e497fd97f5d95cb114a5ccd548"
-  integrity sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==
+is-core-module@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -1652,9 +1652,9 @@ isobject@^3.0.1:
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
 jest-worker@^27.4.1:
-  version "27.4.5"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.5.tgz#d696e3e46ae0f24cff3fa7195ffba22889262242"
-  integrity sha512-f2s8kEdy15cv9r7q4KkzGXvlY0JTcmCbMHZBfSQDwW77REr45IDWwd0lksDFeVHH2jJ5pqb90T77XscrjeGzzg==
+  version "27.4.6"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.4.6.tgz#5d2d93db419566cb680752ca0792780e71b3273e"
+  integrity sha512-gHWJF/6Xi5CTG5QCvROr6GcmpIqNYpDJyc8A1h/DyXqH1tD6SnRCM0d3U5msV31D2LB/U+E0M+W4oyvKV44oNw==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
@@ -1733,9 +1733,9 @@ media-typer@0.3.0:
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
 memfs@^3.2.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.0.tgz#8bc12062b973be6b295d4340595736a656f0a257"
-  integrity sha512-o/RfP0J1d03YwsAxyHxAYs2kyJp55AFkMazlFAZFR2I2IXkxiUTXRabJ6RmNNCQ83LAD2jy52Khj0m3OffpNdA==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.1.tgz#b78092f466a0dce054d63d39275b24c71d3f1305"
+  integrity sha512-1c9VPVvW5P7I85c35zAdEr1TD5+F11IToIHIlrVIcflfnzPkJa0ZoYEoEdYDP8KgPFoSZ/opDrUsAoZWym3mtw==
   dependencies:
     fs-monkey "1.0.3"
 
@@ -1847,9 +1847,9 @@ multicast-dns@^6.0.1:
     thunky "^1.0.2"
 
 nanoid@^3.1.30:
-  version "3.1.30"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.30.tgz#63f93cc548d2a113dc5dfbc63bfa09e2b9b64362"
-  integrity sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -2036,7 +2036,7 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
+path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
@@ -2057,9 +2057,9 @@ picocolors@^1.0.0:
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
-  integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pify@^2.0.0:
   version "2.3.0"
@@ -2128,9 +2128,9 @@ postcss-modules-values@^4.0.0:
     icss-utils "^5.0.0"
 
 postcss-selector-parser@^6.0.2, postcss-selector-parser@^6.0.4:
-  version "6.0.8"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz#f023ed7a9ea736cd7ef70342996e8e78645a7914"
-  integrity sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
+  integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -2249,9 +2249,9 @@ rechoir@^0.7.0:
     resolve "^1.9.0"
 
 regexp.prototype.flags@^1.2.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz#7ef352ae8d159e758c0eadca6f8fcb4eef07be26"
-  integrity sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz#b3f4c0059af9e47eca9f3f660e51d81307e72307"
+  integrity sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==
   dependencies:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
@@ -2295,12 +2295,13 @@ resolve-from@^5.0.0:
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
 resolve@^1.9.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.21.1.tgz#1a88c73f5ca8ab0aabc8b888c4170de26c92c4cc"
+  integrity sha512-lfEImVbnolPuaSZuLQ52cAxPBHeI77sPwCOWRdy12UG/CNa8an7oBHH1R+Fp1/mUqSJi4c8TIP6FOIPSZAUrEQ==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.8.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 retry@^0.13.1:
   version "0.13.1"
@@ -2489,9 +2490,9 @@ sockjs@^0.3.21:
     websocket-driver "^0.7.4"
 
 source-map-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
-  integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map-support@~0.5.20:
   version "0.5.21"
@@ -2590,6 +2591,11 @@ supports-color@^8.0.0:
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
+
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
@@ -2770,15 +2776,15 @@ webpack-merge@^5.7.3:
     clone-deep "^4.0.1"
     wildcard "^2.0.0"
 
-webpack-sources@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.2.tgz#d88e3741833efec57c4c789b6010db9977545260"
-  integrity sha512-cp5qdmHnu5T8wRg2G3vZZHoJPN14aqQ89SyQ11NpGH5zEMDCclt49rzo+MaRazk7/UeILhAI+/sEtcM+7Fr0nw==
+webpack-sources@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
+  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
 webpack@^5.66.0:
-  version "5.66.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.66.0.tgz#789bf36287f407fc92b3e2d6f978ddff1bfc2dbb"
-  integrity sha512-NJNtGT7IKpGzdW7Iwpn/09OXz9inIkeIQ/ibY6B+MdV1x6+uReqz/5z1L89ezWnpPDWpXF0TY5PCYKQdWVn8Vg==
+  version "5.67.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.67.0.tgz#cb43ca2aad5f7cc81c4cd36b626e6b819805dbfd"
+  integrity sha512-LjFbfMh89xBDpUMgA1W9Ur6Rn/gnr2Cq1jjHFPo4v6a79/ypznSYbAyPgGhwsxBtMIaEmDD1oJoA7BEYw/Fbrw==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.50"
@@ -2803,7 +2809,7 @@ webpack@^5.66.0:
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
     watchpack "^2.3.1"
-    webpack-sources "^3.2.2"
+    webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
   version "0.7.4"
@@ -2837,9 +2843,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 ws@^8.1.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.0.tgz#f05e982a0a88c604080e8581576e2a063802bed6"
-  integrity sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
+  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This Pull Request is part of #279.

 It adds a string interner to Boa, which allows many types to not contain heap-allocated strings, and just contain a `NonZeroUsize` instead. This can move types to the stack (hopefully I'll be able to move `Token`, for example, maybe some `Node` types too.

Note that the internet is for now only available in the lexer. Next steps (in this PR or future ones) would include also using interning in the parser, and finally in execution. The idea is that strings should be represented with a `Sym` until they are displayed.

Talking about display. I have changed the `ParseError` type in order to not contain anything that could contain a `Sym` (basically tokens), which might be a bit faster, but what is important is that we don't depend on the interner when displaying errors.

The issue I have now is in order to display tokens. This requires the interner if we want to know identifiers, for example. The issue here is that Rust doesn't allow using a `fmt::Formatter` (only in nightly), which is making my head hurt. Maybe someone of you can find a better way of doing this.

Then, about `cursor.expect()`, this is the only place where we don't have the expected token type as a static string, so it's failing to compile. We have the option of changing the type definition of `ParseError` to contain an owned string, but maybe we can avoid this by having a `&'static str` come from a `TokenKind` with the default values, such as "identifier" for an identifier. I wanted for you to think about it and maybe we can just add that and avoid allocations there.

Oh, and this depends on the VM-only branch, so that has to be merged before :)

Another thing to check: should the interner be in its own module?