### PR TITLE
[Merged by Bors] - Fix bors hanging

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,6 @@
 # docs https://bors.tech/documentation/
 status = [
 	"Tests on Linux",
-	"Tests on Linux with vm enabled",
 	"Tests on Windows",
 	"Tests on MacOS",
 	"Rustfmt",
@@ -11,7 +10,6 @@ status = [
 ]
 pr_status = [
 	"Tests on Linux",
-	"Tests on Linux with vm enabled",
 	"Tests on Windows",
 	"Tests on MacOS",
 	"Rustfmt",


### PR DESCRIPTION
This Pull Request fixes the bors hanging we've had recently
The vm action had been removed but bors was still waiting for it

It changes the following:

- Remove 'Tests on Linux with vm enabled' from the actions to be waited for
