### PR TITLE
[Merged by Bors] - Copy/paste fix in Proxy error message

### DIFF
--- a/boa/src/builtins/proxy/mod.rs
+++ b/boa/src/builtins/proxy/mod.rs
@@ -96,7 +96,7 @@ impl Proxy {
     fn create(target: &JsValue, handler: &JsValue, context: &mut Context) -> JsResult<JsValue> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         let target = target.as_object().ok_or_else(|| {
-            context.construct_type_error("Proxy constructor called with non-object handler")
+            context.construct_type_error("Proxy constructor called with non-object target")
         })?;
 
         // 2. If Type(handler) is not Object, throw a TypeError exception.


### PR DESCRIPTION
(Really small self-explanatory change - maybe the commit message could be better)

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

It changes the following:

When calling `new Proxy(undefined, {})` the error message now refers to the target `undefined` instead of the handler `{}`
