### PR TITLE
[Merged by Bors] - Convert `Codeblock` variables to `Sym`

### DIFF
--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -1544,7 +1544,8 @@ impl<'b> ByteCompiler<'b> {
 
         match kind {
             FunctionKind::Declaration => {
-                let index = self.get_or_insert_name(name.unwrap());
+                let index =
+                    self.get_or_insert_name(name.expect("empty name for a declaration function"));
                 self.emit(Opcode::DefInitVar, &[index]);
             }
             FunctionKind::Expression | FunctionKind::Arrow => {

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -448,7 +448,7 @@ pub enum PropertyDefinition {
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-IdentifierReference
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Property_definitions
-    IdentifierReference(Box<str>),
+    IdentifierReference(Sym),
 
     /// Binds a property name to a JavaScript value.
     ///
@@ -486,11 +486,8 @@ pub enum PropertyDefinition {
 
 impl PropertyDefinition {
     /// Creates an `IdentifierReference` property definition.
-    pub fn identifier_reference<I>(ident: I) -> Self
-    where
-        I: Into<Box<str>>,
-    {
-        Self::IdentifierReference(ident.into())
+    pub fn identifier_reference(ident: Sym) -> Self {
+        Self::IdentifierReference(ident)
     }
 
     /// Creates a `Property` definition.

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -56,11 +56,7 @@ impl Object {
         for property in self.properties().iter() {
             buf.push_str(&match property {
                 PropertyDefinition::IdentifierReference(ident) => {
-                    format!(
-                        "{}{},\n",
-                        indentation,
-                        interner.resolve(*ident).expect("string disappeared")
-                    )
+                    format!("{}{},\n", indentation, interner.resolve_expect(*ident))
                 }
                 PropertyDefinition::Property(key, value) => {
                     format!(

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -55,8 +55,12 @@ impl Object {
         let indentation = "    ".repeat(indent + 1);
         for property in self.properties().iter() {
             buf.push_str(&match property {
-                PropertyDefinition::IdentifierReference(key) => {
-                    format!("{}{},\n", indentation, key)
+                PropertyDefinition::IdentifierReference(ident) => {
+                    format!(
+                        "{}{},\n",
+                        indentation,
+                        interner.resolve(*ident).expect("string disappeared")
+                    )
                 }
                 PropertyDefinition::Property(key, value) => {
                     format!(

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -347,7 +347,7 @@ impl ToInternedString for CodeBlock {
                 f.push_str(&format!(
                     "    {:04}: {}\n",
                     i,
-                    interner.resolve(*value).expect("string disappeared")
+                    interner.resolve_expect(*value)
                 ));
             }
         } else {

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -17,7 +17,7 @@ use crate::{
     property::PropertyDescriptor,
     syntax::ast::node::FormalParameter,
     vm::{call_frame::FinallyReturn, CallFrame, Opcode},
-    Context, JsResult, JsString, JsValue,
+    Context, JsResult, JsValue,
 };
 use boa_interner::{Interner, Sym, ToInternedString};
 use std::{convert::TryInto, mem::size_of};
@@ -75,7 +75,7 @@ pub struct CodeBlock {
     pub(crate) literals: Vec<JsValue>,
 
     /// Variables names
-    pub(crate) variables: Vec<JsString>,
+    pub(crate) variables: Vec<Sym>,
 
     /// Functions inside this function
     pub(crate) functions: Vec<Gc<CodeBlock>>,
@@ -344,7 +344,11 @@ impl ToInternedString for CodeBlock {
         f.push_str("\nNames:\n");
         if !self.variables.is_empty() {
             for (i, value) in self.variables.iter().enumerate() {
-                f.push_str(&format!("    {:04}: {}\n", i, value));
+                f.push_str(&format!(
+                    "    {:04}: {}\n",
+                    i,
+                    interner.resolve(*value).expect("string disappeared")
+                ));
             }
         } else {
             f.push_str("    <empty>");

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -439,11 +439,7 @@ impl Context {
                 };
 
                 let name = self.vm.frame().code.variables[index as usize];
-                let name: PropertyKey = self
-                    .interner()
-                    .resolve(name)
-                    .expect("string disappeared")
-                    .into();
+                let name: PropertyKey = self.interner().resolve_expect(name).into();
                 let result = object.get(name, self)?;
 
                 self.vm.push(result)
@@ -474,11 +470,7 @@ impl Context {
                 };
 
                 let name = self.vm.frame().code.variables[index as usize];
-                let name: PropertyKey = self
-                    .interner()
-                    .resolve(name)
-                    .expect("string disappeared")
-                    .into();
+                let name: PropertyKey = self.interner().resolve_expect(name).into();
 
                 object.set(
                     name,
@@ -499,7 +491,7 @@ impl Context {
                 };
 
                 let name = self.vm.frame().code.variables[index as usize];
-                let name = self.interner().resolve(name).expect("string disappeared");
+                let name = self.interner().resolve_expect(name);
 
                 object.__define_own_property__(
                     name.into(),
@@ -560,11 +552,7 @@ impl Context {
                 let object = object.to_object(self)?;
 
                 let name = self.vm.frame().code.variables[index as usize];
-                let name = self
-                    .interner()
-                    .resolve(name)
-                    .expect("string disappeared")
-                    .into();
+                let name = self.interner().resolve_expect(name).into();
                 let set = object
                     .__get_own_property__(&name, self)?
                     .as_ref()
@@ -609,11 +597,7 @@ impl Context {
                 let value = self.vm.pop();
                 let object = object.to_object(self)?;
                 let name = self.vm.frame().code.variables[index as usize];
-                let name = self
-                    .interner()
-                    .resolve(name)
-                    .expect("string disappeared")
-                    .into();
+                let name = self.interner().resolve_expect(name).into();
                 let get = object
                     .__get_own_property__(&name, self)?
                     .as_ref()
@@ -655,11 +639,7 @@ impl Context {
             Opcode::DeletePropertyByName => {
                 let index = self.vm.read::<u32>();
                 let key = self.vm.frame().code.variables[index as usize];
-                let key = self
-                    .interner()
-                    .resolve(key)
-                    .expect("string disappeared")
-                    .into();
+                let key = self.interner().resolve_expect(key).into();
                 let object = self.vm.pop();
                 let result = object.to_object(self)?.__delete__(&key, self)?;
                 if !result && self.strict() || self.vm.frame().code.strict {

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         function_environment_record::{BindingStatus, FunctionEnvironmentRecord},
         lexical_environment::{Environment, VariableScope},
     },
-    property::PropertyDescriptor,
+    property::{PropertyDescriptor, PropertyKey},
     value::Numeric,
     vm::{call_frame::CatchAddresses, code_block::Readable},
     BoaProfiler, Context, JsBigInt, JsResult, JsString, JsValue,
@@ -301,8 +301,7 @@ impl Context {
             }
             Opcode::DefInitArg => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
                 let local_env = self.get_current_environment();
                 local_env
@@ -312,8 +311,7 @@ impl Context {
             }
             Opcode::DefVar => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 if !self.has_binding(name)? {
                     self.create_mutable_binding(name, false, VariableScope::Function)?;
@@ -322,8 +320,7 @@ impl Context {
             }
             Opcode::DefInitVar => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 if self.has_binding(name)? {
@@ -335,16 +332,14 @@ impl Context {
             }
             Opcode::DefLet => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 self.create_mutable_binding(name, false, VariableScope::Block)?;
                 self.initialize_binding(name, JsValue::Undefined)?;
             }
             Opcode::DefInitLet => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 self.create_mutable_binding(name, false, VariableScope::Block)?;
@@ -352,8 +347,7 @@ impl Context {
             }
             Opcode::DefInitConst => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 self.create_immutable_binding(name, true, VariableScope::Block)?;
@@ -361,16 +355,14 @@ impl Context {
             }
             Opcode::GetName => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 let value = self.get_binding_value(name)?;
                 self.vm.push(value);
             }
             Opcode::GetNameOrUndefined => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 let value = if self.has_binding(name)? {
                     self.get_binding_value(name)?
@@ -382,8 +374,7 @@ impl Context {
             Opcode::SetName => {
                 let index = self.vm.read::<u32>();
                 let value = self.vm.pop();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 self.set_mutable_binding(
                     name,
@@ -447,7 +438,12 @@ impl Context {
                     value.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
+                let name = self.vm.frame().code.variables[index as usize];
+                let name: PropertyKey = self
+                    .interner()
+                    .resolve(name)
+                    .expect("string disappeared")
+                    .into();
                 let result = object.get(name, self)?;
 
                 self.vm.push(result)
@@ -477,7 +473,12 @@ impl Context {
                     object.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
+                let name = self.vm.frame().code.variables[index as usize];
+                let name: PropertyKey = self
+                    .interner()
+                    .resolve(name)
+                    .expect("string disappeared")
+                    .into();
 
                 object.set(
                     name,
@@ -497,7 +498,8 @@ impl Context {
                     object.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
+                let name = self.vm.frame().code.variables[index as usize];
+                let name = self.interner().resolve(name).expect("string disappeared");
 
                 object.__define_own_property__(
                     name.into(),
@@ -557,8 +559,11 @@ impl Context {
                 let value = self.vm.pop();
                 let object = object.to_object(self)?;
 
-                let name = self.vm.frame().code.variables[index as usize]
-                    .clone()
+                let name = self.vm.frame().code.variables[index as usize];
+                let name = self
+                    .interner()
+                    .resolve(name)
+                    .expect("string disappeared")
                     .into();
                 let set = object
                     .__get_own_property__(&name, self)?
@@ -603,8 +608,11 @@ impl Context {
                 let object = self.vm.pop();
                 let value = self.vm.pop();
                 let object = object.to_object(self)?;
-                let name = self.vm.frame().code.variables[index as usize]
-                    .clone()
+                let name = self.vm.frame().code.variables[index as usize];
+                let name = self
+                    .interner()
+                    .resolve(name)
+                    .expect("string disappeared")
                     .into();
                 let get = object
                     .__get_own_property__(&name, self)?
@@ -646,9 +654,14 @@ impl Context {
             }
             Opcode::DeletePropertyByName => {
                 let index = self.vm.read::<u32>();
-                let key = self.vm.frame().code.variables[index as usize].clone();
+                let key = self.vm.frame().code.variables[index as usize];
+                let key = self
+                    .interner()
+                    .resolve(key)
+                    .expect("string disappeared")
+                    .into();
                 let object = self.vm.pop();
-                let result = object.to_object(self)?.__delete__(&key.into(), self)?;
+                let result = object.to_object(self)?.__delete__(&key, self)?;
                 if !result && self.strict() || self.vm.frame().code.strict {
                     return Err(self.construct_type_error("Cannot delete property"));
                 }

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -259,6 +259,9 @@ impl Sym {
     /// Symbol for the `"<main>"` string.
     pub const MAIN: Self = unsafe { Self::from_raw(NonZeroUsize::new_unchecked(11)) };
 
+    /// Symbol for the `"raw"` string.
+    pub const RAW: Self = unsafe { Self::from_raw(NonZeroUsize::new_unchecked(12)) };
+
     /// Creates a `Sym` from a raw `NonZeroUsize`.
     const fn from_raw(value: NonZeroUsize) -> Self {
         Self { value }
@@ -309,7 +312,7 @@ impl Interner {
     /// List of commonly used static strings.
     ///
     /// Make sure that any string added as a `Sym` constant is also added here.
-    const STATIC_STRINGS: [&'static str; 11] = [
+    const STATIC_STRINGS: [&'static str; 12] = [
         "",
         "arguments",
         "await",
@@ -321,5 +324,6 @@ impl Interner {
         "get",
         "set",
         "<main>",
+        "raw",
     ];
 }

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -304,7 +304,7 @@ where
     T: Display,
 {
     fn to_interned_string(&self, _interner: &Interner) -> String {
-        format!("{}", self)
+        self.to_string()
     }
 }
 

--- a/boa_interner/src/tests.rs
+++ b/boa_interner/src/tests.rs
@@ -28,6 +28,7 @@ fn check_constants() {
     assert_eq!(Sym::GET, sym_from_usize(9));
     assert_eq!(Sym::SET, sym_from_usize(10));
     assert_eq!(Sym::MAIN, sym_from_usize(11));
+    assert_eq!(Sym::RAW, sym_from_usize(12));
 }
 
 #[test]


### PR DESCRIPTION
It changes the following:

- Convert `Codeblock` variables to `Sym`
