### PR TITLE
Interner in the VM

### DIFF
--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -60,7 +60,7 @@ enum Access<'a> {
 pub struct ByteCompiler<'b> {
     code_block: CodeBlock,
     literals_map: FxHashMap<Literal, u32>,
-    names_map: FxHashMap<JsString, u32>, // TODO: Sym
+    names_map: FxHashMap<Sym, u32>,
     jump_info: Vec<JumpControlInfo>,
     interner: &'b mut Interner,
 }
@@ -98,15 +98,14 @@ impl<'b> ByteCompiler<'b> {
     }
 
     #[inline]
-    fn get_or_insert_name(&mut self, name_sym: Sym) -> u32 {
-        let name = self.interner.resolve_expect(name_sym);
-        if let Some(index) = self.names_map.get(name) {
+    fn get_or_insert_name(&mut self, name: Sym) -> u32 {
+        if let Some(index) = self.names_map.get(&name) {
             return *index;
         }
 
         let index = self.code_block.variables.len() as u32;
-        self.code_block.variables.push(name_sym);
-        self.names_map.insert(JsString::new(name), index);
+        self.code_block.variables.push(name);
+        self.names_map.insert(name, index);
         index
     }
 

--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -60,9 +60,9 @@ enum Access<'a> {
 pub struct ByteCompiler<'b> {
     code_block: CodeBlock,
     literals_map: FxHashMap<Literal, u32>,
-    names_map: FxHashMap<JsString, u32>,
+    names_map: FxHashMap<JsString, u32>, // TODO: Sym
     jump_info: Vec<JumpControlInfo>,
-    interner: &'b Interner,
+    interner: &'b mut Interner,
 }
 
 impl<'b> ByteCompiler<'b> {
@@ -70,7 +70,7 @@ impl<'b> ByteCompiler<'b> {
     const DUMMY_ADDRESS: u32 = u32::MAX;
 
     #[inline]
-    pub fn new(name: Sym, strict: bool, interner: &'b Interner) -> Self {
+    pub fn new(name: Sym, strict: bool, interner: &'b mut Interner) -> Self {
         Self {
             code_block: CodeBlock::new(name, 0, strict, false),
             literals_map: FxHashMap::default(),
@@ -98,15 +98,15 @@ impl<'b> ByteCompiler<'b> {
     }
 
     #[inline]
-    fn get_or_insert_name(&mut self, name: &str) -> u32 {
+    fn get_or_insert_name(&mut self, name_sym: Sym) -> u32 {
+        let name = self.interner.resolve_expect(name_sym);
         if let Some(index) = self.names_map.get(name) {
             return *index;
         }
 
-        let name = JsString::new(name);
         let index = self.code_block.variables.len() as u32;
-        self.code_block.variables.push(name.clone());
-        self.names_map.insert(name, index);
+        self.code_block.variables.push(name_sym);
+        self.names_map.insert(JsString::new(name), index);
         index
     }
 
@@ -353,7 +353,7 @@ impl<'b> ByteCompiler<'b> {
     fn compile_access<'a>(&mut self, node: &'a Node) -> Access<'a> {
         match node {
             Node::Identifier(name) => {
-                let index = self.get_or_insert_name(self.interner.resolve_expect(name.sym()));
+                let index = self.get_or_insert_name(name.sym());
                 Access::Variable { index }
             }
             Node::GetConstField(node) => Access::ByName { node },
@@ -370,7 +370,7 @@ impl<'b> ByteCompiler<'b> {
                 self.emit(Opcode::GetName, &[name]);
             }
             Access::ByName { node } => {
-                let index = self.get_or_insert_name(self.interner.resolve_expect(node.field()));
+                let index = self.get_or_insert_name(node.field());
                 self.compile_expr(node.obj(), true);
                 self.emit(Opcode::GetPropertyByName, &[index]);
             }
@@ -405,7 +405,7 @@ impl<'b> ByteCompiler<'b> {
             }
             Access::ByName { node } => {
                 self.compile_expr(node.obj(), true);
-                let index = self.get_or_insert_name(self.interner.resolve_expect(node.field()));
+                let index = self.get_or_insert_name(node.field());
                 self.emit(Opcode::SetPropertyByName, &[index]);
             }
             Access::ByValue { node } => {
@@ -488,9 +488,7 @@ impl<'b> ByteCompiler<'b> {
                     }
                     UnaryOp::Delete => match unary.target() {
                         Node::GetConstField(ref get_const_field) => {
-                            let index = self.get_or_insert_name(
-                                self.interner.resolve_expect(get_const_field.field()),
-                            );
+                            let index = self.get_or_insert_name(get_const_field.field());
                             self.compile_expr(get_const_field.obj(), true);
                             self.emit(Opcode::DeletePropertyByName, &[index]);
                             None
@@ -518,9 +516,7 @@ impl<'b> ByteCompiler<'b> {
                     UnaryOp::TypeOf => {
                         match &unary.target() {
                             Node::Identifier(identifier) => {
-                                let index = self.get_or_insert_name(
-                                    self.interner.resolve_expect(identifier.sym()),
-                                );
+                                let index = self.get_or_insert_name(identifier.sym());
                                 self.emit(Opcode::GetNameOrUndefined, &[index]);
                             }
                             expr => self.compile_expr(expr, true),
@@ -678,15 +674,14 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_opcode(Opcode::Dup);
                     match property {
                         PropertyDefinition::IdentifierReference(identifier_reference) => {
-                            let index = self.get_or_insert_name(identifier_reference);
+                            let index = self.get_or_insert_name(*identifier_reference);
                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                         }
                         PropertyDefinition::Property(name, node) => match name {
                             PropertyName::Literal(name) => {
                                 self.compile_stmt(node, true);
                                 self.emit_opcode(Opcode::Swap);
-                                let name = self.interner.resolve_expect(*name);
-                                let index = self.get_or_insert_name(name);
+                                let index = self.get_or_insert_name(*name);
                                 self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
@@ -701,8 +696,7 @@ impl<'b> ByteCompiler<'b> {
                                     PropertyName::Literal(name) => {
                                         self.compile_stmt(&func.clone().into(), true);
                                         self.emit_opcode(Opcode::Swap);
-                                        let name = self.interner.resolve_expect(*name);
-                                        let index = self.get_or_insert_name(name);
+                                        let index = self.get_or_insert_name(*name);
                                         self.emit(Opcode::SetPropertyGetterByName, &[index]);
                                     }
                                     PropertyName::Computed(name_node) => {
@@ -715,8 +709,7 @@ impl<'b> ByteCompiler<'b> {
                                     PropertyName::Literal(name) => {
                                         self.compile_stmt(&func.clone().into(), true);
                                         self.emit_opcode(Opcode::Swap);
-                                        let name = self.interner.resolve_expect(*name);
-                                        let index = self.get_or_insert_name(name);
+                                        let index = self.get_or_insert_name(*name);
                                         self.emit(Opcode::SetPropertySetterByName, &[index]);
                                     }
                                     PropertyName::Computed(name_node) => {
@@ -729,8 +722,7 @@ impl<'b> ByteCompiler<'b> {
                                     PropertyName::Literal(name) => {
                                         self.compile_stmt(&func.clone().into(), true);
                                         self.emit_opcode(Opcode::Swap);
-                                        let name = self.interner.resolve_expect(*name);
-                                        let index = self.get_or_insert_name(name);
+                                        let index = self.get_or_insert_name(*name);
                                         self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                                     }
                                     PropertyName::Computed(name_node) => {
@@ -745,8 +737,7 @@ impl<'b> ByteCompiler<'b> {
                                         PropertyName::Literal(name) => {
                                             self.emit_opcode(Opcode::PushUndefined);
                                             self.emit_opcode(Opcode::Swap);
-                                            let name = self.interner.resolve_expect(*name);
-                                            let index = self.get_or_insert_name(name);
+                                            let index = self.get_or_insert_name(*name);
                                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                                         }
                                         PropertyName::Computed(name_node) => {
@@ -762,8 +753,7 @@ impl<'b> ByteCompiler<'b> {
                                         PropertyName::Literal(name) => {
                                             self.emit_opcode(Opcode::PushUndefined);
                                             self.emit_opcode(Opcode::Swap);
-                                            let name = self.interner.resolve_expect(*name);
-                                            let index = self.get_or_insert_name(name);
+                                            let index = self.get_or_insert_name(*name);
                                             self.emit(Opcode::DefineOwnPropertyByName, &[index])
                                         }
                                         PropertyName::Computed(name_node) => {
@@ -779,8 +769,7 @@ impl<'b> ByteCompiler<'b> {
                                         PropertyName::Literal(name) => {
                                             self.emit_opcode(Opcode::PushUndefined);
                                             self.emit_opcode(Opcode::Swap);
-                                            let name = self.interner.resolve_expect(*name);
-                                            let index = self.get_or_insert_name(name);
+                                            let index = self.get_or_insert_name(*name);
                                             self.emit(Opcode::DefineOwnPropertyByName, &[index])
                                         }
                                         PropertyName::Computed(name_node) => {
@@ -806,7 +795,7 @@ impl<'b> ByteCompiler<'b> {
                 }
             }
             Node::Identifier(name) => {
-                let index = self.get_or_insert_name(self.interner.resolve_expect(name.sym()));
+                let index = self.get_or_insert_name(name.sym());
                 let access = Access::Variable { index };
                 self.access_get(access, use_expr);
             }
@@ -913,8 +902,7 @@ impl<'b> ByteCompiler<'b> {
                     Node::GetConstField(field) => {
                         self.compile_expr(field.obj(), true);
                         self.emit(Opcode::Dup, &[]);
-                        let index =
-                            self.get_or_insert_name(self.interner.resolve_expect(field.field()));
+                        let index = self.get_or_insert_name(field.field());
                         self.emit(Opcode::GetPropertyByName, &[index]);
                     }
                     Node::GetField(field) => {
@@ -953,7 +941,7 @@ impl<'b> ByteCompiler<'b> {
                 }
 
                 self.emit_opcode(Opcode::Swap);
-                let index = self.get_or_insert_name("raw");
+                let index = self.get_or_insert_name(Sym::RAW);
                 self.emit(Opcode::SetPropertyByName, &[index]);
 
                 for expr in template.exprs() {
@@ -973,8 +961,8 @@ impl<'b> ByteCompiler<'b> {
                 for decl in list.as_ref() {
                     match decl {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            if ident == "arguments" {
+                            let ident = ident.sym();
+                            if ident == Sym::ARGUMENTS {
                                 self.code_block.lexical_name_argument = true;
                             }
 
@@ -1011,8 +999,7 @@ impl<'b> ByteCompiler<'b> {
                                 self.code_block.lexical_name_argument = true;
                             }
 
-                            let index =
-                                self.get_or_insert_name(self.interner.resolve_expect(ident.sym()));
+                            let index = self.get_or_insert_name(ident.sym());
 
                             if let Some(expr) = decl.init() {
                                 self.compile_expr(expr, true);
@@ -1045,8 +1032,7 @@ impl<'b> ByteCompiler<'b> {
                                 self.code_block.lexical_name_argument = true;
                             }
 
-                            let index =
-                                self.get_or_insert_name(self.interner.resolve_expect(ident.sym()));
+                            let index = self.get_or_insert_name(ident.sym());
                             let init = decl
                                 .init()
                                 .expect("const declaration must have initializer");
@@ -1133,14 +1119,12 @@ impl<'b> ByteCompiler<'b> {
 
                 match for_in_loop.init() {
                     IterableLoopInitializer::Identifier(ref ident) => {
-                        let ident = self.interner.resolve_expect(ident.sym());
-                        let index = self.get_or_insert_name(ident);
+                        let index = self.get_or_insert_name(ident.sym());
                         self.emit(Opcode::SetName, &[index]);
                     }
                     IterableLoopInitializer::Var(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitVar, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1149,8 +1133,7 @@ impl<'b> ByteCompiler<'b> {
                     },
                     IterableLoopInitializer::Let(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitLet, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1159,8 +1142,7 @@ impl<'b> ByteCompiler<'b> {
                     },
                     IterableLoopInitializer::Const(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitConst, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1193,14 +1175,12 @@ impl<'b> ByteCompiler<'b> {
 
                 match for_of_loop.init() {
                     IterableLoopInitializer::Identifier(ref ident) => {
-                        let ident = self.interner.resolve_expect(ident.sym());
-                        let index = self.get_or_insert_name(ident);
+                        let index = self.get_or_insert_name(ident.sym());
                         self.emit(Opcode::SetName, &[index]);
                     }
                     IterableLoopInitializer::Var(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitVar, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1209,8 +1189,7 @@ impl<'b> ByteCompiler<'b> {
                     },
                     IterableLoopInitializer::Let(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitLet, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1219,8 +1198,7 @@ impl<'b> ByteCompiler<'b> {
                     },
                     IterableLoopInitializer::Const(declaration) => match declaration {
                         Declaration::Identifier { ident, .. } => {
-                            let ident = self.interner.resolve_expect(ident.sym());
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(ident.sym());
                             self.emit(Opcode::DefInitConst, &[index]);
                         }
                         Declaration::Pattern(pattern) => {
@@ -1407,8 +1385,7 @@ impl<'b> ByteCompiler<'b> {
                     if let Some(decl) = catch.parameter() {
                         match decl {
                             Declaration::Identifier { ident, .. } => {
-                                let ident = self.interner.resolve_expect(ident.sym());
-                                let index = self.get_or_insert_name(ident);
+                                let index = self.get_or_insert_name(ident.sym());
                                 self.emit(Opcode::DefInitLet, &[index]);
                             }
                             Declaration::Pattern(pattern) => {
@@ -1527,8 +1504,7 @@ impl<'b> ByteCompiler<'b> {
 
             match parameter.declaration() {
                 Declaration::Identifier { ident, .. } => {
-                    let ident = self.interner.resolve_expect(ident.sym());
-                    let index = compiler.get_or_insert_name(ident);
+                    let index = compiler.get_or_insert_name(ident.sym());
                     if let Some(init) = parameter.declaration().init() {
                         let skip = compiler.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
                         compiler.compile_expr(init, true);
@@ -1569,7 +1545,8 @@ impl<'b> ByteCompiler<'b> {
 
         match kind {
             FunctionKind::Declaration => {
-                let index = self.get_or_insert_name(self.interner.resolve_expect(name.unwrap()));
+                let index =
+                    self.get_or_insert_name(name.expect("empty name for a declaration function"));
                 self.emit(Opcode::DefInitVar, &[index]);
             }
             FunctionKind::Expression | FunctionKind::Arrow => {
@@ -1597,7 +1574,7 @@ impl<'b> ByteCompiler<'b> {
             Node::GetConstField(field) => {
                 self.compile_expr(field.obj(), true);
                 self.emit(Opcode::Dup, &[]);
-                let index = self.get_or_insert_name(self.interner.resolve_expect(field.field()));
+                let index = self.get_or_insert_name(field.field());
                 self.emit(Opcode::GetPropertyByName, &[index]);
             }
             Node::GetField(field) => {
@@ -1671,8 +1648,7 @@ impl<'b> ByteCompiler<'b> {
                             default_init,
                         } => {
                             self.emit_opcode(Opcode::Dup);
-                            let index = self
-                                .get_or_insert_name(self.interner.resolve_expect(*property_name));
+                            let index = self.get_or_insert_name(*property_name);
                             self.emit(Opcode::GetPropertyByName, &[index]);
 
                             if let Some(init) = default_init {
@@ -1681,8 +1657,7 @@ impl<'b> ByteCompiler<'b> {
                                 self.patch_jump(skip);
                             }
 
-                            let ident = self.interner.resolve_expect(*ident);
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(*ident);
                             self.emit(def, &[index]);
                         }
                         //  BindingRestProperty : ... BindingIdentifier
@@ -1701,8 +1676,7 @@ impl<'b> ByteCompiler<'b> {
 
                             self.emit(Opcode::CopyDataProperties, &[excluded_keys.len() as u32]);
 
-                            let ident = self.interner.resolve_expect(*ident);
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(*ident);
                             self.emit(def, &[index]);
                         }
                         BindingPattern {
@@ -1711,8 +1685,7 @@ impl<'b> ByteCompiler<'b> {
                             default_init,
                         } => {
                             self.emit_opcode(Opcode::Dup);
-                            let ident = self.interner.resolve_expect(*ident);
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(*ident);
                             self.emit(Opcode::GetPropertyByName, &[index]);
 
                             if let Some(init) = default_init {
@@ -1770,8 +1743,7 @@ impl<'b> ByteCompiler<'b> {
                                 self.patch_jump(skip);
                             }
 
-                            let ident = self.interner.resolve_expect(*ident);
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(*ident);
                             self.emit(def, &[index]);
                         }
                         // BindingElement : BindingPattern Initializer[opt]
@@ -1783,8 +1755,7 @@ impl<'b> ByteCompiler<'b> {
                         SingleNameRest { ident } => {
                             self.emit_opcode(Opcode::IteratorToArray);
 
-                            let ident = self.interner.resolve_expect(*ident);
-                            let index = self.get_or_insert_name(ident);
+                            let index = self.get_or_insert_name(*ident);
                             self.emit(def, &[index]);
                             self.emit_opcode(Opcode::PushTrue);
                         }

--- a/boa/src/context.rs
+++ b/boa/src/context.rs
@@ -911,7 +911,8 @@ impl Context {
     #[inline]
     pub fn compile(&mut self, statement_list: &StatementList) -> Gc<CodeBlock> {
         let _ = BoaProfiler::global().start_event("Compilation", "Main");
-        let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), &self.interner);
+        let mut compiler =
+            ByteCompiler::new(Sym::MAIN, statement_list.strict(), &mut self.interner);
         compiler.compile_statement_list(statement_list, true);
         Gc::new(compiler.finish())
     }

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -448,7 +448,7 @@ pub enum PropertyDefinition {
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-IdentifierReference
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Property_definitions
-    IdentifierReference(Box<str>),
+    IdentifierReference(Sym),
 
     /// Binds a property name to a JavaScript value.
     ///
@@ -486,11 +486,8 @@ pub enum PropertyDefinition {
 
 impl PropertyDefinition {
     /// Creates an `IdentifierReference` property definition.
-    pub fn identifier_reference<I>(ident: I) -> Self
-    where
-        I: Into<Box<str>>,
-    {
-        Self::IdentifierReference(ident.into())
+    pub fn identifier_reference(ident: Sym) -> Self {
+        Self::IdentifierReference(ident)
     }
 
     /// Creates a `Property` definition.

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -56,7 +56,7 @@ impl Object {
         for property in self.properties().iter() {
             buf.push_str(&match property {
                 PropertyDefinition::IdentifierReference(key) => {
-                    format!("{}{},\n", indentation, key)
+                    format!("{}{},\n", indentation, interner.resolve_expect(*key))
                 }
                 PropertyDefinition::Property(key, value) => {
                     format!(

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -17,7 +17,7 @@ use crate::{
     property::PropertyDescriptor,
     syntax::ast::node::FormalParameter,
     vm::{call_frame::FinallyReturn, CallFrame, Opcode},
-    Context, JsResult, JsString, JsValue,
+    Context, JsResult, JsValue,
 };
 use boa_interner::{Interner, Sym, ToInternedString};
 use std::{convert::TryInto, mem::size_of};
@@ -75,7 +75,7 @@ pub struct CodeBlock {
     pub(crate) literals: Vec<JsValue>,
 
     /// Variables names
-    pub(crate) variables: Vec<JsString>,
+    pub(crate) variables: Vec<Sym>,
 
     /// Functions inside this function
     pub(crate) functions: Vec<Gc<CodeBlock>>,
@@ -343,8 +343,12 @@ impl ToInternedString for CodeBlock {
 
         f.push_str("\nNames:\n");
         if !self.variables.is_empty() {
-            for (i, value) in self.variables.iter().enumerate() {
-                f.push_str(&format!("    {:04}: {}\n", i, value));
+            for (i, value) in self.variables.iter().copied().enumerate() {
+                f.push_str(&format!(
+                    "    {:04}: {}\n",
+                    i,
+                    interner.resolve_expect(value)
+                ));
             }
         } else {
             f.push_str("    <empty>");

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -9,7 +9,7 @@ use crate::{
         function_environment_record::{BindingStatus, FunctionEnvironmentRecord},
         lexical_environment::{Environment, VariableScope},
     },
-    property::PropertyDescriptor,
+    property::{PropertyDescriptor, PropertyKey},
     value::Numeric,
     vm::{call_frame::CatchAddresses, code_block::Readable},
     BoaProfiler, Context, JsBigInt, JsResult, JsString, JsValue,
@@ -301,8 +301,7 @@ impl Context {
             }
             Opcode::DefInitArg => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
                 let local_env = self.get_current_environment();
                 local_env
@@ -312,8 +311,7 @@ impl Context {
             }
             Opcode::DefVar => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 if !self.has_binding(name)? {
                     self.create_mutable_binding(name, false, VariableScope::Function)?;
@@ -322,8 +320,7 @@ impl Context {
             }
             Opcode::DefInitVar => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 if self.has_binding(name)? {
@@ -335,16 +332,14 @@ impl Context {
             }
             Opcode::DefLet => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 self.create_mutable_binding(name, false, VariableScope::Block)?;
                 self.initialize_binding(name, JsValue::Undefined)?;
             }
             Opcode::DefInitLet => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 self.create_mutable_binding(name, false, VariableScope::Block)?;
@@ -352,8 +347,7 @@ impl Context {
             }
             Opcode::DefInitConst => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
                 let value = self.vm.pop();
 
                 self.create_immutable_binding(name, true, VariableScope::Block)?;
@@ -361,16 +355,14 @@ impl Context {
             }
             Opcode::GetName => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 let value = self.get_binding_value(name)?;
                 self.vm.push(value);
             }
             Opcode::GetNameOrUndefined => {
                 let index = self.vm.read::<u32>();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 let value = if self.has_binding(name)? {
                     self.get_binding_value(name)?
@@ -382,8 +374,7 @@ impl Context {
             Opcode::SetName => {
                 let index = self.vm.read::<u32>();
                 let value = self.vm.pop();
-                let name_str = self.vm.frame().code.variables[index as usize].clone();
-                let name = self.interner_mut().get_or_intern(name_str);
+                let name = self.vm.frame().code.variables[index as usize];
 
                 self.set_mutable_binding(
                     name,
@@ -447,8 +438,9 @@ impl Context {
                     value.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
-                let result = object.get(name, self)?;
+                let name = self.vm.frame().code.variables[index as usize];
+                let key = PropertyKey::from(self.interner().resolve_expect(name));
+                let result = object.get(key, self)?;
 
                 self.vm.push(result)
             }
@@ -477,10 +469,11 @@ impl Context {
                     object.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
+                let name = self.vm.frame().code.variables[index as usize];
+                let key = PropertyKey::from(self.interner().resolve_expect(name));
 
                 object.set(
-                    name,
+                    key,
                     value,
                     self.strict() || self.vm.frame().code.strict,
                     self,
@@ -497,10 +490,10 @@ impl Context {
                     object.to_object(self)?
                 };
 
-                let name = self.vm.frame().code.variables[index as usize].clone();
+                let name = self.vm.frame().code.variables[index as usize];
 
                 object.__define_own_property__(
-                    name.into(),
+                    self.interner().resolve_expect(name).into(),
                     PropertyDescriptor::builder()
                         .value(value)
                         .writable(true)
@@ -557,9 +550,8 @@ impl Context {
                 let value = self.vm.pop();
                 let object = object.to_object(self)?;
 
-                let name = self.vm.frame().code.variables[index as usize]
-                    .clone()
-                    .into();
+                let name_sym = self.vm.frame().code.variables[index as usize];
+                let name = self.interner().resolve_expect(name_sym).into();
                 let set = object
                     .__get_own_property__(&name, self)?
                     .as_ref()
@@ -603,9 +595,9 @@ impl Context {
                 let object = self.vm.pop();
                 let value = self.vm.pop();
                 let object = object.to_object(self)?;
-                let name = self.vm.frame().code.variables[index as usize]
-                    .clone()
-                    .into();
+                let name_sym = self.vm.frame().code.variables[index as usize];
+                let name = self.interner().resolve_expect(name_sym).into();
+
                 let get = object
                     .__get_own_property__(&name, self)?
                     .as_ref()
@@ -646,9 +638,10 @@ impl Context {
             }
             Opcode::DeletePropertyByName => {
                 let index = self.vm.read::<u32>();
-                let key = self.vm.frame().code.variables[index as usize].clone();
+                let key_sym = self.vm.frame().code.variables[index as usize];
+                let key = self.interner().resolve_expect(key_sym).into();
                 let object = self.vm.pop();
-                let result = object.to_object(self)?.__delete__(&key.into(), self)?;
+                let result = object.to_object(self)?.__delete__(&key, self)?;
                 if !result && self.strict() || self.vm.frame().code.strict {
                     return Err(self.construct_type_error("Cannot delete property"));
                 }

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -259,6 +259,9 @@ impl Sym {
     /// Symbol for the `"<main>"` string.
     pub const MAIN: Self = unsafe { Self::from_raw(NonZeroUsize::new_unchecked(11)) };
 
+    /// Symbol for the `"raw"` string.
+    pub const RAW: Self = unsafe { Self::from_raw(NonZeroUsize::new_unchecked(12)) };
+
     /// Creates a `Sym` from a raw `NonZeroUsize`.
     const fn from_raw(value: NonZeroUsize) -> Self {
         Self { value }
@@ -301,7 +304,7 @@ where
     T: Display,
 {
     fn to_interned_string(&self, _interner: &Interner) -> String {
-        format!("{}", self)
+        self.to_string()
     }
 }
 
@@ -309,7 +312,7 @@ impl Interner {
     /// List of commonly used static strings.
     ///
     /// Make sure that any string added as a `Sym` constant is also added here.
-    const STATIC_STRINGS: [&'static str; 11] = [
+    const STATIC_STRINGS: [&'static str; 12] = [
         "",
         "arguments",
         "await",
@@ -321,5 +324,6 @@ impl Interner {
         "get",
         "set",
         "<main>",
+        "raw",
     ];
 }

--- a/boa_interner/src/tests.rs
+++ b/boa_interner/src/tests.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 
 #[track_caller]
 fn sym_from_usize(index: usize) -> Sym {
-    Sym::from_raw(NonZeroUsize::new(index).expect("Invalid NonZeroUsize"))
+    Sym::from_raw(NonZeroUsize::new(index).expect("invalid NonZeroUsize"))
 }
 
 #[test]
@@ -28,6 +28,7 @@ fn check_constants() {
     assert_eq!(Sym::GET, sym_from_usize(9));
     assert_eq!(Sym::SET, sym_from_usize(10));
     assert_eq!(Sym::MAIN, sym_from_usize(11));
+    assert_eq!(Sym::RAW, sym_from_usize(12));
 }
 
 #[test]


### PR DESCRIPTION
After adding the interner to the lexer and the parser, this PR extends its usage in the VM, in order to allow more optimisations.