### PR TITLE
[Merged by Bors] - Fixed the GitHub actions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Currently, it has support for some of the language.
 [![](https://docs.rs/Boa/badge.svg)](https://docs.rs/Boa/)
 [![Discord](https://img.shields.io/discord/595323158140158003?logo=discord)](https://discord.gg/tUFFk9Y)
 
-[build_badge]: https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fboa-dev%2Fboa%2Fbadge&style=flat
-[build_link]: https://actions-badge.atrox.dev/boa-dev/boa/goto
+[build_badge]: https://github.com/boa-dev/boa/actions/workflows/rust.yml/badge.svg?event=push&branch=main
+[build_link]: https://github.com/boa-dev/boa/actions/workflows/rust.yml?query=event%3Apush+branch%3Amain
 
 ## Live Demo (WASM)
 


### PR DESCRIPTION
This uses the official GitHub actions badge.

