### PR TITLE
[Merged by Bors] - Fixed #1768

### DIFF
--- a/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
@@ -153,7 +153,6 @@ where
             self.read_index, self.write_index,
             "we reached the read index with the write index"
         );
-
         debug_assert!(
             self.read_index < PEEK_BUF_SIZE,
             "read index went out of bounds"

--- a/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/mod.rs
@@ -17,12 +17,12 @@ const MAX_PEEK_SKIP: usize = 3;
 /// The fixed size of the buffer used for storing values that are peeked ahead.
 ///
 /// The size is calculated for a worst case scenario, where we want to peek `MAX_PEEK_SKIP` tokens
-/// skipping line terminators:
+/// skipping line terminators, and the stream ends just after:
 /// ```text
-/// [\n, B, \n, C, \n, D, \n, E, \n, F]
-///   0  0   1  1   2  2   3  3   4  4
+/// [\n, B, \n, C, \n, D, \n, E, \n, F, None]
+///   0  0   1  1   2  2   3  3   4  4  5
 /// ```
-const PEEK_BUF_SIZE: usize = (MAX_PEEK_SKIP + 1) * 2;
+const PEEK_BUF_SIZE: usize = (MAX_PEEK_SKIP + 1) * 2 + 1;
 
 #[derive(Debug)]
 pub(super) struct BufferedLexer<R> {
@@ -41,6 +41,7 @@ where
         Self {
             lexer,
             peeked: [
+                None::<Token>,
                 None::<Token>,
                 None::<Token>,
                 None::<Token>,
@@ -152,6 +153,7 @@ where
             self.read_index, self.write_index,
             "we reached the read index with the write index"
         );
+
         debug_assert!(
             self.read_index < PEEK_BUF_SIZE,
             "read index went out of bounds"

--- a/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
+++ b/boa/src/syntax/parser/cursor/buffered_lexer/tests.rs
@@ -278,3 +278,11 @@ fn skip_peeked_terminators() {
     // End of stream
     assert!(cur.peek(2, true, &mut interner).unwrap().is_none());
 }
+
+#[test]
+fn issue_1768() {
+    let mut cur = BufferedLexer::from(&b"\n(\nx\n)\n"[..]);
+    let mut interner = Interner::default();
+
+    assert!(cur.peek(3, true, &mut interner).unwrap().is_none());
+}

--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -153,15 +153,11 @@ where
                                         .map(Node::ArrowFunctionDecl);
                                     }
                                     TokenKind::Punctuator(Punctuator::CloseParen) => {
-                                        // Need to check if the token after the close paren is an arrow, if so then this is an ArrowFunction
-                                        // otherwise it is an expression of the form (b).
-                                        #[allow(clippy::match_same_arms)]
-                                        match cursor.peek(3, interner) {
-                                            Ok(Some(t))
-                                                if t.kind()
-                                                    == &TokenKind::Punctuator(
-                                                        Punctuator::Arrow,
-                                                    ) =>
+                                        // Need to check if the token after the close paren is an
+                                        // arrow, if so then this is an ArrowFunction otherwise it
+                                        // is an expression of the form (b).
+                                        if let Some(t) = cursor.peek(3, interner)? {
+                                            if t.kind() == &TokenKind::Punctuator(Punctuator::Arrow)
                                             {
                                                 return ArrowFunction::new(
                                                     self.allow_in,
@@ -171,9 +167,6 @@ where
                                                 .parse(cursor, interner)
                                                 .map(Node::ArrowFunctionDecl);
                                             }
-                                            Err(ParseError::AbruptEnd) => {}
-                                            Err(e) => return Err(e),
-                                            _ => {}
                                         }
                                     }
                                     _ => {}

--- a/boa/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa/src/syntax/parser/expression/assignment/mod.rs
@@ -155,8 +155,13 @@ where
                                     TokenKind::Punctuator(Punctuator::CloseParen) => {
                                         // Need to check if the token after the close paren is an arrow, if so then this is an ArrowFunction
                                         // otherwise it is an expression of the form (b).
-                                        if let Some(t) = cursor.peek(3, interner)? {
-                                            if t.kind() == &TokenKind::Punctuator(Punctuator::Arrow)
+                                        #[allow(clippy::match_same_arms)]
+                                        match cursor.peek(3, interner) {
+                                            Ok(Some(t))
+                                                if t.kind()
+                                                    == &TokenKind::Punctuator(
+                                                        Punctuator::Arrow,
+                                                    ) =>
                                             {
                                                 return ArrowFunction::new(
                                                     self.allow_in,
@@ -166,6 +171,9 @@ where
                                                 .parse(cursor, interner)
                                                 .map(Node::ArrowFunctionDecl);
                                             }
+                                            Err(ParseError::AbruptEnd) => {}
+                                            Err(e) => return Err(e),
+                                            _ => {}
                                         }
                                     }
                                     _ => {}


### PR DESCRIPTION
This Pull Request fixes/closes #1768.

It adds one extra peeked token in the buffered lexer, since it didn't take into account that the stream might end just after the last peeked token. The panic was only happening in debug mode, but still, this was wrong.