### PR TITLE
[Merged by Bors] - Implement Array.from

### DIFF
--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -411,3 +411,23 @@ pub(crate) fn iterable_to_list(
     // 6. Return values.
     Ok(values)
 }
+
+/// A shorthand for a sequence of algorithm steps that use an Iterator Record
+///
+/// More information:
+///  - [ECMA reference][spec]
+///
+///  [spec]: https://tc39.es/ecma262/#sec-ifabruptcloseiterator
+macro_rules! if_abrupt_close_iterator {
+    ($value:expr, $iterator_record:expr, $context:expr) => {
+        match $value {
+            // 1. If value is an abrupt completion, return ? IteratorClose(iteratorRecord, value).
+            Err(err) => return $iterator_record.close(Err(err), $context),
+            // 2. Else if value is a Completion Record, set value to value.
+            Ok(value) => value,
+        }
+    };
+}
+
+// Export macro to crate level
+pub(crate) use if_abrupt_close_iterator;


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1784.

There're still a few tests failing, notably:
- `iter-set-elem-prop-non-writable` - we don't have generator functions implemented
- `calling-from-valid-1-noStrict`, `iter-map-fn-this-non-strict` - `thisArg` in non-strict mode, when undefined, should be inherited (that's what I'm guessing, I haven't confirmed this, but strict counterparts do pass with `thisArg` being `undefined`)
- `source-array-boundary`, `elements-deleted-after` - ~~Not sure yet, still investigating, but they also include thisArg, so perhaps function calling has an underlying issue?~~ Failing because `this` on the top level evaluates to an empty object instead of containing everything from the top scope