### PR TITLE
[Merged by Bors] - Give the arrow function its proper name

### DIFF
--- a/boa/src/bytecompiler.rs
+++ b/boa/src/bytecompiler.rs
@@ -1423,7 +1423,7 @@ impl<'b> ByteCompiler<'b> {
             ),
             Node::ArrowFunctionDecl(function) => (
                 FunctionKind::Arrow,
-                None,
+                function.name(),
                 function.params(),
                 function.body(),
             ),

--- a/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     gc::{Finalize, Trace},
     syntax::ast::node::{join_nodes, FormalParameter, Node, StatementList},
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
@@ -23,21 +23,34 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct ArrowFunctionDecl {
+    name: Option<Sym>,
     params: Box<[FormalParameter]>,
     body: StatementList,
 }
 
 impl ArrowFunctionDecl {
     /// Creates a new `ArrowFunctionDecl` AST node.
-    pub(in crate::syntax) fn new<P, B>(params: P, body: B) -> Self
+    pub(in crate::syntax) fn new<N, P, B>(name: N, params: P, body: B) -> Self
     where
+        N: Into<Option<Sym>>,
         P: Into<Box<[FormalParameter]>>,
         B: Into<StatementList>,
     {
         Self {
+            name: name.into(),
             params: params.into(),
             body: body.into(),
         }
+    }
+
+    /// Gets the name of the function declaration.
+    pub fn name(&self) -> Option<Sym> {
+        self.name
+    }
+
+    /// Sets the name of the function declaration.
+    pub fn set_name(&mut self, name: Option<Sym>) {
+        self.name = name;
     }
 
     /// Gets the list of parameters of the arrow function.

--- a/boa/src/syntax/parser/expression/assignment/conditional.rs
+++ b/boa/src/syntax/parser/expression/assignment/conditional.rs
@@ -72,14 +72,22 @@ where
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Question) {
                 cursor.next(interner)?.expect("? character vanished"); // Consume the token.
-                let then_clause =
-                    AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let then_clause = AssignmentExpression::new(
+                    None,
+                    self.allow_in,
+                    self.allow_yield,
+                    self.allow_await,
+                )
+                .parse(cursor, interner)?;
                 cursor.expect(Punctuator::Colon, "conditional expression", interner)?;
 
-                let else_clause =
-                    AssignmentExpression::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let else_clause = AssignmentExpression::new(
+                    None,
+                    self.allow_in,
+                    self.allow_yield,
+                    self.allow_await,
+                )
+                .parse(cursor, interner)?;
                 return Ok(ConditionalOp::new(lhs, then_clause, else_clause).into());
             }
         }

--- a/boa/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa/src/syntax/parser/expression/assignment/yield.rs
@@ -87,7 +87,7 @@ where
                 delegate = true;
             }
             expr = Some(
-                AssignmentExpression::new(self.allow_in, true, self.allow_await)
+                AssignmentExpression::new(None, self.allow_in, true, self.allow_await)
                     .parse(cursor, interner)?,
             );
         }

--- a/boa/src/syntax/parser/expression/left_hand_side/arguments.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/arguments.rs
@@ -104,7 +104,7 @@ where
             if cursor.next_if(Punctuator::Spread, interner)?.is_some() {
                 args.push(
                     Spread::new(
-                        AssignmentExpression::new(true, self.allow_yield, self.allow_await)
+                        AssignmentExpression::new(None, true, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
                     )
                     .into(),
@@ -112,7 +112,7 @@ where
             } else {
                 cursor.set_goal(InputElement::RegExp);
                 args.push(
-                    AssignmentExpression::new(true, self.allow_yield, self.allow_await)
+                    AssignmentExpression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?,
                 );
             }

--- a/boa/src/syntax/parser/expression/left_hand_side/call.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/call.rs
@@ -111,7 +111,7 @@ where
                 }
                 TokenKind::Punctuator(Punctuator::OpenBracket) => {
                     let _next = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?; // We move the parser.
-                    let idx = Expression::new(true, self.allow_yield, self.allow_await)
+                    let idx = Expression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
                     cursor.expect(Punctuator::CloseBracket, "call expression", interner)?;
                     lhs = GetField::new(lhs, idx).into();

--- a/boa/src/syntax/parser/expression/left_hand_side/member.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/member.rs
@@ -112,7 +112,7 @@ where
                     cursor
                         .next(interner)?
                         .expect("open bracket punctuator token disappeared"); // We move the parser forward.
-                    let idx = Expression::new(true, self.allow_yield, self.allow_await)
+                    let idx = Expression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
                     cursor.expect(Punctuator::CloseBracket, "member expression", interner)?;
                     lhs = GetField::new(lhs, idx).into();

--- a/boa/src/syntax/parser/expression/left_hand_side/template.rs
+++ b/boa/src/syntax/parser/expression/left_hand_side/template.rs
@@ -64,7 +64,7 @@ where
                     raws.push(template_string.as_raw());
                     cookeds.push(template_string.to_owned_cooked(interner).ok());
                     exprs.push(
-                        Expression::new(true, self.allow_yield, self.allow_await)
+                        Expression::new(None, true, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
                     );
                     cursor.expect(

--- a/boa/src/syntax/parser/expression/mod.rs
+++ b/boa/src/syntax/parser/expression/mod.rs
@@ -17,6 +17,8 @@ mod update;
 
 pub(in crate::syntax::parser) mod await_expr;
 
+use boa_interner::Sym;
+
 use self::assignment::ExponentiationExpression;
 pub(super) use self::{assignment::AssignmentExpression, primary::Initializer};
 use super::{AllowAwait, AllowIn, AllowYield, Cursor, ParseResult, TokenParser};
@@ -121,6 +123,7 @@ macro_rules! expression { ($name:ident, $lower:ident, [$( $op:path ),*], [$( $lo
 /// [spec]: https://tc39.es/ecma262/#prod-Expression
 #[derive(Debug, Clone, Copy)]
 pub(super) struct Expression {
+    name: Option<Sym>,
     allow_in: AllowIn,
     allow_yield: AllowYield,
     allow_await: AllowAwait,
@@ -128,13 +131,15 @@ pub(super) struct Expression {
 
 impl Expression {
     /// Creates a new `Expression` parser.
-    pub(super) fn new<I, Y, A>(allow_in: I, allow_yield: Y, allow_await: A) -> Self
+    pub(super) fn new<N, I, Y, A>(name: N, allow_in: I, allow_yield: Y, allow_await: A) -> Self
     where
+        N: Into<Option<Sym>>,
         I: Into<AllowIn>,
         Y: Into<AllowYield>,
         A: Into<AllowAwait>,
     {
         Self {
+            name: name.into(),
             allow_in: allow_in.into(),
             allow_yield: allow_yield.into(),
             allow_await: allow_await.into(),
@@ -146,7 +151,7 @@ expression!(
     Expression,
     AssignmentExpression,
     [Punctuator::Comma],
-    [allow_in, allow_yield, allow_await],
+    [name, allow_in, allow_yield, allow_await],
     None::<InputElement>
 );
 

--- a/boa/src/syntax/parser/expression/primary/array_initializer/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/array_initializer/mod.rs
@@ -84,12 +84,13 @@ where
             let _next = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd); // Check that there are more tokens to read.
 
             if cursor.next_if(Punctuator::Spread, interner)?.is_some() {
-                let node = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                    .parse(cursor, interner)?;
+                let node =
+                    AssignmentExpression::new(None, true, self.allow_yield, self.allow_await)
+                        .parse(cursor, interner)?;
                 elements.push(Spread::new(node).into());
             } else {
                 elements.push(
-                    AssignmentExpression::new(true, self.allow_yield, self.allow_await)
+                    AssignmentExpression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?,
                 );
             }

--- a/boa/src/syntax/parser/expression/primary/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/mod.rs
@@ -108,7 +108,7 @@ where
             }
             TokenKind::Punctuator(Punctuator::OpenParen) => {
                 cursor.set_goal(InputElement::RegExp);
-                let expr = Expression::new(true, self.allow_yield, self.allow_await)
+                let expr = Expression::new(None, true, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
                 cursor.expect(Punctuator::CloseParen, "primary expression", interner)?;
                 Ok(expr)

--- a/boa/src/syntax/parser/expression/primary/template/mod.rs
+++ b/boa/src/syntax/parser/expression/primary/template/mod.rs
@@ -69,7 +69,7 @@ where
         let mut elements = vec![
             TemplateElement::String(self.first),
             TemplateElement::Expr(
-                Expression::new(true, self.allow_yield, self.allow_await)
+                Expression::new(None, true, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?,
             ),
         ];
@@ -88,7 +88,7 @@ where
 
                     elements.push(TemplateElement::String(cooked));
                     elements.push(TemplateElement::Expr(
-                        Expression::new(true, self.allow_yield, self.allow_await)
+                        Expression::new(None, true, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
                     ));
                     cursor.expect(

--- a/boa/src/syntax/parser/function/mod.rs
+++ b/boa/src/syntax/parser/function/mod.rs
@@ -231,7 +231,7 @@ where
                             *t.kind() == TokenKind::Punctuator(Punctuator::Assign)
                         })
                         .map(|_| {
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(None, true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)
                         })
                         .transpose()?;
@@ -257,7 +257,7 @@ where
                             *t.kind() == TokenKind::Punctuator(Punctuator::Assign)
                         })
                         .map(|_| {
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(None, true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)
                         })
                         .transpose()?;
@@ -330,7 +330,7 @@ where
                             *t.kind() == TokenKind::Punctuator(Punctuator::Assign)
                         })
                         .map(|_| {
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(None, true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)
                         })
                         .transpose()?;
@@ -357,7 +357,7 @@ where
                             *t.kind() == TokenKind::Punctuator(Punctuator::Assign)
                         })
                         .map(|_| {
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(None, true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)
                         })
                         .transpose()?;

--- a/boa/src/syntax/parser/function/tests.rs
+++ b/boa/src/syntax/parser/function/tests.rs
@@ -154,6 +154,7 @@ fn check_arrow_only_rest() {
     check_parser(
         "(...a) => {}",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![FormalParameter::new(
                 Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
                 true,
@@ -172,6 +173,7 @@ fn check_arrow_rest() {
     check_parser(
         "(a, b, ...c) => {}",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![
                 FormalParameter::new(
                     Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
@@ -200,6 +202,7 @@ fn check_arrow() {
     check_parser(
         "(a, b) => { return a + b; }",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![
                 FormalParameter::new(
                     Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
@@ -232,6 +235,7 @@ fn check_arrow_semicolon_insertion() {
     check_parser(
         "(a, b) => { return a + b }",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![
                 FormalParameter::new(
                     Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
@@ -264,6 +268,7 @@ fn check_arrow_epty_return() {
     check_parser(
         "(a, b) => { return; }",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![
                 FormalParameter::new(
                     Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
@@ -288,6 +293,7 @@ fn check_arrow_empty_return_semicolon_insertion() {
     check_parser(
         "(a, b) => { return }",
         vec![ArrowFunctionDecl::new(
+            None,
             vec![
                 FormalParameter::new(
                     Declaration::new_with_identifier(interner.get_or_intern_static("a"), None),
@@ -315,6 +321,7 @@ fn check_arrow_assignment() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![FormalParameter::new(
                             Declaration::new_with_identifier(
                                 interner.get_or_intern_static("a"),
@@ -348,6 +355,7 @@ fn check_arrow_assignment_nobrackets() {
                 interner.get_or_intern_static("foo"),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![FormalParameter::new(
                             Declaration::new_with_identifier(
                                 interner.get_or_intern_static("a"),
@@ -381,6 +389,7 @@ fn check_arrow_assignment_noparenthesis() {
                 interner.get_or_intern_static("foo"),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![FormalParameter::new(
                             Declaration::new_with_identifier(
                                 interner.get_or_intern_static("a"),
@@ -414,6 +423,7 @@ fn check_arrow_assignment_noparenthesis_nobrackets() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![FormalParameter::new(
                             Declaration::new_with_identifier(
                                 interner.get_or_intern_static("a"),
@@ -447,6 +457,7 @@ fn check_arrow_assignment_2arg() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![
                             FormalParameter::new(
                                 Declaration::new_with_identifier(
@@ -489,6 +500,7 @@ fn check_arrow_assignment_2arg_nobrackets() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![
                             FormalParameter::new(
                                 Declaration::new_with_identifier(
@@ -531,6 +543,7 @@ fn check_arrow_assignment_3arg() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![
                             FormalParameter::new(
                                 Declaration::new_with_identifier(
@@ -580,6 +593,7 @@ fn check_arrow_assignment_3arg_nobrackets() {
                 Identifier::new(interner.get_or_intern_static("foo")),
                 Some(
                     ArrowFunctionDecl::new(
+                        Some(interner.get_or_intern_static("foo")),
                         vec![
                             FormalParameter::new(
                                 Declaration::new_with_identifier(

--- a/boa/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa/src/syntax/parser/statement/declaration/lexical.rs
@@ -269,8 +269,13 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?,
+                            Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?,
                         )
                     } else {
                         None
@@ -289,8 +294,13 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?,
+                            Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?,
                         )
                     } else {
                         None
@@ -309,7 +319,7 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(Some(ident), true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)?,
                         )
                     } else {

--- a/boa/src/syntax/parser/statement/expression/mod.rs
+++ b/boa/src/syntax/parser/statement/expression/mod.rs
@@ -73,8 +73,8 @@ where
             _ => {}
         }
 
-        let expr =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let expr = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         cursor.expect_semicolon("expression statement", interner)?;
 

--- a/boa/src/syntax/parser/statement/if_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/if_stm/mod.rs
@@ -64,8 +64,8 @@ where
         cursor.expect(Keyword::If, "if statement", interner)?;
         cursor.expect(Punctuator::OpenParen, "if statement", interner)?;
 
-        let condition =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let condition = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         let position = cursor
             .expect(Punctuator::CloseParen, "if statement", interner)?

--- a/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/do_while_statement.rs
@@ -96,8 +96,8 @@ where
 
         cursor.expect(Punctuator::OpenParen, "do while statement", interner)?;
 
-        let cond =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let cond = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         cursor.expect(Punctuator::CloseParen, "do while statement", interner)?;
 

--- a/boa/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/for_statement.rs
@@ -97,7 +97,7 @@ where
             ),
             TokenKind::Punctuator(Punctuator::Semicolon) => None,
             _ => Some(
-                Expression::new(false, self.allow_yield, self.allow_await)
+                Expression::new(None, false, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?,
             ),
         };
@@ -107,7 +107,7 @@ where
                 let init = node_to_iterable_loop_initializer(&init.unwrap(), init_position)?;
 
                 let _next = cursor.next(interner)?;
-                let expr = Expression::new(true, self.allow_yield, self.allow_await)
+                let expr = Expression::new(None, true, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
                 let position = cursor
@@ -129,7 +129,7 @@ where
                 let init = node_to_iterable_loop_initializer(&init.unwrap(), init_position)?;
 
                 let _next = cursor.next(interner)?;
-                let iterable = Expression::new(true, self.allow_yield, self.allow_await)
+                let iterable = Expression::new(None, true, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
                 let position = cursor
@@ -155,7 +155,7 @@ where
         let cond = if cursor.next_if(Punctuator::Semicolon, interner)?.is_some() {
             Const::from(true).into()
         } else {
-            let step = Expression::new(true, self.allow_yield, self.allow_await)
+            let step = Expression::new(None, true, self.allow_yield, self.allow_await)
                 .parse(cursor, interner)?;
             cursor.expect(Punctuator::Semicolon, "for statement", interner)?;
             step
@@ -164,7 +164,7 @@ where
         let step = if cursor.next_if(Punctuator::CloseParen, interner)?.is_some() {
             None
         } else {
-            let step = Expression::new(true, self.allow_yield, self.allow_await)
+            let step = Expression::new(None, true, self.allow_yield, self.allow_await)
                 .parse(cursor, interner)?;
             cursor.expect(
                 TokenKind::Punctuator(Punctuator::CloseParen),

--- a/boa/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa/src/syntax/parser/statement/iteration/while_statement.rs
@@ -62,8 +62,8 @@ where
 
         cursor.expect(Punctuator::OpenParen, "while statement", interner)?;
 
-        let cond =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let cond = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         let position = cursor
             .expect(Punctuator::CloseParen, "while statement", interner)?

--- a/boa/src/syntax/parser/statement/mod.rs
+++ b/boa/src/syntax/parser/statement/mod.rs
@@ -677,9 +677,13 @@ where
             if let Some(peek_token) = cursor.peek(0, interner)? {
                 match peek_token.kind() {
                     TokenKind::Punctuator(Punctuator::Assign) => {
-                        let init =
-                            Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?;
+                        let init = Initializer::new(
+                            None,
+                            self.allow_in,
+                            self.allow_yield,
+                            self.allow_await,
+                        )
+                        .parse(cursor, interner)?;
                         patterns.push(BindingPatternTypeObject::SingleName {
                             ident: property_name,
                             property_name,
@@ -707,6 +711,7 @@ where
                                         match peek_token.kind() {
                                             TokenKind::Punctuator(Punctuator::Assign) => {
                                                 let init = Initializer::new(
+                                                    None,
                                                     self.allow_in,
                                                     self.allow_yield,
                                                     self.allow_await,
@@ -752,6 +757,7 @@ where
                                         match peek_token.kind() {
                                             TokenKind::Punctuator(Punctuator::Assign) => {
                                                 let init = Initializer::new(
+                                                    None,
                                                     self.allow_in,
                                                     self.allow_yield,
                                                     self.allow_await,
@@ -796,6 +802,7 @@ where
                                         match peek_token.kind() {
                                             TokenKind::Punctuator(Punctuator::Assign) => {
                                                 let init = Initializer::new(
+                                                    None,
                                                     self.allow_in,
                                                     self.allow_yield,
                                                     self.allow_await,
@@ -1012,9 +1019,13 @@ where
                         .kind()
                     {
                         TokenKind::Punctuator(Punctuator::Assign) => {
-                            let default_init =
-                                Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                    .parse(cursor, interner)?;
+                            let default_init = Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?;
                             patterns.push(BindingPatternTypeArray::BindingPattern {
                                 pattern: DeclarationPattern::Object(DeclarationPatternObject::new(
                                     bindings,
@@ -1043,9 +1054,13 @@ where
                         .kind()
                     {
                         TokenKind::Punctuator(Punctuator::Assign) => {
-                            let default_init =
-                                Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                    .parse(cursor, interner)?;
+                            let default_init = Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?;
                             patterns.push(BindingPatternTypeArray::BindingPattern {
                                 pattern: DeclarationPattern::Array(DeclarationPatternArray::new(
                                     bindings,
@@ -1073,9 +1088,13 @@ where
                         .kind()
                     {
                         TokenKind::Punctuator(Punctuator::Assign) => {
-                            let default_init =
-                                Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                    .parse(cursor, interner)?;
+                            let default_init = Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?;
                             patterns.push(BindingPatternTypeArray::SingleName {
                                 ident,
                                 default_init: Some(default_init),

--- a/boa/src/syntax/parser/statement/return_stm/mod.rs
+++ b/boa/src/syntax/parser/statement/return_stm/mod.rs
@@ -70,8 +70,8 @@ where
             return Ok(Return::new::<Node, Option<_>, Option<_>>(None, None));
         }
 
-        let expr =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let expr = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         cursor.expect_semicolon("return statement", interner)?;
 

--- a/boa/src/syntax/parser/statement/switch/mod.rs
+++ b/boa/src/syntax/parser/statement/switch/mod.rs
@@ -68,8 +68,8 @@ where
         cursor.expect(Keyword::Switch, "switch statement", interner)?;
         cursor.expect(Punctuator::OpenParen, "switch statement", interner)?;
 
-        let condition =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let condition = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
 
         cursor.expect(Punctuator::CloseParen, "switch statement", interner)?;
 
@@ -130,7 +130,7 @@ where
             match cursor.next(interner)? {
                 Some(token) if token.kind() == &TokenKind::Keyword(Keyword::Case) => {
                     // Case statement.
-                    let cond = Expression::new(true, self.allow_yield, self.allow_await)
+                    let cond = Expression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
 
                     cursor.expect(Punctuator::Colon, "switch case block", interner)?;

--- a/boa/src/syntax/parser/statement/throw/mod.rs
+++ b/boa/src/syntax/parser/statement/throw/mod.rs
@@ -57,8 +57,8 @@ where
 
         cursor.peek_expect_no_lineterminator(0, "throw statement", interner)?;
 
-        let expr =
-            Expression::new(true, self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let expr = Expression::new(None, true, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                 let _next = cursor.next(interner).expect("token disappeared");

--- a/boa/src/syntax/parser/statement/variable/mod.rs
+++ b/boa/src/syntax/parser/statement/variable/mod.rs
@@ -191,8 +191,13 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?,
+                            Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?,
                         )
                     } else {
                         None
@@ -211,8 +216,13 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(self.allow_in, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?,
+                            Initializer::new(
+                                None,
+                                self.allow_in,
+                                self.allow_yield,
+                                self.allow_await,
+                            )
+                            .parse(cursor, interner)?,
                         )
                     } else {
                         None
@@ -231,7 +241,7 @@ where
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
                         Some(
-                            Initializer::new(true, self.allow_yield, self.allow_await)
+                            Initializer::new(Some(ident), true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)?,
                         )
                     } else {

--- a/boa/src/syntax/parser/tests.rs
+++ b/boa/src/syntax/parser/tests.rs
@@ -1,5 +1,7 @@
 //! Tests for the parser.
 
+use boa_interner::Sym;
+
 use super::Parser;
 use crate::{
     syntax::ast::{
@@ -407,7 +409,8 @@ fn spread_in_arrow_function() {
     check_parser(
         s,
         vec![
-            ArrowFunctionDecl::new::<Box<[FormalParameter]>, StatementList>(
+            ArrowFunctionDecl::new::<Option<Sym>, Box<[FormalParameter]>, StatementList>(
+                None,
                 Box::new([FormalParameter::new(
                     Declaration::new_with_identifier::<_, Option<Node>>(b, None),
                     true,


### PR DESCRIPTION
With this change an arrow function name is correctly set to the name of the variable:

```javascript
const myFunction = () => {};
console.log(myFunction.name); // Prints "myFunction"
```

_Note:_ I'm still getting familiar with the codebase and am pretty new to Rust so I won't be offended if this isn't merged. I am actually surprised I had to make so many changes to give the right code the name it needed. Maybe there is a better way? I'm all ears :)

