### PR TITLE
[Merged by Bors] - Using the new formatting arguments from Rust 1.58

### DIFF
--- a/boa/Cargo.toml
+++ b/boa/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["parser-implementations", "wasm"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.58"
 
 [features]
 profiler = ["measureme"]

--- a/boa/examples/closures.rs
+++ b/boa/examples/closures.rs
@@ -20,7 +20,7 @@ fn main() -> Result<(), JsValue> {
     context.register_global_closure("closure", 0, move |_, _, _| {
         println!("Called `closure`");
         // `variable` is captured from the main function.
-        println!("variable = {}", variable);
+        println!("variable = {variable}");
         println!();
 
         // We return the moved variable as a `JsValue`.
@@ -77,7 +77,7 @@ fn main() -> Result<(), JsValue> {
             // We can also mutate the moved data inside the closure.
             captures.greeting = format!("{} Hello!", captures.greeting).into();
 
-            println!("{}", message);
+            println!("{message}");
             println!();
 
             // We convert `message` into `Jsvalue` to be able to return it.

--- a/boa/src/builtins/array_buffer/mod.rs
+++ b/boa/src/builtins/array_buffer/mod.rs
@@ -745,7 +745,7 @@ pub fn create_byte_data_block(size: usize, context: &mut Context) -> JsResult<Ve
     //    create such a Data Block, throw a RangeError exception.
     let mut data_block = Vec::new();
     data_block.try_reserve(size).map_err(|e| {
-        context.construct_range_error(format!("couldn't allocate the data block: {}", e))
+        context.construct_range_error(format!("couldn't allocate the data block: {e}"))
     })?;
 
     // 2. Set all of the bytes of db to 0.

--- a/boa/src/builtins/bigint/mod.rs
+++ b/boa/src/builtins/bigint/mod.rs
@@ -104,7 +104,7 @@ impl BigInt {
     fn number_to_bigint(number: f64, context: &mut Context) -> JsResult<JsValue> {
         // 1. If IsIntegralNumber(number) is false, throw a RangeError exception.
         if number.is_nan() || number.is_infinite() || number.fract() != 0.0 {
-            return context.throw_range_error(format!("Cannot convert {} to BigInt", number));
+            return context.throw_range_error(format!("Cannot convert {number} to BigInt"));
         }
 
         // 2. Return the BigInt value that represents ℝ(number).

--- a/boa/src/builtins/date/tests.rs
+++ b/boa/src/builtins/date/tests.rs
@@ -39,7 +39,7 @@ fn forward_dt_local(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
 #[test]
 fn date_display() {
     let dt = super::Date(None);
-    assert_eq!("[Invalid Date]", format!("[{}]", dt));
+    assert_eq!("[Invalid Date]", format!("[{dt}]"));
 
     let cd = super::Date::default();
     assert_eq!(
@@ -47,7 +47,7 @@ fn date_display() {
             "[{}]",
             cd.to_local().unwrap().format("%a %b %d %Y %H:%M:%S GMT%:z")
         ),
-        format!("[{}]", cd)
+        format!("[{cd}]")
     );
 }
 

--- a/boa/src/builtins/error/mod.rs
+++ b/boa/src/builtins/error/mod.rs
@@ -134,7 +134,7 @@ impl Error {
         } else if message.is_empty() {
             Ok(name.into())
         } else {
-            Ok(format!("{}: {}", name, message).into())
+            Ok(format!("{name}: {message}").into())
         }
     }
 }

--- a/boa/src/builtins/function/mod.rs
+++ b/boa/src/builtins/function/mod.rs
@@ -226,7 +226,7 @@ pub(crate) fn make_builtin_fn<N>(
     N: Into<String>,
 {
     let name = name.into();
-    let _timer = BoaProfiler::global().start_event(&format!("make_builtin_fn: {}", &name), "init");
+    let _timer = BoaProfiler::global().start_event(&format!("make_builtin_fn: {name}"), "init");
 
     let function = JsObject::from_proto_and_data(
         interpreter.standard_objects().function_object().prototype(),
@@ -453,13 +453,11 @@ impl BuiltInFunctionObject {
                     constructor: _,
                 },
                 Some(name),
-            ) => Ok(format!("function {}() {{\n  [native Code]\n}}", &name).into()),
+            ) => Ok(format!("function {name}() {{\n  [native Code]\n}}").into()),
             (Function::VmOrdinary { .. }, Some(name)) if name.is_empty() => {
                 Ok("[Function (anonymous)]".into())
             }
-            (Function::VmOrdinary { .. }, Some(name)) => {
-                Ok(format!("[Function: {}]", &name).into())
-            }
+            (Function::VmOrdinary { .. }, Some(name)) => Ok(format!("[Function: {name}]").into()),
             (Function::VmOrdinary { .. }, None) => Ok("[Function (anonymous)]".into()),
             _ => Ok("TODO".into()),
         }
@@ -552,7 +550,7 @@ fn set_function_name(
             }
         }
         PropertyKey::String(string) => Cow::Borrowed(string),
-        PropertyKey::Index(index) => Cow::Owned(JsString::new(format!("{}", index))),
+        PropertyKey::Index(index) => Cow::Owned(JsString::new(index.to_string())),
     };
 
     // 3. Else if name is a Private Name, then

--- a/boa/src/builtins/json/mod.rs
+++ b/boa/src/builtins/json/mod.rs
@@ -498,7 +498,7 @@ impl Json {
                 {
                     // i. Let unit be the code unit whose numeric value is that of C.
                     // ii. Set product to the string-concatenation of product and UnicodeEscape(unit).
-                    product.push_str(&format!("\\\\uAA{:x}", code_point));
+                    product.push_str(&format!("\\\\uAA{code_point:x}"));
                 }
                 // c. Else,
                 code_point => {
@@ -603,18 +603,15 @@ impl Json {
             } else {
                 // i. Let separator be the string-concatenation of the code unit 0x002C (COMMA),
                 //    the code unit 0x000A (LINE FEED), and state.[[Indent]].
-                let separator = format!(",{}{}", '\u{A}', state.indent.as_str());
+                let separator = format!(",\n{}", state.indent.as_str());
                 // ii. Let properties be the String value formed by concatenating all the element Strings of partial
                 //     with each adjacent pair of Strings separated with separator.
                 //     The separator String is not inserted either before the first String or after the last String.
                 let properties = partial.join(&separator);
                 // iii. Let final be the string-concatenation of "{", the code unit 0x000A (LINE FEED), state.[[Indent]], properties, the code unit 0x000A (LINE FEED), stepback, and "}".
                 format!(
-                    "{{{}{}{}{}{}}}",
-                    '\u{A}',
+                    "{{\n{}{properties}\n{}}}",
                     state.indent.as_str(),
-                    &properties,
-                    '\u{A}',
                     stepback.as_str()
                 )
                 .into()
@@ -703,18 +700,15 @@ impl Json {
             } else {
                 // i. Let separator be the string-concatenation of the code unit 0x002C (COMMA),
                 //    the code unit 0x000A (LINE FEED), and state.[[Indent]].
-                let separator = format!(",{}{}", '\u{A}', state.indent.as_str());
+                let separator = format!(",\n{}", state.indent.as_str());
                 // ii. Let properties be the String value formed by concatenating all the element Strings of partial
                 //     with each adjacent pair of Strings separated with separator.
                 //     The separator String is not inserted either before the first String or after the last String.
                 let properties = partial.join(&separator);
                 // iii. Let final be the string-concatenation of "[", the code unit 0x000A (LINE FEED), state.[[Indent]], properties, the code unit 0x000A (LINE FEED), stepback, and "]".
                 format!(
-                    "[{}{}{}{}{}]",
-                    '\u{A}',
+                    "[\n{}{properties}\n{}]",
                     state.indent.as_str(),
-                    &properties,
-                    '\u{A}',
                     stepback.as_str()
                 )
                 .into()

--- a/boa/src/builtins/number/tests.rs
+++ b/boa/src/builtins/number/tests.rs
@@ -589,10 +589,7 @@ fn parse_int_varying_radix() {
         let expected = i32::from_str_radix(base_str, radix).unwrap();
 
         assert_eq!(
-            forward(
-                &mut context,
-                &format!("parseInt(\"{}\", {} )", base_str, radix)
-            ),
+            forward(&mut context, &format!("parseInt(\"{base_str}\", {radix} )")),
             expected.to_string()
         );
     }
@@ -608,10 +605,7 @@ fn parse_int_negative_varying_radix() {
         let expected = i32::from_str_radix(base_str, radix).unwrap();
 
         assert_eq!(
-            forward(
-                &mut context,
-                &format!("parseInt(\"{}\", {} )", base_str, radix)
-            ),
+            forward(&mut context, &format!("parseInt(\"{base_str}\", {radix} )")),
             expected.to_string()
         );
     }

--- a/boa/src/builtins/object/mod.rs
+++ b/boa/src/builtins/object/mod.rs
@@ -520,7 +520,7 @@ impl Object {
         let tag_str = tag.as_string().map_or(builtin_tag, JsString::as_str);
 
         // 17. Return the string-concatenation of "[object ", tag, and "]".
-        Ok(format!("[object {}]", tag_str).into())
+        Ok(format!("[object {tag_str}]").into())
     }
 
     /// `Object.prototype.hasOwnProperty( property )`

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -317,8 +317,7 @@ impl RegExp {
                 'y' => sticky = true,
                 c => {
                     return context.throw_syntax_error(format!(
-                        "RegExp flags contains unknown code unit '{}'",
-                        c
+                        "RegExp flags contains unknown code unit '{c}'",
                     ))
                 }
             }
@@ -421,8 +420,7 @@ impl RegExp {
         };
 
         context.throw_type_error(format!(
-            "RegExp.prototype.{} getter called on non-RegExp object",
-            name
+            "RegExp.prototype.{name} getter called on non-RegExp object",
         ))
     }
 
@@ -1153,7 +1151,7 @@ impl RegExp {
                 this.display()
             ));
         };
-        Ok(format!("/{}/{}", body, flags).into())
+        Ok(format!("/{body}/{flags}").into())
     }
 
     /// `RegExp.prototype[ @@matchAll ]( string )`
@@ -1444,10 +1442,8 @@ impl RegExp {
                 // ii. Set accumulatedResult to the string-concatenation of accumulatedResult,
                 //     the substring of S from nextSourcePosition to position, and replacement.
                 accumulated_result = format!(
-                    "{}{}{}",
-                    accumulated_result,
+                    "{accumulated_result}{}{replacement}",
                     arg_str.get(next_source_position..position).unwrap(),
-                    replacement
                 )
                 .into();
 
@@ -1578,7 +1574,7 @@ impl RegExp {
         let new_flags = if flags.contains('y') {
             flags.to_string()
         } else {
-            format!("{}{}", flags, 'y')
+            format!("{flags}y")
         };
 
         // 10. Let splitter be ? Construct(C, « rx, newFlags »).

--- a/boa/src/builtins/string/mod.rs
+++ b/boa/src/builtins/string/mod.rs
@@ -893,9 +893,7 @@ impl String {
 
         // 13. Return the string-concatenation of preserved, replacement, and the substring of string from position + searchLength.
         Ok(format!(
-            "{}{}{}",
-            preserved,
-            replacement,
+            "{preserved}{replacement}{}",
             StdString::from_utf16_lossy(
                 &this_str
                     .encode_utf16()
@@ -1055,7 +1053,7 @@ impl String {
                 .expect("GetSubstitution should never fail here.")
             };
             // d. Set result to the string-concatenation of result, preserved, and replacement.
-            result = JsString::new(format!("{}{}{}", result.as_str(), &preserved, &replacement));
+            result = JsString::new(format!("{}{preserved}{replacement}", result.as_str()));
 
             // e. Set endOfLastMatch to p + searchLength.
             end_of_last_match = p + search_length;
@@ -1247,9 +1245,9 @@ impl String {
         let concat_fill_str: StdString = fill_str.chars().take(fill_len as usize).collect();
 
         if at_start {
-            JsValue::new(format!("{}{}", concat_fill_str, &primitive))
+            JsValue::new(format!("{concat_fill_str}{primitive}"))
         } else {
-            JsValue::new(format!("{}{}", primitive, &concat_fill_str))
+            JsValue::new(format!("{primitive}{concat_fill_str}"))
         }
     }
 

--- a/boa/src/object/operations.rs
+++ b/boa/src/object/operations.rs
@@ -91,7 +91,7 @@ impl JsObject {
         let success = self.__set__(key.clone(), value.into(), self.clone().into(), context)?;
         // 5. If success is false and Throw is true, throw a TypeError exception.
         if !success && throw {
-            return context.throw_type_error(format!("cannot set non-writable property: {}", key));
+            return context.throw_type_error(format!("cannot set non-writable property: {key}"));
         }
         // 6. Return success.
         Ok(success)
@@ -150,7 +150,7 @@ impl JsObject {
         let success = self.create_data_property(key.clone(), value, context)?;
         // 4. If success is false, throw a TypeError exception.
         if !success {
-            return context.throw_type_error(format!("cannot redefine property: {}", key));
+            return context.throw_type_error(format!("cannot redefine property: {key}"));
         }
         // 5. Return success.
         Ok(success)
@@ -180,7 +180,7 @@ impl JsObject {
         let success = self.__define_own_property__(key.clone(), desc.into(), context)?;
         // 4. If success is false, throw a TypeError exception.
         if !success {
-            return context.throw_type_error(format!("cannot redefine property: {}", key));
+            return context.throw_type_error(format!("cannot redefine property: {key}"));
         }
         // 5. Return success.
         Ok(success)
@@ -204,7 +204,7 @@ impl JsObject {
         let success = self.__delete__(&key, context)?;
         // 4. If success is false, throw a TypeError exception.
         if !success {
-            return context.throw_type_error(format!("cannot delete property: {}", key));
+            return context.throw_type_error(format!("cannot delete property: {key}"));
         }
         // 5. Return success.
         Ok(success)

--- a/boa/src/symbol.rs
+++ b/boa/src/symbol.rs
@@ -305,7 +305,7 @@ impl Display for JsSymbol {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.inner.description {
-            Some(desc) => write!(f, "Symbol({})", desc),
+            Some(desc) => write!(f, "Symbol({desc})"),
             None => write!(f, "Symbol()"),
         }
     }

--- a/boa/src/syntax/ast/keyword.rs
+++ b/boa/src/syntax/ast/keyword.rs
@@ -548,7 +548,7 @@ impl TryInto<BinOp> for Keyword {
     type Error = String;
     fn try_into(self) -> Result<BinOp, Self::Error> {
         self.as_binop()
-            .ok_or_else(|| format!("No binary operation for {}", self))
+            .ok_or_else(|| format!("No binary operation for {self}"))
     }
 }
 

--- a/boa/src/syntax/ast/node/declaration/mod.rs
+++ b/boa/src/syntax/ast/node/declaration/mod.rs
@@ -296,9 +296,9 @@ impl ToInternedString for DeclarationPatternObject {
         for (i, binding) in self.bindings.iter().enumerate() {
             let binding = binding.to_interned_string(interner);
             let str = if i == self.bindings.len() - 1 {
-                format!("{} ", binding)
+                format!("{binding} ")
             } else {
-                format!("{},", binding)
+                format!("{binding},")
             };
 
             buf.push_str(&str);

--- a/boa/src/syntax/ast/node/iteration/break_node/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/break_node/mod.rs
@@ -53,14 +53,11 @@ unsafe impl Trace for Break {
 
 impl ToInternedString for Break {
     fn to_interned_string(&self, interner: &Interner) -> String {
-        format!(
-            "break{}",
-            if let Some(label) = self.label {
-                format!(" {}", interner.resolve_expect(label))
-            } else {
-                String::new()
-            }
-        )
+        if let Some(label) = self.label {
+            format!("break {}", interner.resolve_expect(label))
+        } else {
+            "break".to_owned()
+        }
     }
 }
 

--- a/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
+++ b/boa/src/syntax/ast/node/iteration/continue_node/mod.rs
@@ -44,11 +44,11 @@ impl Continue {
 
 impl ToInternedString for Continue {
     fn to_interned_string(&self, interner: &Interner) -> String {
-        let mut buf = "continue".to_owned();
         if let Some(label) = self.label {
-            buf.push_str(&format!(" {}", interner.resolve_expect(label)));
+            format!("continue {}", interner.resolve_expect(label))
+        } else {
+            "continue".to_owned()
         }
-        buf
     }
 }
 

--- a/boa/src/syntax/ast/node/mod.rs
+++ b/boa/src/syntax/ast/node/mod.rs
@@ -690,11 +690,11 @@ fn test_formatting(source: &'static str) {
         .expect("parsing failed")
         .to_interned_string(&interner);
     if scenario != result {
-        eprint!("========= Expected:\n{}", scenario);
-        eprint!("========= Got:\n{}", result);
+        eprint!("========= Expected:\n{scenario}");
+        eprint!("========= Got:\n{result}");
         // Might be helpful to find differing whitespace
-        eprintln!("========= Expected: {:?}", scenario);
-        eprintln!("========= Got:      {:?}", result);
+        eprintln!("========= Expected: {scenario:?}");
+        eprintln!("========= Got:      {result:?}");
         panic!("parsing test did not give the correct result (see above)");
     }
 }

--- a/boa/src/syntax/ast/node/object/mod.rs
+++ b/boa/src/syntax/ast/node/object/mod.rs
@@ -56,23 +56,21 @@ impl Object {
         for property in self.properties().iter() {
             buf.push_str(&match property {
                 PropertyDefinition::IdentifierReference(ident) => {
-                    format!("{}{},\n", indentation, interner.resolve_expect(*ident))
+                    format!("{indentation}{},\n", interner.resolve_expect(*ident))
                 }
                 PropertyDefinition::Property(key, value) => {
                     format!(
-                        "{}{}: {},\n",
-                        indentation,
+                        "{indentation}{}: {},\n",
                         key.to_interned_string(interner),
                         value.to_no_indent_string(interner, indent_n + 1)
                     )
                 }
                 PropertyDefinition::SpreadObject(key) => {
-                    format!("{}...{},\n", indentation, key.to_interned_string(interner))
+                    format!("{indentation}...{},\n", key.to_interned_string(interner))
                 }
                 PropertyDefinition::MethodDefinition(kind, key, node) => {
                     format!(
-                        "{}{}{}({}) {},\n",
-                        indentation,
+                        "{indentation}{}{}({}) {},\n",
                         match &kind {
                             MethodDefinitionKind::Get => "get ",
                             MethodDefinitionKind::Set => "set ",

--- a/boa/src/syntax/ast/node/switch/mod.rs
+++ b/boa/src/syntax/ast/node/switch/mod.rs
@@ -118,12 +118,11 @@ impl Switch {
 
         if let Some(ref default) = self.default {
             buf.push_str(&format!(
-                "{}    default:\n{}",
-                indent,
+                "{indent}    default:\n{}",
                 default.to_indented_string(interner, indentation + 2)
             ));
         }
-        buf.push_str(&format!("{}}}", indent));
+        buf.push_str(&format!("{indent}}}"));
 
         buf
     }

--- a/boa/src/syntax/ast/node/switch/tests.rs
+++ b/boa/src/syntax/ast/node/switch/tests.rs
@@ -170,7 +170,7 @@ fn bigger_switch_example() {
     for (i, val) in expected.iter().enumerate() {
         let scenario = format!(
             r#"
-            let a = {};
+            let a = {i};
             let b = "unknown";
 
             switch (a) {{
@@ -200,7 +200,6 @@ fn bigger_switch_example() {
             b;
 
             "#,
-            i
         );
 
         assert_eq!(&exec(&scenario), val);

--- a/boa/src/syntax/ast/node/yield/mod.rs
+++ b/boa/src/syntax/ast/node/yield/mod.rs
@@ -54,7 +54,7 @@ impl ToInternedString for Yield {
     fn to_interned_string(&self, interner: &Interner) -> String {
         let y = if self.delegate { "yield*" } else { "yield" };
         if let Some(ex) = self.expr() {
-            format!("{} {}", y, ex.to_interned_string(interner))
+            format!("{y} {}", ex.to_interned_string(interner))
         } else {
             y.to_owned()
         }

--- a/boa/src/syntax/ast/op.rs
+++ b/boa/src/syntax/ast/op.rs
@@ -95,20 +95,23 @@ pub enum NumOp {
     Mod,
 }
 
+impl NumOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "+",
+            Self::Sub => "-",
+            Self::Div => "/",
+            Self::Mul => "*",
+            Self::Exp => "**",
+            Self::Mod => "%",
+        }
+    }
+}
+
 impl Display for NumOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::Add => "+",
-                Self::Sub => "-",
-                Self::Div => "/",
-                Self::Mul => "*",
-                Self::Exp => "**",
-                Self::Mod => "%",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -308,23 +311,26 @@ pub enum UnaryOp {
     Void,
 }
 
+impl UnaryOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::IncrementPost | Self::IncrementPre => "++",
+            Self::DecrementPost | Self::DecrementPre => "--",
+            Self::Plus => "+",
+            Self::Minus => "-",
+            Self::Not => "!",
+            Self::Tilde => "~",
+            Self::Delete => "delete",
+            Self::TypeOf => "typeof",
+            Self::Void => "void",
+        }
+    }
+}
+
 impl Display for UnaryOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::IncrementPost | Self::IncrementPre => "++",
-                Self::DecrementPost | Self::DecrementPre => "--",
-                Self::Plus => "+",
-                Self::Minus => "-",
-                Self::Not => "!",
-                Self::Tilde => "~",
-                Self::Delete => "delete",
-                Self::TypeOf => "typeof",
-                Self::Void => "void",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -426,20 +432,23 @@ pub enum BitOp {
     UShr,
 }
 
+impl BitOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::And => "&",
+            Self::Or => "|",
+            Self::Xor => "^",
+            Self::Shl => "<<",
+            Self::Shr => ">>",
+            Self::UShr => ">>>",
+        }
+    }
+}
+
 impl Display for BitOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::And => "&",
-                Self::Or => "|",
-                Self::Xor => "^",
-                Self::Shl => "<<",
-                Self::Shr => ">>",
-                Self::UShr => ">>>",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -619,24 +628,27 @@ pub enum CompOp {
     InstanceOf,
 }
 
+impl CompOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Equal => "==",
+            Self::NotEqual => "!=",
+            Self::StrictEqual => "===",
+            Self::StrictNotEqual => "!==",
+            Self::GreaterThan => ">",
+            Self::GreaterThanOrEqual => ">=",
+            Self::LessThan => "<",
+            Self::LessThanOrEqual => "<=",
+            Self::In => "in",
+            Self::InstanceOf => "instanceof",
+        }
+    }
+}
+
 impl Display for CompOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::Equal => "==",
-                Self::NotEqual => "!=",
-                Self::StrictEqual => "===",
-                Self::StrictNotEqual => "!==",
-                Self::GreaterThan => ">",
-                Self::GreaterThanOrEqual => ">=",
-                Self::LessThan => "<",
-                Self::LessThanOrEqual => "<=",
-                Self::In => "in",
-                Self::InstanceOf => "instanceof",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -698,17 +710,20 @@ pub enum LogOp {
     Coalesce,
 }
 
+impl LogOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::And => "&&",
+            Self::Or => "||",
+            Self::Coalesce => "??",
+        }
+    }
+}
+
 impl Display for LogOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::And => "&&",
-                Self::Or => "||",
-                Self::Coalesce => "??",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -779,20 +794,23 @@ impl From<AssignOp> for BinOp {
     }
 }
 
+impl BinOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Num(ref op) => op.as_str(),
+            Self::Bit(ref op) => op.as_str(),
+            Self::Comp(ref op) => op.as_str(),
+            Self::Log(ref op) => op.as_str(),
+            Self::Assign(ref op) => op.as_str(),
+            Self::Comma => ",",
+        }
+    }
+}
+
 impl Display for BinOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::Num(ref op) => op.to_string(),
-                Self::Bit(ref op) => op.to_string(),
-                Self::Comp(ref op) => op.to_string(),
-                Self::Log(ref op) => op.to_string(),
-                Self::Assign(ref op) => op.to_string(),
-                Self::Comma => ",".to_string(),
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }
 
@@ -1006,28 +1024,31 @@ unsafe impl Trace for AssignOp {
     empty_trace!();
 }
 
+impl AssignOp {
+    /// Retrieves the operation as a static string.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Add => "+=",
+            Self::Sub => "-=",
+            Self::Mul => "*=",
+            Self::Exp => "**=",
+            Self::Div => "/=",
+            Self::Mod => "%=",
+            Self::And => "&=",
+            Self::Or => "|=",
+            Self::Xor => "^=",
+            Self::Shl => "<<=",
+            Self::Shr => ">>=",
+            Self::Ushr => ">>>=",
+            Self::BoolAnd => "&&=",
+            Self::BoolOr => "||=",
+            Self::Coalesce => "??=",
+        }
+    }
+}
+
 impl Display for AssignOp {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        write!(
-            f,
-            "{}",
-            match *self {
-                Self::Add => "+=",
-                Self::Sub => "-=",
-                Self::Mul => "*=",
-                Self::Exp => "**=",
-                Self::Div => "/=",
-                Self::Mod => "%=",
-                Self::And => "&=",
-                Self::Or => "|=",
-                Self::Xor => "^=",
-                Self::Shl => "<<=",
-                Self::Shr => ">>=",
-                Self::Ushr => ">>>=",
-                Self::BoolAnd => "&&=",
-                Self::BoolOr => "||=",
-                Self::Coalesce => "??=",
-            }
-        )
+        write!(f, "{}", self.as_str())
     }
 }

--- a/boa/src/syntax/ast/position.rs
+++ b/boa/src/syntax/ast/position.rs
@@ -182,7 +182,7 @@ mod tests {
         let pos = Position::new(10, 50);
 
         assert_eq!("10:50", pos.to_string());
-        assert_eq!("10:50", format!("{}", pos));
+        assert_eq!("10:50", pos.to_string());
     }
 
     /// Checks that we cannot create an invalid span.
@@ -278,7 +278,7 @@ mod tests {
         let span = Span::new(a, b);
 
         assert_eq!("[10:50..11:20]", span.to_string());
-        assert_eq!("[10:50..11:20]", format!("{}", span));
+        assert_eq!("[10:50..11:20]", span.to_string());
     }
 
     /// Checks that the ordering of spans is correct.

--- a/boa/src/syntax/ast/punctuator.rs
+++ b/boa/src/syntax/ast/punctuator.rs
@@ -185,6 +185,7 @@ impl Punctuator {
         }
     }
 
+    /// Retrieves the punctuator as a static string.
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Add => "+",
@@ -251,7 +252,7 @@ impl TryInto<BinOp> for Punctuator {
     type Error = String;
     fn try_into(self) -> Result<BinOp, Self::Error> {
         self.as_binop()
-            .ok_or_else(|| format!("No binary operation for {}", self))
+            .ok_or_else(|| format!("No binary operation for {self}"))
     }
 }
 

--- a/boa/src/syntax/lexer/cursor.rs
+++ b/boa/src/syntax/lexer/cursor.rs
@@ -160,7 +160,7 @@ where
             } else {
                 return Err(io::Error::new(
                     ErrorKind::UnexpectedEof,
-                    format!("Unexpected end of file when looking for character {}", stop),
+                    format!("Unexpected end of file when looking for character {stop}"),
                 ));
             }
         }

--- a/boa/src/syntax/lexer/error.rs
+++ b/boa/src/syntax/lexer/error.rs
@@ -43,8 +43,8 @@ impl Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::IO(e) => write!(f, "I/O error: {}", e),
-            Self::Syntax(e, pos) => write!(f, "Syntax Error: {} at position: {}", e, pos),
+            Self::IO(e) => write!(f, "I/O error: {e}"),
+            Self::Syntax(e, pos) => write!(f, "Syntax Error: {e} at position: {pos}"),
         }
     }
 }

--- a/boa/src/syntax/lexer/identifier.rs
+++ b/boa/src/syntax/lexer/identifier.rs
@@ -122,8 +122,7 @@ impl<R> Tokenizer<R> for Identifier {
             {
                 return Err(Error::Syntax(
                     format!(
-                        "using future reserved keyword '{}' not allowed in strict mode",
-                        identifier_name
+                        "using future reserved keyword '{identifier_name}' not allowed in strict mode",
                     )
                     .into(),
                     start_pos,

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -280,8 +280,7 @@ impl<R> Lexer<R> {
                 }
                 _ => {
                     let details = format!(
-                        "unexpected '{}' at line {}, column {}",
-                        c,
+                        "unexpected '{c}' at line {}, column {}",
                         start.line_number(),
                         start.column_number()
                     );
@@ -298,8 +297,7 @@ impl<R> Lexer<R> {
         } else {
             Err(Error::syntax(
                 format!(
-                    "unexpected utf-8 char '\\u{}' at line {}, column {}",
-                    next_ch,
+                    "unexpected utf-8 char '\\u{next_ch}' at line {}, column {}",
                     start.line_number(),
                     start.column_number()
                 ),

--- a/boa/src/syntax/lexer/token.rs
+++ b/boa/src/syntax/lexer/token.rs
@@ -234,7 +234,7 @@ impl TokenKind {
             Self::NullLiteral => "null".to_owned(),
             Self::NumericLiteral(Numeric::Rational(num)) => num.to_string(),
             Self::NumericLiteral(Numeric::Integer(num)) => num.to_string(),
-            Self::NumericLiteral(Numeric::BigInt(ref num)) => format!("{}n", num),
+            Self::NumericLiteral(Numeric::BigInt(ref num)) => format!("{num}n"),
             Self::Punctuator(punc) => punc.to_string(),
             Self::StringLiteral(lit) => interner.resolve_expect(lit).to_owned(),
             Self::TemplateNoSubstitution(ts) | Self::TemplateMiddle(ts) => {

--- a/boa/src/syntax/parser/error.rs
+++ b/boa/src/syntax/parser/error.rs
@@ -132,7 +132,7 @@ impl fmt::Display for ParseError {
                 context,
             } => write!(
                 f,
-                "expected {}, got '{}' in {} at line {}, col {}",
+                "expected {}, got '{found}' in {context} at line {}, col {}",
                 if expected.len() == 1 {
                     format!("token '{}'", expected.first().unwrap())
                 } else {
@@ -143,7 +143,7 @@ impl fmt::Display for ParseError {
                             .enumerate()
                             .map(|(i, t)| {
                                 format!(
-                                    "{}'{}'",
+                                    "{}'{t}'",
                                     if i == 0 {
                                         ""
                                     } else if i == expected.len() - 1 {
@@ -151,14 +151,11 @@ impl fmt::Display for ParseError {
                                     } else {
                                         ", "
                                     },
-                                    t
                                 )
                             })
                             .collect::<String>()
                     )
                 },
-                found,
-                context,
                 span.start().line_number(),
                 span.start().column_number()
             ),
@@ -168,10 +165,9 @@ impl fmt::Display for ParseError {
                 message,
             } => write!(
                 f,
-                "unexpected token '{}'{} at line {}, col {}",
-                found,
+                "unexpected token '{found}'{} at line {}, col {}",
                 if let Some(m) = message {
-                    format!(", {}", m)
+                    format!(", {m}")
                 } else {
                     String::new()
                 },
@@ -181,16 +177,14 @@ impl fmt::Display for ParseError {
             Self::AbruptEnd => f.write_str("abrupt end"),
             Self::General { message, position } => write!(
                 f,
-                "{} at line {}, col {}",
-                message,
+                "{message} at line {}, col {}",
                 position.line_number(),
                 position.column_number()
             ),
             Self::Lex { err } => fmt::Display::fmt(err, f),
             Self::Unimplemented { message, position } => write!(
                 f,
-                "{} not yet implemented at line {}, col {}",
-                message,
+                "{message} not yet implemented at line {}, col {}",
                 position.line_number(),
                 position.column_number()
             ),

--- a/boa/src/tests.rs
+++ b/boa/src/tests.rs
@@ -1479,7 +1479,7 @@ fn test_strict_mode_reserved_name() {
 
     for case in &test_cases {
         let mut context = Context::default();
-        let scenario = format!("'use strict'; \n {}", case);
+        let scenario = format!("'use strict'; \n {case}");
 
         let string = dbg!(forward(&mut context, &scenario));
 

--- a/boa/src/value/display.rs
+++ b/boa/src/value/display.rs
@@ -89,8 +89,8 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
             // Can use the private "type" field of an Object to match on
             // which type of Object it represents for special printing
             match v.borrow().kind() {
-                ObjectKind::String(ref string) => format!("String {{ \"{}\" }}", string),
-                ObjectKind::Boolean(boolean) => format!("Boolean {{ {} }}", boolean),
+                ObjectKind::String(ref string) => format!("String {{ \"{string}\" }}"),
+                ObjectKind::Boolean(boolean) => format!("Boolean {{ {boolean} }}"),
                 ObjectKind::Number(rational) => {
                     if rational.is_sign_negative() && *rational == 0.0 {
                         "Number { -0 }".to_string()
@@ -135,9 +135,9 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                             .collect::<Vec<String>>()
                             .join(", ");
 
-                        format!("[ {} ]", arr)
+                        format!("[ {arr} ]")
                     } else {
-                        format!("Array({})", len)
+                        format!("Array({len})")
                     }
                 }
                 ObjectKind::Map(ref map) => {
@@ -152,13 +152,13 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                             .map(|(key, value)| {
                                 let key = log_string_from(key, print_internals, false);
                                 let value = log_string_from(value, print_internals, false);
-                                format!("{} → {}", key, value)
+                                format!("{key} → {value}")
                             })
                             .collect::<Vec<String>>()
                             .join(", ");
-                        format!("Map {{ {} }}", mappings)
+                        format!("Map {{ {mappings} }}")
                     } else {
-                        format!("Map({})", size)
+                        format!("Map({size})")
                     }
                 }
                 ObjectKind::Set(ref set) => {
@@ -174,16 +174,16 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                             .map(|value| log_string_from(value, print_internals, false))
                             .collect::<Vec<String>>()
                             .join(", ");
-                        format!("Set {{ {} }}", entries)
+                        format!("Set {{ {entries} }}")
                     } else {
-                        format!("Set({})", size)
+                        format!("Set({size})")
                     }
                 }
                 _ => display_obj(x, print_internals),
             }
         }
         JsValue::Symbol(ref symbol) => symbol.to_string(),
-        _ => format!("{}", x.display()),
+        _ => x.display().to_string(),
     }
 }
 
@@ -229,10 +229,10 @@ pub(crate) fn display_obj(v: &JsValue, print_internals: bool) -> String {
             let closing_indent = String::from_utf8(vec![b' '; indent.wrapping_sub(4)])
                 .expect("Could not create the closing brace's indentation string");
 
-            format!("{{\n{}\n{}}}", result, closing_indent)
+            format!("{{\n{result}\n{closing_indent}}}")
         } else {
             // Every other type of data is printed with the display method
-            format!("{}", data.display())
+            data.display().to_string()
         }
     }
 
@@ -256,7 +256,7 @@ pub(crate) fn display_obj(v: &JsValue, print_internals: bool) -> String {
                 .unwrap_or(&JsValue::Undefined)
                 .display()
                 .to_string();
-            return format!("{}: {}", name, message);
+            return format!("{name}: {message}");
         }
     }
 
@@ -268,16 +268,16 @@ impl Display for ValueDisplay<'_> {
         match self.value {
             JsValue::Null => write!(f, "null"),
             JsValue::Undefined => write!(f, "undefined"),
-            JsValue::Boolean(v) => write!(f, "{}", v),
+            JsValue::Boolean(v) => write!(f, "{v}"),
             JsValue::Symbol(ref symbol) => match symbol.description() {
-                Some(description) => write!(f, "Symbol({})", description),
+                Some(description) => write!(f, "Symbol({description})"),
                 None => write!(f, "Symbol()"),
             },
-            JsValue::String(ref v) => write!(f, "\"{}\"", v),
+            JsValue::String(ref v) => write!(f, "\"{v}\""),
             JsValue::Rational(v) => format_rational(*v, f),
             JsValue::Object(_) => write!(f, "{}", log_string_from(self.value, true, true)),
-            JsValue::Integer(v) => write!(f, "{}", v),
-            JsValue::BigInt(ref num) => write!(f, "{}n", num),
+            JsValue::Integer(v) => write!(f, "{v}"),
+            JsValue::BigInt(ref num) => write!(f, "{num}n"),
         }
     }
 }

--- a/boa/src/value/mod.rs
+++ b/boa/src/value/mod.rs
@@ -473,8 +473,7 @@ impl JsValue {
                     Ok(value)
                 } else {
                     context.throw_syntax_error(format!(
-                        "cannot convert string '{}' to bigint primitive",
-                        string
+                        "cannot convert string '{string}' to bigint primitive",
                     ))
                 }
             }

--- a/boa/src/value/tests.rs
+++ b/boa/src/value/tests.rs
@@ -470,12 +470,14 @@ fn debug_object() {
     let mut context = Context::default();
     let value = forward_val(&mut context, "new Array([new Date()])").unwrap();
 
-    // We don't care about the contents of the debug display (it is *debug* after all). In the commit that this test was
-    // added, this would cause a stack overflow, so executing Debug::fmt is the assertion.
+    // We don't care about the contents of the debug display (it is *debug* after all). In the
+    // commit that this test was added, this would cause a stack overflow, so executing
+    // `Debug::fmt` is the assertion.
     //
-    // However, we want to make sure that no data is being left in the internal hashset, so executing this twice should
-    // result in the same output.
-    assert_eq!(format!("{:?}", value), format!("{:?}", value));
+    // However, we want to make sure that no data is being left in the internal hashset, so
+    // executing the formatting twice should result in the same output.
+
+    assert_eq!(format!("{value:?}"), format!("{value:?}"));
 }
 
 #[test]
@@ -644,7 +646,9 @@ mod cyclic_conversions {
         assert_eq!(result, "[[],[]]",);
     }
 
-    // These tests don't throw errors. Instead we mirror Chrome / Firefox behavior for these conversions
+    // These tests don't throw errors. Instead we mirror Chrome / Firefox behavior for these
+    // conversions
+
     #[test]
     fn to_string_cyclic() {
         let mut context = Context::default();

--- a/boa/src/vm/code_block.rs
+++ b/boa/src/vm/code_block.rs
@@ -185,16 +185,14 @@ impl CodeBlock {
                 *pc += size_of::<u32>();
                 let operand2 = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
-                format!("{}, {}", operand1, operand2)
+                format!("{operand1}, {operand2}")
             }
             Opcode::GetFunction => {
                 let operand = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
                 format!(
-                    "{:04}: '{:?}' (length: {})",
-                    operand,
-                    self.functions[operand as usize].name,
-                    self.functions[operand as usize].length
+                    "{operand:04}: '{:?}' (length: {})",
+                    self.functions[operand as usize].name, self.functions[operand as usize].length
                 )
             }
             Opcode::DefInitArg
@@ -216,7 +214,7 @@ impl CodeBlock {
             | Opcode::CopyDataProperties => {
                 let operand = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
-                format!("{:04}: '{:?}'", operand, self.variables[operand as usize])
+                format!("{operand:04}: '{:?}'", self.variables[operand as usize])
             }
             Opcode::Pop
             | Opcode::Dup
@@ -308,9 +306,8 @@ impl ToInternedString for CodeBlock {
         };
 
         f.push_str(&format!(
-            "{:-^width$}\n    Location  Count   Opcode                     Operands\n\n",
-            format!("Compiled Output: '{}'", name),
-            width = 70
+            "{:-^70}\n    Location  Count   Opcode                     Operands\n\n",
+            format!("Compiled Output: '{name}'"),
         ));
 
         let mut pc = 0;
@@ -319,11 +316,8 @@ impl ToInternedString for CodeBlock {
             let opcode: Opcode = self.code[pc].try_into().unwrap();
             let operands = self.instruction_operands(&mut pc);
             f.push_str(&format!(
-                "    {:06}    {:04}    {:<27}\n{}",
-                pc,
-                count,
+                "    {pc:06}    {count:04}    {:<27}\n{operands}",
                 opcode.as_str(),
-                operands
             ));
             count += 1;
         }
@@ -335,8 +329,7 @@ impl ToInternedString for CodeBlock {
         } else {
             for (i, value) in self.literals.iter().enumerate() {
                 f.push_str(&format!(
-                    "    {:04}: <{}> {}\n",
-                    i,
+                    "    {i:04}: <{}> {}\n",
                     value.type_of(),
                     value.display()
                 ));
@@ -349,8 +342,7 @@ impl ToInternedString for CodeBlock {
         } else {
             for (i, value) in self.variables.iter().enumerate() {
                 f.push_str(&format!(
-                    "    {:04}: {}\n",
-                    i,
+                    "    {i:04}: {}\n",
                     interner.resolve_expect(*value)
                 ));
             }
@@ -362,8 +354,7 @@ impl ToInternedString for CodeBlock {
         } else {
             for (i, code) in self.functions.iter().enumerate() {
                 f.push_str(&format!(
-                    "    {:04}: name: '{}' (length: {})\n",
-                    i,
+                    "    {i:04}: name: '{}' (length: {})\n",
                     interner.resolve_expect(code.name),
                     code.length
                 ));

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -112,7 +112,7 @@ impl Context {
         };
 
         let _timer =
-            BoaProfiler::global().start_event(&format!("INST - {}", &opcode.as_str()), "vm");
+            BoaProfiler::global().start_event(&format!("INST - {}", opcode.as_str()), "vm");
 
         match opcode {
             Opcode::Nop => {}
@@ -1124,18 +1124,14 @@ impl Context {
                 self.vm.frame().code.to_interned_string(self.interner())
             );
             println!(
-                "{:-^width$}",
-                msg,
+                "{msg:-^width$}",
                 width = COLUMN_WIDTH * NUMBER_OF_COLUMNS - 10
             );
             println!(
-                "{:<time_width$} {:<opcode_width$} {:<operand_width$} Top Of Stack\n",
+                "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {:<OPERAND_COLUMN_WIDTH$} Top Of Stack\n",
                 "Time",
                 "Opcode",
                 "Operands",
-                time_width = TIME_COLUMN_WIDTH,
-                opcode_width = OPCODE_COLUMN_WIDTH,
-                operand_width = OPERAND_COLUMN_WIDTH,
             );
         }
 
@@ -1151,10 +1147,9 @@ impl Context {
                 let duration = instant.elapsed();
 
                 println!(
-                    "{:<time_width$} {:<opcode_width$} {:<operand_width$} {}",
+                    "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {}",
                     format!("{}μs", duration.as_micros()),
                     opcode.as_str(),
-                    operands,
                     match self.vm.stack.last() {
                         None => "<empty>".to_string(),
                         Some(value) => {
@@ -1163,13 +1158,10 @@ impl Context {
                             } else if value.is_object() {
                                 "[object]".to_string()
                             } else {
-                                format!("{}", value.display())
+                                value.display().to_string()
                             }
                         }
                     },
-                    time_width = TIME_COLUMN_WIDTH,
-                    opcode_width = OPCODE_COLUMN_WIDTH,
-                    operand_width = OPERAND_COLUMN_WIDTH,
                 );
 
                 result
@@ -1218,15 +1210,14 @@ impl Context {
             } else {
                 for (i, value) in self.vm.stack.iter().enumerate() {
                     println!(
-                        "{:04}{:<width$} {}",
-                        i,
+                        "{i:04}{:<width$} {}",
                         "",
                         if value.is_callable() {
                             "[function]".to_string()
                         } else if value.is_object() {
                             "[object]".to_string()
                         } else {
-                            format!("{}", value.display())
+                            value.display().to_string()
                         },
                         width = COLUMN_WIDTH / 2 - 4,
                     );

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["command-line-utilities"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 default-run = "boa"
 
 [dependencies]

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -150,7 +150,7 @@ where
     let src_bytes = src.as_ref();
     Parser::new(src_bytes, false)
         .parse_all(interner)
-        .map_err(|e| format!("ParsingError: {}", e))
+        .map_err(|e| format!("ParsingError: {e}"))
 }
 
 /// Dumps the AST to stdout with format controlled by the given arguments.
@@ -167,14 +167,14 @@ where
 
         match arg {
             Some(format) => match format {
-                DumpFormat::Debug => println!("{:#?}", ast),
+                DumpFormat::Debug => println!("{ast:#?}"),
                 DumpFormat::Json => println!("{}", serde_json::to_string(&ast).unwrap()),
                 DumpFormat::JsonPretty => {
                     println!("{}", serde_json::to_string_pretty(&ast).unwrap());
                 }
             },
             // Default ast dumping format.
-            None => println!("{:#?}", ast),
+            None => println!("{ast:#?}"),
         }
     }
 
@@ -194,7 +194,7 @@ pub fn main() -> Result<(), std::io::Error> {
 
         if args.has_dump_flag() {
             if let Err(e) = dump(&buffer, &args) {
-                eprintln!("{}", e);
+                eprintln!("{e}");
             }
         } else {
             match context.eval(&buffer) {
@@ -233,7 +233,7 @@ pub fn main() -> Result<(), std::io::Error> {
 
                     if args.has_dump_flag() {
                         if let Err(e) = dump(&line, &args) {
-                            eprintln!("{}", e);
+                            eprintln!("{e}");
                         }
                     } else {
                         match context.eval(line.trim_end()) {
@@ -250,7 +250,7 @@ pub fn main() -> Result<(), std::io::Error> {
                 }
 
                 Err(err) => {
-                    eprintln!("Unknown error: {:?}", err);
+                    eprintln!("Unknown error: {err:?}");
                     break;
                 }
             }

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -9,7 +9,7 @@ categories = ["parser-implementations", "wasm"]
 license = "Unlicense/MIT"
 exclude = ["../.vscode/*", "../Dockerfile", "../Makefile", "../.editorConfig"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.58"
 
 [dependencies]
 Boa = { path = "../boa" }

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -28,8 +28,6 @@ pub(super) fn init(context: &mut Context) -> JsObject {
 /// returns the `$262` property of the new realm's global object.
 #[allow(clippy::unnecessary_wraps)]
 fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
-    // eprintln!("called $262.createRealm()");
-
     let mut context = Context::default();
 
     // add the $262 object.
@@ -86,7 +84,7 @@ fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
     if let Some(source_text) = args.get(0).and_then(JsValue::as_string) {
         match context.parse(source_text.as_str()) {
             // TODO: check strict
-            Err(e) => context.throw_type_error(format!("Uncaught Syntax Error: {}", e)),
+            Err(e) => context.throw_type_error(format!("Uncaught Syntax Error: {e}")),
             // Calling eval here parses the code a second time.
             // TODO: We can fix this after we have have defined the public api for the vm executer.
             Ok(_) => context.eval(source_text.as_str()),

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -70,14 +70,18 @@ impl TestSuite {
 
         if verbose != 0 {
             println!(
-                "Suite {} results: total: {}, passed: {}, ignored: {}, failed: {} (panics: {}{}), conformance: {:.2}%",
+                "Suite {} results: total: {total}, passed: {}, ignored: {}, failed: {} (panics: \
+                    {}{}), conformance: {:.2}%",
                 self.name,
-                total,
                 passed.to_string().green(),
                 ignored.to_string().yellow(),
                 (total - passed - ignored).to_string().red(),
-                if panic == 0 {"0".normal()} else {panic.to_string().red()},
-                if panic == 0 {""} else {" ⚠"}.red(),
+                if panic == 0 {
+                    "0".normal()
+                } else {
+                    panic.to_string().red()
+                },
+                if panic == 0 { "" } else { " ⚠" }.red(),
                 (passed as f64 / total as f64) * 100.0
             );
         }
@@ -155,7 +159,7 @@ impl Test {
 
                             let passed = res.is_ok();
                             let text = match res {
-                                Ok(val) => format!("{}", val.display()),
+                                Ok(val) => val.display().to_string(),
                                 Err(e) => format!("Uncaught {}", e.display()),
                             };
 
@@ -177,8 +181,8 @@ impl Test {
 
                     let mut interner = Interner::default();
                     match Parser::new(self.content.as_bytes(), strict).parse_all(&mut interner) {
-                        Ok(n) => (false, format!("{:?}", n)),
-                        Err(e) => (true, format!("Uncaught {}", e)),
+                        Ok(n) => (false, format!("{n:?}")),
+                        Err(e) => (true, format!("Uncaught {e}")),
                     }
                 }
                 Outcome::Negative {
@@ -193,13 +197,13 @@ impl Test {
                     if let Err(e) =
                         Parser::new(self.content.as_bytes(), strict).parse_all(&mut interner)
                     {
-                        (false, format!("Uncaught {}", e))
+                        (false, format!("Uncaught {e}"))
                     } else {
                         match self.set_up_env(harness, strict) {
                             Ok(mut context) => {
                                 context.set_strict_mode(strict);
                                 match context.eval(&self.content.as_ref()) {
-                                    Ok(res) => (false, format!("{}", res.display())),
+                                    Ok(res) => (false, res.display().to_string()),
                                     Err(e) => {
                                         let passed =
                                             e.display().to_string().contains(error_type.as_ref());
@@ -273,7 +277,7 @@ impl Test {
                 self.name,
                 if strict { " (strict mode)" } else { "" },
             );
-            println!("{}", result_text);
+            println!("{result_text}");
             println!();
         }
 
@@ -322,13 +326,12 @@ impl Test {
                     &harness
                         .includes
                         .get(include)
-                        .ok_or_else(|| format!("could not find the {} include file.", include))?
+                        .ok_or_else(|| format!("could not find the {include} include file."))?
                         .as_ref(),
                 )
                 .map_err(|e| {
                     format!(
-                        "could not run the {} include file:\nUncaught {}",
-                        include,
+                        "could not run the {include} include file:\nUncaught {}",
                         e.display()
                     )
                 })?;

--- a/boa_tester/src/read.rs
+++ b/boa_tester/src/read.rs
@@ -67,7 +67,7 @@ impl FromStr for TestFlag {
             "CanBlockIsFalse" => Ok(Self::CanBlockIsFalse),
             "CanBlockIsTrue" => Ok(Self::CanBlockIsTrue),
             "non-deterministic" => Ok(Self::NonDeterministic),
-            _ => Err(format!("unknown test flag: {}", s)),
+            _ => Err(format!("unknown test flag: {s}")),
         }
     }
 }

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -278,7 +278,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             );
             println!("\n```");
             for test in test_diff.fixed {
-                println!("{}", test);
+                println!("{test}");
             }
             println!("```");
             println!("</details>");
@@ -292,7 +292,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             );
             println!("\n```");
             for test in test_diff.broken {
-                println!("{}", test);
+                println!("{test}");
             }
             println!("```");
             println!("</details>");
@@ -306,7 +306,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             );
             println!("\n```");
             for test in test_diff.new_panics {
-                println!("{}", test);
+                println!("{test}");
             }
             println!("```");
             println!("</details>");
@@ -320,7 +320,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             );
             println!("\n```");
             for test in test_diff.panic_fixes {
-                println!("{}", test);
+                println!("{test}");
             }
             println!("```");
             println!("</details>");
@@ -329,27 +329,19 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         println!("Test262 conformance changes:");
         println!("| Test result | main |    PR   | difference |");
         println!(
-            "|    Passed   | {:^6} | {:^5} | {:^10} |",
-            base_passed,
-            new_passed,
+            "|    Passed   | {base_passed:^6} | {new_passed:^5} | {:^10} |",
             base_passed - new_passed
         );
         println!(
-            "|   Ignored   | {:^6} | {:^5} | {:^10} |",
-            base_ignored,
-            new_ignored,
+            "|   Ignored   | {base_ignored:^6} | {new_ignored:^5} | {:^10} |",
             base_ignored - new_ignored
         );
         println!(
-            "|   Failed    | {:^6} | {:^5} | {:^10} |",
-            base_failed,
-            new_failed,
+            "|   Failed    | {base_failed:^6} | {new_failed:^5} | {:^10} |",
             base_failed - new_failed,
         );
         println!(
-            "|   Panics    | {:^6} | {:^5} | {:^10} |",
-            base_panics,
-            new_panics,
+            "|   Panics    | {base_panics:^6} | {new_panics:^5} | {:^10} |",
             base_panics - new_panics
         );
 
@@ -357,7 +349,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             println!();
             println!("Fixed tests ({}):", test_diff.fixed.len());
             for test in test_diff.fixed {
-                println!("{}", test);
+                println!("{test}");
             }
         }
 
@@ -365,7 +357,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             println!();
             println!("Broken tests ({}):", test_diff.broken.len());
             for test in test_diff.broken {
-                println!("{}", test);
+                println!("{test}");
             }
         }
 
@@ -373,7 +365,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             println!();
             println!("New panics ({}):", test_diff.new_panics.len());
             for test in test_diff.new_panics {
-                println!("{}", test);
+                println!("{test}");
             }
         }
 
@@ -381,7 +373,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             println!();
             println!("Fixed panics ({}):", test_diff.panic_fixes.len());
             for test in test_diff.panic_fixes {
-                println!("{}", test);
+                println!("{test}");
             }
         }
     }


### PR DESCRIPTION
In [Rust 1.58](https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html#captured-identifiers-in-format-strings), capturing of bindings were added to format strings. This makes things more clear, so I added this where possible.