### PR TITLE
Allow `arguments` and `eval` in the return position of strict functions

### DIFF
--- a/boa/src/syntax/lexer/identifier.rs
+++ b/boa/src/syntax/lexer/identifier.rs
@@ -14,9 +14,7 @@ use core::convert::TryFrom;
 use std::io::Read;
 use std::str;
 
-const STRICT_FORBIDDEN_IDENTIFIERS: [&str; 11] = [
-    "eval",
-    "arguments",
+const STRICT_FORBIDDEN_IDENTIFIERS: [&str; 9] = [
     "implements",
     "interface",
     "let",


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1598 .

It changes the following:

- updated `STRICT_FORBIDDEN_IDENTIFIERS`
- updated `LexicalBinding` to throw Error when assigning to `eval` or `arguments` in strict mode
- updated `VariableDeclaration` to throw Error when assigning to `eval` or `arguments` in strict mode
