### PR TITLE
[Merged by Bors] - Rework RegExp struct to include bitflags field

### DIFF
--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -23,8 +23,8 @@ use crate::{
     symbol::WellKnownSymbols,
     value::{IntegerOrInfinity, JsValue},
     BoaProfiler, Context, JsResult, JsString,
+    syntax::lexer::regex::RegExpFlags,
 };
-use bitflags::bitflags;
 use regexp_string_iterator::RegExpStringIterator;
 use regress::Regex;
 
@@ -1704,19 +1704,6 @@ impl RegExp {
 
         // 22. Return A.
         Ok(a.into())
-    }
-}
-
-bitflags! {
-    /// Flags of a regular expression.
-    #[derive(Default)]
-    pub struct RegExpFlags: u8 {
-        const GLOBAL = 0b0000_0001;
-        const IGNORE_CASE = 0b0000_0010;
-        const MULTILINE = 0b0000_0100;
-        const DOT_ALL = 0b0000_1000;
-        const UNICODE = 0b0001_0000;
-        const STICKY = 0b0010_0000;
     }
 }
 

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -360,16 +360,16 @@ impl RegExp {
     }
 
     #[inline]
-    fn regexp_has_flag(this: &JsValue, flag: char, context: &mut Context) -> JsResult<JsValue> {
+    fn regexp_has_flag(this: &JsValue, flag: u8, context: &mut Context) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             if let Some(regexp) = object.borrow().as_regexp() {
                 return Ok(JsValue::new(match flag {
-                    'g' => regexp.flags.contains(RegExpFlags::GLOBAL),
-                    'm' => regexp.flags.contains(RegExpFlags::MULTILINE),
-                    's' => regexp.flags.contains(RegExpFlags::DOT_ALL),
-                    'i' => regexp.flags.contains(RegExpFlags::IGNORE_CASE),
-                    'u' => regexp.flags.contains(RegExpFlags::UNICODE),
-                    'y' => regexp.flags.contains(RegExpFlags::STICKY),
+                    b'g' => regexp.flags.contains(RegExpFlags::GLOBAL),
+                    b'm' => regexp.flags.contains(RegExpFlags::MULTILINE),
+                    b's' => regexp.flags.contains(RegExpFlags::DOT_ALL),
+                    b'i' => regexp.flags.contains(RegExpFlags::IGNORE_CASE),
+                    b'u' => regexp.flags.contains(RegExpFlags::UNICODE),
+                    b'y' => regexp.flags.contains(RegExpFlags::STICKY),
                     _ => unreachable!(),
                 }));
             }
@@ -383,12 +383,12 @@ impl RegExp {
         }
 
         let name = match flag {
-            'g' => "global",
-            'm' => "multiline",
-            's' => "dotAll",
-            'i' => "ignoreCase",
-            'u' => "unicode",
-            'y' => "sticky",
+            b'g' => "global",
+            b'm' => "multiline",
+            b's' => "dotAll",
+            b'i' => "ignoreCase",
+            b'u' => "unicode",
+            b'y' => "sticky",
             _ => unreachable!(),
         };
 
@@ -412,7 +412,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 'g', context)
+        Self::regexp_has_flag(this, b'g', context)
     }
 
     /// `get RegExp.prototype.ignoreCase`
@@ -430,7 +430,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 'i', context)
+        Self::regexp_has_flag(this, b'i', context)
     }
 
     /// `get RegExp.prototype.multiline`
@@ -448,7 +448,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 'm', context)
+        Self::regexp_has_flag(this, b'm', context)
     }
 
     /// `get RegExp.prototype.dotAll`
@@ -466,7 +466,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 's', context)
+        Self::regexp_has_flag(this, b's', context)
     }
 
     /// `get RegExp.prototype.unicode`
@@ -485,7 +485,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 'u', context)
+        Self::regexp_has_flag(this, b'u', context)
     }
 
     /// `get RegExp.prototype.sticky`
@@ -504,7 +504,7 @@ impl RegExp {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        Self::regexp_has_flag(this, 'y', context)
+        Self::regexp_has_flag(this, b'y', context)
     }
 
     /// `get RegExp.prototype.flags`

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -23,9 +23,9 @@ use crate::{
     },
     property::Attribute,
     symbol::WellKnownSymbols,
+    syntax::lexer::regex::RegExpFlags,
     value::{IntegerOrInfinity, JsValue},
     BoaProfiler, Context, JsResult, JsString,
-    syntax::lexer::regex::RegExpFlags,
 };
 use regexp_string_iterator::RegExpStringIterator;
 use regress::Regex;
@@ -270,7 +270,7 @@ impl RegExp {
         //    or if it contains the same code unit more than once, throw a SyntaxError exception.
         let flags = match RegExpFlags::from_str(&f) {
             Err(msg) => return context.throw_syntax_error(msg),
-            Ok(result) => result
+            Ok(result) => result,
         };
 
         // 12. Set obj.[[OriginalSource]] to P.

--- a/boa/src/builtins/regexp/mod.rs
+++ b/boa/src/builtins/regexp/mod.rs
@@ -11,6 +11,8 @@
 
 pub mod regexp_string_iterator;
 
+use std::str::FromStr;
+
 use crate::{
     builtins::{array::Array, string, BuiltIn},
     context::StandardObjects,
@@ -266,40 +268,10 @@ impl RegExp {
 
         // 5. If F contains any code unit other than "g", "i", "m", "s", "u", or "y"
         //    or if it contains the same code unit more than once, throw a SyntaxError exception.
-        let mut flags = RegExpFlags::default();
-        for c in f.chars() {
-            match c {
-                'g' if flags.contains(RegExpFlags::GLOBAL) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 'g'")
-                }
-                'g' => flags.insert(RegExpFlags::GLOBAL),
-                'i' if flags.contains(RegExpFlags::IGNORE_CASE) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 'i'")
-                }
-                'i' => flags.insert(RegExpFlags::IGNORE_CASE),
-                'm' if flags.contains(RegExpFlags::MULTILINE) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 'm'")
-                }
-                'm' => flags.insert(RegExpFlags::MULTILINE),
-                's' if flags.contains(RegExpFlags::DOT_ALL) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 's'")
-                }
-                's' => flags.insert(RegExpFlags::DOT_ALL),
-                'u' if flags.contains(RegExpFlags::UNICODE) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 'u'")
-                }
-                'u' => flags.insert(RegExpFlags::UNICODE),
-                'y' if flags.contains(RegExpFlags::STICKY) => {
-                    return context.throw_syntax_error("RegExp flags contains multiple 'y'")
-                }
-                'y' => flags.insert(RegExpFlags::STICKY),
-                c => {
-                    return context.throw_syntax_error(format!(
-                        "RegExp flags contains unknown code unit '{c}'",
-                    ))
-                }
-            }
-        }
+        let flags = match RegExpFlags::from_str(&f) {
+            Err(msg) => return context.throw_syntax_error(msg),
+            Ok(result) => result
+        };
 
         // 12. Set obj.[[OriginalSource]] to P.
         // 13. Set obj.[[OriginalFlags]] to F.

--- a/boa/src/syntax/lexer/mod.rs
+++ b/boa/src/syntax/lexer/mod.rs
@@ -20,7 +20,7 @@ pub mod error;
 mod identifier;
 mod number;
 mod operator;
-mod regex;
+pub mod regex;
 mod spread;
 mod string;
 mod template;

--- a/boa/src/syntax/lexer/regex.rs
+++ b/boa/src/syntax/lexer/regex.rs
@@ -2,13 +2,13 @@
 
 use super::{Cursor, Error, Span, Tokenizer};
 use crate::{
-    builtins::regexp::RegExpFlags,
     profiler::BoaProfiler,
     syntax::{
         ast::Position,
         lexer::{Token, TokenKind},
     },
 };
+use bitflags::bitflags;
 use boa_interner::{Interner, Sym};
 use std::{
     io::{self, ErrorKind, Read},
@@ -127,6 +127,19 @@ impl<R> Tokenizer<R> for RegexLiteral {
                 "Invalid UTF-8 character in regular expressions",
             )))
         }
+    }
+}
+
+bitflags! {
+    /// Flags of a regular expression.
+    #[derive(Default)]
+    pub struct RegExpFlags: u8 {
+        const GLOBAL = 0b0000_0001;
+        const IGNORE_CASE = 0b0000_0010;
+        const MULTILINE = 0b0000_0100;
+        const DOT_ALL = 0b0000_1000;
+        const UNICODE = 0b0001_0000;
+        const STICKY = 0b0010_0000;
     }
 }
 

--- a/boa/src/syntax/lexer/regex.rs
+++ b/boa/src/syntax/lexer/regex.rs
@@ -156,17 +156,18 @@ impl FromStr for RegExpFlags {
                 b's' => Self::DOT_ALL,
                 b'u' => Self::UNICODE,
                 b'y' => Self::STICKY,
-                _ => {
-                    return Err(format!("invalid regular expression flag {}", char::from(c)))
-                }
+                _ => return Err(format!("invalid regular expression flag {}", char::from(c))),
             };
 
             if flags.contains(new_flag) {
-                return Err(format!("repeated regular expression flag {}", char::from(c)));
+                return Err(format!(
+                    "repeated regular expression flag {}",
+                    char::from(c)
+                ));
             }
             flags.insert(new_flag);
         }
-        
+
         Ok(flags)
     }
 }
@@ -174,10 +175,8 @@ impl FromStr for RegExpFlags {
 fn parse_regex_flags(s: &str, start: Position, interner: &mut Interner) -> Result<Sym, Error> {
     match RegExpFlags::from_str(s) {
         Err(message) => Err(Error::Syntax(message.into(), start)),
-        Ok(flags) => {
-            Ok(interner.get_or_intern(flags.to_string()))
-        }
-    }    
+        Ok(flags) => Ok(interner.get_or_intern(flags.to_string())),
+    }
 }
 
 impl ToString for RegExpFlags {

--- a/boa/src/syntax/lexer/regex.rs
+++ b/boa/src/syntax/lexer/regex.rs
@@ -2,13 +2,13 @@
 
 use super::{Cursor, Error, Span, Tokenizer};
 use crate::{
+    builtins::regexp::RegExpFlags,
     profiler::BoaProfiler,
     syntax::{
         ast::Position,
         lexer::{Token, TokenKind},
     },
 };
-use bitflags::bitflags;
 use boa_interner::{Interner, Sym};
 use std::{
     io::{self, ErrorKind, Read},
@@ -127,19 +127,6 @@ impl<R> Tokenizer<R> for RegexLiteral {
                 "Invalid UTF-8 character in regular expressions",
             )))
         }
-    }
-}
-
-bitflags! {
-    /// Flags of a regular expression.
-    #[derive(Default)]
-    struct RegExpFlags: u8 {
-        const GLOBAL = 0b0000_0001;
-        const IGNORE_CASE = 0b0000_0010;
-        const MULTILINE = 0b0000_0100;
-        const DOT_ALL = 0b0000_1000;
-        const UNICODE = 0b0001_0000;
-        const STICKY = 0b0010_0000;
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #1819.

It changes the following:

- Move the bitflags from `boa/src/syntax/lexer/regex.rs` to `boa/src/builtins/regexp/mod.rs`
- Replace the booleans in the RegExp struct to include the bitflags struct
- Update match expressions to make use of the bitflags struct
