### PR TITLE
[Merged by Bors] - Ignore wastefull `RegExp` tests

### DIFF
--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -15,3 +15,31 @@ feature:tail-call-optimization
 // These generate a stack overflow
 tco-call
 tco-member
+
+// RegExp tests that check individual codepoints.
+// They are not usefull in comparision to the cpu time they waste.
+feature:regexp-unicode-property-escapes
+character-class-non-whitespace-class-escape-plus-quantifier
+character-class-non-whitespace-class-escape-plus-quantifier-flags-u
+character-class-non-word-class-escape-flags-u
+character-class-non-whitespace-class-escape
+character-class-non-digit-class-escape-plus-quantifier-flags-u
+character-class-non-word-class-escape
+character-class-non-whitespace-class-escape-flags-u
+character-class-digit-class-escape-flags-u
+character-class-digit-class-escape
+character-class-non-digit-class-escape-plus-quantifier
+character-class-whitespace-class-escape-flags-u
+character-class-whitespace-class-escape-plus-quantifier-flags-u
+character-class-word-class-escape
+character-class-digit-class-escape-plus-quantifier-flags-u
+character-class-non-digit-class-escape
+character-class-digit-class-escape-plus-quantifier
+character-class-whitespace-class-escape
+character-class-whitespace-class-escape-plus-quantifier
+character-class-word-class-escape-plus-quantifier
+character-class-non-word-class-escape-plus-quantifier
+character-class-word-class-escape-flags-u
+character-class-word-class-escape-plus-quantifier-flags-u
+character-class-non-digit-class-escape-flags-u
+character-class-non-word-class-escape-plus-quantifier-flags-u


### PR DESCRIPTION
With the implementation of `String.fromCodePoint` in #1123 some `RegExp` tests are now running for a long time. These tests check every unicode codepoint for all regexp property escape/character classes.

This not only makes the developer experience significantly worse, but also wastes cpu resources for the benefit of "completeness". I think these tests are completely useless. Ironically the unicode tables in the tests are generated - from the same data, that the unicode tables in the regex engine are also generated.

262 suite runtime:
Before: ~03:30 https://github.com/boa-dev/boa/runs/5191567446?check_suite_focus=true
After: ~31:00 https://github.com/boa-dev/boa/runs/5196405437?check_suite_focus=true
