### PR TITLE
[Merged by Bors] - Added conversions from and to serde_json's Value type

### DIFF
--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -456,17 +456,6 @@ impl Object {
         )
     }
 
-    #[inline]
-    pub fn as_array(&self) -> Option<()> {
-        match self.data {
-            ObjectData {
-                kind: ObjectKind::Array,
-                ..
-            } => Some(()),
-            _ => None,
-        }
-    }
-
     /// Checks if it is an `ArrayIterator` object.
     #[inline]
     pub fn is_array_iterator(&self) -> bool {
@@ -791,17 +780,6 @@ impl Object {
                 ..
             }
         )
-    }
-
-    #[inline]
-    pub fn as_error(&self) -> Option<()> {
-        match self.data {
-            ObjectData {
-                kind: ObjectKind::Error,
-                ..
-            } => Some(()),
-            _ => None,
-        }
     }
 
     /// Checks if it a Boolean object.
@@ -1159,7 +1137,10 @@ impl Object {
         &self.properties
     }
 
-    /// Helper function for property insertion.
+    /// Inserts a field in the object `properties` without checking if it's writable.
+    ///
+    /// If a field was already in the object with the same name, then a `Some` is returned
+    /// with that field's value, otherwise, `None` is returned.
     #[inline]
     pub(crate) fn insert<K, P>(&mut self, key: K, property: P) -> Option<PropertyDescriptor>
     where
@@ -1173,19 +1154,6 @@ impl Object {
     #[inline]
     pub(crate) fn remove(&mut self, key: &PropertyKey) -> Option<PropertyDescriptor> {
         self.properties.remove(key)
-    }
-
-    /// Inserts a field in the object `properties` without checking if it's writable.
-    ///
-    /// If a field was already in the object with the same name that a `Some` is returned
-    /// with that field, otherwise None is returned.
-    #[inline]
-    pub fn insert_property<K, P>(&mut self, key: K, property: P) -> Option<PropertyDescriptor>
-    where
-        K: Into<PropertyKey>,
-        P: Into<PropertyDescriptor>,
-    {
-        self.insert(key, property)
     }
 }
 
@@ -1406,8 +1374,8 @@ impl<'context> FunctionBuilder<'context> {
             .writable(false)
             .enumerable(false)
             .configurable(true);
-        object.insert_property("name", property.clone().value(self.name.clone()));
-        object.insert_property("length", property.value(self.length));
+        object.insert("name", property.clone().value(self.name.clone()));
+        object.insert("length", property.value(self.length));
     }
 }
 
@@ -1473,7 +1441,7 @@ impl<'context> ObjectInitializer<'context> {
             .constructor(false)
             .build();
 
-        self.object.borrow_mut().insert_property(
+        self.object.borrow_mut().insert(
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
@@ -1595,7 +1563,7 @@ impl<'context> ConstructorBuilder<'context> {
             .constructor(false)
             .build();
 
-        self.prototype.borrow_mut().insert_property(
+        self.prototype.borrow_mut().insert(
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
@@ -1624,7 +1592,7 @@ impl<'context> ConstructorBuilder<'context> {
             .constructor(false)
             .build();
 
-        self.constructor_object.borrow_mut().insert_property(
+        self.constructor_object.borrow_mut().insert(
             binding.binding,
             PropertyDescriptor::builder()
                 .value(function)
@@ -1842,7 +1810,7 @@ impl<'context> ConstructorBuilder<'context> {
             }
 
             if self.constructor_has_prototype {
-                constructor.insert_property(
+                constructor.insert(
                     PROTOTYPE,
                     PropertyDescriptor::builder()
                         .value(self.prototype.clone())
@@ -1855,7 +1823,7 @@ impl<'context> ConstructorBuilder<'context> {
 
         {
             let mut prototype = self.prototype.borrow_mut();
-            prototype.insert_property(
+            prototype.insert(
                 "constructor",
                 PropertyDescriptor::builder()
                     .value(self.constructor_object.clone())

--- a/boa_engine/src/value/conversions.rs
+++ b/boa_engine/src/value/conversions.rs
@@ -127,16 +127,6 @@ impl From<JsObject> for JsValue {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
-pub struct TryFromObjectError;
-
-impl Display for TryFromObjectError {
-    #[inline]
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Could not convert value to an Object type")
-    }
-}
-
 impl From<()> for JsValue {
     #[inline]
     fn from(_: ()) -> Self {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod display;
 mod equality;
 mod hash;
 mod operations;
+mod serde_json;
 mod r#type;
 
 pub use conversions::*;

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -1,0 +1,109 @@
+//! This module implements the conversions from and into [`serde_json::Value`].
+
+use super::JsValue;
+use crate::{
+    builtins::Array,
+    property::{PropertyDescriptor, PropertyKey},
+    Context, JsResult,
+};
+use serde_json::{Map, Value};
+
+impl JsValue {
+    /// Converts a [`serde_json::Value`] to a `JsValue`.
+    pub fn from_json(json: Value, context: &mut Context) -> JsResult<Self> {
+        /// Biggest possible integer, as i64.
+        const MAX_INT: i64 = i32::MAX as i64;
+
+        match json {
+            Value::Null => Ok(Self::Null),
+            Value::Bool(b) => Ok(Self::Boolean(b)),
+            Value::Number(num) => match num.as_i64() {
+                Some(s @ 0..=MAX_INT) => Ok(Self::Integer(s as i32)),
+                Some(s) => Ok(Self::Rational(s as f64)),
+                None => {
+                    if let Some(i) = num.as_u64() {
+                        Ok(Self::Rational(i as f64))
+                    } else {
+                        Ok(Self::Rational(num.as_f64().ok_or_else(|| {
+                            context.construct_type_error(format!(
+                                "could not convert JSON number {num} to JsValue"
+                            ))
+                        })?))
+                    }
+                }
+            },
+            Value::String(string) => Ok(Self::from(string)),
+            Value::Array(vec) => {
+                let mut arr = Vec::with_capacity(vec.len());
+                for val in vec {
+                    arr.push(Self::from_json(val, context)?);
+                }
+                Ok(Array::create_array_from_list(arr, context).into())
+            }
+            Value::Object(obj) => {
+                let js_obj = context.construct_object();
+                for (key, value) in obj {
+                    let property = PropertyDescriptor::builder()
+                        .value(Self::from_json(value, context)?)
+                        .writable(true)
+                        .enumerable(true)
+                        .configurable(true);
+                    js_obj.borrow_mut().insert(key, property);
+                }
+
+                Ok(js_obj.into())
+            }
+        }
+    }
+
+    /// Converts the `JsValue` to a [`serde_json::Value`].
+    pub fn to_json(&self, context: &mut Context) -> JsResult<Value> {
+        match self {
+            Self::Null => Ok(Value::Null),
+            Self::Undefined => todo!("undefined to JSON"),
+            &Self::Boolean(b) => Ok(b.into()),
+            Self::String(string) => Ok(string.as_str().into()),
+            &Self::Rational(rat) => Ok(rat.into()),
+            &Self::Integer(int) => Ok(int.into()),
+            Self::BigInt(_bigint) => context.throw_type_error("cannot convert bigint to JSON"),
+            Self::Object(obj) => {
+                if obj.is_array() {
+                    let len = obj.length_of_array_like(context)?;
+                    let mut arr = Vec::with_capacity(len);
+
+                    let obj = obj.borrow();
+
+                    for k in 0..len as u32 {
+                        let val = obj.properties().get(&k.into()).map_or(Self::Null, |desc| {
+                            desc.value().cloned().unwrap_or(Self::Null)
+                        });
+                        arr.push(val.to_json(context)?);
+                    }
+
+                    Ok(Value::Array(arr))
+                } else {
+                    let mut map = Map::new();
+                    for (key, property) in obj.borrow().properties().iter() {
+                        let key = match &key {
+                            PropertyKey::String(string) => string.as_str().to_owned(),
+                            PropertyKey::Index(i) => i.to_string(),
+                            PropertyKey::Symbol(_sym) => {
+                                return context.throw_type_error("cannot convert Symbol to JSON")
+                            }
+                        };
+
+                        let value = match property.value() {
+                            Some(val) => val.to_json(context)?,
+                            None => Value::Null,
+                        };
+
+                        map.insert(key, value);
+                    }
+
+                    Ok(Value::Object(map))
+                }
+            }
+            Self::Symbol(_sym) => context.throw_type_error("cannot convert Symbol to JSON"),
+        }
+    }
+}

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -14,7 +14,7 @@ impl JsValue {
     /// # Example
     ///
     /// ```
-    /// use boa::{Context, JsValue};
+    /// use boa_engine::{Context, JsValue};
     ///
     /// let data = r#"
     ///     {
@@ -82,7 +82,7 @@ impl JsValue {
     /// # Example
     ///
     /// ```
-    /// use boa::{Context, JsValue};
+    /// use boa_engine::{Context, JsValue};
     ///
     /// let data = r#"
     ///     {

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -37,7 +37,7 @@ impl JsValue {
         /// Biggest possible integer, as i64.
         const MAX_INT: i64 = i32::MAX as i64;
 
-        /// Biggest possible integer, as i64.
+        /// Smallest possible integer, as i64.
         const MIN_INT: i64 = i32::MIN as i64;
 
         match json {

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -187,7 +187,7 @@ mod tests {
 
         let obj = value.as_object().unwrap();
         assert_eq!(obj.get("name", &mut context).unwrap(), "John Doe".into());
-        assert_eq!(obj.get("age", &mut context).unwrap(), 43.into());
+        assert_eq!(obj.get("age", &mut context).unwrap(), 43_i32.into());
         assert_eq!(obj.get("minor", &mut context).unwrap(), false.into());
         assert_eq!(obj.get("adult", &mut context).unwrap(), true.into());
         {
@@ -201,7 +201,7 @@ mod tests {
 
             let arr = JsArray::from_object(phones.clone(), &mut context).unwrap();
             assert_eq!(arr.at(0, &mut context).unwrap(), "+44 1234567".into());
-            assert_eq!(arr.at(1, &mut context).unwrap(), -45.into());
+            assert_eq!(arr.at(1, &mut context).unwrap(), JsValue::from(-45_i32));
             assert!(arr.at(2, &mut context).unwrap().is_object());
             assert_eq!(arr.at(3, &mut context).unwrap(), true.into());
         }


### PR DESCRIPTION
This Pull Request closes #1693.

It changes the following:

- It adds a fallible conversion from `serde_json::Value` to `JsValue`, which requires a context.
- It adds a fallible conversion from `JsValue` to `serde_json::Value`, which requires a context.
- Added examples to the documentation of both methods.
- Removed some duplicate and non-needed code that I found while doing this.
