### PR TITLE
[Merged by Bors] - Removing internal deprecated functions

### DIFF
--- a/boa_engine/src/builtins/array/tests.rs
+++ b/boa_engine/src/builtins/array/tests.rs
@@ -1543,8 +1543,12 @@ fn get_relative_end() {
 fn array_length_is_not_enumerable() {
     let mut context = Context::default();
 
-    let array = Array::new_array(&mut context);
-    let desc = array.get_property("length").unwrap();
+    let array =
+        Array::array_create(0, None, &mut context).expect("could not create an empty array");
+    let desc = array
+        .__get_own_property__(&"length".into(), &mut context)
+        .expect("accessing length property on array should not throw")
+        .expect("there should always be a length property on arrays");
     assert!(!desc.expect_enumerable());
 }
 

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -373,7 +373,7 @@ impl Json {
         // 2. If Type(value) is Object or BigInt, then
         if value.is_object() || value.is_bigint() {
             // a. Let toJSON be ? GetV(value, "toJSON").
-            let to_json = value.get_field("toJSON", context)?;
+            let to_json = value.get_v("toJSON", context)?;
 
             // b. If IsCallable(toJSON) is true, then
             if let Some(obj) = to_json.as_object() {

--- a/boa_engine/src/builtins/json/tests.rs
+++ b/boa_engine/src/builtins/json/tests.rs
@@ -343,7 +343,7 @@ fn json_parse_array_with_reviver() {
     .unwrap();
     assert_eq!(
         result
-            .get_field("0", &mut context)
+            .get_v("0", &mut context)
             .unwrap()
             .to_number(&mut context)
             .unwrap() as u8,
@@ -351,7 +351,7 @@ fn json_parse_array_with_reviver() {
     );
     assert_eq!(
         result
-            .get_field("1", &mut context)
+            .get_v("1", &mut context)
             .unwrap()
             .to_number(&mut context)
             .unwrap() as u8,
@@ -359,7 +359,7 @@ fn json_parse_array_with_reviver() {
     );
     assert_eq!(
         result
-            .get_field("2", &mut context)
+            .get_v("2", &mut context)
             .unwrap()
             .to_number(&mut context)
             .unwrap() as u8,
@@ -367,7 +367,7 @@ fn json_parse_array_with_reviver() {
     );
     assert_eq!(
         result
-            .get_field("3", &mut context)
+            .get_v("3", &mut context)
             .unwrap()
             .to_number(&mut context)
             .unwrap() as u8,

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -2065,6 +2065,9 @@ pub(crate) fn get_substitution(
                         result.push_str("$<");
                     } else {
                         // a. Assert: Type(namedCaptures) is Object.
+                        let named_captures = named_captures
+                            .as_object()
+                            .expect("should be an object according to spec");
 
                         // b. Scan until the next > U+003E (GREATER-THAN SIGN).
                         let mut group_name = StdString::new();
@@ -2089,7 +2092,7 @@ pub(crate) fn get_substitution(
                         } else {
                             // i. Let groupName be the enclosed substring.
                             // ii. Let capture be ? Get(namedCaptures, groupName).
-                            let capture = named_captures.get_field(group_name, context)?;
+                            let capture = named_captures.get(group_name, context)?;
 
                             // iii. If capture is undefined, replace the text through > with the empty String.
                             // iv. Otherwise, replace the text through > with ? ToString(capture).

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -449,12 +449,14 @@ impl JsObject {
         }
 
         // 4. If Type(C) is not Object, throw a TypeError exception.
-        if !c.is_object() {
+        let c = if let Some(c) = c.as_object() {
+            c
+        } else {
             return context.throw_type_error("property 'constructor' is not an object");
-        }
+        };
 
         // 5. Let S be ? Get(C, @@species).
-        let s = c.get_field(WellKnownSymbols::species(), context)?;
+        let s = c.get(WellKnownSymbols::species(), context)?;
 
         // 6. If S is either undefined or null, return defaultConstructor.
         if s.is_null_or_undefined() {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -339,68 +339,11 @@ impl JsValue {
         }
     }
 
-    /// Set the field in the value
-    ///
-    /// Similar to `7.3.4 Set ( O, P, V, Throw )`, but returns the value instead of a boolean.
-    ///
-    /// More information:
-    ///  - [ECMAScript][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-set-o-p-v-throw
-    #[inline]
-    pub(crate) fn set_field<K, V>(
-        &self,
-        key: K,
-        value: V,
-        throw: bool,
-        context: &mut Context,
-    ) -> JsResult<Self>
-    where
-        K: Into<PropertyKey>,
-        V: Into<Self>,
-    {
-        // 1. Assert: Type(O) is Object.
-        // TODO: Currently the value may not be an object.
-        //       In that case this function does nothing.
-        // 2. Assert: IsPropertyKey(P) is true.
-        // 3. Assert: Type(Throw) is Boolean.
-
-        let key = key.into();
-        let value = value.into();
-        let _timer = Profiler::global().start_event("Value::set_field", "value");
-        if let Self::Object(ref obj) = *self {
-            // 4. Let success be ? O.[[Set]](P, V, O).
-            let success = obj
-                .clone()
-                .__set__(key, value.clone(), obj.clone().into(), context)?;
-
-            // 5. If success is false and Throw is true, throw a TypeError exception.
-            // 6. Return success.
-            if !success && throw {
-                return context.throw_type_error("Cannot assign value to property");
-            }
-            return Ok(value);
-        }
-        Ok(value)
-    }
-
     /// Set the kind of an object.
     #[inline]
     pub fn set_data(&self, data: ObjectData) {
         if let Self::Object(ref obj) = *self {
             obj.borrow_mut().data = data;
-        }
-    }
-
-    /// Set the property in the value.
-    #[inline]
-    pub(crate) fn set_property<K, P>(&self, key: K, property: P)
-    where
-        K: Into<PropertyKey>,
-        P: Into<PropertyDescriptor>,
-    {
-        if let Some(object) = self.as_object() {
-            object.insert(key.into(), property.into());
         }
     }
 


### PR DESCRIPTION
This Pull Request is related to #577 .

It changes the following:
- Remove `JsValue::set_field`
- Remove `JsValue::set_property`
- Remove almost all uses of `JsValue::get_field`
- Use `.get_v()` instead of `get_field` according to spec in `serialize_json_property`
- Remove `Array::new_array()`
- Remove `Array::add_to_array_object()`
