### PR TITLE
[Merged by Bors] - Correct reference error message

### DIFF
--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -459,8 +459,9 @@ impl Context {
                     let exists = self.global_bindings_mut().contains_key(&key);
 
                     if !exists && (self.strict() || self.vm.frame().code.strict) {
-                        return self
-                            .throw_reference_error(format!("assignment to undeclared variable {key}"));
+                        return self.throw_reference_error(format!(
+                            "assignment to undeclared variable {key}"
+                        ));
                     }
 
                     let success = crate::object::internal_methods::global::global_set_no_receiver(

--- a/boa/src/vm/mod.rs
+++ b/boa/src/vm/mod.rs
@@ -460,7 +460,7 @@ impl Context {
 
                     if !exists && (self.strict() || self.vm.frame().code.strict) {
                         return self
-                            .throw_reference_error(format!("binding already exists: {key}"));
+                            .throw_reference_error(format!("assignment to undeclared variable {key}"));
                     }
 
                     let success = crate::object::internal_methods::global::global_set_no_receiver(


### PR DESCRIPTION
This Pull Request fixes/closes the incorrect message thrown for the following code:

```javascript
"use strict";
foo = "bar";
```

Which would throw the following before the change (incorrect):
`Uncaught "ReferenceError": "binding already exists: foo"`

And would throw the following after the change (correct):
`Uncaught "ReferenceError": "assignment to undeclared variable foo"`