### PR TITLE
Make missing break labels not panic

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -1480,11 +1480,12 @@ impl<'b> ByteCompiler<'b> {
                             break;
                         }
                     }
-                    assert!(
-                        found,
-                        "Undefined label '{}'",
-                        self.interner().resolve_expect(label_name)
-                    );
+                    if !found {
+                        return self.context.throw_syntax_error(format!(
+                            "Undefined label '{}'",
+                            self.interner().resolve_expect(label_name)
+                        ));
+                    }
                 } else {
                     self.jump_info
                         .last_mut()

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -431,15 +431,14 @@ fn for_loop_iteration_variable_does_not_leak() {
 }
 
 #[test]
-#[should_panic]
 fn test_invalid_break_target() {
     let src = r#"
-        while (false) {
+        while (true) {
           break nonexistent;
         }
         "#;
 
-    let _ = &exec(src);
+    assert!(matches!(Context::default().eval(src.as_bytes()), Err(_)));
 }
 
 #[test]


### PR DESCRIPTION
This PR changes the following:

- Causes missing break labels to no longer panic
- Updates relevant test from should_panic to matches Err variant
