### PR TITLE
[Merged by Bors] - Fix equality between objects and `undefined` or `null`

### DIFF
--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -83,16 +83,34 @@ impl JsValue {
 
             // 10. If Type(x) is either String, Number, BigInt, or Symbol and Type(y) is Object, return the result
             // of the comparison x == ? ToPrimitive(y).
-            (Self::Object(_), _) => {
+            (
+                Self::Object(_),
+                Self::String(_)
+                | Self::Rational(_)
+                | Self::Integer(_)
+                | Self::BigInt(_)
+                | Self::Symbol(_),
+            ) => {
                 let primitive = self.to_primitive(context, PreferredType::Default)?;
-                return primitive.equals(other, context);
+                return Ok(primitive
+                    .equals(other, context)
+                    .expect("should not fail according to spec"));
             }
 
             // 11. If Type(x) is Object and Type(y) is either String, Number, BigInt, or Symbol, return the result
             // of the comparison ? ToPrimitive(x) == y.
-            (_, Self::Object(_)) => {
+            (
+                Self::String(_)
+                | Self::Rational(_)
+                | Self::Integer(_)
+                | Self::BigInt(_)
+                | Self::Symbol(_),
+                Self::Object(_),
+            ) => {
                 let primitive = other.to_primitive(context, PreferredType::Default)?;
-                return primitive.equals(self, context);
+                return Ok(primitive
+                    .equals(self, context)
+                    .expect("should not fail according to spec"));
             }
 
             // 12. If Type(x) is BigInt and Type(y) is Number, or if Type(x) is Number and Type(y) is BigInt, then


### PR DESCRIPTION
This PR fixes equality between object and `null` or `undefined` (like `[] == null`), which was failing the test262 harness test [`compare-array-symbol.js`](https://github.com/tc39/test262/blob/18ce639a4c4768de337fa30b83bbb6de02b0e1a5/test/harness/compare-array-symbol.js).
