### PR TITLE
[Merged by Bors] - Removing the panic in favour of an error result

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -1510,11 +1510,12 @@ impl<'b> ByteCompiler<'b> {
                             break;
                         }
                     }
-                    assert!(
-                        found,
-                        "Undefined label '{}'",
-                        self.interner().resolve_expect(label_name)
-                    );
+                    if !found {
+                        return self.context.throw_syntax_error(format!(
+                            "Cannot use the undeclared label '{}",
+                            self.interner().resolve_expect(label_name)
+                        ));
+                    }
                 } else {
                     self.jump_info
                         .last_mut()

--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -1512,7 +1512,7 @@ impl<'b> ByteCompiler<'b> {
                     }
                     if !found {
                         return self.context.throw_syntax_error(format!(
-                            "Cannot use the undeclared label '{}",
+                            "Cannot use the undeclared label '{}'",
                             self.interner().resolve_expect(label_name)
                         ));
                     }

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -431,7 +431,6 @@ fn for_loop_iteration_variable_does_not_leak() {
 }
 
 #[test]
-#[should_panic]
 fn test_invalid_break_target() {
     let src = r#"
         while (false) {
@@ -439,7 +438,7 @@ fn test_invalid_break_target() {
         }
         "#;
 
-    let _ = &exec(src);
+    assert!(Context::default().eval(src).is_err());
 }
 
 #[test]


### PR DESCRIPTION
This Pull Request is related to #1873.

It changes the following:

- Removes the panic in case a label is not found. I think this should be an early syntax error, but at least we shouldn't panic while we fix the issue with the labels.

I think we should solve the issue with labeled statements for 0.15.