### PR TITLE
[Merged by Bors] - Make `Error` and `%NativeError%` spec compliant

### DIFF
--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -12,7 +12,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     context::StandardObjects,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsObject, ObjectData,
@@ -21,6 +21,8 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
+
+use super::Error;
 
 /// JavaScript `EvalError` impleentation.
 #[derive(Debug, Clone, Copy)]
@@ -64,14 +66,29 @@ impl EvalError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::error());
-        if let Some(message) = args.get(0) {
-            if !message.is_undefined() {
-                obj.set("message", message.to_string(context)?, false, context)?;
-            }
+        // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
+        // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
+        let prototype = get_prototype_from_constructor(
+            new_target,
+            StandardObjects::eval_error_object,
+            context,
+        )?;
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+
+        // 3. If message is not undefined, then
+        let message = args.get_or_undefined(0);
+        if !message.is_undefined() {
+            // a. Let msg be ? ToString(message).
+            let msg = message.to_string(context)?;
+
+            // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+            o.create_non_enumerable_data_property_or_throw("message", msg, context);
         }
-        Ok(obj.into())
+
+        // 4. Perform ? InstallErrorCause(O, options).
+        Error::install_error_cause(&o, args.get_or_undefined(1), context)?;
+
+        // 5. Return O.
+        Ok(o.into())
     }
 }

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -10,7 +10,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     context::StandardObjects,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsObject, ObjectData,
@@ -19,6 +19,8 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
+
+use super::Error;
 
 /// JavaScript `RangeError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -62,14 +64,29 @@ impl RangeError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::error());
-        if let Some(message) = args.get(0) {
-            if !message.is_undefined() {
-                obj.set("message", message.to_string(context)?, false, context)?;
-            }
+        // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
+        // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
+        let prototype = get_prototype_from_constructor(
+            new_target,
+            StandardObjects::range_error_object,
+            context,
+        )?;
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+
+        // 3. If message is not undefined, then
+        let message = args.get_or_undefined(0);
+        if !message.is_undefined() {
+            // a. Let msg be ? ToString(message).
+            let msg = message.to_string(context)?;
+
+            // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+            o.create_non_enumerable_data_property_or_throw("message", msg, context);
         }
-        Ok(obj.into())
+
+        // 4. Perform ? InstallErrorCause(O, options).
+        Error::install_error_cause(&o, args.get_or_undefined(1), context)?;
+
+        // 5. Return O.
+        Ok(o.into())
     }
 }

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -10,7 +10,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     context::StandardObjects,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsObject, ObjectData,
@@ -19,6 +19,8 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
+
+use super::Error;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReferenceError;
@@ -61,14 +63,29 @@ impl ReferenceError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::error());
-        if let Some(message) = args.get(0) {
-            if !message.is_undefined() {
-                obj.set("message", message.to_string(context)?, false, context)?;
-            }
+        // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
+        // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
+        let prototype = get_prototype_from_constructor(
+            new_target,
+            StandardObjects::reference_error_object,
+            context,
+        )?;
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+
+        // 3. If message is not undefined, then
+        let message = args.get_or_undefined(0);
+        if !message.is_undefined() {
+            // a. Let msg be ? ToString(message).
+            let msg = message.to_string(context)?;
+
+            // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+            o.create_non_enumerable_data_property_or_throw("message", msg, context);
         }
-        Ok(obj.into())
+
+        // 4. Perform ? InstallErrorCause(O, options).
+        Error::install_error_cause(&o, args.get_or_undefined(1), context)?;
+
+        // 5. Return O.
+        Ok(o.into())
     }
 }

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -12,7 +12,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     context::StandardObjects,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsObject, ObjectData,
@@ -21,6 +21,8 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
+
+use super::Error;
 
 /// JavaScript `SyntaxError` impleentation.
 #[derive(Debug, Clone, Copy)]
@@ -64,14 +66,29 @@ impl SyntaxError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::error());
-        if let Some(message) = args.get(0) {
-            if !message.is_undefined() {
-                obj.set("message", message.to_string(context)?, false, context)?;
-            }
+        // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
+        // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
+        let prototype = get_prototype_from_constructor(
+            new_target,
+            StandardObjects::syntax_error_object,
+            context,
+        )?;
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+
+        // 3. If message is not undefined, then
+        let message = args.get_or_undefined(0);
+        if !message.is_undefined() {
+            // a. Let msg be ? ToString(message).
+            let msg = message.to_string(context)?;
+
+            // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+            o.create_non_enumerable_data_property_or_throw("message", msg, context);
         }
-        Ok(obj.into())
+
+        // 4. Perform ? InstallErrorCause(O, options).
+        Error::install_error_cause(&o, args.get_or_undefined(1), context)?;
+
+        // 5. Return O.
+        Ok(o.into())
     }
 }

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -11,7 +11,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError
 
 use crate::{
-    builtins::BuiltIn,
+    builtins::{BuiltIn, JsArgs},
     context::StandardObjects,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsObject, ObjectData,
@@ -20,6 +20,8 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
+
+use super::Error;
 
 /// JavaScript `URIError` impleentation.
 #[derive(Debug, Clone, Copy)]
@@ -63,14 +65,26 @@ impl UriError {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
+        // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
+        // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
-            get_prototype_from_constructor(new_target, StandardObjects::error_object, context)?;
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::error());
-        if let Some(message) = args.get(0) {
-            if !message.is_undefined() {
-                obj.set("message", message.to_string(context)?, false, context)?;
-            }
+            get_prototype_from_constructor(new_target, StandardObjects::uri_error_object, context)?;
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+
+        // 3. If message is not undefined, then
+        let message = args.get_or_undefined(0);
+        if !message.is_undefined() {
+            // a. Let msg be ? ToString(message).
+            let msg = message.to_string(context)?;
+
+            // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "message", msg).
+            o.create_non_enumerable_data_property_or_throw("message", msg, context);
         }
-        Ok(obj.into())
+
+        // 4. Perform ? InstallErrorCause(O, options).
+        Error::install_error_cause(&o, args.get_or_undefined(1), context)?;
+
+        // 5. Return O.
+        Ok(o.into())
     }
 }


### PR DESCRIPTION
This PR makes `Error` and `%NativeError%` spec compliant.

It changes the following:
- Adds cause argument object.
- Makes `message` non-enumerable.