### PR TITLE
`%NativeError%.[[prototype]]` should be `Error` constructor

### DIFF
--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -38,7 +38,9 @@ impl BuiltIn for EvalError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let eval_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -48,6 +50,7 @@ impl BuiltIn for EvalError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -36,7 +36,9 @@ impl BuiltIn for RangeError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let range_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -46,6 +48,7 @@ impl BuiltIn for RangeError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -35,7 +35,9 @@ impl BuiltIn for ReferenceError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let reference_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -45,6 +47,7 @@ impl BuiltIn for ReferenceError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -38,7 +38,9 @@ impl BuiltIn for SyntaxError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let syntax_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -48,6 +50,7 @@ impl BuiltIn for SyntaxError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -42,7 +42,9 @@ impl BuiltIn for TypeError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let type_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -52,6 +54,7 @@ impl BuiltIn for TypeError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -37,7 +37,9 @@ impl BuiltIn for UriError {
     fn init(context: &mut Context) -> JsValue {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
+        let error_constructor = context.standard_objects().error_object().constructor();
         let error_prototype = context.standard_objects().error_object().prototype();
+
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
         let uri_error_object = ConstructorBuilder::with_standard_object(
             context,
@@ -47,6 +49,7 @@ impl BuiltIn for UriError {
         .name(Self::NAME)
         .length(Self::LENGTH)
         .inherit(error_prototype)
+        .custom_prototype(error_constructor)
         .property("name", Self::NAME, attribute)
         .property("message", "", attribute)
         .build();


### PR DESCRIPTION
Before the `%NativeError%` objects (like `TypeError`, `ReferenceError`, etc) `[[prototype]]` field was set to `Function.prototype` but this is wrong it should be the `Error` constructor object itself.