### PR TITLE
[Merged by Bors] - Fix `PropertyKey` to `JsValue` conversion

### DIFF
--- a/boa_engine/src/property/mod.rs
+++ b/boa_engine/src/property/mod.rs
@@ -580,13 +580,7 @@ impl From<PropertyKey> for JsValue {
         match property_key {
             PropertyKey::String(ref string) => string.clone().into(),
             PropertyKey::Symbol(ref symbol) => symbol.clone().into(),
-            PropertyKey::Index(index) => {
-                if let Ok(integer) = i32::try_from(index) {
-                    Self::new(integer)
-                } else {
-                    Self::new(index)
-                }
-            }
+            PropertyKey::Index(index) => index.to_string().into(),
         }
     }
 }


### PR DESCRIPTION
We store string `PropertyKey`s with two enums `String` and `Index` for performance reasons, but the spec does not differentiate between string and index property keys so before conversion to `JsValue` we have to convert to a string.

This was failing tests like `Reflect.ownKeys([true, "", 1])` because it was returning (integer numbers) `[1, 2, 3]` instead of `['1', '2', '3']`