### PR TITLE
[Merged by Bors] - Fix `BigInt` and `Number` comparison

### DIFF
--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -538,7 +538,7 @@ impl JsValue {
                             }
 
                             if let Ok(y) = JsBigInt::try_from(y) {
-                            	return Ok((*x < y).into());
+                                return Ok((*x < y).into());
                             }
 
                             (x.to_f64() < y).into()
@@ -552,7 +552,7 @@ impl JsValue {
                             }
 
                             if let Ok(x) = JsBigInt::try_from(x) {
-                            	return Ok((x < *y).into());
+                                return Ok((x < *y).into());
                             }
 
                             (x < y.to_f64()).into()

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -536,13 +536,12 @@ impl JsValue {
                             if y.is_infinite() {
                                 return Ok(y.is_sign_positive().into());
                             }
-                            let n = if y.is_sign_negative() {
-                                y.floor()
-                            } else {
-                                y.ceil()
-                            };
-                            (*x < JsBigInt::try_from(n).expect("invalid conversion to BigInt"))
-                                .into()
+
+                            if let Ok(y) = JsBigInt::try_from(y) {
+                            	return Ok((*x < y).into());
+                            }
+
+                            (x.to_f64() < y).into()
                         }
                         (Numeric::Number(x), Numeric::BigInt(ref y)) => {
                             if x.is_nan() {
@@ -551,13 +550,12 @@ impl JsValue {
                             if x.is_infinite() {
                                 return Ok(x.is_sign_negative().into());
                             }
-                            let n = if x.is_sign_negative() {
-                                x.floor()
-                            } else {
-                                x.ceil()
-                            };
-                            (JsBigInt::try_from(n).expect("invalid conversion to BigInt") < *y)
-                                .into()
+
+                            if let Ok(x) = JsBigInt::try_from(x) {
+                            	return Ok((x < *y).into());
+                            }
+
+                            (x < y.to_f64()).into()
                         }
                     },
                 }


### PR DESCRIPTION
Fixes `BigInt` and `Number` comparison, and vice versa. Before we were removing the decimal point of the floating-point number which was causing cases like `0.000001 > 0n` (or `0n < 0.000001`) to fail.