### PR TITLE
Avoid returning clones of pointer types on `JsValue` methods

### DIFF
--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -64,7 +64,7 @@ impl ArrayIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let array_iterator = this.as_object();
-        let mut array_iterator = array_iterator.map(JsObject::borrow_mut);
+        let mut array_iterator = array_iterator.as_deref().map(JsObject::borrow_mut);
         let array_iterator = array_iterator
             .as_mut()
             .and_then(|obj| obj.as_array_iterator_mut())

--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -64,7 +64,7 @@ impl ArrayIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let array_iterator = this.as_object();
-        let mut array_iterator = array_iterator.as_ref().map(JsObject::borrow_mut);
+        let mut array_iterator = array_iterator.map(JsObject::borrow_mut);
         let array_iterator = array_iterator
             .as_mut()
             .and_then(|obj| obj.as_array_iterator_mut())

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -416,6 +416,7 @@ impl Array {
             Some(constructor) => constructor
                 .construct(&[len.into()], this, context)?
                 .as_object()
+                .as_deref()
                 .cloned()
                 .ok_or_else(|| {
                     context.construct_type_error("object constructor didn't return an object")
@@ -1537,7 +1538,7 @@ impl Array {
             source_len as u64,
             0,
             1,
-            Some(mapper_function),
+            Some(&mapper_function),
             args.get_or_undefined(1),
             context,
         )?;
@@ -1627,7 +1628,7 @@ impl Array {
                     // 4. Set targetIndex to ? FlattenIntoArray(target, element, elementLen, targetIndex, newDepth)
                     target_index = Self::flatten_into_array(
                         target,
-                        element,
+                        &element,
                         element_len as u64,
                         target_index,
                         new_depth,
@@ -2193,7 +2194,7 @@ impl Array {
                 }
 
                 // 4. If comparefn is not undefined, then
-                if let Some(cmp) = comparefn {
+                if let Some(ref cmp) = comparefn {
                     let args = [x.clone(), y.clone()];
                     // a. Let v be ? ToNumber(? Call(comparefn, undefined, « x, y »)).
                     let v = cmp

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -363,7 +363,8 @@ impl Array {
             Ok(
                 c.construct(&[JsValue::new(length)], &c.clone().into(), context)?
                     .as_object()
-                    .expect("constructing an object should always return an object"),
+                    .expect("constructing an object should always return an object")
+                    .clone(),
             )
         } else {
             context.throw_type_error("Symbol.species must be a constructor")
@@ -415,6 +416,7 @@ impl Array {
             Some(constructor) => constructor
                 .construct(&[len.into()], this, context)?
                 .as_object()
+                .cloned()
                 .ok_or_else(|| {
                     context.construct_type_error("object constructor didn't return an object")
                 })?,
@@ -1535,7 +1537,7 @@ impl Array {
             source_len as u64,
             0,
             1,
-            Some(&mapper_function),
+            Some(mapper_function),
             args.get_or_undefined(1),
             context,
         )?;
@@ -1625,7 +1627,7 @@ impl Array {
                     // 4. Set targetIndex to ? FlattenIntoArray(target, element, elementLen, targetIndex, newDepth)
                     target_index = Self::flatten_into_array(
                         target,
-                        &element,
+                        element,
                         element_len as u64,
                         target_index,
                         new_depth,
@@ -2191,7 +2193,7 @@ impl Array {
                 }
 
                 // 4. If comparefn is not undefined, then
-                if let Some(ref cmp) = comparefn {
+                if let Some(cmp) = comparefn {
                     let args = [x.clone(), y.clone()];
                     // a. Let v be ? ToNumber(? Call(comparefn, undefined, « x, y »)).
                     let v = cmp

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -236,7 +236,7 @@ impl ArrayBuffer {
         let new = ctor.construct(&[new_len.into()], &ctor.clone().into(), context)?;
 
         // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
-        let new_obj = new.as_object().cloned().ok_or_else(|| {
+        let new_obj = new.as_object().as_deref().cloned().ok_or_else(|| {
             context.construct_type_error("ArrayBuffer constructor returned non-object value")
         })?;
 

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -236,7 +236,7 @@ impl ArrayBuffer {
         let new = ctor.construct(&[new_len.into()], &ctor.clone().into(), context)?;
 
         // 17. Perform ? RequireInternalSlot(new, [[ArrayBufferData]]).
-        let new_obj = new.as_object().ok_or_else(|| {
+        let new_obj = new.as_object().cloned().ok_or_else(|| {
             context.construct_type_error("ArrayBuffer constructor returned non-object value")
         })?;
 

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -127,6 +127,7 @@ impl BigInt {
         value
             // 1. If Type(value) is BigInt, return value.
             .as_bigint()
+            .as_deref()
             .cloned()
             // 2. If Type(value) is Object and value has a [[BigIntData]] internal slot, then
             //    a. Assert: Type(value.[[BigIntData]]) is BigInt.

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -127,6 +127,7 @@ impl BigInt {
         value
             // 1. If Type(value) is BigInt, return value.
             .as_bigint()
+            .cloned()
             // 2. If Type(value) is Object and value has a [[BigIntData]] internal slot, then
             //    a. Assert: Type(value.[[BigIntData]]) is BigInt.
             //    b. Return value.[[BigIntData]].

--- a/boa_engine/src/builtins/boolean/tests.rs
+++ b/boa_engine/src/builtins/boolean/tests.rs
@@ -60,6 +60,6 @@ fn instances_have_correct_proto_set() {
 
     assert_eq!(
         &*bool_instance.as_object().unwrap().prototype(),
-        &bool_prototype.as_object()
+        &bool_prototype.as_object().cloned()
     );
 }

--- a/boa_engine/src/builtins/boolean/tests.rs
+++ b/boa_engine/src/builtins/boolean/tests.rs
@@ -60,6 +60,6 @@ fn instances_have_correct_proto_set() {
 
     assert_eq!(
         &*bool_instance.as_object().unwrap().prototype(),
-        &bool_prototype.as_object().cloned()
+        &bool_prototype.as_object().as_deref().cloned()
     );
 }

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -197,7 +197,8 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object().map(JsObject::borrow);
+        let dataview = this.as_object();
+        let dataview = dataview.as_deref().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -226,7 +227,8 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object().map(JsObject::borrow);
+        let dataview = this.as_object();
+        let dataview = dataview.as_deref().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -265,7 +267,8 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object().map(JsObject::borrow);
+        let dataview = this.as_object();
+        let dataview = dataview.as_deref().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -305,7 +308,8 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view.as_object().map(JsObject::borrow);
+        let view = view.as_object();
+        let view = view.as_deref().map(JsObject::borrow);
         let view = view
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -664,7 +668,8 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view.as_object().map(JsObject::borrow);
+        let view = view.as_object();
+        let view = view.as_deref().map(JsObject::borrow);
         let view = view
             .as_ref()
             .and_then(|obj| obj.as_data_view())

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -167,7 +167,7 @@ impl DataView {
             prototype,
             ObjectData::data_view(Self {
                 // 11. Set O.[[ViewedArrayBuffer]] to buffer.
-                viewed_array_buffer: buffer_obj,
+                viewed_array_buffer: buffer_obj.clone(),
                 // 12. Set O.[[ByteLength]] to viewByteLength.
                 byte_length: view_byte_length,
                 // 13. Set O.[[ByteOffset]] to offset.
@@ -197,8 +197,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object();
-        let dataview = dataview.as_ref().map(JsObject::borrow);
+        let dataview = this.as_object().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -227,8 +226,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object();
-        let dataview = dataview.as_ref().map(JsObject::borrow);
+        let dataview = this.as_object().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -267,8 +265,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
-        let dataview = this.as_object();
-        let dataview = dataview.as_ref().map(JsObject::borrow);
+        let dataview = this.as_object().map(JsObject::borrow);
         let dataview = dataview
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -308,8 +305,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view.as_object();
-        let view = view.as_ref().map(JsObject::borrow);
+        let view = view.as_object().map(JsObject::borrow);
         let view = view
             .as_ref()
             .and_then(|obj| obj.as_data_view())
@@ -668,8 +664,7 @@ impl DataView {
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
-        let view = view.as_object();
-        let view = view.as_ref().map(JsObject::borrow);
+        let view = view.as_object().map(JsObject::borrow);
         let view = view
             .as_ref()
             .and_then(|obj| obj.as_data_view())

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -404,7 +404,7 @@ impl Date {
             dt.0
         } else {
             let tv = value.to_primitive(context, PreferredType::Default)?;
-            if let JsVariant::String(str) = tv.variant() {
+            if let JsVariant::String(ref str) = tv.variant() {
                 match chrono::DateTime::parse_from_rfc3339(str) {
                     Ok(dt) => Some(dt.naive_utc()),
                     _ => None,
@@ -523,7 +523,7 @@ impl Date {
 
         let hint = args.get_or_undefined(0);
 
-        let try_first = match hint.as_string().map(JsString::as_str) {
+        let try_first = match hint.as_string().as_deref().map(JsString::as_str) {
             // 3. If hint is "string" or "default", then
             // a. Let tryFirst be string.
             Some("string" | "default") => PreferredType::String,

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -404,7 +404,7 @@ impl Date {
             dt.0
         } else {
             let tv = value.to_primitive(context, PreferredType::Default)?;
-            if let JsVariant::String(ref str) = tv.variant() {
+            if let JsVariant::String(str) = tv.variant() {
                 match chrono::DateTime::parse_from_rfc3339(str) {
                     Ok(dt) => Some(dt.naive_utc()),
                     _ => None,
@@ -523,7 +523,7 @@ impl Date {
 
         let hint = args.get_or_undefined(0);
 
-        let try_first = match hint.as_string().as_ref().map(JsString::as_str) {
+        let try_first = match hint.as_string().map(JsString::as_str) {
             // 3. If hint is "string" or "default", then
             // a. Let tryFirst be string.
             Some("string" | "default") => PreferredType::String,

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -392,7 +392,7 @@ impl BuiltInFunctionObject {
         let target_name = target.get("name", context)?;
 
         // 9. If Type(targetName) is not String, set targetName to the empty String.
-        let target_name = target_name.as_string().unwrap_or_default();
+        let target_name = target_name.as_string().cloned().unwrap_or_default();
 
         // 10. Perform SetFunctionName(F, targetName, "bound").
         set_function_name(&f, &target_name.into(), Some("bound"), context);
@@ -428,8 +428,7 @@ impl BuiltInFunctionObject {
 
     #[allow(clippy::wrong_self_convention)]
     fn to_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object();
-        let object = object.as_ref().map(JsObject::borrow);
+        let object = this.as_object().map(JsObject::borrow);
         let function = object
             .as_deref()
             .and_then(Object::as_function)

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -392,7 +392,11 @@ impl BuiltInFunctionObject {
         let target_name = target.get("name", context)?;
 
         // 9. If Type(targetName) is not String, set targetName to the empty String.
-        let target_name = target_name.as_string().cloned().unwrap_or_default();
+        let target_name = target_name
+            .as_string()
+            .as_deref()
+            .cloned()
+            .unwrap_or_default();
 
         // 10. Perform SetFunctionName(F, targetName, "bound").
         set_function_name(&f, &target_name.into(), Some("bound"), context);
@@ -428,7 +432,8 @@ impl BuiltInFunctionObject {
 
     #[allow(clippy::wrong_self_convention)]
     fn to_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let object = this.as_object().map(JsObject::borrow);
+        let object = this.as_object();
+        let object = object.as_deref().map(JsObject::borrow);
         let function = object
             .as_deref()
             .and_then(Object::as_function)

--- a/boa_engine/src/builtins/function/tests.rs
+++ b/boa_engine/src/builtins/function/tests.rs
@@ -129,7 +129,7 @@ fn function_prototype_call() {
         "#;
     let value = forward_val(&mut context, func).unwrap();
     assert!(value.is_string());
-    assert_eq!(value.as_string().unwrap(), "[object Error]");
+    assert_eq!(*value.as_string().unwrap(), "[object Error]");
 }
 
 #[test]
@@ -246,7 +246,7 @@ fn closure_capture_clone() {
                 object
                     .__get_own_property__(&"key".into(), context)?
                     .and_then(|prop| prop.value().cloned())
-                    .and_then(|val| val.as_string().cloned())
+                    .and_then(|val| val.as_string().as_deref().cloned())
                     .ok_or_else(|| context.construct_type_error("invalid `key` property"))?,
             );
             Ok(hw.into())

--- a/boa_engine/src/builtins/function/tests.rs
+++ b/boa_engine/src/builtins/function/tests.rs
@@ -246,7 +246,7 @@ fn closure_capture_clone() {
                 object
                     .__get_own_property__(&"key".into(), context)?
                     .and_then(|prop| prop.value().cloned())
-                    .and_then(|val| val.as_string())
+                    .and_then(|val| val.as_string().cloned())
                     .ok_or_else(|| context.construct_type_error("invalid `key` property"))?,
             );
             Ok(hw.into())

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -145,7 +145,7 @@ impl Generator {
         // 1. Return ? GeneratorResume(this value, value, empty).
         match this.as_object() {
             Some(obj) if obj.is_generator() => {
-                Self::generator_resume(&obj, args.get_or_undefined(0), context)
+                Self::generator_resume(obj, args.get_or_undefined(0), context)
             }
             _ => context.throw_type_error("Generator.prototype.next called on non generator"),
         }

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -144,7 +144,7 @@ impl Generator {
     ) -> JsResult<JsValue> {
         // 1. Return ? GeneratorResume(this value, value, empty).
         match this.as_object() {
-            Some(obj) if obj.is_generator() => {
+            Some(ref obj) if obj.is_generator() => {
                 Self::generator_resume(obj, args.get_or_undefined(0), context)
             }
             _ => context.throw_type_error("Generator.prototype.next called on non generator"),

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -285,7 +285,7 @@ impl IteratorRecord {
         // 3. If Type(result) is not Object, throw a TypeError exception.
         // 4. Return result.
         if let Some(o) = result.as_object() {
-            Ok(IteratorResult { object: o })
+            Ok(IteratorResult { object: o.clone() })
         } else {
             context.throw_type_error("next value should be an object")
         }

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -108,7 +108,7 @@ impl Json {
                 .expect("CreateDataPropertyOrThrow should never throw here");
 
             // d. Return ? InternalizeJSONProperty(root, rootName, reviver).
-            Self::internalize_json_property(&root, "".into(), &obj, context)
+            Self::internalize_json_property(&root, "".into(), obj, context)
         } else {
             // 12. Else,
             // a. Return unfiltered.
@@ -144,7 +144,7 @@ impl Json {
                     // 1. Let prop be ! ToString(𝔽(I)).
                     // 2. Let newElement be ? InternalizeJSONProperty(val, prop, reviver).
                     let new_element = Self::internalize_json_property(
-                        &obj,
+                        obj,
                         i.to_string().into(),
                         reviver,
                         context,
@@ -176,7 +176,7 @@ impl Json {
 
                     // 1. Let newElement be ? InternalizeJSONProperty(val, P, reviver).
                     let new_element =
-                        Self::internalize_json_property(&obj, p.clone(), reviver, context)?;
+                        Self::internalize_json_property(obj, p.clone(), reviver, context)?;
 
                     // 2. If newElement is undefined, then
                     if new_element.is_undefined() {
@@ -391,7 +391,7 @@ impl Json {
         }
 
         // 4. If Type(value) is Object, then
-        if let Some(obj) = value.as_object() {
+        if let Some(obj) = value.as_object().cloned() {
             // a. If value has a [[NumberData]] internal slot, then
             if obj.is_number() {
                 // i. Set value to ? ToNumber(value).
@@ -431,7 +431,7 @@ impl Json {
 
         // 8. If Type(value) is String, return QuoteJSONString(value).
         if let Some(s) = value.as_string() {
-            return Ok(Some(Self::quote_json_string(&s)));
+            return Ok(Some(Self::quote_json_string(s)));
         }
 
         // 9. If Type(value) is Number, then
@@ -461,9 +461,9 @@ impl Json {
                 // b. If isArray is true, return ? SerializeJSONArray(state, value).
                 // c. Return ? SerializeJSONObject(state, value).
                 return if obj.is_array_abstract(context)? {
-                    Ok(Some(Self::serialize_json_array(state, &obj, context)?))
+                    Ok(Some(Self::serialize_json_array(state, obj, context)?))
                 } else {
-                    Ok(Some(Self::serialize_json_object(state, &obj, context)?))
+                    Ok(Some(Self::serialize_json_object(state, obj, context)?))
                 };
             }
         }

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -98,7 +98,7 @@ impl Json {
         let unfiltered = context.eval(script_string.as_bytes())?;
 
         // 11. If IsCallable(reviver) is true, then
-        if let Some(obj) = args.get_or_undefined(1).as_callable() {
+        if let Some(ref obj) = args.get_or_undefined(1).as_callable() {
             // a. Let root be ! OrdinaryObjectCreate(%Object.prototype%).
             let root = context.construct_object();
 
@@ -132,7 +132,7 @@ impl Json {
         let val = holder.get(name.clone(), context)?;
 
         // 2. If Type(val) is Object, then
-        if let Some(obj) = val.as_object() {
+        if let Some(ref obj) = val.as_object() {
             // a. Let isArray be ? IsArray(val).
             // b. If isArray is true, then
             if obj.is_array_abstract(context)? {
@@ -391,7 +391,7 @@ impl Json {
         }
 
         // 4. If Type(value) is Object, then
-        if let Some(obj) = value.as_object().cloned() {
+        if let Some(obj) = value.as_object().as_deref().cloned() {
             // a. If value has a [[NumberData]] internal slot, then
             if obj.is_number() {
                 // i. Set value to ? ToNumber(value).
@@ -430,7 +430,7 @@ impl Json {
         }
 
         // 8. If Type(value) is String, return QuoteJSONString(value).
-        if let Some(s) = value.as_string() {
+        if let Some(ref s) = value.as_string() {
             return Ok(Some(Self::quote_json_string(s)));
         }
 
@@ -455,7 +455,7 @@ impl Json {
         }
 
         // 11. If Type(value) is Object and IsCallable(value) is false, then
-        if let Some(obj) = value.as_object() {
+        if let Some(ref obj) = value.as_object() {
             if !obj.is_callable() {
                 // a. Let isArray be ? IsArray(value).
                 // b. If isArray is true, return ? SerializeJSONArray(state, value).

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -67,7 +67,8 @@ impl MapIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut map_iterator = this.as_object().map(JsObject::borrow_mut);
+        let map_iterator = this.as_object();
+        let mut map_iterator = map_iterator.as_deref().map(JsObject::borrow_mut);
         let map_iterator = map_iterator
             .as_mut()
             .and_then(|obj| obj.as_map_iterator_mut())

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -67,8 +67,7 @@ impl MapIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let map_iterator = this.as_object();
-        let mut map_iterator = map_iterator.as_ref().map(JsObject::borrow_mut);
+        let mut map_iterator = this.as_object().map(JsObject::borrow_mut);
         let map_iterator = map_iterator
             .as_mut()
             .and_then(|obj| obj.as_map_iterator_mut())

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -434,7 +434,7 @@ impl Map {
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         let map = this
             .as_object()
-            .filter(JsObject::is_map)
+            .filter(|obj| obj.is_map())
             .ok_or_else(|| context.construct_type_error("`this` is not a Map"))?;
 
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -63,8 +63,7 @@ impl ForInIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let iterator = this.as_object();
-        let mut iterator = iterator.as_ref().map(JsObject::borrow_mut);
+        let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_for_in_iterator_mut())

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -63,7 +63,8 @@ impl ForInIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut iterator = this.as_object().map(JsObject::borrow_mut);
+        let iterator = this.as_object();
+        let mut iterator = iterator.as_deref().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_for_in_iterator_mut())

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -137,7 +137,7 @@ impl Object {
 
         let obj = match prototype.variant() {
             JsVariant::Object(_) | JsVariant::Null => JsObject::from_proto_and_data(
-                prototype.as_object().cloned(),
+                prototype.as_object().as_deref().cloned(),
                 ObjectData::ordinary(),
             ),
             _ => {
@@ -453,7 +453,7 @@ impl Object {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         let arg = args.get_or_undefined(0);
-        if let Some(obj) = arg.as_object() {
+        if let Some(ref obj) = arg.as_object() {
             let props = args.get_or_undefined(1);
             object_define_properties(obj, props, context)?;
             Ok(arg.clone())
@@ -531,7 +531,8 @@ impl Object {
         let tag = o.get(WellKnownSymbols::to_string_tag(), context)?;
 
         // 16. If Type(tag) is not String, set tag to builtinTag.
-        let tag_str = tag.as_string().map_or(builtin_tag, JsString::as_str);
+        let tag_str = tag.as_string();
+        let tag_str = tag_str.as_deref().map_or(builtin_tag, JsString::as_str);
 
         // 17. Return the string-concatenation of "[object ", tag, and "]".
         Ok(format!("[object {tag_str}]").into())

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -116,7 +116,7 @@ impl Proxy {
         let p = JsObject::from_proto_and_data(
             context.standard_objects().object_object().prototype(),
             ObjectData::proxy(
-                Self::new(target.clone(), handler),
+                Self::new(target.clone(), handler.clone()),
                 target.is_callable(),
                 target.is_constructor(),
             ),

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -116,12 +116,7 @@ impl Reflect {
         }
 
         let new_target = if let Some(new_target) = args.get(2) {
-            if new_target
-                .as_object()
-                .as_ref()
-                .map(JsObject::is_constructor)
-                != Some(true)
-            {
+            if new_target.as_object().map(JsObject::is_constructor) != Some(true) {
                 return context.throw_type_error("newTarget must be constructor");
             }
             new_target.clone()
@@ -153,7 +148,7 @@ impl Reflect {
         let key = args.get_or_undefined(1).to_property_key(context)?;
         let prop_desc: JsValue = args
             .get(2)
-            .and_then(JsValue::as_object)
+            .and_then(|v| v.as_object().cloned())
             .ok_or_else(|| context.construct_type_error("property descriptor must be an object"))?
             .into();
 
@@ -390,7 +385,7 @@ impl Reflect {
             .and_then(JsValue::as_object)
             .ok_or_else(|| context.construct_type_error("target must be an object"))?;
         let proto = match args.get_or_undefined(1).variant() {
-            JsVariant::Object(ref obj) => Some(obj.clone()),
+            JsVariant::Object(obj) => Some(obj.clone()),
             JsVariant::Null => None,
             _ => return context.throw_type_error("proto must be an object or null"),
         };

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -116,7 +116,12 @@ impl Reflect {
         }
 
         let new_target = if let Some(new_target) = args.get(2) {
-            if new_target.as_object().map(JsObject::is_constructor) != Some(true) {
+            if new_target
+                .as_object()
+                .as_deref()
+                .map(JsObject::is_constructor)
+                != Some(true)
+            {
                 return context.throw_type_error("newTarget must be constructor");
             }
             new_target.clone()
@@ -148,7 +153,7 @@ impl Reflect {
         let key = args.get_or_undefined(1).to_property_key(context)?;
         let prop_desc: JsValue = args
             .get(2)
-            .and_then(|v| v.as_object().cloned())
+            .and_then(|v| v.as_object().as_deref().cloned())
             .ok_or_else(|| context.construct_type_error("property descriptor must be an object"))?
             .into();
 

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -185,13 +185,13 @@ impl RegExp {
         if new_target.is_undefined() {
             // a. Let newTarget be the active function object.
             // b. If patternIsRegExp is true and flags is undefined, then
-            if let Some(pattern) = pattern_is_regexp {
+            if let Some(ref pattern) = pattern_is_regexp {
                 if flags.is_undefined() {
                     // i. Let patternConstructor be ? Get(pattern, "constructor").
                     let pattern_constructor = pattern.get("constructor", context)?;
                     // ii. If SameValue(newTarget, patternConstructor) is true, return pattern.
                     if JsValue::same_value(new_target, &pattern_constructor) {
-                        return Ok(pattern.clone().into());
+                        return Ok((&**pattern).clone().into());
                     }
                 }
             }
@@ -334,7 +334,7 @@ impl RegExp {
 
     #[inline]
     fn regexp_has_flag(this: &JsValue, flag: u8, context: &mut Context) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
+        if let Some(ref object) = this.as_object() {
             if let Some(regexp) = object.borrow().as_regexp() {
                 return Ok(JsValue::new(match flag {
                     b'g' => regexp.flags.contains(RegExpFlags::GLOBAL),
@@ -652,7 +652,7 @@ impl RegExp {
             .to_string(context)?;
 
         // 4. Let match be ? RegExpExec(R, string).
-        let m = Self::abstract_exec(this, arg_str, context)?;
+        let m = Self::abstract_exec(&this, arg_str, context)?;
 
         // 5. If match is not null, return true; else return false.
         if m.is_some() {
@@ -692,7 +692,7 @@ impl RegExp {
         let arg_str = args.get_or_undefined(0).to_string(context)?;
 
         // 4. Return ? RegExpBuiltinExec(R, S).
-        if let Some(v) = Self::abstract_builtin_exec(obj, &arg_str, context)? {
+        if let Some(v) = Self::abstract_builtin_exec(&obj, &arg_str, context)? {
             Ok(v.into())
         } else {
             Ok(JsValue::null())
@@ -727,7 +727,7 @@ impl RegExp {
             }
 
             // c. Return result.
-            return Ok(result.as_object().cloned());
+            return Ok(result.as_object().as_deref().cloned());
         }
 
         // 5. Perform ? RequireInternalSlot(R, [[RegExpMatcher]]).
@@ -1004,7 +1004,7 @@ impl RegExp {
         #[allow(clippy::if_not_else)]
         if !global {
             // a. Return ? RegExpExec(rx, S).
-            if let Some(v) = Self::abstract_exec(rx, arg_str, context)? {
+            if let Some(v) = Self::abstract_exec(&rx, arg_str, context)? {
                 Ok(v.into())
             } else {
                 Ok(JsValue::null())
@@ -1029,7 +1029,7 @@ impl RegExp {
             // f. Repeat,
             loop {
                 // i. Let result be ? RegExpExec(rx, S).
-                let result = Self::abstract_exec(rx, arg_str.clone(), context)?;
+                let result = Self::abstract_exec(&rx, arg_str.clone(), context)?;
 
                 // ii. If result is null, then
                 // iii. Else,
@@ -1208,6 +1208,7 @@ impl RegExp {
         let mut replace_value = args.get_or_undefined(1).clone();
         let functional_replace = replace_value
             .as_object()
+            .as_deref()
             .map(JsObject::is_callable)
             .unwrap_or_default();
 
@@ -1237,7 +1238,7 @@ impl RegExp {
         // 11. Repeat, while done is false,
         loop {
             // a. Let result be ? RegExpExec(rx, S).
-            let result = Self::abstract_exec(rx, arg_str.clone(), context)?;
+            let result = Self::abstract_exec(&rx, arg_str.clone(), context)?;
 
             // b. If result is null, set done to true.
             // c. Else,
@@ -1455,7 +1456,7 @@ impl RegExp {
         }
 
         // 6. Let result be ? RegExpExec(rx, S).
-        let result = Self::abstract_exec(rx, arg_str, context)?;
+        let result = Self::abstract_exec(&rx, arg_str, context)?;
 
         // 7. Let currentLastIndex be ? Get(rx, "lastIndex").
         let current_last_index = rx.get("lastIndex", context)?;
@@ -1561,7 +1562,7 @@ impl RegExp {
         // 16. If size is 0, then
         if size == 0 {
             // a. Let z be ? RegExpExec(splitter, S).
-            let result = Self::abstract_exec(splitter, arg_str.clone(), context)?;
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
 
             // b. If z is not null, return A.
             if result.is_some() {
@@ -1587,7 +1588,7 @@ impl RegExp {
             splitter.set("lastIndex", JsValue::new(q), true, context)?;
 
             // b. Let z be ? RegExpExec(splitter, S).
-            let result = Self::abstract_exec(splitter, arg_str.clone(), context)?;
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
 
             // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
             // d. Else,

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -77,8 +77,7 @@ impl RegExpStringIterator {
     }
 
     pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let iterator = this.as_object();
-        let mut iterator = iterator.as_ref().map(JsObject::borrow_mut);
+        let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_regexp_string_iterator_mut())

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -77,7 +77,8 @@ impl RegExpStringIterator {
     }
 
     pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut iterator = this.as_object().map(JsObject::borrow_mut);
+        let iterator = this.as_object();
+        let mut iterator = iterator.as_deref().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_regexp_string_iterator_mut())

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -62,8 +62,7 @@ impl SetIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let set_iterator = this.as_object();
-        let mut set_iterator = set_iterator.as_ref().map(JsObject::borrow_mut);
+        let mut set_iterator = this.as_object().map(JsObject::borrow_mut);
 
         let set_iterator = set_iterator
             .as_mut()
@@ -82,8 +81,7 @@ impl SetIterator {
                 ));
             }
 
-            let entries = m.as_object();
-            let entries = entries.as_ref().map(JsObject::borrow);
+            let entries = m.as_object().map(JsObject::borrow);
             let entries = entries
                 .as_ref()
                 .and_then(|obj| obj.as_set_ref())

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -62,7 +62,8 @@ impl SetIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
     pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut set_iterator = this.as_object().map(JsObject::borrow_mut);
+        let set_iterator = this.as_object();
+        let mut set_iterator = set_iterator.as_deref().map(JsObject::borrow_mut);
 
         let set_iterator = set_iterator
             .as_mut()
@@ -81,7 +82,8 @@ impl SetIterator {
                 ));
             }
 
-            let entries = m.as_object().map(JsObject::borrow);
+            let entries = m.as_object();
+            let entries = entries.as_deref().map(JsObject::borrow);
             let entries = entries
                 .as_ref()
                 .and_then(|obj| obj.as_set_ref())

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -253,6 +253,7 @@ impl String {
     fn this_string_value(this: &JsValue, context: &mut Context) -> JsResult<JsString> {
         // 1. If Type(value) is String, return value.
         this.as_string()
+            .cloned()
             // 2. If Type(value) is Object and value has a [[StringData]] internal slot, then
             //     a. Let s be value.[[StringData]].
             //     b. Assert: Type(s) is String.
@@ -1005,7 +1006,6 @@ impl String {
         // 5. Let functionalReplace be IsCallable(replaceValue).
         let functional_replace = replace_value
             .as_object()
-            .as_ref()
             .map(JsObject::is_callable)
             .unwrap_or_default();
 
@@ -1101,7 +1101,7 @@ impl String {
             // a. Let isRegExp be ? IsRegExp(searchValue).
             if let Some(obj) = search_value.as_object() {
                 // b. If isRegExp is true, then
-                if is_reg_exp_object(&obj, context)? {
+                if is_reg_exp_object(obj, context)? {
                     // i. Let flags be ? Get(searchValue, "flags").
                     let flags = obj.get("flags", context)?;
 
@@ -1136,7 +1136,6 @@ impl String {
         // 5. Let functionalReplace be IsCallable(replaceValue).
         let functional_replace = replace_value
             .as_object()
-            .as_ref()
             .map(JsObject::is_callable)
             .unwrap_or_default();
 
@@ -1981,7 +1980,7 @@ impl String {
         if !regexp.is_null_or_undefined() {
             // a. Let isRegExp be ? IsRegExp(regexp).
             // b. If isRegExp is true, then
-            if let Some(regexp_obj) = regexp.as_object().filter(JsObject::is_regexp) {
+            if let Some(regexp_obj) = regexp.as_object().filter(|obj| obj.is_regexp()) {
                 // i. Let flags be ? Get(regexp, "flags").
                 let flags = regexp_obj.get("flags", context)?;
 
@@ -2209,7 +2208,7 @@ pub(crate) fn get_substitution(
                         result.push(second);
                         result.push(*third);
                     } else if let Some(capture) = captures.get(nn - 1) {
-                        if let Some(ref s) = capture.as_string() {
+                        if let Some(s) = capture.as_string() {
                             result.push_str(s);
                         }
                     }
@@ -2230,7 +2229,7 @@ pub(crate) fn get_substitution(
                         result.push('$');
                         result.push(second);
                     } else if let Some(capture) = captures.get(n - 1) {
-                        if let Some(ref s) = capture.as_string() {
+                        if let Some(s) = capture.as_string() {
                             result.push_str(s);
                         }
                     }
@@ -2346,7 +2345,7 @@ fn is_reg_exp(argument: &JsValue, context: &mut Context) -> JsResult<bool> {
         return Ok(false);
     };
 
-    is_reg_exp_object(&argument, context)
+    is_reg_exp_object(argument, context)
 }
 fn is_reg_exp_object(argument: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 2. Let matcher be ? Get(argument, @@match).

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -253,6 +253,7 @@ impl String {
     fn this_string_value(this: &JsValue, context: &mut Context) -> JsResult<JsString> {
         // 1. If Type(value) is String, return value.
         this.as_string()
+            .as_deref()
             .cloned()
             // 2. If Type(value) is Object and value has a [[StringData]] internal slot, then
             //     a. Let s be value.[[StringData]].
@@ -1006,6 +1007,7 @@ impl String {
         // 5. Let functionalReplace be IsCallable(replaceValue).
         let functional_replace = replace_value
             .as_object()
+            .as_deref()
             .map(JsObject::is_callable)
             .unwrap_or_default();
 
@@ -1099,7 +1101,7 @@ impl String {
         // 2. If searchValue is neither undefined nor null, then
         if !search_value.is_null_or_undefined() {
             // a. Let isRegExp be ? IsRegExp(searchValue).
-            if let Some(obj) = search_value.as_object() {
+            if let Some(ref obj) = search_value.as_object() {
                 // b. If isRegExp is true, then
                 if is_reg_exp_object(obj, context)? {
                     // i. Let flags be ? Get(searchValue, "flags").
@@ -1136,6 +1138,7 @@ impl String {
         // 5. Let functionalReplace be IsCallable(replaceValue).
         let functional_replace = replace_value
             .as_object()
+            .as_deref()
             .map(JsObject::is_callable)
             .unwrap_or_default();
 
@@ -2208,7 +2211,7 @@ pub(crate) fn get_substitution(
                         result.push(second);
                         result.push(*third);
                     } else if let Some(capture) = captures.get(nn - 1) {
-                        if let Some(s) = capture.as_string() {
+                        if let Some(ref s) = capture.as_string() {
                             result.push_str(s);
                         }
                     }
@@ -2229,7 +2232,7 @@ pub(crate) fn get_substitution(
                         result.push('$');
                         result.push(second);
                     } else if let Some(capture) = captures.get(n - 1) {
-                        if let Some(s) = capture.as_string() {
+                        if let Some(ref s) = capture.as_string() {
                             result.push_str(s);
                         }
                     }
@@ -2345,7 +2348,7 @@ fn is_reg_exp(argument: &JsValue, context: &mut Context) -> JsResult<bool> {
         return Ok(false);
     };
 
-    is_reg_exp_object(argument, context)
+    is_reg_exp_object(&argument, context)
 }
 fn is_reg_exp_object(argument: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 2. Let matcher be ? Get(argument, @@match).

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -33,8 +33,7 @@ impl StringIterator {
     }
 
     pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let string_iterator = this.as_object();
-        let mut string_iterator = string_iterator.as_ref().map(JsObject::borrow_mut);
+        let mut string_iterator = this.as_object().map(JsObject::borrow_mut);
         let string_iterator = string_iterator
             .as_mut()
             .and_then(|obj| obj.as_string_iterator_mut())

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -33,7 +33,8 @@ impl StringIterator {
     }
 
     pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let mut string_iterator = this.as_object().map(JsObject::borrow_mut);
+        let string_iterator = this.as_object();
+        let mut string_iterator = string_iterator.as_deref().map(JsObject::borrow_mut);
         let string_iterator = string_iterator
             .as_mut()
             .and_then(|obj| obj.as_string_iterator_mut())

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -190,6 +190,7 @@ impl Symbol {
     fn this_symbol_value(value: &JsValue, context: &mut Context) -> JsResult<JsSymbol> {
         value
             .as_symbol()
+            .cloned()
             .or_else(|| value.as_object().and_then(|obj| obj.borrow().as_symbol()))
             .ok_or_else(|| context.construct_type_error("'this' is not a Symbol"))
     }
@@ -312,7 +313,7 @@ impl Symbol {
             // 4. Return undefined.
             let symbol = GLOBAL_SYMBOL_REGISTRY.with(move |registry| {
                 let registry = registry.borrow();
-                registry.get_symbol(&sym)
+                registry.get_symbol(sym)
             });
 
             Ok(symbol.map(JsValue::from).unwrap_or_default())

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -190,6 +190,7 @@ impl Symbol {
     fn this_symbol_value(value: &JsValue, context: &mut Context) -> JsResult<JsSymbol> {
         value
             .as_symbol()
+            .as_deref()
             .cloned()
             .or_else(|| value.as_object().and_then(|obj| obj.borrow().as_symbol()))
             .ok_or_else(|| context.construct_type_error("'this' is not a Symbol"))
@@ -306,7 +307,7 @@ impl Symbol {
     ) -> JsResult<JsValue> {
         let sym = args.get_or_undefined(0);
         // 1. If Type(sym) is not Symbol, throw a TypeError exception.
-        if let Some(sym) = sym.as_symbol() {
+        if let Some(ref sym) = sym.as_symbol() {
             // 2. For each element e of the GlobalSymbolRegistry List (see 20.4.2.2), do
             //     a. If SameValue(e.[[Symbol]], sym) is true, return e.[[Key]].
             // 3. Assert: GlobalSymbolRegistry does not currently contain an entry for sym.

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -421,7 +421,7 @@ impl TypedArray {
 
             // b. Let len be the number of elements in values.
             // c. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-            let target_obj = Self::create(constructor, &[values.len().into()], context)?;
+            let target_obj = Self::create(&constructor, &[values.len().into()], context)?;
 
             // d. Let k be 0.
             // e. Repeat, while k < len,
@@ -457,7 +457,7 @@ impl TypedArray {
         let len = array_like.length_of_array_like(context)?;
 
         // 10. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let target_obj = Self::create(constructor, &[len.into()], context)?;
+        let target_obj = Self::create(&constructor, &[len.into()], context)?;
 
         // 11. Let k be 0.
         // 12. Repeat, while k < len,
@@ -503,7 +503,7 @@ impl TypedArray {
         };
 
         // 4. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let new_obj = Self::create(constructor, &[args.len().into()], context)?;
+        let new_obj = Self::create(&constructor, &[args.len().into()], context)?;
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -1063,7 +1063,7 @@ impl TypedArray {
         }
 
         // 9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(captured) »).
-        let a = Self::species_create(obj, o.typed_array_name(), &[captured.into()], context)?;
+        let a = Self::species_create(&obj, o.typed_array_name(), &[captured.into()], context)?;
 
         // 10. Let n be 0.
         // 11. For each element e of kept, do
@@ -1622,7 +1622,7 @@ impl TypedArray {
         };
 
         // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
-        let a = Self::species_create(obj, o.typed_array_name(), &[len.into()], context)?;
+        let a = Self::species_create(&obj, o.typed_array_name(), &[len.into()], context)?;
 
         // 6. Let k be 0.
         // 7. Repeat, while k < len,
@@ -1894,12 +1894,12 @@ impl TypedArray {
             // 6. If source is an Object that has a [[TypedArrayName]] internal slot, then
             JsVariant::Object(source) if source.is_typed_array() => {
                 // a. Perform ? SetTypedArrayFromTypedArray(target, targetOffset, source).
-                Self::set_typed_array_from_typed_array(target, target_offset, source, context)?;
+                Self::set_typed_array_from_typed_array(&target, target_offset, &source, context)?;
             }
             // 7. Else,
             _ => {
                 // a. Perform ? SetTypedArrayFromArrayLike(target, targetOffset, source).
-                Self::set_typed_array_from_array_like(target, target_offset, source, context)?;
+                Self::set_typed_array_from_array_like(&target, target_offset, source, context)?;
             }
         }
 
@@ -2291,7 +2291,7 @@ impl TypedArray {
         let count = std::cmp::max(r#final - k, 0) as usize;
 
         // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
-        let a = Self::species_create(obj, o.typed_array_name(), &[count.into()], context)?;
+        let a = Self::species_create(&obj, o.typed_array_name(), &[count.into()], context)?;
         let a_borrow = a.borrow();
         let a_array = a_borrow
             .as_typed_array()
@@ -2637,7 +2637,7 @@ impl TypedArray {
         let mut sort_err = Ok(());
         items.sort_by(|x, y| {
             if sort_err.is_ok() {
-                sort_compare(x, y, compare_fn, context).unwrap_or_else(|err| {
+                sort_compare(x, y, compare_fn.as_deref(), context).unwrap_or_else(|err| {
                     sort_err = Err(err);
                     Ordering::Equal
                 })
@@ -2737,7 +2737,7 @@ impl TypedArray {
         // 19. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
         // 20. Return ? TypedArraySpeciesCreate(O, argumentsList).
         Ok(Self::species_create(
-            obj,
+            &obj,
             o.typed_array_name(),
             &[
                 buffer.clone().into(),

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -421,7 +421,7 @@ impl TypedArray {
 
             // b. Let len be the number of elements in values.
             // c. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-            let target_obj = Self::create(&constructor, &[values.len().into()], context)?;
+            let target_obj = Self::create(constructor, &[values.len().into()], context)?;
 
             // d. Let k be 0.
             // e. Repeat, while k < len,
@@ -457,7 +457,7 @@ impl TypedArray {
         let len = array_like.length_of_array_like(context)?;
 
         // 10. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let target_obj = Self::create(&constructor, &[len.into()], context)?;
+        let target_obj = Self::create(constructor, &[len.into()], context)?;
 
         // 11. Let k be 0.
         // 12. Repeat, while k < len,
@@ -503,7 +503,7 @@ impl TypedArray {
         };
 
         // 4. Let newObj be ? TypedArrayCreate(C, « 𝔽(len) »).
-        let new_obj = Self::create(&constructor, &[args.len().into()], context)?;
+        let new_obj = Self::create(constructor, &[args.len().into()], context)?;
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -852,7 +852,7 @@ impl TypedArray {
 
         // 3. Return CreateArrayIterator(O, key+value).
         Ok(ArrayIterator::create_array_iterator(
-            o,
+            o.clone(),
             PropertyNameKind::KeyAndValue,
             context,
         ))
@@ -1063,7 +1063,7 @@ impl TypedArray {
         }
 
         // 9. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(captured) »).
-        let a = Self::species_create(&obj, o.typed_array_name(), &[captured.into()], context)?;
+        let a = Self::species_create(obj, o.typed_array_name(), &[captured.into()], context)?;
 
         // 10. Let n be 0.
         // 11. For each element e of kept, do
@@ -1479,7 +1479,7 @@ impl TypedArray {
 
         // 3. Return CreateArrayIterator(O, key).
         Ok(ArrayIterator::create_array_iterator(
-            o,
+            o.clone(),
             PropertyNameKind::Key,
             context,
         ))
@@ -1622,7 +1622,7 @@ impl TypedArray {
         };
 
         // 5. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(len) »).
-        let a = Self::species_create(&obj, o.typed_array_name(), &[len.into()], context)?;
+        let a = Self::species_create(obj, o.typed_array_name(), &[len.into()], context)?;
 
         // 6. Let k be 0.
         // 7. Repeat, while k < len,
@@ -1892,14 +1892,14 @@ impl TypedArray {
         let source = args.get_or_undefined(0);
         match source.variant() {
             // 6. If source is an Object that has a [[TypedArrayName]] internal slot, then
-            JsVariant::Object(ref source) if source.is_typed_array() => {
+            JsVariant::Object(source) if source.is_typed_array() => {
                 // a. Perform ? SetTypedArrayFromTypedArray(target, targetOffset, source).
-                Self::set_typed_array_from_typed_array(&target, target_offset, source, context)?;
+                Self::set_typed_array_from_typed_array(target, target_offset, source, context)?;
             }
             // 7. Else,
             _ => {
                 // a. Perform ? SetTypedArrayFromArrayLike(target, targetOffset, source).
-                Self::set_typed_array_from_array_like(&target, target_offset, source, context)?;
+                Self::set_typed_array_from_array_like(target, target_offset, source, context)?;
             }
         }
 
@@ -2291,7 +2291,7 @@ impl TypedArray {
         let count = std::cmp::max(r#final - k, 0) as usize;
 
         // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
-        let a = Self::species_create(&obj, o.typed_array_name(), &[count.into()], context)?;
+        let a = Self::species_create(obj, o.typed_array_name(), &[count.into()], context)?;
         let a_borrow = a.borrow();
         let a_array = a_borrow
             .as_typed_array()
@@ -2637,7 +2637,7 @@ impl TypedArray {
         let mut sort_err = Ok(());
         items.sort_by(|x, y| {
             if sort_err.is_ok() {
-                sort_compare(x, y, compare_fn.as_ref(), context).unwrap_or_else(|err| {
+                sort_compare(x, y, compare_fn, context).unwrap_or_else(|err| {
                     sort_err = Err(err);
                     Ordering::Equal
                 })
@@ -2737,7 +2737,7 @@ impl TypedArray {
         // 19. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
         // 20. Return ? TypedArraySpeciesCreate(O, argumentsList).
         Ok(Self::species_create(
-            &obj,
+            obj,
             o.typed_array_name(),
             &[
                 buffer.clone().into(),
@@ -2773,7 +2773,7 @@ impl TypedArray {
 
         // 3. Return CreateArrayIterator(O, value).
         Ok(ArrayIterator::create_array_iterator(
-            o,
+            o.clone(),
             PropertyNameKind::Value,
             context,
         ))

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -131,10 +131,10 @@ impl<T: Class> ClassConstructor for T {
 
         let prototype = this
             .as_object()
-            .cloned()
+            .as_deref()
             .map(|obj| {
                 obj.get(PROTOTYPE, context)
-                    .map(|val| val.as_object().cloned())
+                    .map(|val| val.as_object().as_deref().cloned())
             })
             .transpose()?
             .flatten()

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -121,7 +121,7 @@ impl<T: Class> ClassConstructor for T {
         };
         let class_prototype =
             if let Some(object) = class_constructor.get(PROTOTYPE, context)?.as_object() {
-                object
+                object.clone()
             } else {
                 return context.throw_type_error(format!(
                     "invalid default prototype for native class `{}`",
@@ -131,7 +131,11 @@ impl<T: Class> ClassConstructor for T {
 
         let prototype = this
             .as_object()
-            .map(|obj| obj.get(PROTOTYPE, context).map(|val| val.as_object()))
+            .cloned()
+            .map(|obj| {
+                obj.get(PROTOTYPE, context)
+                    .map(|val| val.as_object().cloned())
+            })
             .transpose()?
             .flatten()
             .unwrap_or(class_prototype);

--- a/boa_engine/src/context.rs
+++ b/boa_engine/src/context.rs
@@ -434,7 +434,8 @@ impl Default for Context {
             .get("prototype", &mut context)
             .expect("prototype must exist")
             .as_object()
-            .expect("prototype must be object");
+            .expect("prototype must be object")
+            .clone();
         context.typed_array_constructor.constructor = typed_array_constructor_constructor;
         context.typed_array_constructor.prototype = typed_array_constructor_prototype;
         context.iterator_prototypes = IteratorPrototypes::init(&mut context);

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -91,7 +91,9 @@ fn bound_function_exotic_construct(
 
     // 5. If SameValue(F, newTarget) is true, set newTarget to target.
     let new_target = match new_target.variant() {
-        JsVariant::Object(new_target) if JsObject::equals(obj, new_target) => target.clone().into(),
+        JsVariant::Object(ref new_target) if JsObject::equals(obj, new_target) => {
+            target.clone().into()
+        }
         _ => new_target.clone(),
     };
 

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -91,9 +91,7 @@ fn bound_function_exotic_construct(
 
     // 5. If SameValue(F, newTarget) is true, set newTarget to target.
     let new_target = match new_target.variant() {
-        JsVariant::Object(ref new_target) if JsObject::equals(obj, new_target) => {
-            target.clone().into()
-        }
+        JsVariant::Object(new_target) if JsObject::equals(obj, new_target) => target.clone().into(),
         _ => new_target.clone(),
     };
 

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -961,7 +961,7 @@ where
     // 2. Let proto be ? Get(constructor, "prototype").
     if let Some(object) = constructor.as_object() {
         if let Some(proto) = object.get(PROTOTYPE, context)?.as_object() {
-            return Ok(proto);
+            return Ok(proto.clone());
         }
     }
     // 3. If Type(proto) is not Object, then

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -98,7 +98,7 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 
     // 8. If Type(handlerProto) is neither Object nor Null, throw a TypeError exception.
     let handler_proto = match handler_proto.variant() {
-        JsVariant::Object(ref obj) => Some(obj.clone()),
+        JsVariant::Object(obj) => Some(obj.clone()),
         JsVariant::Null => None,
         _ => return context.throw_type_error("Proxy trap result is neither object nor null"),
     };
@@ -826,7 +826,7 @@ pub(crate) fn proxy_exotic_own_property_keys(
     let mut trap_result = Vec::new();
     for value in &trap_result_raw {
         match value.variant() {
-            JsVariant::String(ref s) => {
+            JsVariant::String(s) => {
                 if !unchecked_result_keys.insert(s.clone().into()) {
                     return context.throw_type_error(
                         "Proxy trap result contains duplicate string property keys",
@@ -834,7 +834,7 @@ pub(crate) fn proxy_exotic_own_property_keys(
                 }
                 trap_result.push(s.clone().into());
             }
-            JsVariant::Symbol(ref s) => {
+            JsVariant::Symbol(s) => {
                 if !unchecked_result_keys.insert(s.clone().into()) {
                     return context.throw_type_error(
                         "Proxy trap result contains duplicate symbol property keys",

--- a/boa_engine/src/object/jsarray.rs
+++ b/boa_engine/src/object/jsarray.rs
@@ -108,6 +108,7 @@ impl JsArray {
     pub fn concat(&self, items: &[JsValue], context: &mut Context) -> JsResult<Self> {
         let object = Array::concat(&self.inner.clone().into(), items, context)?
             .as_object()
+            .cloned()
             .expect("Array.prototype.filter should always return object");
 
         Self::from_object(object, context)
@@ -117,6 +118,7 @@ impl JsArray {
     pub fn join(&self, separator: Option<JsString>, context: &mut Context) -> JsResult<JsString> {
         Array::join(&self.inner.clone().into(), &[separator.into()], context).map(|x| {
             x.as_string()
+                .cloned()
                 .expect("Array.prototype.join always returns string")
         })
     }
@@ -219,6 +221,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .cloned()
         .expect("Array.prototype.filter should always return object");
 
         Self::from_object(object, context)
@@ -237,6 +240,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .cloned()
         .expect("Array.prototype.map should always return object");
 
         Self::from_object(object, context)
@@ -298,6 +302,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .cloned()
         .expect("Array.prototype.slice should always return object");
 
         Self::from_object(object, context)

--- a/boa_engine/src/object/jsarray.rs
+++ b/boa_engine/src/object/jsarray.rs
@@ -108,6 +108,7 @@ impl JsArray {
     pub fn concat(&self, items: &[JsValue], context: &mut Context) -> JsResult<Self> {
         let object = Array::concat(&self.inner.clone().into(), items, context)?
             .as_object()
+            .as_deref()
             .cloned()
             .expect("Array.prototype.filter should always return object");
 
@@ -118,6 +119,7 @@ impl JsArray {
     pub fn join(&self, separator: Option<JsString>, context: &mut Context) -> JsResult<JsString> {
         Array::join(&self.inner.clone().into(), &[separator.into()], context).map(|x| {
             x.as_string()
+                .as_deref()
                 .cloned()
                 .expect("Array.prototype.join always returns string")
         })
@@ -221,6 +223,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .as_deref()
         .cloned()
         .expect("Array.prototype.filter should always return object");
 
@@ -240,6 +243,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .as_deref()
         .cloned()
         .expect("Array.prototype.map should always return object");
 
@@ -302,6 +306,7 @@ impl JsArray {
             context,
         )?
         .as_object()
+        .as_deref()
         .cloned()
         .expect("Array.prototype.slice should always return object");
 

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -503,7 +503,7 @@ impl JsObject {
         // 7. If IsConstructor(S) is true, return S.
         // 8. Throw a TypeError exception.
         match s.as_object() {
-            Some(obj) if obj.is_constructor() => Ok(obj),
+            Some(obj) if obj.is_constructor() => Ok(obj.clone()),
             _ => context.throw_type_error("property 'constructor' is not a constructor"),
         }
     }
@@ -594,7 +594,7 @@ impl JsObject {
             // 3. If func is either undefined or null, return undefined.
             JsVariant::Undefined | JsVariant::Null => Ok(None),
             // 5. Return func.
-            JsVariant::Object(ref object) if object.is_callable() => Ok(Some(object.clone())),
+            JsVariant::Object(object) if object.is_callable() => Ok(Some(object.clone())),
             // 4. If IsCallable(func) is false, throw a TypeError exception.
             _ => {
                 context.throw_type_error("value returned for property of object is not a function")
@@ -802,7 +802,7 @@ impl JsValue {
         }
 
         let mut object = if let Some(obj) = object.as_object() {
-            obj
+            obj.clone()
         } else {
             // 3. If Type(O) is not Object, return false.
             return Ok(false);
@@ -829,7 +829,7 @@ impl JsValue {
             };
 
             // c. If SameValue(P, O) is true, return true.
-            if JsObject::equals(&object, &prototype) {
+            if JsObject::equals(&object, prototype) {
                 return Ok(true);
             }
         }

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -829,7 +829,7 @@ impl JsValue {
             };
 
             // c. If SameValue(P, O) is true, return true.
-            if JsObject::equals(&object, prototype) {
+            if JsObject::equals(&object, &prototype) {
                 return Ok(true);
             }
         }

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -805,9 +805,11 @@ mod in_operator {
         let foo_val = forward_val(&mut context, "Foo").unwrap();
         assert_eq!(
             *bar_obj.prototype(),
-            foo_val
+            foo_val.as_object().and_then(|obj| obj
+                .get("prototype", &mut context)
+                .unwrap()
                 .as_object()
-                .and_then(|obj| obj.get("prototype", &mut context).unwrap().as_object())
+                .cloned())
         );
     }
 }

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -809,6 +809,7 @@ mod in_operator {
                 .get("prototype", &mut context)
                 .unwrap()
                 .as_object()
+                .as_deref()
                 .cloned())
         );
     }

--- a/boa_engine/src/value/display.rs
+++ b/boa_engine/src/value/display.rs
@@ -288,13 +288,13 @@ impl Display for ValueDisplay<'_> {
                 Some(description) => write!(f, "Symbol({description})"),
                 None => write!(f, "Symbol()"),
             },
-            JsVariant::String(v) => write!(f, "\"{v}\""),
+            JsVariant::String(v) => write!(f, "\"{}\"", *v),
             JsVariant::Rational(v) => format_rational(v, f),
             JsVariant::Object(_) => {
                 write!(f, "{}", log_string_from(self.value, self.internals, true))
             }
             JsVariant::Integer(v) => write!(f, "{v}"),
-            JsVariant::BigInt(num) => write!(f, "{num}n"),
+            JsVariant::BigInt(num) => write!(f, "{}n", *num),
         }
     }
 }

--- a/boa_engine/src/value/display.rs
+++ b/boa_engine/src/value/display.rs
@@ -98,7 +98,7 @@ macro_rules! print_obj_value {
 pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children: bool) -> String {
     match x.variant() {
         // We don't want to print private (compiler) or prototype properties
-        JsVariant::Object(ref v) => {
+        JsVariant::Object(v) => {
             // Can use the private "type" field of an Object to match on
             // which type of Object it represents for special printing
             match v.borrow().kind() {
@@ -284,17 +284,17 @@ impl Display for ValueDisplay<'_> {
             JsVariant::Null => write!(f, "null"),
             JsVariant::Undefined => write!(f, "undefined"),
             JsVariant::Boolean(v) => write!(f, "{v}"),
-            JsVariant::Symbol(ref symbol) => match symbol.description() {
+            JsVariant::Symbol(symbol) => match symbol.description() {
                 Some(description) => write!(f, "Symbol({description})"),
                 None => write!(f, "Symbol()"),
             },
-            JsVariant::String(ref v) => write!(f, "\"{v}\""),
+            JsVariant::String(v) => write!(f, "\"{v}\""),
             JsVariant::Rational(v) => format_rational(v, f),
             JsVariant::Object(_) => {
                 write!(f, "{}", log_string_from(self.value, self.internals, true))
             }
             JsVariant::Integer(v) => write!(f, "{v}"),
-            JsVariant::BigInt(ref num) => write!(f, "{num}n"),
+            JsVariant::BigInt(num) => write!(f, "{num}n"),
         }
     }
 }

--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -15,7 +15,7 @@ impl JsValue {
         match (self.variant(), other.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::equal(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::equal(x, y),
+            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::equal(x, y),
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::equal(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Number::equal(x, f64::from(y)),
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Number::equal(f64::from(x), y),
@@ -69,14 +69,14 @@ impl JsValue {
             //    a. Let n be ! StringToBigInt(y).
             //    b. If n is NaN, return false.
             //    c. Return the result of the comparison x == n.
-            (JsVariant::BigInt(a), JsVariant::String(b)) => match JsBigInt::from_string(b) {
-                Some(ref b) => a == b,
+            (JsVariant::BigInt(a), JsVariant::String(ref b)) => match JsBigInt::from_string(b) {
+                Some(b) => a == b,
                 None => false,
             },
 
             // 7. If Type(x) is String and Type(y) is BigInt, return the result of the comparison y == x.
-            (JsVariant::String(a), JsVariant::BigInt(b)) => match JsBigInt::from_string(a) {
-                Some(ref a) => a == b,
+            (JsVariant::String(ref a), JsVariant::BigInt(b)) => match JsBigInt::from_string(a) {
+                Some(a) => a == *b,
                 None => false,
             },
 
@@ -121,10 +121,10 @@ impl JsValue {
             // 12. If Type(x) is BigInt and Type(y) is Number, or if Type(x) is Number and Type(y) is BigInt, then
             //    a. If x or y are any of NaN, +∞, or -∞, return false.
             //    b. If the mathematical value of x is equal to the mathematical value of y, return true; otherwise return false.
-            (JsVariant::BigInt(a), JsVariant::Rational(ref b)) => a == b,
-            (JsVariant::Rational(ref a), JsVariant::BigInt(b)) => a == b,
-            (JsVariant::BigInt(a), JsVariant::Integer(ref b)) => a == b,
-            (JsVariant::Integer(ref a), JsVariant::BigInt(b)) => a == b,
+            (JsVariant::BigInt(a), JsVariant::Rational(b)) => *a == b,
+            (JsVariant::Rational(a), JsVariant::BigInt(b)) => a == *b,
+            (JsVariant::BigInt(a), JsVariant::Integer(b)) => *a == b,
+            (JsVariant::Integer(a), JsVariant::BigInt(b)) => a == *b,
 
             // 13. Return false.
             _ => false,
@@ -147,7 +147,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValue(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value(x, y),
+            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::same_value(x, y),
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::same_value(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Number::same_value(x, f64::from(y)),
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Number::same_value(f64::from(x), y),
@@ -175,7 +175,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValueZero(x, y).
-            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value_zero(x, y),
+            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::same_value_zero(x, y),
 
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::same_value_zero(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => {
@@ -199,7 +199,7 @@ impl JsValue {
             }
             (JsVariant::String(x), JsVariant::String(y)) => x == y,
             (JsVariant::Boolean(x), JsVariant::Boolean(y)) => x == y,
-            (JsVariant::Object(x), JsVariant::Object(y)) => JsObject::equals(x, y),
+            (JsVariant::Object(ref x), JsVariant::Object(ref y)) => JsObject::equals(x, y),
             (JsVariant::Symbol(x), JsVariant::Symbol(y)) => x == y,
             _ => false,
         }

--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -15,7 +15,7 @@ impl JsValue {
         match (self.variant(), other.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::equal(x, y).
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::equal(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::equal(x, y),
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::equal(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Number::equal(x, f64::from(y)),
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Number::equal(f64::from(x), y),
@@ -69,20 +69,16 @@ impl JsValue {
             //    a. Let n be ! StringToBigInt(y).
             //    b. If n is NaN, return false.
             //    c. Return the result of the comparison x == n.
-            (JsVariant::BigInt(ref a), JsVariant::String(ref b)) => {
-                match JsBigInt::from_string(b) {
-                    Some(ref b) => a == b,
-                    None => false,
-                }
-            }
+            (JsVariant::BigInt(a), JsVariant::String(b)) => match JsBigInt::from_string(b) {
+                Some(ref b) => a == b,
+                None => false,
+            },
 
             // 7. If Type(x) is String and Type(y) is BigInt, return the result of the comparison y == x.
-            (JsVariant::String(ref a), JsVariant::BigInt(ref b)) => {
-                match JsBigInt::from_string(a) {
-                    Some(ref a) => a == b,
-                    None => false,
-                }
-            }
+            (JsVariant::String(a), JsVariant::BigInt(b)) => match JsBigInt::from_string(a) {
+                Some(ref a) => a == b,
+                None => false,
+            },
 
             // 8. If Type(x) is Boolean, return the result of the comparison ! ToNumber(x) == y.
             (JsVariant::Boolean(x), _) => return other.equals(&Self::new(i32::from(x)), context),
@@ -125,10 +121,10 @@ impl JsValue {
             // 12. If Type(x) is BigInt and Type(y) is Number, or if Type(x) is Number and Type(y) is BigInt, then
             //    a. If x or y are any of NaN, +∞, or -∞, return false.
             //    b. If the mathematical value of x is equal to the mathematical value of y, return true; otherwise return false.
-            (JsVariant::BigInt(ref a), JsVariant::Rational(ref b)) => a == b,
-            (JsVariant::Rational(ref a), JsVariant::BigInt(ref b)) => a == b,
-            (JsVariant::BigInt(ref a), JsVariant::Integer(ref b)) => a == b,
-            (JsVariant::Integer(ref a), JsVariant::BigInt(ref b)) => a == b,
+            (JsVariant::BigInt(a), JsVariant::Rational(ref b)) => a == b,
+            (JsVariant::Rational(ref a), JsVariant::BigInt(b)) => a == b,
+            (JsVariant::BigInt(a), JsVariant::Integer(ref b)) => a == b,
+            (JsVariant::Integer(ref a), JsVariant::BigInt(b)) => a == b,
 
             // 13. Return false.
             _ => false,
@@ -151,7 +147,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValue(x, y).
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::same_value(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value(x, y),
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::same_value(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Number::same_value(x, f64::from(y)),
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Number::same_value(f64::from(x), y),
@@ -179,7 +175,7 @@ impl JsValue {
         match (x.variant(), y.variant()) {
             // 2. If Type(x) is Number or BigInt, then
             //    a. Return ! Type(x)::SameValueZero(x, y).
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => JsBigInt::same_value_zero(x, y),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => JsBigInt::same_value_zero(x, y),
 
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::same_value_zero(x, y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => {
@@ -201,10 +197,10 @@ impl JsValue {
             (JsVariant::Null, JsVariant::Null) | (JsVariant::Undefined, JsVariant::Undefined) => {
                 true
             }
-            (JsVariant::String(ref x), JsVariant::String(ref y)) => x == y,
+            (JsVariant::String(x), JsVariant::String(y)) => x == y,
             (JsVariant::Boolean(x), JsVariant::Boolean(y)) => x == y,
-            (JsVariant::Object(ref x), JsVariant::Object(ref y)) => JsObject::equals(x, y),
-            (JsVariant::Symbol(ref x), JsVariant::Symbol(ref y)) => x == y,
+            (JsVariant::Object(x), JsVariant::Object(y)) => JsObject::equals(x, y),
+            (JsVariant::Symbol(x), JsVariant::Symbol(y)) => x == y,
             _ => false,
         }
     }

--- a/boa_engine/src/value/hash.rs
+++ b/boa_engine/src/value/hash.rs
@@ -40,13 +40,13 @@ impl Hash for JsValue {
         match self.variant() {
             JsVariant::Undefined => UndefinedHashable.hash(state),
             JsVariant::Null => NullHashable.hash(state),
-            JsVariant::String(ref string) => string.hash(state),
+            JsVariant::String(string) => string.hash(state),
             JsVariant::Boolean(boolean) => boolean.hash(state),
             JsVariant::Integer(integer) => RationalHashable(f64::from(integer)).hash(state),
-            JsVariant::BigInt(ref bigint) => bigint.hash(state),
+            JsVariant::BigInt(bigint) => bigint.hash(state),
             JsVariant::Rational(rational) => RationalHashable(rational).hash(state),
-            JsVariant::Symbol(ref symbol) => Hash::hash(symbol, state),
-            JsVariant::Object(ref object) => std::ptr::hash(object.as_ref(), state),
+            JsVariant::Symbol(symbol) => Hash::hash(symbol.as_ref(), state),
+            JsVariant::Object(object) => std::ptr::hash(object.as_ref(), state),
         }
     }
 }

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -573,6 +573,16 @@ pub(crate) unsafe trait PointerType {
     unsafe fn into_void_ptr(ty: ManuallyDrop<Self>) -> *mut ();
 }
 
+/// Represents a reference to a boxed pointer type inside a [`JsValue`]
+///
+/// This is exclusively used to return references to [`JsString`], [`JsObject`],
+/// [`JsSymbol`] and [`JsBigInt`], since NaN boxing makes returning proper references
+/// difficult. It is mainly returned by the [`JsValue::variant`] method and the
+/// `as_` methods for checked casts to pointer types.
+///
+/// [`Ref`] implements [`Deref`][`std::ops::Deref`], which facilitates conversion
+/// to a proper [`reference`] by using the `ref` keyword or the
+/// [`Option::as_deref`][`std::option::Option::as_deref`] method.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Ref<'a, T> {
     inner: ManuallyDrop<T>,

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -253,12 +253,21 @@ impl JsValue {
     ///
     /// Calling this method with a [`JsValue`] that doesn't box
     /// a [`JsObject`] is undefined behaviour.
-    pub unsafe fn as_object_unchecked(&self) -> JsObject {
+    pub unsafe fn as_object_unchecked(&self) -> &JsObject {
         // SAFETY: The safety contract must be upheld by the caller
-        unsafe { JsObject::clone(&JsObject::from_void_ptr(self.as_pointer())) }
+        let object = unsafe {
+            JsObject::from_void_ptr(self.as_pointer());
+        };
+
+        // SAFETY: Assuming the above is safe, this is safe because
+        // we currently are manipulating a [`ManuallyDrop`] that is
+        // manually dropped until this [`JsValue`] is dropped,
+        // which implies that the lifetime of `&object` can be extended
+        // to the lifetime of `&self`.
+        unsafe { std::mem::transmute(&object) }
     }
 
-    pub fn as_object(&self) -> Option<JsObject> {
+    pub fn as_object(&self) -> Option<&JsObject> {
         if self.is_object() {
             return unsafe { Some(self.as_object_unchecked()) };
         }
@@ -279,14 +288,23 @@ impl JsValue {
     ///
     /// Calling this method with a [`JsValue`] that doesn't box
     /// a [`JsString`] is undefined behaviour.
-    pub unsafe fn as_string_unchecked(&self) -> JsString {
+    pub unsafe fn as_string_unchecked(&self) -> &JsString {
         // SAFETY: The safety contract must be upheld by the caller
-        unsafe { JsString::clone(&JsString::from_void_ptr(self.as_pointer())) }
+        let string = unsafe {
+            JsString::from_void_ptr(self.as_pointer());
+        };
+
+        // SAFETY: Assuming the above is safe, this is safe because
+        // we currently are manipulating a [`ManuallyDrop`] that is
+        // manually dropped until this [`JsValue`] is dropped,
+        // which implies that the lifetime of `&string` can be extended
+        // to the lifetime of `&self`.
+        unsafe { std::mem::transmute(&string) }
     }
 
     /// Returns the string if the values is a string, otherwise `None`.
     #[inline]
-    pub fn as_string(&self) -> Option<JsString> {
+    pub fn as_string(&self) -> Option<&JsString> {
         if self.is_string() {
             return unsafe { Some(self.as_string_unchecked()) };
         }
@@ -305,12 +323,19 @@ impl JsValue {
     ///
     /// Calling this method with a [`JsValue`] that doesn't box
     /// a [`JsSymbol`] is undefined behaviour.
-    pub unsafe fn as_symbol_unchecked(&self) -> JsSymbol {
+    pub unsafe fn as_symbol_unchecked(&self) -> &JsSymbol {
         // SAFETY: The safety contract must be upheld by the caller
-        unsafe { JsSymbol::clone(&JsSymbol::from_void_ptr(self.as_pointer())) }
+        let symbol = unsafe { JsSymbol::from_void_ptr(self.as_pointer()) };
+
+        // SAFETY: Assuming the above is safe, this is safe because
+        // we currently are manipulating a [`ManuallyDrop`] that is
+        // manually dropped until this [`JsValue`] is dropped,
+        // which implies that the lifetime of `&symbol` can be extended
+        // to the lifetime of `&self`.
+        unsafe { std::mem::transmute(&symbol) }
     }
 
-    pub fn as_symbol(&self) -> Option<JsSymbol> {
+    pub fn as_symbol(&self) -> Option<&JsSymbol> {
         if self.is_symbol() {
             return unsafe { Some(self.as_symbol_unchecked()) };
         }
@@ -332,12 +357,21 @@ impl JsValue {
     /// Calling this method with a [`JsValue`] that doesn't box
     /// a [`JsBigInt`] is undefined behaviour.
     #[inline]
-    pub unsafe fn as_bigint_unchecked(&self) -> JsBigInt {
+    pub unsafe fn as_bigint_unchecked(&self) -> &JsBigInt {
         // SAFETY: The safety contract must be upheld by the caller
-        unsafe { JsBigInt::clone(&JsBigInt::from_void_ptr(self.as_pointer())) }
+        let bigint = unsafe {
+            JsBigInt::from_void_ptr(self.as_pointer());
+        };
+
+        // SAFETY: Assuming the above is safe, this is safe because
+        // we currently are manipulating a [`ManuallyDrop`] that is
+        // manually dropped until this [`JsValue`] is dropped,
+        // which implies that the lifetime of `&bigint` can be extended
+        // to the lifetime of `&self`.
+        unsafe { std::mem::transmute(&bigint) }
     }
 
-    pub fn as_bigint(&self) -> Option<JsBigInt> {
+    pub fn as_bigint(&self) -> Option<&JsBigInt> {
         if self.is_bigint() {
             return unsafe { Some(self.as_bigint_unchecked()) };
         }
@@ -345,7 +379,7 @@ impl JsValue {
         None
     }
 
-    pub fn variant(&self) -> JsVariant {
+    pub fn variant(&self) -> JsVariant<'_> {
         unsafe {
             match self.tag() {
                 ValueTag::Null => JsVariant::Null,
@@ -363,16 +397,16 @@ impl JsValue {
 }
 
 #[derive(Debug, Clone)]
-pub enum JsVariant {
+pub enum JsVariant<'a> {
     Null,
     Undefined,
     Rational(f64),
     Integer(i32),
     Boolean(bool),
-    String(JsString),
-    Symbol(JsSymbol),
-    BigInt(JsBigInt),
-    Object(JsObject),
+    String(&'a JsString),
+    Symbol(&'a JsSymbol),
+    BigInt(&'a JsBigInt),
+    Object(&'a JsObject),
 }
 
 impl From<bool> for JsValue {
@@ -575,24 +609,8 @@ pub(crate) unsafe trait PointerType {
     unsafe fn into_void_ptr(ty: ManuallyDrop<Self>) -> *mut ();
 }
 
-impl Clone for JsValue {
-    #[inline]
-    fn clone(&self) -> Self {
-        unsafe {
-            match self.tag() {
-                ValueTag::Object => Self::new(self.as_object_unchecked()),
-                ValueTag::String => Self::new(self.as_string_unchecked()),
-                ValueTag::Symbol => Self::new(self.as_symbol_unchecked()),
-                ValueTag::BigInt => Self::new(self.as_bigint_unchecked()),
-                _ => Self {
-                    value: Cell::new(self.value.get()),
-                },
-            }
-        }
-    }
-}
-
 impl Drop for JsValue {
+    #[inline]
     fn drop(&mut self) {
         unsafe {
             match self.tag() {
@@ -614,41 +632,47 @@ impl Drop for JsValue {
     }
 }
 
+impl Clone for JsValue {
+    #[inline]
+    fn clone(&self) -> Self {
+        unsafe {
+            match self.tag() {
+                ValueTag::Object => Self::new(self.as_object_unchecked().clone()),
+                ValueTag::String => Self::new(self.as_string_unchecked().clone()),
+                ValueTag::Symbol => Self::new(self.as_symbol_unchecked().clone()),
+                ValueTag::BigInt => Self::new(self.as_bigint_unchecked().clone()),
+                _ => Self {
+                    value: Cell::new(self.value.get()),
+                },
+            }
+        }
+    }
+}
+
 impl Finalize for JsValue {}
 
 unsafe impl Trace for JsValue {
+    #[inline]
     unsafe fn trace(&self) {
         if let Some(o) = self.as_object() {
             // SAFETY: `self.as_object()` must always return a valid `JsObject
-            unsafe {
-                o.trace();
-            }
+            unsafe { o.trace() }
         }
     }
 
+    #[inline]
     unsafe fn root(&self) {
-        if self.tag() == ValueTag::Object {
-            // SAFETY: Implementors of `PointerType` must guarantee the
-            // safety of both `from_void_ptr` and `into_void_ptr`
-            unsafe {
-                let o = JsObject::from_void_ptr(self.as_pointer());
-                o.root();
-                self.value
-                    .set(OBJECT_TYPE | (JsObject::into_void_ptr(o) as u64));
-            }
+        if let Some(o) = self.as_object() {
+            // SAFETY: `self.as_object()` must always return a valid `JsObject
+            unsafe { o.root() }
         }
     }
 
+    #[inline]
     unsafe fn unroot(&self) {
-        if self.tag() == ValueTag::Object {
-            // SAFETY: Implementors of `PointerType` must guarantee the
-            // safety of both `from_void_ptr` and `into_void_ptr`
-            unsafe {
-                let o = JsObject::from_void_ptr(self.as_pointer());
-                o.unroot();
-                self.value
-                    .set(OBJECT_TYPE | (JsObject::into_void_ptr(o) as u64));
-            }
+        if let Some(o) = self.as_object() {
+            // SAFETY: `self.as_object()` must always return a valid `JsObject
+            unsafe { o.unroot() }
         }
     }
 
@@ -681,7 +705,7 @@ mod tests_nan_box {
 
         let bigint = value.as_bigint().unwrap();
 
-        assert_eq!(&bigint, &JsBigInt::new(12345));
+        assert_eq!(bigint, &JsBigInt::new(12345));
     }
 
     #[test]
@@ -720,7 +744,7 @@ mod tests_nan_box {
 
         let string = value.as_string().unwrap();
 
-        assert_eq!(JsString::refcount(&string), 2);
+        assert_eq!(JsString::refcount(string), 2);
 
         assert_eq!(string, "I am a string :)");
     }
@@ -744,7 +768,7 @@ mod tests_nan_box {
         assert!(value.is_object());
 
         let o2 = value.as_object().unwrap();
-        assert!(JsObject::equals(&o1, &o2));
+        assert!(JsObject::equals(&o1, o2));
     }
 
     #[test]
@@ -866,27 +890,23 @@ impl JsValue {
     /// [spec]: https://tc39.es/ecma262/#sec-iscallable
     #[inline]
     pub fn is_callable(&self) -> bool {
-        self.as_object()
-            .as_ref()
-            .map_or(false, JsObject::is_callable)
+        self.as_object().map_or(false, JsObject::is_callable)
     }
 
     #[inline]
-    pub fn as_callable(&self) -> Option<JsObject> {
-        self.as_object().filter(JsObject::is_callable)
+    pub fn as_callable(&self) -> Option<&JsObject> {
+        self.as_object().filter(|obj| obj.is_callable())
     }
 
     /// Returns true if the value is a constructor object
     #[inline]
     pub fn is_constructor(&self) -> bool {
-        self.as_object()
-            .as_ref()
-            .map_or(false, JsObject::is_constructor)
+        self.as_object().map_or(false, JsObject::is_constructor)
     }
 
     #[inline]
-    pub fn as_constructor(&self) -> Option<JsObject> {
-        self.as_object().filter(JsObject::is_constructor)
+    pub fn as_constructor(&self) -> Option<&JsObject> {
+        self.as_object().filter(|obj| obj.is_constructor())
     }
 
     /// Returns true if the value is a 64-bit floating-point number.
@@ -937,10 +957,10 @@ impl JsValue {
         match self.variant() {
             JsVariant::Undefined | JsVariant::Null => false,
             JsVariant::Symbol(_) | JsVariant::Object(_) => true,
-            JsVariant::String(ref s) if !s.is_empty() => true,
+            JsVariant::String(s) if !s.is_empty() => true,
             JsVariant::Rational(n) if n != 0.0 && !n.is_nan() => true,
             JsVariant::Integer(n) if n != 0 => true,
-            JsVariant::BigInt(ref n) if !n.is_zero() => true,
+            JsVariant::BigInt(n) if !n.is_zero() => true,
             JsVariant::Boolean(v) => v,
             _ => false,
         }
@@ -1045,7 +1065,7 @@ impl JsValue {
             JsVariant::Undefined => {
                 context.throw_type_error("cannot convert undefined to a BigInt")
             }
-            JsVariant::String(ref string) => {
+            JsVariant::String(string) => {
                 if let Some(value) = JsBigInt::from_string(string) {
                     Ok(value)
                 } else {
@@ -1059,7 +1079,7 @@ impl JsValue {
             JsVariant::Integer(_) | JsVariant::Rational(_) => {
                 context.throw_type_error("cannot convert Number to a BigInt")
             }
-            JsVariant::BigInt(ref b) => Ok(b.clone()),
+            JsVariant::BigInt(b) => Ok(b.clone()),
             JsVariant::Object(_) => {
                 let primitive = self.to_primitive(context, PreferredType::Number)?;
                 primitive.to_bigint(context)
@@ -1100,9 +1120,9 @@ impl JsValue {
             JsVariant::Boolean(boolean) => Ok(boolean.to_string().into()),
             JsVariant::Rational(rational) => Ok(Number::to_native_string(rational).into()),
             JsVariant::Integer(integer) => Ok(integer.to_string().into()),
-            JsVariant::String(ref string) => Ok(string.clone()),
+            JsVariant::String(string) => Ok(string.clone()),
             JsVariant::Symbol(_) => context.throw_type_error("can't convert symbol to string"),
-            JsVariant::BigInt(ref bigint) => Ok(bigint.to_string().into()),
+            JsVariant::BigInt(bigint) => Ok(bigint.to_string().into()),
             JsVariant::Object(_) => {
                 let primitive = self.to_primitive(context, PreferredType::String)?;
                 primitive.to_string(context)
@@ -1141,7 +1161,7 @@ impl JsValue {
                     ObjectData::number(rational),
                 ))
             }
-            JsVariant::String(ref string) => {
+            JsVariant::String(string) => {
                 let prototype = context.standard_objects().string_object().prototype();
 
                 let object =
@@ -1157,21 +1177,21 @@ impl JsValue {
                 );
                 Ok(object)
             }
-            JsVariant::Symbol(ref symbol) => {
+            JsVariant::Symbol(symbol) => {
                 let prototype = context.standard_objects().symbol_object().prototype();
                 Ok(JsObject::from_proto_and_data(
                     prototype,
                     ObjectData::symbol(symbol.clone()),
                 ))
             }
-            JsVariant::BigInt(ref bigint) => {
+            JsVariant::BigInt(bigint) => {
                 let prototype = context.standard_objects().bigint_object().prototype();
                 Ok(JsObject::from_proto_and_data(
                     prototype,
                     ObjectData::big_int(bigint.clone()),
                 ))
             }
-            JsVariant::Object(ref jsobject) => Ok(jsobject.clone()),
+            JsVariant::Object(jsobject) => Ok(jsobject.clone()),
         }
     }
 
@@ -1181,14 +1201,14 @@ impl JsValue {
     pub fn to_property_key(&self, context: &mut Context) -> JsResult<PropertyKey> {
         Ok(match self.variant() {
             // Fast path:
-            JsVariant::String(ref string) => string.clone().into(),
-            JsVariant::Symbol(ref symbol) => symbol.clone().into(),
+            JsVariant::String(string) => string.clone().into(),
+            JsVariant::Symbol(symbol) => symbol.clone().into(),
             // Slow path:
             _ => {
                 let primitive = self.to_primitive(context, PreferredType::String)?;
                 match primitive.variant() {
-                    JsVariant::String(ref string) => string.clone().into(),
-                    JsVariant::Symbol(ref symbol) => symbol.clone().into(),
+                    JsVariant::String(string) => string.clone().into(),
+                    JsVariant::Symbol(symbol) => symbol.clone().into(),
                     _ => primitive.to_string(context)?.into(),
                 }
             }
@@ -1201,7 +1221,7 @@ impl JsValue {
     pub fn to_numeric(&self, context: &mut Context) -> JsResult<Numeric> {
         let primitive = self.to_primitive(context, PreferredType::Number)?;
         if let Some(bigint) = primitive.as_bigint() {
-            return Ok(bigint.into());
+            return Ok(bigint.clone().into());
         }
         Ok(self.to_number(context)?.into())
     }
@@ -1511,7 +1531,7 @@ impl JsValue {
             JsVariant::Null => Ok(0.0),
             JsVariant::Undefined => Ok(f64::NAN),
             JsVariant::Boolean(b) => Ok(if b { 1.0 } else { 0.0 }),
-            JsVariant::String(ref string) => Ok(string.string_to_number()),
+            JsVariant::String(string) => Ok(string.string_to_number()),
             JsVariant::Rational(number) => Ok(number),
             JsVariant::Integer(integer) => Ok(f64::from(integer)),
             JsVariant::Symbol(_) => context.throw_type_error("argument must not be a symbol"),
@@ -1584,7 +1604,7 @@ impl JsValue {
             JsVariant::Null => "object",
             JsVariant::Undefined => "undefined",
             JsVariant::BigInt(_) => "bigint",
-            JsVariant::Object(ref object) => {
+            JsVariant::Object(object) => {
                 if object.is_callable() {
                     "function"
                 } else {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -576,7 +576,7 @@ pub(crate) unsafe trait PointerType {
 /// Represents a reference to a boxed pointer type inside a [`JsValue`]
 ///
 /// This is exclusively used to return references to [`JsString`], [`JsObject`],
-/// [`JsSymbol`] and [`JsBigInt`], since NaN boxing makes returning proper references
+/// [`JsSymbol`] and [`JsBigInt`], since `NaN` boxing makes returning proper references
 /// difficult. It is mainly returned by the [`JsValue::variant`] method and the
 /// `as_` methods for checked casts to pointer types.
 ///
@@ -600,14 +600,16 @@ impl<T> Ref<'_, T> {
 }
 
 impl<T> std::borrow::Borrow<T> for Ref<'_, T> {
+    #[inline]
     fn borrow(&self) -> &T {
-        &*self.inner
+        &**self
     }
 }
 
 impl<T> AsRef<T> for Ref<'_, T> {
+    #[inline]
     fn as_ref(&self) -> &T {
-        &*self.inner
+        &**self
     }
 }
 
@@ -621,8 +623,9 @@ impl<T> std::ops::Deref for Ref<'_, T> {
 }
 
 impl<T: PartialEq> PartialEq<T> for Ref<'_, T> {
+    #[inline]
     fn eq(&self, other: &T) -> bool {
-        &*self.inner == other
+        &**self == other
     }
 }
 
@@ -732,8 +735,6 @@ mod tests_nan_box {
         assert!(value.is_bigint());
 
         let bigint = value.as_bigint().unwrap();
-
-        println!("pass!");
 
         assert_eq!(&bigint, &JsBigInt::new(12345));
     }

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -25,7 +25,7 @@ impl JsValue {
             (_, JsVariant::String(ref y)) => {
                 Self::new(JsString::concat(self.to_string(context)?, y))
             }
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => Self::new(JsBigInt::add(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::add(x, y)),
 
             // Slow path:
             (_, _) => {
@@ -65,7 +65,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(f64::from(x) - y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(x - f64::from(y)),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => Self::new(JsBigInt::sub(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::sub(x, y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -91,7 +91,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(f64::from(x) * y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(x * f64::from(y)),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => Self::new(JsBigInt::mul(x, y)),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::mul(x, y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -117,7 +117,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(f64::from(x) / y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(x / f64::from(y)),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => {
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => {
                 if y.is_zero() {
                     return context.throw_range_error("BigInt division by zero");
                 }
@@ -164,7 +164,7 @@ impl JsValue {
             (JsVariant::Rational(x), JsVariant::Integer(y)) => {
                 Self::new((x % f64::from(y)).copysign(x))
             }
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => {
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => {
                 if y.is_zero() {
                     return context.throw_range_error("BigInt division by zero");
                 }
@@ -197,7 +197,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(f64::from(x).powf(y)),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(x.powi(y)),
 
-            (JsVariant::BigInt(ref a), JsVariant::BigInt(ref b)) => {
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => {
                 Self::new(JsBigInt::pow(a, b, context)?)
             }
 
@@ -227,9 +227,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(x & f64_to_int32(y)),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(f64_to_int32(x) & y),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => {
-                Self::new(JsBigInt::bitand(x, y))
-            }
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitand(x, y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -259,9 +257,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(x | f64_to_int32(y)),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(f64_to_int32(x) | y),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => {
-                Self::new(JsBigInt::bitor(x, y))
-            }
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitor(x, y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -291,9 +287,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Self::new(x ^ f64_to_int32(y)),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Self::new(f64_to_int32(x) ^ y),
 
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => {
-                Self::new(JsBigInt::bitxor(x, y))
-            }
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => Self::new(JsBigInt::bitxor(x, y)),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -327,7 +321,7 @@ impl JsValue {
                 Self::new(f64_to_int32(x).wrapping_shl(y as u32))
             }
 
-            (JsVariant::BigInt(ref a), JsVariant::BigInt(ref b)) => {
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => {
                 Self::new(JsBigInt::shift_left(a, b, context)?)
             }
 
@@ -363,7 +357,7 @@ impl JsValue {
                 Self::new(f64_to_int32(x).wrapping_shr(y as u32))
             }
 
-            (JsVariant::BigInt(ref a), JsVariant::BigInt(ref b)) => {
+            (JsVariant::BigInt(a), JsVariant::BigInt(b)) => {
                 Self::new(JsBigInt::shift_right(a, b, context)?)
             }
 
@@ -463,7 +457,7 @@ impl JsValue {
                 Ok(num) => -num,
                 Err(_) => f64::NAN,
             }),
-            JsVariant::String(ref str) => Self::new(match f64::from_str(str) {
+            JsVariant::String(str) => Self::new(match f64::from_str(str) {
                 Ok(num) => -num,
                 Err(_) => f64::NAN,
             }),
@@ -472,7 +466,7 @@ impl JsValue {
             JsVariant::Integer(num) => Self::new(-num),
             JsVariant::Boolean(true) => Self::new(1),
             JsVariant::Boolean(false) | JsVariant::Null => Self::new(0),
-            JsVariant::BigInt(ref x) => Self::new(JsBigInt::neg(x)),
+            JsVariant::BigInt(x) => Self::new(JsBigInt::neg(x)),
         })
     }
 
@@ -510,7 +504,7 @@ impl JsValue {
             (JsVariant::Integer(x), JsVariant::Rational(y)) => Number::less_than(f64::from(x), y),
             (JsVariant::Rational(x), JsVariant::Integer(y)) => Number::less_than(x, f64::from(y)),
             (JsVariant::Rational(x), JsVariant::Rational(y)) => Number::less_than(x, y),
-            (JsVariant::BigInt(ref x), JsVariant::BigInt(ref y)) => (x < y).into(),
+            (JsVariant::BigInt(x), JsVariant::BigInt(y)) => (x < y).into(),
 
             // Slow path:
             (_, _) => {
@@ -526,7 +520,7 @@ impl JsValue {
                 };
 
                 match (px.variant(), py.variant()) {
-                    (JsVariant::String(ref x), JsVariant::String(ref y)) => {
+                    (JsVariant::String(x), JsVariant::String(y)) => {
                         if x.starts_with(y.as_str()) {
                             return Ok(AbstractRelation::False);
                         }
@@ -540,14 +534,14 @@ impl JsValue {
                         }
                         unreachable!()
                     }
-                    (JsVariant::BigInt(ref x), JsVariant::String(ref y)) => {
+                    (JsVariant::BigInt(x), JsVariant::String(y)) => {
                         if let Some(y) = JsBigInt::from_string(y) {
                             (*x < y).into()
                         } else {
                             AbstractRelation::Undefined
                         }
                     }
-                    (JsVariant::String(ref x), JsVariant::BigInt(ref y)) => {
+                    (JsVariant::String(x), JsVariant::BigInt(y)) => {
                         if let Some(x) = JsBigInt::from_string(x) {
                             (x < *y).into()
                         } else {

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -108,11 +108,11 @@ impl JsValue {
             JsVariant::Null => Ok(Value::Null),
             JsVariant::Undefined => todo!("undefined to JSON"),
             JsVariant::Boolean(b) => Ok(b.into()),
-            JsVariant::String(ref string) => Ok(string.as_str().into()),
+            JsVariant::String(string) => Ok(string.as_str().into()),
             JsVariant::Rational(rat) => Ok(rat.into()),
             JsVariant::Integer(int) => Ok(int.into()),
             JsVariant::BigInt(_bigint) => context.throw_type_error("cannot convert bigint to JSON"),
-            JsVariant::Object(ref obj) => {
+            JsVariant::Object(obj) => {
                 if obj.is_array() {
                     let len = obj.length_of_array_like(context)?;
                     let mut arr = Vec::with_capacity(len);
@@ -202,7 +202,7 @@ mod tests {
             let phones = obj.get("phones", &mut context).unwrap();
             let phones = phones.as_object().unwrap();
 
-            let arr = JsArray::from_object(phones, &mut context).unwrap();
+            let arr = JsArray::from_object(phones.clone(), &mut context).unwrap();
             assert_eq!(arr.at(0, &mut context).unwrap(), "+44 1234567".into());
             assert_eq!(arr.at(1, &mut context).unwrap(), JsValue::from(-45_i32));
             assert!(arr.at(2, &mut context).unwrap().is_object());

--- a/boa_engine/src/value/tests.rs
+++ b/boa_engine/src/value/tests.rs
@@ -643,7 +643,7 @@ mod cyclic_conversions {
 
         let value = forward_val(&mut context, src).unwrap();
         let result = value.as_string().unwrap();
-        assert_eq!(result, "[[],[]]",);
+        assert_eq!(*result, "[[],[]]",);
     }
 
     // These tests don't throw errors. Instead we mirror Chrome / Firefox behavior for these
@@ -660,7 +660,7 @@ mod cyclic_conversions {
 
         let value = forward_val(&mut context, src).unwrap();
         let result = value.as_string().unwrap();
-        assert_eq!(result, "");
+        assert_eq!(*result, "");
     }
 
     #[test]

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -788,7 +788,7 @@ impl JsObject {
                     .expect("GeneratorFunction must have a prototype property")
                     .as_object()
                 {
-                    prototype
+                    prototype.clone()
                 } else {
                     context.standard_objects().generator_object().prototype()
                 };

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -566,7 +566,7 @@ impl Context {
 
                 let value = self.vm.pop();
                 let object = if let Some(object) = value.as_object() {
-                    object
+                    object.clone()
                 } else {
                     value.to_object(self)?
                 };
@@ -581,7 +581,7 @@ impl Context {
                 let object = self.vm.pop();
                 let key = self.vm.pop();
                 let object = if let Some(object) = object.as_object() {
-                    object
+                    object.clone()
                 } else {
                     object.to_object(self)?
                 };
@@ -597,7 +597,7 @@ impl Context {
                 let object = self.vm.pop();
                 let value = self.vm.pop();
                 let object = if let Some(object) = object.as_object() {
-                    object
+                    object.clone()
                 } else {
                     object.to_object(self)?
                 };
@@ -618,7 +618,7 @@ impl Context {
                 let object = self.vm.pop();
                 let value = self.vm.pop();
                 let object = if let Some(object) = object.as_object() {
-                    object
+                    object.clone()
                 } else {
                     object.to_object(self)?
                 };
@@ -642,7 +642,7 @@ impl Context {
                 let key = self.vm.pop();
                 let value = self.vm.pop();
                 let object = if let Some(object) = object.as_object() {
-                    object
+                    object.clone()
                 } else {
                     object.to_object(self)?
                 };
@@ -660,7 +660,7 @@ impl Context {
                 let key = self.vm.pop();
                 let object = self.vm.pop();
                 let object = if let Some(object) = object.as_object() {
-                    object
+                    object.clone()
                 } else {
                     object.to_object(self)?
                 };
@@ -981,7 +981,7 @@ impl Context {
                 arguments.append(&mut rest_arguments);
 
                 let object = match func.variant() {
-                    JsVariant::Object(ref object) if object.is_callable() => object.clone(),
+                    JsVariant::Object(object) if object.is_callable() => object.clone(),
                     _ => return self.throw_type_error("not a callable function"),
                 };
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request creates a new `Ref` struct (design by @HalidOdat) that represents a reference for boxed pointer types (`JsValue`, `JsString`, `JsSymbol`, `JsBigInt`), skipping unnecessary clones.

It changes the following:

- Creates a new `Ref` struct representing a reference to a pointer value.
- Makes methods of `JsValue` return `Ref<{PointerValue}>` when possible. 
- Refactors the codebase to accomodate to the new API.
