### PR TITLE
[Merged by Bors] - Implement `Number.parseInt` and `Number.parseFloat`

### DIFF
--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -56,7 +56,7 @@ impl BuiltIn for AggregateError {
 
 impl AggregateError {
     /// The amount of arguments this function object takes.
-    pub(crate) const LENGTH: usize = 1;
+    pub(crate) const LENGTH: usize = 2;
 
     /// Create a new aggregate error object.
     pub(crate) fn constructor(

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -56,7 +56,7 @@ impl BuiltIn for Reflect {
             .function(Self::own_keys, "ownKeys", 1)
             .function(Self::prevent_extensions, "preventExtensions", 1)
             .function(Self::set, "set", 3)
-            .function(Self::set_prototype_of, "setPrototypeOf", 3)
+            .function(Self::set_prototype_of, "setPrototypeOf", 2)
             .property(
                 to_string_tag,
                 Self::NAME,


### PR DESCRIPTION
This PR add `Number.parseInt` and `Number.parseFloat` which according to spec are clones of the global objects `parseInt` and `parseFloat`.

It also fixes the last failing test of  the `NativeError` feature with this we get 100% spec complaint `NativeError`s :tada: 

It changes the following:
- Add `Number.parseInt()`
- Add `Number.parseFloat()`
- Fix length of `AggregateError`
- Fix length of `Reflect.setPrototypeOf`
