### PR TITLE
[Merged by Bors] - Deny const declarations without initializer inside for loops

### DIFF
--- a/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
@@ -167,11 +167,9 @@ where
                         const_decls.push(decl);
                     } else {
                         let next = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
-                        return Err(ParseError::expected(
-                            ["=".to_owned()],
-                            next.to_string(interner),
-                            next.span(),
-                            "const declaration",
+                        return Err(ParseError::general(
+                            "Expected initializer for const declaration",
+                            next.span().start(),
                         ));
                     }
                 } else {

--- a/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
@@ -146,6 +146,18 @@ where
 
                 return Ok(ForOfLoop::new(init, iterable, body).into());
             }
+            (Some(Node::ConstDeclList(list)), _) => {
+                // Reject const declarations without initializers inside for loops
+                for decl in list.as_ref() {
+                    if decl.init().is_none() {
+                        return Err(ParseError::general(
+                            "Expected initializer for const declaration",
+                            // TODO: get exact position of uninitialized const decl
+                            init_position,
+                        ));
+                    }
+                }
+            }
             _ => {}
         }
 

--- a/boa_engine/src/syntax/parser/statement/iteration/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/tests.rs
@@ -7,7 +7,7 @@ use crate::syntax::{
         op::{self, AssignOp, CompOp},
         Const,
     },
-    parser::tests::check_parser,
+    parser::tests::{check_invalid, check_parser},
 };
 use boa_interner::Interner;
 
@@ -178,4 +178,10 @@ fn do_while_spaces() {
         .into()],
         &mut interner,
     );
+}
+
+/// Checks rejection of const bindings without init in for loops
+#[test]
+fn reject_const_no_init_for_loop() {
+    check_invalid("for (const h;;);");
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1897.

It changes the following:

- Rejects uninitialized const declarations inside the init value of a for loop statement.
- Adds test for the case.
