### PR TITLE
[Merged by Bors] - Compile StatementList after parse passes on negative tests

### DIFF
--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -180,9 +180,13 @@ impl Test {
                         self.name
                     );
 
-                    let mut interner = Interner::default();
-                    match Parser::new(self.content.as_bytes(), strict).parse_all(&mut interner) {
-                        Ok(n) => (false, format!("{n:?}")),
+                    let mut context = Context::default();
+                    context.set_strict_mode(strict);
+                    match context.parse(self.content.as_bytes()) {
+                        Ok(statement_list) => match context.compile(&statement_list) {
+                            Ok(_) => (false, "StatementList compilation should fail".to_owned()),
+                            Err(e) => (true, format!("Uncaught {:?}", e)),
+                        },
                         Err(e) => (true, format!("Uncaught {e}")),
                     }
                 }

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -185,7 +185,7 @@ impl Test {
                     match context.parse(self.content.as_bytes()) {
                         Ok(statement_list) => match context.compile(&statement_list) {
                             Ok(_) => (false, "StatementList compilation should fail".to_owned()),
-                            Err(e) => (true, format!("Uncaught {:?}", e)),
+                            Err(e) => (true, format!("Uncaught {e:?}")),
                         },
                         Err(e) => (true, format!("Uncaught {e}")),
                     }


### PR DESCRIPTION
This fixes an issue with 262 negative tests, that should produce a syntax errors. Currently we only parse the test code is such cases. If the parsing does not return an error, we do not compile the code further. This caused some panics. Most of them are fixed by now, the last ones will be fixed with #1860.