### PR TITLE
[Merged by Bors] - Use function name from identifiers in assignment expressions

### DIFF
--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -194,8 +194,13 @@ where
 
         cursor.set_goal(InputElement::Div);
 
-        let mut lhs = ConditionalExpression::new(self.allow_in, self.allow_yield, self.allow_await)
-            .parse(cursor, interner)?;
+        let mut lhs = ConditionalExpression::new(
+            self.name,
+            self.allow_in,
+            self.allow_yield,
+            self.allow_await,
+        )
+        .parse(cursor, interner)?;
 
         // Review if we are trying to assign to an invalid left hand side expression.
         // TODO: can we avoid cloning?

--- a/boa_engine/src/syntax/parser/expression/await_expr.rs
+++ b/boa_engine/src/syntax/parser/expression/await_expr.rs
@@ -57,7 +57,7 @@ where
             "Await expression parsing",
             interner,
         )?;
-        let expr = UnaryExpression::new(self.allow_yield, true).parse(cursor, interner)?;
+        let expr = UnaryExpression::new(None, self.allow_yield, true).parse(cursor, interner)?;
         Ok(expr.into())
     }
 }

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/mod.rs
@@ -18,7 +18,7 @@ use crate::syntax::{
     lexer::{InputElement, TokenKind},
     parser::{AllowAwait, AllowYield, Cursor, ParseResult, TokenParser},
 };
-use boa_interner::Interner;
+use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use std::io::Read;
 
@@ -32,18 +32,21 @@ use std::io::Read;
 /// [spec]: https://tc39.es/ecma262/#prod-LeftHandSideExpression
 #[derive(Debug, Clone, Copy)]
 pub(super) struct LeftHandSideExpression {
+    name: Option<Sym>,
     allow_yield: AllowYield,
     allow_await: AllowAwait,
 }
 
 impl LeftHandSideExpression {
     /// Creates a new `LeftHandSideExpression` parser.
-    pub(super) fn new<Y, A>(allow_yield: Y, allow_await: A) -> Self
+    pub(super) fn new<N, Y, A>(name: N, allow_yield: Y, allow_await: A) -> Self
     where
+        N: Into<Option<Sym>>,
         Y: Into<AllowYield>,
         A: Into<AllowAwait>,
     {
         Self {
+            name: name.into(),
             allow_yield: allow_yield.into(),
             allow_await: allow_await.into(),
         }
@@ -62,8 +65,8 @@ where
         cursor.set_goal(InputElement::TemplateTail);
 
         // TODO: Implement NewExpression: new MemberExpression
-        let lhs =
-            MemberExpression::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
+        let lhs = MemberExpression::new(self.name, self.allow_yield, self.allow_await)
+            .parse(cursor, interner)?;
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
                 return CallExpression::new(self.allow_yield, self.allow_await, lhs)

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/tests.rs
@@ -14,6 +14,7 @@ use boa_interner::{Interner, Sym};
 #[test]
 fn check_async_expression() {
     let mut interner = Interner::default();
+    let add = interner.get_or_intern_static("add");
     check_parser(
         "const add = async function() {
             return 1;
@@ -21,10 +22,10 @@ fn check_async_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("add"),
+                add,
                 Some(
                     AsyncFunctionExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(add),
                         FormalParameterList::default(),
                         vec![Return::new::<_, _, Option<Sym>>(Const::from(1), None).into()].into(),
                     )
@@ -41,6 +42,8 @@ fn check_async_expression() {
 #[test]
 fn check_nested_async_expression() {
     let mut interner = Interner::default();
+    let a = interner.get_or_intern_static("a");
+    let b = interner.get_or_intern_static("b");
     check_parser(
         "const a = async function() {
             const b = async function() {
@@ -50,17 +53,17 @@ fn check_nested_async_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("a"),
+                a,
                 Some(
                     AsyncFunctionExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(a),
                         FormalParameterList::default(),
                         vec![DeclarationList::Const(
                             vec![Declaration::new_with_identifier(
-                                interner.get_or_intern_static("b"),
+                                b,
                                 Some(
                                     AsyncFunctionExpr::new::<_, _, StatementList>(
-                                        None,
+                                        Some(b),
                                         FormalParameterList::default(),
                                         vec![Return::new::<_, _, Option<Sym>>(
                                             Const::from(1),

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/tests.rs
@@ -15,6 +15,7 @@ use boa_interner::{Interner, Sym};
 #[test]
 fn check_async_generator_expr() {
     let mut interner = Interner::default();
+    let add = interner.get_or_intern_static("add");
     check_parser(
         "const add = async function*(){
             return 1;
@@ -22,10 +23,10 @@ fn check_async_generator_expr() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("add"),
+                add,
                 Some(
                     AsyncGeneratorExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(add),
                         FormalParameterList::default(),
                         vec![Return::new::<_, _, Option<Sym>>(Const::from(1), None).into()].into(),
                     )
@@ -42,6 +43,8 @@ fn check_async_generator_expr() {
 #[test]
 fn check_nested_async_generator_expr() {
     let mut interner = Interner::default();
+    let a = interner.get_or_intern_static("a");
+    let b = interner.get_or_intern_static("b");
     check_parser(
         "const a = async function*() {
             const b = async function*() {
@@ -51,17 +54,17 @@ fn check_nested_async_generator_expr() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("a"),
+                a,
                 Some(
                     AsyncGeneratorExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(a),
                         FormalParameterList::default(),
                         vec![DeclarationList::Const(
                             vec![Declaration::new_with_identifier(
-                                interner.get_or_intern_static("b"),
+                                b,
                                 Some(
                                     AsyncGeneratorExpr::new::<_, _, StatementList>(
-                                        None,
+                                        Some(b),
                                         FormalParameterList::default(),
                                         vec![Return::new::<_, _, Option<Sym>>(
                                             Const::from(1),

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
@@ -13,6 +13,7 @@ use boa_interner::{Interner, Sym};
 #[test]
 fn check_function_expression() {
     let mut interner = Interner::default();
+    let add = interner.get_or_intern_static("add");
     check_parser(
         "const add = function() {
             return 1;
@@ -20,10 +21,10 @@ fn check_function_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("add"),
+                add,
                 Some(
                     FunctionExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(add),
                         FormalParameterList::default(),
                         vec![Return::new::<_, _, Option<Sym>>(Const::from(1), None).into()].into(),
                     )
@@ -40,6 +41,8 @@ fn check_function_expression() {
 #[test]
 fn check_nested_function_expression() {
     let mut interner = Interner::default();
+    let a = interner.get_or_intern_static("a");
+    let b = interner.get_or_intern_static("b");
     check_parser(
         "const a = function() {
             const b = function() {
@@ -49,17 +52,17 @@ fn check_nested_function_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("a"),
+                a,
                 Some(
                     FunctionExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(a),
                         FormalParameterList::default(),
                         vec![DeclarationList::Const(
                             vec![Declaration::new_with_identifier(
-                                interner.get_or_intern_static("b"),
+                                b,
                                 Some(
                                     FunctionExpr::new::<_, _, StatementList>(
-                                        None,
+                                        Some(b),
                                         FormalParameterList::default(),
                                         vec![Return::new::<_, _, Option<Sym>>(
                                             Const::from(1),

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
@@ -12,6 +12,7 @@ use boa_interner::Interner;
 #[test]
 fn check_generator_function_expression() {
     let mut interner = Interner::default();
+    let gen = interner.get_or_intern_static("gen");
     check_parser(
         "const gen = function*() {
             yield 1;
@@ -19,10 +20,10 @@ fn check_generator_function_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("gen"),
+                gen,
                 Some(
                     GeneratorExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(gen),
                         FormalParameterList::default(),
                         vec![Yield::new(Const::from(1), false).into()].into(),
                     )
@@ -39,6 +40,7 @@ fn check_generator_function_expression() {
 #[test]
 fn check_generator_function_delegate_yield_expression() {
     let mut interner = Interner::default();
+    let gen = interner.get_or_intern_static("gen");
     check_parser(
         "const gen = function*() {
             yield* 1;
@@ -46,10 +48,10 @@ fn check_generator_function_delegate_yield_expression() {
         ",
         vec![DeclarationList::Const(
             vec![Declaration::new_with_identifier(
-                interner.get_or_intern_static("gen"),
+                gen,
                 Some(
                     GeneratorExpr::new::<_, _, StatementList>(
-                        None,
+                        Some(gen),
                         FormalParameterList::default(),
                         vec![Yield::new(Const::from(1), true).into()].into(),
                     )

--- a/boa_engine/src/syntax/parser/expression/update.rs
+++ b/boa_engine/src/syntax/parser/expression/update.rs
@@ -26,18 +26,21 @@ use std::io::Read;
 /// [spec]: https://tc39.es/ecma262/#prod-UpdateExpression
 #[derive(Debug, Clone, Copy)]
 pub(super) struct UpdateExpression {
+    name: Option<Sym>,
     allow_yield: AllowYield,
     allow_await: AllowAwait,
 }
 
 impl UpdateExpression {
     /// Creates a new `UpdateExpression` parser.
-    pub(super) fn new<Y, A>(allow_yield: Y, allow_await: A) -> Self
+    pub(super) fn new<N, Y, A>(name: N, allow_yield: Y, allow_await: A) -> Self
     where
+        N: Into<Option<Sym>>,
         Y: Into<AllowYield>,
         A: Into<AllowAwait>,
     {
         Self {
+            name: name.into(),
             allow_yield: allow_yield.into(),
             allow_await: allow_await.into(),
         }
@@ -61,7 +64,7 @@ where
                     .expect("Punctuator::Inc token disappeared");
                 return Ok(node::UnaryOp::new(
                     UnaryOp::IncrementPre,
-                    UnaryExpression::new(self.allow_yield, self.allow_await)
+                    UnaryExpression::new(self.name, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?,
                 )
                 .into());
@@ -72,7 +75,7 @@ where
                     .expect("Punctuator::Dec token disappeared");
                 return Ok(node::UnaryOp::new(
                     UnaryOp::DecrementPre,
-                    UnaryExpression::new(self.allow_yield, self.allow_await)
+                    UnaryExpression::new(self.name, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?,
                 )
                 .into());
@@ -80,7 +83,7 @@ where
             _ => {}
         }
 
-        let lhs = LeftHandSideExpression::new(self.allow_yield, self.allow_await)
+        let lhs = LeftHandSideExpression::new(self.name, self.allow_yield, self.allow_await)
             .parse(cursor, interner)?;
         let strict = cursor.strict_mode();
         if let Some(tok) = cursor.peek(0, interner)? {


### PR DESCRIPTION
Use function name from identifiers in assignment expressions, when a function expressions does not contain a name.