### PR TITLE
[Merged by Bors] - Fix postfix increment and decrement return values

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -595,8 +595,7 @@ impl<'b> ByteCompiler<'b> {
                     }
                     UnaryOp::IncrementPost => {
                         self.compile_expr(unary.target(), true)?;
-                        self.emit(Opcode::Dup, &[]);
-                        self.emit(Opcode::Inc, &[]);
+                        self.emit(Opcode::IncPost, &[]);
 
                         let access = Self::compile_access(unary.target()).ok_or_else(|| {
                             self.context
@@ -608,8 +607,7 @@ impl<'b> ByteCompiler<'b> {
                     }
                     UnaryOp::DecrementPost => {
                         self.compile_expr(unary.target(), true)?;
-                        self.emit(Opcode::Dup, &[]);
-                        self.emit(Opcode::Dec, &[]);
+                        self.emit(Opcode::DecPost, &[]);
 
                         let access = Self::compile_access(unary.target()).ok_or_else(|| {
                             self.context

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -287,7 +287,9 @@ impl CodeBlock {
             | Opcode::Pos
             | Opcode::Neg
             | Opcode::Inc
+            | Opcode::IncPost
             | Opcode::Dec
+            | Opcode::DecPost
             | Opcode::GetPropertyByValue
             | Opcode::SetPropertyByValue
             | Opcode::DefineOwnPropertyByValue

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -314,9 +314,31 @@ impl Context {
                     }
                 }
             }
+            Opcode::IncPost => {
+                let value = self.vm.pop();
+                let value = value.to_numeric(self)?;
+                self.vm.push(value.clone());
+                match value {
+                    Numeric::Number(number) => self.vm.push(number + 1f64),
+                    Numeric::BigInt(bigint) => {
+                        self.vm.push(JsBigInt::add(&bigint, &JsBigInt::one()));
+                    }
+                }
+            }
             Opcode::Dec => {
                 let value = self.vm.pop();
                 match value.to_numeric(self)? {
+                    Numeric::Number(number) => self.vm.push(number - 1f64),
+                    Numeric::BigInt(bigint) => {
+                        self.vm.push(JsBigInt::sub(&bigint, &JsBigInt::one()));
+                    }
+                }
+            }
+            Opcode::DecPost => {
+                let value = self.vm.pop();
+                let value = value.to_numeric(self)?;
+                self.vm.push(value.clone());
+                match value {
                     Numeric::Number(number) => self.vm.push(number - 1f64),
                     Numeric::BigInt(bigint) => {
                         self.vm.push(JsBigInt::sub(&bigint, &JsBigInt::one()));

--- a/boa_engine/src/vm/opcode.rs
+++ b/boa_engine/src/vm/opcode.rs
@@ -390,12 +390,26 @@ pub enum Opcode {
     /// Stack: value **=>** (value + 1)
     Inc,
 
+    /// Unary postfix `++` operator.
+    ///
+    /// Operands:
+    ///
+    /// Stack: value **=>** (ToNumeric(value)), (value + 1)
+    IncPost,
+
     /// Unary `--` operator.
     ///
     /// Operands:
     ///
     /// Stack: value **=>** (value - 1)
     Dec,
+
+    /// Unary postfix `--` operator.
+    ///
+    /// Operands:
+    ///
+    /// Stack: value **=>** (ToNumeric(value)), (value - 1)
+    DecPost,
 
     /// Declare and initialize a function argument.
     ///
@@ -978,7 +992,9 @@ impl Opcode {
             Opcode::Pos => "Pos",
             Opcode::Neg => "Neg",
             Opcode::Inc => "Inc",
+            Opcode::IncPost => "IncPost",
             Opcode::Dec => "Dec",
+            Opcode::DecPost => "DecPost",
             Opcode::DefInitArg => "DefInitArg",
             Opcode::DefVar => "DefVar",
             Opcode::DefInitVar => "DefInitVar",


### PR DESCRIPTION
This fixes a bug with the postfix increment and decrement. Before those operators would return the left-hand-side value, but the spec specifies they should return ToNumeric(left-had-side value).
