### PR TITLE
tests web view: Change individual test links to be <a> instead of <div>, for better accessibility

### DIFF
--- a/test262/results.js
+++ b/test262/results.js
@@ -295,12 +295,13 @@
           }
 
           let testCard = $(
-            `<div title="${innerTest.n}" class="card test embed-responsive ${style}"></div>`
-          ).click(() => {
-            window.open(
+            `<a title="${innerTest.n}" class="card test embed-responsive ${style}"></a>`
+          )
+            .attr(
+              "href",
               `https://github.com/tc39/test262/blob/${upstream}/${name}`
-            );
-          });
+            )
+            .attr("target", "_blank");
 
           if (innerTest.r === "P") {
             testCard.append($('<i class="bi-exclamation-triangle"></i>'));


### PR DESCRIPTION
This Pull Request fixes/closes #1949

It changes the following:

- Replace the testCard `<div />` with a `<a />`
- Replace `.click()` callback with an `href` attribute, and specify `target="_blank"` so that the link opens in a new tab by default

