### PR TITLE
[Merged by Bors] - add README for crates.io publish

### DIFF
--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -10,24 +10,6 @@ keywords = ["javascript", "compiler", "lexer", "parser", "js", "cli"]
 categories = ["command-line-utilities"]
 license = "Unlicense/MIT"
 default-run = "boa"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 boa_engine = { path = "../boa_engine", features = ["deser", "console"], version = "0.14.0" }

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "js", "compiler", "lexer", "parser"]
 categories = ["parser-implementations", "compilers"]
 license = "Unlicense/MIT"
+readme = "../README.md"
 exclude = [
     "../.vscode/*",
     "../.editorconfig",

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -10,24 +10,6 @@ keywords = ["javascript", "js", "compiler", "lexer", "parser"]
 categories = ["parser-implementations", "compilers"]
 license = "Unlicense/MIT"
 readme = "../README.md"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [features]
 profiler = ["boa_profiler/profiler"]

--- a/boa_gc/Cargo.toml
+++ b/boa_gc/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "js", "garbage", "memory"]
 categories = ["command-line-utilities"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 gc = { version = "0.4.1", features = ["derive"] }

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "js", "string", "interner"]
 categories = ["data-structures"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 string-interner = "0.14.0"

--- a/boa_profiler/Cargo.toml
+++ b/boa_profiler/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "js", "compiler", "profiler"]
 categories = ["development-tools::profiling"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [features]
 profiler = ["measureme", "once_cell"]

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "ECMASCript", "compiler", "test262", "tester"]
 categories = ["command-line-utilites"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 boa_engine = { path = "../boa_engine", version = "0.14.0" }

--- a/boa_unicode/Cargo.toml
+++ b/boa_unicode/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "compiler", "lexer", "parser", "unicode"]
 categories = ["parsing"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 unicode-general-category = "0.5.1"

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -9,24 +9,6 @@ repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "compiler", "lexer", "parser", "js"]
 categories = ["parser-implementations", "wasm", "compilers"]
 license = "Unlicense/MIT"
-exclude = [
-    "../.vscode/*",
-    "../.editorconfig",
-    "../test262/*",
-    "../node_modules/*",
-    "../target/*",
-    "../dist/*",
-    "../.github/*",
-    "../assets/*",
-    "../docs/*",
-    "../*.js",
-    "../test_ignore.txt",
-    "../yarn.lock",
-    "../package.json",
-    "../index.html",
-    "../tests/*",
-    "../.github/*",
-]
 
 [dependencies]
 boa_engine = { path = "../boa_engine", features = ["console"], version = "0.14.0" }


### PR DESCRIPTION
This Pull Request closes #1948.

It changes the following:

- set `readme` in `boa_engine` so `README.md` will be published to crates.io
- remove unnecessary `exclude` field from `Cargo.toml` in all apps

I was unsure whether using a path outside of the workspace root was allowed for `readme` since it [doesn't get included in the release tarball](https://github.com/rust-lang/cargo/issues/5911), but this exact path is used by [juniper](https://github.com/graphql-rust/juniper/blob/master/juniper/Cargo.toml#L13) and [seems to work there](https://crates.io/crates/juniper). I believe `cargo publish` does a bit more than just uploading the tarball, including pulling the `readme` from any arbitrary path.

The default behaviour of `cargo package`/`cargo publish` if neither `exclude` or `include` is specified is to include all files from the package root, excluding

- dotfiles
- .gitignore'd files
- subpackages (any subdirectory with a `Cargo.toml` file)
- the `/target` directory

There's no need to explicitly exclude files from the parent directory since they're already excluded by default. This can be verified by running `cargo package --list` inside any workspace app:

```plain
$ cd boa_wasm
$ cargo package --list
.gitignore
Cargo.toml
Cargo.toml.orig
src/lib.rs
```

You can read more [here](https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields).