### PR TITLE
[Merged by Bors] - convert inner datetime to local in `to_date_string`

### DIFF
--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -1634,7 +1634,12 @@ impl Date {
         // 4. Let t be LocalTime(tv).
         // 5. Return DateString(t).
         if let Some(t) = tv.0 {
-            Ok(t.format("%a %b %d %Y").to_string().into())
+            Ok(Local::now()
+                .timezone()
+                .from_utc_datetime(&t)
+                .format("%a %b %d %Y")
+                .to_string()
+                .into())
         } else {
             Ok(JsString::from("Invalid Date").into())
         }

--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -1199,7 +1199,7 @@ fn date_proto_to_string() {
         Some(JsValue::new(
             Local
                 .from_local_datetime(&NaiveDateTime::new(
-                    NaiveDate::from_ymd(2020, 6, 8),
+                    NaiveDate::from_ymd(2020, 7, 8),
                     NaiveTime::from_hms_milli(9, 16, 15, 779)
                 ))
                 .earliest()
@@ -1225,7 +1225,7 @@ fn date_proto_to_time_string() {
         Some(JsValue::new(
             Local
                 .from_local_datetime(&NaiveDateTime::new(
-                    NaiveDate::from_ymd(2020, 6, 8),
+                    NaiveDate::from_ymd(2020, 7, 8),
                     NaiveTime::from_hms_milli(9, 16, 15, 779)
                 ))
                 .earliest()


### PR DESCRIPTION
This Pull Request fixes/closes #1942.

`Date.prototype.toDateString` should return a value representing the local date. The Rust `Date` inner value represents UTC time, so it should be adjusted to local time before formatting (see equivalent conversions performed by `to_string` and `to_time_string`).

To verify this is working as intended, run the test suite with your OS timezone set to `GMT+0`, then again with `GMT+10`. The test `date_proto_to_date_string` should pass for each. For me (Ubuntu via WSL), this can be done with `sudo dpkg-reconfigure tzdata`.

This PR also fixes a couple other test cases that used the wrong month value (as noted at the top of the file, JS months are 0-based while `chrono` months are 1-based).