### PR TITLE
[Merged by Bors] - Fix panic on AST dump in JSON format

### DIFF
--- a/boa_engine/src/syntax/ast/node/array/mod.rs
+++ b/boa_engine/src/syntax/ast/node/array/mod.rs
@@ -29,7 +29,6 @@ mod tests;
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct ArrayDecl {
-    #[cfg_attr(feature = "deser", serde(flatten))]
     arr: Box<[Node]>,
     has_trailing_comma_spread: bool,
 }

--- a/boa_engine/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa_engine/src/syntax/ast/node/statement_list/mod.rs
@@ -23,7 +23,6 @@ mod tests;
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Trace, Finalize, PartialEq)]
 pub struct StatementList {
-    #[cfg_attr(feature = "deser", serde(flatten))]
     items: Box<[Node]>,
     strict: bool,
 }


### PR DESCRIPTION
Some of the fields in AST structs were both

1. Arrays
2. Marked as 'flatten'

This is illegal per serde docs (and doesn't really make sense).
The fix is to remove the attribute.

See: https://serde.rs/attr-flatten.html
Fixes: #1920