### PR TITLE
[Merged by Bors] - Fix panic in do while 

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -1476,7 +1476,6 @@ impl<'b> ByteCompiler<'b> {
 
                 self.pop_loop_control_info();
                 self.emit_opcode(Opcode::LoopEnd);
-
             }
             Node::Continue(node) => {
                 let next = self.next_opcode_location();

--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -1472,11 +1472,11 @@ impl<'b> ByteCompiler<'b> {
 
                 self.compile_stmt(do_while.body(), false)?;
                 self.emit(Opcode::Jump, &[condition_label_address]);
+                self.patch_jump(exit);
 
                 self.pop_loop_control_info();
                 self.emit_opcode(Opcode::LoopEnd);
 
-                self.patch_jump(exit);
             }
             Node::Continue(node) => {
                 let next = self.next_opcode_location();

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -382,6 +382,21 @@ fn do_while_post_inc() {
 }
 
 #[test]
+fn do_while_in_block(){
+    let in_block = r#"
+        {
+            var i = 0;
+            do {
+                i += 1;
+            }
+            while(false);
+            i;
+        }
+    "#;
+    assert_eq!(&exec(in_block),"1");
+}
+
+#[test]
 fn for_loop() {
     let simple = r#"
         const a = ['h', 'e', 'l', 'l', 'o'];

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -382,7 +382,7 @@ fn do_while_post_inc() {
 }
 
 #[test]
-fn do_while_in_block(){
+fn do_while_in_block() {
     let in_block = r#"
         {
             var i = 0;
@@ -393,7 +393,7 @@ fn do_while_in_block(){
             i;
         }
     "#;
-    assert_eq!(&exec(in_block),"1");
+    assert_eq!(&exec(in_block), "1");
 }
 
 #[test]


### PR DESCRIPTION
 `Node::DoWhileLoop` ast node had a buggy bytecode generation where `self.patch_jump(exit)` was called after emitting `LoopEnd` opcode. This would patch the loop exit to the instruction following the do while code, which would panic in cases where do while was enclosed in a block statement.

This Pull Request fixes #1929.

It changes the following:
- Patch jump before emitting `Opcode::LoopEnd`
- Add test which has do while statement inside a block statement to demonstrate that the change fixes the panic.
