### PR TITLE
[Merged by Bors] - Retrieve feature-based results for Test262 runs

### DIFF
--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -43,6 +43,13 @@ impl TestSuite {
                 .collect()
         };
 
+        let mut features = Vec::new();
+        for test_iter in self.tests.iter() {
+            for feature_iter in test_iter.features.iter() {
+                features.push(feature_iter.to_string());
+            }
+        }
+
         if verbose != 0 {
             println!();
         }
@@ -67,6 +74,7 @@ impl TestSuite {
             passed += suite.passed;
             ignored += suite.ignored;
             panic += suite.panic;
+            features.append(&mut suite.features.clone())
         }
 
         if verbose != 0 {
@@ -95,6 +103,7 @@ impl TestSuite {
             panic,
             suites,
             tests,
+            features,
         }
     }
 }

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -74,7 +74,7 @@ impl TestSuite {
             passed += suite.passed;
             ignored += suite.ignored;
             panic += suite.panic;
-            features.append(&mut suite.features.clone())
+            features.append(&mut suite.features.clone());
         }
 
         if verbose != 0 {

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -357,6 +357,9 @@ struct SuiteResult {
     #[serde(rename = "t")]
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     tests: Vec<TestResult>,
+    #[serde(rename = "f")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    features: Vec<String>,
 }
 
 /// Outcome of a test.

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -62,8 +62,8 @@ struct FeaturesInfo {
     features: Vec<String>,
 }
 
-fn remove_duplicates(features_vec: &Vec<String>) -> Vec<String> {
-    let mut result = features_vec.clone();
+fn remove_duplicates(features_vec: &[String]) -> Vec<String> {
+    let mut result = features_vec.to_vec();
     result.sort();
     result.dedup();
     result


### PR DESCRIPTION
This Pull Request fixes/closes #1645.

It changes the following:

- Add `features` field to `SuiteResult` structure
- Fetch features from `TestSuite` and propagate them via `SuiteResult`
- Add `FeaturesInfo` structure and serialize it to `features.json`