### PR TITLE
[Merged by Bors] - Added better error handling for the Boa tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +154,7 @@ dependencies = [
 name = "boa_tester"
 version = "0.14.0"
 dependencies = [
+ "anyhow",
  "bitflags",
  "boa_engine",
  "boa_interner",

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -27,3 +27,4 @@ hex = "0.4.3"
 num-format = "0.4.0"
 gc = { version = "0.4.1", features = ["derive"] }
 rayon = "1.5.1"
+anyhow = "1.0.56"

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -71,6 +71,7 @@ use self::{
     read::{read_harness, read_suite, read_test, MetaData, Negative, TestFlag},
     results::{compare_results, write_json},
 };
+use anyhow::{bail, Context};
 use bitflags::bitflags;
 use colored::Colorize;
 use fxhash::{FxHashMap, FxHashSet};
@@ -242,13 +243,21 @@ fn main() {
             output,
             disable_parallelism,
         } => {
-            run_test_suite(
+            if let Err(e) = run_test_suite(
                 verbose,
                 !disable_parallelism,
                 test262_path.as_path(),
                 suite.as_path(),
                 output.as_deref(),
-            );
+            ) {
+                eprintln!("Error: {e}");
+                let mut src = e.source();
+                while let Some(e) = src {
+                    eprintln!("    caused by: {e}");
+                    src = e.source();
+                }
+                std::process::exit(1);
+            }
         }
         Cli::Compare {
             base,
@@ -265,25 +274,27 @@ fn run_test_suite(
     test262_path: &Path,
     suite: &Path,
     output: Option<&Path>,
-) {
+) -> anyhow::Result<()> {
     if let Some(path) = output {
         if path.exists() {
             if !path.is_dir() {
-                eprintln!("The output path must be a directory.");
-                std::process::exit(1);
+                bail!("the output path must be a directory.");
             }
         } else {
-            fs::create_dir_all(path).expect("could not create the output directory");
+            fs::create_dir_all(path).context("could not create the output directory")?;
         }
     }
 
     if verbose != 0 {
         println!("Loading the test suite...");
     }
-    let harness = read_harness(test262_path).expect("could not read initialization bindings");
+    let harness = read_harness(test262_path).context("could not read harness")?;
 
     if suite.to_string_lossy().ends_with(".js") {
-        let test = read_test(&test262_path.join(suite)).expect("could not get the test to run");
+        let test = read_test(&test262_path.join(suite)).with_context(|| {
+            let suite = suite.display();
+            format!("could not read the test {suite}")
+        })?;
 
         if verbose != 0 {
             println!("Test loaded, starting...");
@@ -292,8 +303,10 @@ fn run_test_suite(
 
         println!();
     } else {
-        let suite =
-            read_suite(&test262_path.join(suite)).expect("could not get the list of tests to run");
+        let suite = read_suite(&test262_path.join(suite)).with_context(|| {
+            let suite = suite.display();
+            format!("could not read the suite {suite}")
+        })?;
 
         if verbose != 0 {
             println!("Test suite loaded, starting tests...");
@@ -318,8 +331,10 @@ fn run_test_suite(
         );
 
         write_json(results, output, verbose)
-            .expect("could not write the results to the output JSON file");
+            .context("could not write the results to the output JSON file")?;
     }
+
+    Ok(())
 }
 
 /// All the harness include files.


### PR DESCRIPTION
Trying to fix the issue in #1982, I noticed that we didn't have a proper error handling for the boa tester.

This adds the `anyhow` dependency to the tester, which makes it much easier to handle errors and bubble them up with attached context. Thanks to this I was able to easily find out the issue, and I think it could be useful to have it. It gives errors such as this one:

```
Error: could not read the suite test
    caused by: error reading sub-suite ./test262/test/built-ins
    caused by: error reading sub-suite ./test262/test/built-ins/ShadowRealm
    caused by: error reading sub-suite ./test262/test/built-ins/ShadowRealm/WrappedFunction
    caused by: error reading test ./test262/test/built-ins/ShadowRealm/WrappedFunction/throws-typeerror-on-revoked-proxy.js
    caused by: while scanning a block scalar, found a tab character where an indentation space is expected at line 4 column 3
    caused by: while scanning a block scalar, found a tab character where an indentation space is expected at line 4 column 3
```