### PR TITLE
[Merged by Bors] - Allow boolean/null as property identifier by dot operator assignment

### DIFF
--- a/boa_engine/src/syntax/parser/expression/left_hand_side/member.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/member.rs
@@ -99,6 +99,21 @@ where
                         TokenKind::Keyword(kw) => {
                             lhs = GetConstField::new(lhs, kw.to_sym(interner)).into();
                         }
+                        TokenKind::BooleanLiteral(bool) => {
+                            match bool {
+                                true => {
+                                    lhs = GetConstField::new(lhs, Keyword::True.to_sym(interner))
+                                        .into();
+                                }
+                                false => {
+                                    lhs = GetConstField::new(lhs, Keyword::False.to_sym(interner))
+                                        .into();
+                                }
+                            };
+                        }
+                        TokenKind::NullLiteral => {
+                            lhs = GetConstField::new(lhs, Keyword::Null.to_sym(interner)).into();
+                        }
                         _ => {
                             return Err(ParseError::expected(
                                 ["identifier".to_owned()],


### PR DESCRIPTION
This Pull Request lets true/false/null be used as object property identifiers, when using dot assignment.

`foo.null = 'bar';`

It changes the following:

- AST parsing of member expressions
