### PR TITLE
JsValue from primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
+checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -741,9 +741,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"

--- a/boa_engine/src/value/conversions.rs
+++ b/boa_engine/src/value/conversions.rs
@@ -54,6 +54,18 @@ impl From<f64> for JsValue {
     }
 }
 
+impl From<f32> for JsValue {
+    #[allow(clippy::float_cmp)]
+    #[inline]
+    fn from(value: f32) -> Self {
+        // if value as i32 as f32 == value {
+        //     Self::Integer(value as i32)
+        // } else {
+        Self::Rational(value.into())
+        // }
+    }
+}
+
 impl From<u32> for JsValue {
     #[inline]
     fn from(value: u32) -> Self {

--- a/boa_engine/src/value/conversions.rs
+++ b/boa_engine/src/value/conversions.rs
@@ -76,7 +76,11 @@ impl From<u128> for JsValue {
 impl From<u64> for JsValue {
     #[inline]
     fn from(value: u64) -> Self {
-        Self::BigInt(value.into())
+        if let Ok(value) = i32::try_from(value) {
+            Self::Integer(value)
+        } else {
+            Self::Rational(value as f64)
+        }
     }
 }
 
@@ -115,7 +119,11 @@ impl From<i128> for JsValue {
 impl From<i64> for JsValue {
     #[inline]
     fn from(value: i64) -> Self {
-        Self::BigInt(value.into())
+        if let Ok(value) = i32::try_from(value) {
+            Self::Integer(value)
+        } else {
+            Self::Rational(value as f64)
+        }
     }
 }
 

--- a/boa_engine/src/value/conversions.rs
+++ b/boa_engine/src/value/conversions.rs
@@ -66,6 +66,20 @@ impl From<f32> for JsValue {
     }
 }
 
+impl From<u128> for JsValue {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+
+impl From<u64> for JsValue {
+    #[inline]
+    fn from(value: u64) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+
 impl From<u32> for JsValue {
     #[inline]
     fn from(value: u32) -> Self {
@@ -77,10 +91,52 @@ impl From<u32> for JsValue {
     }
 }
 
+impl From<u16> for JsValue {
+    #[inline]
+    fn from(value: u16) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<u8> for JsValue {
+    #[inline]
+    fn from(value: u8) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<i128> for JsValue {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+
+impl From<i64> for JsValue {
+    #[inline]
+    fn from(value: i64) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+
 impl From<i32> for JsValue {
     #[inline]
     fn from(value: i32) -> Self {
         Self::Integer(value)
+    }
+}
+
+impl From<i16> for JsValue {
+    #[inline]
+    fn from(value: i16) -> Self {
+        Self::Integer(value.into())
+    }
+}
+
+impl From<i8> for JsValue {
+    #[inline]
+    fn from(value: i8) -> Self {
+        Self::Integer(value.into())
     }
 }
 
@@ -94,28 +150,6 @@ impl From<JsBigInt> for JsValue {
 impl From<usize> for JsValue {
     #[inline]
     fn from(value: usize) -> Self {
-        if let Ok(value) = i32::try_from(value) {
-            Self::Integer(value)
-        } else {
-            Self::Rational(value as f64)
-        }
-    }
-}
-
-impl From<u64> for JsValue {
-    #[inline]
-    fn from(value: u64) -> Self {
-        if let Ok(value) = i32::try_from(value) {
-            Self::Integer(value)
-        } else {
-            Self::Rational(value as f64)
-        }
-    }
-}
-
-impl From<i64> for JsValue {
-    #[inline]
-    fn from(value: i64) -> Self {
         if let Ok(value) = i32::try_from(value) {
             Self::Integer(value)
         } else {

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -14,7 +14,7 @@ license = "Unlicense/MIT"
 boa_engine = { path = "../boa_engine", features = ["console"], version = "0.14.0" }
 # BUG: Pump when 0.2.80 releases. See https://github.com/rustwasm/wasm-bindgen/issues/2774
 wasm-bindgen = "=0.2.78"
-getrandom = { version = "0.2.5", features = ["js"] }
+getrandom = { version = "0.2.6", features = ["js"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #1994 and #1991 and depends on https://github.com/boa-dev/boa/pull/1971.

It changes the following:

- Adds many primitive conversions, From<T> for JsValue where T are integers
- Makes some opinions about `i128`, `u128`, `i64`, and `u64` when converting to JsValue, always converting to BigInt