### PR TITLE
[Merged by Bors] - fix(vm): off-by-one in code block stringification.

### DIFF
--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -351,9 +351,10 @@ impl ToInternedString for CodeBlock {
         while pc < self.code.len() {
             let opcode: Opcode = self.code[pc].try_into().expect("invalid opcode");
             let opcode = opcode.as_str();
+            let previous_pc = pc;
             let operands = self.instruction_operands(&mut pc, interner);
             f.push_str(&format!(
-                "{pc:06}    {count:04}    {opcode:<27}{operands}\n",
+                "{previous_pc:06}    {count:04}    {opcode:<27}{operands}\n",
             ));
             count += 1;
         }


### PR DESCRIPTION
Acked-by: Taylor Sutton <tsutton125@gmail.com>

This Pull Request fixes/closes #1998 

The call to retrieve operands modifies pc, setting it to the index of
the *next* instruction. So, we save its initial value and use that
for printing.

