### PR TITLE
[Merged by Bors] - Indicate bigint has constructor

### DIFF
--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -51,7 +51,7 @@ impl BuiltIn for BigInt {
         .static_method(Self::as_int_n, "asIntN", 2)
         .static_method(Self::as_uint_n, "asUintN", 2)
         .callable(true)
-        .constructor(false)
+        .constructor(true)
         .property(
             to_string_tag,
             Self::NAME,


### PR DESCRIPTION
This Pull Request changes BigInt so that isConstructor returns true.

It changes a single boolean value for BigInt's ConstructorBuilder.