### PR TITLE
[Merged by Bors] - Fix rust 1.60 clippy lints

### DIFF
--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -764,7 +764,7 @@ pub fn create_byte_data_block(size: usize, context: &mut Context) -> JsResult<Ve
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-copydatablockbytes
 fn copy_data_block_bytes(
-    to_block: &mut Vec<u8>,
+    to_block: &mut [u8],
     mut to_index: usize,
     from_block: &[u8],
     mut from_index: usize,

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1386,7 +1386,9 @@ impl RegExp {
                 //     the substring of S from nextSourcePosition to position, and replacement.
                 accumulated_result = format!(
                     "{accumulated_result}{}{replacement}",
-                    arg_str.get(next_source_position..position).unwrap(),
+                    arg_str
+                        .get(next_source_position..position)
+                        .expect("index of a regexp match cannot be greater than the input string"),
                 )
                 .into();
 
@@ -1404,7 +1406,9 @@ impl RegExp {
         Ok(format!(
             "{}{}",
             accumulated_result,
-            arg_str.get(next_source_position..).unwrap()
+            arg_str
+                .get(next_source_position..)
+                .expect("next_source_position cannot be greater than the input string")
         )
         .into())
     }

--- a/boa_engine/src/value/display.rs
+++ b/boa_engine/src/value/display.rs
@@ -117,8 +117,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                         .borrow()
                         .properties()
                         .get(&PropertyKey::from("length"))
-                        // TODO: do this in a better way `unwrap`
-                        .unwrap()
+                        .expect("array object must have 'length' property")
                         // FIXME: handle accessor descriptors
                         .expect_value()
                         .as_number()


### PR DESCRIPTION
This Pull Request fixes new / improved clippy lints with rust 1.60.
