### PR TITLE
[Merged by Bors] - Fix `ArrayBuffer.isView()`

### DIFF
--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -128,7 +128,7 @@ impl ArrayBuffer {
         Ok(args
             .get_or_undefined(0)
             .as_object()
-            .map(|obj| obj.borrow().is_typed_array())
+            .map(|obj| obj.borrow().has_viewed_array_buffer())
             .unwrap_or_default()
             .into())
     }

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -519,6 +519,23 @@ impl Object {
         }
     }
 
+    #[inline]
+    pub(crate) fn has_viewed_array_buffer(&self) -> bool {
+        self.is_typed_array() || self.is_data_view()
+    }
+
+    /// Checks if it an `DataView` object.
+    #[inline]
+    pub fn is_data_view(&self) -> bool {
+        matches!(
+            self.data,
+            ObjectData {
+                kind: ObjectKind::DataView(_),
+                ..
+            }
+        )
+    }
+
     /// Checks if it an `ArrayBuffer` object.
     #[inline]
     pub fn is_array_buffer(&self) -> bool {


### PR DESCRIPTION
`ArrayBuffer.isView()` should check whether the object contains a `[[ViewedArrayBuffer]]` internal slot, which `DataView` has.

It changes the following:
- Fix `ArrayBuffer.isView()`
