### PR TITLE
[Merged by Bors] - Allow unicode escaped characters in identifiers that are keywords

### DIFF
--- a/boa_engine/src/syntax/lexer/identifier.rs
+++ b/boa_engine/src/syntax/lexer/identifier.rs
@@ -90,13 +90,6 @@ impl<R> Tokenizer<R> for Identifier {
             Self::take_identifier_name(cursor, start_pos, self.init)?;
 
         let token_kind = if let Ok(keyword) = identifier_name.parse() {
-            if contains_escaped_chars {
-                return Err(Error::Syntax(
-                    "unicode escaped characters are not allowed in keyword".into(),
-                    start_pos,
-                ));
-            }
-
             if cursor.strict_mode() && keyword == Keyword::With {
                 return Err(Error::Syntax(
                     "using 'with' statement not allowed in strict mode".into(),
@@ -108,7 +101,7 @@ impl<R> Tokenizer<R> for Identifier {
                 Keyword::True => TokenKind::BooleanLiteral(true),
                 Keyword::False => TokenKind::BooleanLiteral(false),
                 Keyword::Null => TokenKind::NullLiteral,
-                _ => TokenKind::Keyword(keyword),
+                _ => TokenKind::Keyword((keyword, contains_escaped_chars)),
             }
         } else {
             if cursor.strict_mode()

--- a/boa_engine/src/syntax/lexer/tests.rs
+++ b/boa_engine/src/syntax/lexer/tests.rs
@@ -36,7 +36,7 @@ fn check_single_line_comment() {
     let mut interner = Interner::default();
 
     let expected = [
-        TokenKind::Keyword(Keyword::Var),
+        TokenKind::Keyword((Keyword::Var, false)),
         TokenKind::LineTerminator,
         TokenKind::LineTerminator,
         TokenKind::BooleanLiteral(true),
@@ -52,7 +52,7 @@ fn check_single_line_comment_with_crlf_ending() {
     let mut interner = Interner::default();
 
     let expected = [
-        TokenKind::Keyword(Keyword::Var),
+        TokenKind::Keyword((Keyword::Var, false)),
         TokenKind::LineTerminator,
         TokenKind::LineTerminator,
         TokenKind::BooleanLiteral(true),
@@ -69,7 +69,7 @@ fn check_multi_line_comment() {
 
     let sym = interner.get_or_intern_static("x");
     let expected = [
-        TokenKind::Keyword(Keyword::Var),
+        TokenKind::Keyword((Keyword::Var, false)),
         TokenKind::LineTerminator,
         TokenKind::identifier(sym),
     ];
@@ -251,40 +251,40 @@ fn check_keywords() {
     let mut interner = Interner::default();
 
     let expected = [
-        TokenKind::Keyword(Keyword::Await),
-        TokenKind::Keyword(Keyword::Break),
-        TokenKind::Keyword(Keyword::Case),
-        TokenKind::Keyword(Keyword::Catch),
-        TokenKind::Keyword(Keyword::Class),
-        TokenKind::Keyword(Keyword::Const),
-        TokenKind::Keyword(Keyword::Continue),
-        TokenKind::Keyword(Keyword::Debugger),
-        TokenKind::Keyword(Keyword::Default),
-        TokenKind::Keyword(Keyword::Delete),
-        TokenKind::Keyword(Keyword::Do),
-        TokenKind::Keyword(Keyword::Else),
-        TokenKind::Keyword(Keyword::Export),
-        TokenKind::Keyword(Keyword::Extends),
-        TokenKind::Keyword(Keyword::Finally),
-        TokenKind::Keyword(Keyword::For),
-        TokenKind::Keyword(Keyword::Function),
-        TokenKind::Keyword(Keyword::If),
-        TokenKind::Keyword(Keyword::Import),
-        TokenKind::Keyword(Keyword::In),
-        TokenKind::Keyword(Keyword::InstanceOf),
-        TokenKind::Keyword(Keyword::New),
-        TokenKind::Keyword(Keyword::Return),
-        TokenKind::Keyword(Keyword::Super),
-        TokenKind::Keyword(Keyword::Switch),
-        TokenKind::Keyword(Keyword::This),
-        TokenKind::Keyword(Keyword::Throw),
-        TokenKind::Keyword(Keyword::Try),
-        TokenKind::Keyword(Keyword::TypeOf),
-        TokenKind::Keyword(Keyword::Var),
-        TokenKind::Keyword(Keyword::Void),
-        TokenKind::Keyword(Keyword::While),
-        TokenKind::Keyword(Keyword::With),
-        TokenKind::Keyword(Keyword::Yield),
+        TokenKind::Keyword((Keyword::Await, false)),
+        TokenKind::Keyword((Keyword::Break, false)),
+        TokenKind::Keyword((Keyword::Case, false)),
+        TokenKind::Keyword((Keyword::Catch, false)),
+        TokenKind::Keyword((Keyword::Class, false)),
+        TokenKind::Keyword((Keyword::Const, false)),
+        TokenKind::Keyword((Keyword::Continue, false)),
+        TokenKind::Keyword((Keyword::Debugger, false)),
+        TokenKind::Keyword((Keyword::Default, false)),
+        TokenKind::Keyword((Keyword::Delete, false)),
+        TokenKind::Keyword((Keyword::Do, false)),
+        TokenKind::Keyword((Keyword::Else, false)),
+        TokenKind::Keyword((Keyword::Export, false)),
+        TokenKind::Keyword((Keyword::Extends, false)),
+        TokenKind::Keyword((Keyword::Finally, false)),
+        TokenKind::Keyword((Keyword::For, false)),
+        TokenKind::Keyword((Keyword::Function, false)),
+        TokenKind::Keyword((Keyword::If, false)),
+        TokenKind::Keyword((Keyword::Import, false)),
+        TokenKind::Keyword((Keyword::In, false)),
+        TokenKind::Keyword((Keyword::InstanceOf, false)),
+        TokenKind::Keyword((Keyword::New, false)),
+        TokenKind::Keyword((Keyword::Return, false)),
+        TokenKind::Keyword((Keyword::Super, false)),
+        TokenKind::Keyword((Keyword::Switch, false)),
+        TokenKind::Keyword((Keyword::This, false)),
+        TokenKind::Keyword((Keyword::Throw, false)),
+        TokenKind::Keyword((Keyword::Try, false)),
+        TokenKind::Keyword((Keyword::TypeOf, false)),
+        TokenKind::Keyword((Keyword::Var, false)),
+        TokenKind::Keyword((Keyword::Void, false)),
+        TokenKind::Keyword((Keyword::While, false)),
+        TokenKind::Keyword((Keyword::With, false)),
+        TokenKind::Keyword((Keyword::Yield, false)),
     ];
 
     expect_tokens(&mut lexer, &expected, &mut interner);
@@ -299,7 +299,7 @@ fn check_variable_definition_tokens() {
     let a_sym = interner.get_or_intern_static("a");
     let hello_sym = interner.get_or_intern_static("hello");
     let expected = [
-        TokenKind::Keyword(Keyword::Let),
+        TokenKind::Keyword((Keyword::Let, false)),
         TokenKind::identifier(a_sym),
         TokenKind::Punctuator(Punctuator::Assign),
         TokenKind::string_literal(hello_sym),

--- a/boa_engine/src/syntax/lexer/token.rs
+++ b/boa_engine/src/syntax/lexer/token.rs
@@ -105,8 +105,8 @@ pub enum TokenKind {
     /// A private identifier.
     PrivateIdentifier(Sym),
 
-    /// A keyword.
-    Keyword(Keyword),
+    /// A keyword and a flag if the keyword contains unicode escaped chars.
+    Keyword((Keyword, bool)),
 
     /// A `null` literal.
     NullLiteral,
@@ -142,8 +142,8 @@ impl From<bool> for TokenKind {
     }
 }
 
-impl From<Keyword> for TokenKind {
-    fn from(kw: Keyword) -> Self {
+impl From<(Keyword, bool)> for TokenKind {
+    fn from(kw: (Keyword, bool)) -> Self {
         Self::Keyword(kw)
     }
 }
@@ -174,11 +174,6 @@ impl TokenKind {
     /// Creates an `Identifier` token type.
     pub fn identifier(ident: Sym) -> Self {
         Self::Identifier(ident)
-    }
-
-    /// Creates a `Keyword` token kind.
-    pub fn keyword(keyword: Keyword) -> Self {
-        Self::Keyword(keyword)
     }
 
     /// Creates a `NumericLiteral` token kind.
@@ -229,7 +224,7 @@ impl TokenKind {
             Self::EOF => "end of file".to_owned(),
             Self::Identifier(ident) => interner.resolve_expect(ident).to_owned(),
             Self::PrivateIdentifier(ident) => format!("#{}", interner.resolve_expect(ident)),
-            Self::Keyword(word) => word.to_string(),
+            Self::Keyword((word, _)) => word.to_string(),
             Self::NullLiteral => "null".to_owned(),
             Self::NumericLiteral(Numeric::Rational(num)) => num.to_string(),
             Self::NumericLiteral(Numeric::Integer(num)) => num.to_string(),

--- a/boa_engine/src/syntax/parser/expression/assignment/exponentiation.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/exponentiation.rs
@@ -70,7 +70,7 @@ where
     Ok(if let Some(tok) = cursor.peek(0, interner)? {
         matches!(
             tok.kind(),
-            TokenKind::Keyword(Keyword::Delete | Keyword::Void | Keyword::TypeOf)
+            TokenKind::Keyword((Keyword::Delete | Keyword::Void | Keyword::TypeOf, _))
                 | TokenKind::Punctuator(
                     Punctuator::Add | Punctuator::Sub | Punctuator::Not | Punctuator::Neg
                 )

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -97,12 +97,12 @@ where
             .kind()
         {
             // [+Yield]YieldExpression[?In, ?Await]
-            TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
+            TokenKind::Keyword((Keyword::Yield, _)) if self.allow_yield.0 => {
                 return YieldExpression::new(self.allow_in, self.allow_await)
                     .parse(cursor, interner)
             }
             // ArrowFunction[?In, ?Yield, ?Await] -> ArrowParameters[?Yield, ?Await] -> BindingIdentifier[?Yield, ?Await]
-            TokenKind::Identifier(_) | TokenKind::Keyword(Keyword::Yield | Keyword::Await) => {
+            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 if let Ok(tok) =
                     cursor.peek_expect_no_lineterminator(1, "assignment expression", interner)
                 {

--- a/boa_engine/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/yield.rs
@@ -58,7 +58,7 @@ where
         let _timer = Profiler::global().start_event("YieldExpression", "Parsing");
 
         cursor.expect(
-            TokenKind::Keyword(Keyword::Yield),
+            TokenKind::Keyword((Keyword::Yield, false)),
             "yield expression",
             interner,
         )?;
@@ -87,7 +87,7 @@ where
                 | Punctuator::OpenBlock
                 | Punctuator::Div,
             )
-            | TokenKind::Keyword(
+            | TokenKind::Keyword((
                 Keyword::Yield
                 | Keyword::Await
                 | Keyword::Delete
@@ -98,7 +98,8 @@ where
                 | Keyword::Function
                 | Keyword::Class
                 | Keyword::Async,
-            )
+                _,
+            ))
             | TokenKind::BooleanLiteral(_)
             | TokenKind::NullLiteral
             | TokenKind::StringLiteral(_)

--- a/boa_engine/src/syntax/parser/expression/await_expr.rs
+++ b/boa_engine/src/syntax/parser/expression/await_expr.rs
@@ -53,7 +53,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         cursor.expect(
-            TokenKind::Keyword(Keyword::Await),
+            TokenKind::Keyword((Keyword::Await, false)),
             "Await expression parsing",
             interner,
         )?;

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/call.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/call.rs
@@ -94,7 +94,7 @@ where
                         TokenKind::Identifier(name) => {
                             lhs = GetConstField::new(lhs, *name).into();
                         }
-                        TokenKind::Keyword(kw) => {
+                        TokenKind::Keyword((kw, _)) => {
                             lhs = GetConstField::new(lhs, kw.to_sym(interner)).into();
                         }
                         _ => {

--- a/boa_engine/src/syntax/parser/expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/mod.rs
@@ -98,7 +98,7 @@ macro_rules! expression { ($name:ident, $lower:ident, [$( $op:path ),*], [$( $lo
                             $lower::new($( self.$low_param ),*).parse(cursor, interner)?
                         ).into();
                     }
-                    TokenKind::Keyword(op) if $( op == $op )||* => {
+                    TokenKind::Keyword((op, false)) if $( op == $op )||* => {
                         let _next = cursor.next(interner).expect("token disappeared");
                         lhs = BinOp::new(
                             op.as_binop().expect("Could not get binary operation."),
@@ -540,7 +540,13 @@ where
                     )
                     .into();
                 }
-                TokenKind::Keyword(op)
+                TokenKind::Keyword((Keyword::InstanceOf | Keyword::In, true)) => {
+                    return Err(ParseError::general(
+                        "Keyword must not contain escaped characters",
+                        tok.span().start(),
+                    ));
+                }
+                TokenKind::Keyword((op, false))
                     if op == Keyword::InstanceOf
                         || (op == Keyword::In && self.allow_in == AllowIn(true)) =>
                 {

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -55,7 +55,11 @@ where
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("AsyncFunctionExpression", "Parsing");
         cursor.peek_expect_no_lineterminator(0, "async function expression", interner)?;
-        cursor.expect(Keyword::Function, "async function expression", interner)?;
+        cursor.expect(
+            (Keyword::Function, false),
+            "async function expression",
+            interner,
+        )?;
 
         let name = match cursor
             .peek(0, interner)?

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
@@ -59,7 +59,11 @@ where
         let _timer = Profiler::global().start_event("AsyncGeneratorExpression", "Parsing");
 
         cursor.peek_expect_no_lineterminator(0, "async generator expression", interner)?;
-        cursor.expect(Keyword::Function, "async generator expression", interner)?;
+        cursor.expect(
+            (Keyword::Function, false),
+            "async generator expression",
+            interner,
+        )?;
         cursor.expect(
             TokenKind::Punctuator(Punctuator::Mul),
             "async generator expression",

--- a/boa_engine/src/syntax/parser/expression/primary/class_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/class_expression/mod.rs
@@ -56,7 +56,7 @@ where
 
         let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         let name = match token.kind() {
-            TokenKind::Identifier(_) | TokenKind::Keyword(Keyword::Yield | Keyword::Await) => {
+            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
             }

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -64,7 +64,7 @@ where
             .ok_or(ParseError::AbruptEnd)?
             .kind()
         {
-            TokenKind::Identifier(_) | TokenKind::Keyword(Keyword::Yield | Keyword::Await) => {
+            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 Some(BindingIdentifier::new(false, false).parse(cursor, interner)?)
             }
             _ => self.name,

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -66,7 +66,10 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         let token_start = tok.span().start();
         match tok.kind() {
-            TokenKind::Keyword(Keyword::Delete) => {
+            TokenKind::Keyword((Keyword::Delete | Keyword::Void | Keyword::TypeOf, true)) => Err(
+                ParseError::general("Keyword must not contain escaped characters", token_start),
+            ),
+            TokenKind::Keyword((Keyword::Delete, false)) => {
                 cursor.next(interner)?.expect("Delete keyword vanished");
                 let position = cursor
                     .peek(0, interner)?
@@ -93,11 +96,11 @@ where
 
                 Ok(node::UnaryOp::new(UnaryOp::Delete, val).into())
             }
-            TokenKind::Keyword(Keyword::Void) => {
+            TokenKind::Keyword((Keyword::Void, false)) => {
                 cursor.next(interner)?.expect("Void keyword vanished"); // Consume the token.
                 Ok(node::UnaryOp::new(UnaryOp::Void, self.parse(cursor, interner)?).into())
             }
-            TokenKind::Keyword(Keyword::TypeOf) => {
+            TokenKind::Keyword((Keyword::TypeOf, false)) => {
                 cursor.next(interner)?.expect("TypeOf keyword vanished"); // Consume the token.
                 Ok(node::UnaryOp::new(UnaryOp::TypeOf, self.parse(cursor, interner)?).into())
             }

--- a/boa_engine/src/syntax/parser/statement/break_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/break_stm/mod.rs
@@ -63,7 +63,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("BreakStatement", "Parsing");
-        cursor.expect(Keyword::Break, "break statement", interner)?;
+        cursor.expect((Keyword::Break, false), "break statement", interner)?;
 
         let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {

--- a/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
@@ -63,7 +63,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("ContinueStatement", "Parsing");
-        cursor.expect(Keyword::Continue, "continue statement", interner)?;
+        cursor.expect((Keyword::Continue, false), "continue statement", interner)?;
 
         let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -80,9 +80,17 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Async, "async function declaration", interner)?;
+        cursor.expect(
+            (Keyword::Async, false),
+            "async function declaration",
+            interner,
+        )?;
         cursor.peek_expect_no_lineterminator(0, "async function declaration", interner)?;
-        cursor.expect(Keyword::Function, "async function declaration", interner)?;
+        cursor.expect(
+            (Keyword::Function, false),
+            "async function declaration",
+            interner,
+        )?;
 
         let result = parse_callable_declaration(&self, cursor, interner)?;
 

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -98,9 +98,17 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Async, "async generator declaration", interner)?;
+        cursor.expect(
+            (Keyword::Async, false),
+            "async generator declaration",
+            interner,
+        )?;
         cursor.peek_expect_no_lineterminator(0, "async generator declaration", interner)?;
-        cursor.expect(Keyword::Function, "async generator declaration", interner)?;
+        cursor.expect(
+            (Keyword::Function, false),
+            "async generator declaration",
+            interner,
+        )?;
         cursor.expect(Punctuator::Mul, "async generator declaration", interner)?;
 
         let result = parse_callable_declaration(&self, cursor, interner)?;

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -85,7 +85,7 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Function, "function declaration", interner)?;
+        cursor.expect((Keyword::Function, false), "function declaration", interner)?;
 
         let result = parse_callable_declaration(&self, cursor, interner)?;
 

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -80,7 +80,11 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
-        cursor.expect(Keyword::Function, "generator declaration", interner)?;
+        cursor.expect(
+            (Keyword::Function, false),
+            "generator declaration",
+            interner,
+        )?;
         cursor.expect(Punctuator::Mul, "generator declaration", interner)?;
 
         let result = parse_callable_declaration(&self, cursor, interner)?;

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -75,7 +75,13 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
-            TokenKind::Keyword(Keyword::Function) => {
+            TokenKind::Keyword((Keyword::Function | Keyword::Async | Keyword::Class, true)) => {
+                Err(ParseError::general(
+                    "Keyword must not contain escaped characters",
+                    tok.span().start(),
+                ))
+            }
+            TokenKind::Keyword((Keyword::Function, false)) => {
                 let next_token = cursor.peek(1, interner)?.ok_or(ParseError::AbruptEnd)?;
                 if let TokenKind::Punctuator(Punctuator::Mul) = next_token.kind() {
                     GeneratorDeclaration::new(self.allow_yield, self.allow_await, self.is_default)
@@ -87,7 +93,7 @@ where
                         .map(Node::from)
                 }
             }
-            TokenKind::Keyword(Keyword::Async) => {
+            TokenKind::Keyword((Keyword::Async, false)) => {
                 let next_token = cursor.peek(2, interner)?.ok_or(ParseError::AbruptEnd)?;
                 if let TokenKind::Punctuator(Punctuator::Mul) = next_token.kind() {
                     AsyncGeneratorDeclaration::new(
@@ -103,7 +109,7 @@ where
                         .map(Node::from)
                 }
             }
-            TokenKind::Keyword(Keyword::Class) => {
+            TokenKind::Keyword((Keyword::Class, false)) => {
                 ClassDeclaration::new(false, false, self.is_default)
                     .parse(cursor, interner)
                     .map(Node::from)

--- a/boa_engine/src/syntax/parser/statement/declaration/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/mod.rs
@@ -67,11 +67,11 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
-            TokenKind::Keyword(Keyword::Function | Keyword::Async | Keyword::Class) => {
+            TokenKind::Keyword((Keyword::Function | Keyword::Async | Keyword::Class, _)) => {
                 HoistableDeclaration::new(self.allow_yield, self.allow_await, false)
                     .parse(cursor, interner)
             }
-            TokenKind::Keyword(Keyword::Const | Keyword::Let) => LexicalDeclaration::new(
+            TokenKind::Keyword((Keyword::Const | Keyword::Let, _)) => LexicalDeclaration::new(
                 true,
                 self.allow_yield,
                 self.allow_await,

--- a/boa_engine/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/while_statement.rs
@@ -56,7 +56,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("WhileStatement", "Parsing");
-        cursor.expect(Keyword::While, "while statement", interner)?;
+        cursor.expect((Keyword::While, false), "while statement", interner)?;
 
         cursor.expect(Punctuator::OpenParen, "while statement", interner)?;
 

--- a/boa_engine/src/syntax/parser/statement/labelled_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/labelled_stm/mod.rs
@@ -69,13 +69,13 @@ where
             // Early Error: It is a Syntax Error if any strict mode source code matches this rule.
             // https://tc39.es/ecma262/#sec-labelled-statements-static-semantics-early-errors
             // https://tc39.es/ecma262/#sec-labelled-function-declarations
-            TokenKind::Keyword(Keyword::Function) if strict => {
+            TokenKind::Keyword((Keyword::Function, _)) if strict => {
                 return Err(ParseError::general(
                     "In strict mode code, functions can only be declared at top level or inside a block.",
                     next_token.span().start()
                 ))
             }
-            TokenKind::Keyword(Keyword::Function) => {
+            TokenKind::Keyword((Keyword::Function, _)) => {
                 FunctionDeclaration::new(self.allow_yield, self.allow_await, false)
                 .parse(cursor, interner)?
                 .into()

--- a/boa_engine/src/syntax/parser/statement/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/mod.rs
@@ -123,35 +123,35 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
-            TokenKind::Keyword(Keyword::Await) => AwaitExpression::new(self.allow_yield)
+            TokenKind::Keyword((Keyword::Await, _)) => AwaitExpression::new(self.allow_yield)
                 .parse(cursor, interner)
                 .map(Node::from),
-            TokenKind::Keyword(Keyword::If) => {
+            TokenKind::Keyword((Keyword::If, _)) => {
                 IfStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Var) => {
+            TokenKind::Keyword((Keyword::Var, _)) => {
                 VariableStatement::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::While) => {
+            TokenKind::Keyword((Keyword::While, _)) => {
                 WhileStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Do) => {
+            TokenKind::Keyword((Keyword::Do, _)) => {
                 DoWhileStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::For) => {
+            TokenKind::Keyword((Keyword::For, _)) => {
                 ForStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Return) => {
+            TokenKind::Keyword((Keyword::Return, _)) => {
                 if self.allow_return.0 {
                     ReturnStatement::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)
@@ -164,27 +164,27 @@ where
                     ))
                 }
             }
-            TokenKind::Keyword(Keyword::Break) => {
+            TokenKind::Keyword((Keyword::Break, _)) => {
                 BreakStatement::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Continue) => {
+            TokenKind::Keyword((Keyword::Continue, _)) => {
                 ContinueStatement::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Try) => {
+            TokenKind::Keyword((Keyword::Try, _)) => {
                 TryStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Throw) => {
+            TokenKind::Keyword((Keyword::Throw, _)) => {
                 ThrowStatement::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)
                     .map(Node::from)
             }
-            TokenKind::Keyword(Keyword::Switch) => {
+            TokenKind::Keyword((Keyword::Switch, _)) => {
                 SwitchStatement::new(self.allow_yield, self.allow_await, self.allow_return)
                     .parse(cursor, interner)
                     .map(Node::from)
@@ -468,7 +468,7 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match *tok.kind() {
-            TokenKind::Keyword(Keyword::Function | Keyword::Async | Keyword::Class) => {
+            TokenKind::Keyword((Keyword::Function | Keyword::Async | Keyword::Class, _)) => {
                 if strict_mode && self.in_block {
                     return Err(ParseError::lex(LexError::Syntax(
                         "Function declaration in blocks not allowed in strict mode".into(),
@@ -477,7 +477,7 @@ where
                 }
                 Declaration::new(self.allow_yield, self.allow_await, true).parse(cursor, interner)
             }
-            TokenKind::Keyword(Keyword::Const | Keyword::Let) => {
+            TokenKind::Keyword((Keyword::Const | Keyword::Let, _)) => {
                 Declaration::new(self.allow_yield, self.allow_await, true).parse(cursor, interner)
             }
             _ => Statement::new(self.allow_yield, self.allow_await, self.allow_return)
@@ -552,14 +552,14 @@ where
                 )))
             }
             TokenKind::Identifier(ref s) => Ok(*s),
-            TokenKind::Keyword(Keyword::Yield) if self.allow_yield.0 => {
+            TokenKind::Keyword((Keyword::Yield, _)) if self.allow_yield.0 => {
                 // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".
                 Err(ParseError::general(
                     "Unexpected identifier",
                     next_token.span().start(),
                 ))
             }
-            TokenKind::Keyword(Keyword::Yield) if !self.allow_yield.0 => {
+            TokenKind::Keyword((Keyword::Yield, _)) if !self.allow_yield.0 => {
                 if cursor.strict_mode() {
                     Err(ParseError::general(
                         "yield keyword in binding identifier not allowed in strict mode",
@@ -569,15 +569,15 @@ where
                     Ok(Sym::YIELD)
                 }
             }
-            TokenKind::Keyword(Keyword::Await) if cursor.arrow() => Ok(Sym::AWAIT),
-            TokenKind::Keyword(Keyword::Await) if self.allow_await.0 => {
+            TokenKind::Keyword((Keyword::Await, _)) if cursor.arrow() => Ok(Sym::AWAIT),
+            TokenKind::Keyword((Keyword::Await, _)) if self.allow_await.0 => {
                 // Early Error: It is a Syntax Error if this production has an [Await] parameter and StringValue of Identifier is "await".
                 Err(ParseError::general(
                     "Unexpected identifier",
                     next_token.span().start(),
                 ))
             }
-            TokenKind::Keyword(Keyword::Await) if !self.allow_await.0 => {
+            TokenKind::Keyword((Keyword::Await, _)) if !self.allow_await.0 => {
                 if cursor.strict_mode() {
                     Err(ParseError::general(
                         "await keyword in binding identifier not allowed in strict mode",

--- a/boa_engine/src/syntax/parser/statement/return_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/return_stm/mod.rs
@@ -51,7 +51,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("ReturnStatement", "Parsing");
-        cursor.expect(Keyword::Return, "return statement", interner)?;
+        cursor.expect((Keyword::Return, false), "return statement", interner)?;
 
         if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {

--- a/boa_engine/src/syntax/parser/statement/throw/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/throw/mod.rs
@@ -50,7 +50,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("ThrowStatement", "Parsing");
-        cursor.expect(Keyword::Throw, "throw statement", interner)?;
+        cursor.expect((Keyword::Throw, false), "throw statement", interner)?;
 
         cursor.peek_expect_no_lineterminator(0, "throw statement", interner)?;
 

--- a/boa_engine/src/syntax/parser/statement/try_stm/catch.rs
+++ b/boa_engine/src/syntax/parser/statement/try_stm/catch.rs
@@ -57,7 +57,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("Catch", "Parsing");
-        cursor.expect(Keyword::Catch, "try statement", interner)?;
+        cursor.expect((Keyword::Catch, false), "try statement", interner)?;
         let catch_param = if cursor.next_if(Punctuator::OpenParen, interner)?.is_some() {
             let catch_param =
                 CatchParameter::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;

--- a/boa_engine/src/syntax/parser/statement/try_stm/finally.rs
+++ b/boa_engine/src/syntax/parser/statement/try_stm/finally.rs
@@ -52,7 +52,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("Finally", "Parsing");
-        cursor.expect(Keyword::Finally, "try statement", interner)?;
+        cursor.expect((Keyword::Finally, false), "try statement", interner)?;
         Ok(
             Block::new(self.allow_yield, self.allow_await, self.allow_return)
                 .parse(cursor, interner)?

--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -60,7 +60,7 @@ where
         interner: &mut Interner,
     ) -> Result<Self::Output, ParseError> {
         let _timer = Profiler::global().start_event("VariableStatement", "Parsing");
-        cursor.expect(Keyword::Var, "variable statement", interner)?;
+        cursor.expect((Keyword::Var, false), "variable statement", interner)?;
 
         let decl_list = VariableDeclarationList::new(true, self.allow_yield, self.allow_await)
             .parse(cursor, interner)?;


### PR DESCRIPTION
This Pull Request changes the following:

- Remove syntax error for unicode escaped characters in keywords from the lexer.
- Adjust the lexer tokens for keywords to indicate if they contain unicode escaped characters.
- Throw syntax errors in parser, when keywords cannot contain unicode escaped characters.