### PR TITLE
[Merged by Bors] - Allow `PropertyName`s in `BindingProperty`in `ObjectBindingPattern`

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -2076,8 +2076,17 @@ impl<'b> ByteCompiler<'b> {
                             default_init,
                         } => {
                             self.emit_opcode(Opcode::Dup);
-                            let index = self.get_or_insert_name(*property_name);
-                            self.emit(Opcode::GetPropertyByName, &[index]);
+                            match property_name {
+                                PropertyName::Literal(name) => {
+                                    let index = self.get_or_insert_name(*name);
+                                    self.emit(Opcode::GetPropertyByName, &[index]);
+                                }
+                                PropertyName::Computed(node) => {
+                                    self.compile_expr(node, true)?;
+                                    self.emit_opcode(Opcode::Swap);
+                                    self.emit_opcode(Opcode::GetPropertyByValue);
+                                }
+                            }
 
                             if let Some(init) = default_init {
                                 let skip = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);
@@ -2129,8 +2138,17 @@ impl<'b> ByteCompiler<'b> {
                             default_init,
                         } => {
                             self.emit_opcode(Opcode::Dup);
-                            let index = self.get_or_insert_name(*ident);
-                            self.emit(Opcode::GetPropertyByName, &[index]);
+                            match ident {
+                                PropertyName::Literal(name) => {
+                                    let index = self.get_or_insert_name(*name);
+                                    self.emit(Opcode::GetPropertyByName, &[index]);
+                                }
+                                PropertyName::Computed(node) => {
+                                    self.compile_expr(node, true)?;
+                                    self.emit_opcode(Opcode::Swap);
+                                    self.emit_opcode(Opcode::GetPropertyByValue);
+                                }
+                            }
 
                             if let Some(init) = default_init {
                                 let skip = self.jump_with_custom_opcode(Opcode::JumpIfNotUndefined);

--- a/boa_engine/src/syntax/ast/node/operator/assign/mod.rs
+++ b/boa_engine/src/syntax/ast/node/operator/assign/mod.rs
@@ -149,7 +149,7 @@ pub(crate) fn object_decl_to_declaration_pattern(object: &Object) -> Option<Decl
                 excluded_keys.push(*ident);
                 bindings.push(BindingPatternTypeObject::SingleName {
                     ident: *ident,
-                    property_name: *ident,
+                    property_name: PropertyName::Literal(*ident),
                     default_init: None,
                 });
             }
@@ -158,7 +158,7 @@ pub(crate) fn object_decl_to_declaration_pattern(object: &Object) -> Option<Decl
                     excluded_keys.push(*name);
                     bindings.push(BindingPatternTypeObject::SingleName {
                         ident: *name,
-                        property_name: *name,
+                        property_name: PropertyName::Literal(*name),
                         default_init: None,
                     });
                 }

--- a/boa_engine/src/syntax/parser/statement/try_stm/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/try_stm/tests.rs
@@ -2,6 +2,7 @@ use crate::syntax::{
     ast::{
         node::{
             declaration::{BindingPatternTypeArray, BindingPatternTypeObject},
+            object::PropertyName,
             Block, Catch, Declaration, DeclarationList, Finally, Try,
         },
         Const,
@@ -173,12 +174,14 @@ fn check_inline_with_binding_pattern_object() {
                     vec![
                         BindingPatternTypeObject::SingleName {
                             ident: a,
-                            property_name: a,
+                            property_name: PropertyName::Literal(a),
                             default_init: None,
                         },
                         BindingPatternTypeObject::SingleName {
                             ident: interner.get_or_intern_static("c"),
-                            property_name: interner.get_or_intern_static("b"),
+                            property_name: PropertyName::Literal(
+                                interner.get_or_intern_static("b"),
+                            ),
                             default_init: None,
                         },
                     ],


### PR DESCRIPTION
This Pull Request changes the following:

- Allow `PropertyName`s in `BindingProperty`in `ObjectBindingPattern`. Previously only `BindingIdentifier`s where allowed.