### PR TITLE
implement `u128` and `i128` to `Numeric`

### DIFF
--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -370,6 +370,24 @@ impl From<u64> for JsBigInt {
     }
 }
 
+impl From<i128> for JsBigInt {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
+
+impl From<u128> for JsBigInt {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
+
 impl From<isize> for JsBigInt {
     #[inline]
     fn from(value: isize) -> Self {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -1000,6 +1000,13 @@ impl From<f32> for Numeric {
     }
 }
 
+impl From<i128> for Numeric {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+
 impl From<i64> for Numeric {
     #[inline]
     fn from(value: i64) -> Self {
@@ -1025,6 +1032,13 @@ impl From<i8> for Numeric {
     #[inline]
     fn from(value: i8) -> Self {
         Self::Number(value.into())
+    }
+}
+
+impl From<u128> for Numeric {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self::BigInt(value.into())
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes/closes #1970 .

It changes the following:
- Add conversion from `u128` and `i128` to `JsBigInt` type
- Add conversion from `u128` and `i128` to `Numeric` type