### PR TITLE
[Merged by Bors] - Allow creating object with true/false property names

### DIFF
--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -480,6 +480,10 @@ where
                 Node::Const(Const::from(interner.get_or_intern_static(word.as_str()))).into()
             }
             TokenKind::NullLiteral => Node::Const(Const::from(Sym::NULL)).into(),
+            TokenKind::BooleanLiteral(bool) => match bool {
+                true => Node::Const(Const::from(interner.get_or_intern_static("true"))).into(),
+                false => Node::Const(Const::from(interner.get_or_intern_static("false"))).into(),
+            },
             _ => return Err(ParseError::AbruptEnd),
         };
         cursor.next(interner).expect("token disappeared");


### PR DESCRIPTION
This Pull Request allows "true"/"false" as property names when instantiating objects. This should make some additional tests in the test suite pass.
