### PR TITLE
[Merged by Bors] - Fix casting negative number to usize in `Array.splice`

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -2071,7 +2071,9 @@ impl Array {
             // c. Let actualDeleteCount be the result of clamping dc between 0 and len - actualStart.
             let max = len - actual_start;
             match dc {
-                IntegerOrInfinity::Integer(i) => (i as usize).clamp(0, max),
+                IntegerOrInfinity::Integer(i) => {
+                    usize::try_from(i).unwrap_or_default().clamp(0, max)
+                }
                 IntegerOrInfinity::PositiveInfinity => max,
                 IntegerOrInfinity::NegativeInfinity => 0,
             }


### PR DESCRIPTION
This Pull Request fixes a faulty cast for `Array.splice`. 

Negative values for delete_count were being directly casted to usize, which was not the intended behavior. This pull request fixes the issue by using a fallible conversion, defaulting to 0 if the conversion fails.

It changes the following:

- Replace cast in `Array.splice` prototype method with fallible conversion.
