### PR TITLE
[Merged by Bors] - Make `Array.prototype` an array object

### DIFF
--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -1,6 +1,7 @@
 use crate::{
     builtins::{error::r#type::create_throw_type_error, iterable::IteratorPrototypes},
     object::{JsObject, ObjectData},
+    property::PropertyDescriptorBuilder,
     Context,
 };
 
@@ -111,13 +112,16 @@ pub struct StandardConstructors {
 
 impl Default for StandardConstructors {
     fn default() -> Self {
-        Self {
+        let result = Self {
             object: StandardConstructor::default(),
             proxy: StandardConstructor::default(),
             function: StandardConstructor::default(),
             generator: StandardConstructor::default(),
             generator_function: StandardConstructor::default(),
-            array: StandardConstructor::default(),
+            array: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
+                None,
+                ObjectData::array(),
+            )),
             bigint: StandardConstructor::default(),
             number: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
                 None,
@@ -157,7 +161,20 @@ impl Default for StandardConstructors {
             typed_float64_array: StandardConstructor::default(),
             array_buffer: StandardConstructor::default(),
             data_view: StandardConstructor::default(),
-        }
+        };
+
+        // The value of `Array.prototype` is the Array prototype object.
+        result.array.prototype.insert(
+            "length",
+            PropertyDescriptorBuilder::new()
+                .value(0)
+                .writable(true)
+                .enumerable(false)
+                .configurable(false)
+                .build(),
+        );
+
+        result
     }
 }
 


### PR DESCRIPTION

It changes the following:
- Make `Array.prototype` an array object
