### PR TITLE
[Merged by Bors] - Implement the global `eval()` function

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -1,0 +1,125 @@
+//! This module implements the global `eval` function.
+//!
+//! The `eval()` function evaluates JavaScript code represented as a string.
+//!
+//! More information:
+//!  - [ECMAScript reference][spec]
+//!  - [MDN documentation][mdn]
+//!
+//! [spec]: https://tc39.es/ecma262/#sec-eval-x
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
+
+use crate::{
+    builtins::{function::Function, BuiltIn, JsArgs},
+    object::{JsObject, ObjectData},
+    property::Attribute,
+    Context, JsValue,
+};
+use boa_profiler::Profiler;
+use rustc_hash::FxHashSet;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Eval;
+
+impl BuiltIn for Eval {
+    const NAME: &'static str = "eval";
+
+    const ATTRIBUTE: Attribute = Attribute::READONLY
+        .union(Attribute::NON_ENUMERABLE)
+        .union(Attribute::PERMANENT);
+
+    fn init(context: &mut Context) -> Option<JsValue> {
+        let _timer = Profiler::global().start_event(Self::NAME, "init");
+
+        let object = JsObject::from_proto_and_data(
+            context.intrinsics().constructors().function().prototype(),
+            ObjectData::function(Function::Native {
+                function: Self::eval,
+                constructor: false,
+            }),
+        );
+
+        Some(object.into())
+    }
+}
+
+impl Eval {
+    /// `19.2.1 eval ( x )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-eval-x
+    fn eval(_: &JsValue, args: &[JsValue], context: &mut Context) -> Result<JsValue, JsValue> {
+        // 1. Return ? PerformEval(x, false, false).
+        Self::perform_eval(args.get_or_undefined(0), false, false, context)
+    }
+
+    /// `19.2.1.1 PerformEval ( x, callerRealm, strictCaller, direct )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-performeval
+    pub(crate) fn perform_eval(
+        x: &JsValue,
+        direct: bool,
+        strict: bool,
+        context: &mut Context,
+    ) -> Result<JsValue, JsValue> {
+        let x = if let Some(x) = x.as_string() {
+            x.clone()
+        } else {
+            return Ok(x.clone());
+        };
+
+        let parsing_result = context.parse(x.as_bytes()).map_err(|e| e.to_string());
+
+        let statement_list = match parsing_result {
+            Ok(statement_list) => statement_list,
+            Err(e) => return context.throw_syntax_error(e),
+        };
+
+        if direct {
+            context.realm.environments.poison_current();
+            context.realm.compile_env = context.realm.environments.current_compile_environment();
+            let environments_len = context.realm.environments.len();
+
+            let mut vars = FxHashSet::default();
+            statement_list.var_declared_names_new(&mut vars);
+            if let Some(name) = context
+                .realm
+                .environments
+                .has_lex_binding_until_function_environment(&vars)
+            {
+                return context.throw_syntax_error(format!("variable declaration {} in eval function already exists as lexically declaration", context.interner().resolve_expect(name)));
+            }
+
+            let code_block = context.compile_with_new_declarative(&statement_list, strict)?;
+            context
+                .realm
+                .environments
+                .extend_outer_function_environment();
+            let result = context.execute(code_block);
+
+            context.realm.environments.truncate(environments_len);
+
+            result
+        } else {
+            context.realm.environments.poison_all();
+
+            let environments = context.realm.environments.pop_to_global();
+            let environments_len = context.realm.environments.len();
+
+            context.realm.compile_env = context.realm.environments.current_compile_environment();
+
+            let code_block = context.compile_with_new_declarative(&statement_list, false)?;
+            let result = context.execute(code_block);
+
+            context.realm.environments.truncate(environments_len);
+            context.realm.environments.extend(environments);
+
+            result
+        }
+    }
+}

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -55,7 +55,7 @@ impl Eval {
         Self::perform_eval(args.get_or_undefined(0), false, false, context)
     }
 
-    /// `19.2.1.1 PerformEval ( x, callerRealm, strictCaller, direct )`
+    /// `19.2.1.1 PerformEval ( x, strictCaller, direct )`
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
@@ -67,55 +67,82 @@ impl Eval {
         strict: bool,
         context: &mut Context,
     ) -> Result<JsValue, JsValue> {
+        // 1. Assert: If direct is false, then strictCaller is also false.
+        if !direct {
+            debug_assert!(!strict);
+        }
+
+        // 2. If Type(x) is not String, return x.
         let x = if let Some(x) = x.as_string() {
             x.clone()
         } else {
             return Ok(x.clone());
         };
 
-        let parsing_result = context.parse(x.as_bytes()).map_err(|e| e.to_string());
+        // Because of implementation details the following code differs from the spec.
 
-        let statement_list = match parsing_result {
-            Ok(statement_list) => statement_list,
+        // Parse the script body (11.a - 11.d)
+        // TODO: Implement errors for 11.e - 11.h
+        let body = match context.parse(x.as_bytes()).map_err(|e| e.to_string()) {
+            Ok(body) => body,
             Err(e) => return context.throw_syntax_error(e),
         };
 
+        // 12 - 13 are implicit in the call of `Context::compile_with_new_declarative`.
+
+        // Because our environment model does not map directly to the spec this section looks very different.
+        // 14 - 33 are in the following section, together with EvalDeclarationInstantiation.
         if direct {
+            // If the call to eval is direct, the code is executed in the current environment.
+
+            // Poison the current environment, because it may contain new declarations after/during eval.
             context.realm.environments.poison_current();
+
+            // Set the compile time environment to the current running environment and save the number of current environments.
             context.realm.compile_env = context.realm.environments.current_compile_environment();
             let environments_len = context.realm.environments.len();
 
+            // Error if any var declaration in the eval code already exists as a let/const declaration in the current running environment.
             let mut vars = FxHashSet::default();
-            statement_list.var_declared_names_new(&mut vars);
+            body.var_declared_names_new(&mut vars);
             if let Some(name) = context
                 .realm
                 .environments
                 .has_lex_binding_until_function_environment(&vars)
             {
-                return context.throw_syntax_error(format!("variable declaration {} in eval function already exists as lexically declaration", context.interner().resolve_expect(name)));
+                let name = context.interner().resolve_expect(name);
+                let msg = format!("variable declaration {name} in eval function already exists as lexically declaration");
+                return context.throw_syntax_error(msg);
             }
 
-            let code_block = context.compile_with_new_declarative(&statement_list, strict)?;
+            // Compile and execute the eval statement list.
+            let code_block = context.compile_with_new_declarative(&body, strict)?;
             context
                 .realm
                 .environments
                 .extend_outer_function_environment();
             let result = context.execute(code_block);
 
+            // Pop any added runtime environments that where not removed during the eval execution.
             context.realm.environments.truncate(environments_len);
 
             result
         } else {
+            // If the call to eval is indirect, the code is executed in the global environment.
+
+            // Poison all environments, because the global environment may contain new declarations after/during eval.
             context.realm.environments.poison_all();
 
+            // Pop all environments before the eval execution.
             let environments = context.realm.environments.pop_to_global();
             let environments_len = context.realm.environments.len();
-
             context.realm.compile_env = context.realm.environments.current_compile_environment();
 
-            let code_block = context.compile_with_new_declarative(&statement_list, false)?;
+            // Compile and execute the eval statement list.
+            let code_block = context.compile_with_new_declarative(&body, false)?;
             let result = context.execute(code_block);
 
+            // Restore all environments to the state from before the eval execution.
             context.realm.environments.truncate(environments_len);
             context.realm.environments.extend(environments);
 

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -9,6 +9,7 @@ pub mod console;
 pub mod dataview;
 pub mod date;
 pub mod error;
+pub mod eval;
 pub mod function;
 pub mod generator;
 pub mod generator_function;
@@ -41,6 +42,7 @@ pub(crate) use self::{
         AggregateError, Error, EvalError, RangeError, ReferenceError, SyntaxError, TypeError,
         UriError,
     },
+    eval::Eval,
     function::BuiltInFunctionObject,
     global_this::GlobalThis,
     infinity::Infinity,
@@ -152,6 +154,7 @@ pub fn init(context: &mut Context) {
         DataView,
         Map,
         Number,
+        Eval,
         Set,
         String,
         RegExp,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -670,6 +670,23 @@ impl Context {
         Ok(Gc::new(compiler.finish()))
     }
 
+    /// Compile the AST into a `CodeBlock` with an additional declarative environment.
+    #[inline]
+    pub(crate) fn compile_with_new_declarative(
+        &mut self,
+        statement_list: &StatementList,
+        strict: bool,
+    ) -> JsResult<Gc<CodeBlock>> {
+        let _timer = Profiler::global().start_event("Compilation", "Main");
+        let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), self);
+        compiler.compile_statement_list_with_new_declarative(
+            statement_list.items(),
+            true,
+            strict || statement_list.strict(),
+        )?;
+        Ok(Gc::new(compiler.finish()))
+    }
+
     /// Call the VM with a `CodeBlock` and return the result.
     ///
     /// Since this function receives a `Gc<CodeBlock>`, cloning the code is very cheap, since it's

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -1,6 +1,7 @@
 use crate::{
     environments::runtime::BindingLocator, property::PropertyDescriptor, Context, JsString, JsValue,
 };
+use boa_gc::{Cell, Finalize, Gc, Trace};
 use boa_interner::Sym;
 use rustc_hash::FxHashMap;
 
@@ -11,60 +12,195 @@ use rustc_hash::FxHashMap;
 struct CompileTimeBinding {
     index: usize,
     mutable: bool,
+    lex: bool,
 }
 
 /// A compile time environment maps bound identifiers to their binding positions.
 ///
 /// A compile time environment also indicates, if it is a function environment.
-#[derive(Debug)]
+#[derive(Debug, Finalize, Trace)]
 pub(crate) struct CompileTimeEnvironment {
+    outer: Option<Gc<Cell<Self>>>,
+    environment_index: usize,
+    #[unsafe_ignore_trace]
     bindings: FxHashMap<Sym, CompileTimeBinding>,
     function_scope: bool,
 }
 
 impl CompileTimeEnvironment {
+    /// Crate a new global compile time environment.
+    #[inline]
+    pub(crate) fn new_global() -> Self {
+        Self {
+            outer: None,
+            environment_index: 0,
+            bindings: FxHashMap::default(),
+            function_scope: true,
+        }
+    }
+
+    /// Check if environment has a lexical binding with the given name.
+    #[inline]
+    pub(crate) fn has_lex_binding(&self, name: Sym) -> bool {
+        self.bindings
+            .get(&name)
+            .map_or(false, |binding| binding.lex)
+    }
+
     /// Returns the number of bindings in this environment.
     #[inline]
     pub(crate) fn num_bindings(&self) -> usize {
         self.bindings.len()
     }
-}
 
-/// The compile time environment stack contains a stack of all environments at bytecode compile time.
-///
-/// The first environment on the stack represents the global environment.
-/// This is never being deleted and is tied to the existence of the realm.
-/// All other environments are being dropped once they are not needed anymore.
-#[derive(Debug)]
-pub(crate) struct CompileTimeEnvironmentStack {
-    stack: Vec<CompileTimeEnvironment>,
-}
-
-impl CompileTimeEnvironmentStack {
-    /// Creates a new compile time environment stack.
-    ///
-    /// This function should only be used once, on realm creation.
+    /// Check if the environment is a function environment.
     #[inline]
-    pub(crate) fn new() -> Self {
-        Self {
-            stack: vec![CompileTimeEnvironment {
-                bindings: FxHashMap::default(),
-                function_scope: true,
-            }],
+    pub(crate) fn is_function(&self) -> bool {
+        self.function_scope
+    }
+
+    /// Get the locator for a binding name.
+    #[inline]
+    pub(crate) fn get_binding(&self, name: Sym) -> Option<BindingLocator> {
+        self.bindings
+            .get(&name)
+            .map(|binding| BindingLocator::declarative(name, self.environment_index, binding.index))
+    }
+
+    /// Get the locator for a binding name in this and all outer environments.
+    #[inline]
+    pub(crate) fn get_binding_recursive(&self, name: Sym) -> BindingLocator {
+        if let Some(binding) = self.bindings.get(&name) {
+            BindingLocator::declarative(name, self.environment_index, binding.index)
+        } else if let Some(outer) = &self.outer {
+            outer.borrow().get_binding_recursive(name)
+        } else {
+            BindingLocator::global(name)
         }
     }
 
-    /// Get the number of bindings for the current last environment.
+    /// Check if a binding name exists in this and all outer environments.
+    #[inline]
+    pub(crate) fn has_binding_recursive(&self, name: Sym) -> bool {
+        if self.bindings.contains_key(&name) {
+            true
+        } else if let Some(outer) = &self.outer {
+            outer.borrow().has_binding_recursive(name)
+        } else {
+            false
+        }
+    }
+
+    /// Create a mutable binding.
+    ///
+    /// If the binding is a function scope binding and this is a declarative environment, try the outer environment.
+    #[inline]
+    pub(crate) fn create_mutable_binding(&mut self, name: Sym, function_scope: bool) -> bool {
+        if let Some(outer) = &self.outer {
+            if !function_scope || self.function_scope {
+                if !self.bindings.contains_key(&name) {
+                    let binding_index = self.bindings.len();
+                    self.bindings.insert(
+                        name,
+                        CompileTimeBinding {
+                            index: binding_index,
+                            mutable: true,
+                            lex: !function_scope,
+                        },
+                    );
+                }
+                true
+            } else {
+                return outer
+                    .borrow_mut()
+                    .create_mutable_binding(name, function_scope);
+            }
+        } else if function_scope {
+            false
+        } else {
+            if !self.bindings.contains_key(&name) {
+                let binding_index = self.bindings.len();
+                self.bindings.insert(
+                    name,
+                    CompileTimeBinding {
+                        index: binding_index,
+                        mutable: true,
+                        lex: !function_scope,
+                    },
+                );
+            }
+            true
+        }
+    }
+
+    /// Crate an immutable binding.
+    #[inline]
+    pub(crate) fn create_immutable_binding(&mut self, name: Sym) {
+        let binding_index = self.bindings.len();
+        self.bindings.insert(
+            name,
+            CompileTimeBinding {
+                index: binding_index,
+                mutable: false,
+                lex: true,
+            },
+        );
+    }
+
+    /// Return the binding locator for a mutable binding with the given binding name and scope.
+    #[inline]
+    pub(crate) fn initialize_mutable_binding(
+        &self,
+        name: Sym,
+        function_scope: bool,
+    ) -> BindingLocator {
+        if let Some(outer) = &self.outer {
+            if function_scope && !self.function_scope {
+                return outer
+                    .borrow()
+                    .initialize_mutable_binding(name, function_scope);
+            }
+            if let Some(binding) = self.bindings.get(&name) {
+                BindingLocator::declarative(name, self.environment_index, binding.index)
+            } else {
+                outer
+                    .borrow()
+                    .initialize_mutable_binding(name, function_scope)
+            }
+        } else if let Some(binding) = self.bindings.get(&name) {
+            BindingLocator::declarative(name, self.environment_index, binding.index)
+        } else {
+            BindingLocator::global(name)
+        }
+    }
+
+    /// Return the binding locator for an immutable binding.
     ///
     /// # Panics
     ///
-    /// Panics if there are no environments on the stack.
+    /// Panics if the binding is not in the current environment.
     #[inline]
-    pub(crate) fn get_binding_number(&self) -> usize {
-        self.stack
-            .last()
-            .expect("global environment must always exist")
-            .num_bindings()
+    pub(crate) fn initialize_immutable_binding(&self, name: Sym) -> BindingLocator {
+        let binding = self.bindings.get(&name).expect("binding must exist");
+        BindingLocator::declarative(name, self.environment_index, binding.index)
+    }
+
+    /// Return the binding locator for a mutable binding.
+    #[inline]
+    pub(crate) fn set_mutable_binding_recursive(&self, name: Sym) -> BindingLocator {
+        match self.bindings.get(&name) {
+            Some(binding) if binding.mutable => {
+                BindingLocator::declarative(name, self.environment_index, binding.index)
+            }
+            Some(_) => BindingLocator::mutate_immutable(name),
+            None => {
+                if let Some(outer) = &self.outer {
+                    outer.borrow().set_mutable_binding_recursive(name)
+                } else {
+                    BindingLocator::global(name)
+                }
+            }
+        }
     }
 }
 
@@ -74,10 +210,15 @@ impl Context {
     /// Note: This function only works at bytecode compile time!
     #[inline]
     pub(crate) fn push_compile_time_environment(&mut self, function_scope: bool) {
-        self.realm.compile_env.stack.push(CompileTimeEnvironment {
+        let environment_index = self.realm.compile_env.borrow().environment_index + 1;
+        let outer = self.realm.compile_env.clone();
+
+        self.realm.compile_env = Gc::new(Cell::new(CompileTimeEnvironment {
+            outer: Some(outer),
+            environment_index,
             bindings: FxHashMap::default(),
             function_scope,
-        });
+        }));
     }
 
     /// Pop the last compile time environment from the stack.
@@ -88,16 +229,20 @@ impl Context {
     ///
     /// Panics if there are no more environments that can be pop'ed.
     #[inline]
-    pub(crate) fn pop_compile_time_environment(&mut self) -> CompileTimeEnvironment {
-        assert!(
-            self.realm.compile_env.stack.len() > 1,
-            "cannot pop global environment"
-        );
-        self.realm
-            .compile_env
-            .stack
-            .pop()
-            .expect("len > 1 already checked")
+    pub(crate) fn pop_compile_time_environment(
+        &mut self,
+    ) -> (usize, Gc<Cell<CompileTimeEnvironment>>) {
+        let current_env_borrow = self.realm.compile_env.borrow();
+        if let Some(outer) = &current_env_borrow.outer {
+            let outer_clone = outer.clone();
+            let num_bindings = current_env_borrow.num_bindings();
+            drop(current_env_borrow);
+            let current = self.realm.compile_env.clone();
+            self.realm.compile_env = outer_clone;
+            (num_bindings, current)
+        } else {
+            panic!("cannot pop global environment")
+        }
     }
 
     /// Get the number of bindings for the current compile time environment.
@@ -109,12 +254,7 @@ impl Context {
     /// Panics if there are no environments on the compile time environment stack.
     #[inline]
     pub(crate) fn get_binding_number(&self) -> usize {
-        self.realm
-            .compile_env
-            .stack
-            .last()
-            .expect("global environment must always exist")
-            .num_bindings()
+        self.realm.compile_env.borrow().num_bindings()
     }
 
     /// Get the binding locator of the binding at bytecode compile time.
@@ -122,12 +262,7 @@ impl Context {
     /// Note: This function only works at bytecode compile time!
     #[inline]
     pub(crate) fn get_binding_value(&self, name: Sym) -> BindingLocator {
-        for (i, env) in self.realm.compile_env.stack.iter().enumerate().rev() {
-            if let Some(binding) = env.bindings.get(&name) {
-                return BindingLocator::declarative(name, i, binding.index);
-            }
-        }
-        BindingLocator::global(name)
+        self.realm.compile_env.borrow().get_binding_recursive(name)
     }
 
     /// Return if a declarative binding exists at bytecode compile time.
@@ -136,12 +271,7 @@ impl Context {
     /// Note: This function only works at bytecode compile time!
     #[inline]
     pub(crate) fn has_binding(&self, name: Sym) -> bool {
-        for env in self.realm.compile_env.stack.iter().rev() {
-            if env.bindings.contains_key(&name) {
-                return true;
-            }
-        }
-        false
+        self.realm.compile_env.borrow().has_binding_recursive(name)
     }
 
     /// Create a mutable binding at bytecode compile time.
@@ -154,49 +284,30 @@ impl Context {
     /// Panics if the global environment is not function scoped.
     #[inline]
     pub(crate) fn create_mutable_binding(&mut self, name: Sym, function_scope: bool) {
-        let name_str = JsString::from(self.interner().resolve_expect(name));
-
-        for (i, env) in self.realm.compile_env.stack.iter_mut().enumerate().rev() {
-            if !function_scope || env.function_scope {
-                if env.bindings.contains_key(&name) {
-                    return;
-                }
-
-                if i == 0 {
-                    let desc = self
-                        .realm
-                        .global_property_map
-                        .string_property_map()
-                        .get(&name_str);
-                    if function_scope && desc.is_none() {
-                        self.global_bindings_mut().insert(
-                            name_str,
-                            PropertyDescriptor::builder()
-                                .value(JsValue::Undefined)
-                                .writable(true)
-                                .enumerable(true)
-                                .configurable(true)
-                                .build(),
-                        );
-                        return;
-                    } else if function_scope {
-                        return;
-                    }
-                }
-
-                let binding_index = env.bindings.len();
-                env.bindings.insert(
-                    name,
-                    CompileTimeBinding {
-                        index: binding_index,
-                        mutable: true,
-                    },
+        if !self
+            .realm
+            .compile_env
+            .borrow_mut()
+            .create_mutable_binding(name, function_scope)
+        {
+            let name_str = JsString::from(self.interner().resolve_expect(name));
+            let desc = self
+                .realm
+                .global_property_map
+                .string_property_map()
+                .get(&name_str);
+            if desc.is_none() {
+                self.global_bindings_mut().insert(
+                    name_str,
+                    PropertyDescriptor::builder()
+                        .value(JsValue::Undefined)
+                        .writable(true)
+                        .enumerable(true)
+                        .configurable(true)
+                        .build(),
                 );
-                return;
             }
-            continue;
         }
-        panic!("global environment must be function scoped")
     }
 
     /// Initialize a mutable binding at bytecode compile time and return it's binding locator.
@@ -208,16 +319,10 @@ impl Context {
         name: Sym,
         function_scope: bool,
     ) -> BindingLocator {
-        for (i, env) in self.realm.compile_env.stack.iter().enumerate().rev() {
-            if function_scope && !env.function_scope {
-                continue;
-            }
-            if let Some(binding) = env.bindings.get(&name) {
-                return BindingLocator::declarative(name, i, binding.index);
-            }
-            return BindingLocator::global(name);
-        }
-        BindingLocator::global(name)
+        self.realm
+            .compile_env
+            .borrow()
+            .initialize_mutable_binding(name, function_scope)
     }
 
     /// Create an immutable binding at bytecode compile time.
@@ -230,21 +335,10 @@ impl Context {
     /// Panics if the global environment does not exist.
     #[inline]
     pub(crate) fn create_immutable_binding(&mut self, name: Sym) {
-        let env = self
-            .realm
+        self.realm
             .compile_env
-            .stack
-            .last_mut()
-            .expect("global environment must always exist");
-
-        let binding_index = env.bindings.len();
-        env.bindings.insert(
-            name,
-            CompileTimeBinding {
-                index: binding_index,
-                mutable: false,
-            },
-        );
+            .borrow_mut()
+            .create_immutable_binding(name);
     }
 
     /// Initialize an immutable binding at bytecode compile time and return it's binding locator.
@@ -256,16 +350,10 @@ impl Context {
     /// Panics if the global environment does not exist or a the binding was not created on the current environment.
     #[inline]
     pub(crate) fn initialize_immutable_binding(&self, name: Sym) -> BindingLocator {
-        let environment_index = self.realm.compile_env.stack.len() - 1;
-        let env = self
-            .realm
+        self.realm
             .compile_env
-            .stack
-            .last()
-            .expect("global environment must always exist");
-
-        let binding = env.bindings.get(&name).expect("binding must exist");
-        BindingLocator::declarative(name, environment_index, binding.index)
+            .borrow()
+            .initialize_immutable_binding(name)
     }
 
     /// Return the binding locator for a set operation on an existing binding.
@@ -273,14 +361,9 @@ impl Context {
     /// Note: This function only works at bytecode compile time!
     #[inline]
     pub(crate) fn set_mutable_binding(&self, name: Sym) -> BindingLocator {
-        for (i, env) in self.realm.compile_env.stack.iter().enumerate().rev() {
-            if let Some(binding) = env.bindings.get(&name) {
-                if binding.mutable {
-                    return BindingLocator::declarative(name, i, binding.index);
-                }
-                return BindingLocator::mutate_immutable(name);
-            }
-        }
-        BindingLocator::global(name)
+        self.realm
+            .compile_env
+            .borrow()
+            .set_mutable_binding_recursive(name)
     }
 }

--- a/boa_engine/src/environments/mod.rs
+++ b/boa_engine/src/environments/mod.rs
@@ -28,7 +28,7 @@ mod compile;
 mod runtime;
 
 pub(crate) use {
-    compile::CompileTimeEnvironmentStack,
+    compile::CompileTimeEnvironment,
     runtime::{BindingLocator, DeclarativeEnvironment, DeclarativeEnvironmentStack},
 };
 

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -1,18 +1,34 @@
-use crate::{Context, JsResult, JsValue};
+use crate::{environments::CompileTimeEnvironment, Context, JsResult, JsValue};
 use boa_gc::{Cell, Finalize, Gc, Trace};
 use boa_interner::Sym;
+use rustc_hash::FxHashSet;
 
-/// A declarative environment holds the bindings values at runtime.
+/// A declarative environment holds binding values at runtime.
 ///
 /// Bindings are stored in a fixed size list of optional values.
 /// If a binding is not initialized, the value is `None`.
 ///
 /// Optionally, an environment can hold a `this` value.
 /// The `this` value is present only if the environment is a function environment.
+///
+/// Code evaluation at runtime (e.g. the `eval` built-in function) can add
+/// bindings to existing, compiled function environments.
+/// This makes it impossible to determine the location of all bindings at compile time.
+/// To dynamically check for added bindings at runtime, a reference to the
+/// corresponding compile time environment is needed.
+///
+/// Checking all environments for potential added bindings at runtime on every get/set
+/// would offset the performance improvement of determining binding locations at compile time.
+/// To minimize this, each environment holds a `poisoned` flag.
+/// If bindings where added at runtime, the current environment and all inner environments
+/// are marked as poisoned.
+/// All poisoned environments have to be checked for added bindings.
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct DeclarativeEnvironment {
     bindings: Cell<Vec<Option<JsValue>>>,
     this: Option<JsValue>,
+    compile: Gc<Cell<CompileTimeEnvironment>>,
+    poisoned: Cell<bool>,
 }
 
 impl DeclarativeEnvironment {
@@ -59,13 +75,75 @@ pub struct DeclarativeEnvironmentStack {
 impl DeclarativeEnvironmentStack {
     /// Create a new environment stack with the most outer declarative environment.
     #[inline]
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(global_compile_environment: Gc<Cell<CompileTimeEnvironment>>) -> Self {
         Self {
             stack: vec![Gc::new(DeclarativeEnvironment {
                 bindings: Cell::new(Vec::new()),
                 this: None,
+                compile: global_compile_environment,
+                poisoned: Cell::new(false),
             })],
         }
+    }
+
+    /// Extends the length of the next outer function environment to the number of compiled bindings.
+    ///
+    /// This is only useful when compiled bindings are added after the initial compilation (eval).
+    pub(crate) fn extend_outer_function_environment(&mut self) {
+        for env in self.stack.iter().rev() {
+            if env.this.is_some() {
+                let compile_bindings_number = env.compile.borrow().num_bindings();
+                let mut bindings_mut = env.bindings.borrow_mut();
+
+                if compile_bindings_number > bindings_mut.len() {
+                    let diff = compile_bindings_number - bindings_mut.len();
+                    bindings_mut.extend(vec![None; diff]);
+                }
+                break;
+            }
+        }
+    }
+
+    /// Check if any of the provided binding names are defined as lexical bindings.
+    ///
+    /// Start at the current environment.
+    /// Stop at the next outer function environment.
+    pub(crate) fn has_lex_binding_until_function_environment(
+        &self,
+        names: &FxHashSet<Sym>,
+    ) -> Option<Sym> {
+        for env in self.stack.iter().rev() {
+            let compile = env.compile.borrow();
+            for name in names {
+                if compile.has_lex_binding(*name) {
+                    return Some(*name);
+                }
+            }
+            if compile.is_function() {
+                break;
+            }
+        }
+        None
+    }
+
+    /// Pop all current environments except the global environment.
+    pub(crate) fn pop_to_global(&mut self) -> Vec<Gc<DeclarativeEnvironment>> {
+        self.stack.split_off(1)
+    }
+
+    /// Get the number of current environments.
+    pub(crate) fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Truncate current environments to the given number.
+    pub(crate) fn truncate(&mut self, len: usize) {
+        self.stack.truncate(len);
+    }
+
+    /// Extend the current environment stack with the given environments.
+    pub(crate) fn extend(&mut self, other: Vec<Gc<DeclarativeEnvironment>>) {
+        self.stack.extend(other);
     }
 
     /// Set the number of bindings on the global environment.
@@ -97,20 +175,57 @@ impl DeclarativeEnvironmentStack {
     }
 
     /// Push a declarative environment on the environments stack.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no environment exists on the stack.
     #[inline]
-    pub(crate) fn push_declarative(&mut self, num_bindings: usize) {
+    pub(crate) fn push_declarative(
+        &mut self,
+        num_bindings: usize,
+        compile_environment: Gc<Cell<CompileTimeEnvironment>>,
+    ) {
+        let poisoned = self
+            .stack
+            .last()
+            .expect("global environment must always exist")
+            .poisoned
+            .borrow()
+            .to_owned();
+
         self.stack.push(Gc::new(DeclarativeEnvironment {
             bindings: Cell::new(vec![None; num_bindings]),
             this: None,
+            compile: compile_environment,
+            poisoned: Cell::new(poisoned),
         }));
     }
 
     /// Push a function environment on the environments stack.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no environment exists on the stack.
     #[inline]
-    pub(crate) fn push_function(&mut self, num_bindings: usize, this: JsValue) {
+    pub(crate) fn push_function(
+        &mut self,
+        num_bindings: usize,
+        compile_environment: Gc<Cell<CompileTimeEnvironment>>,
+        this: JsValue,
+    ) {
+        let poisoned = self
+            .stack
+            .last()
+            .expect("global environment must always exist")
+            .poisoned
+            .borrow()
+            .to_owned();
+
         self.stack.push(Gc::new(DeclarativeEnvironment {
             bindings: Cell::new(vec![None; num_bindings]),
             this: Some(this),
+            compile: compile_environment,
+            poisoned: Cell::new(poisoned),
         }));
     }
 
@@ -134,6 +249,47 @@ impl DeclarativeEnvironmentStack {
             .clone()
     }
 
+    /// Get the compile environment for the current runtime environment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no environment exists on the stack.
+    pub(crate) fn current_compile_environment(&self) -> Gc<Cell<CompileTimeEnvironment>> {
+        self.stack
+            .last()
+            .expect("global environment must always exist")
+            .compile
+            .clone()
+    }
+
+    /// Mark that there may be added bindings in the current environment.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no environment exists on the stack.
+    #[inline]
+    pub(crate) fn poison_current(&mut self) {
+        let mut poisoned = self
+            .stack
+            .last()
+            .expect("global environment must always exist")
+            .poisoned
+            .borrow_mut();
+        *poisoned = true;
+    }
+
+    /// Mark that there may be added binding in all environments.
+    #[inline]
+    pub(crate) fn poison_all(&mut self) {
+        for env in &mut self.stack {
+            let mut poisoned = env.poisoned.borrow_mut();
+            if *poisoned {
+                return;
+            }
+            *poisoned = true;
+        }
+    }
+
     /// Get the value of a binding.
     ///
     /// # Panics
@@ -142,9 +298,30 @@ impl DeclarativeEnvironmentStack {
     #[inline]
     pub(crate) fn get_value_optional(
         &self,
-        environment_index: usize,
-        binding_index: usize,
+        mut environment_index: usize,
+        mut binding_index: usize,
+        name: Sym,
     ) -> Option<JsValue> {
+        if environment_index != self.stack.len() - 1 {
+            for env_index in (environment_index + 1..self.stack.len()).rev() {
+                let env = self
+                    .stack
+                    .get(env_index)
+                    .expect("environment index must be in range");
+                if !*env.poisoned.borrow() {
+                    break;
+                }
+                let compile = env.compile.borrow();
+                if compile.is_function() {
+                    if let Some(b) = compile.get_binding(name) {
+                        environment_index = b.environment_index;
+                        binding_index = b.binding_index;
+                        break;
+                    }
+                }
+            }
+        }
+
         self.stack
             .get(environment_index)
             .expect("environment index must be in range")
@@ -153,6 +330,34 @@ impl DeclarativeEnvironmentStack {
             .get(binding_index)
             .expect("binding index must be in range")
             .clone()
+    }
+
+    /// Get the value of a binding by it's name.
+    ///
+    /// This only considers function environments that are poisoned.
+    /// All other bindings are accessed via indices.
+    #[inline]
+    pub(crate) fn get_value_global_poisoned(&self, name: Sym) -> Option<JsValue> {
+        for env in self.stack.iter().rev() {
+            if !*env.poisoned.borrow() {
+                return None;
+            }
+            let compile = env.compile.borrow();
+            if compile.is_function() {
+                if let Some(b) = compile.get_binding(name) {
+                    return self
+                        .stack
+                        .get(b.environment_index)
+                        .expect("environment index must be in range")
+                        .bindings
+                        .borrow()
+                        .get(b.binding_index)
+                        .expect("binding index must be in range")
+                        .clone();
+                }
+            }
+        }
+        None
     }
 
     /// Set the value of a binding.
@@ -188,10 +393,31 @@ impl DeclarativeEnvironmentStack {
     #[inline]
     pub(crate) fn put_value_if_initialized(
         &mut self,
-        environment_index: usize,
-        binding_index: usize,
+        mut environment_index: usize,
+        mut binding_index: usize,
+        name: Sym,
         value: JsValue,
     ) -> bool {
+        if environment_index != self.stack.len() - 1 {
+            for env_index in (environment_index + 1..self.stack.len()).rev() {
+                let env = self
+                    .stack
+                    .get(env_index)
+                    .expect("environment index must be in range");
+                if !*env.poisoned.borrow() {
+                    break;
+                }
+                let compile = env.compile.borrow();
+                if compile.is_function() {
+                    if let Some(b) = compile.get_binding(name) {
+                        environment_index = b.environment_index;
+                        binding_index = b.binding_index;
+                        break;
+                    }
+                }
+            }
+        }
+
         let mut bindings = self
             .stack
             .get(environment_index)
@@ -233,6 +459,36 @@ impl DeclarativeEnvironmentStack {
         if binding.is_none() {
             *binding = Some(value);
         }
+    }
+
+    /// Set the value of a binding by it's name.
+    ///
+    /// This only considers function environments that are poisoned.
+    /// All other bindings are set via indices.
+    #[inline]
+    pub(crate) fn put_value_global_poisoned(&mut self, name: Sym, value: &JsValue) -> bool {
+        for env in self.stack.iter().rev() {
+            if !*env.poisoned.borrow() {
+                return false;
+            }
+            let compile = env.compile.borrow();
+            if compile.is_function() {
+                if let Some(b) = compile.get_binding(name) {
+                    let mut bindings = self
+                        .stack
+                        .get(b.environment_index)
+                        .expect("environment index must be in range")
+                        .bindings
+                        .borrow_mut();
+                    let binding = bindings
+                        .get_mut(b.binding_index)
+                        .expect("binding index must be in range");
+                    *binding = Some(value.clone());
+                    return true;
+                }
+            }
+        }
+        false
     }
 }
 

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -465,6 +465,10 @@ impl DeclarativeEnvironmentStack {
     ///
     /// This only considers function environments that are poisoned.
     /// All other bindings are set via indices.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the environment or binding index are out of range.
     #[inline]
     pub(crate) fn put_value_global_poisoned(&mut self, name: Sym, value: &JsValue) -> bool {
         for env in self.stack.iter().rev() {

--- a/boa_engine/src/vm/opcode.rs
+++ b/boa_engine/src/vm/opcode.rs
@@ -825,6 +825,20 @@ pub enum Opcode {
     /// Stack: **=>** func
     GetGenerator,
 
+    /// Call a function named "eval".
+    ///
+    /// Operands: argument_count: `u32`
+    ///
+    /// Stack: func, this, argument_1, ... argument_n **=>** result
+    CallEval,
+
+    /// Call a function named "eval" where the last argument is a rest parameter.
+    ///
+    /// Operands: argument_count: `u32`
+    ///
+    /// Stack: func, this, argument_1, ... argument_n **=>** result
+    CallEvalWithRest,
+
     /// Call a function.
     ///
     /// Operands: argument_count: `u32`
@@ -862,14 +876,14 @@ pub enum Opcode {
 
     /// Push a declarative environment.
     ///
-    /// Operands: num_bindings: `u32`
+    /// Operands: num_bindings: `u32`, compile_environments_index: `u32`
     ///
     /// Stack: **=>**
     PushDeclarativeEnvironment,
 
     /// Push a function environment.
     ///
-    /// Operands:
+    /// Operands: num_bindings: `u32`, compile_environments_index: `u32`
     ///
     /// Stack: **=>**
     PushFunctionEnvironment,
@@ -1155,6 +1169,8 @@ impl Opcode {
             Opcode::Default => "Default",
             Opcode::GetFunction => "GetFunction",
             Opcode::GetGenerator => "GetGenerator",
+            Opcode::CallEval => "CallEval",
+            Opcode::CallEvalWithRest => "CallEvalWithRest",
             Opcode::Call => "Call",
             Opcode::CallWithRest => "CallWithRest",
             Opcode::New => "New",
@@ -1287,6 +1303,8 @@ impl Opcode {
             Opcode::Default => "INST - Default",
             Opcode::GetFunction => "INST - GetFunction",
             Opcode::GetGenerator => "INST - GetGenerator",
+            Opcode::CallEval => "INST - CallEval",
+            Opcode::CallEvalWithRest => "INST - CallEvalWithRest",
             Opcode::Call => "INST - Call",
             Opcode::CallWithRest => "INST - CallWithRest",
             Opcode::New => "INST - New",


### PR DESCRIPTION
This Pull Request fixes/closes #948.

It changes the following:

- Implement the global `eval()` function.

Runtime code evaluation brings some challenges for environments. Currently the setting and getting of variable bindings is done via indices that are calculated at compile time. This prevents costly hashmap lookups at runtime.
Evaluiation at runtime needs access to existing compile time environments. This is a relatively easy change. We wrap compile time environments in `Gc` and make them accessible at runtime.

Because `eval()` can add var bindings to existing function environments, we have to adjust the environments for this. Because we cannot recompile all previously stored binding indices, we have to fallback to hashmap lookups at runtime. To prevent this from tanking our performance we add a flag to each environment that marks if any `eval()` has been executed in that environment (or outer environments). This makes it possible to retain the performance of precompiled environment lookups while having a fallback for `eval()`.

TLDR: `eval()` is not only horribly unsafe but also a burden for performance. [Never use eval()!](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#never_use_eval!)
