### PR TITLE
[Merged by Bors] - Allow `let` as variable declaration name

### DIFF
--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -142,6 +142,7 @@ where
             TokenKind::BooleanLiteral(boolean) => Ok(Const::from(*boolean).into()),
             TokenKind::NullLiteral => Ok(Const::Null.into()),
             TokenKind::Identifier(ident) => Ok(Identifier::new(*ident).into()),
+            TokenKind::Keyword((Keyword::Let, _)) => Ok(Identifier::new(Sym::LET).into()),
             TokenKind::Keyword((Keyword::Yield, _)) if self.allow_yield.0 => {
                 // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".
                 Err(ParseError::general(

--- a/boa_engine/src/syntax/parser/statement/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/mod.rs
@@ -554,6 +554,13 @@ where
                     next_token.span().start(),
                 )))
             }
+            TokenKind::Keyword((Keyword::Let, _)) if cursor.strict_mode() => {
+                Err(ParseError::lex(LexError::Syntax(
+                    "unexpected identifier 'let' in strict mode".into(),
+                    next_token.span().start(),
+                )))
+            }
+            TokenKind::Keyword((Keyword::Let, _)) => Ok(Sym::LET),
             TokenKind::Identifier(ref s) => Ok(*s),
             TokenKind::Keyword((Keyword::Yield, _)) if self.allow_yield.0 => {
                 // Early Error: It is a Syntax Error if this production has a [Yield] parameter and StringValue of Identifier is "yield".


### PR DESCRIPTION

This Pull Request changes the following:

- Allow `let` as variable declaration name
