### PR TITLE
[Merged by Bors] - Remove `strict` flag from `Context`

### DIFF
--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -141,7 +141,7 @@ where
     use boa_engine::syntax::parser::Parser;
 
     let src_bytes = src.as_ref();
-    Parser::new(src_bytes, false)
+    Parser::new(src_bytes)
         .parse_all(context)
         .map_err(|e| format!("ParsingError: {e}"))
 }

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -83,7 +83,12 @@ impl Eval {
 
         // Parse the script body (11.a - 11.d)
         // TODO: Implement errors for 11.e - 11.h
-        let body = match context.parse(x.as_bytes()).map_err(|e| e.to_string()) {
+        let parse_result = if strict {
+            context.parse_strict(x.as_bytes())
+        } else {
+            context.parse(x.as_bytes())
+        };
+        let body = match parse_result.map_err(|e| e.to_string()) {
             Ok(body) => body,
             Err(e) => return context.throw_syntax_error(e),
         };

--- a/boa_engine/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/await_expr/mod.rs
@@ -25,6 +25,13 @@ pub struct AwaitExpr {
     expr: Box<Node>,
 }
 
+impl AwaitExpr {
+    /// Return the expression that should be awaited.
+    pub(crate) fn expr(&self) -> &Node {
+        &self.expr
+    }
+}
+
 impl<T> From<T> for AwaitExpr
 where
     T: Into<Box<Node>>,

--- a/boa_engine/src/syntax/ast/node/identifier/mod.rs
+++ b/boa_engine/src/syntax/ast/node/identifier/mod.rs
@@ -1,6 +1,9 @@
 //! Local identifier node.
 
-use crate::syntax::ast::node::Node;
+use crate::syntax::{
+    ast::{node::Node, Position},
+    parser::ParseError,
+};
 use boa_gc::{unsafe_empty_trace, Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
@@ -38,6 +41,24 @@ impl Identifier {
     /// Retrieves the identifier's string symbol in the interner.
     pub fn sym(self) -> Sym {
         self.ident
+    }
+
+    /// Returns an error if `arguments` or `eval` are used as identifier in strict mode.
+    pub(crate) fn check_strict_arguments_or_eval(
+        self,
+        position: Position,
+    ) -> Result<(), ParseError> {
+        match self.ident {
+            Sym::ARGUMENTS => Err(ParseError::general(
+                "unexpected identifier 'arguments' in strict mode",
+                position,
+            )),
+            Sym::EVAL => Err(ParseError::general(
+                "unexpected identifier 'eval' in strict mode",
+                position,
+            )),
+            _ => Ok(()),
+        }
     }
 }
 

--- a/boa_engine/src/syntax/parser/error.rs
+++ b/boa_engine/src/syntax/parser/error.rs
@@ -98,7 +98,7 @@ impl ParseError {
     }
 
     /// Creates a "general" parsing error.
-    pub(super) fn general(message: &'static str, position: Position) -> Self {
+    pub(crate) fn general(message: &'static str, position: Position) -> Self {
         Self::General { message, position }
     }
 

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -214,17 +214,7 @@ where
                 TokenKind::Punctuator(Punctuator::Assign) => {
                     if cursor.strict_mode() {
                         if let Node::Identifier(ident) = lhs {
-                            if ident.sym() == Sym::ARGUMENTS {
-                                return Err(ParseError::lex(LexError::Syntax(
-                                    "unexpected identifier 'arguments' in strict mode".into(),
-                                    position,
-                                )));
-                            } else if ident.sym() == Sym::EVAL {
-                                return Err(ParseError::lex(LexError::Syntax(
-                                    "unexpected identifier 'eval' in strict mode".into(),
-                                    position,
-                                )));
-                            }
+                            ident.check_strict_arguments_or_eval(position)?;
                         }
                     }
 
@@ -245,17 +235,7 @@ where
                 TokenKind::Punctuator(p) if p.as_binop().is_some() && p != &Punctuator::Comma => {
                     if cursor.strict_mode() {
                         if let Node::Identifier(ident) = lhs {
-                            if ident.sym() == Sym::ARGUMENTS {
-                                return Err(ParseError::lex(LexError::Syntax(
-                                    "unexpected identifier 'arguments' in strict mode".into(),
-                                    position,
-                                )));
-                            } else if ident.sym() == Sym::EVAL {
-                                return Err(ParseError::lex(LexError::Syntax(
-                                    "unexpected identifier 'eval' in strict mode".into(),
-                                    position,
-                                )));
-                            }
+                            ident.check_strict_arguments_or_eval(position)?;
                         }
                     }
 

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -243,6 +243,22 @@ where
                     }
                 }
                 TokenKind::Punctuator(p) if p.as_binop().is_some() && p != &Punctuator::Comma => {
+                    if cursor.strict_mode() {
+                        if let Node::Identifier(ident) = lhs {
+                            if ident.sym() == Sym::ARGUMENTS {
+                                return Err(ParseError::lex(LexError::Syntax(
+                                    "unexpected identifier 'arguments' in strict mode".into(),
+                                    position,
+                                )));
+                            } else if ident.sym() == Sym::EVAL {
+                                return Err(ParseError::lex(LexError::Syntax(
+                                    "unexpected identifier 'eval' in strict mode".into(),
+                                    position,
+                                )));
+                            }
+                        }
+                    }
+
                     cursor.next(interner)?.expect("token vanished");
                     if is_assignable(&lhs) {
                         let binop = p.as_binop().expect("binop disappeared");

--- a/boa_engine/src/syntax/parser/expression/identifiers.rs
+++ b/boa_engine/src/syntax/parser/expression/identifiers.rs
@@ -15,7 +15,7 @@ use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use std::io::Read;
 
-const RESERVED_IDENTIFIERS_STRICT: [Sym; 9] = [
+pub(in crate::syntax) const RESERVED_IDENTIFIERS_STRICT: [Sym; 9] = [
     Sym::IMPLEMENTS,
     Sym::INTERFACE,
     Sym::LET,

--- a/boa_engine/src/syntax/parser/expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/mod.rs
@@ -36,6 +36,7 @@ use boa_profiler::Profiler;
 use std::io::Read;
 
 pub(super) use self::{assignment::AssignmentExpression, primary::Initializer};
+pub(in crate::syntax) use identifiers::RESERVED_IDENTIFIERS_STRICT;
 pub(in crate::syntax::parser) use {
     identifiers::{BindingIdentifier, LabelIdentifier},
     left_hand_side::LeftHandSideExpression,

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -113,7 +113,8 @@ where
             }
             TokenKind::Keyword((Keyword::Class, _)) => {
                 cursor.next(interner).expect("token disappeared");
-                ClassExpression::new(self.name, false, false).parse(cursor, interner)
+                ClassExpression::new(self.name, self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)
             }
             TokenKind::Keyword((Keyword::Async, false)) => {
                 cursor.next(interner).expect("token disappeared");

--- a/boa_engine/src/syntax/parser/expression/update.rs
+++ b/boa_engine/src/syntax/parser/expression/update.rs
@@ -69,17 +69,7 @@ where
 
                 if cursor.strict_mode() {
                     if let Node::Identifier(ident) = target {
-                        if ident.sym() == Sym::ARGUMENTS {
-                            return Err(ParseError::lex(LexError::Syntax(
-                                "unexpected identifier 'arguments' in strict mode".into(),
-                                position,
-                            )));
-                        } else if ident.sym() == Sym::EVAL {
-                            return Err(ParseError::lex(LexError::Syntax(
-                                "unexpected identifier 'eval' in strict mode".into(),
-                                position,
-                            )));
-                        }
+                        ident.check_strict_arguments_or_eval(position)?;
                     }
                 }
 
@@ -95,17 +85,7 @@ where
 
                 if cursor.strict_mode() {
                     if let Node::Identifier(ident) = target {
-                        if ident.sym() == Sym::ARGUMENTS {
-                            return Err(ParseError::lex(LexError::Syntax(
-                                "unexpected identifier 'arguments' in strict mode".into(),
-                                position,
-                            )));
-                        } else if ident.sym() == Sym::EVAL {
-                            return Err(ParseError::lex(LexError::Syntax(
-                                "unexpected identifier 'eval' in strict mode".into(),
-                                position,
-                            )));
-                        }
+                        ident.check_strict_arguments_or_eval(position)?;
                     }
                 }
 

--- a/boa_engine/src/syntax/parser/function/mod.rs
+++ b/boa_engine/src/syntax/parser/function/mod.rs
@@ -541,7 +541,6 @@ where
             self.allow_yield,
             self.allow_await,
             true,
-            true,
             &FUNCTION_BREAK_TOKENS,
         )
         .parse(cursor, interner);

--- a/boa_engine/src/syntax/parser/function/tests.rs
+++ b/boa_engine/src/syntax/parser/function/tests.rs
@@ -70,7 +70,7 @@ fn check_duplicates_strict_on() {
     let js = "'use strict'; function foo(a, a) {}";
     let mut context = Context::default();
 
-    let res = Parser::new(js.as_bytes(), false).parse_all(&mut context);
+    let res = Parser::new(js.as_bytes()).parse_all(&mut context);
     dbg!(&res);
     assert!(res.is_err());
 }

--- a/boa_engine/src/syntax/parser/statement/block/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/block/mod.rs
@@ -91,7 +91,6 @@ where
             self.allow_yield,
             self.allow_await,
             self.allow_return,
-            true,
             &BLOCK_BREAK_TOKENS,
         )
         .parse(cursor, interner)

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -111,7 +111,7 @@ where
                 }
             }
             TokenKind::Keyword((Keyword::Class, false)) => {
-                ClassDeclaration::new(false, false, self.is_default)
+                ClassDeclaration::new(self.allow_yield, self.allow_await, false)
                     .parse(cursor, interner)
                     .map(Node::from)
             }

--- a/boa_engine/src/syntax/parser/statement/switch/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/switch/mod.rs
@@ -150,7 +150,6 @@ where
                         self.allow_yield,
                         self.allow_await,
                         self.allow_return,
-                        false,
                         &CASE_BREAK_TOKENS,
                     )
                     .parse(cursor, interner)?;
@@ -173,7 +172,6 @@ where
                         self.allow_yield,
                         self.allow_await,
                         self.allow_return,
-                        false,
                         &CASE_BREAK_TOKENS,
                     )
                     .parse(cursor, interner)?;

--- a/boa_engine/src/syntax/parser/tests.rs
+++ b/boa_engine/src/syntax/parser/tests.rs
@@ -25,7 +25,7 @@ where
 {
     let mut context = Context::new(interner);
     assert_eq!(
-        Parser::new(js.as_bytes(), false)
+        Parser::new(js.as_bytes())
             .parse_all(&mut context)
             .expect("failed to parse"),
         StatementList::from(expr)
@@ -36,9 +36,7 @@ where
 #[track_caller]
 pub(super) fn check_invalid(js: &str) {
     let mut context = Context::default();
-    assert!(Parser::new(js.as_bytes(), false)
-        .parse_all(&mut context)
-        .is_err());
+    assert!(Parser::new(js.as_bytes()).parse_all(&mut context).is_err());
 }
 
 /// Should be parsed as `new Class().method()` instead of `new (Class().method())`

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -1608,24 +1608,6 @@ fn test_strict_mode_reserved_name() {
 }
 
 #[test]
-fn test_strict_mode_func_decl_in_block() {
-    // Checks that a function declaration in a block is an error in
-    // strict mode code as per https://tc39.es/ecma262/#early-error.
-
-    let scenario = r#"
-    'use strict';
-    let a = 4;
-    let b = 5;
-    if (a < b) { function f() {} }
-    "#;
-
-    check_output(&[TestAction::TestStartsWith(
-        scenario,
-        "Uncaught \"SyntaxError\": ",
-    )]);
-}
-
-#[test]
 fn test_strict_mode_dup_func_parameters() {
     // Checks that a function cannot contain duplicate parameter
     // names in strict mode code as per https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors.

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -634,10 +634,14 @@ impl JsObject {
                     } else {
                         context.global_object().clone().into()
                     }
-                } else if (!code.strict && !context.strict()) && this.is_null_or_undefined() {
+                } else if code.strict {
+                    this.clone()
+                } else if this.is_null_or_undefined() {
                     context.global_object().clone().into()
                 } else {
-                    this.clone()
+                    this.to_object(context)
+                        .expect("conversion cannot fail")
+                        .into()
                 };
 
                 if code.params.has_expressions() {
@@ -655,19 +659,18 @@ impl JsObject {
                 }
 
                 if let Some(binding) = code.arguments_binding {
-                    let arguments_obj =
-                        if context.strict() || code.strict || !code.params.is_simple() {
-                            Arguments::create_unmapped_arguments_object(args, context)
-                        } else {
-                            let env = context.realm.environments.current();
-                            Arguments::create_mapped_arguments_object(
-                                &this_function_object,
-                                &code.params,
-                                args,
-                                &env,
-                                context,
-                            )
-                        };
+                    let arguments_obj = if code.strict || !code.params.is_simple() {
+                        Arguments::create_unmapped_arguments_object(args, context)
+                    } else {
+                        let env = context.realm.environments.current();
+                        Arguments::create_mapped_arguments_object(
+                            &this_function_object,
+                            &code.params,
+                            args,
+                            &env,
+                            context,
+                        )
+                    };
                     context.realm.environments.put_value(
                         binding.environment_index(),
                         binding.binding_index(),
@@ -742,7 +745,7 @@ impl JsObject {
                     } else {
                         context.global_object().clone().into()
                     }
-                } else if (!code.strict && !context.strict()) && this.is_null_or_undefined() {
+                } else if !code.strict && this.is_null_or_undefined() {
                     context.global_object().clone().into()
                 } else {
                     this.clone()
@@ -763,19 +766,18 @@ impl JsObject {
                 }
 
                 if let Some(binding) = code.arguments_binding {
-                    let arguments_obj =
-                        if context.strict() || code.strict || !code.params.is_simple() {
-                            Arguments::create_unmapped_arguments_object(args, context)
-                        } else {
-                            let env = context.realm.environments.current();
-                            Arguments::create_mapped_arguments_object(
-                                &this_function_object,
-                                &code.params,
-                                args,
-                                &env,
-                                context,
-                            )
-                        };
+                    let arguments_obj = if code.strict || !code.params.is_simple() {
+                        Arguments::create_unmapped_arguments_object(args, context)
+                    } else {
+                        let env = context.realm.environments.current();
+                        Arguments::create_mapped_arguments_object(
+                            &this_function_object,
+                            &code.params,
+                            args,
+                            &env,
+                            context,
+                        )
+                    };
                     context.realm.environments.put_value(
                         binding.environment_index(),
                         binding.binding_index(),
@@ -957,19 +959,18 @@ impl JsObject {
                 }
 
                 if let Some(binding) = code.arguments_binding {
-                    let arguments_obj =
-                        if context.strict() || code.strict || !code.params.is_simple() {
-                            Arguments::create_unmapped_arguments_object(args, context)
-                        } else {
-                            let env = context.realm.environments.current();
-                            Arguments::create_mapped_arguments_object(
-                                &this_function_object,
-                                &code.params,
-                                args,
-                                &env,
-                                context,
-                            )
-                        };
+                    let arguments_obj = if code.strict || !code.params.is_simple() {
+                        Arguments::create_unmapped_arguments_object(args, context)
+                    } else {
+                        let env = context.realm.environments.current();
+                        Arguments::create_mapped_arguments_object(
+                            &this_function_object,
+                            &code.params,
+                            args,
+                            &env,
+                            context,
+                        )
+                    };
                     context.realm.environments.put_value(
                         binding.environment_index(),
                         binding.binding_index(),


### PR DESCRIPTION
The `Context` currently contains a `strict` flag that indicates is global strict mode is active. This is redundant to the strict flag that is set on every function and causes some non spec compliant situations. This pull request removes the strict flag from `Context` and fixes some resulting errors.

Detailed changes:

- Remove strict flag from `Context`
- Make 262 tester compliant with the strict section in [test262/INTERPRETING.md](https://github.com/tc39/test262/blob/2e7cdfbe18eae4309677033673bb4b5ac6b1de40/INTERPRETING.md#strict-mode)
- Make 262 tester compliant with the `raw` flag in [test262/INTERPRETING.md](https://github.com/tc39/test262/blob/2e7cdfbe18eae4309677033673bb4b5ac6b1de40/INTERPRETING.md#flags)
- Allow function declarations in strict mode
- Fix parser flag propagation for classes
- Move some early errors from the lexer to the parser
- Add / fix some early errors for 'arguments' and 'eval' identifier usage in strict mode
- Refactor `ArrayLiteral` parser for readability and correct early errors