### PR TITLE
[Merged by Bors] - Integrate ICU4X into `Intl` module

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ Explain what you expected to happen, and what is happening instead.
 <!-- E.g.:
 Running this code, `a` should be set to `10` and printed, but `a` is instead set to `20`. The expected behaviour can be found in the [ECMAScript specification][spec].
 
-[spec]: https://www.ecma-international.org/ecma-262/10.0/index.html#sec-variable-statement-runtime-semantics-evaluation
+[spec]: https://tc39.es/ecma262/#sec-variable-statement-runtime-semantics-evaluation
 -->
 
 **Build environment (please complete the following information):**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -16,7 +16,7 @@ Explain the ECMAScript feature that you'd like to see implemented.
 <!-- E.g.:
 I would like to see `switch` statement parsing and execution implemented. [ECMAScript specification][spec].
 
-[spec]: https://www.ecma-international.org/ecma-262/10.0/index.html#sec-switch-statement
+[spec]: https://tc39.es/ecma262/#sec-switch-statement
 -->
 
 **Example code**

--- a/.github/workflows/bors.yml
+++ b/.github/workflows/bors.yml
@@ -159,4 +159,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -v --document-private-items
+          args: -v --document-private-items --all-features

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -v --document-private-items
+          args: -v --document-private-items --all-features
       - run: echo "<meta http-equiv=refresh content=0;url=boa_engine/index.html>" > target/doc/index.html
       - run: |
           if [ -d target/doc_upload ]; then rm -rf target/doc_upload; fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -163,4 +163,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -v --document-private-items
+          args: -v --document-private-items --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          args: --ignore-tests
+          args: --features intl --ignore-tests
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
 
@@ -55,7 +55,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -v
+          args: -v --features intl
 
   test_on_macos:
     name: Tests on MacOS
@@ -70,7 +70,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -v
+          args: -v --features intl
 
   fmt:
     name: Rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,12 @@ dependencies = [
  "fast-float",
  "float-cmp",
  "gc",
- "icu",
+ "icu_datetime",
+ "icu_locale_canonicalizer",
+ "icu_locid",
+ "icu_plurals",
+ "icu_provider",
+ "icu_testdata",
  "indexmap",
  "jemallocator",
  "num-bigint",
@@ -113,6 +118,7 @@ dependencies = [
  "ryu-js",
  "serde",
  "serde_json",
+ "sys-locale",
  "tap",
  "unicode-normalization",
 ]
@@ -196,7 +202,7 @@ checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
  "lazy_static",
  "memchr",
- "regex-automata 0.1.10",
+ "regex-automata",
  "serde",
 ]
 
@@ -404,6 +410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cstr_core"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644828c273c063ab0d39486ba42a5d1f3a499d35529c759e763a9c6cb8a0fb08"
+dependencies = [
+ "cty",
+ "memchr",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +440,12 @@ checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
 
 [[package]]
 name = "dirs-next"
@@ -633,24 +655,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a4e90a2faa6719f4b3b1dac871d1f2794474d453b8e6ca1264062c4bf2c9da"
-dependencies = [
- "fixed_decimal",
- "icu_calendar",
- "icu_datetime",
- "icu_decimal",
- "icu_list",
- "icu_locale_canonicalizer",
- "icu_locid",
- "icu_plurals",
- "icu_properties",
- "writeable",
-]
-
-[[package]]
 name = "icu_calendar"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,20 +663,8 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_provider",
+ "serde",
  "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_codepointtrie"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdb6b96093158ec0031f9831283085cf897cf4bffc9a1a35a8360a777141058"
-dependencies = [
- "displaydoc",
- "icu_uniset",
- "yoke",
- "zerofrom",
  "zerovec",
 ]
 
@@ -689,35 +681,9 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "litemap",
+ "serde",
  "smallvec",
  "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_decimal"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614ff51266354e8c8d75bfc65f806fbc0d0177da079c2482402cfc20b72de47d"
-dependencies = [
- "displaydoc",
- "fixed_decimal",
- "icu_locid",
- "icu_provider",
- "writeable",
-]
-
-[[package]]
-name = "icu_list"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c144d074b8de0f6adcb6941ac4544abf83483fa5681154dcc361253c3a122c5c"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider",
- "regex-automata 0.2.0",
  "writeable",
  "zerovec",
 ]
@@ -731,6 +697,7 @@ dependencies = [
  "icu_locid",
  "icu_provider",
  "litemap",
+ "serde",
  "tinystr",
  "zerovec",
 ]
@@ -759,19 +726,7 @@ dependencies = [
  "fixed_decimal",
  "icu_locid",
  "icu_provider",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ca8f26685a463ff47dc0d9f7b270e8d955d3c2dd9f748292af14940b659671"
-dependencies = [
- "displaydoc",
- "icu_codepointtrie",
- "icu_provider",
- "icu_uniset",
+ "serde",
  "zerovec",
 ]
 
@@ -785,9 +740,25 @@ dependencies = [
  "icu_locid",
  "icu_provider_macros",
  "litemap",
+ "postcard",
+ "serde",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_blob"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "474b884a565f7ec52a26754a8b57646c128195e7af629caa52317ef6674e3e0d"
+dependencies = [
+ "icu_provider",
+ "postcard",
+ "serde",
+ "writeable",
+ "yoke",
  "zerovec",
 ]
 
@@ -803,16 +774,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_uniset"
-version = "0.5.0"
+name = "icu_testdata"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecdc2859b6efd75ae22e6350e62f21c87cfe3cfdc11bef6f9565995e88d14ba9"
+checksum = "a5580eeaa6ea70b94f286120ffcfb70f75ac8d759d95ccf6223a3c479ff99285"
 dependencies = [
- "displaydoc",
- "tinystr",
- "yoke",
- "zerofrom",
- "zerovec",
+ "icu_provider",
+ "icu_provider_blob",
 ]
 
 [[package]]
@@ -857,9 +825,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "jemalloc-sys"
@@ -899,9 +867,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec647867e2bf0772e28c8bcde4f0d19a9216916e890543b5a03ed8ef27b8f259"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "linked-hash-map"
@@ -911,9 +879,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.42"
+version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5284f00d480e1c39af34e72f8ad60b94f47007e3481cd3b731c1d67190ddc7b7"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "litemap"
@@ -921,6 +889,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d268a51abaaee3b8686e56396eb725b0da510bddd266a52e784aa1029dae73"
 dependencies = [
+ "serde",
  "yoke",
 ]
 
@@ -936,9 +905,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -959,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
@@ -1074,9 +1043,9 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+checksum = "029d8d0b2f198229de29dca79676f2738ff952edf3fde542eb8bf94d8c21b435"
 
 [[package]]
 name = "parking_lot"
@@ -1185,6 +1154,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "postcard"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25c0b0ae06fcffe600ad392aabfa535696c8973f2253d9ac83171924c58a858"
+dependencies = [
+ "postcard-cobs",
+ "serde",
+]
+
+[[package]]
+name = "postcard-cobs"
+version = "0.1.5-pre"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c68cb38ed13fd7bc9dd5db8f165b7c8d9c1a315104083a2b10f11354c2af97f"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,18 +1207,18 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
@@ -1292,9 +1277,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1340,15 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
-name = "regex-automata"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.34.2"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96619609a54d638872db136f56941d34e2a00bb0acf3fa783a90d6b96a093ba2"
+checksum = "f117495127afb702af6706f879fb2b5c008c38ccf3656afc514e26f35bdb8180"
 dependencies = [
  "bitflags",
  "errno",
@@ -1428,9 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "ryu-js"
@@ -1455,9 +1431,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
@@ -1495,7 +1471,7 @@ version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
- "itoa 1.0.1",
+ "itoa 1.0.2",
  "ryu",
  "serde",
 ]
@@ -1523,6 +1499,9 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1591,13 +1570,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1610,6 +1589,19 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "sys-locale"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3913c5a3d30054d7f77cf07cdd800c8103ace15c6e44437c5db66a43dd3a92cf"
+dependencies = [
+ "cc",
+ "cstr_core",
+ "libc",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1644,18 +1636,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1696,9 +1688,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1714,6 +1706,12 @@ name = "unicode-general-category"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1218098468b8085b19a2824104c70d976491d247ce194bbd9dc77181150cdfd6"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "unicode-normalization"
@@ -1738,9 +1736,9 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
 name = "utf8parse"
@@ -1981,6 +1979,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c1b475ff48237bf7281cfa1721a52f0ad7f95ede1a46385e555870a354afc45"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_cli"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Boa is a Javascript lexer, parser and Just-in-Time compiler written in Rust. Currently, it has support for some of the language."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -14,6 +14,15 @@ readme = "../README.md"
 [features]
 profiler = ["boa_profiler/profiler"]
 deser = ["boa_interner/serde"]
+intl = [
+    "dep:icu_locale_canonicalizer",
+    "dep:icu_locid",
+    "dep:icu_datetime",
+    "dep:icu_plurals",
+    "dep:icu_provider",
+    "dep:icu_testdata",
+    "dep:sys-locale"
+]
 
 # Enable Boa's WHATWG console object implementation.
 console = []
@@ -41,7 +50,13 @@ unicode-normalization = "0.1.19"
 dyn-clone = "1.0.5"
 once_cell = "1.12.0"
 tap = "1.0.1"
-icu = "0.6.0"
+icu_locale_canonicalizer = { version = "0.6.0", features = ["serde"], optional = true }
+icu_locid = { version = "0.6.0", features = ["serde"],  optional = true }
+icu_datetime = { version = "0.6.0", features = ["serde"], optional = true }
+icu_plurals = { version = "0.6.0", features = ["serde"], optional = true }
+icu_provider = { version = "0.6.0", optional = true }
+icu_testdata = {version = "0.6.0", optional = true}
+sys-locale = { version = "0.2.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3.5"

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_engine"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Boa is a Javascript lexer, parser and Just-in-Time compiler written in Rust. Currently, it has support for some of the language."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -58,6 +58,8 @@ impl BuiltIn for Intl {
 }
 
 impl Intl {
+    /// `Intl.getCanonicalLocales ( locales )`
+    ///
     /// Returns an array containing the canonical locale names.
     ///
     /// More information:
@@ -91,9 +93,10 @@ struct MatcherRecord {
     extension: JsString,
 }
 
-/// The `DefaultLocale` abstract operation returns a String value representing the structurally
-/// valid and canonicalized Unicode BCP 47 locale identifier for the host environment's current
-/// locale.
+/// Abstract operation `DefaultLocale ( )`
+///
+/// Returns a String value representing the structurally valid and canonicalized
+/// Unicode BCP 47 locale identifier for the host environment's current locale.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -106,11 +109,13 @@ fn default_locale(canonicalizer: &LocaleCanonicalizer) -> Locale {
         .unwrap_or(locale!("en-US"))
 }
 
-/// The `BestAvailableLocale` abstract operation compares the provided argument `locale`,
-/// which must be a String value with a structurally valid and canonicalized Unicode BCP 47
-/// locale identifier, against the locales in `availableLocales` and returns either the longest
-/// non-empty prefix of `locale` that is an element of `availableLocales`, or undefined if
-/// there is no such element.
+/// Abstract operation `BestAvailableLocale ( availableLocales, locale )`
+///
+/// Compares the provided argument `locale`, which must be a String value with a
+/// structurally valid and canonicalized Unicode BCP 47 locale identifier, against
+/// the locales in `availableLocales` and returns either the longest non-empty prefix
+/// of `locale` that is an element of `availableLocales`, or undefined if there is no
+/// such element.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -146,9 +151,11 @@ fn best_available_locale(available_locales: &[JsString], locale: &JsString) -> O
     }
 }
 
-/// The `LookupMatcher` abstract operation compares `requestedLocales`, which must be a `List`
-/// as returned by `CanonicalizeLocaleList`, against the locales in `availableLocales` and
-/// determines the best available language to meet the request.
+/// Abstract operation `LookupMatcher ( availableLocales, requestedLocales )`
+///
+/// Compares `requestedLocales`, which must be a `List` as returned by `CanonicalizeLocaleList`,
+/// against the locales in `availableLocales` and determines the best available language to
+/// meet the request.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -202,11 +209,13 @@ fn lookup_matcher(
     }
 }
 
-/// The `BestFitMatcher` abstract operation compares `requestedLocales`, which must be a `List`
-/// as returned by `CanonicalizeLocaleList`, against the locales in `availableLocales` and
-/// determines the best available language to meet the request. The algorithm is implementation
-/// dependent, but should produce results that a typical user of the requested locales would
-/// perceive as at least as good as those produced by the `LookupMatcher` abstract operation.
+/// Abstract operation `BestFitMatcher ( availableLocales, requestedLocales )`
+///
+/// Compares `requestedLocales`, which must be a `List` as returned by `CanonicalizeLocaleList`,
+/// against the locales in `availableLocales` and determines the best available language to
+/// meet the request. The algorithm is implementation dependent, but should produce results
+/// that a typical user of the requested locales would perceive as at least as good as those
+/// produced by the `LookupMatcher` abstract operation.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -241,9 +250,10 @@ struct UniExtRecord {
     keywords: Vec<Keyword>,
 }
 
-/// The `UnicodeExtensionComponents` abstract operation returns the attributes and keywords from
-/// `extension`, which must be a String value whose contents are a `Unicode locale extension`
-/// sequence.
+/// Abstract operation `UnicodeExtensionComponents ( extension )`
+///
+/// Returns the attributes and keywords from `extension`, which must be a String
+/// value whose contents are a `Unicode locale extension` sequence.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -345,9 +355,11 @@ fn unicode_extension_components(extension: &JsString) -> UniExtRecord {
     }
 }
 
-/// The `InsertUnicodeExtensionAndCanonicalize` abstract operation inserts `extension`, which must
-/// be a Unicode locale extension sequence, into `locale`, which must be a String value with a
-/// structurally valid and canonicalized Unicode BCP 47 locale identifier.
+/// Abstract operation `InsertUnicodeExtensionAndCanonicalize ( locale, extension )`
+///
+/// Inserts `extension`, which must be a Unicode locale extension sequence, into
+/// `locale`, which must be a String value with a structurally valid and canonicalized
+/// Unicode BCP 47 locale identifier.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -395,8 +407,22 @@ fn insert_unicode_extension_and_canonicalize(
     new_locale.to_string().into()
 }
 
+/// Abstract operation `CanonicalizeLocaleList ( locales )`
+///
+/// Converts an array of [`JsValue`]s containing structurally valid
+/// [Unicode BCP 47 locale identifiers][bcp-47] into their [canonical form][canon].
+///
+/// For efficiency, this returns a [`Vec`] of [`Locale`]s instead of a [`Vec`] of
+/// [`String`]s, since [`Locale`] allows us to modify individual parts of the locale
+/// without scanning the whole string again.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma402/#sec-canonicalizelocalelist
+/// [bcp-47]: https://unicode.org/reports/tr35/#Unicode_locale_identifier
+/// [canon]: https://unicode.org/reports/tr35/#LocaleId_Canonicalization
 fn canonicalize_locale_list(args: &[JsValue], context: &mut Context) -> JsResult<Vec<Locale>> {
-    // https://tc39.es/ecma402/#sec-canonicalizelocalelist
     // 1. If locales is undefined, then
     let locales = args.get_or_undefined(0);
     if locales.is_undefined() {
@@ -484,10 +510,12 @@ struct ResolveLocaleRecord {
     pub(crate) data_locale: JsString,
 }
 
-/// The `ResolveLocale` abstract operation compares a BCP 47 language priority list
-/// `requestedLocales` against the locales in `availableLocales` and determines the best
-/// available language to meet the request. `availableLocales`, `requestedLocales`, and
-/// `relevantExtensionKeys` must be provided as `List` values, options and `localeData` as Records.
+/// Abstract operation `ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )`
+///
+/// Compares a BCP 47 language priority list `requestedLocales` against the locales
+/// in `availableLocales` and determines the best available language to meet the request.
+/// `availableLocales`, `requestedLocales`, and `relevantExtensionKeys` must be provided as
+/// `List` values, options and `localeData` as Records.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -682,9 +710,11 @@ pub(crate) enum GetOptionType {
     Boolean,
 }
 
-/// The abstract operation `GetOption` extracts the value of the property named `property` from the
-/// provided `options` object, converts it to the required `type`, checks whether it is one of a
-/// `List` of allowed `values`, and fills in a `fallback` value if necessary. If `values` is
+/// Abstract operation `GetOption ( options, property, type, values, fallback )`
+///
+/// Extracts the value of the property named `property` from the provided `options` object,
+/// converts it to the required `type`, checks whether it is one of a `List` of allowed
+/// `values`, and fills in a `fallback` value if necessary. If `values` is
 /// undefined, there is no fixed set of values and any is permitted.
 ///
 /// More information:
@@ -731,9 +761,11 @@ pub(crate) fn get_option(
     Ok(value)
 }
 
-/// The abstract operation `GetNumberOption` extracts the value of the property named `property`
-/// from the provided `options` object, converts it to a `Number value`, checks whether it is in
-/// the allowed range, and fills in a `fallback` value if necessary.
+/// Abstract operation `GetNumberOption ( options, property, minimum, maximum, fallback )`
+///
+/// Extracts the value of the property named `property` from the provided `options`
+/// object, converts it to a `Number value`, checks whether it is in the allowed range,
+/// and fills in a `fallback` value if necessary.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -756,8 +788,10 @@ pub(crate) fn get_number_option(
     default_number_option(&value, minimum, maximum, fallback, context)
 }
 
-/// The abstract operation `DefaultNumberOption` converts `value` to a `Number value`, checks
-/// whether it is in the allowed range, and fills in a `fallback` value if necessary.
+/// Abstract operation `DefaultNumberOption ( value, minimum, maximum, fallback )`
+///
+/// Converts `value` to a `Number value`, checks whether it is in the allowed range,
+/// and fills in a `fallback` value if necessary.
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -796,7 +830,7 @@ pub(crate) fn default_number_option(
 /// More information:
 ///  - [ECMAScript reference][spec]
 ///
-/// [spec]: https://402.ecma-international.org/8.0/#sec-canonicalizeunicodelocaleid
+/// [spec]: https://tc39.es/ecma402/#sec-canonicalizeunicodelocaleid
 fn canonicalize_unicode_locale_id(locale: &mut Locale, canonicalizer: &LocaleCanonicalizer) {
     canonicalizer.canonicalize(locale);
 }

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -33,7 +33,7 @@ impl MapIterator {
     /// More information:
     ///  - [ECMA reference][spec]
     ///
-    /// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-createmapiterator
+    /// [spec]: https://tc39.es/ecma262/#sec-createmapiterator
     pub(crate) fn create_map_iterator(
         map: &JsValue,
         kind: PropertyNameKind,

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -170,7 +170,7 @@ impl Map {
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-map.prototype.entries
+    /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.entries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/entries
     pub(crate) fn entries(
         this: &JsValue,

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -4,8 +4,6 @@ pub mod array;
 pub mod array_buffer;
 pub mod bigint;
 pub mod boolean;
-#[cfg(feature = "console")]
-pub mod console;
 pub mod dataview;
 pub mod date;
 pub mod error;
@@ -15,7 +13,6 @@ pub mod generator;
 pub mod generator_function;
 pub mod global_this;
 pub mod infinity;
-pub mod intl;
 pub mod iterable;
 pub mod json;
 pub mod map;
@@ -32,6 +29,12 @@ pub mod symbol;
 pub mod typed_array;
 pub mod undefined;
 
+#[cfg(feature = "console")]
+pub mod console;
+
+#[cfg(feature = "intl")]
+pub mod intl;
+
 pub(crate) use self::{
     array::{array_iterator::ArrayIterator, Array},
     bigint::BigInt,
@@ -46,7 +49,6 @@ pub(crate) use self::{
     function::BuiltInFunctionObject,
     global_this::GlobalThis,
     infinity::Infinity,
-    intl::Intl,
     json::Json,
     map::map_iterator::MapIterator,
     map::Map,
@@ -143,7 +145,6 @@ pub fn init(context: &mut Context) {
         BuiltInFunctionObject,
         BuiltInObjectObject,
         Math,
-        Intl,
         Json,
         Array,
         Proxy,
@@ -183,6 +184,9 @@ pub fn init(context: &mut Context) {
         Generator,
         GeneratorFunction
     };
+
+    #[cfg(feature = "intl")]
+    init_builtin::<intl::Intl>(context);
 
     #[cfg(feature = "console")]
     init_builtin::<console::Console>(context);

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -40,7 +40,7 @@ impl SetIterator {
     /// More information:
     ///  - [ECMA reference][spec]
     ///
-    /// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#sec-createsetiterator
+    /// [spec]: https://tc39.es/ecma262/#sec-createsetiterator
     pub(crate) fn create_set_iterator(
         set: JsValue,
         kind: PropertyNameKind,

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use icu_datetime::provider::{
     calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
     week_data::WeekDataV1Marker,
@@ -38,7 +40,7 @@ impl<T> BoaProvider for T where
 /// for the functionality of `Intl`.
 #[allow(unused)]
 pub(crate) struct Icu {
-    provider: Box<dyn BoaProvider>,
+    provider: Rc<dyn BoaProvider>,
     locale_canonicalizer: LocaleCanonicalizer,
 }
 
@@ -59,10 +61,10 @@ impl Icu {
     ///
     /// This method will return an error if any of the tools
     /// required cannot be constructed.
-    pub(crate) fn new<P: 'static + BoaProvider>(provider: P) -> Result<Self, DataError> {
+    pub(crate) fn new(provider: Rc<dyn BoaProvider>) -> Result<Self, DataError> {
         Ok(Self {
-            locale_canonicalizer: LocaleCanonicalizer::new(&provider)?,
-            provider: Box::new(provider),
+            locale_canonicalizer: LocaleCanonicalizer::new(&*provider)?,
+            provider,
         })
     }
 

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -1,0 +1,79 @@
+use icu_datetime::provider::{
+    calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
+    week_data::WeekDataV1Marker,
+};
+use icu_locale_canonicalizer::{
+    provider::{AliasesV1Marker, LikelySubtagsV1Marker},
+    LocaleCanonicalizer,
+};
+use icu_plurals::provider::OrdinalV1Marker;
+use icu_provider::prelude::*;
+
+/// Trait encompassing all the required implementations that define
+/// a valid icu data provider.
+pub trait BoaProvider:
+    ResourceProvider<AliasesV1Marker>
+    + ResourceProvider<LikelySubtagsV1Marker>
+    + ResourceProvider<DateSymbolsV1Marker>
+    + ResourceProvider<DatePatternsV1Marker>
+    + ResourceProvider<DateSkeletonPatternsV1Marker>
+    + ResourceProvider<OrdinalV1Marker>
+    + ResourceProvider<WeekDataV1Marker>
+{
+}
+
+impl<T> BoaProvider for T where
+    T: ResourceProvider<AliasesV1Marker>
+        + ResourceProvider<LikelySubtagsV1Marker>
+        + ResourceProvider<DateSymbolsV1Marker>
+        + ResourceProvider<DatePatternsV1Marker>
+        + ResourceProvider<DateSkeletonPatternsV1Marker>
+        + ResourceProvider<OrdinalV1Marker>
+        + ResourceProvider<WeekDataV1Marker>
+        + ?Sized
+{
+}
+
+/// Collection of tools initialized from a [`BoaProvider`] that are used
+/// for the functionality of `Intl`.
+#[allow(unused)]
+pub(crate) struct Icu {
+    provider: Box<dyn BoaProvider>,
+    locale_canonicalizer: LocaleCanonicalizer,
+}
+
+impl std::fmt::Debug for Icu {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[derive(Debug)]
+        struct Canonicalizer;
+        f.debug_struct("Icu")
+            .field("locale_canonicalizer", &Canonicalizer)
+            .finish()
+    }
+}
+
+impl Icu {
+    /// Create a new [`Icu`] from a valid [`BoaProvider`]
+    ///
+    /// # Errors
+    ///
+    /// This method will return an error if any of the tools
+    /// required cannot be constructed.
+    pub(crate) fn new<P: 'static + BoaProvider>(provider: P) -> Result<Self, DataError> {
+        Ok(Self {
+            locale_canonicalizer: LocaleCanonicalizer::new(&provider)?,
+            provider: Box::new(provider),
+        })
+    }
+
+    /// Get the [`LocaleCanonicalizer`] tool.
+    pub(crate) fn locale_canonicalizer(&self) -> &LocaleCanonicalizer {
+        &self.locale_canonicalizer
+    }
+
+    /// Get the inner icu data provider
+    #[allow(unused)]
+    pub(crate) fn provider(&self) -> &dyn BoaProvider {
+        self.provider.as_ref()
+    }
+}

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-
 use icu_datetime::provider::{
     calendar::{DatePatternsV1Marker, DateSkeletonPatternsV1Marker, DateSymbolsV1Marker},
     week_data::WeekDataV1Marker,
@@ -40,7 +38,7 @@ impl<T> BoaProvider for T where
 /// for the functionality of `Intl`.
 #[allow(unused)]
 pub(crate) struct Icu {
-    provider: Rc<dyn BoaProvider>,
+    provider: Box<dyn BoaProvider>,
     locale_canonicalizer: LocaleCanonicalizer,
 }
 
@@ -61,7 +59,7 @@ impl Icu {
     ///
     /// This method will return an error if any of the tools
     /// required cannot be constructed.
-    pub(crate) fn new(provider: Rc<dyn BoaProvider>) -> Result<Self, DataError> {
+    pub(crate) fn new(provider: Box<dyn BoaProvider>) -> Result<Self, DataError> {
         Ok(Self {
             locale_canonicalizer: LocaleCanonicalizer::new(&*provider)?,
             provider,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -736,9 +736,10 @@ impl Context {
 /// Additionally, if the `intl` feature is enabled, [`ContextBuilder`] becomes
 /// the only way to create a new [`Context`], since now it requires a
 /// valid data provider for the `Intl` functionality.
+///
 #[cfg_attr(
     feature = "intl",
-    doc = "The required data for a valid data provider is specified in [`BoaProvider`]"
+    doc = "The required data in a valid provider is specified in [`BoaProvider`]"
 )]
 #[derive(Debug, Default)]
 pub struct ContextBuilder {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -762,9 +762,9 @@ impl ContextBuilder {
     ///
     /// This function is only available if the `intl` feature is enabled.
     #[cfg(any(feature = "intl", docs))]
-    pub fn icu_provider<P: icu::BoaProvider + 'static>(
+    pub fn icu_provider(
         mut self,
-        provider: P,
+        provider: std::rc::Rc<dyn icu::BoaProvider>,
     ) -> Result<Self, DataError> {
         self.icu = Some(icu::Icu::new(provider)?);
         Ok(self)
@@ -794,8 +794,8 @@ impl ContextBuilder {
             #[cfg(feature = "intl")]
             icu: self.icu.unwrap_or_else(|| {
                 // TODO: Replace with a more fitting default
-                let provider = icu_testdata::get_provider();
-                icu::Icu::new(provider).expect("Failed to initialize default icu data.")
+                icu::Icu::new(std::rc::Rc::new(icu_testdata::get_provider()))
+                    .expect("Failed to initialize default icu data.")
             }),
         };
 

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -763,10 +763,7 @@ impl ContextBuilder {
     ///
     /// This function is only available if the `intl` feature is enabled.
     #[cfg(any(feature = "intl", docs))]
-    pub fn icu_provider(
-        mut self,
-        provider: std::rc::Rc<dyn icu::BoaProvider>,
-    ) -> Result<Self, DataError> {
+    pub fn icu_provider(mut self, provider: Box<dyn icu::BoaProvider>) -> Result<Self, DataError> {
         self.icu = Some(icu::Icu::new(provider)?);
         Ok(self)
     }
@@ -795,7 +792,7 @@ impl ContextBuilder {
             #[cfg(feature = "intl")]
             icu: self.icu.unwrap_or_else(|| {
                 // TODO: Replace with a more fitting default
-                icu::Icu::new(std::rc::Rc::new(icu_testdata::get_provider()))
+                icu::Icu::new(Box::new(icu_testdata::get_provider()))
                     .expect("Failed to initialize default icu data.")
             }),
         };

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -8,7 +8,7 @@
 //!  - **intl** - Enables `boa`'s [ECMA-402 Internationalization API][ecma-402] (`Intl` object)
 //!
 //! [whatwg]: https://console.spec.whatwg.org
-//! [ecma-402]: https://402.ecma-international.org
+//! [ecma-402]: https://tc39.es/ecma402
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -3,8 +3,12 @@
 //!
 //! # Crate Features
 //!  - **serde** - Enables serialization and deserialization of the AST (Abstract Syntax Tree).
-//!  - **console** - Enables `boa`s WHATWG `console` object implementation.
+//!  - **console** - Enables `boa`'s [WHATWG `console`][whatwg] object implementation.
 //!  - **profiler** - Enables profiling with measureme (this is mostly internal).
+//!  - **intl** - Enables `boa`'s [ECMA-402 Internationalization API][ecma-402] (`Intl` object)
+//!
+//! [whatwg]: https://console.spec.whatwg.org
+//! [ecma-402]: https://402.ecma-international.org
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_engine/src/object/jsproxy.rs
+++ b/boa_engine/src/object/jsproxy.rs
@@ -65,6 +65,7 @@ impl JsObjectType for JsProxy {}
 /// accessible from [`JsProxy::builder`]; with the [`JsProxyBuilder::build_revocable`]
 /// method.
 ///
+/// [proxy]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
 /// [revocable]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/revocable
 #[derive(Debug, Trace, Finalize)]
 pub struct JsRevocableProxy {

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -20,6 +20,8 @@ use self::internal_methods::{
     string::STRING_EXOTIC_INTERNAL_METHODS,
     InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
 };
+#[cfg(feature = "intl")]
+use crate::builtins::intl::date_time_format::DateTimeFormat;
 use crate::{
     builtins::{
         array::array_iterator::ArrayIterator,
@@ -29,7 +31,6 @@ use crate::{
             arguments::ParameterMap, BoundFunction, Captures, Function, NativeFunctionSignature,
         },
         generator::Generator,
-        intl::date_time_format::DateTimeFormat,
         map::map_iterator::MapIterator,
         map::ordered_map::OrderedMap,
         object::for_in_iterator::ForInIterator,
@@ -45,6 +46,7 @@ use crate::{
     property::{Attribute, PropertyDescriptor, PropertyKey},
     Context, JsBigInt, JsResult, JsString, JsSymbol, JsValue,
 };
+
 use boa_gc::{Finalize, Trace};
 use boa_interner::Sym;
 use rustc_hash::FxHashMap;
@@ -168,6 +170,7 @@ pub enum ObjectKind {
     Arguments(Arguments),
     NativeObject(Box<dyn NativeObject>),
     IntegerIndexed(IntegerIndexed),
+    #[cfg(feature = "intl")]
     DateTimeFormat(Box<DateTimeFormat>),
 }
 
@@ -427,6 +430,7 @@ impl ObjectData {
     }
 
     /// Create the `DateTimeFormat` object data
+    #[cfg(feature = "intl")]
     pub fn date_time_format(date_time_fmt: Box<DateTimeFormat>) -> Self {
         Self {
             kind: ObjectKind::DateTimeFormat(date_time_fmt),
@@ -467,6 +471,7 @@ impl Display for ObjectKind {
             Self::NativeObject(_) => "NativeObject",
             Self::IntegerIndexed(_) => "TypedArray",
             Self::DataView(_) => "DataView",
+            #[cfg(feature = "intl")]
             Self::DateTimeFormat(_) => "DateTimeFormat",
         })
     }

--- a/boa_engine/src/syntax/ast/keyword.rs
+++ b/boa_engine/src/syntax/ast/keyword.rs
@@ -4,7 +4,7 @@
 //!  - [ECMAScript reference][spec]
 //!  - [MDN documentation][mdn]
 //!
-//! [spec]: https://www.ecma-international.org/ecma-262/#sec-keywords
+//! [spec]: https://tc39.es/ecma262/#sec-keywords-and-reserved-words
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
 
 use crate::syntax::ast::op::{BinOp, CompOp};
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
 ///  - [ECMAScript reference][spec]
 ///  - [MDN documentation][mdn]
 ///
-/// [spec]: https://www.ecma-international.org/ecma-262/#sec-keywords
+/// [spec]: https://tc39.es/ecma262/#sec-keywords-and-reserved-words
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/boa_engine/src/syntax/lexer/regex.rs
+++ b/boa_engine/src/syntax/lexer/regex.rs
@@ -23,7 +23,7 @@ use std::{
 ///  - [ECMAScript reference][spec]
 ///  - [MDN documentation][mdn]
 ///
-/// [spec]: https://www.ecma-international.org/ecma-262/#sec-literals-regular-expression-literals
+/// [spec]: https://tc39.es/ecma262/#sec-literals-regular-expression-literals
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 #[derive(Debug, Clone, Copy)]
 pub(super) struct RegexLiteral;

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -18,7 +18,7 @@ use std::io::Read;
 ///  - [ECMAScript specification][spec]
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
-/// [spec]: https://www.ecma-international.org/ecma-262/11.0/index.html#prod-AsyncFunctionDeclaration
+/// [spec]: https://tc39.es/ecma262/#prod-AsyncFunctionDeclaration
 #[derive(Debug, Clone, Copy)]
 pub(super) struct AsyncFunctionDeclaration {
     allow_yield: AllowYield,

--- a/boa_engine/src/syntax/parser/tests.rs
+++ b/boa_engine/src/syntax/parser/tests.rs
@@ -2,6 +2,7 @@
 
 use super::Parser;
 use crate::{
+    context::ContextBuilder,
     syntax::ast::{
         node::{
             field::GetConstField, object::PropertyDefinition, ArrowFunctionDecl, Assign, BinOp,
@@ -23,7 +24,7 @@ pub(super) fn check_parser<L>(js: &str, expr: L, interner: Interner)
 where
     L: Into<Box<[Node]>>,
 {
-    let mut context = Context::new(interner);
+    let mut context = ContextBuilder::default().interner(interner).build();
     assert_eq!(
         Parser::new(js.as_bytes())
             .parse_all(&mut context)
@@ -469,7 +470,7 @@ fn hashbang_use_strict_no_with() {
 fn hashbang_use_strict_with_with_statement() {
     check_parser(
         r#"#!\"use strict"
-        
+
         with({}) {}
         "#,
         vec![],

--- a/boa_gc/Cargo.toml
+++ b/boa_gc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_gc"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Garbage collector used in Boa."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_interner"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "String interner used in Boa."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_profiler/Cargo.toml
+++ b/boa_profiler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_profiler"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Profiler used in Boa."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -12,7 +12,7 @@ license = "Unlicense/MIT"
 publish = false
 
 [dependencies]
-boa_engine = { path = "../boa_engine", version = "0.14.0" }
+boa_engine = { path = "../boa_engine", features = ["intl"], version = "0.14.0" }
 boa_interner = { path = "../boa_interner", version = "0.14.0" }
 structopt = "0.3.26"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_tester"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Test runner for the Boa JavaScript engine."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_unicode/Cargo.toml
+++ b/boa_unicode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_unicode"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "Unicode support for the Boa JavaScript engine."
 repository = "https://github.com/boa-dev/boa"

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_wasm"
 version = "0.14.0"
 edition = "2021"
-rust-version = "1.58"
+rust-version = "1.60"
 authors = ["boa-dev"]
 description = "WASM package for the Boa JavaScript engine."
 repository = "https://github.com/boa-dev/boa"


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request integrates an `ICU4X` data provider API in our codebase, to make use of the internationalization APIs that this crate provides.

It changes the following:

- Creates an API for pluggable icu data providers at `Context` creation, adding an `Icu` struct to store the provider (and some other internationalization tools) at runtime.
- Slightly changes locale related functions to preserve the `Locale` type and ensure correctness. (Will make some other changes related to this).
- Integrates the `sys_locale` crate to fetch the current default locale of an user instead of always returning `en-US`.