### PR TITLE
Implement `Function` constructor

### DIFF
--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -96,7 +96,7 @@ impl TypeError {
 
 pub(crate) fn create_throw_type_error(context: &mut Context) -> JsObject {
     fn throw_type_error(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        context.throw_type_error("invalid type")
+        context.throw_type_error("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them")
     }
 
     let function = JsObject::from_proto_and_data(

--- a/boa_engine/src/syntax/parser/mod.rs
+++ b/boa_engine/src/syntax/parser/mod.rs
@@ -13,9 +13,15 @@ mod tests;
 
 use crate::{
     syntax::{
-        ast::{node::StatementList, Position},
+        ast::{
+            node::{FormalParameterList, StatementList},
+            Position,
+        },
         lexer::TokenKind,
-        parser::cursor::Cursor,
+        parser::{
+            cursor::Cursor,
+            function::{FormalParameters, FunctionStatementList},
+        },
     },
     Context,
 };
@@ -189,6 +195,36 @@ impl<R> Parser<R> {
         }
 
         Ok(statement_list)
+    }
+
+    /// Parse the full input as an [ECMAScript `FunctionBody`][spec] into the boa AST representation.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-FunctionBody
+    pub(crate) fn parse_function_body(
+        &mut self,
+        interner: &mut Interner,
+        allow_yield: bool,
+        allow_await: bool,
+    ) -> Result<StatementList, ParseError>
+    where
+        R: Read,
+    {
+        FunctionStatementList::new(allow_yield, allow_await).parse(&mut self.cursor, interner)
+    }
+
+    /// Parse the full input as an [ECMAScript `FormalParameterList`][spec] into the boa AST representation.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-FormalParameterList
+    pub(crate) fn parse_formal_parameters(
+        &mut self,
+        interner: &mut Interner,
+        allow_yield: bool,
+        allow_await: bool,
+    ) -> Result<FormalParameterList, ParseError>
+    where
+        R: Read,
+    {
+        FormalParameters::new(allow_yield, allow_await).parse(&mut self.cursor, interner)
     }
 }
 

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -8,8 +8,9 @@ feature:SharedArrayBuffer
 feature:resizable-arraybuffer
 feature:Temporal
 feature:tail-call-optimization
-//feature:async-iteration
-//feature:class
+
+// Non-standard
+feature:caller
 
 // These generate a stack overflow
 tco-call


### PR DESCRIPTION
This Pull Request changes the following:

- Implement `Function` constructor
- Ignore non-standard `caller` feature in 262 tests
- Fix `Function.apply` length
- Use `TypeError` in `Function.caller` and `Function.arguments` accessors

