### PR TITLE
[Merged by Bors] - Remove unnecessary `Trace` and `Finalize` implementations from AST

### DIFF
--- a/boa_engine/src/syntax/ast/node/array/mod.rs
+++ b/boa_engine/src/syntax/ast/node/array/mod.rs
@@ -1,7 +1,6 @@
 //! Array declaration node.
 
 use super::{join_nodes, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -27,7 +26,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-ArrayLiteral
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ArrayDecl {
     arr: Box<[Node]>,
     has_trailing_comma_spread: bool,

--- a/boa_engine/src/syntax/ast/node/await_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/await_expr/mod.rs
@@ -1,7 +1,6 @@
 //! Await expression node.
 
 use super::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -20,7 +19,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-AwaitExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AwaitExpr {
     expr: Box<Node>,
 }

--- a/boa_engine/src/syntax/ast/node/block/mod.rs
+++ b/boa_engine/src/syntax/ast/node/block/mod.rs
@@ -1,7 +1,6 @@
 //! Block AST node.
 
 use super::{Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -27,7 +26,7 @@ mod tests;
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "deser", serde(transparent))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Block {
     #[cfg_attr(feature = "deser", serde(flatten))]
     statements: StatementList,

--- a/boa_engine/src/syntax/ast/node/call/mod.rs
+++ b/boa_engine/src/syntax/ast/node/call/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -23,7 +22,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-CallExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#Calling_functions
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Call {
     expr: Box<Node>,
     args: Box<[Node]>,

--- a/boa_engine/src/syntax/ast/node/conditional/conditional_op/mod.rs
+++ b/boa_engine/src/syntax/ast/node/conditional/conditional_op/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -20,7 +19,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-ConditionalExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ConditionalOp {
     condition: Box<Node>,
     if_true: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/conditional/if_node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/conditional/if_node/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -22,7 +21,7 @@ use serde::{Deserialize, Serialize};
 /// [falsy]: https://developer.mozilla.org/en-US/docs/Glossary/falsy
 /// [expression]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Expressions
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct If {
     cond: Box<Node>,
     body: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/arrow_function_decl/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -19,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-ArrowFunction
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ArrowFunctionDecl {
     name: Option<Sym>,
     params: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -1,7 +1,6 @@
 //! Async Function Declaration.
 
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -16,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#sec-async-function-prototype-properties
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AsyncFunctionDecl {
     name: Sym,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/async_function_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/async_function_expr/mod.rs
@@ -1,7 +1,6 @@
 //! Async Function Expression.
 
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -17,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-AsyncFunctionExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/async_function
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AsyncFunctionExpr {
     name: Option<Sym>,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/async_generator_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/async_generator_decl/mod.rs
@@ -1,7 +1,6 @@
 //! Async Generator Declaration
 
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -14,7 +13,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-AsyncGeneratorMethod
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AsyncGeneratorDecl {
     name: Sym,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/async_generator_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/async_generator_expr/mod.rs
@@ -1,7 +1,6 @@
 //! Async Generator Expression
 
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -16,7 +15,7 @@ use super::block_to_string;
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-AsyncGeneratorExpression
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AsyncGeneratorExpr {
     name: Option<Sym>,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/class_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/class_decl/mod.rs
@@ -7,7 +7,6 @@ use crate::syntax::ast::node::{
     object::{MethodDefinition, PropertyName},
     Node, StatementList,
 };
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -24,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#sec-class-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Class {
     name: Sym,
     super_ref: Option<Box<Node>>,
@@ -353,7 +352,7 @@ impl ToInternedString for Class {
 
 /// Class element types.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum ClassElement {
     MethodDefinition(PropertyName, MethodDefinition),
     StaticMethodDefinition(PropertyName, MethodDefinition),

--- a/boa_engine/src/syntax/ast/node/declaration/function_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/function_decl/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -24,7 +23,7 @@ use serde::{Deserialize, Serialize};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function
 /// [func_expr]: ../enum.Node.html#variant.FunctionExpr
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FunctionDecl {
     name: Sym,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/function_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/function_expr/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -24,7 +23,7 @@ use super::block_to_string;
 /// [spec]: https://tc39.es/ecma262/#sec-terms-and-definitions-function
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FunctionExpr {
     name: Option<Sym>,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/generator_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/generator_decl/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -15,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-GeneratorDeclaration
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GeneratorDecl {
     name: Sym,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/generator_expr/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/generator_expr/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{join_nodes, FormalParameterList, Node, StatementList};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -16,7 +15,7 @@ use super::block_to_string;
 /// [spec]: https://tc39.es/ecma262/#prod-GeneratorExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function*
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GeneratorExpr {
     name: Option<Sym>,
     parameters: FormalParameterList,

--- a/boa_engine/src/syntax/ast/node/declaration/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/mod.rs
@@ -6,7 +6,6 @@ use crate::syntax::ast::node::{
     statement_list::StatementList,
     Identifier, Node,
 };
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -34,7 +33,7 @@ pub use self::{
 mod tests;
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DeclarationList {
     /// The `const` statements are block-scoped, much like variables defined using the `let`
     /// keyword.
@@ -154,7 +153,7 @@ impl From<Declaration> for Box<[Declaration]> {
 /// [spec2]: https://tc39.es/ecma262/#prod-VariableDeclaration
 /// [spec3]:  https://tc39.es/ecma262/#sec-declarations-and-the-variable-statement
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Declaration {
     Identifier {
         ident: Identifier,
@@ -241,7 +240,7 @@ impl Declaration {
 ///
 /// [spec1]: https://tc39.es/ecma262/#prod-BindingPattern
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum DeclarationPattern {
     Object(DeclarationPatternObject),
     Array(DeclarationPatternArray),
@@ -395,7 +394,7 @@ impl DeclarationPattern {
 ///
 /// [spec1]: https://tc39.es/ecma262/#prod-ObjectBindingPattern
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DeclarationPatternObject {
     bindings: Vec<BindingPatternTypeObject>,
     init: Option<Node>,
@@ -494,7 +493,7 @@ impl DeclarationPatternObject {
 ///
 /// [spec1]: https://tc39.es/ecma262/#prod-ArrayBindingPattern
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DeclarationPatternArray {
     bindings: Vec<BindingPatternTypeArray>,
     init: Option<Node>,
@@ -588,7 +587,7 @@ impl DeclarationPatternArray {
 ///
 /// [spec1]: https://tc39.es/ecma262/#prod-ObjectBindingPattern
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BindingPatternTypeObject {
     /// Empty represents an empty object binding pattern e.g. `{ }`.
     Empty,
@@ -732,7 +731,7 @@ impl ToInternedString for BindingPatternTypeObject {
 ///
 /// [spec1]: https://tc39.es/ecma262/#prod-ArrayBindingPattern
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum BindingPatternTypeArray {
     /// Empty represents an empty array binding pattern e.g. `[ ]`.
     ///

--- a/boa_engine/src/syntax/ast/node/field/get_const_field/mod.rs
+++ b/boa_engine/src/syntax/ast/node/field/get_const_field/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -27,7 +26,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#sec-property-accessors
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Dot_notation
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GetConstField {
     obj: Box<Node>,
     field: Sym,

--- a/boa_engine/src/syntax/ast/node/field/get_field/mod.rs
+++ b/boa_engine/src/syntax/ast/node/field/get_field/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -28,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// [symbol]: https://developer.mozilla.org/en-US/docs/Glossary/Symbol
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Property_accessors#Bracket_notation
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GetField {
     obj: Box<Node>,
     field: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/field/get_private_field/mod.rs
+++ b/boa_engine/src/syntax/ast/node/field/get_private_field/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -17,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-MemberExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct GetPrivateField {
     obj: Box<Node>,
     field: Sym,

--- a/boa_engine/src/syntax/ast/node/iteration/do_while_loop/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/do_while_loop/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -18,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#sec-do-while-statement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct DoWhileLoop {
     body: Box<Node>,
     cond: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/iteration/for_in_loop/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/for_in_loop/mod.rs
@@ -1,12 +1,11 @@
 use crate::syntax::ast::node::{iteration::IterableLoopInitializer, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ForInLoop {
     init: Box<IterableLoopInitializer>,
     expr: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/iteration/for_loop/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/for_loop/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -17,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-ForDeclaration
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ForLoop {
     #[cfg_attr(feature = "deser", serde(flatten))]
     inner: Box<InnerForLoop>,
@@ -113,7 +112,7 @@ impl From<ForLoop> for Node {
 
 /// Inner structure to avoid multiple indirections in the heap.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct InnerForLoop {
     init: Option<Node>,
     condition: Option<Node>,

--- a/boa_engine/src/syntax/ast/node/iteration/for_of_loop/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/for_of_loop/mod.rs
@@ -1,12 +1,11 @@
 use crate::syntax::ast::node::{iteration::IterableLoopInitializer, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct ForOfLoop {
     init: Box<IterableLoopInitializer>,
     iterable: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/iteration/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/mod.rs
@@ -7,7 +7,6 @@ pub use self::{
 use crate::syntax::ast::node::{
     declaration::Declaration, identifier::Identifier, DeclarationPattern,
 };
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -17,7 +16,7 @@ use serde::{Deserialize, Serialize};
 mod tests;
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum IterableLoopInitializer {
     Identifier(Identifier),
     Var(Declaration),

--- a/boa_engine/src/syntax/ast/node/iteration/while_loop/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/while_loop/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -17,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-grammar-notation-WhileStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct WhileLoop {
     cond: Box<Node>,
     body: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/mod.rs
@@ -45,7 +45,7 @@ pub use self::{
     r#yield::Yield,
     return_smt::Return,
     spread::Spread,
-    statement_list::{RcStatementList, StatementList},
+    statement_list::StatementList,
     switch::{Case, Switch},
     template::{TaggedTemplate, TemplateLit},
     throw::Throw,
@@ -60,7 +60,6 @@ use self::{
 pub(crate) use self::parameters::FormalParameterListFlags;
 
 use super::Const;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 use rustc_hash::FxHashSet;
 use std::cmp::Ordering;
@@ -70,7 +69,7 @@ use serde::{Deserialize, Serialize};
 
 // TODO: This should be split into Expression and Statement.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Node {
     /// Array declaration node. [More information](./array/struct.ArrayDecl.html).
     ArrayDecl(ArrayDecl),

--- a/boa_engine/src/syntax/ast/node/new/mod.rs
+++ b/boa_engine/src/syntax/ast/node/new/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{Call, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -24,7 +23,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-NewExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct New {
     call: Call,
 }

--- a/boa_engine/src/syntax/ast/node/object/mod.rs
+++ b/boa_engine/src/syntax/ast/node/object/mod.rs
@@ -7,7 +7,6 @@ use crate::syntax::ast::{
     },
     Const,
 };
-use boa_gc::{unsafe_empty_trace, Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -37,7 +36,7 @@ mod tests;
 /// [primitive]: https://developer.mozilla.org/en-US/docs/Glossary/primitive
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "deser", serde(transparent))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Object {
     properties: Box<[PropertyDefinition]>,
 }
@@ -158,7 +157,7 @@ impl From<Object> for Node {
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/property/JavaScript
 // TODO: Support all features: https://tc39.es/ecma262/#prod-PropertyDefinition
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Trace, Finalize)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PropertyDefinition {
     /// Puts a variable into an object.
     ///
@@ -248,7 +247,7 @@ impl PropertyDefinition {
 /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Finalize, Trace)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum MethodDefinition {
     /// The `get` syntax binds an object property to a function that will be called when that property is looked up.
     ///
@@ -329,7 +328,7 @@ pub enum MethodDefinition {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-PropertyName
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Finalize)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PropertyName {
     /// A `Literal` property name can be either an identifier, a string or a numeric literal.
     ///
@@ -387,10 +386,6 @@ impl From<Node> for PropertyName {
     }
 }
 
-unsafe impl Trace for PropertyName {
-    unsafe_empty_trace!();
-}
-
 /// `ClassElementName` can be either a property name or a private identifier.
 ///
 /// More information:
@@ -398,12 +393,8 @@ unsafe impl Trace for PropertyName {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-ClassElementName
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Finalize)]
+#[derive(Clone, Debug, PartialEq)]
 pub(crate) enum ClassElementName {
     PropertyName(PropertyName),
     PrivateIdentifier(Sym),
-}
-
-unsafe impl Trace for ClassElementName {
-    unsafe_empty_trace!();
 }

--- a/boa_engine/src/syntax/ast/node/operator/assign/mod.rs
+++ b/boa_engine/src/syntax/ast/node/operator/assign/mod.rs
@@ -10,7 +10,6 @@ use crate::syntax::{
     },
     parser::RESERVED_IDENTIFIERS_STRICT,
 };
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -28,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-AssignmentExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Assignment_Operators
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Assign {
     lhs: Box<AssignTarget>,
     rhs: Box<Node>,
@@ -81,7 +80,7 @@ impl From<Assign> for Node {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-AssignmentExpression
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum AssignTarget {
     Identifier(Identifier),
     GetPrivateField(GetPrivateField),

--- a/boa_engine/src/syntax/ast/node/operator/bin_op/mod.rs
+++ b/boa_engine/src/syntax/ast/node/operator/bin_op/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::{node::Node, op};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -12,7 +11,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Operators
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct BinOp {
     op: op::BinOp,
     lhs: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/operator/unary_op/mod.rs
+++ b/boa_engine/src/syntax/ast/node/operator/unary_op/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::{node::Node, op};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -14,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-UnaryExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Unary_operators
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct UnaryOp {
     op: op::UnaryOp,
     target: Box<Node>,

--- a/boa_engine/src/syntax/ast/node/parameters.rs
+++ b/boa_engine/src/syntax/ast/node/parameters.rs
@@ -2,7 +2,6 @@ use crate::syntax::{ast::Position, parser::ParseError};
 
 use super::{Declaration, DeclarationPattern, Node};
 use bitflags::bitflags;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -15,10 +14,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-FormalParameterList
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Default, PartialEq, Trace, Finalize)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct FormalParameterList {
     pub(crate) parameters: Box<[FormalParameter]>,
-    #[unsafe_ignore_trace]
     pub(crate) flags: FormalParameterListFlags,
     pub(crate) length: u32,
 }
@@ -163,7 +161,7 @@ impl Default for FormalParameterListFlags {
 /// [spec]: https://tc39.es/ecma262/#prod-FormalParameter
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_formal_parameter
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq, Trace, Finalize)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct FormalParameter {
     declaration: Declaration,
     is_rest_param: bool,

--- a/boa_engine/src/syntax/ast/node/return_smt/mod.rs
+++ b/boa_engine/src/syntax/ast/node/return_smt/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -27,7 +26,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-ReturnStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Return {
     expr: Option<Box<Node>>,
     label: Option<Sym>,

--- a/boa_engine/src/syntax/ast/node/spread/mod.rs
+++ b/boa_engine/src/syntax/ast/node/spread/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -26,7 +25,7 @@ mod tests;
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "deser", serde(transparent))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Spread {
     val: Box<Node>,
 }

--- a/boa_engine/src/syntax/ast/node/switch/mod.rs
+++ b/boa_engine/src/syntax/ast/node/switch/mod.rs
@@ -1,7 +1,6 @@
 //! Switch node.
 //!
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 use crate::syntax::ast::node::StatementList;
@@ -13,7 +12,7 @@ use serde::{Deserialize, Serialize};
 mod tests;
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Case {
     condition: Node,
     body: StatementList,
@@ -60,7 +59,7 @@ impl Case {
 /// [spec]: https://tc39.es/ecma262/#prod-SwitchStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Switch {
     val: Box<Node>,
     cases: Box<[Case]>,

--- a/boa_engine/src/syntax/ast/node/template/mod.rs
+++ b/boa_engine/src/syntax/ast/node/template/mod.rs
@@ -1,7 +1,6 @@
 //! Template literal node.
 
 use super::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -19,7 +18,7 @@ mod tests;
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
 /// [spec]: https://tc39.es/ecma262/#sec-template-literals
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TemplateLit {
     elements: Box<[TemplateElement]>,
 }
@@ -57,7 +56,7 @@ impl ToInternedString for TemplateLit {
     }
 }
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TaggedTemplate {
     tag: Box<Node>,
     raws: Box<[Sym]>,
@@ -122,7 +121,7 @@ impl From<TaggedTemplate> for Node {
 }
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TemplateElement {
     String(Sym),
     Expr(Node),

--- a/boa_engine/src/syntax/ast/node/throw/mod.rs
+++ b/boa_engine/src/syntax/ast/node/throw/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -23,7 +22,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-ThrowStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Throw {
     expr: Box<Node>,
 }

--- a/boa_engine/src/syntax/ast/node/try_node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/try_node/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::{Block, Declaration, Node};
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -22,7 +21,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-TryStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Try {
     block: Block,
     catch: Option<Catch>,
@@ -103,7 +102,7 @@ impl From<Try> for Node {
 
 /// Catch block.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Catch {
     parameter: Option<Box<Declaration>>,
     block: Block,
@@ -156,7 +155,7 @@ impl ToInternedString for Catch {
 
 /// Finally block.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Finally {
     block: Block,
 }

--- a/boa_engine/src/syntax/ast/node/yield/mod.rs
+++ b/boa_engine/src/syntax/ast/node/yield/mod.rs
@@ -1,5 +1,4 @@
 use crate::syntax::ast::node::Node;
-use boa_gc::{Finalize, Trace};
 use boa_interner::{Interner, ToInternedString};
 
 #[cfg(feature = "deser")]
@@ -14,7 +13,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-YieldExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Trace, Finalize, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Yield {
     expr: Option<Box<Node>>,
     delegate: bool,

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -69,6 +69,7 @@ pub struct CodeBlock {
     pub(crate) this_mode: ThisMode,
 
     /// Parameters passed to this function.
+    #[unsafe_ignore_trace]
     pub(crate) params: FormalParameterList,
 
     /// Bytecode


### PR DESCRIPTION
This Pull Request fchanges the following:

- Remove unnecessary `Trace` and `Finalize` implementations from AST
- Add `#[unsafe_ignore_trace]` to parameters stored in `CodeBlock`
- Remove unused `RcStatementList` type

Relates to #1615