### PR TITLE
[Merged by Bors] - Only run benchmarks on PRs when a label is set

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,7 +1,18 @@
-on: [pull_request]
 name: Benchmarks
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
 jobs:
   runBenchmark:
+    if: contains(github.event.pull_request.labels.*.name, 'run-benchmark')
     name: run benchmark
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This changes our ci benchmarks to only run when the label `run-benchmark` is set on the PR.

The motivation is to reduce the time waiting on benchmarks to run while working on PRs. Also this saves some ci minutes which is always good.
When we spot changes that we suspect impact performance, we can add the `run-benchmark` label to the PR and the benchmarks will run.