### PR TITLE
Introduce NonMaxU32 for array index

### DIFF
--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -78,6 +78,7 @@ pub mod class;
 pub mod context;
 pub mod environments;
 pub mod job;
+pub mod nonmaxu32;
 pub mod object;
 pub mod property;
 pub mod realm;

--- a/boa_engine/src/nonmaxu32.rs
+++ b/boa_engine/src/nonmaxu32.rs
@@ -1,0 +1,180 @@
+//! This module implements `NonMaxU32`
+//! which is known not to equal `u32::MAX`.
+//!
+//! This would be useful for integers like `https://tc39.es/ecma262/#array-index`.
+
+use boa_gc::{unsafe_empty_trace, Finalize, Trace};
+use std::fmt;
+use std::ops::{BitOr, BitOrAssign};
+
+/// An integer that is known not to equal `u32::MAX`.
+///
+/// This enables some memory layout optimization.
+/// For example, `Option<NonMaxU32>` is the same size as `u32`:
+///
+/// ```rust
+/// use std::mem::size_of;
+/// use boa_engine::nonmaxu32::NonMaxU32;
+/// assert_eq!(size_of::<Option<NonMaxU32>>(), size_of::<u32>());
+/// ```
+#[derive(Copy, Clone, Eq, Finalize, PartialEq, Ord, PartialOrd, Hash)]
+#[repr(transparent)]
+pub struct NonMaxU32(u32);
+
+// Safety: `NonMaxU32` does not contain any objects which needs to be traced,
+// so this is safe.
+unsafe impl Trace for NonMaxU32 {
+    unsafe_empty_trace!();
+}
+
+/// An error type returned when a checked integral type conversion fails (mimics [`std::num::TryFromIntError`])
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TryFromIntError(());
+
+impl fmt::Display for TryFromIntError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "out of range integral type conversion attempted".fmt(fmt)
+    }
+}
+
+impl From<core::num::TryFromIntError> for TryFromIntError {
+    fn from(_: core::num::TryFromIntError) -> Self {
+        Self(())
+    }
+}
+
+impl From<core::convert::Infallible> for TryFromIntError {
+    fn from(never: core::convert::Infallible) -> Self {
+        match never {}
+    }
+}
+
+/// An error type returned when an integer cannot be parsed (mimics [`std::num::ParseIntError`])
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct ParseIntError(());
+
+impl fmt::Display for ParseIntError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "unable to parse integer".fmt(fmt)
+    }
+}
+
+impl From<core::num::ParseIntError> for ParseIntError {
+    fn from(_: core::num::ParseIntError) -> Self {
+        Self(())
+    }
+}
+
+impl NonMaxU32 {
+    /// Creates a non-u32-max without checking the value.
+    ///
+    /// # Safety
+    ///
+    /// The value must not be `u32::MAX`.
+    #[inline]
+    pub const unsafe fn new_unchecked(n: u32) -> Self {
+        // SAFETY: this is guaranteed to be safe by the caller.
+        Self(n)
+    }
+
+    /// Creates a non-u32-max if the given value is not `u32::MAX`.
+    #[inline]
+    pub const fn new(n: u32) -> Option<Self> {
+        if n == u32::MAX {
+            None
+        } else {
+            // SAFETY: we just checked that there's no `u32::MAX`
+            Some(Self(n))
+        }
+    }
+
+    /// Returns the value as a primitive type.
+    #[inline]
+    pub const fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<u32> for NonMaxU32 {
+    type Error = TryFromIntError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Self::new(value).ok_or(TryFromIntError(()))
+    }
+}
+
+impl From<NonMaxU32> for u32 {
+    /// Converts a `NonMaxU32` into an `u32`
+    fn from(nonzero: NonMaxU32) -> Self {
+        nonzero.0
+    }
+}
+
+impl core::str::FromStr for NonMaxU32 {
+    type Err = ParseIntError;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::new(u32::from_str(value)?).ok_or(ParseIntError(()))
+    }
+}
+
+impl BitOr for NonMaxU32 {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, rhs: Self) -> Self::Output {
+        // Safety: since `self` and `rhs` are both nonzero, the
+        // result of the bitwise-or will be nonzero.
+        unsafe { NonMaxU32::new_unchecked(self.get() | rhs.get()) }
+    }
+}
+
+impl BitOr<u32> for NonMaxU32 {
+    type Output = Self;
+
+    #[inline]
+    fn bitor(self, rhs: u32) -> Self::Output {
+        // Safety: since `self` is nonzero, the result of the
+        // bitwise-or will be nonzero regardless of the value of
+        // `rhs`.
+        unsafe { NonMaxU32::new_unchecked(self.get() | rhs) }
+    }
+}
+
+impl BitOr<NonMaxU32> for u32 {
+    type Output = NonMaxU32;
+
+    #[inline]
+    fn bitor(self, rhs: NonMaxU32) -> Self::Output {
+        // Safety: since `rhs` is nonzero, the result of the
+        // bitwise-or will be nonzero regardless of the value of
+        // `self`.
+        unsafe { NonMaxU32::new_unchecked(self | rhs.get()) }
+    }
+}
+
+impl BitOrAssign for NonMaxU32 {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = *self | rhs;
+    }
+}
+
+impl BitOrAssign<u32> for NonMaxU32 {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: u32) {
+        *self = *self | rhs;
+    }
+}
+
+impl fmt::Debug for NonMaxU32 {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
+impl fmt::Display for NonMaxU32 {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -44,7 +44,7 @@ pub(crate) fn arguments_exotic_get_own_property(
             .borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(*index as usize)
+            .get(index.get() as usize)
         {
             // a. Set desc.[[Value]] to Get(map, P).
             return Ok(Some(
@@ -81,8 +81,8 @@ pub(crate) fn arguments_exotic_define_own_property(
         obj.borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(index as usize)
-            .map(|value| (index as usize, value))
+            .get(index.get() as usize)
+            .map(|value| (index.get() as usize, value))
     } else {
         None
     };
@@ -173,7 +173,7 @@ pub(crate) fn arguments_exotic_get(
             .borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(*index as usize)
+            .get(index.get() as usize)
         {
             // a. Assert: map contains a formal parameter mapping for P.
             // b. Return Get(map, P).
@@ -212,7 +212,7 @@ pub(crate) fn arguments_exotic_set(
             obj.borrow_mut()
                 .as_mapped_arguments_mut()
                 .expect("arguments exotic method must only be callable from arguments objects")
-                .set(index as usize, &value);
+                .set(index.get() as usize, &value);
         }
     }
 
@@ -243,7 +243,7 @@ pub(crate) fn arguments_exotic_delete(
             obj.borrow_mut()
                 .as_mapped_arguments_mut()
                 .expect("arguments exotic method must only be callable from arguments objects")
-                .delete(*index as usize);
+                .delete(index.get() as usize);
         }
     }
 

--- a/boa_engine/src/object/internal_methods/array.rs
+++ b/boa_engine/src/object/internal_methods/array.rs
@@ -38,7 +38,9 @@ pub(crate) fn array_exotic_define_own_property(
             array_set_length(obj, desc, context)
         }
         // 3. Else if P is an array index, then
-        PropertyKey::Index(index) if index < u32::MAX => {
+        PropertyKey::Index(index) => {
+            let index = index.get();
+
             // a. Let oldLenDesc be OrdinaryGetOwnProperty(A, "length").
             let old_len_desc = super::ordinary_get_own_property(obj, &"length".into(), context)?
                 .expect("the property descriptor must exist");
@@ -201,7 +203,7 @@ fn array_set_length(
             .borrow()
             .properties
             .index_property_keys()
-            .filter(|idx| new_len <= **idx && **idx < u32::MAX)
+            .filter(|idx| new_len <= idx.get())
             .copied()
             .collect();
         keys.sort_unstable_by(|x, y| y.cmp(x));
@@ -209,6 +211,8 @@ fn array_set_length(
     };
 
     for index in ordered_keys {
+        let index = index.get();
+
         // a. Let deleteSucceeded be ! A.[[Delete]](P).
         // b. If deleteSucceeded is false, then
         if !obj.__delete__(&index.into(), context)? {

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -737,7 +737,7 @@ pub(crate) fn ordinary_own_property_keys(
 
     // 2. For each own property key P of O such that P is an array index, in ascending numeric index order, do
     // a. Add P as the last element of keys.
-    keys.extend(ordered_indexes.into_iter().map(Into::into));
+    keys.extend(ordered_indexes.into_iter().map(|idx| idx.get().into()));
 
     // 3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
     // a. Add P as the last element of keys.

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -113,10 +113,10 @@ pub(crate) fn string_exotic_own_property_keys(
         .properties
         .index_property_keys()
         .copied()
-        .filter(|idx| (*idx as usize) >= len)
+        .filter(|idx| (idx.get() as usize) >= len)
         .collect();
     remaining_indices.sort_unstable();
-    keys.extend(remaining_indices.into_iter().map(Into::into));
+    keys.extend(remaining_indices.into_iter().map(|idx| idx.get().into()));
 
     // 7. For each own property key P of O such that Type(P) is String and P is not
     // an array index, in ascending chronological order of property creation, do
@@ -159,7 +159,7 @@ fn string_get_own_property(obj: &JsObject, key: &PropertyKey) -> Option<Property
     // 6. If IsIntegralNumber(index) is false, return undefined.
     // 7. If index is -0𝔽, return undefined.
     let pos = match key {
-        PropertyKey::Index(index) => *index as usize,
+        PropertyKey::Index(index) => index.get() as usize,
         _ => return None,
     };
 


### PR DESCRIPTION
It changes the following:

- Introduce `NonMaxU32` type
- Use `NonMaxU32` for index property key instead of `u32`

---

While looking into the failed `built-ins/Reflect/ownKeys/return-on-corresponding-order-large-index.js` in test262, I found that the root cause is related to [`array index`](https://tc39.es/ecma262/#array-index) for property keys.

The root cause of the failure is, the test uses `u32::MAX` as key and we're ordering it wrong because we see `u32::MAX` as a [array index](https://tc39.es/ecma262/#array-index) instead of an [integer index](https://tc39.es/ecma262/#integer-index). Based on the spec, array index's range is from 0 <= n < u32::MAX so the max number is exclusive.

We can avoid transforming `u32::MAX` into property key in some functions like `From<T>` traits though, it might be forgettable and error-prone. So, I wonder it might be good to introduce the `NonMaxU32` type which is similar to `NonZeroU32` in std but excluding max instead.

Then, we can use it for the index property key

```diff
-    Index(u32),
+    Index(NonMaxU32),
```

With doing so, we can always guarantee the integer hold by Index property key is valid.

WDYT?

(On the other hand, I'm not sure where is the best place for such types. Please feel free to let me know if I should move it to other places 🙏)