### PR TITLE
[Merged by Bors] - Refactor `construct` and `PromiseCapability` to preserve `JsObject` invariants 

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -366,10 +366,7 @@ impl Array {
         // 7. If IsConstructor(C) is false, throw a TypeError exception.
         if let Some(c) = c.as_constructor() {
             // 8. Return ? Construct(C, « 𝔽(length) »).
-            Ok(c.construct(&[JsValue::new(length)], Some(c), context)?
-                .as_object()
-                .expect("constructing an object should always return an object")
-                .clone())
+            c.construct(&[JsValue::new(length)], Some(c), context)
         } else {
             context.throw_type_error("Symbol.species must be a constructor")
         }
@@ -418,13 +415,7 @@ impl Array {
             // b. Else,
             //     i. Let A be ? ArrayCreate(0en).
             let a = match this.as_constructor() {
-                Some(constructor) => constructor
-                    .construct(&[], None, context)?
-                    .as_object()
-                    .cloned()
-                    .ok_or_else(|| {
-                        context.construct_type_error("Object constructor didn't return an object")
-                    })?,
+                Some(constructor) => constructor.construct(&[], None, context)?,
                 _ => Self::array_create(0, None, context)?,
             };
 
@@ -497,13 +488,7 @@ impl Array {
             // 10. Else,
             //     a. Let A be ? ArrayCreate(len).
             let a = match this.as_constructor() {
-                Some(constructor) => constructor
-                    .construct(&[len.into()], None, context)?
-                    .as_object()
-                    .cloned()
-                    .ok_or_else(|| {
-                        context.construct_type_error("Object constructor didn't return an object")
-                    })?,
+                Some(constructor) => constructor.construct(&[len.into()], None, context)?,
                 _ => Self::array_create(len, None, context)?,
             };
 
@@ -579,13 +564,7 @@ impl Array {
         // 5. Else,
         //     a. Let A be ? ArrayCreate(len).
         let a = match this.as_constructor() {
-            Some(constructor) => constructor
-                .construct(&[len.into()], None, context)?
-                .as_object()
-                .cloned()
-                .ok_or_else(|| {
-                    context.construct_type_error("object constructor didn't return an object")
-                })?,
+            Some(constructor) => constructor.construct(&[len.into()], None, context)?,
             _ => Self::array_create(len, None, context)?,
         };
 

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -260,7 +260,11 @@ impl ArrayBuffer {
             }
         }
         // 20. If SameValue(new, O) is true, throw a TypeError exception.
-        if this.as_object().map(|obj| obj == &new).unwrap_or_default() {
+        if this
+            .as_object()
+            .map(|obj| JsObject::equals(obj, &new))
+            .unwrap_or_default()
+        {
             return context.throw_type_error("New ArrayBuffer is the same as this ArrayBuffer");
         }
 

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -103,7 +103,7 @@ pub(crate) fn create_throw_type_error(context: &mut Context) -> JsObject {
         context.intrinsics().constructors().function().prototype(),
         ObjectData::function(Function::Native {
             function: throw_type_error,
-            constructor: false,
+            constructor: None,
         }),
     );
 

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -26,7 +26,7 @@ use crate::{
     value::IntegerOrInfinity,
     Context, JsResult, JsString, JsValue,
 };
-use boa_gc::{self, unsafe_empty_trace, Finalize, Gc, Trace};
+use boa_gc::{self, Finalize, Gc, Trace};
 use boa_interner::Sym;
 use boa_profiler::Profiler;
 use dyn_clone::DynClone;
@@ -108,15 +108,10 @@ impl ThisMode {
     }
 }
 
-#[derive(Debug, Finalize, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum ConstructorKind {
     Base,
     Derived,
-}
-
-// SAFETY: `Copy` types are trivially not `Trace`.
-unsafe impl Trace for ConstructorKind {
-    unsafe_empty_trace!();
 }
 
 impl ConstructorKind {
@@ -183,11 +178,13 @@ pub enum Function {
     Native {
         #[unsafe_ignore_trace]
         function: NativeFunctionSignature,
+        #[unsafe_ignore_trace]
         constructor: Option<ConstructorKind>,
     },
     Closure {
         #[unsafe_ignore_trace]
         function: Box<dyn ClosureFunctionSignature>,
+        #[unsafe_ignore_trace]
         constructor: Option<ConstructorKind>,
         captures: Captures,
     },

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -21,6 +21,8 @@ use crate::{
 };
 use boa_profiler::Profiler;
 
+use super::function::ConstructorKind;
+
 /// The internal representation on a `Generator` object.
 #[derive(Debug, Clone, Copy)]
 pub struct GeneratorFunction;
@@ -71,7 +73,7 @@ impl BuiltIn for GeneratorFunction {
         constructor.borrow_mut().insert("prototype", property);
         constructor.borrow_mut().data = ObjectData::function(Function::Native {
             function: Self::constructor,
-            constructor: true,
+            constructor: Some(ConstructorKind::Base),
         });
 
         prototype.set_prototype(Some(
@@ -124,7 +126,7 @@ impl GeneratorFunction {
             prototype,
             ObjectData::function(Function::Native {
                 function: |_, _, _| Ok(JsValue::undefined()),
-                constructor: true,
+                constructor: Some(ConstructorKind::Base),
             }),
         );
 

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -185,7 +185,7 @@ impl PromiseCapability {
                 }
 
                 // 9. Set promiseCapability.[[Promise]] to promise.
-                promise_capability.reject = promise;
+                promise_capability.reject = promise.into();
 
                 // 10. Return promiseCapability.
                 Ok(promise_capability.clone())

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     job::JobCallback,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
-        JsObject, ObjectData,
+        JsFunction, JsObject, ObjectData,
     },
     property::Attribute,
     symbol::WellKnownSymbols,
@@ -39,10 +39,14 @@ macro_rules! if_abrupt_reject_promise {
             // 1. If value is an abrupt completion, then
             Err(value) => {
                 // a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »).
-                $context.call(&$capability.reject, &JsValue::undefined(), &[value])?;
+                $context.call(
+                    &$capability.reject.clone().into(),
+                    &JsValue::undefined(),
+                    &[value],
+                )?;
 
                 // b. Return capability.[[Promise]].
-                return Ok($capability.promise.clone());
+                return Ok($capability.promise.clone().into());
             }
             // 2. Else if value is a Completion Record, set value to value.[[Value]].
             Ok(value) => value,
@@ -83,20 +87,9 @@ enum ReactionType {
 
 #[derive(Debug, Clone, Trace, Finalize)]
 struct PromiseCapability {
-    promise: JsValue,
-    resolve: JsValue,
-    reject: JsValue,
-}
-
-#[derive(Debug, Trace, Finalize)]
-struct PromiseCapabilityCaptures {
-    promise_capability: Gc<boa_gc::Cell<PromiseCapability>>,
-}
-
-#[derive(Debug, Trace, Finalize)]
-struct ReactionJobCaptures {
-    reaction: ReactionRecord,
-    argument: JsValue,
+    promise: JsObject,
+    resolve: JsFunction,
+    reject: JsFunction,
 }
 
 impl PromiseCapability {
@@ -107,6 +100,12 @@ impl PromiseCapability {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-newpromisecapability
     fn new(c: &JsValue, context: &mut Context) -> JsResult<Self> {
+        #[derive(Debug, Clone, Trace, Finalize)]
+        struct RejectResolve {
+            reject: JsValue,
+            resolve: JsValue,
+        }
+
         match c.as_constructor() {
             // 1. If IsConstructor(C) is false, throw a TypeError exception.
             None => context.throw_type_error("PromiseCapability: expected constructor"),
@@ -115,20 +114,17 @@ impl PromiseCapability {
 
                 // 2. NOTE: C is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see 27.2.3.1).
                 // 3. Let promiseCapability be the PromiseCapability Record { [[Promise]]: undefined, [[Resolve]]: undefined, [[Reject]]: undefined }.
-                let promise_capability = Gc::new(boa_gc::Cell::new(Self {
-                    promise: JsValue::Undefined,
-                    reject: JsValue::Undefined,
-                    resolve: JsValue::Undefined,
+                let promise_capability = Gc::new(boa_gc::Cell::new(RejectResolve {
+                    reject: JsValue::undefined(),
+                    resolve: JsValue::undefined(),
                 }));
 
                 // 4. Let executorClosure be a new Abstract Closure with parameters (resolve, reject) that captures promiseCapability and performs the following steps when called:
                 // 5. Let executor be CreateBuiltinFunction(executorClosure, 2, "", « »).
                 let executor = FunctionBuilder::closure_with_captures(
                     context,
-                    |_this, args: &[JsValue], captures: &mut PromiseCapabilityCaptures, context| {
-                        let promise_capability: &mut Self =
-                            &mut captures.promise_capability.try_borrow_mut().expect("msg");
-
+                    |_this, args: &[JsValue], captures, context| {
+                        let mut promise_capability = captures.borrow_mut();
                         // a. If promiseCapability.[[Resolve]] is not undefined, throw a TypeError exception.
                         if !promise_capability.resolve.is_undefined() {
                             return context.throw_type_error(
@@ -154,9 +150,7 @@ impl PromiseCapability {
                         // e. Return undefined.
                         Ok(JsValue::Undefined)
                     },
-                    PromiseCapabilityCaptures {
-                        promise_capability: promise_capability.clone(),
-                    },
+                    promise_capability.clone(),
                 )
                 .name("")
                 .length(2)
@@ -166,29 +160,37 @@ impl PromiseCapability {
                 // 6. Let promise be ? Construct(C, « executor »).
                 let promise = c.construct(&[executor], Some(&c), context)?;
 
-                let promise_capability: &mut Self =
-                    &mut promise_capability.try_borrow_mut().expect("msg");
+                let promise_capability = promise_capability.borrow();
 
                 let resolve = promise_capability.resolve.clone();
                 let reject = promise_capability.reject.clone();
 
                 // 7. If IsCallable(promiseCapability.[[Resolve]]) is false, throw a TypeError exception.
-                if !resolve.is_callable() {
-                    return context
-                        .throw_type_error("promiseCapability.[[Resolve]] is not callable");
-                }
+                let resolve = resolve
+                    .as_object()
+                    .cloned()
+                    .and_then(JsFunction::from_object)
+                    .ok_or_else(|| {
+                        context
+                            .construct_type_error("promiseCapability.[[Resolve]] is not callable")
+                    })?;
 
                 // 8. If IsCallable(promiseCapability.[[Reject]]) is false, throw a TypeError exception.
-                if !reject.is_callable() {
-                    return context
-                        .throw_type_error("promiseCapability.[[Reject]] is not callable");
-                }
+                let reject = reject
+                    .as_object()
+                    .cloned()
+                    .and_then(JsFunction::from_object)
+                    .ok_or_else(|| {
+                        context.construct_type_error("promiseCapability.[[Reject]] is not callable")
+                    })?;
 
                 // 9. Set promiseCapability.[[Promise]] to promise.
-                promise_capability.reject = promise.into();
-
                 // 10. Return promiseCapability.
-                Ok(promise_capability.clone())
+                Ok(PromiseCapability {
+                    promise,
+                    resolve,
+                    reject,
+                })
             }
         }
     }
@@ -246,13 +248,6 @@ struct ResolvingFunctionsRecord {
     reject: JsValue,
 }
 
-#[derive(Debug, Trace, Finalize)]
-struct RejectResolveCaptures {
-    promise: JsObject,
-    #[unsafe_ignore_trace]
-    already_resolved: Rc<Cell<bool>>,
-}
-
 impl Promise {
     const LENGTH: usize = 1;
 
@@ -298,10 +293,10 @@ impl Promise {
             }),
         );
 
-        // // 8. Let resolvingFunctions be CreateResolvingFunctions(promise).
+        // 8. Let resolvingFunctions be CreateResolvingFunctions(promise).
         let resolving_functions = Self::create_resolving_functions(&promise, context);
 
-        // // 9. Let completion Completion(Call(executor, undefined, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »)be ).
+        // 9. Let completion Completion(Call(executor, undefined, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »)be ).
         let completion = context.call(
             executor,
             &JsValue::Undefined,
@@ -331,6 +326,13 @@ impl Promise {
         promise: &JsObject,
         context: &mut Context,
     ) -> ResolvingFunctionsRecord {
+        #[derive(Debug, Trace, Finalize)]
+        struct RejectResolveCaptures {
+            promise: JsObject,
+            #[unsafe_ignore_trace]
+            already_resolved: Rc<Cell<bool>>,
+        }
+
         // 1. Let alreadyResolved be the Record { [[Value]]: false }.
         let already_resolved = Rc::new(Cell::new(false));
 
@@ -739,8 +741,8 @@ impl Promise {
                 next_promise.invoke(
                     "then",
                     &[
-                        result_capability.resolve.clone(),
-                        result_capability.reject.clone(),
+                        result_capability.resolve.clone().into(),
+                        result_capability.reject.clone().into(),
                     ],
                     context,
                 )?;
@@ -750,7 +752,7 @@ impl Promise {
                 iterator_record.set_done(true);
 
                 // ii. Return resultCapability.[[Promise]].
-                return Ok(result_capability.promise.clone());
+                return Ok(result_capability.promise.clone().into());
             }
         }
     }
@@ -774,13 +776,13 @@ impl Promise {
 
         // 3. Perform ? Call(promiseCapability.[[Reject]], undefined, « r »).
         context.call(
-            &promise_capability.reject,
+            &promise_capability.reject.clone().into(),
             &JsValue::undefined(),
             &[r.clone()],
         )?;
 
         // 4. Return promiseCapability.[[Promise]].
-        Ok(promise_capability.promise.clone())
+        Ok(promise_capability.promise.clone().into())
     }
 
     /// `Promise.resolve ( x )`
@@ -1131,7 +1133,7 @@ impl Promise {
 
             // 14. Else,
             //   a. Return resultCapability.[[Promise]].
-            Some(result_capability) => result_capability.promise.clone(),
+            Some(result_capability) => result_capability.promise.clone().into(),
         }
     }
 
@@ -1160,10 +1162,14 @@ impl Promise {
         let promise_capability = PromiseCapability::new(&c.into(), context)?;
 
         // 3. Perform ? Call(promiseCapability.[[Resolve]], undefined, « x »).
-        context.call(&promise_capability.resolve, &JsValue::undefined(), &[x])?;
+        context.call(
+            &promise_capability.resolve.clone().into(),
+            &JsValue::undefined(),
+            &[x],
+        )?;
 
         // 4. Return promiseCapability.[[Promise]].
-        Ok(promise_capability.promise.clone())
+        Ok(promise_capability.promise.clone().into())
     }
 
     /// `GetPromiseResolve ( promiseConstructor )`

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -126,7 +126,9 @@ impl Reflect {
             .create_list_from_array_like(&[], context)?;
 
         // 5. Return ? Construct(target, args, newTarget).
-        target.construct(&args, Some(new_target), context)
+        target
+            .construct(&args, Some(new_target), context)
+            .map(JsValue::from)
     }
 
     /// Defines a property on an object.

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1184,9 +1184,6 @@ impl RegExp {
 
         // 6. Let matcher be ? Construct(C, « R, flags »).
         let matcher = c.construct(&[this.clone(), flags.clone().into()], Some(&c), context)?;
-        let matcher = matcher
-            .as_object()
-            .expect("construct must always return an Object");
 
         // 7. Let lastIndex be ? ToLength(? Get(R, "lastIndex")).
         let last_index = regexp.get("lastIndex", context)?.to_length(context)?;
@@ -1579,11 +1576,6 @@ impl RegExp {
             Some(&constructor),
             context,
         )?;
-        let splitter = splitter
-            .as_object()
-            // TODO: remove when we handle realms on `get_prototype_from_constructor` and make
-            // `construct` always return a `JsObject`
-            .ok_or_else(|| context.construct_type_error("constructor did not return an object"))?;
 
         // 11. Let A be ! ArrayCreate(0).
         let a = Array::array_create(0, None, context).expect("this ArrayCreate call must not fail");
@@ -1610,7 +1602,7 @@ impl RegExp {
         // 16. If size is 0, then
         if size == 0 {
             // a. Let z be ? RegExpExec(splitter, S).
-            let result = Self::abstract_exec(splitter, arg_str.clone(), context)?;
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
 
             // b. If z is not null, return A.
             if result.is_some() {
@@ -1636,7 +1628,7 @@ impl RegExp {
             splitter.set("lastIndex", JsValue::new(q), true, context)?;
 
             // b. Let z be ? RegExpExec(splitter, S).
-            let result = Self::abstract_exec(splitter, arg_str.clone(), context)?;
+            let result = Self::abstract_exec(&splitter, arg_str.clone(), context)?;
 
             // c. If z is null, set q to AdvanceStringIndex(S, q, unicodeMatching).
             // d. Else,

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -2970,11 +2970,8 @@ impl TypedArray {
         // 1. Let newTypedArray be ? Construct(constructor, argumentList).
         let new_typed_array = constructor.construct(args, Some(constructor), context)?;
 
+        let obj_borrow = new_typed_array.borrow();
         // 2. Perform ? ValidateTypedArray(newTypedArray).
-        let obj = new_typed_array
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
-        let obj_borrow = obj.borrow();
         let o = obj_borrow
             .as_typed_array()
             .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
@@ -2994,7 +2991,7 @@ impl TypedArray {
         }
 
         // 4. Return newTypedArray.
-        Ok(obj.clone())
+        Ok(new_typed_array.clone())
     }
 
     /// <https://tc39.es/ecma262/#sec-allocatetypedarraybuffer>

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -70,7 +70,7 @@ fn bound_function_exotic_construct(
     arguments_list: &[JsValue],
     new_target: &JsObject,
     context: &mut Context,
-) -> JsResult<JsValue> {
+) -> JsResult<JsObject> {
     let object = obj.borrow();
     let bound_function = object
         .as_bound_function()

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -55,6 +55,6 @@ fn function_construct(
     args: &[JsValue],
     new_target: &JsObject,
     context: &mut Context,
-) -> JsResult<JsValue> {
+) -> JsResult<JsObject> {
     obj.construct_internal(args, &new_target.clone().into(), context)
 }

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -261,7 +261,7 @@ impl JsObject {
         args: &[JsValue],
         new_target: &JsObject,
         context: &mut Context,
-    ) -> JsResult<JsValue> {
+    ) -> JsResult<JsObject> {
         let _timer = Profiler::global().start_event("Object::__construct__", "object");
         let func = self.borrow().data.internal_methods.__construct__;
         func.expect("called `[[Construct]]` for object without a `[[Construct]]` internal method")(
@@ -324,7 +324,7 @@ pub(crate) struct InternalObjectMethods {
     pub(crate) __call__:
         Option<fn(&JsObject, &JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>>,
     pub(crate) __construct__:
-        Option<fn(&JsObject, &[JsValue], &JsObject, &mut Context) -> JsResult<JsValue>>,
+        Option<fn(&JsObject, &[JsValue], &JsObject, &mut Context) -> JsResult<JsObject>>,
 }
 
 /// Abstract operation `OrdinaryGetPrototypeOf`.

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -946,7 +946,7 @@ fn proxy_exotic_construct(
     args: &[JsValue],
     new_target: &JsObject,
     context: &mut Context,
-) -> JsResult<JsValue> {
+) -> JsResult<JsObject> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
     // 3. Assert: Type(handler) is Object.
@@ -984,9 +984,9 @@ fn proxy_exotic_construct(
     )?;
 
     // 10. If Type(newObj) is not Object, throw a TypeError exception.
-    if !new_obj.is_object() {
-        return context.throw_type_error("Proxy trap constructor returned non-object value");
-    }
+    let new_obj = new_obj.as_object().cloned().ok_or_else(|| {
+        context.construct_type_error("Proxy trap constructor returned non-object value")
+    })?;
 
     // 11. Return newObj.
     Ok(new_obj)

--- a/boa_engine/src/object/jsfunction.rs
+++ b/boa_engine/src/object/jsfunction.rs
@@ -1,6 +1,6 @@
 use crate::{
     object::{JsObject, JsObjectType},
-    Context, JsResult, JsValue,
+    JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use std::ops::Deref;
@@ -17,16 +17,14 @@ impl JsFunction {
         Self { inner: object }
     }
 
-    /// Create a [`JsFunction`] from a [`JsObject`], if the object is not a function throw a `TypeError`.
+    /// Create a [`JsFunction`] from a [`JsObject`], or return None if the object is not a function.
     ///
     /// This does not clone the fields of the function, it only does a shallow clone of the object.
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
-        if object.borrow().is_function() {
-            Ok(Self::from_object_unchecked(object))
-        } else {
-            context.throw_type_error("object is not an Function")
-        }
+    pub fn from_object(object: JsObject) -> Option<Self> {
+        object
+            .is_callable()
+            .then(|| Self::from_object_unchecked(object))
     }
 }
 

--- a/boa_engine/src/object/jsfunction.rs
+++ b/boa_engine/src/object/jsfunction.rs
@@ -17,7 +17,7 @@ impl JsFunction {
         Self { inner: object }
     }
 
-    /// Create a [`JsFunction`] from a [`JsObject`], or return None if the object is not a function.
+    /// Create a [`JsFunction`] from a [`JsObject`], or return `None` if the object is not a function.
     ///
     /// This does not clone the fields of the function, it only does a shallow clone of the object.
     #[inline]

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -328,7 +328,7 @@ impl JsObject {
         args: &[JsValue],
         new_target: Option<&JsObject>,
         context: &mut Context,
-    ) -> JsResult<JsValue> {
+    ) -> JsResult<JsObject> {
         // 1. If newTarget is not present, set newTarget to F.
         let new_target = new_target.unwrap_or(self);
         // 2. If argumentsList is not present, set argumentsList to a new empty List.

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -63,6 +63,7 @@ pub struct CodeBlock {
     pub(crate) strict: bool,
 
     /// Constructor type of this function, or `None` if the function is not constructable.
+    #[unsafe_ignore_trace]
     pub(crate) constructor: Option<ConstructorKind>,
 
     /// \[\[ThisMode\]\]

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -1481,9 +1481,9 @@ impl Context {
                     [compile_environments_index as usize]
                     .clone();
 
-                let is_constructor = self.vm.frame().code.constructor;
+                let constructor = self.vm.frame().code.constructor;
                 let is_lexical = self.vm.frame().code.this_mode.is_lexical();
-                let this = if is_constructor || !is_lexical {
+                let this = if constructor.is_some() || !is_lexical {
                     self.vm.frame().this.clone()
                 } else {
                     JsValue::undefined()


### PR DESCRIPTION
This Pull Request changes the signature of `construct` to always return `JsObject`s, and refactors `PromiseCapability` to store only `JsObject`/`JsFunction`s. This preserves the following invariants specified in the spec:

https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-ecmascript-function-objects-construct-argumentslist-newtarget
> The [[Construct]] internal method of an ECMAScript function object ... returns either a normal completion containing an Object or a throw completion ... 

https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promisecapability-records

Table 82: [PromiseCapability Record](https://tc39.es/ecma262/multipage/control-abstraction-objects.html#sec-promisecapability-records) Fields
Field Name | Value | Meaning
-- | -- | --
[[Promise]] | an Object | An object that is usable as a promise.
[[Resolve]] | a function object | The function that is used to resolve the given promise.
[[Reject]] | a function object | The function that is used to reject the given promise.