### PR TITLE
Make all built-in constructors public

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -36,7 +36,7 @@ use std::cmp::{max, min, Ordering};
 
 /// JavaScript `Array` built-in implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Array;
+pub struct Array;
 
 impl BuiltIn for Array {
     const NAME: &'static str = "Array";
@@ -133,7 +133,7 @@ impl BuiltIn for Array {
 impl Array {
     const LENGTH: usize = 1;
 
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -84,7 +84,7 @@ impl ArrayBuffer {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer-length
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -77,7 +77,7 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint-objects
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/BigInt
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -25,7 +25,7 @@ use tap::{Conv, Pipe};
 
 /// Boolean implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Boolean;
+pub struct Boolean;
 
 impl BuiltIn for Boolean {
     /// The name of the object.
@@ -56,7 +56,7 @@ impl Boolean {
     /// `[[Construct]]` Create a new boolean object
     ///
     /// `[[Call]]` Creates a new boolean primitive
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -93,7 +93,7 @@ impl DataView {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/DataView/DataView
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -332,7 +332,7 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -22,7 +22,7 @@ use tap::{Conv, Pipe};
 use super::Error;
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct AggregateError;
+pub struct AggregateError;
 
 impl BuiltIn for AggregateError {
     const NAME: &'static str = "AggregateError";
@@ -61,7 +61,7 @@ impl AggregateError {
     pub(crate) const LENGTH: usize = 2;
 
     /// Create a new aggregate error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -27,7 +27,7 @@ use super::Error;
 
 /// JavaScript `EvalError` impleentation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct EvalError;
+pub struct EvalError;
 
 impl BuiltIn for EvalError {
     const NAME: &'static str = "EvalError";
@@ -61,7 +61,7 @@ impl EvalError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -33,19 +33,19 @@ pub(crate) mod uri;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use self::aggregate::AggregateError;
-pub(crate) use self::eval::EvalError;
-pub(crate) use self::r#type::TypeError;
-pub(crate) use self::range::RangeError;
-pub(crate) use self::reference::ReferenceError;
-pub(crate) use self::syntax::SyntaxError;
-pub(crate) use self::uri::UriError;
+pub use self::aggregate::AggregateError;
+pub use self::eval::EvalError;
+pub use self::r#type::TypeError;
+pub use self::range::RangeError;
+pub use self::reference::ReferenceError;
+pub use self::syntax::SyntaxError;
+pub use self::uri::UriError;
 
 use super::JsArgs;
 
 /// Built-in `Error` object.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Error;
+pub struct Error;
 
 impl BuiltIn for Error {
     const NAME: &'static str = "Error";
@@ -97,7 +97,7 @@ impl Error {
     /// `Error( message [ , options ] )`
     ///
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -25,7 +25,7 @@ use super::Error;
 
 /// JavaScript `RangeError` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct RangeError;
+pub struct RangeError;
 
 impl BuiltIn for RangeError {
     const NAME: &'static str = "RangeError";
@@ -59,7 +59,7 @@ impl RangeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -24,7 +24,7 @@ use tap::{Conv, Pipe};
 use super::Error;
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ReferenceError;
+pub struct ReferenceError;
 
 impl BuiltIn for ReferenceError {
     const NAME: &'static str = "ReferenceError";
@@ -62,7 +62,7 @@ impl ReferenceError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -27,7 +27,7 @@ use super::Error;
 
 /// JavaScript `SyntaxError` impleentation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct SyntaxError;
+pub struct SyntaxError;
 
 impl BuiltIn for SyntaxError {
     const NAME: &'static str = "SyntaxError";
@@ -61,7 +61,7 @@ impl SyntaxError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -31,7 +31,7 @@ use super::Error;
 
 /// JavaScript `TypeError` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TypeError;
+pub struct TypeError;
 
 impl BuiltIn for TypeError {
     const NAME: &'static str = "TypeError";
@@ -65,7 +65,7 @@ impl TypeError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -26,7 +26,7 @@ use super::Error;
 
 /// JavaScript `URIError` impleentation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct UriError;
+pub struct UriError;
 
 impl BuiltIn for UriError {
     const NAME: &'static str = "URIError";
@@ -60,7 +60,7 @@ impl UriError {
     pub(crate) const LENGTH: usize = 1;
 
     /// Create a new error object.
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -288,7 +288,7 @@ impl BuiltInFunctionObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-function-p1-p2-pn-body
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/Function
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -112,11 +112,7 @@ impl Generator {
     pub(crate) const LENGTH: usize = 0;
 
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn constructor(
-        _: &JsValue,
-        _: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub fn constructor(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let prototype = context.intrinsics().constructors().generator().prototype();
 
         let this = JsObject::from_proto_and_data(

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -109,7 +109,7 @@ impl BuiltIn for GeneratorFunction {
 }
 
 impl GeneratorFunction {
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         _: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -65,7 +65,7 @@ impl DateTimeFormat {
     ///
     /// [spec]: https://tc39.es/ecma402/#datetimeformat-objects
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         _args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -35,7 +35,7 @@ pub mod ordered_map;
 mod tests;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Map(OrderedMap<JsValue>);
+pub struct Map(OrderedMap<JsValue>);
 
 impl BuiltIn for Map {
     const NAME: &'static str = "Map";
@@ -116,7 +116,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map-iterable
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/Map
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -39,7 +39,7 @@ const BUF_SIZE: usize = 2200;
 
 /// `Number` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Number;
+pub struct Number;
 
 impl BuiltIn for Number {
     const NAME: &'static str = "Number";
@@ -167,7 +167,7 @@ impl Number {
     pub(crate) const MIN_VALUE: f64 = f64::MIN_POSITIVE;
 
     /// `Number( value )`
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -114,7 +114,7 @@ impl BuiltIn for Object {
 impl Object {
     const LENGTH: usize = 1;
 
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -262,7 +262,7 @@ impl Promise {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise-executor
-    fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -70,7 +70,7 @@ impl Proxy {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-proxy-target-handler
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -169,7 +169,7 @@ impl RegExp {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp-pattern-flags
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -32,7 +32,7 @@ pub mod set_iterator;
 mod tests;
 
 #[derive(Debug, Clone)]
-pub(crate) struct Set(OrderedSet<JsValue>);
+pub struct Set(OrderedSet<JsValue>);
 
 impl BuiltIn for Set {
     const NAME: &'static str = "Set";
@@ -110,7 +110,7 @@ impl Set {
     pub(crate) const LENGTH: usize = 0;
 
     /// Create a new set
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -96,7 +96,7 @@ pub(crate) fn is_trailing_surrogate(value: u16) -> bool {
 
 /// JavaScript `String` implementation.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct String;
+pub struct String;
 
 impl BuiltIn for String {
     const NAME: &'static str = "String";
@@ -169,7 +169,7 @@ impl String {
     /// `String( value )`
     ///
     /// <https://tc39.es/ecma262/#sec-string-constructor-string-value>
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -168,7 +168,7 @@ impl Symbol {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol-description
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/Symbol
-    pub(crate) fn constructor(
+    pub fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -114,7 +114,7 @@ macro_rules! typed_array {
             ///  - [ECMAScript reference][spec]
             ///
             /// [spec]: https://tc39.es/ecma262/#sec-typedarray
-            pub(crate) fn constructor(
+            pub fn constructor(
                 new_target: &JsValue,
                 args: &[JsValue],
                 context: &mut Context,
@@ -242,7 +242,7 @@ macro_rules! typed_array {
 ///
 /// <https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object>
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct TypedArray;
+pub struct TypedArray;
 
 impl BuiltIn for TypedArray {
     const NAME: &'static str = "TypedArray";
@@ -380,7 +380,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%
-    fn constructor(
+    pub fn constructor(
         _new_target: &JsValue,
         _args: &[JsValue],
         context: &mut Context,


### PR DESCRIPTION
This Pull Request makes all our built-in constructors public. This should ensure our users can still construct objects from Rust without having to compile and run any JS code.