### PR TITLE
[Merged by Bors] - Implement `async function` and `await`

### DIFF
--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -1,0 +1,107 @@
+//! This module implements the global `AsyncFunction` object.
+//!
+//! More information:
+//!  - [ECMAScript reference][spec]
+//!  - [MDN documentation][mdn]
+//!
+//! [spec]: https://tc39.es/ecma262/#sec-async-function-objects
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncFunction
+
+use crate::{
+    builtins::{
+        function::{ConstructorKind, Function},
+        BuiltIn,
+    },
+    object::ObjectData,
+    property::PropertyDescriptor,
+    symbol::WellKnownSymbols,
+    Context, JsResult, JsValue,
+};
+use boa_profiler::Profiler;
+
+#[derive(Debug, Clone, Copy)]
+pub struct AsyncFunction;
+
+impl BuiltIn for AsyncFunction {
+    const NAME: &'static str = "AsyncFunction";
+
+    fn init(context: &mut Context) -> Option<JsValue> {
+        let _timer = Profiler::global().start_event(Self::NAME, "init");
+
+        let prototype = &context
+            .intrinsics()
+            .constructors()
+            .async_function()
+            .prototype;
+        let constructor = &context
+            .intrinsics()
+            .constructors()
+            .async_function()
+            .constructor;
+
+        constructor.set_prototype(Some(
+            context.intrinsics().constructors().function().constructor(),
+        ));
+        let property = PropertyDescriptor::builder()
+            .value(1)
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
+        constructor.borrow_mut().insert("length", property);
+        let property = PropertyDescriptor::builder()
+            .value(Self::NAME)
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
+        constructor.borrow_mut().insert("name", property);
+        let property = PropertyDescriptor::builder()
+            .value(prototype.clone())
+            .writable(false)
+            .enumerable(false)
+            .configurable(false);
+        constructor.borrow_mut().insert("prototype", property);
+        constructor.borrow_mut().data = ObjectData::function(Function::Native {
+            function: Self::constructor,
+            constructor: Some(ConstructorKind::Base),
+        });
+
+        prototype.set_prototype(Some(
+            context.intrinsics().constructors().function().prototype(),
+        ));
+        let property = PropertyDescriptor::builder()
+            .value(constructor.clone())
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
+        prototype.borrow_mut().insert("constructor", property);
+        let property = PropertyDescriptor::builder()
+            .value(Self::NAME)
+            .writable(false)
+            .enumerable(false)
+            .configurable(true);
+        prototype
+            .borrow_mut()
+            .insert(WellKnownSymbols::to_string_tag(), property);
+
+        None
+    }
+}
+
+impl AsyncFunction {
+    /// `AsyncFunction ( p1, p2, … , pn, body )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-async-function-constructor-arguments
+    fn constructor(
+        new_target: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        crate::builtins::function::BuiltInFunctionObject::create_dynamic_function(
+            new_target, args, true, context,
+        )
+        .map(Into::into)
+    }
+}

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod array;
 pub mod array_buffer;
+pub mod async_function;
 pub mod bigint;
 pub mod boolean;
 pub mod dataview;
@@ -38,6 +39,7 @@ pub mod intl;
 
 pub(crate) use self::{
     array::{array_iterator::ArrayIterator, Array},
+    async_function::AsyncFunction,
     bigint::BigInt,
     boolean::Boolean,
     dataview::DataView,
@@ -185,7 +187,8 @@ pub fn init(context: &mut Context) {
         Reflect,
         Generator,
         GeneratorFunction,
-        Promise
+        Promise,
+        AsyncFunction
     };
 
     #[cfg(feature = "intl")]

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -86,7 +86,7 @@ enum ReactionType {
 }
 
 #[derive(Debug, Clone, Trace, Finalize)]
-struct PromiseCapability {
+pub struct PromiseCapability {
     promise: JsObject,
     resolve: JsFunction,
     reject: JsFunction,
@@ -99,7 +99,7 @@ impl PromiseCapability {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-newpromisecapability
-    fn new(c: &JsValue, context: &mut Context) -> JsResult<Self> {
+    pub(crate) fn new(c: &JsValue, context: &mut Context) -> JsResult<Self> {
         #[derive(Debug, Clone, Trace, Finalize)]
         struct RejectResolve {
             reject: JsValue,
@@ -193,6 +193,21 @@ impl PromiseCapability {
                 })
             }
         }
+    }
+
+    /// Returns the promise object.
+    pub(crate) fn promise(&self) -> &JsObject {
+        &self.promise
+    }
+
+    /// Returns the resolve function.
+    pub(crate) fn resolve(&self) -> &JsFunction {
+        &self.resolve
+    }
+
+    /// Returns the reject function.
+    pub(crate) fn reject(&self) -> &JsFunction {
+        &self.reject
     }
 }
 
@@ -1878,7 +1893,7 @@ impl Promise {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-performpromisethen
-    fn perform_promise_then(
+    pub(crate) fn perform_promise_then(
         &mut self,
         on_fulfilled: &JsValue,
         on_rejected: &JsValue,
@@ -2000,7 +2015,11 @@ impl Promise {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise-resolve
-    fn promise_resolve(c: JsObject, x: JsValue, context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn promise_resolve(
+        c: JsObject,
+        x: JsValue,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         // 1. If IsPromise(x) is true, then
         if let Some(x) = x.as_promise() {
             // a. Let xConstructor be ? Get(x, "constructor").

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -76,6 +76,7 @@ pub struct StandardConstructors {
     proxy: StandardConstructor,
     date: StandardConstructor,
     function: StandardConstructor,
+    async_function: StandardConstructor,
     generator: StandardConstructor,
     generator_function: StandardConstructor,
     array: StandardConstructor,
@@ -120,6 +121,7 @@ impl Default for StandardConstructors {
             proxy: StandardConstructor::default(),
             date: StandardConstructor::default(),
             function: StandardConstructor::default(),
+            async_function: StandardConstructor::default(),
             generator: StandardConstructor::default(),
             generator_function: StandardConstructor::default(),
             array: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
@@ -203,6 +205,11 @@ impl StandardConstructors {
     #[inline]
     pub fn function(&self) -> &StandardConstructor {
         &self.function
+    }
+
+    #[inline]
+    pub fn async_function(&self) -> &StandardConstructor {
+        &self.async_function
     }
 
     #[inline]

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1574,7 +1574,7 @@ impl<'context> FunctionBuilder<'context> {
             } => {
                 *constructor = yes.then(|| ConstructorKind::Base);
             }
-            Function::Ordinary { .. } | Function::Generator { .. } => {
+            Function::Ordinary { .. } | Function::Generator { .. } | Function::Async { .. } => {
                 unreachable!("function must be native or closure");
             }
         }

--- a/boa_engine/src/syntax/ast/node/declaration/async_function_decl/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/async_function_decl/mod.rs
@@ -47,8 +47,8 @@ impl AsyncFunctionDecl {
     }
 
     /// Gets the body of the async function declaration.
-    pub fn body(&self) -> &[Node] {
-        self.body.items()
+    pub fn body(&self) -> &StatementList {
+        &self.body
     }
 
     /// Implements the display formatting with indentation.
@@ -62,7 +62,7 @@ impl AsyncFunctionDecl {
             interner.resolve_expect(self.name),
             join_nodes(interner, &self.parameters.parameters)
         );
-        if self.body().is_empty() {
+        if self.body.items().is_empty() {
             buf.push_str(") {}");
         } else {
             buf.push_str(&format!(

--- a/boa_engine/src/syntax/ast/node/statement_list/mod.rs
+++ b/boa_engine/src/syntax/ast/node/statement_list/mod.rs
@@ -19,7 +19,7 @@ mod tests;
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-StatementList
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct StatementList {
     items: Box<[Node]>,
     strict: bool,

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -121,7 +121,7 @@ where
                 Ok(node::UnaryOp::new(UnaryOp::Not, self.parse(cursor, interner)?).into())
             }
             TokenKind::Keyword((Keyword::Await, true)) if self.allow_await.0 => Err(
-                ParseError::general("Keyword must not contain escaped characters", token_start),
+                ParseError::general("Keyword 'await' must not contain escaped characters", token_start),
             ),
             TokenKind::Keyword((Keyword::Await, false)) if self.allow_await.0 => {
                 Ok((AwaitExpression::new(self.allow_yield).parse(cursor, interner)?).into())

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -120,9 +120,12 @@ where
                 cursor.next(interner)?.expect("! token vanished"); // Consume the token.
                 Ok(node::UnaryOp::new(UnaryOp::Not, self.parse(cursor, interner)?).into())
             }
-            TokenKind::Keyword((Keyword::Await, true)) if self.allow_await.0 => Err(
-                ParseError::general("Keyword 'await' must not contain escaped characters", token_start),
-            ),
+            TokenKind::Keyword((Keyword::Await, true)) if self.allow_await.0 => {
+                Err(ParseError::general(
+                    "Keyword 'await' must not contain escaped characters",
+                    token_start,
+                ))
+            }
             TokenKind::Keyword((Keyword::Await, false)) if self.allow_await.0 => {
                 Ok((AwaitExpression::new(self.allow_yield).parse(cursor, interner)?).into())
             }

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -67,10 +67,10 @@ impl CallableDeclaration for FunctionDeclaration {
         false
     }
     fn body_allow_yield(&self) -> bool {
-        self.allow_yield.0
+        false
     }
     fn body_allow_await(&self) -> bool {
-        self.allow_await.0
+        false
     }
 }
 

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -2416,6 +2416,8 @@ impl Context {
 
         let start_stack_size = self.vm.stack.len();
 
+        // If the current executing function is an async function we have to resolve/reject it's promise at the end.
+        // The relevant spec section is 3. in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
         let promise_capability = self
             .realm
             .environments
@@ -2478,6 +2480,7 @@ impl Context {
                     let result = self.vm.pop();
                     self.vm.stack.truncate(start_stack_size);
 
+                    // Step 3.e in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
                     if let Some(promise_capability) = promise_capability {
                         promise_capability
                             .resolve()
@@ -2539,6 +2542,8 @@ impl Context {
                         self.vm.push(e);
                     } else {
                         self.vm.stack.truncate(start_stack_size);
+
+                        // Step 3.f in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
                         if let Some(promise_capability) = promise_capability {
                             promise_capability
                                 .reject()
@@ -2578,6 +2583,7 @@ impl Context {
         }
 
         if self.vm.stack.len() <= start_stack_size {
+            // Step 3.d in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
             if let Some(promise_capability) = promise_capability {
                 promise_capability
                     .resolve()
@@ -2591,6 +2597,7 @@ impl Context {
         let result = self.vm.pop();
         self.vm.stack.truncate(start_stack_size);
 
+        // Step 3.d in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
         if let Some(promise_capability) = promise_capability {
             promise_capability
                 .resolve()

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -6,10 +6,10 @@ use crate::{
     builtins::{
         function::{ConstructorKind, Function},
         iterable::IteratorRecord,
-        Array, ForInIterator, Number,
+        Array, ForInIterator, JsArgs, Number, Promise,
     },
     environments::EnvironmentSlots,
-    object::{JsFunction, JsObject, ObjectData, PrivateElement},
+    object::{FunctionBuilder, JsFunction, JsObject, ObjectData, PrivateElement},
     property::{DescriptorKind, PropertyDescriptor, PropertyDescriptorBuilder, PropertyKey},
     value::Numeric,
     vm::{
@@ -115,6 +115,7 @@ enum ShouldExit {
     True,
     False,
     Yield,
+    Await,
 }
 
 /// Indicates if the execution of a codeblock has ended normally or has been yielded.
@@ -1686,7 +1687,13 @@ impl Context {
             Opcode::GetFunction => {
                 let index = self.vm.read::<u32>();
                 let code = self.vm.frame().code.functions[index as usize].clone();
-                let function = create_function_object(code, self);
+                let function = create_function_object(code, false, self);
+                self.vm.push(function);
+            }
+            Opcode::GetFunctionAsync => {
+                let index = self.vm.read::<u32>();
+                let code = self.vm.frame().code.functions[index as usize].clone();
+                let function = create_function_object(code, true, self);
                 self.vm.push(function);
             }
             Opcode::GetGenerator => {
@@ -2270,6 +2277,106 @@ impl Context {
                     }
                 }
             }
+            Opcode::Await => {
+                let value = self.vm.pop();
+
+                // 2. Let promise be ? PromiseResolve(%Promise%, value).
+                let promise = Promise::promise_resolve(
+                    self.intrinsics().constructors().promise().constructor(),
+                    value,
+                    self,
+                )?;
+
+                // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
+                // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
+                let on_fulfilled = FunctionBuilder::closure_with_captures(
+                    self,
+                    |_this, args, captures, context| {
+                        // a. Let prevContext be the running execution context.
+                        // b. Suspend prevContext.
+                        // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+                        // d. Resume the suspended evaluation of asyncContext using NormalCompletion(value) as the result of the operation that suspended it.
+                        // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
+                        // f. Return undefined.
+
+                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
+                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+                        context.vm.push_frame(captures.2.clone());
+
+                        context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Normal;
+                        context.vm.push(args.get_or_undefined(0));
+                        context.run()?;
+
+                        captures.2 = *context
+                            .vm
+                            .pop_frame()
+                            .expect("generator call frame must exist");
+                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
+                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+
+                        Ok(JsValue::undefined())
+                    },
+                    (
+                        self.realm.environments.clone(),
+                        self.vm.stack.clone(),
+                        self.vm.frame().clone(),
+                    ),
+                )
+                .name("")
+                .length(1)
+                .build();
+
+                // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
+                // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
+                let on_rejected = FunctionBuilder::closure_with_captures(
+                    self,
+                    |_this, args, captures, context| {
+                        // a. Let prevContext be the running execution context.
+                        // b. Suspend prevContext.
+                        // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
+                        // d. Resume the suspended evaluation of asyncContext using ThrowCompletion(reason) as the result of the operation that suspended it.
+                        // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
+                        // f. Return undefined.
+
+                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
+                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+                        context.vm.push_frame(captures.2.clone());
+
+                        context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Throw;
+                        context.vm.push(args.get_or_undefined(0));
+                        context.run()?;
+
+                        captures.2 = *context
+                            .vm
+                            .pop_frame()
+                            .expect("generator call frame must exist");
+                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
+                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+
+                        Ok(JsValue::undefined())
+                    },
+                    (
+                        self.realm.environments.clone(),
+                        self.vm.stack.clone(),
+                        self.vm.frame().clone(),
+                    ),
+                )
+                .name("")
+                .length(1)
+                .build();
+
+                // 7. Perform PerformPromiseThen(promise, onFulfilled, onRejected).
+                promise
+                    .as_object()
+                    .expect("promise was not an object")
+                    .borrow_mut()
+                    .as_promise_mut()
+                    .expect("promise was not a promise")
+                    .perform_promise_then(&on_fulfilled.into(), &on_rejected.into(), None, self);
+
+                self.vm.push(JsValue::undefined());
+                return Ok(ShouldExit::Await);
+            }
         }
 
         Ok(ShouldExit::False)
@@ -2308,6 +2415,20 @@ impl Context {
         }
 
         let start_stack_size = self.vm.stack.len();
+
+        let promise_capability = self
+            .realm
+            .environments
+            .get_this_environment()
+            .as_function_slots()
+            .and_then(|slots| {
+                let slots_borrow = slots.borrow();
+                let function_object = slots_borrow.function_object();
+                let function = function_object.borrow();
+                function
+                    .as_function()
+                    .and_then(|f| f.get_promise_capability().cloned())
+            });
 
         while self.vm.frame().pc < self.vm.frame().code.code.len() {
             let result = if self.vm.trace {
@@ -2354,6 +2475,19 @@ impl Context {
 
             match result {
                 Ok(ShouldExit::True) => {
+                    let result = self.vm.pop();
+                    self.vm.stack.truncate(start_stack_size);
+
+                    if let Some(promise_capability) = promise_capability {
+                        promise_capability
+                            .resolve()
+                            .call(&JsValue::undefined(), &[result.clone()], self)
+                            .expect("cannot fail per spec");
+                    }
+
+                    return Ok((result, ReturnType::Normal));
+                }
+                Ok(ShouldExit::Await) => {
                     let result = self.vm.pop();
                     self.vm.stack.truncate(start_stack_size);
                     return Ok((result, ReturnType::Normal));
@@ -2405,6 +2539,15 @@ impl Context {
                         self.vm.push(e);
                     } else {
                         self.vm.stack.truncate(start_stack_size);
+                        if let Some(promise_capability) = promise_capability {
+                            promise_capability
+                                .reject()
+                                .call(&JsValue::undefined(), &[e.clone()], self)
+                                .expect("cannot fail per spec");
+
+                            return Ok((e, ReturnType::Normal));
+                        }
+
                         return Err(e);
                     }
                 }
@@ -2435,11 +2578,26 @@ impl Context {
         }
 
         if self.vm.stack.len() <= start_stack_size {
+            if let Some(promise_capability) = promise_capability {
+                promise_capability
+                    .resolve()
+                    .call(&JsValue::undefined(), &[], self)
+                    .expect("cannot fail per spec");
+            }
+
             return Ok((JsValue::undefined(), ReturnType::Normal));
         }
 
         let result = self.vm.pop();
         self.vm.stack.truncate(start_stack_size);
+
+        if let Some(promise_capability) = promise_capability {
+            promise_capability
+                .resolve()
+                .call(&JsValue::undefined(), &[result.clone()], self)
+                .expect("cannot fail per spec");
+        }
+
         Ok((result, ReturnType::Normal))
     }
 }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -2291,7 +2291,7 @@ impl Context {
                 // 4. Let onFulfilled be CreateBuiltinFunction(fulfilledClosure, 1, "", « »).
                 let on_fulfilled = FunctionBuilder::closure_with_captures(
                     self,
-                    |_this, args, captures, context| {
+                    |_this, args, (environment, stack, frame), context| {
                         // a. Let prevContext be the running execution context.
                         // b. Suspend prevContext.
                         // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
@@ -2299,20 +2299,20 @@ impl Context {
                         // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
                         // f. Return undefined.
 
-                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
-                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
-                        context.vm.push_frame(captures.2.clone());
+                        std::mem::swap(&mut context.realm.environments, environment);
+                        std::mem::swap(&mut context.vm.stack, stack);
+                        context.vm.push_frame(frame.clone());
 
                         context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Normal;
                         context.vm.push(args.get_or_undefined(0));
                         context.run()?;
 
-                        captures.2 = *context
+                        *frame = *context
                             .vm
                             .pop_frame()
                             .expect("generator call frame must exist");
-                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
-                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+                        std::mem::swap(&mut context.realm.environments, environment);
+                        std::mem::swap(&mut context.vm.stack, stack);
 
                         Ok(JsValue::undefined())
                     },
@@ -2330,7 +2330,7 @@ impl Context {
                 // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).
                 let on_rejected = FunctionBuilder::closure_with_captures(
                     self,
-                    |_this, args, captures, context| {
+                    |_this, args, (environment, stack, frame), context| {
                         // a. Let prevContext be the running execution context.
                         // b. Suspend prevContext.
                         // c. Push asyncContext onto the execution context stack; asyncContext is now the running execution context.
@@ -2338,20 +2338,20 @@ impl Context {
                         // e. Assert: When we reach this step, asyncContext has already been removed from the execution context stack and prevContext is the currently running execution context.
                         // f. Return undefined.
 
-                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
-                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
-                        context.vm.push_frame(captures.2.clone());
+                        std::mem::swap(&mut context.realm.environments, environment);
+                        std::mem::swap(&mut context.vm.stack, stack);
+                        context.vm.push_frame(frame.clone());
 
                         context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Throw;
                         context.vm.push(args.get_or_undefined(0));
                         context.run()?;
 
-                        captures.2 = *context
+                        *frame = *context
                             .vm
                             .pop_frame()
                             .expect("generator call frame must exist");
-                        std::mem::swap(&mut context.realm.environments, &mut captures.0);
-                        std::mem::swap(&mut context.vm.stack, &mut captures.1);
+                        std::mem::swap(&mut context.realm.environments, environment);
+                        std::mem::swap(&mut context.vm.stack, stack);
 
                         Ok(JsValue::undefined())
                     },

--- a/boa_engine/src/vm/opcode.rs
+++ b/boa_engine/src/vm/opcode.rs
@@ -913,6 +913,13 @@ pub enum Opcode {
     /// Stack: **=>** func
     GetFunction,
 
+    /// Get async function from the pre-compiled inner functions.
+    ///
+    /// Operands: address: `u32`
+    ///
+    /// Stack: **=>** func
+    GetFunctionAsync,
+
     /// Get generator function from the pre-compiled inner functions.
     ///
     /// Operands: address: `u32`
@@ -1125,6 +1132,13 @@ pub enum Opcode {
     /// Stack: iterator, next_method, done, received **=>** iterator, next_method, done
     GeneratorNextDelegate,
 
+    /// Stops the current async function and schedules it to resume later.
+    ///
+    /// Operands:
+    ///
+    /// Stack: promise **=>**
+    Await,
+
     /// No-operation instruction, does nothing.
     ///
     /// Operands:
@@ -1269,6 +1283,7 @@ impl Opcode {
             Self::Case => "Case",
             Self::Default => "Default",
             Self::GetFunction => "GetFunction",
+            Self::GetFunctionAsync => "GetFunctionAsync",
             Self::GetGenerator => "GetGenerator",
             Self::CallEval => "CallEval",
             Self::CallEvalWithRest => "CallEvalWithRest",
@@ -1298,6 +1313,7 @@ impl Opcode {
             Self::PopOnReturnSub => "PopOnReturnSub",
             Self::Yield => "Yield",
             Self::GeneratorNext => "GeneratorNext",
+            Self::Await => "Await",
             Self::GeneratorNextDelegate => "GeneratorNextDelegate",
             Self::Nop => "Nop",
         }
@@ -1407,6 +1423,7 @@ impl Opcode {
             Self::Case => "INST - Case",
             Self::Default => "INST - Default",
             Self::GetFunction => "INST - GetFunction",
+            Self::GetFunctionAsync => "INST - GetFunctionAsync",
             Self::GetGenerator => "INST - GetGenerator",
             Self::CallEval => "INST - CallEval",
             Self::CallEvalWithRest => "INST - CallEvalWithRest",
@@ -1436,6 +1453,7 @@ impl Opcode {
             Self::PopOnReturnSub => "INST - PopOnReturnSub",
             Self::Yield => "INST - Yield",
             Self::GeneratorNext => "INST - GeneratorNext",
+            Self::Await => "INST - Await",
             Self::GeneratorNextDelegate => "INST - GeneratorNextDelegate",
             Self::Nop => "INST - Nop",
             Self::PushClassPrototype => "INST - PushClassPrototype",


### PR DESCRIPTION
This Pull Request changes the following:

- Implement `AsyncFunction` builtin object.
- Add `Async` as a function object data type.
- Implement `async function` and `await` compilation and execution.
- Parse `await` in more positions.
