### PR TITLE
[Merged by Bors] - Store call frames in `Vec` instead of singly-linked list

### DIFF
--- a/boa_engine/src/builtins/console/mod.rs
+++ b/boa_engine/src/builtins/console/mod.rs
@@ -294,16 +294,14 @@ impl Console {
 
     fn get_stack_trace(context: &mut Context) -> Vec<String> {
         let mut stack_trace: Vec<String> = vec![];
-        let mut prev_frame = context.vm.frame.as_ref();
 
-        while let Some(frame) = prev_frame {
+        for frame in context.vm.frames.iter().rev() {
             stack_trace.push(
                 context
                     .interner()
                     .resolve_expect(frame.code.name)
                     .to_owned(),
             );
-            prev_frame = frame.prev.as_ref();
         }
 
         stack_trace

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -263,7 +263,7 @@ impl Generator {
 
         let result = context.run();
 
-        generator_context.call_frame = *context
+        generator_context.call_frame = context
             .vm
             .pop_frame()
             .expect("generator call frame must exist");
@@ -384,7 +384,7 @@ impl Generator {
                 context.run()
             }
         };
-        generator_context.call_frame = *context
+        generator_context.call_frame = context
             .vm
             .pop_frame()
             .expect("generator call frame must exist");

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -714,7 +714,6 @@ impl Context {
         let _timer = Profiler::global().start_event("Execution", "Main");
 
         self.vm.push_frame(CallFrame {
-            prev: None,
             code: code_block,
             pc: 0,
             catch: Vec::new(),
@@ -833,7 +832,7 @@ impl ContextBuilder {
             console: Console::default(),
             intrinsics: Intrinsics::default(),
             vm: Vm {
-                frame: None,
+                frames: Vec::with_capacity(16),
                 stack: Vec::with_capacity(1024),
                 trace: false,
                 stack_size_limit: 1024,

--- a/boa_engine/src/vm/call_frame.rs
+++ b/boa_engine/src/vm/call_frame.rs
@@ -7,7 +7,6 @@ use boa_gc::{Finalize, Gc, Trace};
 
 #[derive(Clone, Debug, Finalize, Trace)]
 pub struct CallFrame {
-    pub(crate) prev: Option<Box<Self>>,
     pub(crate) code: Gc<CodeBlock>,
     pub(crate) pc: usize,
     #[unsafe_ignore_trace]

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -723,7 +723,6 @@ impl JsObject {
                 let has_expressions = code.params.has_expressions();
 
                 context.vm.push_frame(CallFrame {
-                    prev: None,
                     code,
                     pc: 0,
                     catch: Vec::new(),
@@ -844,7 +843,6 @@ impl JsObject {
                 let has_expressions = code.params.has_expressions();
 
                 context.vm.push_frame(CallFrame {
-                    prev: None,
                     code,
                     pc: 0,
                     catch: Vec::new(),
@@ -955,7 +953,6 @@ impl JsObject {
                 let param_count = code.params.parameters.len();
 
                 let call_frame = CallFrame {
-                    prev: None,
                     code,
                     pc: 0,
                     catch: Vec::new(),
@@ -999,7 +996,7 @@ impl JsObject {
                         state: GeneratorState::SuspendedStart,
                         context: Some(Gc::new(Cell::new(GeneratorContext {
                             environments,
-                            call_frame: *call_frame,
+                            call_frame,
                             stack,
                         }))),
                     }),
@@ -1189,7 +1186,6 @@ impl JsObject {
                 let param_count = code.params.parameters.len();
 
                 context.vm.push_frame(CallFrame {
-                    prev: None,
                     code,
                     pc: 0,
                     catch: Vec::new(),


### PR DESCRIPTION
This storage method should be more cache friendly since we store in contiguous memory, besides that it should make #2157 a bit easier. Will work on that next after this gets merged :)

It changes the following:
- Remove the unneeded `prev` field in `CallFrame`
- Preallocate some space for future calls (16 slots) 
