### PR TITLE
Implement arrow function parsing based on `CoverParenthesizedExpressionAndArrowParameterList`

### DIFF
--- a/boa_engine/src/bytecompiler.rs
+++ b/boa_engine/src/bytecompiler.rs
@@ -994,6 +994,11 @@ impl<'b> ByteCompiler<'b> {
                             self.emit(Opcode::CopyDataProperties, &[0]);
                             self.emit_opcode(Opcode::Pop);
                         }
+                        PropertyDefinition::CoverInitializedName(_, _) => {
+                            return self.context.throw_syntax_error(
+                                "invalid assignment pattern in object literal",
+                            );
+                        }
                     }
                 }
 
@@ -2025,6 +2030,8 @@ impl<'b> ByteCompiler<'b> {
         let env_label = if parameters.has_expressions() {
             compiler.code_block.num_bindings = compiler.context.get_binding_number();
             compiler.context.push_compile_time_environment(true);
+            compiler.code_block.function_environment_push_location =
+                compiler.next_opcode_location();
             Some(compiler.emit_opcode_with_two_operands(Opcode::PushFunctionEnvironment))
         } else {
             None
@@ -2665,6 +2672,8 @@ impl<'b> ByteCompiler<'b> {
             let env_label = if expr.parameters().has_expressions() {
                 compiler.code_block.num_bindings = compiler.context.get_binding_number();
                 compiler.context.push_compile_time_environment(true);
+                compiler.code_block.function_environment_push_location =
+                    compiler.next_opcode_location();
                 Some(compiler.emit_opcode_with_two_operands(Opcode::PushFunctionEnvironment))
             } else {
                 None

--- a/boa_engine/src/syntax/ast/node/declaration/mod.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/mod.rs
@@ -514,7 +514,7 @@ impl DeclarationPattern {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeclarationPatternObject {
     bindings: Vec<BindingPatternTypeObject>,
-    init: Option<Node>,
+    pub(crate) init: Option<Node>,
 }
 
 impl ToInternedString for DeclarationPatternObject {
@@ -613,7 +613,7 @@ impl DeclarationPatternObject {
 #[derive(Clone, Debug, PartialEq)]
 pub struct DeclarationPatternArray {
     bindings: Vec<BindingPatternTypeArray>,
-    init: Option<Node>,
+    pub(crate) init: Option<Node>,
 }
 
 impl ToInternedString for DeclarationPatternArray {

--- a/boa_engine/src/syntax/ast/node/object/mod.rs
+++ b/boa_engine/src/syntax/ast/node/object/mod.rs
@@ -112,6 +112,13 @@ impl Object {
                         },
                     )
                 }
+                PropertyDefinition::CoverInitializedName(ident, expr) => {
+                    format!(
+                        "{indentation}{} = {},\n",
+                        interner.resolve_expect(*ident),
+                        expr.to_no_indent_string(interner, indent_n + 1)
+                    )
+                }
             });
         }
         buf.push_str(&format!("{}}}", "    ".repeat(indent_n)));
@@ -201,6 +208,14 @@ pub enum PropertyDefinition {
     /// [spec]: https://tc39.es/ecma262/#prod-PropertyDefinition
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer#Spread_properties
     SpreadObject(Node),
+
+    /// Cover grammar for when an object literal is used as an object biding pattern.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-CoverInitializedName
+    CoverInitializedName(Sym, Node),
 }
 
 impl PropertyDefinition {

--- a/boa_engine/src/syntax/ast/punctuator.rs
+++ b/boa_engine/src/syntax/ast/punctuator.rs
@@ -141,7 +141,7 @@ impl Punctuator {
     /// Attempts to convert a punctuator (`+`, `=`...) to a Binary Operator
     ///
     /// If there is no match, `None` will be returned.
-    pub fn as_binop(self) -> Option<BinOp> {
+    pub const fn as_binop(self) -> Option<BinOp> {
         match self {
             Self::AssignAdd => Some(BinOp::Assign(AssignOp::Add)),
             Self::AssignAnd => Some(BinOp::Assign(AssignOp::And)),

--- a/boa_engine/src/syntax/parser/cursor/mod.rs
+++ b/boa_engine/src/syntax/parser/cursor/mod.rs
@@ -261,6 +261,20 @@ where
         }
     }
 
+    /// Check if the peeked token is a line terminator.
+    #[inline]
+    pub(super) fn peek_expect_is_line_terminator(
+        &mut self,
+        skip_n: usize,
+        interner: &mut Interner,
+    ) -> Result<bool, ParseError> {
+        if let Some(t) = self.buffered_lexer.peek(skip_n, false, interner)? {
+            Ok(t.kind() == &TokenKind::LineTerminator)
+        } else {
+            Err(ParseError::AbruptEnd)
+        }
+    }
+
     /// Advance the cursor to the next token and retrieve it, only if it's of `kind` type.
     ///
     /// When the next token is a `kind` token, get the token, otherwise return `None`.

--- a/boa_engine/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -158,13 +158,13 @@ where
 
 /// <https://tc39.es/ecma262/#prod-ConciseBody>
 #[derive(Debug, Clone, Copy)]
-struct ConciseBody {
+pub(in crate::syntax::parser) struct ConciseBody {
     allow_in: AllowIn,
 }
 
 impl ConciseBody {
     /// Creates a new `ConciseBody` parser.
-    fn new<I>(allow_in: I) -> Self
+    pub(in crate::syntax::parser) fn new<I>(allow_in: I) -> Self
     where
         I: Into<AllowIn>,
     {

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -28,14 +28,24 @@ use self::{
 };
 use crate::syntax::{
     ast::{
-        node::{Call, Identifier, New, Node},
-        Const, Keyword, Punctuator,
+        node::{
+            declaration::{BindingPatternTypeArray, BindingPatternTypeObject},
+            operator::assign::{
+                array_decl_to_declaration_pattern, object_decl_to_declaration_pattern, AssignTarget,
+            },
+            Call, Declaration, DeclarationPattern, FormalParameter, FormalParameterList,
+            Identifier, New, Node,
+        },
+        op::BinOp,
+        Const, Keyword, Punctuator, Span,
     },
-    lexer::{token::Numeric, InputElement, TokenKind},
+    lexer::{token::Numeric, InputElement, Token, TokenKind},
     parser::{
         expression::{
-            identifiers::IdentifierReference, primary::template::TemplateLiteral, Expression,
+            identifiers::IdentifierReference, primary::template::TemplateLiteral,
+            BindingIdentifier, Expression,
         },
+        statement::{ArrayBindingPattern, ObjectBindingPattern},
         AllowAwait, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
     },
 };
@@ -132,9 +142,12 @@ where
             TokenKind::Punctuator(Punctuator::OpenParen) => {
                 cursor.next(interner).expect("token disappeared");
                 cursor.set_goal(InputElement::RegExp);
-                let expr = Expression::new(self.name, true, self.allow_yield, self.allow_await)
-                    .parse(cursor, interner)?;
-                cursor.expect(Punctuator::CloseParen, "primary expression", interner)?;
+                let expr = CoverParenthesizedExpressionAndArrowParameterList::new(
+                    self.name,
+                    self.allow_yield,
+                    self.allow_await,
+                )
+                .parse(cursor, interner)?;
                 Ok(expr)
             }
             TokenKind::Punctuator(Punctuator::OpenBracket) => {
@@ -242,4 +255,305 @@ where
             )),
         }
     }
+}
+
+/// Parses a `CoverParenthesizedExpressionAndArrowParameterList` expression.
+///
+/// More information:
+///  - [ECMAScript specification][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-CoverParenthesizedExpressionAndArrowParameterList
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CoverParenthesizedExpressionAndArrowParameterList {
+    name: Option<Sym>,
+    allow_yield: AllowYield,
+    allow_await: AllowAwait,
+}
+
+impl CoverParenthesizedExpressionAndArrowParameterList {
+    /// Creates a new `CoverParenthesizedExpressionAndArrowParameterList` parser.
+    pub(super) fn new<N, Y, A>(name: N, allow_yield: Y, allow_await: A) -> Self
+    where
+        N: Into<Option<Sym>>,
+        Y: Into<AllowYield>,
+        A: Into<AllowAwait>,
+    {
+        Self {
+            name: name.into(),
+            allow_yield: allow_yield.into(),
+            allow_await: allow_await.into(),
+        }
+    }
+}
+
+impl<R> TokenParser<R> for CoverParenthesizedExpressionAndArrowParameterList
+where
+    R: Read,
+{
+    type Output = Node;
+
+    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
+        #[derive(Debug)]
+        enum InnerExpression {
+            Expression(Node),
+            SpreadObject(Vec<BindingPatternTypeObject>),
+            SpreadArray(Vec<BindingPatternTypeArray>),
+            SpreadBinding(Sym),
+        }
+
+        let _timer = Profiler::global().start_event(
+            "CoverParenthesizedExpressionAndArrowParameterList",
+            "Parsing",
+        );
+
+        let start_span = cursor
+            .peek(0, interner)?
+            .ok_or(ParseError::AbruptEnd)?
+            .span();
+
+        let mut expressions = Vec::new();
+        let mut tailing_comma = None;
+
+        let close_span = loop {
+            let next = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+            match next.kind() {
+                TokenKind::Punctuator(Punctuator::CloseParen) => {
+                    let span = next.span();
+                    cursor.next(interner).expect("token disappeared");
+                    break span;
+                }
+                TokenKind::Punctuator(Punctuator::Comma) => {
+                    let span = next.span();
+                    cursor.next(interner).expect("token disappeared");
+                    if let Some(token) = cursor.next_if(Punctuator::CloseParen, interner)? {
+                        tailing_comma = Some(span);
+                        break token.span();
+                    }
+                }
+                TokenKind::Punctuator(Punctuator::Spread) => {
+                    cursor.next(interner).expect("token disappeared");
+                    let next = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+                    match next.kind() {
+                        TokenKind::Punctuator(Punctuator::OpenBlock) => {
+                            let bindings =
+                                ObjectBindingPattern::new(self.allow_yield, self.allow_await)
+                                    .parse(cursor, interner)?;
+                            expressions.push(InnerExpression::SpreadObject(bindings));
+                        }
+                        TokenKind::Punctuator(Punctuator::OpenBracket) => {
+                            let bindings =
+                                ArrayBindingPattern::new(self.allow_yield, self.allow_await)
+                                    .parse(cursor, interner)?;
+                            expressions.push(InnerExpression::SpreadArray(bindings));
+                        }
+                        _ => {
+                            let binding =
+                                BindingIdentifier::new(self.allow_yield, self.allow_await)
+                                    .parse(cursor, interner)?;
+                            expressions.push(InnerExpression::SpreadBinding(binding));
+                        }
+                    }
+                }
+                _ => {
+                    let expression =
+                        Expression::new(self.name, true, self.allow_yield, self.allow_await)
+                            .parse(cursor, interner)?;
+                    expressions.push(InnerExpression::Expression(expression));
+                }
+            }
+        };
+
+        let is_arrow = if let Some(TokenKind::Punctuator(Punctuator::Arrow)) =
+            cursor.peek(0, interner)?.map(Token::kind)
+        {
+            !cursor.peek_expect_is_line_terminator(0, interner)?
+        } else {
+            false
+        };
+
+        // If the next token is not an arrow, we know that we must parse a parenthesized expression.
+        if !is_arrow {
+            if let Some(span) = tailing_comma {
+                return Err(ParseError::unexpected(
+                    ",".to_string(),
+                    span,
+                    "trailing comma in parenthesized expression",
+                ));
+            }
+            if expressions.is_empty() {
+                return Err(ParseError::unexpected(
+                    ")".to_string(),
+                    close_span,
+                    "empty parenthesized expression",
+                ));
+            }
+            if expressions.len() != 1 {
+                return Err(ParseError::unexpected(
+                    ")".to_string(),
+                    close_span,
+                    "multiple expressions in parenthesized expression",
+                ));
+            }
+            if let InnerExpression::Expression(expression) = &expressions[0] {
+                return Ok(expression.clone());
+            }
+            return Err(ParseError::unexpected(
+                ")".to_string(),
+                close_span,
+                "parenthesized expression with spread expressions",
+            ));
+        }
+
+        // We know that we must parse an arrow function.
+        // We parse the expressions in to a parameter list.
+
+        let mut parameters = Vec::new();
+
+        for expression in expressions {
+            match expression {
+                InnerExpression::Expression(node) => {
+                    node_to_formal_parameters(
+                        &node,
+                        &mut parameters,
+                        cursor.strict_mode(),
+                        start_span,
+                    )?;
+                }
+                InnerExpression::SpreadObject(bindings) => {
+                    let declaration = Declaration::new_with_object_pattern(bindings, None);
+                    let parameter = FormalParameter::new(declaration, true);
+                    parameters.push(parameter);
+                }
+                InnerExpression::SpreadArray(bindings) => {
+                    let declaration = Declaration::new_with_array_pattern(bindings, None);
+                    let parameter = FormalParameter::new(declaration, true);
+                    parameters.push(parameter);
+                }
+                InnerExpression::SpreadBinding(ident) => {
+                    let declaration = Declaration::new_with_identifier(ident, None);
+                    let parameter = FormalParameter::new(declaration, true);
+                    parameters.push(parameter);
+                }
+            }
+        }
+
+        let parameters = FormalParameterList::from(parameters);
+
+        if let Some(span) = tailing_comma {
+            if parameters.has_rest_parameter() {
+                return Err(ParseError::general(
+                    "rest parameter must be last formal parameter",
+                    span.start(),
+                ));
+            }
+        }
+
+        if parameters.contains_yield_expression() {
+            return Err(ParseError::general(
+                "yield expression is not allowed in formal parameter list of arrow function",
+                start_span.start(),
+            ));
+        }
+
+        Ok(Node::FormalParameterList(parameters))
+    }
+}
+
+/// Convert a node to a formal parameter and append it to the given parameter list.
+fn node_to_formal_parameters(
+    node: &Node,
+    parameters: &mut Vec<FormalParameter>,
+    strict: bool,
+    span: Span,
+) -> Result<(), ParseError> {
+    match node {
+        Node::Identifier(identifier) if strict && identifier.sym() == Sym::EVAL => {
+            return Err(ParseError::general(
+                "parameter name 'eval' not allowed in strict mode",
+                span.start(),
+            ));
+        }
+        Node::Identifier(identifier) if strict && identifier.sym() == Sym::ARGUMENTS => {
+            return Err(ParseError::general(
+                "parameter name 'arguments' not allowed in strict mode",
+                span.start(),
+            ));
+        }
+        Node::Identifier(identifier) => {
+            parameters.push(FormalParameter::new(
+                Declaration::new_with_identifier(identifier.sym(), None),
+                false,
+            ));
+        }
+        Node::BinOp(bin_op) if bin_op.op() == BinOp::Comma => {
+            node_to_formal_parameters(bin_op.lhs(), parameters, strict, span)?;
+            node_to_formal_parameters(bin_op.rhs(), parameters, strict, span)?;
+        }
+        Node::Assign(assign) => match assign.lhs() {
+            AssignTarget::Identifier(ident) => {
+                parameters.push(FormalParameter::new(
+                    Declaration::new_with_identifier(ident.sym(), Some(assign.rhs().clone())),
+                    false,
+                ));
+            }
+            AssignTarget::DeclarationPattern(pattern) => match pattern {
+                DeclarationPattern::Object(pattern) => {
+                    parameters.push(FormalParameter::new(
+                        Declaration::new_with_object_pattern(
+                            pattern.bindings().clone(),
+                            Some(assign.rhs().clone()),
+                        ),
+                        false,
+                    ));
+                }
+                DeclarationPattern::Array(pattern) => {
+                    parameters.push(FormalParameter::new(
+                        Declaration::new_with_array_pattern(
+                            pattern.bindings().clone(),
+                            Some(assign.rhs().clone()),
+                        ),
+                        false,
+                    ));
+                }
+            },
+            _ => {
+                return Err(ParseError::general(
+                    "invalid initialization expression in formal parameter list",
+                    span.start(),
+                ));
+            }
+        },
+        Node::Object(object) => {
+            let decl = object_decl_to_declaration_pattern(object, strict);
+
+            if let Some(pattern) = decl {
+                parameters.push(FormalParameter::new(Declaration::Pattern(pattern), false));
+            } else {
+                return Err(ParseError::general(
+                    "invalid object binding pattern in formal parameter list",
+                    span.start(),
+                ));
+            }
+        }
+        Node::ArrayDecl(array) => {
+            let decl = array_decl_to_declaration_pattern(array, strict);
+
+            if let Some(pattern) = decl {
+                parameters.push(FormalParameter::new(Declaration::Pattern(pattern), false));
+            } else {
+                return Err(ParseError::general(
+                    "invalid array binding pattern in formal parameter list",
+                    span.start(),
+                ));
+            }
+        }
+        _ => {
+            return Err(ParseError::unexpected(
+                ")".to_string(),
+                span,
+                "parenthesized expression with non-binding expression",
+            ));
+        }
+    }
+    Ok(())
 }

--- a/boa_engine/src/syntax/parser/function/mod.rs
+++ b/boa_engine/src/syntax/parser/function/mod.rs
@@ -99,7 +99,10 @@ where
                 _ => {
                     let param = FormalParameter::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
-                    if param.init().is_none() {
+                    if !(flags.contains(FormalParameterListFlags::HAS_EXPRESSIONS)
+                        || param.is_rest_param()
+                        || param.init().is_some())
+                    {
                         length += 1;
                     }
                     param
@@ -300,7 +303,7 @@ where
         if let Some(t) = cursor.peek(0, interner)? {
             let declaration = match *t.kind() {
                 TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                    let param = ObjectBindingPattern::new(true, self.allow_yield, self.allow_await)
+                    let param = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
 
                     let init = cursor
@@ -320,7 +323,7 @@ where
 
                 TokenKind::Punctuator(Punctuator::OpenBracket) => {
                     Declaration::new_with_array_pattern(
-                        ArrayBindingPattern::new(true, self.allow_yield, self.allow_await)
+                        ArrayBindingPattern::new(self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
                         None,
                     )
@@ -399,9 +402,8 @@ where
         if let Some(t) = cursor.peek(0, interner)? {
             let declaration = match *t.kind() {
                 TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                    let bindings =
-                        ObjectBindingPattern::new(true, self.allow_yield, self.allow_await)
-                            .parse(cursor, interner)?;
+                    let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
+                        .parse(cursor, interner)?;
                     let init = if *cursor
                         .peek(0, interner)?
                         .ok_or(ParseError::AbruptEnd)?
@@ -419,9 +421,8 @@ where
                     Declaration::new_with_object_pattern(bindings, init)
                 }
                 TokenKind::Punctuator(Punctuator::OpenBracket) => {
-                    let bindings =
-                        ArrayBindingPattern::new(true, self.allow_yield, self.allow_await)
-                            .parse(cursor, interner)?;
+                    let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
+                        .parse(cursor, interner)?;
                     let init = if *cursor
                         .peek(0, interner)?
                         .ok_or(ParseError::AbruptEnd)?

--- a/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
@@ -274,9 +274,8 @@ where
 
         match peek_token.kind() {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                let bindings =
-                    ObjectBindingPattern::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
@@ -309,9 +308,8 @@ where
                 Ok(Declaration::Pattern(declaration))
             }
             TokenKind::Punctuator(Punctuator::OpenBracket) => {
-                let bindings =
-                    ArrayBindingPattern::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {

--- a/boa_engine/src/syntax/parser/statement/try_stm/catch.rs
+++ b/boa_engine/src/syntax/parser/statement/try_stm/catch.rs
@@ -192,13 +192,13 @@ where
 
         match token.kind() {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                let pat = ObjectBindingPattern::new(true, self.allow_yield, self.allow_await)
+                let pat = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
                 Ok(node::Declaration::new_with_object_pattern(pat, None))
             }
             TokenKind::Punctuator(Punctuator::OpenBracket) => {
-                let pat = ArrayBindingPattern::new(true, self.allow_yield, self.allow_await)
+                let pat = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
                 Ok(node::Declaration::new_with_array_pattern(pat, None))
             }

--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -183,9 +183,8 @@ where
 
         match peek_token.kind() {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                let bindings =
-                    ObjectBindingPattern::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
@@ -208,9 +207,8 @@ where
                 Ok(Declaration::new_with_object_pattern(bindings, init))
             }
             TokenKind::Punctuator(Punctuator::OpenBracket) => {
-                let bindings =
-                    ArrayBindingPattern::new(self.allow_in, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?;
+                let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?;
 
                 let init = if let Some(t) = cursor.peek(0, interner)? {
                     if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -2388,7 +2388,7 @@ impl Context {
         let _timer = Profiler::global().start_event("run", "vm");
 
         if self.vm.trace {
-            let msg = if self.vm.frames.get(self.vm.frames.len() - 2).is_some() {
+            let msg = if self.vm.frames.last().is_some() {
                 " Call Frame "
             } else {
                 " VM Start "


### PR DESCRIPTION
Previously we parsed arrow functions without the relevant cover grammar `CoverParenthesizedExpressionAndArrowParameterList`. This leads to either arrow functions or parenthesized expressions not being parsed correctly. Implementing this is a bit tricky, as the cover grammar is being parsed in `PrimaryExpression` while arrow functions are parsed in `AssignmentExpression`. This means that we have to return the covered parameter list that was parsed via `CoverParenthesizedExpressionAndArrowParameterList` in `PrimaryExpression` to `AssignmentExpression`. Fortunately this works pretty good and now the full arrow function test suite, with the exception of a few tests that require other features, passes.

This Pull Request changes the following:

- Implement `CoverParenthesizedExpressionAndArrowParameterList` parsing.
- Implement `CoverInitializedName` parsing in object literals.
- Fix a bug where an environment would be wrongly removed from the environment stack when an expression in default function parameters throws.
- Add more valid cases where on object literal can be converted to an object declaration pattern.
- Implement `Expression` parsing manually to avoid some cases where the parser would prematurely throw an error.
- Implement parsing of arrow functions via `CoverParenthesizedExpressionAndArrowParameterList`.
- Remove unneeded `AllowIn` flag on array and object declaration pattern parsers.
- Fix an of-by-one bug in the trace output.