### PR TITLE
[Merged by Bors] - Implement Generator Function Constructor

### DIFF
--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -100,7 +100,7 @@ impl AsyncFunction {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         crate::builtins::function::BuiltInFunctionObject::create_dynamic_function(
-            new_target, args, true, context,
+            new_target, args, true, false, context,
         )
         .map(Into::into)
     }

--- a/boa_engine/src/syntax/ast/node/yield/mod.rs
+++ b/boa_engine/src/syntax/ast/node/yield/mod.rs
@@ -29,13 +29,12 @@ impl Yield {
     }
 
     /// Creates a `Yield` AST node.
-    pub fn new<E, OE>(expr: OE, delegate: bool) -> Self
+    pub fn new<E>(expr: Option<E>, delegate: bool) -> Self
     where
         E: Into<Node>,
-        OE: Into<Option<E>>,
     {
         Self {
-            expr: expr.into().map(E::into).map(Box::new),
+            expr: expr.map(Into::into).map(Box::new),
             delegate,
         }
     }

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
@@ -25,7 +25,7 @@ fn check_generator_function_expression() {
                     GeneratorExpr::new::<_, _, StatementList>(
                         Some(gen),
                         FormalParameterList::default(),
-                        vec![Yield::new(Const::from(1), false).into()].into(),
+                        vec![Yield::new(Some(Const::from(1)), false).into()].into(),
                     )
                     .into(),
                 ),
@@ -53,7 +53,7 @@ fn check_generator_function_delegate_yield_expression() {
                     GeneratorExpr::new::<_, _, StatementList>(
                         Some(gen),
                         FormalParameterList::default(),
-                        vec![Yield::new(Const::from(1), true).into()].into(),
+                        vec![Yield::new(Some(Const::from(1)), true).into()].into(),
                     )
                     .into(),
                 ),

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -446,11 +446,14 @@ impl ToInternedString for CodeBlock {
 pub(crate) fn create_function_object(
     code: Gc<CodeBlock>,
     r#async: bool,
+    prototype: Option<JsObject>,
     context: &mut Context,
 ) -> JsObject {
     let _timer = Profiler::global().start_event("JsVmFunction::new", "vm");
 
-    let function_prototype = if r#async {
+    let function_prototype = if let Some(prototype) = prototype {
+        prototype
+    } else if r#async {
         context
             .intrinsics()
             .constructors()

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     value::Numeric,
     vm::{
         call_frame::CatchAddresses,
-        code_block::{create_generator_function_object, initialize_instance_elements, Readable},
+        code_block::{initialize_instance_elements, Readable},
     },
     Context, JsBigInt, JsResult, JsString, JsValue,
 };
@@ -30,7 +30,7 @@ pub use {call_frame::CallFrame, code_block::CodeBlock, opcode::Opcode};
 
 pub(crate) use {
     call_frame::{FinallyReturn, GeneratorResumeKind, TryStackEntry},
-    code_block::create_function_object,
+    code_block::{create_function_object, create_generator_function_object},
     opcode::BindingOpcode,
 };
 
@@ -1683,13 +1683,13 @@ impl Context {
             Opcode::GetFunction => {
                 let index = self.vm.read::<u32>();
                 let code = self.vm.frame().code.functions[index as usize].clone();
-                let function = create_function_object(code, false, self);
+                let function = create_function_object(code, false, None, self);
                 self.vm.push(function);
             }
             Opcode::GetFunctionAsync => {
                 let index = self.vm.read::<u32>();
                 let code = self.vm.frame().code.functions[index as usize].clone();
-                let function = create_function_object(code, true, self);
+                let function = create_function_object(code, true, None, self);
                 self.vm.push(function);
             }
             Opcode::GetGenerator => {

--- a/boa_interner/src/sym.rs
+++ b/boa_interner/src/sym.rs
@@ -82,6 +82,9 @@ impl Sym {
     /// Symbol for the `"public"` string.
     pub const PUBLIC: Self = unsafe { Self::new_unchecked(22) };
 
+    /// Symbol for the `"anonymous"` string.
+    pub const ANONYMOUS: Self = unsafe { Self::new_unchecked(23) };
+
     /// Creates a new [`Sym`] from the provided `value`, or returns `None` if `index` is zero.
     #[inline]
     pub(super) fn new(value: usize) -> Option<Self> {
@@ -141,6 +144,7 @@ pub(super) static COMMON_STRINGS: phf::OrderedSet<&'static str> = {
         "private",
         "protected",
         "public",
+        "anonymous",
     };
     // A `COMMON_STRINGS` of size `usize::MAX` would cause an overflow on our `Interner`
     sa::const_assert!(COMMON_STRINGS.len() < usize::MAX);


### PR DESCRIPTION
This Pull Request changes the following:

- Modify `CreateDynamicFunction` to work with generator functions.
- Add the name `anonymus` to functions created via `CreateDynamicFunction` to comply with the spec. 
- Fix a bug in the `Yield` parser where the parser would expect a token when no token is a legal case.
- Change the `Yield::new` function to require less turbofishes.
