### PR TITLE
Remove incorrect `cursor.set_goal()` call in `AssignmentExpression` parsing

### DIFF
--- a/boa_engine/src/syntax/lexer/tests.rs
+++ b/boa_engine/src/syntax/lexer/tests.rs
@@ -635,6 +635,22 @@ fn regex_literal() {
 }
 
 #[test]
+fn regex_equals_following_assignment() {
+    let mut lexer = Lexer::new(&b"const myRegex = /=/;"[..]);
+    let mut interner = Interner::default();
+
+    let expected = [
+        TokenKind::Keyword((Keyword::Const, false)),
+        TokenKind::identifier(interner.get_or_intern_static("myRegex")),
+        TokenKind::Punctuator(Punctuator::Assign),
+        TokenKind::regular_expression_literal(interner.get_or_intern_static("="), Sym::EMPTY_STRING),
+        TokenKind::Punctuator(Punctuator::Semicolon),
+    ];
+
+    expect_tokens(&mut lexer, &expected, &mut interner);
+}
+
+#[test]
 fn regex_literal_flags() {
     let mut lexer = Lexer::new(&br"/\/[^\/]*\/*/gmi"[..]);
     let mut interner = Interner::default();

--- a/boa_engine/src/syntax/lexer/tests.rs
+++ b/boa_engine/src/syntax/lexer/tests.rs
@@ -643,7 +643,10 @@ fn regex_equals_following_assignment() {
         TokenKind::Keyword((Keyword::Const, false)),
         TokenKind::identifier(interner.get_or_intern_static("myRegex")),
         TokenKind::Punctuator(Punctuator::Assign),
-        TokenKind::regular_expression_literal(interner.get_or_intern_static("="), Sym::EMPTY_STRING),
+        TokenKind::regular_expression_literal(
+            interner.get_or_intern_static("="), 
+            Sym::EMPTY_STRING
+        ),
         TokenKind::Punctuator(Punctuator::Semicolon),
     ];
 

--- a/boa_engine/src/syntax/lexer/tests.rs
+++ b/boa_engine/src/syntax/lexer/tests.rs
@@ -644,8 +644,8 @@ fn regex_equals_following_assignment() {
         TokenKind::identifier(interner.get_or_intern_static("myRegex")),
         TokenKind::Punctuator(Punctuator::Assign),
         TokenKind::regular_expression_literal(
-            interner.get_or_intern_static("="), 
-            Sym::EMPTY_STRING
+            interner.get_or_intern_static("="),
+            Sym::EMPTY_STRING,
         ),
         TokenKind::Punctuator(Punctuator::Semicolon),
     ];

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -90,7 +90,6 @@ where
 
     fn parse(mut self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult {
         let _timer = Profiler::global().start_event("AssignmentExpression", "Parsing");
-        cursor.set_goal(InputElement::Div);
 
         match cursor
             .peek(0, interner)?

--- a/boa_engine/src/syntax/parser/tests.rs
+++ b/boa_engine/src/syntax/parser/tests.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     Context,
 };
-use boa_interner::Interner;
+use boa_interner::{Interner, Sym};
 
 /// Checks that the given JavaScript string gives the expected expression.
 #[allow(clippy::unwrap_used)]
@@ -72,6 +72,29 @@ fn assign_operator_precedence() {
                 Identifier::new(interner.get_or_intern_static("a")),
                 Const::from(1),
             ),
+        )
+        .into()],
+        interner,
+    );
+}
+
+#[test]
+fn assign_regex_equals() {
+    let mut interner = Interner::default();
+    check_parser(
+        "let myRegex = /=/;",
+        vec![DeclarationList::Let(
+            vec![Declaration::new_with_identifier(
+                interner.get_or_intern_static("myRegex"),
+                Node::from(New::from(Call::new(
+                    Identifier::new(Sym::REGEXP),
+                    vec![
+                        Node::from(Const::from(interner.get_or_intern_static("="))),
+                        Node::from(Const::from(Sym::EMPTY_STRING)),
+                    ],
+                ))),
+            )]
+            .into(),
         )
         .into()],
         interner,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes/closes #2148 .

It changes the following:

- Adds a test to the lexer showing that the lexar produces correct tokens
- Removes `cursor.set_goal()` call from the AssignmentExpression parse expression
