### PR TITLE
[Merged by Bors] - Upgraded rustyline & phf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -949,15 +949,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1071,20 +1069,19 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+checksum = "4724fa946c8d1e7cd881bd3dbee63ce32fc1e9e191e35786b3dc1320a3f68131"
 dependencies = [
  "phf_macros",
  "phf_shared",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "5b450720b6f75cfbfabc195814bd3765f337a4f9a83186f8537297cac12f6705"
 dependencies = [
  "phf_shared",
  "rand",
@@ -1092,13 +1089,12 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+checksum = "cd94351ac44e70e56b59883e15029a5135f902a8a3020f9c18d580a420e526aa"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -1106,9 +1102,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "9dd5609d4b2df87167f908a32e1b146ce309c16cf35df76bc11f440b756048e4"
 dependencies = [
  "siphasher",
 ]
@@ -1186,12 +1182,6 @@ dependencies = [
  "quote",
  "version_check",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
@@ -1358,9 +1348,9 @@ dependencies = [
 
 [[package]]
 name = "rustyline"
-version = "9.1.2"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7826789c0e25614b03e5a54a0717a86f9ff6e6e5247f92b369472869320039"
+checksum = "1d1cd5ae51d3f7bf65d7969d579d502168ef578f289452bd8ccc91de28fda20e"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1373,7 +1363,6 @@ dependencies = [
  "nix",
  "radix_trie",
  "scopeguard",
- "smallvec",
  "unicode-segmentation",
  "unicode-width",
  "utf8parse",

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -14,13 +14,13 @@ default-run = "boa"
 [dependencies]
 boa_engine = { path = "../boa_engine", features = ["deser", "console"], version = "0.15.0" }
 boa_interner = { path = "../boa_interner", version = "0.15.0" }
-rustyline = "9.1.2"
+rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
 clap = { version = "3.2.12", features = ["derive"] }
 serde_json = "1.0.82"
 colored = "2.0.0"
 regex = "1.6.0"
-phf = { version = "0.10.1", features = ["macros"] }
+phf = { version = "0.11.0", features = ["macros"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5.0"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -180,7 +180,7 @@ where
     Ok(())
 }
 
-pub fn main() -> Result<(), std::io::Error> {
+pub fn main() -> Result<(), io::Error> {
     let args = Opt::parse();
 
     let mut context = Context::default();
@@ -213,7 +213,8 @@ pub fn main() -> Result<(), std::io::Error> {
             })
             .build();
 
-        let mut editor = Editor::with_config(config);
+        let mut editor =
+            Editor::with_config(config).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         editor.load_history(CLI_HISTORY).map_err(|err| match err {
             ReadlineError::Io(e) => e,
             e => io::Error::new(io::ErrorKind::Other, e),


### PR DESCRIPTION
This Pull Request overrides #2183 #2187, #2189 and #2190.

It changes the following:

- Updates rustyline to 10.0.0 (this uses the new phf 0.11)
- Updates phf to 0.11 to avoid different dependency versions
- Fixes the `Editor` creation, which now returns a `Result`.
