### PR TITLE
[Merged by Bors] - Fix length/index in `32bit` architectures

### DIFF
--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -17,7 +17,7 @@ use boa_profiler::Profiler;
 #[derive(Debug, Clone, Finalize, Trace)]
 pub struct ArrayIterator {
     array: JsObject,
-    next_index: usize,
+    next_index: u64,
     kind: PropertyNameKind,
     done: bool,
 }

--- a/boa_engine/src/builtins/array_buffer/tests.rs
+++ b/boa_engine/src/builtins/array_buffer/tests.rs
@@ -11,5 +11,5 @@ fn ut_sunny_day_create_byte_data_block() {
 fn ut_rainy_day_create_byte_data_block() {
     let mut context = Context::default();
 
-    assert!(create_byte_data_block(usize::MAX, &mut context).is_err());
+    assert!(create_byte_data_block(u64::MAX, &mut context).is_err());
 }

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -16,8 +16,8 @@ use tap::{Conv, Pipe};
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct DataView {
     viewed_array_buffer: JsObject,
-    byte_length: usize,
-    byte_offset: usize,
+    byte_length: u64,
+    byte_offset: u64,
 }
 
 impl BuiltIn for DataView {

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -812,7 +812,7 @@ impl RegExp {
         // 2. Assert: Type(S) is String.
 
         // 3. Let length be the number of code units in S.
-        let length = input.encode_utf16().count();
+        let length = input.encode_utf16().count() as u64;
 
         // 4. Let lastIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
         let mut last_index = this.get("lastIndex", context)?.to_length(context)?;
@@ -855,7 +855,10 @@ impl RegExp {
             // b. Let r be matcher(S, lastIndex).
             // Check if last_index is a valid utf8 index into input.
             let last_byte_index = match String::from_utf16(
-                &input.encode_utf16().take(last_index).collect::<Vec<u16>>(),
+                &input
+                    .encode_utf16()
+                    .take(last_index as usize)
+                    .collect::<Vec<u16>>(),
             ) {
                 Ok(s) => s.len(),
                 Err(_) => {
@@ -884,7 +887,7 @@ impl RegExp {
                 Some(m) => {
                     // c. If r is failure, then
                     #[allow(clippy::if_not_else)]
-                    if m.start() != last_index {
+                    if m.start() as u64 != last_index {
                         // i. If sticky is true, then
                         if sticky {
                             // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
@@ -925,9 +928,9 @@ impl RegExp {
         }
 
         // 16. Let n be the number of elements in r's captures List. (This is the same value as 22.2.2.1's NcapturingParens.)
-        let n = match_value.captures.len();
+        let n = match_value.captures.len() as u64;
         // 17. Assert: n < 23^2 - 1.
-        debug_assert!(n < 23usize.pow(2) - 1);
+        debug_assert!(n < 23u64.pow(2) - 1);
 
         // 18. Let A be ! ArrayCreate(n + 1).
         // 19. Assert: The mathematical value of A's "length" property is n + 1.
@@ -990,7 +993,7 @@ impl RegExp {
         // 27. For each integer i such that i ≥ 1 and i ≤ n, in ascending order, do
         for i in 1..=n {
             // a. Let captureI be ith element of r's captures List.
-            let capture = match_value.group(i);
+            let capture = match_value.group(i as usize);
 
             let captured_value = match capture {
                 // b. If captureI is undefined, let capturedValue be undefined.
@@ -1597,7 +1600,7 @@ impl RegExp {
         }
 
         // 15. Let size be the length of S.
-        let size = arg_str.encode_utf16().count();
+        let size = arg_str.encode_utf16().count() as u64;
 
         // 16. If size is 0, then
         if size == 0 {
@@ -1648,8 +1651,8 @@ impl RegExp {
                     let arg_str_substring = String::from_utf16_lossy(
                         &arg_str
                             .encode_utf16()
-                            .skip(p)
-                            .take(q - p)
+                            .skip(p as usize)
+                            .take((q - p) as usize)
                             .collect::<Vec<u16>>(),
                     );
 
@@ -1709,8 +1712,8 @@ impl RegExp {
         let arg_str_substring = String::from_utf16_lossy(
             &arg_str
                 .encode_utf16()
-                .skip(p)
-                .take(size - p)
+                .skip(p as usize)
+                .take((size - p) as usize)
                 .collect::<Vec<u16>>(),
         );
 
@@ -1729,7 +1732,7 @@ impl RegExp {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-advancestringindex
-fn advance_string_index(s: &JsString, index: usize, unicode: bool) -> usize {
+fn advance_string_index(s: &JsString, index: u64, unicode: bool) -> u64 {
     // Regress only works with utf8, so this function differs from the spec.
 
     // 1. Assert: index ≤ 2^53 - 1.
@@ -1740,7 +1743,7 @@ fn advance_string_index(s: &JsString, index: usize, unicode: bool) -> usize {
     }
 
     // 3. Let length be the number of code units in S.
-    let length = s.encode_utf16().count();
+    let length = s.encode_utf16().count() as u64;
 
     // 4. If index + 1 ≥ length, return index + 1.
     if index + 1 > length {
@@ -1750,5 +1753,5 @@ fn advance_string_index(s: &JsString, index: usize, unicode: bool) -> usize {
     // 5. Let cp be ! CodePointAt(S, index).
     let (_, offset, _) = crate::builtins::string::code_point_at(s, index);
 
-    index + offset as usize
+    index + u64::from(offset)
 }

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -40,12 +40,12 @@ pub(crate) enum Placement {
     End,
 }
 
-pub(crate) fn code_point_at(string: &JsString, position: usize) -> (u32, u8, bool) {
+pub(crate) fn code_point_at(string: &JsString, position: u64) -> (u32, u8, bool) {
     let mut encoded = string.encode_utf16();
-    let size = encoded.clone().count();
+    let size = encoded.clone().count() as u64;
 
     let first = encoded
-        .nth(position)
+        .nth(position as usize)
         .expect("The callers of this function must've already checked bounds.");
     if !is_leading_surrogate(first) && !is_trailing_surrogate(first) {
         return (u32::from(first), 1, false);
@@ -309,7 +309,7 @@ impl String {
         let substitutions = args.get(1..).unwrap_or_default();
 
         // 1. Let numberOfSubstitutions be the number of elements in substitutions.
-        let number_of_substitutions = substitutions.len();
+        let number_of_substitutions = substitutions.len() as u64;
 
         // 2. Let cooked be ? ToObject(template).
         let cooked = args.get_or_undefined(0).to_object(context)?;
@@ -351,7 +351,7 @@ impl String {
 
             // e. If nextIndex < numberOfSubstitutions, let next be substitutions[nextIndex].
             let next = if next_index < number_of_substitutions {
-                substitutions.get_or_undefined(next_index).clone()
+                substitutions.get_or_undefined(next_index as usize).clone()
 
             // f. Else, let next be the empty String.
             } else {
@@ -544,7 +544,7 @@ impl String {
             IntegerOrInfinity::Integer(position) if (0..size).contains(&position) => {
                 // 6. Let cp be ! CodePointAt(S, position).
                 // 7. Return 𝔽(cp.[[CodePoint]]).
-                Ok(code_point_at(&string, position as usize).0.into())
+                Ok(code_point_at(&string, position as u64).0.into())
             }
             // 5. If position < 0 or position ≥ size, return undefined.
             _ => Ok(JsValue::undefined()),
@@ -1408,7 +1408,7 @@ impl String {
         let int_max_length = max_length.to_length(context)?;
 
         // 3. Let stringLength be the length of S.
-        let string_length = string.encode_utf16().count();
+        let string_length = string.encode_utf16().count() as u64;
 
         // 4. If intMaxLength ≤ stringLength, return S.
         if int_max_length <= string_length {
@@ -1430,7 +1430,7 @@ impl String {
 
         // 8. Let fillLen be intMaxLength - stringLength.
         let fill_len = int_max_length - string_length;
-        let filler_len = filler.encode_utf16().count();
+        let filler_len = filler.encode_utf16().count() as u64;
 
         // 9. Let truncatedStringFiller be the String value consisting of repeated
         // concatenations of filler truncated to length fillLen.
@@ -1445,9 +1445,9 @@ impl String {
         };
 
         let truncated_string_filler = filler
-            .repeat(repetitions)
+            .repeat(repetitions as usize)
             .encode_utf16()
-            .take(fill_len)
+            .take(fill_len as usize)
             .collect::<Vec<_>>();
         let truncated_string_filler =
             std::string::String::from_utf16_lossy(truncated_string_filler.as_slice());

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -61,7 +61,7 @@ impl StringIterator {
                 context,
             ));
         }
-        let (_, code_unit_count, _) = code_point_at(&native_string, position as usize);
+        let (_, code_unit_count, _) = code_point_at(&native_string, position as u64);
         string_iterator.next_index += i32::from(code_unit_count);
         let result_string = crate::builtins::string::String::substring(
             &string_iterator.string,

--- a/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
+++ b/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
@@ -32,18 +32,18 @@ unsafe impl Trace for ContentType {
 pub struct IntegerIndexed {
     viewed_array_buffer: Option<JsObject>,
     typed_array_name: TypedArrayKind,
-    byte_offset: usize,
-    byte_length: usize,
-    array_length: usize,
+    byte_offset: u64,
+    byte_length: u64,
+    array_length: u64,
 }
 
 impl IntegerIndexed {
     pub(crate) fn new(
         viewed_array_buffer: Option<JsObject>,
         typed_array_name: TypedArrayKind,
-        byte_offset: usize,
-        byte_length: usize,
-        array_length: usize,
+        byte_offset: u64,
+        byte_length: u64,
+        array_length: u64,
     ) -> Self {
         Self {
             viewed_array_buffer,
@@ -105,12 +105,12 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's byte offset.
-    pub(crate) fn byte_offset(&self) -> usize {
+    pub(crate) fn byte_offset(&self) -> u64 {
         self.byte_offset
     }
 
     /// Set the integer indexed object's byte offset.
-    pub(crate) fn set_byte_offset(&mut self, byte_offset: usize) {
+    pub(crate) fn set_byte_offset(&mut self, byte_offset: u64) {
         self.byte_offset = byte_offset;
     }
 
@@ -130,22 +130,22 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's byte length.
-    pub fn byte_length(&self) -> usize {
+    pub fn byte_length(&self) -> u64 {
         self.byte_length
     }
 
     /// Set the integer indexed object's byte length.
-    pub(crate) fn set_byte_length(&mut self, byte_length: usize) {
+    pub(crate) fn set_byte_length(&mut self, byte_length: u64) {
         self.byte_length = byte_length;
     }
 
     /// Get the integer indexed object's array length.
-    pub fn array_length(&self) -> usize {
+    pub fn array_length(&self) -> u64 {
         self.array_length
     }
 
     /// Set the integer indexed object's array length.
-    pub(crate) fn set_array_length(&mut self, array_length: usize) {
+    pub(crate) fn set_array_length(&mut self, array_length: u64) {
         self.array_length = array_length;
     }
 }

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -819,7 +819,7 @@ impl TypedArray {
             while count_bytes > 0 {
                 // i. Let value be GetValueFromBuffer(buffer, fromByteIndex, Uint8, true, Unordered).
                 let value = buffer.get_value_from_buffer(
-                    from_byte_index as usize,
+                    from_byte_index as u64,
                     TypedArrayKind::Uint8,
                     true,
                     SharedMemoryOrder::Unordered,
@@ -828,7 +828,7 @@ impl TypedArray {
 
                 // ii. Perform SetValueInBuffer(buffer, toByteIndex, Uint8, value, true, Unordered).
                 buffer.set_value_in_buffer(
-                    to_byte_index as usize,
+                    to_byte_index as u64,
                     TypedArrayKind::Uint8,
                     &value,
                     SharedMemoryOrder::Unordered,
@@ -2061,7 +2061,7 @@ impl TypedArray {
 
         // 15. If targetOffset is +∞, throw a RangeError exception.
         let target_offset = match target_offset {
-            IntegerOrInfinity::Integer(i) if i >= 0 => i as usize,
+            IntegerOrInfinity::Integer(i) if i >= 0 => i as u64,
             IntegerOrInfinity::PositiveInfinity => {
                 return context.throw_range_error("Target offset cannot be Infinity");
             }
@@ -2254,7 +2254,7 @@ impl TypedArray {
             IntegerOrInfinity::PositiveInfinity => {
                 return context.throw_range_error("Target offset cannot be Infinity")
             }
-            IntegerOrInfinity::Integer(i) if i >= 0 => i as usize,
+            IntegerOrInfinity::Integer(i) if i >= 0 => i as u64,
             _ => unreachable!(),
         };
 
@@ -2378,7 +2378,7 @@ impl TypedArray {
         };
 
         // 12. Let count be max(final - k, 0).
-        let count = std::cmp::max(r#final - k, 0) as usize;
+        let count = std::cmp::max(r#final - k, 0) as u64;
 
         // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
         let a = Self::species_create(obj, o.typed_array_name(), &[count.into()], context)?;
@@ -2449,7 +2449,7 @@ impl TypedArray {
                 let mut target_byte_index = a_array.byte_offset();
 
                 // vii. Let srcByteIndex be (k × elementSize) + srcByteOffset.
-                let mut src_byte_index = k as usize * element_size + src_byte_offset;
+                let mut src_byte_index = k as u64 * element_size + src_byte_offset;
 
                 // viii. Let limit be targetByteIndex + count × elementSize.
                 let limit = target_byte_index + count * element_size;
@@ -2601,7 +2601,7 @@ impl TypedArray {
         };
 
         // 4. Let items be a new empty List.
-        let mut items = Vec::with_capacity(len);
+        let mut items = Vec::with_capacity(len as usize);
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -2754,7 +2754,7 @@ impl TypedArray {
         }
 
         // 11. Repeat, while j < len,
-        for j in item_count..len {
+        for j in item_count..(len as usize) {
             // a. Perform ? DeletePropertyOrThrow(obj, ! ToString(𝔽(j))).
             obj.delete_property_or_throw(j, context)?;
             // b. Set j to j + 1.
@@ -2834,7 +2834,7 @@ impl TypedArray {
         let src_byte_offset = o.byte_offset();
 
         // 18. Let beginByteOffset be srcByteOffset + beginIndex × elementSize.
-        let begin_byte_offset = src_byte_offset + begin_index as usize * element_size;
+        let begin_byte_offset = src_byte_offset + begin_index as u64 * element_size;
 
         // 19. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
         // 20. Return ? TypedArraySpeciesCreate(O, argumentsList).
@@ -2997,7 +2997,7 @@ impl TypedArray {
     /// <https://tc39.es/ecma262/#sec-allocatetypedarraybuffer>
     fn allocate_buffer(
         indexed: &mut IntegerIndexed,
-        length: usize,
+        length: u64,
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. Assert: O.[[ViewedArrayBuffer]] is undefined.
@@ -3042,7 +3042,7 @@ impl TypedArray {
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. Let len be the number of elements in values.
-        let len = values.len();
+        let len = values.len() as u64;
         {
             let mut o = o.borrow_mut();
             let o_inner = o.as_typed_array_mut().expect("expected a TypedArray");
@@ -3080,7 +3080,7 @@ impl TypedArray {
         constructor_name: TypedArrayKind,
         new_target: &JsValue,
         default_proto: P,
-        length: Option<usize>,
+        length: Option<u64>,
         context: &mut Context,
     ) -> JsResult<JsObject>
     where
@@ -3310,14 +3310,14 @@ impl TypedArray {
             }
 
             // b. Let newByteLength be bufferByteLength - offset.
-            let new_byte_length = buffer_byte_length as isize - offset as isize;
+            let new_byte_length = buffer_byte_length as i64 - offset as i64;
 
             // c. If newByteLength < 0, throw a RangeError exception.
             if new_byte_length < 0 {
                 return context.throw_range_error("Invalid length for typed array");
             }
 
-            new_byte_length as usize
+            new_byte_length as u64
         // 9. Else,
         } else {
             // 5. If length is not undefined, then
@@ -3413,7 +3413,7 @@ impl TypedArrayKind {
     ///
     /// [spec]: https://tc39.es/ecma262/#table-the-typedarray-constructors
     #[inline]
-    pub(crate) const fn element_size(self) -> usize {
+    pub(crate) const fn element_size(self) -> u64 {
         match self {
             Self::Int8 | Self::Uint8 | Self::Uint8Clamped => 1,
             Self::Int16 | Self::Uint16 => 2,

--- a/boa_engine/src/object/jsarray.rs
+++ b/boa_engine/src/object/jsarray.rs
@@ -50,7 +50,7 @@ impl JsArray {
     ///
     /// Same a `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn length(&self, context: &mut Context) -> JsResult<u64> {
         self.inner.length_of_array_like(context)
     }
 

--- a/boa_engine/src/object/jsarraybuffer.rs
+++ b/boa_engine/src/object/jsarraybuffer.rs
@@ -26,7 +26,7 @@ impl JsArrayBuffer {
                 .array_buffer()
                 .constructor()
                 .into(),
-            byte_length,
+            byte_length as u64,
             context,
         )?;
 
@@ -68,7 +68,7 @@ impl JsArrayBuffer {
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
         obj.borrow_mut().data = ObjectData::array_buffer(ArrayBuffer {
             array_buffer_data: Some(block),
-            array_buffer_byte_length: byte_length,
+            array_buffer_byte_length: byte_length as u64,
             array_buffer_detach_key: JsValue::Undefined,
         });
 

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -457,7 +457,7 @@ impl JsObject {
     }
 
     #[inline]
-    pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<usize> {
+    pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<u64> {
         // 1. Assert: Type(obj) is Object.
         // 2. Return ℝ(? ToLength(? Get(obj, "length"))).
         self.get("length", context)?.to_length(context)
@@ -735,7 +735,7 @@ impl JsValue {
         let len = obj.length_of_array_like(context)?;
 
         // 4. Let list be a new empty List.
-        let mut list = Vec::with_capacity(len);
+        let mut list = Vec::with_capacity(len as usize);
 
         // 5. Let index be 0.
         // 6. Repeat, while index < len,

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -1066,7 +1066,7 @@ fn to_length() {
     );
     assert_eq!(
         JsValue::new(f64::INFINITY).to_length(&mut context).unwrap(),
-        Number::MAX_SAFE_INTEGER as usize
+        Number::MAX_SAFE_INTEGER as u64
     );
     assert_eq!(JsValue::new(0.0).to_length(&mut context).unwrap(), 0);
     assert_eq!(JsValue::new(-0.0).to_length(&mut context).unwrap(), 0);
@@ -1075,7 +1075,7 @@ fn to_length() {
     assert_eq!(
         JsValue::new(100000000000.0)
             .to_length(&mut context)
-            .unwrap() as u64,
+            .unwrap(),
         100000000000
     );
     assert_eq!(

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -786,7 +786,7 @@ impl JsValue {
     /// Converts a value to a non-negative integer if it is a valid integer index value.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toindex>
-    pub fn to_index(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn to_index(&self, context: &mut Context) -> JsResult<u64> {
         // 1. If value is undefined, then
         if self.is_undefined() {
             // a. Return 0.
@@ -809,19 +809,19 @@ impl JsValue {
         debug_assert!(0 <= clamped && clamped <= Number::MAX_SAFE_INTEGER as i64);
 
         // e. Return integer.
-        Ok(clamped as usize)
+        Ok(clamped as u64)
     }
 
     /// Converts argument to an integer suitable for use as the length of an array-like object.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tolength>
-    pub fn to_length(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn to_length(&self, context: &mut Context) -> JsResult<u64> {
         // 1. Let len be ? ToInteger(argument).
         // 2. If len ≤ +0, return +0.
         // 3. Return min(len, 2^53 - 1).
         Ok(self
             .to_integer_or_infinity(context)?
-            .clamp_finite(0, Number::MAX_SAFE_INTEGER as i64) as usize)
+            .clamp_finite(0, Number::MAX_SAFE_INTEGER as i64) as u64)
     }
 
     /// Abstract operation `ToIntegerOrInfinity ( argument )`

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -115,7 +115,7 @@ impl JsValue {
             Self::Object(obj) => {
                 if obj.is_array() {
                     let len = obj.length_of_array_like(context)?;
-                    let mut arr = Vec::with_capacity(len);
+                    let mut arr = Vec::with_capacity(len as usize);
 
                     let obj = obj.borrow();
 


### PR DESCRIPTION
This PR fixes the length/index types from `usize` to `u64`, because in JavaScript the length can be from `0` to `2^53 - 1` it cannot be represented in a `usize`. On `64-bit` architectures this is fine because it is already a unsigned 64bit number and these changes essentially do nothing. But on 32bit architectures this was causing the length to be truncated giving an unexpected result. 

fixes/closes #2182 

It changes the following:
- Make length a `u64` to be able to represent all possible length values
- Change `JsValue::to_length()` t return `u64`
- Change `JsValue::to_index()` t return `u64`
