### PR TITLE
[Merged by Bors] - Add field accessors to destructing assignment

### DIFF
--- a/boa_engine/src/syntax/ast/node/object/mod.rs
+++ b/boa_engine/src/syntax/ast/node/object/mod.rs
@@ -390,7 +390,7 @@ pub enum PropertyName {
 
 impl PropertyName {
     /// Returns the literal property name if it exists.
-    pub(in crate::syntax) fn literal(&self) -> Option<Sym> {
+    pub(crate) fn literal(&self) -> Option<Sym> {
         if let Self::Literal(sym) = self {
             Some(*sym)
         } else {
@@ -399,7 +399,7 @@ impl PropertyName {
     }
 
     /// Returns the expression node if the property name is computed.
-    pub(in crate::syntax) fn computed(&self) -> Option<&Node> {
+    pub(crate) fn computed(&self) -> Option<&Node> {
         if let Self::Computed(node) = self {
             Some(node)
         } else {

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -209,7 +209,6 @@ impl CodeBlock {
             | Opcode::ForInLoopInitIterator
             | Opcode::ForInLoopNext
             | Opcode::ConcatToString
-            | Opcode::CopyDataProperties
             | Opcode::GeneratorNextDelegate => {
                 let result = self.read::<u32>(*pc).to_string();
                 *pc += size_of::<u32>();
@@ -217,7 +216,8 @@ impl CodeBlock {
             }
             Opcode::TryStart
             | Opcode::PushDeclarativeEnvironment
-            | Opcode::PushFunctionEnvironment => {
+            | Opcode::PushFunctionEnvironment
+            | Opcode::CopyDataProperties => {
                 let operand1 = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
                 let operand2 = self.read::<u32>(*pc);
@@ -329,6 +329,7 @@ impl CodeBlock {
             | Opcode::Dec
             | Opcode::DecPost
             | Opcode::GetPropertyByValue
+            | Opcode::GetPropertyByValuePush
             | Opcode::SetPropertyByValue
             | Opcode::DefineOwnPropertyByValue
             | Opcode::DefineClassMethodByValue

--- a/boa_engine/src/vm/opcode.rs
+++ b/boa_engine/src/vm/opcode.rs
@@ -520,6 +520,15 @@ pub enum Opcode {
     /// Stack: key, object **=>** value
     GetPropertyByValue,
 
+    /// Get a property by value from an object an push the key and value on the stack.
+    ///
+    /// Like `object[key]`
+    ///
+    /// Operands:
+    ///
+    /// Stack: key, object **=>** key, value
+    GetPropertyByValuePush,
+
     /// Sets a property by name of an object.
     ///
     /// Like `object.name = value`
@@ -747,9 +756,9 @@ pub enum Opcode {
 
     /// Copy all properties of one object to another object.
     ///
-    /// Operands: excluded_key_count: `u32`
+    /// Operands: excluded_key_count: `u32`, excluded_key_count_computed: `u32`
     ///
-    /// Stack: source, value, excluded_key_0 ... excluded_key_n **=>** value
+    /// Stack: excluded_key_computed_0 ... excluded_key_computed_n, source, value, excluded_key_0 ... excluded_key_n **=>** value
     CopyDataProperties,
 
     /// Call ToPropertyKey on the value on the stack.
@@ -1247,6 +1256,7 @@ impl Opcode {
             Self::SetName => "SetName",
             Self::GetPropertyByName => "GetPropertyByName",
             Self::GetPropertyByValue => "GetPropertyByValue",
+            Self::GetPropertyByValuePush => "GetPropertyByValuePush",
             Self::SetPropertyByName => "SetPropertyByName",
             Self::DefineOwnPropertyByName => "DefineOwnPropertyByName",
             Self::DefineClassMethodByName => "DefineClassMethodByName",
@@ -1407,6 +1417,7 @@ impl Opcode {
             Self::SetName => "INST - SetName",
             Self::GetPropertyByName => "INST - GetPropertyByName",
             Self::GetPropertyByValue => "INST - GetPropertyByValue",
+            Self::GetPropertyByValuePush => "INST - GetPropertyByValuePush",
             Self::SetPropertyByName => "INST - SetPropertyByName",
             Self::DefineOwnPropertyByName => "INST - DefineOwnPropertyByName",
             Self::SetPropertyByValue => "INST - SetPropertyByValue",


### PR DESCRIPTION
This Pull Request changes the following:

- Implement parsing/cover-conversion for field accessor member expressions in [DestructuringAssignmentTarget](https://tc39.es/ecma262/#prod-DestructuringAssignmentTarget).
- Modify the `CopyDataProperties` opcode to account for excluded keys that are only known at runtime.
