### PR TITLE
[Merged by Bors] - Fix Rust 1.63 clippy lints

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -89,7 +89,7 @@ impl<T> ClosureFunctionSignature for T where
 // Allows cloning Box<dyn ClosureFunctionSignature>
 dyn_clone::clone_trait_object!(ClosureFunctionSignature);
 
-#[derive(Debug, Trace, Finalize, PartialEq, Clone)]
+#[derive(Debug, Trace, Finalize, PartialEq, Eq, Clone)]
 pub enum ThisMode {
     Lexical,
     Strict,
@@ -119,7 +119,7 @@ impl ThisMode {
 ///  - [ECMAScript specification][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ConstructorKind {
     Base,
     Derived,

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -473,7 +473,7 @@ fn canonicalize_locale_list(args: &[JsValue], context: &mut Context) -> JsResult
             })?;
 
             // vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
-            canonicalize_unicode_locale_id(&mut tag, &*context.icu().locale_canonicalizer());
+            canonicalize_unicode_locale_id(&mut tag, context.icu().locale_canonicalizer());
             seen.insert(tag);
             // vii. If canonicalizedTag is not an element of seen, append canonicalizedTag as the last element of seen.
         }

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -10,8 +10,6 @@
 //! [spec]: https://tc39.es/ecma262/#sec-map-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
 
-#![allow(clippy::mutable_key_type)]
-
 use self::{map_iterator::MapIterator, ordered_map::OrderedMap};
 use super::JsArgs;
 use crate::{

--- a/boa_engine/src/syntax/ast/keyword.rs
+++ b/boa_engine/src/syntax/ast/keyword.rs
@@ -25,7 +25,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#sec-keywords-and-reserved-words
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Keyword {
     /// The `await` keyword.
     ///

--- a/boa_engine/src/syntax/ast/node/identifier/mod.rs
+++ b/boa_engine/src/syntax/ast/node/identifier/mod.rs
@@ -27,7 +27,7 @@ use serde::{Deserialize, Serialize};
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/Identifier
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "deser", serde(transparent))]
-#[derive(Debug, Clone, Copy, Finalize, PartialEq)]
+#[derive(Debug, Clone, Copy, Finalize, PartialEq, Eq)]
 pub struct Identifier {
     ident: Sym,
 }

--- a/boa_engine/src/syntax/ast/node/iteration/break_node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/break_node/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 /// [spec]: https://tc39.es/ecma262/#prod-BreakStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, Finalize, PartialEq)]
+#[derive(Debug, Clone, Copy, Finalize, PartialEq, Eq)]
 pub struct Break {
     label: Option<Sym>,
 }

--- a/boa_engine/src/syntax/ast/node/iteration/continue_node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/iteration/continue_node/mod.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 /// [spec]: https://tc39.es/ecma262/#prod-ContinueStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Continue {
     label: Option<Sym>,
 }

--- a/boa_engine/src/syntax/ast/node/mod.rs
+++ b/boa_engine/src/syntax/ast/node/mod.rs
@@ -266,7 +266,6 @@ impl From<Const> for Node {
 
 impl Node {
     /// Returns a node ordering based on the hoistability of each node.
-    #[allow(clippy::match_same_arms)]
     pub(crate) fn hoistable_order(a: &Self, b: &Self) -> Ordering {
         match (a, b) {
             (Node::FunctionDecl(_), Node::FunctionDecl(_)) => Ordering::Equal,

--- a/boa_engine/src/syntax/ast/op.rs
+++ b/boa_engine/src/syntax/ast/op.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Arithmetic
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum NumOp {
     /// The addition operator produces the sum of numeric operands or string concatenation.
     ///
@@ -132,7 +132,7 @@ unsafe impl Trace for NumOp {
 /// [spec]: https://tc39.es/ecma262/#prod-UnaryExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Unary
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum UnaryOp {
     /// The increment operator increments (adds one to) its operand and returns a value.
     ///
@@ -346,7 +346,7 @@ unsafe impl Trace for UnaryOp {
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum BitOp {
     /// Performs the AND operation on each pair of bits. a AND b yields 1 only if both a and b are 1.
     ///
@@ -472,7 +472,7 @@ unsafe impl Trace for BitOp {
 /// [spec]: tc39.es/ecma262/#sec-testing-and-comparison-operations
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Comparison
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum CompOp {
     /// The equality operator converts the operands if they are not of the same type, then applies
     /// strict comparison.
@@ -668,7 +668,7 @@ unsafe impl Trace for CompOp {
 /// [spec]: https://tc39.es/ecma262/#sec-binary-logical-operators
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Logical
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum LogOp {
     /// The logical AND operator returns the value of the first operand if it can be coerced into `false`;
     /// otherwise, it returns the second operand.
@@ -733,7 +733,7 @@ unsafe impl Trace for LogOp {
 
 /// This represents a binary operation between two values.
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum BinOp {
     /// Numeric operation.
     ///
@@ -832,7 +832,7 @@ unsafe impl Trace for BinOp {
 /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Clone, Copy, Debug, Finalize, PartialEq)]
+#[derive(Clone, Copy, Debug, Finalize, PartialEq, Eq)]
 pub enum AssignOp {
     /// The addition assignment operator adds the value of the right operand to a variable and assigns the result to the variable.
     ///

--- a/boa_engine/src/syntax/ast/punctuator.rs
+++ b/boa_engine/src/syntax/ast/punctuator.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-Punctuator
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Punctuator {
     /// `+`
     Add,

--- a/boa_engine/src/syntax/lexer/template.rs
+++ b/boa_engine/src/syntax/lexer/template.rs
@@ -16,7 +16,7 @@ use std::io::{self, ErrorKind, Read};
 use serde::{Deserialize, Serialize};
 
 #[cfg_attr(feature = "deser", derive(Serialize, Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TemplateString {
     /// The template string of template literal with argument `raw` true.
     raw: Sym,

--- a/boa_engine/src/syntax/mod.rs
+++ b/boa_engine/src/syntax/mod.rs
@@ -1,6 +1,5 @@
 //! Syntactical analysis, such as Abstract Syntax Tree (AST), Parsing and Lexing
 // syntax module has a lot of acronyms
-#![allow(clippy::upper_case_acronyms)]
 
 pub mod ast;
 pub mod lexer;

--- a/boa_engine/src/syntax/parser/function/tests.rs
+++ b/boa_engine/src/syntax/parser/function/tests.rs
@@ -71,7 +71,6 @@ fn check_duplicates_strict_on() {
     let mut context = Context::default();
 
     let res = Parser::new(js.as_bytes()).parse_all(&mut context);
-    dbg!(&res);
     assert!(res.is_err());
 }
 

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -133,7 +133,6 @@ trait CallableDeclaration {
 
 // This is a helper function to not duplicate code in the individual callable deceleration parsers.
 #[inline]
-#[allow(clippy::type_complexity)]
 fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
     c: &C,
     cursor: &mut Cursor<R>,

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -1424,7 +1424,7 @@ fn multicharacter_assignment_to_non_assignable() {
     let test_cases = ["3 **= 5", "3 <<= 5", "3 >>= 5"];
 
     for case in &test_cases {
-        let string = dbg!(forward(&mut context, case));
+        let string = forward(&mut context, case);
 
         assert!(string.starts_with("Uncaught \"SyntaxError\": "));
         assert!(string.contains("1:3"));
@@ -1448,7 +1448,7 @@ fn multicharacter_bitwise_assignment_to_non_assignable() {
     let test_cases = ["3 >>>= 5", "3 &&= 5", "3 ||= 5", "3 ??= 5"];
 
     for case in &test_cases {
-        let string = dbg!(forward(&mut context, case));
+        let string = forward(&mut context, case);
 
         assert!(string.starts_with("Uncaught \"SyntaxError\": "));
         assert!(string.contains("1:3"));
@@ -1601,7 +1601,7 @@ fn test_strict_mode_reserved_name() {
         let mut context = Context::default();
         let scenario = format!("'use strict'; \n {case}");
 
-        let string = dbg!(forward(&mut context, &scenario));
+        let string = forward(&mut context, &scenario);
 
         assert!(string.starts_with("Uncaught \"SyntaxError\": "));
     }


### PR DESCRIPTION
This Pull Request changes the following:

- Fix Rust 1.63 clippy lints
