### PR TITLE
[Merged by Bors] - Fix `yield` expression to end on line terminator

### DIFF
--- a/boa_engine/src/syntax/parser/cursor/mod.rs
+++ b/boa_engine/src/syntax/parser/cursor/mod.rs
@@ -263,15 +263,15 @@ where
 
     /// Check if the peeked token is a line terminator.
     #[inline]
-    pub(super) fn peek_expect_is_line_terminator(
+    pub(super) fn peek_is_line_terminator(
         &mut self,
         skip_n: usize,
         interner: &mut Interner,
-    ) -> Result<bool, ParseError> {
+    ) -> Result<Option<bool>, ParseError> {
         if let Some(t) = self.buffered_lexer.peek(skip_n, false, interner)? {
-            Ok(t.kind() == &TokenKind::LineTerminator)
+            Ok(Some(t.kind() == &TokenKind::LineTerminator))
         } else {
-            Err(ParseError::AbruptEnd)
+            Ok(None)
         }
     }
 

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -106,7 +106,10 @@ where
             TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 // Because we already peeked the identifier token, there may be a line terminator before the identifier token.
                 // In that case we have to skip an additional token on the next peek.
-                let skip_n = if cursor.peek_expect_is_line_terminator(0, interner)? {
+                let skip_n = if cursor
+                    .peek_is_line_terminator(0, interner)?
+                    .ok_or(ParseError::AbruptEnd)?
+                {
                     2
                 } else {
                     1

--- a/boa_engine/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/yield.rs
@@ -63,11 +63,11 @@ where
             interner,
         )?;
 
-        match cursor.peek_is_line_terminator(0, interner)? {
-            Some(false) => {}
-            Some(true) | None => {
-                return Ok(Node::Yield(Yield::new::<Node>(None, false)));
-            }
+        if matches!(
+            cursor.peek_is_line_terminator(0, interner)?,
+            Some(true) | None
+        ) {
+            return Ok(Node::Yield(Yield::new::<Node>(None, false)));
         }
 
         let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;

--- a/boa_engine/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/yield.rs
@@ -14,7 +14,7 @@ use crate::syntax::{
         Keyword, Punctuator,
     },
     lexer::TokenKind,
-    parser::{AllowAwait, AllowIn, Cursor, ParseResult, TokenParser},
+    parser::{AllowAwait, AllowIn, Cursor, ParseError, ParseResult, TokenParser},
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
@@ -63,12 +63,14 @@ where
             interner,
         )?;
 
-        let token = if let Some(token) = cursor.peek(0, interner)? {
-            token
-        } else {
-            return Ok(Node::Yield(Yield::new::<Node>(None, false)));
-        };
+        match cursor.peek_is_line_terminator(0, interner)? {
+            Some(false) => {}
+            Some(true) | None => {
+                return Ok(Node::Yield(Yield::new::<Node>(None, false)));
+            }
+        }
 
+        let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         match token.kind() {
             TokenKind::Punctuator(Punctuator::Mul) => {
                 cursor.next(interner)?.expect("token disappeared");

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -366,7 +366,9 @@ where
         let is_arrow = if let Some(TokenKind::Punctuator(Punctuator::Arrow)) =
             cursor.peek(0, interner)?.map(Token::kind)
         {
-            !cursor.peek_expect_is_line_terminator(0, interner)?
+            !cursor
+                .peek_is_line_terminator(0, interner)?
+                .ok_or(ParseError::AbruptEnd)?
         } else {
             false
         };


### PR DESCRIPTION
This Pull Request changes the following:

- Fix `yield` expression to end on line terminator
