### PR TITLE
[Merged by Bors] - Removed some non-needed dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,28 +21,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "atty"
@@ -165,17 +147,16 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "boa_interner",
+ "clap 3.2.17",
  "colored",
  "fxhash",
  "gc",
- "num-format",
  "once_cell",
  "rayon",
  "regex",
  "serde",
  "serde_json",
  "serde_yaml",
- "structopt",
 ]
 
 [[package]]
@@ -260,13 +241,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags",
- "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
- "vec_map",
 ]
 
 [[package]]
@@ -281,7 +258,7 @@ dependencies = [
  "clap_lex",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap 0.15.0",
 ]
@@ -292,7 +269,7 @@ version = "3.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
 dependencies = [
- "heck 0.4.0",
+ "heck",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -637,15 +614,6 @@ checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
@@ -983,12 +951,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,16 +960,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-format"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bafe4179722c2894288ee77a9f044f02811c86af699344c498b0840c698a2465"
-dependencies = [
- "arrayvec",
- "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1526,39 +1478,9 @@ checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "syn"
@@ -1745,12 +1667,6 @@ name = "utf8parse"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "936e4b492acfd135421d8dca4b1aa80a7bfc26e702ef3af710e0752684df5372"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -83,7 +83,7 @@ const READLINE_COLOR: Color = Color::Cyan;
 // https://docs.rs/structopt/0.3.11/structopt/#type-magic
 #[allow(clippy::option_option)]
 #[derive(Debug, Parser)]
-#[clap(author, about, name = "boa")]
+#[clap(author, version, about, name = "boa")]
 struct Opt {
     /// The JavaScript file(s) to be evaluated.
     #[clap(name = "FILE", parse(from_os_str))]

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -15,7 +15,7 @@ publish = false
 boa_engine = { path = "../boa_engine", features = ["intl"], version = "0.15.0" }
 boa_interner = { path = "../boa_interner", version = "0.15.0" }
 boa_gc = { path = "../boa_gc", version = "0.15.0" }
-structopt = "0.3.26"
+clap = { version = "3.2.17", features = ["derive"] }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_yaml = "0.9.9"
 serde_json = "1.0.83"
@@ -24,7 +24,6 @@ regex = "1.6.0"
 once_cell = "1.13.1"
 colored = "2.0.0"
 fxhash = "0.2.1"
-num-format = "0.4.0"
 gc = { version = "0.4.1", features = ["derive"] }
 rayon = "1.5.3"
 anyhow = "1.0.62"

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -73,6 +73,7 @@ use self::{
 };
 use anyhow::{bail, Context};
 use bitflags::bitflags;
+use clap::Parser;
 use colored::Colorize;
 use fxhash::{FxHashMap, FxHashSet};
 use once_cell::sync::Lazy;
@@ -81,7 +82,6 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use structopt::StructOpt;
 
 /// Structure to allow defining ignored tests, features and files that should
 /// be ignored even when reading.
@@ -193,49 +193,49 @@ static IGNORED: Lazy<Ignored> = Lazy::new(|| {
 });
 
 /// Boa test262 tester
-#[derive(StructOpt, Debug)]
-#[structopt(name = "Boa test262 tester")]
+#[derive(Debug, Parser)]
+#[clap(author, version, about, name = "Boa test262 tester")]
 enum Cli {
     /// Run the test suite.
     Run {
         /// Whether to show verbose output.
-        #[structopt(short, long, parse(from_occurrences))]
+        #[clap(short, long, parse(from_occurrences))]
         verbose: u8,
 
         /// Path to the Test262 suite.
-        #[structopt(long, parse(from_os_str), default_value = "./test262")]
+        #[clap(long, parse(from_os_str), default_value = "./test262")]
         test262_path: PathBuf,
 
         /// Which specific test or test suite to run. Should be a path relative to the Test262 directory: e.g. "test/language/types/number"
-        #[structopt(short, long, parse(from_os_str), default_value = "test")]
+        #[clap(short, long, parse(from_os_str), default_value = "test")]
         suite: PathBuf,
 
         /// Optional output folder for the full results information.
-        #[structopt(short, long, parse(from_os_str))]
+        #[clap(short, long, parse(from_os_str))]
         output: Option<PathBuf>,
 
         /// Execute tests serially
-        #[structopt(short, long)]
+        #[clap(short, long)]
         disable_parallelism: bool,
     },
     Compare {
         /// Base results of the suite.
-        #[structopt(parse(from_os_str))]
+        #[clap(parse(from_os_str))]
         base: PathBuf,
 
         /// New results to compare.
-        #[structopt(parse(from_os_str))]
+        #[clap(parse(from_os_str))]
         new: PathBuf,
 
         /// Whether to use markdown output
-        #[structopt(short, long)]
+        #[clap(short, long)]
         markdown: bool,
     },
 }
 
 /// Program entry point.
 fn main() {
-    match Cli::from_args() {
+    match Cli::parse() {
         Cli::Run {
             verbose,
             test262_path,

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -246,7 +246,18 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
     let test_diff = compute_result_diff(Path::new(""), &base_results.results, &new_results.results);
 
     if markdown {
-        use num_format::{Locale, ToFormattedString};
+        /// Simple function to add commas as thousands separator for integers.
+        fn pretty_int(i: isize) -> String {
+            let mut res = String::new();
+
+            for (idx, val) in i.to_string().chars().rev().enumerate() {
+                if idx != 0 && idx % 3 == 0 {
+                    res.insert(0, ',');
+                }
+                res.insert(0, val);
+            }
+            res
+        }
 
         /// Generates a proper diff format, with some bold text if things change.
         fn diff_format(diff: isize) -> String {
@@ -254,7 +265,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
                 "{}{}{}{}",
                 if diff == 0 { "" } else { "**" },
                 if diff > 0 { "+" } else { "" },
-                diff.to_formatted_string(&Locale::en),
+                pretty_int(diff),
                 if diff == 0 { "" } else { "**" }
             )
         }
@@ -265,32 +276,32 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         println!("| :---------: | :----------: | :------: | :--------: |");
         println!(
             "| Total | {} | {} | {} |",
-            base_total.to_formatted_string(&Locale::en),
-            new_total.to_formatted_string(&Locale::en),
+            pretty_int(base_total),
+            pretty_int(new_total),
             diff_format(total_diff),
         );
         println!(
             "| Passed | {} | {} | {} |",
-            base_passed.to_formatted_string(&Locale::en),
-            new_passed.to_formatted_string(&Locale::en),
+            pretty_int(base_passed),
+            pretty_int(new_passed),
             diff_format(passed_diff),
         );
         println!(
             "| Ignored | {} | {} | {} |",
-            base_ignored.to_formatted_string(&Locale::en),
-            new_ignored.to_formatted_string(&Locale::en),
+            pretty_int(base_ignored),
+            pretty_int(new_ignored),
             diff_format(ignored_diff),
         );
         println!(
             "| Failed | {} | {} | {} |",
-            base_failed.to_formatted_string(&Locale::en),
-            new_failed.to_formatted_string(&Locale::en),
+            pretty_int(base_failed),
+            pretty_int(new_failed),
             diff_format(failed_diff),
         );
         println!(
             "| Panics | {} | {} | {} |",
-            base_panics.to_formatted_string(&Locale::en),
-            new_panics.to_formatted_string(&Locale::en),
+            pretty_int(base_panics),
+            pretty_int(new_panics),
             diff_format(panic_diff),
         );
         println!(


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request removes two dependencies that were not really needed, and fixes #2244 by no longer having the package in the dependency tree.

It changes the following:

- The `structopt` dependency in `boa_tester` has been replaced by `clap` v3, the same way as we did in `boa_cli`. This means that we have one less dependency (at least), and that `clap` v2 is only used as a dev-dependency by `criterion` (which will probably be removed in 0.4, as per https://github.com/bheisler/criterion.rs/issues/596).
- The no-longer-updated `num-format` dependency has been removed from `boa_tester`. We were only using it to add comma thousands separator on results, so I added a simple function to do it (not very performant, but it will only be used a few times when showing results).

Looking at this, I noticed a couple of things:

 - The `csv` dependency, used by `criterion` has not been updated in more than a year, and it's using a very old `itoa` dependency. They updated the dependency in the repository in March, but unfortunately, the release is taking some more time than expected, and a tracking issue can be found here: https://github.com/BurntSushi/rust-csv/issues/271
 - `cargo update` fails, because the latest update to `tinystr` in the ICU4x breaks ICU4x 0.6. I have reported this here: https://github.com/unicode-org/icu4x/issues/2428 and their recommendation is for us to use a beta version of the library, but I don't think we should go for that, since this is a semver breakage.