### PR TITLE
[Merged by Bors] - Ignored a bunch of tests for features that we do not implement

### DIFF
--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -7,6 +7,22 @@ feature:SharedArrayBuffer
 feature:resizable-arraybuffer
 feature:Temporal
 feature:tail-call-optimization
+feature:ShadowRealm
+feature:FinalizationRegistry
+feature:Atomics
+feature:dynamic_import
+feature:decorators
+
+// Non-implemented Intl features
+feature:intl-normative-optional
+feature:Intl.DurationFormat
+feature:Intl.NumberFormat-v3
+feature:Intl.NumberFormat-unified
+feature:Intl.ListFormat
+feature:Intl.DisplayNames
+feature:Intl.RelativeTimeFormat
+feature:Intl.Segmenter
+feature:Intl.Locale
 
 // Non-standard
 feature:caller


### PR DESCRIPTION
This Pull Request ignores a bunch of features in the Boa tester, since we do not implement those. The new "failures" were in fact false positives (for example, a parsing test that should fail, and it failed not because it detected wrong syntax, but because it didn't even understand it).

I wanted to bring down the "failed" tests, and I was able to do it a bit, but not quite. One feature that I noticed was failing a lot was "async-iteration". It makes around 5k tests fail, but it also makes around 6k tests work, so I guess it's just 50% implemented.

In any case, this gives a better overview on the real conformance.