### PR TITLE
Fixing global object not being populated with the global object properties

### DIFF
--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -130,7 +130,11 @@ fn init_builtin<B: BuiltIn>(context: &mut Context) {
             .build();
         context
             .global_bindings_mut()
-            .insert(B::NAME.into(), property);
+            .insert(B::NAME.into(), property.clone());
+        context
+            .global_object()
+            .borrow_mut()
+            .insert(B::NAME, property);
     }
 }
 


### PR DESCRIPTION
This Pull Request fixes part of #1987.

It changes the following:

- When a built-in gets initialized, not only the global binding gets updated, but the global object receives that built-in as a property.

This is a fairly inefficient way of doing this, since it clones the property and assigns it to the global object. Ideally, if I'm not mistaken, these properties shouldn't be declared in the global bindings, they should just be properties of the global binding, so we should avoid creating the global binding. Nevertheless, this, as I mentioned in #1987, this breaks a ton of tests.

The issue here is that the naming resolution at global level doesn't check the global object, unfortunately. Should this be changed?

Also, this doesn't solve the full issue, since the main problem of #1987 comes from the fact that the global object doesn't have any prototype, but as per the spec:

> has a `[[Prototype]]` internal slot whose value is [host-defined](https://tc39.es/ecma262/#host-defined).

[Full spec](https://tc39.es/ecma262/#sec-global-object)

I could not find anywhere that the prototype should be the `Object` prototype, though. This would require some further changes to be fixed.