### PR TITLE
[Merged by Bors] - Do not auto-insert semicolon in VariableDeclarationList

### DIFF
--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -8,10 +8,8 @@ use crate::syntax::{
     lexer::TokenKind,
     parser::statement::{ArrayBindingPattern, ObjectBindingPattern},
     parser::{
-        cursor::Cursor,
-        expression::Initializer,
-        statement::BindingIdentifier,
-        AllowAwait, AllowIn, AllowYield, ParseError, TokenParser,
+        cursor::Cursor, expression::Initializer, statement::BindingIdentifier, AllowAwait, AllowIn,
+        AllowYield, ParseError, TokenParser,
     },
 };
 use boa_interner::Interner;

--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -8,7 +8,7 @@ use crate::syntax::{
     lexer::TokenKind,
     parser::statement::{ArrayBindingPattern, ObjectBindingPattern},
     parser::{
-        cursor::{Cursor, SemicolonResult},
+        cursor::Cursor,
         expression::Initializer,
         statement::BindingIdentifier,
         AllowAwait, AllowIn, AllowYield, ParseError, TokenParser,
@@ -125,13 +125,8 @@ where
                     .parse(cursor, interner)?,
             );
 
-            match cursor.peek_semicolon(interner)? {
-                SemicolonResult::NotFound(tk)
-                    if tk.kind() == &TokenKind::Punctuator(Punctuator::Comma) =>
-                {
-                    let _next = cursor.next(interner).expect("token disappeared");
-                }
-                _ => break,
+            if cursor.next_if(Punctuator::Comma, interner)?.is_none() {
+                break;
             }
         }
 


### PR DESCRIPTION
There can be a line terminator in the middle of variable declaration statement. For example,
```js
var a
, b;
```

In this case, we should not insert semicolon automatically.

This fixes:
- test262/test/language/asi/S7.9_A7_T8.js
- test262/test/language/asi/S7.9_A7_T9.js