### PR TITLE
[Merged by Bors] - Allow some keywords as identifiers

### DIFF
--- a/boa_engine/src/syntax/ast/node/declaration/class_decl/tests.rs
+++ b/boa_engine/src/syntax/ast/node/declaration/class_decl/tests.rs
@@ -44,6 +44,8 @@ fn class_declaration_elements() {
             }
             set e(value) {}
             get e() {}
+            set(a, b) {}
+            get(a, b) {}
         };
         "#,
     );

--- a/boa_engine/src/syntax/parser/cursor/mod.rs
+++ b/boa_engine/src/syntax/parser/cursor/mod.rs
@@ -84,6 +84,30 @@ where
     }
 
     #[inline]
+    pub(super) fn peek_or_abrupt(
+        &mut self,
+        skip_n: usize,
+        interner: &mut Interner,
+    ) -> Result<&Token, ParseError> {
+        self.buffered_lexer
+            .peek(skip_n, true, interner)?
+            .ok_or(ParseError::AbruptEnd)
+    }
+
+    #[inline]
+    pub(super) fn peek_kind(
+        &mut self,
+        skip_n: usize,
+        interner: &mut Interner,
+    ) -> Result<&TokenKind, ParseError> {
+        Ok(self
+            .buffered_lexer
+            .peek(skip_n, true, interner)?
+            .ok_or(ParseError::AbruptEnd)?
+            .kind())
+    }
+
+    #[inline]
     pub(super) fn strict_mode(&self) -> bool {
         self.buffered_lexer.strict_mode()
     }

--- a/boa_engine/src/syntax/parser/cursor/mod.rs
+++ b/boa_engine/src/syntax/parser/cursor/mod.rs
@@ -84,30 +84,6 @@ where
     }
 
     #[inline]
-    pub(super) fn peek_or_abrupt(
-        &mut self,
-        skip_n: usize,
-        interner: &mut Interner,
-    ) -> Result<&Token, ParseError> {
-        self.buffered_lexer
-            .peek(skip_n, true, interner)?
-            .ok_or(ParseError::AbruptEnd)
-    }
-
-    #[inline]
-    pub(super) fn peek_kind(
-        &mut self,
-        skip_n: usize,
-        interner: &mut Interner,
-    ) -> Result<&TokenKind, ParseError> {
-        Ok(self
-            .buffered_lexer
-            .peek(skip_n, true, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .kind())
-    }
-
-    #[inline]
     pub(super) fn strict_mode(&self) -> bool {
         self.buffered_lexer.strict_mode()
     }

--- a/boa_engine/src/syntax/parser/expression/identifiers.rs
+++ b/boa_engine/src/syntax/parser/expression/identifiers.rs
@@ -111,6 +111,8 @@ where
             TokenKind::Keyword((Keyword::Await, _)) if !self.allow_await.0 => {
                 Ok(Identifier::new(Sym::AWAIT))
             }
+            TokenKind::Keyword((Keyword::Async, _)) => Ok(Identifier::new(Sym::ASYNC)),
+            TokenKind::Keyword((Keyword::Of, _)) => Ok(Identifier::new(Sym::OF)),
             _ => Err(ParseError::unexpected(
                 token.to_string(interner),
                 token.span(),
@@ -217,6 +219,8 @@ where
                 ))
             }
             TokenKind::Keyword((Keyword::Await, _)) if !self.allow_await.0 => Ok(Sym::AWAIT),
+            TokenKind::Keyword((Keyword::Async, _)) => Ok(Sym::ASYNC),
+            TokenKind::Keyword((Keyword::Of, _)) => Ok(Sym::OF),
             _ => Err(ParseError::expected(
                 ["identifier".to_owned()],
                 next_token.to_string(interner),

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -67,9 +67,11 @@ where
             .ok_or(ParseError::AbruptEnd)?
             .kind()
         {
-            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
-                Some(BindingIdentifier::new(false, false).parse(cursor, interner)?)
-            }
+            TokenKind::Identifier(_)
+            | TokenKind::Keyword((
+                Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
+                _,
+            )) => Some(BindingIdentifier::new(false, false).parse(cursor, interner)?),
             _ => self.name,
         };
 

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
@@ -88,3 +88,60 @@ fn check_nested_function_expression() {
         interner,
     );
 }
+
+#[test]
+fn check_function_non_reserved_keyword() {
+    let genast = |keyword, interner: &mut Interner| {
+        vec![DeclarationList::Const(
+            vec![Declaration::new_with_identifier(
+                interner.get_or_intern_static("add"),
+                Some(
+                    FunctionExpr::new::<_, _, StatementList>(
+                        Some(interner.get_or_intern_static(keyword)),
+                        FormalParameterList::default(),
+                        vec![Return::new::<_, _, Option<Sym>>(Const::from(1), None).into()].into(),
+                    )
+                    .into(),
+                ),
+            )]
+            .into(),
+        )
+        .into()]
+    };
+
+    let mut interner = Interner::default();
+    let ast = genast("as", &mut interner);
+    check_parser("const add = function as() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("async", &mut interner);
+    check_parser("const add = function async() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("from", &mut interner);
+    check_parser("const add = function from() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("get", &mut interner);
+    check_parser("const add = function get() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("meta", &mut interner);
+    check_parser("const add = function meta() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("of", &mut interner);
+    check_parser("const add = function of() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("set", &mut interner);
+    check_parser("const add = function set() { return 1; };", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("target", &mut interner);
+    check_parser(
+        "const add = function target() { return 1; };",
+        ast,
+        interner,
+    );
+}

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -100,7 +100,7 @@ where
         let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
 
         match tok.kind() {
-            TokenKind::Keyword((Keyword::This | Keyword::Async, true)) => Err(ParseError::general(
+            TokenKind::Keyword((Keyword::This, true)) => Err(ParseError::general(
                 "Keyword must not contain escaped characters",
                 tok.span().start(),
             )),
@@ -126,17 +126,42 @@ where
                 ClassExpression::new(self.name, self.allow_yield, self.allow_await)
                     .parse(cursor, interner)
             }
-            TokenKind::Keyword((Keyword::Async, false)) => {
-                cursor.next(interner).expect("token disappeared");
-                let mul_peek = cursor.peek(1, interner)?.ok_or(ParseError::AbruptEnd)?;
-                if mul_peek.kind() == &TokenKind::Punctuator(Punctuator::Mul) {
-                    AsyncGeneratorExpression::new(self.name)
-                        .parse(cursor, interner)
-                        .map(Node::from)
+            TokenKind::Keyword((Keyword::Async, contain_escaped_char)) => {
+                let contain_escaped_char = *contain_escaped_char;
+                let is_generator = if let Ok(kind) = cursor.peek_kind(2, interner) {
+                    kind == &TokenKind::Punctuator(Punctuator::Mul)
                 } else {
-                    AsyncFunctionExpression::new(self.name, self.allow_yield)
+                    false
+                };
+
+                // FIXME: even if the next character is OpenParen, it could be an identifier.
+                // e.g.) async();
+                match cursor.peek_kind(1, interner) {
+                    Ok(
+                        TokenKind::Keyword((Keyword::Function, _))
+                        | TokenKind::Punctuator(Punctuator::OpenParen),
+                    ) if contain_escaped_char => Err(ParseError::general(
+                        "Keyword must not contain escaped characters",
+                        cursor.peek_or_abrupt(0, interner)?.span().start(),
+                    )),
+                    Ok(
+                        TokenKind::Keyword((Keyword::Function, _))
+                        | TokenKind::Punctuator(Punctuator::OpenParen),
+                    ) => {
+                        cursor.next(interner).expect("token disappeared");
+                        if is_generator {
+                            AsyncGeneratorExpression::new(self.name)
+                                .parse(cursor, interner)
+                                .map(Node::from)
+                        } else {
+                            AsyncFunctionExpression::new(self.name, self.allow_yield)
+                                .parse(cursor, interner)
+                                .map(Node::from)
+                        }
+                    }
+                    _ => IdentifierReference::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)
-                        .map(Node::from)
+                        .map(Node::from),
                 }
             }
             TokenKind::Punctuator(Punctuator::OpenParen) => {
@@ -174,11 +199,12 @@ where
                 Ok(Const::Null.into())
             }
             TokenKind::Identifier(_)
-            | TokenKind::Keyword((Keyword::Let | Keyword::Yield | Keyword::Await, _)) => {
-                IdentifierReference::new(self.allow_yield, self.allow_await)
-                    .parse(cursor, interner)
-                    .map(Node::from)
-            }
+            | TokenKind::Keyword((
+                Keyword::Let | Keyword::Yield | Keyword::Await | Keyword::Of,
+                _,
+            )) => IdentifierReference::new(self.allow_yield, self.allow_await)
+                .parse(cursor, interner)
+                .map(Node::from),
             TokenKind::StringLiteral(lit) => {
                 let node = Const::from(*lit).into();
                 cursor.next(interner).expect("token disappeared");

--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -166,15 +166,22 @@ where
         }
 
         //Async [AsyncMethod, AsyncGeneratorMethod] object methods
+        let is_keyword = !matches!(
+            cursor
+                .peek(1, interner)?
+                .ok_or(ParseError::AbruptEnd)?
+                .kind(),
+            TokenKind::Punctuator(Punctuator::OpenParen | Punctuator::Colon)
+        );
         let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         match token.kind() {
-            TokenKind::Keyword((Keyword::Async, true)) => {
+            TokenKind::Keyword((Keyword::Async, true)) if is_keyword => {
                 return Err(ParseError::general(
                     "Keyword must not contain escaped characters",
                     token.span().start(),
                 ));
             }
-            TokenKind::Keyword((Keyword::Async, false)) => {
+            TokenKind::Keyword((Keyword::Async, false)) if is_keyword => {
                 cursor.next(interner)?.expect("token disappeared");
                 cursor.peek_expect_no_lineterminator(0, "Async object methods", interner)?;
 

--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -3,7 +3,7 @@ use crate::syntax::{
         node::{
             object::{MethodDefinition, PropertyDefinition},
             AsyncFunctionExpr, AsyncGeneratorExpr, Declaration, DeclarationList, FormalParameter,
-            FormalParameterList, FormalParameterListFlags, FunctionExpr, Identifier, Object,
+            FormalParameterList, FormalParameterListFlags, FunctionExpr, Identifier, Node, Object,
         },
         Const,
     },
@@ -445,5 +445,61 @@ fn check_async_gen_method_lineterminator() {
             * vroom() {}
         };
         ",
+    );
+}
+
+#[test]
+fn check_async_ordinary_method() {
+    let mut interner = Interner::default();
+
+    let object_properties = vec![PropertyDefinition::method_definition(
+        MethodDefinition::Ordinary(FunctionExpr::new(
+            None,
+            FormalParameterList::default(),
+            vec![],
+        )),
+        Node::Const(Const::from(interner.get_or_intern_static("async"))),
+    )];
+
+    check_parser(
+        "const x = {
+            async() {}
+         };
+        ",
+        vec![DeclarationList::Const(
+            vec![Declaration::new_with_identifier(
+                interner.get_or_intern_static("x"),
+                Some(Object::from(object_properties).into()),
+            )]
+            .into(),
+        )
+        .into()],
+        interner,
+    );
+}
+
+#[test]
+fn check_async_property() {
+    let mut interner = Interner::default();
+
+    let object_properties = vec![PropertyDefinition::property(
+        Node::Const(Const::from(interner.get_or_intern_static("async"))),
+        Const::from(true),
+    )];
+
+    check_parser(
+        "const x = {
+            async: true
+         };
+        ",
+        vec![DeclarationList::Const(
+            vec![Declaration::new_with_identifier(
+                interner.get_or_intern_static("x"),
+                Some(Object::from(object_properties).into()),
+            )]
+            .into(),
+        )
+        .into()],
+        interner,
     );
 }

--- a/boa_engine/src/syntax/parser/expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/tests.rs
@@ -590,3 +590,31 @@ fn check_logical_expressions() {
     check_invalid("a ?? b || c");
     check_invalid("a || b ?? c");
 }
+
+#[track_caller]
+fn check_non_reserved_identifier(keyword: &'static str) {
+    let mut interner = Interner::default();
+    check_parser(
+        format!("({})", keyword).as_str(),
+        vec![Identifier::new(interner.get_or_intern_static(keyword)).into()],
+        interner,
+    );
+}
+
+#[test]
+fn check_non_reserved_identifiers() {
+    // https://tc39.es/ecma262/#sec-keywords-and-reserved-words
+    // Those that are always allowed as identifiers, but also appear as
+    // keywords within certain syntactic productions, at places where
+    // Identifier is not allowed: as, async, from, get, meta, of, set,
+    // and target.
+
+    check_non_reserved_identifier("as");
+    check_non_reserved_identifier("async");
+    check_non_reserved_identifier("from");
+    check_non_reserved_identifier("get");
+    check_non_reserved_identifier("meta");
+    check_non_reserved_identifier("of");
+    check_non_reserved_identifier("set");
+    check_non_reserved_identifier("target");
+}

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -1,0 +1,95 @@
+use crate::syntax::{
+    ast::{
+        node::{
+            declaration::class_decl::ClassElement as ClassElementNode,
+            object::{MethodDefinition, PropertyName},
+            Class, FormalParameterList, FunctionExpr, Node,
+        },
+        Const,
+    },
+    parser::tests::check_parser,
+};
+use boa_interner::Interner;
+
+#[test]
+fn check_async_ordinary_method() {
+    let mut interner = Interner::default();
+
+    let elements = vec![ClassElementNode::MethodDefinition(
+        PropertyName::Computed(Node::Const(Const::from(
+            interner.get_or_intern_static("async"),
+        ))),
+        MethodDefinition::Ordinary(FunctionExpr::new(
+            None,
+            FormalParameterList::default(),
+            vec![],
+        )),
+    )];
+
+    check_parser(
+        "class A {
+            async() { }
+         }
+        ",
+        [Node::ClassDecl(Class::new(
+            interner.get_or_intern_static("A"),
+            None,
+            None,
+            elements,
+        ))],
+        interner,
+    );
+}
+
+#[test]
+fn check_async_field_initialization() {
+    let mut interner = Interner::default();
+
+    let elements = vec![ClassElementNode::FieldDefinition(
+        PropertyName::Computed(Node::Const(Const::from(
+            interner.get_or_intern_static("async"),
+        ))),
+        Some(Node::Const(Const::from(1))),
+    )];
+
+    check_parser(
+        "class A {
+            async
+              = 1
+         }
+        ",
+        [Node::ClassDecl(Class::new(
+            interner.get_or_intern_static("A"),
+            None,
+            None,
+            elements,
+        ))],
+        interner,
+    );
+}
+
+#[test]
+fn check_async_field() {
+    let mut interner = Interner::default();
+
+    let elements = vec![ClassElementNode::FieldDefinition(
+        PropertyName::Computed(Node::Const(Const::from(
+            interner.get_or_intern_static("async"),
+        ))),
+        None,
+    )];
+
+    check_parser(
+        "class A {
+            async
+         }
+        ",
+        [Node::ClassDecl(Class::new(
+            interner.get_or_intern_static("A"),
+            None,
+            None,
+            elements,
+        ))],
+        interner,
+    );
+}

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/function_decl/tests.rs
@@ -23,27 +23,52 @@ fn function_declaration() {
 /// Function declaration parsing with keywords.
 #[test]
 fn function_declaration_keywords() {
-    let mut interner = Interner::default();
-    check_parser(
-        "function yield() {}",
+    let genast = |keyword, interner: &mut Interner| {
         vec![FunctionDecl::new(
-            interner.get_or_intern_static("yield"),
+            interner.get_or_intern_static(keyword),
             FormalParameterList::default(),
             vec![],
         )
-        .into()],
-        interner,
-    );
+        .into()]
+    };
 
     let mut interner = Interner::default();
-    check_parser(
-        "function await() {}",
-        vec![FunctionDecl::new(
-            interner.get_or_intern_static("await"),
-            FormalParameterList::default(),
-            vec![],
-        )
-        .into()],
-        interner,
-    );
+    let ast = genast("yield", &mut interner);
+    check_parser("function yield() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("await", &mut interner);
+    check_parser("function await() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("as", &mut interner);
+    check_parser("function as() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("async", &mut interner);
+    check_parser("function async() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("from", &mut interner);
+    check_parser("function from() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("get", &mut interner);
+    check_parser("function get() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("meta", &mut interner);
+    check_parser("function meta() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("of", &mut interner);
+    check_parser("function of() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("set", &mut interner);
+    check_parser("function set() {}", ast, interner);
+
+    let mut interner = Interner::default();
+    let ast = genast("target", &mut interner);
+    check_parser("function target() {}", ast, interner);
 }

--- a/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
@@ -168,6 +168,14 @@ where
                 return Ok(ForInLoop::new(init, expr, body).into());
             }
             (Some(init), TokenKind::Keyword((Keyword::Of, false))) => {
+                if let Node::Identifier(identifier) = init {
+                    if identifier.sym() == Sym::ASYNC {
+                        return Err(ParseError::lex(LexError::Syntax(
+                            "invalid left-hand side expression 'async' of a for-of loop".into(),
+                            init_position,
+                        )));
+                    }
+                }
                 let init =
                     node_to_iterable_loop_initializer(init, init_position, cursor.strict_mode())?;
 

--- a/boa_engine/src/syntax/parser/statement/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/mod.rs
@@ -359,10 +359,20 @@ where
 
         match *tok.kind() {
             TokenKind::Keyword((
-                Keyword::Function | Keyword::Async | Keyword::Class | Keyword::Const | Keyword::Let,
+                Keyword::Function | Keyword::Class | Keyword::Const | Keyword::Let,
                 _,
             )) => {
                 Declaration::new(self.allow_yield, self.allow_await, true).parse(cursor, interner)
+            }
+            TokenKind::Keyword((Keyword::Async, _)) => {
+                match cursor.peek(1, interner)?.map(Token::kind) {
+                    Some(TokenKind::Keyword((Keyword::Function, _))) => {
+                        Declaration::new(self.allow_yield, self.allow_await, true)
+                            .parse(cursor, interner)
+                    }
+                    _ => Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+                        .parse(cursor, interner),
+                }
             }
             _ => Statement::new(self.allow_yield, self.allow_await, self.allow_return)
                 .parse(cursor, interner),

--- a/boa_interner/src/sym.rs
+++ b/boa_interner/src/sym.rs
@@ -85,6 +85,12 @@ impl Sym {
     /// Symbol for the `"anonymous"` string.
     pub const ANONYMOUS: Self = unsafe { Self::new_unchecked(23) };
 
+    /// Symbol for the `"async"` string.
+    pub const ASYNC: Self = unsafe { Self::new_unchecked(24) };
+
+    /// Symbol for the `"of"` string.
+    pub const OF: Self = unsafe { Self::new_unchecked(25) };
+
     /// Creates a new [`Sym`] from the provided `value`, or returns `None` if `index` is zero.
     #[inline]
     pub(super) fn new(value: usize) -> Option<Self> {
@@ -145,6 +151,8 @@ pub(super) static COMMON_STRINGS: phf::OrderedSet<&'static str> = {
         "protected",
         "public",
         "anonymous",
+        "async",
+        "of",
     };
     // A `COMMON_STRINGS` of size `usize::MAX` would cause an overflow on our `Interner`
     sa::const_assert!(COMMON_STRINGS.len() < usize::MAX);


### PR DESCRIPTION
This PR fixes #2275 

There are keywords that are allowed as identifiers.
https://tc39.es/ecma262/#sec-keywords-and-reserved-words
> Those that are always allowed as identifiers, but also appear as keywords within certain syntactic productions, at places where Identifier is not allowed: as, async, from, get, meta, of, set, and target.

This PR adds test cases for them, and fixes some cases such as
`class A { set(a, b) { } }`
`function of() { }`
`let obj = {async: true}`
`async()`