### PR TITLE
[Merged by Bors] - fix computed property methods can call super methods

### DIFF
--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -1523,7 +1523,7 @@ impl Context {
                         .expect("must be function object");
                     let mut home_object = function.get_home_object().cloned();
 
-                    if home_object == None {
+                    if home_object.is_none() {
                         home_object = env
                             .get_this_binding()
                             .expect("can not get `this` object")

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -1524,7 +1524,13 @@ impl Context {
                     let mut home_object = function.get_home_object().cloned();
 
                     if home_object == None {
-                        home_object = self.vm.stack.last().expect("stack is empty").as_object().cloned();
+                        home_object = self
+                            .vm
+                            .stack
+                            .last()
+                            .expect("stack is empty")
+                            .as_object()
+                            .cloned();
                     }
                     home_object
                 } else {

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -1521,7 +1521,12 @@ impl Context {
                     let function = function_object
                         .as_function()
                         .expect("must be function object");
-                    function.get_home_object().cloned()
+                    let mut home_object = function.get_home_object().cloned();
+
+                    if home_object == None {
+                        home_object = self.vm.stack.last().expect("stack is empty").as_object().cloned();
+                    }
+                    home_object
                 } else {
                     return self.throw_range_error("Must call super constructor in derived class before accessing 'this' or returning from derived constructor");
                 };

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -137,3 +137,29 @@ fn finally_block_binding_env() {
         Ok(JsValue::from("Hey hey people"))
     );
 }
+
+#[test]
+fn run_super_method_in_object() {
+    let source = r#"
+        let obj = {
+            v() {
+                return super.m();
+            }
+        };
+
+        let proto = {
+            m() {
+                return "super";
+            }
+        };
+
+        Object.setPrototypeOf(obj, proto);
+
+        obj.v();
+    "#;
+
+    assert_eq!(
+        Context::default().eval(source.as_bytes()),
+        Ok(JsValue::from("super"))
+    )
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel neccesary.
--->

This Pull Request fixes: https://github.com/tc39/test262/blob/79e3bc5176b6f29a5aed3b7164a9c623a3a9a63b/test/language/computed-property-names/object/method/super.js

This PR solves the bug of using the `super` keyword in the method attribute of object. When the environment is `None`, the `vm` gets the top element  of `vm.stack` as `this`, such as:
```js
var a = {
    f() {
        return super.m();
    }
};

var b = {
    m() {
        retrun "super";
    }
};

Object.setPrototypeOf(a, b);

a.f(); // the top of stack is `a`
let f = a.f;
f(); // the top of stack is `global_this`, so `super` cannot be used
```

### Can be improved

What I think is that when I use `object.method()`, the engine should bind `this_object`  to the `environment`, instead of using `vm.stack.last()...`.

### TODOS
1. `super` need to look for properties all the way to the end.