### PR TITLE
[Merged by Bors] - Create new lazy Error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ dependencies = [
  "static_assertions",
  "sys-locale",
  "tap",
+ "thiserror",
  "unicode-normalization",
 ]
 

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -118,7 +118,6 @@ impl Opt {
 #[derive(Debug, Clone, ValueEnum)]
 enum DumpFormat {
     /// The different types of format available for dumping.
-    ///
     // NOTE: This can easily support other formats just by
     // adding a field to this enum and adding the necessary
     // implementation. Example: Toml, Html, etc.

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -204,7 +204,7 @@ pub fn main() -> Result<(), io::Error> {
         } else {
             match context.eval(&buffer) {
                 Ok(v) => println!("{}", v.display()),
-                Err(v) => eprintln!("Uncaught {}", v.display()),
+                Err(v) => eprintln!("Uncaught {v}"),
             }
         }
     }
@@ -251,11 +251,7 @@ pub fn main() -> Result<(), io::Error> {
                         match context.eval(line.trim_end()) {
                             Ok(v) => println!("{}", v.display()),
                             Err(v) => {
-                                eprintln!(
-                                    "{}: {}",
-                                    "Uncaught".red(),
-                                    v.display().to_string().red()
-                                );
+                                eprintln!("{}: {}", "Uncaught".red(), v.to_string().red());
                             }
                         }
                     }

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -53,6 +53,7 @@ once_cell = "1.15.0"
 tap = "1.0.1"
 sptr = "0.3.2"
 static_assertions = "1.1.0"
+thiserror = "1.0.35"
 icu_locale_canonicalizer = { version = "0.6.0", features = ["serde"], optional = true }
 icu_locid = { version = "0.6.0", features = ["serde"], optional = true }
 icu_datetime = { version = "0.6.0", features = ["serde"], optional = true }

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -53,7 +53,7 @@ once_cell = "1.15.0"
 tap = "1.0.1"
 sptr = "0.3.2"
 static_assertions = "1.1.0"
-thiserror = "1.0.35"
+thiserror = "1.0.37"
 icu_locale_canonicalizer = { version = "0.6.0", features = ["serde"], optional = true }
 icu_locid = { version = "0.6.0", features = ["serde"], optional = true }
 icu_datetime = { version = "0.6.0", features = ["serde"], optional = true }

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -1,6 +1,6 @@
 //! This module implements the JavaScript bigint primitive rust type.
 
-use crate::{builtins::Number, Context, JsValue};
+use crate::{builtins::Number, error::JsNativeError, JsResult};
 use num_integer::Integer;
 use num_traits::{pow::Pow, FromPrimitive, One, ToPrimitive, Zero};
 use std::{
@@ -148,11 +148,13 @@ impl JsBigInt {
     }
 
     #[inline]
-    pub fn pow(x: &Self, y: &Self, context: &mut Context) -> Result<Self, JsValue> {
+    pub fn pow(x: &Self, y: &Self) -> JsResult<Self> {
         let y = if let Some(y) = y.inner.to_biguint() {
             y
         } else {
-            return context.throw_range_error("BigInt negative exponent");
+            return Err(JsNativeError::range()
+                .with_message("BigInt negative exponent")
+                .into());
         };
 
         let num_bits = (x.inner.bits() as f64
@@ -161,14 +163,16 @@ impl JsBigInt {
             + 1f64;
 
         if num_bits > 1_000_000_000f64 {
-            return context.throw_range_error("Maximum BigInt size exceeded");
+            return Err(JsNativeError::range()
+                .with_message("Maximum BigInt size exceeded")
+                .into());
         }
 
         Ok(Self::new(x.inner.as_ref().clone().pow(y)))
     }
 
     #[inline]
-    pub fn shift_right(x: &Self, y: &Self, context: &mut Context) -> Result<Self, JsValue> {
+    pub fn shift_right(x: &Self, y: &Self) -> JsResult<Self> {
         if let Some(n) = y.inner.to_i32() {
             let inner = if n > 0 {
                 x.inner.as_ref().clone().shr(n as usize)
@@ -178,12 +182,14 @@ impl JsBigInt {
 
             Ok(Self::new(inner))
         } else {
-            context.throw_range_error("Maximum BigInt size exceeded")
+            Err(JsNativeError::range()
+                .with_message("Maximum BigInt size exceeded")
+                .into())
         }
     }
 
     #[inline]
-    pub fn shift_left(x: &Self, y: &Self, context: &mut Context) -> Result<Self, JsValue> {
+    pub fn shift_left(x: &Self, y: &Self) -> JsResult<Self> {
         if let Some(n) = y.inner.to_i32() {
             let inner = if n > 0 {
                 x.inner.as_ref().clone().shl(n as usize)
@@ -193,7 +199,9 @@ impl JsBigInt {
 
             Ok(Self::new(inner))
         } else {
-            context.throw_range_error("Maximum BigInt size exceeded")
+            Err(JsNativeError::range()
+                .with_message("Maximum BigInt size exceeded")
+                .into())
         }
     }
 

--- a/boa_engine/src/builtins/array/tests.rs
+++ b/boa_engine/src/builtins/array/tests.rs
@@ -1421,50 +1421,55 @@ fn array_spread_non_iterable() {
 fn get_relative_start() {
     let mut context = Context::default();
 
-    assert_eq!(Array::get_relative_start(&mut context, None, 10), Ok(0));
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::undefined()), 10),
-        Ok(0)
+        Array::get_relative_start(&mut context, None, 10).unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::NEG_INFINITY)), 10),
-        Ok(0)
+        Array::get_relative_start(&mut context, Some(&JsValue::undefined()), 10).unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::INFINITY)), 10),
-        Ok(10)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::NEG_INFINITY)), 10)
+            .unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(-1)), 10),
-        Ok(9)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::INFINITY)), 10).unwrap(),
+        10
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(1)), 10),
-        Ok(1)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(-1)), 10).unwrap(),
+        9
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(-11)), 10),
-        Ok(0)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(1)), 10).unwrap(),
+        1
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(11)), 10),
-        Ok(10)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(-11)), 10).unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::MIN)), 10),
-        Ok(0)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(11)), 10).unwrap(),
+        10
+    );
+    assert_eq!(
+        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::MIN)), 10).unwrap(),
+        0
     );
     assert_eq!(
         Array::get_relative_start(
             &mut context,
             Some(&JsValue::new(Number::MIN_SAFE_INTEGER)),
             10
-        ),
-        Ok(0)
+        )
+        .unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::MAX)), 10),
-        Ok(10)
+        Array::get_relative_start(&mut context, Some(&JsValue::new(f64::MAX)), 10).unwrap(),
+        10
     );
 
     // This test is relevant only on 32-bit archs (where usize == u32 thus `len` is u32)
@@ -1473,8 +1478,9 @@ fn get_relative_start() {
             &mut context,
             Some(&JsValue::new(Number::MAX_SAFE_INTEGER)),
             10
-        ),
-        Ok(10)
+        )
+        .unwrap(),
+        10
     );
 }
 
@@ -1482,50 +1488,51 @@ fn get_relative_start() {
 fn get_relative_end() {
     let mut context = Context::default();
 
-    assert_eq!(Array::get_relative_end(&mut context, None, 10), Ok(10));
+    assert_eq!(Array::get_relative_end(&mut context, None, 10).unwrap(), 10);
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::undefined()), 10),
-        Ok(10)
+        Array::get_relative_end(&mut context, Some(&JsValue::undefined()), 10).unwrap(),
+        10
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::NEG_INFINITY)), 10),
-        Ok(0)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::NEG_INFINITY)), 10).unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::INFINITY)), 10),
-        Ok(10)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::INFINITY)), 10).unwrap(),
+        10
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(-1)), 10),
-        Ok(9)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(-1)), 10).unwrap(),
+        9
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(1)), 10),
-        Ok(1)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(1)), 10).unwrap(),
+        1
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(-11)), 10),
-        Ok(0)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(-11)), 10).unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(11)), 10),
-        Ok(10)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(11)), 10).unwrap(),
+        10
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::MIN)), 10),
-        Ok(0)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::MIN)), 10).unwrap(),
+        0
     );
     assert_eq!(
         Array::get_relative_end(
             &mut context,
             Some(&JsValue::new(Number::MIN_SAFE_INTEGER)),
             10
-        ),
-        Ok(0)
+        )
+        .unwrap(),
+        0
     );
     assert_eq!(
-        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::MAX)), 10),
-        Ok(10)
+        Array::get_relative_end(&mut context, Some(&JsValue::new(f64::MAX)), 10).unwrap(),
+        10
     );
 
     // This test is relevant only on 32-bit archs (where usize == u32 thus `len` is u32)
@@ -1534,8 +1541,9 @@ fn get_relative_end() {
             &mut context,
             Some(&JsValue::new(Number::MAX_SAFE_INTEGER)),
             10
-        ),
-        Ok(10)
+        )
+        .unwrap(),
+        10
     );
 }
 

--- a/boa_engine/src/builtins/array_buffer/tests.rs
+++ b/boa_engine/src/builtins/array_buffer/tests.rs
@@ -2,14 +2,10 @@ use super::*;
 
 #[test]
 fn ut_sunny_day_create_byte_data_block() {
-    let mut context = Context::default();
-
-    assert!(create_byte_data_block(100, &mut context).is_ok());
+    assert!(create_byte_data_block(100).is_ok());
 }
 
 #[test]
 fn ut_rainy_day_create_byte_data_block() {
-    let mut context = Context::default();
-
-    assert!(create_byte_data_block(u64::MAX, &mut context).is_err());
+    assert!(create_byte_data_block(u64::MAX).is_err());
 }

--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -7,21 +7,10 @@ use chrono::prelude::*;
 // this.
 
 fn forward_dt_utc(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
-    let date_time = if let Ok(v) = forward_val(context, src) {
-        v
-    } else {
-        panic!("expected success")
-    };
-
-    if let JsValue::Object(ref date_time) = date_time {
-        if let Some(date_time) = date_time.borrow().as_date() {
-            date_time.0
-        } else {
-            panic!("expected date")
-        }
-    } else {
-        panic!("expected object")
-    }
+    let date_time = forward_val(context, src).unwrap();
+    let date_time = date_time.as_object().unwrap();
+    let date_time = date_time.borrow();
+    date_time.as_date().unwrap().0
 }
 
 fn forward_dt_local(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
@@ -59,14 +48,9 @@ fn date_this_time_value() {
         &mut context,
         "({toString: Date.prototype.toString}).toString()",
     )
-    .expect_err("Expected error");
-    let message_property = &error
-        .get_property("message")
-        .expect("Expected 'message' property")
-        .expect_value()
-        .clone();
-
-    assert_eq!(JsValue::new("\'this\' is not a Date"), *message_property);
+    .unwrap_err();
+    let error = error.as_native().unwrap();
+    assert_eq!("\'this\' is not a Date", error.message());
 }
 
 #[test]
@@ -201,7 +185,7 @@ fn date_ctor_parse_call() {
 
     let date_time = forward_val(&mut context, "Date.parse('2020-06-08T09:16:15.779-07:30')");
 
-    assert_eq!(Ok(JsValue::new(1591634775779f64)), date_time);
+    assert_eq!(JsValue::new(1591634775779f64), date_time.unwrap());
 }
 
 #[test]
@@ -210,14 +194,14 @@ fn date_ctor_utc_call() {
 
     let date_time = forward_val(&mut context, "Date.UTC(2020, 06, 08, 09, 16, 15, 779)");
 
-    assert_eq!(Ok(JsValue::new(1594199775779f64)), date_time);
+    assert_eq!(JsValue::new(1594199775779f64), date_time.unwrap());
 }
 
 #[test]
 fn date_ctor_utc_call_nan() {
     fn check(src: &str) {
         let mut context = Context::default();
-        let date_time = forward_val(&mut context, src).expect("Expected Success");
+        let date_time = forward_val(&mut context, src).unwrap();
         assert_eq!(JsValue::nan(), date_time);
     }
 
@@ -238,10 +222,10 @@ fn date_proto_get_date_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getDate()",
     );
-    assert_eq!(Ok(JsValue::new(08f64)), actual);
+    assert_eq!(JsValue::new(08f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getDate()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -252,10 +236,10 @@ fn date_proto_get_day_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getDay()",
     );
-    assert_eq!(Ok(JsValue::new(3f64)), actual);
+    assert_eq!(JsValue::new(3f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getDay()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -266,10 +250,10 @@ fn date_proto_get_full_year_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getFullYear()",
     );
-    assert_eq!(Ok(JsValue::new(2020f64)), actual);
+    assert_eq!(JsValue::new(2020f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getFullYear()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -280,10 +264,10 @@ fn date_proto_get_hours_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getHours()",
     );
-    assert_eq!(Ok(JsValue::new(09f64)), actual);
+    assert_eq!(JsValue::new(09f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getHours()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -294,10 +278,10 @@ fn date_proto_get_milliseconds_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getMilliseconds()",
     );
-    assert_eq!(Ok(JsValue::new(779f64)), actual);
+    assert_eq!(JsValue::new(779f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getMilliseconds()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -308,10 +292,10 @@ fn date_proto_get_minutes_call() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getMinutes()",
     );
-    assert_eq!(Ok(JsValue::new(16f64)), actual);
+    assert_eq!(JsValue::new(16f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getMinutes()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -322,10 +306,10 @@ fn date_proto_get_month() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getMonth()",
     );
-    assert_eq!(Ok(JsValue::new(06f64)), actual);
+    assert_eq!(JsValue::new(06f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getMonth()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -336,10 +320,10 @@ fn date_proto_get_seconds() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getSeconds()",
     );
-    assert_eq!(Ok(JsValue::new(15f64)), actual);
+    assert_eq!(JsValue::new(15f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getSeconds()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -355,10 +339,10 @@ fn date_proto_get_time() {
         .ymd(2020, 07, 08)
         .and_hms_milli(09, 16, 15, 779)
         .timestamp_millis() as f64;
-    assert_eq!(Ok(JsValue::new(ts)), actual);
+    assert_eq!(JsValue::new(ts), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getTime()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -369,10 +353,10 @@ fn date_proto_get_year() {
         &mut context,
         "new Date(2020, 06, 08, 09, 16, 15, 779).getYear()",
     );
-    assert_eq!(Ok(JsValue::new(120f64)), actual);
+    assert_eq!(JsValue::new(120f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getYear()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -385,7 +369,7 @@ fn date_proto_get_timezone_offset() {
     );
 
     // NB: Host Settings, not TZ specified in the DateTime.
-    assert_eq!(Ok(JsValue::new(true)), actual);
+    assert_eq!(JsValue::new(true), actual.unwrap());
 
     let actual = forward_val(
         &mut context,
@@ -395,13 +379,13 @@ fn date_proto_get_timezone_offset() {
     // The value of now().offset() depends on the host machine, so we have to replicate the method code here.
     let offset_seconds = f64::from(chrono::Local::now().offset().local_minus_utc());
     let offset_minutes = -offset_seconds / 60f64;
-    assert_eq!(Ok(JsValue::new(offset_minutes)), actual);
+    assert_eq!(JsValue::new(offset_minutes), actual.unwrap());
 
     let actual = forward_val(
         &mut context,
         "new Date('1975-08-19T23:15:30+07:00').getTimezoneOffset()",
     );
-    assert_eq!(Ok(JsValue::new(offset_minutes)), actual);
+    assert_eq!(JsValue::new(offset_minutes), actual.unwrap());
 }
 
 #[test]
@@ -412,10 +396,10 @@ fn date_proto_get_utc_date_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCDate()",
     );
-    assert_eq!(Ok(JsValue::new(08f64)), actual);
+    assert_eq!(JsValue::new(08f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCDate()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -426,10 +410,10 @@ fn date_proto_get_utc_day_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCDay()",
     );
-    assert_eq!(Ok(JsValue::new(3f64)), actual);
+    assert_eq!(JsValue::new(3f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCDay()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -440,10 +424,10 @@ fn date_proto_get_utc_full_year_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCFullYear()",
     );
-    assert_eq!(Ok(JsValue::new(2020f64)), actual);
+    assert_eq!(JsValue::new(2020f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCFullYear()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -454,10 +438,10 @@ fn date_proto_get_utc_hours_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCHours()",
     );
-    assert_eq!(Ok(JsValue::new(09f64)), actual);
+    assert_eq!(JsValue::new(09f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCHours()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -468,10 +452,10 @@ fn date_proto_get_utc_milliseconds_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMilliseconds()",
     );
-    assert_eq!(Ok(JsValue::new(779f64)), actual);
+    assert_eq!(JsValue::new(779f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCMilliseconds()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -482,10 +466,10 @@ fn date_proto_get_utc_minutes_call() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMinutes()",
     );
-    assert_eq!(Ok(JsValue::new(16f64)), actual);
+    assert_eq!(JsValue::new(16f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCMinutes()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -496,10 +480,10 @@ fn date_proto_get_utc_month() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMonth()",
     );
-    assert_eq!(Ok(JsValue::new(06f64)), actual);
+    assert_eq!(JsValue::new(06f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCMonth()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -510,10 +494,10 @@ fn date_proto_get_utc_seconds() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCSeconds()",
     );
-    assert_eq!(Ok(JsValue::new(15f64)), actual);
+    assert_eq!(JsValue::new(15f64), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCSeconds()");
-    assert_eq!(Ok(JsValue::nan()), actual);
+    assert_eq!(JsValue::nan(), actual.unwrap());
 }
 
 #[test]
@@ -1145,7 +1129,7 @@ fn date_proto_to_date_string() {
         &mut context,
         "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.toDateString()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new("Wed Jul 08 2020"), actual);
 }
 
@@ -1157,7 +1141,7 @@ fn date_proto_to_gmt_string() {
         &mut context,
         "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toGMTString()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
 }
 
@@ -1169,7 +1153,7 @@ fn date_proto_to_iso_string() {
         &mut context,
         "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toISOString()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new("2020-07-08T09:16:15.779Z"), actual);
 }
 
@@ -1181,7 +1165,7 @@ fn date_proto_to_json() {
         &mut context,
         "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toJSON()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new("2020-07-08T09:16:15.779Z"), actual);
 }
 
@@ -1245,7 +1229,7 @@ fn date_proto_to_utc_string() {
         &mut context,
         "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toUTCString()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
 }
 
@@ -1257,7 +1241,7 @@ fn date_proto_value_of() {
         &mut context,
         "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).valueOf()",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new(1594199775779f64), actual);
 }
 
@@ -1269,7 +1253,7 @@ fn date_neg() {
         &mut context,
         "-new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779))",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(JsValue::new(-1594199775779f64), actual);
 }
 
@@ -1281,7 +1265,7 @@ fn date_json() {
         &mut context,
         "JSON.stringify({ date: new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)) })",
     )
-    .expect("Successful eval");
+    .unwrap();
     assert_eq!(
         JsValue::new(r#"{"date":"2020-07-08T09:16:15.779Z"}"#),
         actual

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -19,7 +19,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct AggregateError;
@@ -73,7 +73,7 @@ impl AggregateError {
             StandardConstructors::aggregate_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Aggregate));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(1);

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -23,7 +23,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `EvalError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -70,7 +70,7 @@ impl EvalError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::eval_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Eval));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -46,6 +46,18 @@ pub(crate) use self::uri::UriError;
 
 use super::JsArgs;
 
+/// The kind of a `NativeError` object, per the [ECMAScript spec][spec].
+///
+/// This is used internally to convert between [`JsObject`] and
+/// [`JsNativeError`] correctly, but it can also be used to manually create `Error`
+/// objects. However, the recommended way to create them is to construct a
+/// `JsNativeError` first, then call [`JsNativeError::to_opaque`],
+/// which will assign its prototype, properties and kind automatically.
+///
+/// For a description of every error kind and its usage, see
+/// [`JsNativeErrorKind`][crate::error::JsNativeErrorKind].
+///
+/// [spec]: https://tc39.es/ecma262/#sec-error-objects
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ErrorKind {
     Aggregate,

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -21,7 +21,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `RangeError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -68,7 +68,7 @@ impl RangeError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::range_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Range));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -21,7 +21,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ReferenceError;
@@ -74,7 +74,7 @@ impl ReferenceError {
             StandardConstructors::reference_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Reference));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -23,7 +23,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `SyntaxError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -73,7 +73,7 @@ impl SyntaxError {
             StandardConstructors::syntax_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Syntax));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -22,7 +22,7 @@ use crate::{
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
-use super::Error;
+use super::{Error, ErrorKind};
 
 /// JavaScript `URIError` implementation.
 #[derive(Debug, Clone, Copy)]
@@ -69,7 +69,7 @@ impl UriError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::uri_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error());
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Uri));
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -9,6 +9,7 @@
 
 use crate::{
     context::intrinsics::StandardConstructors,
+    error::JsNativeError,
     js_string,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, JsFunction, JsObject,
@@ -205,13 +206,17 @@ pub(crate) fn to_date_time_options(
     // 9. If required is "date" and timeStyle is not undefined, then
     if required == &DateTimeReqs::Date && !time_style.is_undefined() {
         // a. Throw a TypeError exception.
-        return context.throw_type_error("'date' is required, but timeStyle was defined");
+        return Err(JsNativeError::typ()
+            .with_message("'date' is required, but timeStyle was defined")
+            .into());
     }
 
     // 10. If required is "time" and dateStyle is not undefined, then
     if required == &DateTimeReqs::Time && !date_style.is_undefined() {
         // a. Throw a TypeError exception.
-        return context.throw_type_error("'time' is required, but dateStyle was defined");
+        return Err(JsNativeError::typ()
+            .with_message("'time' is required, but dateStyle was defined")
+            .into());
     }
 
     // 11. If needDefaults is true and defaults is either "date" or "all", then

--- a/boa_engine/src/builtins/intl/tests.rs
+++ b/boa_engine/src/builtins/intl/tests.rs
@@ -380,8 +380,9 @@ fn get_opt() {
     let maximum = 10.0;
     let fallback_val = 5.0;
     let fallback = Some(fallback_val);
-    let get_option_result = default_number_option(&value, minimum, maximum, fallback, &mut context);
-    assert_eq!(get_option_result, Ok(fallback));
+    let get_option_result =
+        default_number_option(&value, minimum, maximum, fallback, &mut context).unwrap();
+    assert_eq!(get_option_result, fallback);
 
     let value = JsValue::nan();
     let minimum = 1.0;
@@ -409,8 +410,9 @@ fn get_opt() {
     let minimum = 1.0;
     let maximum = 10.0;
     let fallback = Some(5.0);
-    let get_option_result = default_number_option(&value, minimum, maximum, fallback, &mut context);
-    assert_eq!(get_option_result, Ok(Some(value_f64)));
+    let get_option_result =
+        default_number_option(&value, minimum, maximum, fallback, &mut context).unwrap();
+    assert_eq!(get_option_result, Some(value_f64));
 
     let options = JsObject::empty();
     let property = "fractionalSecondDigits";
@@ -419,8 +421,8 @@ fn get_opt() {
     let fallback_val = 5.0;
     let fallback = Some(fallback_val);
     let get_option_result =
-        get_number_option(&options, property, minimum, maximum, fallback, &mut context);
-    assert_eq!(get_option_result, Ok(fallback));
+        get_number_option(&options, property, minimum, maximum, fallback, &mut context).unwrap();
+    assert_eq!(get_option_result, fallback);
 
     let options = JsObject::empty();
     let value_f64 = 8.0;
@@ -433,8 +435,8 @@ fn get_opt() {
     let maximum = 10.0;
     let fallback = Some(5.0);
     let get_option_result =
-        get_number_option(&options, property, minimum, maximum, fallback, &mut context);
-    assert_eq!(get_option_result, Ok(Some(value_f64)));
+        get_number_option(&options, property, minimum, maximum, fallback, &mut context).unwrap();
+    assert_eq!(get_option_result, Some(value_f64));
 }
 
 #[test]
@@ -475,16 +477,16 @@ fn to_date_time_opts() {
 
     let numeric_jsstring = JsValue::String("numeric".into());
     assert_eq!(
-        date_time_opts.get("year", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("year", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("month", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("month", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("day", &mut context),
-        Ok(numeric_jsstring)
+        date_time_opts.get("day", &mut context).unwrap(),
+        numeric_jsstring
     );
 
     let date_time_opts = to_date_time_options(
@@ -497,16 +499,16 @@ fn to_date_time_opts() {
 
     let numeric_jsstring = JsValue::String("numeric".into());
     assert_eq!(
-        date_time_opts.get("hour", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("hour", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("minute", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("minute", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("second", &mut context),
-        Ok(numeric_jsstring)
+        date_time_opts.get("second", &mut context).unwrap(),
+        numeric_jsstring
     );
 
     let date_time_opts = to_date_time_options(
@@ -519,27 +521,27 @@ fn to_date_time_opts() {
 
     let numeric_jsstring = JsValue::String("numeric".into());
     assert_eq!(
-        date_time_opts.get("year", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("year", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("month", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("month", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("day", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("day", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("hour", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("hour", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("minute", &mut context),
-        Ok(numeric_jsstring.clone())
+        date_time_opts.get("minute", &mut context).unwrap(),
+        numeric_jsstring.clone()
     );
     assert_eq!(
-        date_time_opts.get("second", &mut context),
-        Ok(numeric_jsstring)
+        date_time_opts.get("second", &mut context).unwrap(),
+        numeric_jsstring
     );
 }

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -244,7 +244,8 @@ impl AsyncFromSyncIterator {
                     &JsValue::Undefined,
                     &[JsNativeError::typ()
                         .with_message("iterator return function returned non-object")
-                        .to_value(context)],
+                        .to_opaque(context)
+                        .into()],
                     context,
                 )
                 .expect("cannot fail according to spec");
@@ -343,7 +344,8 @@ impl AsyncFromSyncIterator {
                     &JsValue::Undefined,
                     &[JsNativeError::typ()
                         .with_message("iterator throw function returned non-object")
-                        .to_value(context)],
+                        .to_opaque(context)
+                        .into()],
                     context,
                 )
                 .expect("cannot fail according to spec");

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     object::{FunctionBuilder, JsObject, ObjectData},
     property::PropertyDescriptor,
-    Context, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
@@ -234,24 +234,24 @@ impl AsyncFromSyncIterator {
         if_abrupt_reject_promise!(result, promise_capability, context);
 
         // 11. If Type(result) is not Object, then
-        let result =
-            if let Some(result) = result.as_object() {
-                result
-            } else {
-                // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
-                promise_capability
-                    .reject()
-                    .call(
-                        &JsValue::Undefined,
-                        &[context
-                            .construct_type_error("iterator return function returned non-object")],
-                        context,
-                    )
-                    .expect("cannot fail according to spec");
+        let result = if let Some(result) = result.as_object() {
+            result
+        } else {
+            // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
+            promise_capability
+                .reject()
+                .call(
+                    &JsValue::Undefined,
+                    &[JsNativeError::typ()
+                        .with_message("iterator return function returned non-object")
+                        .to_value(context)],
+                    context,
+                )
+                .expect("cannot fail according to spec");
 
-                // b. Return promiseCapability.[[Promise]].
-                return Ok(promise_capability.promise().clone().into());
-            };
+            // b. Return promiseCapability.[[Promise]].
+            return Ok(promise_capability.promise().clone().into());
+        };
 
         // 12. Return AsyncFromSyncIteratorContinuation(result, promiseCapability).
         Self::continuation(
@@ -341,7 +341,9 @@ impl AsyncFromSyncIterator {
                 .reject()
                 .call(
                     &JsValue::Undefined,
-                    &[context.construct_type_error("iterator throw function returned non-object")],
+                    &[JsNativeError::typ()
+                        .with_message("iterator throw function returned non-object")
+                        .to_value(context)],
                     context,
                 )
                 .expect("cannot fail according to spec");

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -1,6 +1,7 @@
 use super::ordered_map::MapLock;
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, JsValue},
+    error::JsNativeError,
     object::{JsObject, ObjectData},
     property::{PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
@@ -60,7 +61,9 @@ impl MapIterator {
                 return Ok(map_iterator.into());
             }
         }
-        context.throw_type_error("`this` is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("`this` is not a Map")
+            .into())
     }
 
     /// %MapIteratorPrototype%.next( )
@@ -76,7 +79,7 @@ impl MapIterator {
         let map_iterator = map_iterator
             .as_mut()
             .and_then(|obj| obj.as_map_iterator_mut())
-            .ok_or_else(|| context.construct_type_error("`this` is not a MapIterator"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a MapIterator"))?;
 
         let item_kind = map_iterator.map_iteration_kind;
 

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -15,6 +15,7 @@ use super::JsArgs;
 use crate::{
     builtins::BuiltIn,
     context::intrinsics::StandardConstructors,
+    error::JsNativeError,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
         JsObject, ObjectData,
@@ -121,8 +122,9 @@ impl Map {
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
-            return context
-                .throw_type_error("calling a builtin Map constructor without new is forbidden");
+            return Err(JsNativeError::typ()
+                .with_message("calling a builtin Map constructor without new is forbidden")
+                .into());
         }
 
         // 2. Let map be ? OrdinaryCreateFromConstructor(NewTarget, "%Map.prototype%", « [[MapData]] »).
@@ -206,11 +208,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
-    pub(crate) fn set(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn set(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let key = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
 
@@ -241,7 +239,9 @@ impl Map {
                 return Ok(this.clone());
             }
         }
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `get Map.prototype.size`
@@ -255,11 +255,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-map.prototype.size
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size
-    pub(crate) fn get_size(
-        this: &JsValue,
-        _: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn get_size(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         if let Some(object) = this.as_object() {
             // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
@@ -272,7 +268,9 @@ impl Map {
                 return Ok(map.len().into());
             }
         }
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `Map.prototype.delete( key )`
@@ -286,11 +284,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.delete
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
-    pub(crate) fn delete(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn delete(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let key = args.get_or_undefined(0);
 
         // 1. Let M be the this value.
@@ -306,7 +300,9 @@ impl Map {
                 return Ok(map.remove(key).is_some().into());
             }
         }
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `Map.prototype.get( key )`
@@ -319,11 +315,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
-    pub(crate) fn get(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn get(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Rational(0f64);
 
         let key = args.get_or_undefined(0);
@@ -350,7 +342,9 @@ impl Map {
             }
         }
 
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `Map.prototype.clear( )`
@@ -363,7 +357,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
-    pub(crate) fn clear(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         if let Some(object) = this.as_object() {
@@ -378,7 +372,9 @@ impl Map {
                 return Ok(JsValue::undefined());
             }
         }
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `Map.prototype.has( key )`
@@ -391,11 +387,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Rational(0f64);
 
         let key = args.get_or_undefined(0);
@@ -422,7 +414,9 @@ impl Map {
             }
         }
 
-        context.throw_type_error("'this' is not a Map")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Map")
+            .into())
     }
 
     /// `Map.prototype.forEach( callbackFn [ , thisArg ] )`
@@ -445,12 +439,12 @@ impl Map {
         let map = this
             .as_object()
             .filter(|obj| obj.is_map())
-            .ok_or_else(|| context.construct_type_error("`this` is not a Map"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a Map"))?;
 
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let callback = args.get_or_undefined(0);
         let callback = callback.as_callable().ok_or_else(|| {
-            context.construct_type_error(format!("{} is not a function", callback.display()))
+            JsNativeError::typ().with_message(format!("{} is not a function", callback.display()))
         })?;
 
         let this_arg = args.get_or_undefined(1);
@@ -533,7 +527,7 @@ pub(crate) fn add_entries_from_iterable(
 ) -> JsResult<JsValue> {
     // 1. If IsCallable(adder) is false, throw a TypeError exception.
     let adder = adder.as_callable().ok_or_else(|| {
-        context.construct_type_error("property `set` of `NewTarget` is not callable")
+        JsNativeError::typ().with_message("property `set` of `NewTarget` is not callable")
     })?;
 
     // 2. Let iteratorRecord be ? GetIterator(iterable).
@@ -557,8 +551,9 @@ pub(crate) fn add_entries_from_iterable(
         // d. If Type(nextItem) is not Object, then
         } else {
             // i. Let error be ThrowCompletion(a newly created TypeError object).
-            let err = context
-                .throw_type_error("cannot get key and value from primitive item of `iterable`");
+            let err = Err(JsNativeError::typ()
+                .with_message("cannot get key and value from primitive item of `iterable`")
+                .into());
 
             // ii. Return ? IteratorClose(iteratorRecord, error).
             return iterator_record.close(err, context);

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -327,7 +327,6 @@ impl Number {
     ///
     /// This function traverses a string representing a number,
     /// returning the floored log10 of this number.
-    ///
     fn flt_str_to_exp(flt: &str) -> i32 {
         let mut non_zero_encountered = false;
         let mut dot_encountered = false;
@@ -361,7 +360,6 @@ impl Number {
     ///   the exponent. The string is kept at an exact length of `precision`.
     ///
     /// When this procedure returns, `digits` is exactly `precision` long.
-    ///
     fn round_to_precision(digits: &mut String, precision: usize) -> bool {
         if digits.len() > precision {
             let to_round = digits.split_off(precision);

--- a/boa_engine/src/builtins/number/tests.rs
+++ b/boa_engine/src/builtins/number/tests.rs
@@ -170,7 +170,8 @@ fn to_precision() {
         String::from("\"0.333333333333333314829616256247390992939472198486328125000000\"")
     );
 
-    let expected = "Uncaught \"RangeError\": \"precision must be an integer at least 1 and no greater than 100\"";
+    let expected =
+        "Uncaught RangeError: precision must be an integer at least 1 and no greater than 100";
 
     let range_error_1 = r#"(1).toPrecision(101);"#;
     let range_error_2 = r#"(1).toPrecision(0);"#;

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object},
+    error::JsNativeError,
     object::{JsObject, ObjectData},
     property::PropertyDescriptor,
     property::PropertyKey,
@@ -71,7 +72,7 @@ impl ForInIterator {
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_for_in_iterator_mut())
-            .ok_or_else(|| context.construct_type_error("`this` is not a ForInIterator"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not a ForInIterator"))?;
         let mut object = iterator.object.to_object(context)?;
         loop {
             if !iterator.object_was_visited {

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -13,10 +13,13 @@
 //! [spec]: https://tc39.es/ecma262/#sec-objects
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object
 
+use std::ops::Deref;
+
 use super::Array;
 use crate::{
     builtins::{map, BuiltIn, JsArgs},
     context::intrinsics::StandardConstructors,
+    error::JsNativeError,
     js_string,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
@@ -26,7 +29,7 @@ use crate::{
     string::utf16,
     symbol::WellKnownSymbols,
     value::JsValue,
-    Context, JsResult,
+    Context, JsResult, JsString,
 };
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
@@ -177,7 +180,7 @@ impl Object {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
-        let this = this.require_object_coercible(context)?;
+        let this = this.require_object_coercible()?;
 
         // 2. If Type(proto) is neither Object nor Null, return undefined.
         let proto = match args.get_or_undefined(0) {
@@ -197,7 +200,9 @@ impl Object {
 
         // 5. If status is false, throw a TypeError exception.
         if !status {
-            return context.throw_type_error("__proto__ called on null or undefined");
+            return Err(JsNativeError::typ()
+                .with_message("__proto__ called on null or undefined")
+                .into());
         }
 
         // 6. Return undefined.
@@ -226,8 +231,9 @@ impl Object {
 
         // 2. If IsCallable(getter) is false, throw a TypeError exception.
         if !getter.is_callable() {
-            return context
-                .throw_type_error("Object.prototype.__defineGetter__: Expecting function");
+            return Err(JsNativeError::typ()
+                .with_message("Object.prototype.__defineGetter__: Expecting function")
+                .into());
         }
 
         // 3. Let desc be PropertyDescriptor { [[Get]]: getter, [[Enumerable]]: true, [[Configurable]]: true }.
@@ -268,8 +274,9 @@ impl Object {
 
         // 2. If IsCallable(setter) is false, throw a TypeError exception.
         if !setter.is_callable() {
-            return context
-                .throw_type_error("Object.prototype.__defineSetter__: Expecting function");
+            return Err(JsNativeError::typ()
+                .with_message("Object.prototype.__defineSetter__: Expecting function")
+                .into());
         }
 
         // 3. Let desc be PropertyDescriptor { [[Set]]: setter, [[Enumerable]]: true, [[Configurable]]: true }.
@@ -397,10 +404,12 @@ impl Object {
                 ObjectData::ordinary(),
             ),
             _ => {
-                return context.throw_type_error(format!(
-                    "Object prototype may only be an Object or null: {}",
-                    prototype.display()
-                ))
+                return Err(JsNativeError::typ()
+                    .with_message(format!(
+                        "Object prototype may only be an Object or null: {}",
+                        prototype.display()
+                    ))
+                    .into())
             }
         };
 
@@ -563,19 +572,25 @@ impl Object {
     /// [More information][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.setprototypeof
-    pub fn get_prototype_of(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    pub fn get_prototype_of(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         if args.is_empty() {
-            return ctx.throw_type_error(
-                "Object.getPrototypeOf: At least 1 argument required, but only 0 passed",
-            );
+            return Err(JsNativeError::typ()
+                .with_message(
+                    "Object.getPrototypeOf: At least 1 argument required, but only 0 passed",
+                )
+                .into());
         }
 
         // 1. Let obj be ? ToObject(O).
-        let obj = args[0].clone().to_object(ctx)?;
+        let obj = args[0].clone().to_object(context)?;
 
         // 2. Return ? obj.[[GetPrototypeOf]]().
         Ok(obj
-            .__get_prototype_of__(ctx)?
+            .__get_prototype_of__(context)?
             .map_or(JsValue::Null, JsValue::new))
     }
 
@@ -584,12 +599,18 @@ impl Object {
     /// [More information][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.setprototypeof
-    pub fn set_prototype_of(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+    pub fn set_prototype_of(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         if args.len() < 2 {
-            return ctx.throw_type_error(format!(
-                "Object.setPrototypeOf: At least 2 arguments required, but only {} passed",
-                args.len()
-            ));
+            return Err(JsNativeError::typ()
+                .with_message(format!(
+                    "Object.setPrototypeOf: At least 2 arguments required, but only {} passed",
+                    args.len()
+                ))
+                .into());
         }
 
         // 1. Set O to ? RequireObjectCoercible(O).
@@ -597,7 +618,7 @@ impl Object {
             .get(0)
             .cloned()
             .unwrap_or_default()
-            .require_object_coercible(ctx)?
+            .require_object_coercible()?
             .clone();
 
         let proto = match args.get_or_undefined(1) {
@@ -605,10 +626,12 @@ impl Object {
             JsValue::Null => None,
             // 2. If Type(proto) is neither Object nor Null, throw a TypeError exception.
             val => {
-                return ctx.throw_type_error(format!(
-                    "expected an object or null, got {}",
-                    val.type_of().to_std_string_escaped()
-                ))
+                return Err(JsNativeError::typ()
+                    .with_message(format!(
+                        "expected an object or null, got {}",
+                        val.type_of().to_std_string_escaped()
+                    ))
+                    .into())
             }
         };
 
@@ -620,11 +643,13 @@ impl Object {
         };
 
         // 4. Let status be ? O.[[SetPrototypeOf]](proto).
-        let status = obj.__set_prototype_of__(proto, ctx)?;
+        let status = obj.__set_prototype_of__(proto, context)?;
 
         // 5. If status is false, throw a TypeError exception.
         if !status {
-            return ctx.throw_type_error("can't set prototype of this object");
+            return Err(JsNativeError::typ()
+                .with_message("can't set prototype of this object")
+                .into());
         }
 
         // 6. Return O.
@@ -684,7 +709,9 @@ impl Object {
 
             Ok(object.clone().into())
         } else {
-            context.throw_type_error("Object.defineProperty called on non-object")
+            Err(JsNativeError::typ()
+                .with_message("Object.defineProperty called on non-object")
+                .into())
         }
     }
 
@@ -709,7 +736,9 @@ impl Object {
             object_define_properties(obj, props, context)?;
             Ok(arg.clone())
         } else {
-            context.throw_type_error("Expected an object")
+            Err(JsNativeError::typ()
+                .with_message("Expected an object")
+                .into())
         }
     }
 
@@ -752,7 +781,7 @@ impl Object {
         //  4. Let isArray be ? IsArray(O).
         //  5. If isArray is true, let builtinTag be "Array".
         let builtin_tag = if o.is_array_abstract(context)? {
-            js_string!("Array")
+            utf16!("Array")
         } else {
             // 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".
             // 7. Else if O has a [[Call]] internal method, let builtinTag be "Function".
@@ -765,15 +794,15 @@ impl Object {
             // 14. Else, let builtinTag be "Object".
             let o = o.borrow();
             match o.kind() {
-                ObjectKind::Arguments(_) => js_string!("Arguments"),
-                ObjectKind::Function(_) => js_string!("Function"),
-                ObjectKind::Error => js_string!("Error"),
-                ObjectKind::Boolean(_) => js_string!("Boolean"),
-                ObjectKind::Number(_) => js_string!("Number"),
-                ObjectKind::String(_) => js_string!("String"),
-                ObjectKind::Date(_) => js_string!("Date"),
-                ObjectKind::RegExp(_) => js_string!("RegExp"),
-                _ => js_string!("Object"),
+                ObjectKind::Arguments(_) => utf16!("Arguments"),
+                ObjectKind::Function(_) => utf16!("Function"),
+                ObjectKind::Error(_) => utf16!("Error"),
+                ObjectKind::Boolean(_) => utf16!("Boolean"),
+                ObjectKind::Number(_) => utf16!("Number"),
+                ObjectKind::String(_) => utf16!("String"),
+                ObjectKind::Date(_) => utf16!("Date"),
+                ObjectKind::RegExp(_) => utf16!("RegExp"),
+                _ => utf16!("Object"),
             }
         };
 
@@ -781,7 +810,7 @@ impl Object {
         let tag = o.get(WellKnownSymbols::to_string_tag(), context)?;
 
         // 16. If Type(tag) is not String, set tag to builtinTag.
-        let tag_str = tag.as_string().unwrap_or(&builtin_tag);
+        let tag_str = tag.as_string().map_or(builtin_tag, JsString::deref);
 
         // 17. Return the string-concatenation of "[object ", tag, and "]".
         Ok(js_string!(utf16!("[object "), tag_str, utf16!("]")).into())
@@ -1015,7 +1044,9 @@ impl Object {
             let status = o.set_integrity_level(IntegrityLevel::Sealed, context)?;
             // 3. If status is false, throw a TypeError exception.
             if !status {
-                return context.throw_type_error("cannot seal object");
+                return Err(JsNativeError::typ()
+                    .with_message("cannot seal object")
+                    .into());
             }
         }
         // 1. If Type(O) is not Object, return O.
@@ -1060,7 +1091,9 @@ impl Object {
             let status = o.set_integrity_level(IntegrityLevel::Frozen, context)?;
             // 3. If status is false, throw a TypeError exception.
             if !status {
-                return context.throw_type_error("cannot freeze object");
+                return Err(JsNativeError::typ()
+                    .with_message("cannot freeze object")
+                    .into());
             }
         }
         // 1. If Type(O) is not Object, return O.
@@ -1109,7 +1142,9 @@ impl Object {
             let status = o.__prevent_extensions__(context)?;
             // 3. If status is false, throw a TypeError exception.
             if !status {
-                return context.throw_type_error("cannot prevent extensions");
+                return Err(JsNativeError::typ()
+                    .with_message("cannot prevent extensions")
+                    .into());
             }
         }
         // 1. If Type(O) is not Object, return O.
@@ -1205,7 +1240,7 @@ impl Object {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
     pub fn from_entries(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Perform ? RequireObjectCoercible(iterable).
-        let iterable = args.get_or_undefined(0).require_object_coercible(context)?;
+        let iterable = args.get_or_undefined(0).require_object_coercible()?;
 
         // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
         // 3. Assert: obj is an extensible ordinary object with no own properties.

--- a/boa_engine/src/builtins/object/tests.rs
+++ b/boa_engine/src/builtins/object/tests.rs
@@ -323,7 +323,7 @@ fn object_is_prototype_of() {
 
 #[test]
 fn object_get_own_property_names_invalid_args() {
-    let error_message = r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#;
+    let error_message = "Uncaught TypeError: cannot convert 'null' or 'undefined' to object";
 
     check_output(&[
         TestAction::TestEq("Object.getOwnPropertyNames()", error_message),
@@ -358,7 +358,7 @@ fn object_get_own_property_names() {
 
 #[test]
 fn object_get_own_property_symbols_invalid_args() {
-    let error_message = r#"Uncaught "TypeError": "cannot convert 'null' or 'undefined' to object""#;
+    let error_message = "Uncaught TypeError: cannot convert 'null' or 'undefined' to object";
 
     check_output(&[
         TestAction::TestEq("Object.getOwnPropertySymbols()", error_message),
@@ -391,7 +391,7 @@ fn object_get_own_property_symbols() {
 
 #[test]
 fn object_from_entries_invalid_args() {
-    let error_message = r#"Uncaught "TypeError": "cannot convert null or undefined to Object""#;
+    let error_message = "Uncaught TypeError: cannot convert null or undefined to Object";
 
     check_output(&[
         TestAction::TestEq("Object.fromEntries()", error_message),

--- a/boa_engine/src/builtins/promise/promise_job.rs
+++ b/boa_engine/src/builtins/promise/promise_job.rs
@@ -54,9 +54,9 @@ impl PromiseJob {
                         }
                     },
                     //   e. Else, let handlerResult be Completion(HostCallJobCallback(handler, undefined, « argument »)).
-                    Some(handler) => {
-                        handler.call_job_callback(&JsValue::Undefined, &[argument.clone()], context)
-                    }
+                    Some(handler) => handler
+                        .call_job_callback(&JsValue::Undefined, &[argument.clone()], context)
+                        .map_err(|e| e.to_value(context)),
                 };
 
                 match promise_capability {
@@ -146,6 +146,7 @@ impl PromiseJob {
 
                 //    c. If thenCallResult is an abrupt completion, then
                 if let Err(value) = then_call_result {
+                    let value = value.to_value(context);
                     //    i. Return ? Call(resolvingFunctions.[[Reject]], undefined, « thenCallResult.[[Value]] »).
                     return context.call(
                         &resolving_functions.reject,

--- a/boa_engine/src/builtins/promise/promise_job.rs
+++ b/boa_engine/src/builtins/promise/promise_job.rs
@@ -56,7 +56,7 @@ impl PromiseJob {
                     //   e. Else, let handlerResult be Completion(HostCallJobCallback(handler, undefined, « argument »)).
                     Some(handler) => handler
                         .call_job_callback(&JsValue::Undefined, &[argument.clone()], context)
-                        .map_err(|e| e.to_value(context)),
+                        .map_err(|e| e.to_opaque(context)),
                 };
 
                 match promise_capability {
@@ -146,7 +146,7 @@ impl PromiseJob {
 
                 //    c. If thenCallResult is an abrupt completion, then
                 if let Err(value) = then_call_result {
-                    let value = value.to_value(context);
+                    let value = value.to_opaque(context);
                     //    i. Return ? Call(resolvingFunctions.[[Reject]], undefined, « thenCallResult.[[Value]] »).
                     return context.call(
                         &resolving_functions.reject,

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -13,6 +13,7 @@
 use super::{Array, JsArgs};
 use crate::{
     builtins::{self, BuiltIn},
+    error::JsNativeError,
     object::ObjectInitializer,
     property::Attribute,
     symbol::WellKnownSymbols,
@@ -78,12 +79,14 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be a function"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be a function"))?;
         let this_arg = args.get_or_undefined(1);
         let args_list = args.get_or_undefined(2);
 
         if !target.is_callable() {
-            return context.throw_type_error("target must be a function");
+            return Err(JsNativeError::typ()
+                .with_message("target must be a function")
+                .into());
         }
         let args = args_list.create_list_from_array_like(&[], context)?;
         target.call(this_arg, &args, context)
@@ -106,14 +109,16 @@ impl Reflect {
         let target = args
             .get_or_undefined(0)
             .as_constructor()
-            .ok_or_else(|| context.construct_type_error("target must be a constructor"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be a constructor"))?;
 
         let new_target = if let Some(new_target) = args.get(2) {
             // 3. Else if IsConstructor(newTarget) is false, throw a TypeError exception.
             if let Some(new_target) = new_target.as_constructor() {
                 new_target
             } else {
-                return context.throw_type_error("newTarget must be a constructor");
+                return Err(JsNativeError::typ()
+                    .with_message("newTarget must be a constructor")
+                    .into());
             }
         } else {
             // 2. If newTarget is not present, set newTarget to target.
@@ -147,12 +152,14 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         let key = args.get_or_undefined(1).to_property_key(context)?;
         let prop_desc: JsValue = args
             .get(2)
             .and_then(|v| v.as_object().cloned())
-            .ok_or_else(|| context.construct_type_error("property descriptor must be an object"))?
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("property descriptor must be an object")
+            })?
             .into();
 
         target
@@ -176,7 +183,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         let key = args.get_or_undefined(1).to_property_key(context)?;
 
         Ok(target.__delete__(&key, context)?.into())
@@ -195,7 +202,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         // 2. Let key be ? ToPropertyKey(propertyKey).
         let key = args.get_or_undefined(1).to_property_key(context)?;
         // 3. If receiver is not present, then
@@ -231,7 +238,9 @@ impl Reflect {
                 context,
             )
         } else {
-            context.throw_type_error("target must be an object")
+            Err(JsNativeError::typ()
+                .with_message("target must be an object")
+                .into())
         }
     }
 
@@ -251,7 +260,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         Ok(target
             .__get_prototype_of__(context)?
             .map_or(JsValue::Null, JsValue::new))
@@ -269,7 +278,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         let key = args
             .get(1)
             .unwrap_or(&JsValue::undefined())
@@ -293,7 +302,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         Ok(target.__is_extensible__(context)?.into())
     }
 
@@ -313,7 +322,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
 
         let keys: Vec<JsValue> = target
             .__own_property_keys__(context)?
@@ -340,7 +349,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
 
         Ok(target.__prevent_extensions__(context)?.into())
     }
@@ -357,7 +366,7 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         let key = args.get_or_undefined(1).to_property_key(context)?;
         let value = args.get_or_undefined(2);
         let receiver = if let Some(receiver) = args.get(3).cloned() {
@@ -386,11 +395,15 @@ impl Reflect {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
-            .ok_or_else(|| context.construct_type_error("target must be an object"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("target must be an object"))?;
         let proto = match args.get_or_undefined(1) {
             JsValue::Object(obj) => Some(obj.clone()),
             JsValue::Null => None,
-            _ => return context.throw_type_error("proto must be an object or null"),
+            _ => {
+                return Err(JsNativeError::typ()
+                    .with_message("proto must be an object or null")
+                    .into())
+            }
         };
         Ok(target.__set_prototype_of__(proto, context)?.into())
     }

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -12,6 +12,7 @@
 
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, regexp},
+    error::JsNativeError,
     object::{JsObject, ObjectData},
     property::PropertyDescriptor,
     symbol::WellKnownSymbols,
@@ -85,7 +86,9 @@ impl RegExpStringIterator {
         let iterator = iterator
             .as_mut()
             .and_then(|obj| obj.as_regexp_string_iterator_mut())
-            .ok_or_else(|| context.construct_type_error("`this` is not a RegExpStringIterator"))?;
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("`this` is not a RegExpStringIterator")
+            })?;
         if iterator.completed {
             return Ok(create_iter_result_object(
                 JsValue::undefined(),

--- a/boa_engine/src/builtins/regexp/tests.rs
+++ b/boa_engine/src/builtins/regexp/tests.rs
@@ -214,7 +214,8 @@ fn search() {
     assert_eq!(forward(&mut context, "/c/[Symbol.search]('abc')"), "2");
 
     // this-val-non-obj
-    let error = "Uncaught \"TypeError\": \"RegExp.prototype[Symbol.search] method called on incompatible value\"";
+    let error =
+        "Uncaught TypeError: RegExp.prototype[Symbol.search] method called on incompatible value";
     let init = "var search = RegExp.prototype[Symbol.search]";
     eprintln!("{}", forward(&mut context, init));
     assert_eq!(forward(&mut context, "search.call()"), error);

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object, Array, JsValue},
+    error::JsNativeError,
     object::{JsObject, ObjectData},
     property::{PropertyDescriptor, PropertyNameKind},
     symbol::WellKnownSymbols,
@@ -72,7 +73,7 @@ impl SetIterator {
         let set_iterator = set_iterator
             .as_mut()
             .and_then(|obj| obj.as_set_iterator_mut())
-            .ok_or_else(|| context.construct_type_error("`this` is not an SetIterator"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not an SetIterator"))?;
         {
             let m = &set_iterator.iterated_set;
             let mut index = set_iterator.next_index;
@@ -90,7 +91,7 @@ impl SetIterator {
             let entries = entries
                 .as_ref()
                 .and_then(|obj| obj.as_set_ref())
-                .ok_or_else(|| context.construct_type_error("'this' is not a Set"))?;
+                .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
 
             let num_entries = entries.size();
             while index < num_entries {

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::{function::make_builtin_fn, iterable::create_iter_result_object},
+    error::JsNativeError,
     object::{JsObject, ObjectData},
     property::PropertyDescriptor,
     symbol::WellKnownSymbols,
@@ -39,7 +40,7 @@ impl StringIterator {
         let string_iterator = string_iterator
             .as_mut()
             .and_then(|obj| obj.as_string_iterator_mut())
-            .ok_or_else(|| context.construct_type_error("`this` is not an ArrayIterator"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("`this` is not an ArrayIterator"))?;
 
         if string_iterator.string.is_undefined() {
             return Ok(create_iter_result_object(

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         Array, ArrayIterator, BuiltIn, JsArgs,
     },
     context::intrinsics::{StandardConstructor, StandardConstructors},
+    error::JsNativeError,
     js_string,
     object::{
         internal_methods::get_prototype_from_constructor, ConstructorBuilder, FunctionBuilder,
@@ -121,10 +122,12 @@ macro_rules! typed_array {
             ) -> JsResult<JsValue> {
                 // 1. If NewTarget is undefined, throw a TypeError exception.
                 if new_target.is_undefined() {
-                    return context.throw_type_error(concat!(
-                        "new target was undefined when constructing an ",
-                        $name
-                    ));
+                    return Err(JsNativeError::typ()
+                        .with_message(concat!(
+                            "new target was undefined when constructing an ",
+                            $name
+                        ))
+                        .into());
                 }
 
                 // 2. Let constructorName be the String value of the Constructor Name value specified in Table 72 for this TypedArray constructor.
@@ -380,13 +383,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%
-    fn constructor(
-        _new_target: &JsValue,
-        _args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    fn constructor(_new_target: &JsValue, _args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
-        context.throw_type_error("the TypedArray constructor should never be called directly")
+        Err(JsNativeError::typ()
+            .with_message("the TypedArray constructor should never be called directly")
+            .into())
     }
 
     /// `23.2.2.1 %TypedArray%.from ( source [ , mapfn [ , thisArg ] ] )`
@@ -401,8 +402,9 @@ impl TypedArray {
         let constructor = match this.as_object() {
             Some(obj) if obj.is_constructor() => obj,
             _ => {
-                return context
-                    .throw_type_error("TypedArray.from called on non-constructable value")
+                return Err(JsNativeError::typ()
+                    .with_message("TypedArray.from called on non-constructable value")
+                    .into())
             }
         };
 
@@ -415,8 +417,9 @@ impl TypedArray {
                 Some(obj) if obj.is_callable() => Some(obj),
                 // a. If IsCallable(mapfn) is false, throw a TypeError exception.
                 _ => {
-                    return context
-                        .throw_type_error("TypedArray.from called with non-callable mapfn")
+                    return Err(JsNativeError::typ()
+                        .with_message("TypedArray.from called with non-callable mapfn")
+                        .into())
                 }
             },
         };
@@ -511,7 +514,9 @@ impl TypedArray {
         let constructor = match this.as_object() {
             Some(obj) if obj.is_constructor() => obj,
             _ => {
-                return context.throw_type_error("TypedArray.of called on non-constructable value")
+                return Err(JsNativeError::typ()
+                    .with_message("TypedArray.of called on non-constructable value")
+                    .into())
             }
         };
 
@@ -552,15 +557,17 @@ impl TypedArray {
     pub(crate) fn at(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -597,17 +604,17 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
-    fn buffer(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let typed_array = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let typed_array = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. Return buffer.
@@ -622,21 +629,17 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength
-    pub(crate) fn byte_length(
-        this: &JsValue,
-        _: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn byte_length(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let typed_array = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let typed_array = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
@@ -655,21 +658,17 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset
-    pub(crate) fn byte_offset(
-        this: &JsValue,
-        _: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn byte_offset(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let typed_array = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let typed_array = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
@@ -690,19 +689,21 @@ impl TypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
     fn copy_within(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         let len = {
             let obj_borrow = obj.borrow();
-            let o = obj_borrow
-                .as_typed_array()
-                .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+            let o = obj_borrow.as_typed_array().ok_or_else(|| {
+                JsNativeError::typ().with_message("Value is not a typed array object")
+            })?;
 
             // 2. Perform ? ValidateTypedArray(O).
             if o.is_detached() {
-                return context.throw_type_error("Buffer of the typed array is detached");
+                return Err(JsNativeError::typ()
+                    .with_message("Buffer of the typed array is detached")
+                    .into());
             }
 
             // 3. Let len be O.[[ArrayLength]].
@@ -757,9 +758,9 @@ impl TypedArray {
         let count = std::cmp::min(r#final - from, len - to);
 
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 17. If count > 0, then
         if count > 0 {
@@ -767,7 +768,9 @@ impl TypedArray {
             // b. Let buffer be O.[[ViewedArrayBuffer]].
             // c. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
             if o.is_detached() {
-                return context.throw_type_error("Buffer of the typed array is detached");
+                return Err(JsNativeError::typ()
+                    .with_message("Buffer of the typed array is detached")
+                    .into());
             }
 
             // d. Let typedArrayName be the String value of O.[[TypedArrayName]].
@@ -860,15 +863,17 @@ impl TypedArray {
     fn entries(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let o = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.borrow()
             .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?
+            .ok_or_else(|| JsNativeError::typ().with_message("Value is not a typed array object"))?
             .is_detached()
         {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Return CreateArrayIterator(O, key+value).
@@ -892,15 +897,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -910,9 +917,11 @@ impl TypedArray {
         let callback_fn = match args.get_or_undefined(0).as_object() {
             Some(obj) if obj.is_callable() => obj,
             _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.every called with non-callable callback function",
-                )
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.every called with non-callable callback function",
+                    )
+                    .into())
             }
         };
 
@@ -955,15 +964,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1008,7 +1019,9 @@ impl TypedArray {
 
         // 14. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 15. Repeat, while k < final,
@@ -1039,29 +1052,32 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-        let callback_fn = match args.get_or_undefined(0).as_object() {
-            Some(obj) if obj.is_callable() => obj,
-            _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.filter called with non-callable callback function",
-                )
-            }
-        };
+        let callback_fn =
+            match args.get_or_undefined(0).as_object() {
+                Some(obj) if obj.is_callable() => obj,
+                _ => return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.filter called with non-callable callback function",
+                    )
+                    .into()),
+            };
 
         // 5. Let kept be a new empty List.
         let mut kept = Vec::new();
@@ -1124,15 +1140,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1142,9 +1160,11 @@ impl TypedArray {
         let predicate = match args.get_or_undefined(0).as_object() {
             Some(obj) if obj.is_callable() => obj,
             _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.find called with non-callable predicate function",
-                )
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.find called with non-callable predicate function",
+                    )
+                    .into())
             }
         };
 
@@ -1186,28 +1206,31 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
         // 4. If IsCallable(predicate) is false, throw a TypeError exception.
-        let predicate =
-            match args.get_or_undefined(0).as_object() {
-                Some(obj) if obj.is_callable() => obj,
-                _ => return context.throw_type_error(
+        let predicate = match args.get_or_undefined(0).as_object() {
+            Some(obj) if obj.is_callable() => obj,
+            _ => return Err(JsNativeError::typ()
+                .with_message(
                     "TypedArray.prototype.findindex called with non-callable predicate function",
-                ),
-            };
+                )
+                .into()),
+        };
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -1247,29 +1270,32 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-        let callback_fn = match args.get_or_undefined(0).as_object() {
-            Some(obj) if obj.is_callable() => obj,
-            _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.foreach called with non-callable callback function",
-                )
-            }
-        };
+        let callback_fn =
+            match args.get_or_undefined(0).as_object() {
+                Some(obj) if obj.is_callable() => obj,
+                _ => return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.foreach called with non-callable callback function",
+                    )
+                    .into()),
+            };
 
         // 5. Let k be 0.
         // 6. Repeat, while k < len,
@@ -1303,15 +1329,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1380,15 +1408,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1466,15 +1496,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1523,15 +1555,17 @@ impl TypedArray {
     pub(crate) fn keys(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let o = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.borrow()
             .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?
+            .ok_or_else(|| JsNativeError::typ().with_message("Value is not a typed array object"))?
             .is_detached()
         {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Return CreateArrayIterator(O, key).
@@ -1555,15 +1589,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1626,21 +1662,17 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
-    pub(crate) fn length(
-        this: &JsValue,
-        _: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
+    pub(crate) fn length(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let typed_array = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let typed_array = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         // 5. If IsDetachedBuffer(buffer) is true, return +0𝔽.
@@ -1666,15 +1698,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1684,9 +1718,11 @@ impl TypedArray {
         let callback_fn = match args.get_or_undefined(0).as_object() {
             Some(obj) if obj.is_callable() => obj,
             _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.map called with non-callable callback function",
-                )
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.map called with non-callable callback function",
+                    )
+                    .into())
             }
         };
 
@@ -1728,34 +1764,38 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-        let callback_fn = match args.get_or_undefined(0).as_object() {
-            Some(obj) if obj.is_callable() => obj,
-            _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.reduce called with non-callable callback function",
-                )
-            }
-        };
+        let callback_fn =
+            match args.get_or_undefined(0).as_object() {
+                Some(obj) if obj.is_callable() => obj,
+                _ => return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.reduce called with non-callable callback function",
+                    )
+                    .into()),
+            };
 
         // 5. If len = 0 and initialValue is not present, throw a TypeError exception.
         if len == 0 && args.get(1).is_none() {
-            return context
-                .throw_type_error("Typed array length is 0 and initial value is not present");
+            return Err(JsNativeError::typ()
+                .with_message("Typed array length is 0 and initial value is not present")
+                .into());
         }
 
         // 6. Let k be 0.
@@ -1809,33 +1849,37 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length() as i64;
 
         // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
-        let callback_fn =
-            match args.get_or_undefined(0).as_object() {
-                Some(obj) if obj.is_callable() => obj,
-                _ => return context.throw_type_error(
+        let callback_fn = match args.get_or_undefined(0).as_object() {
+            Some(obj) if obj.is_callable() => obj,
+            _ => return Err(JsNativeError::typ()
+                .with_message(
                     "TypedArray.prototype.reduceright called with non-callable callback function",
-                ),
-            };
+                )
+                .into()),
+        };
 
         // 5. If len = 0 and initialValue is not present, throw a TypeError exception.
         if len == 0 && args.get(1).is_none() {
-            return context
-                .throw_type_error("Typed array length is 0 and initial value is not present");
+            return Err(JsNativeError::typ()
+                .with_message("Typed array length is 0 and initial value is not present")
+                .into());
         }
 
         // 6. Let k be len - 1.
@@ -1893,15 +1937,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -1954,10 +2000,12 @@ impl TypedArray {
         // 2. Perform ? RequireInternalSlot(target, [[TypedArrayName]]).
         // 3. Assert: target has a [[ViewedArrayBuffer]] internal slot.
         let target = this.as_object().ok_or_else(|| {
-            context.construct_type_error("TypedArray.set must be called on typed array object")
+            JsNativeError::typ().with_message("TypedArray.set must be called on typed array object")
         })?;
         if !target.is_typed_array() {
-            return context.throw_type_error("TypedArray.set must be called on typed array object");
+            return Err(JsNativeError::typ()
+                .with_message("TypedArray.set must be called on typed array object")
+                .into());
         }
 
         // 4. Let targetOffset be ? ToIntegerOrInfinity(offset).
@@ -1966,10 +2014,14 @@ impl TypedArray {
         // 5. If targetOffset < 0, throw a RangeError exception.
         match target_offset {
             IntegerOrInfinity::Integer(i) if i < 0 => {
-                return context.throw_range_error("TypedArray.set called with negative offset")
+                return Err(JsNativeError::range()
+                    .with_message("TypedArray.set called with negative offset")
+                    .into())
             }
             IntegerOrInfinity::NegativeInfinity => {
-                return context.throw_range_error("TypedArray.set called with negative offset")
+                return Err(JsNativeError::range()
+                    .with_message("TypedArray.set called with negative offset")
+                    .into())
             }
             _ => {}
         }
@@ -2017,7 +2069,9 @@ impl TypedArray {
         // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
         // 2. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
         if target_array.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
         let target_buffer_obj = target_array
             .viewed_array_buffer()
@@ -2029,7 +2083,9 @@ impl TypedArray {
         // 4. Let srcBuffer be source.[[ViewedArrayBuffer]].
         // 5. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
         if source_array.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
         let mut src_buffer_obj = source_array
             .viewed_array_buffer()
@@ -2063,23 +2119,27 @@ impl TypedArray {
         let target_offset = match target_offset {
             IntegerOrInfinity::Integer(i) if i >= 0 => i as u64,
             IntegerOrInfinity::PositiveInfinity => {
-                return context.throw_range_error("Target offset cannot be Infinity");
+                return Err(JsNativeError::range()
+                    .with_message("Target offset cannot be Infinity")
+                    .into());
             }
             _ => unreachable!(),
         };
 
         // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
         if src_length + target_offset > target_length {
-            return context.throw_range_error(
-                "Source typed array and target offset longer than target typed array",
-            );
+            return Err(JsNativeError::range()
+                .with_message("Source typed array and target offset longer than target typed array")
+                .into());
         }
 
         // 17. If target.[[ContentType]] ≠ source.[[ContentType]], throw a TypeError exception.
         if target_name.content_type() != src_name.content_type() {
-            return context.throw_type_error(
-                "Source typed array and target typed array have different content types",
-            );
+            return Err(JsNativeError::typ()
+                .with_message(
+                    "Source typed array and target typed array have different content types",
+                )
+                .into());
         }
 
         // TODO: Shared Array Buffer
@@ -2227,7 +2287,9 @@ impl TypedArray {
         // 1. Let targetBuffer be target.[[ViewedArrayBuffer]].
         // 2. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
         if target_array.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let targetLength be target.[[ArrayLength]].
@@ -2252,7 +2314,9 @@ impl TypedArray {
         let target_offset = match target_offset {
             // 10. If targetOffset is +∞, throw a RangeError exception.
             IntegerOrInfinity::PositiveInfinity => {
-                return context.throw_range_error("Target offset cannot be Infinity")
+                return Err(JsNativeError::range()
+                    .with_message("Target offset cannot be Infinity")
+                    .into())
             }
             IntegerOrInfinity::Integer(i) if i >= 0 => i as u64,
             _ => unreachable!(),
@@ -2260,9 +2324,9 @@ impl TypedArray {
 
         // 11. If srcLength + targetOffset > targetLength, throw a RangeError exception.
         if src_length + target_offset > target_length {
-            return context.throw_range_error(
-                "Source object and target offset longer than target typed array",
-            );
+            return Err(JsNativeError::range()
+                .with_message("Source object and target offset longer than target typed array")
+                .into());
         }
 
         // 12. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
@@ -2298,7 +2362,9 @@ impl TypedArray {
 
             // e. If IsDetachedBuffer(targetBuffer) is true, throw a TypeError exception.
             if target_buffer.is_detached_buffer() {
-                return context.throw_type_error("Cannot set value on detached array buffer");
+                return Err(JsNativeError::typ()
+                    .with_message("Cannot set value on detached array buffer")
+                    .into());
             }
 
             // f. Perform SetValueInBuffer(targetBuffer, targetByteIndex, targetType, value, true, Unordered).
@@ -2334,15 +2400,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -2391,7 +2459,9 @@ impl TypedArray {
         if count > 0 {
             // a. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
             if o.is_detached() {
-                return context.throw_type_error("Buffer of the typed array is detached");
+                return Err(JsNativeError::typ()
+                    .with_message("Buffer of the typed array is detached")
+                    .into());
             }
 
             // b. Let srcName be the String value of O.[[TypedArrayName]].
@@ -2503,15 +2573,17 @@ impl TypedArray {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Let len be O.[[ArrayLength]].
@@ -2521,9 +2593,11 @@ impl TypedArray {
         let callback_fn = match args.get_or_undefined(0).as_object() {
             Some(obj) if obj.is_callable() => obj,
             _ => {
-                return context.throw_type_error(
-                    "TypedArray.prototype.some called with non-callable callback function",
-                )
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "TypedArray.prototype.some called with non-callable callback function",
+                    )
+                    .into())
             }
         };
 
@@ -2568,37 +2642,41 @@ impl TypedArray {
             None | Some(JsValue::Undefined) => None,
             Some(JsValue::Object(obj)) if obj.is_callable() => Some(obj),
             _ => {
-                return context
-                    .throw_type_error("TypedArray.sort called with non-callable comparefn")
+                return Err(JsNativeError::typ()
+                    .with_message("TypedArray.sort called with non-callable comparefn")
+                    .into())
             }
         };
 
         // 2. Let obj be the this value.
         let obj = this.as_object().ok_or_else(|| {
-            context.construct_type_error("TypedArray.sort must be called on typed array object")
+            JsNativeError::typ()
+                .with_message("TypedArray.sort must be called on typed array object")
         })?;
 
         // 4. Let buffer be obj.[[ViewedArrayBuffer]].
         // 5. Let len be obj.[[ArrayLength]].
-        let (buffer, len) = {
-            // 3. Perform ? ValidateTypedArray(obj).
-            let obj_borrow = obj.borrow();
-            let o = obj_borrow.as_typed_array().ok_or_else(|| {
-                context.construct_type_error("TypedArray.sort must be called on typed array object")
-            })?;
-            if o.is_detached() {
-                return context.throw_type_error(
+        let (buffer, len) =
+            {
+                // 3. Perform ? ValidateTypedArray(obj).
+                let obj_borrow = obj.borrow();
+                let o = obj_borrow.as_typed_array().ok_or_else(|| {
+                    JsNativeError::typ()
+                        .with_message("TypedArray.sort must be called on typed array object")
+                })?;
+                if o.is_detached() {
+                    return Err(JsNativeError::typ().with_message(
                     "TypedArray.sort called on typed array object with detached array buffer",
-                );
-            }
+                ).into());
+                }
 
-            (
-                o.viewed_array_buffer()
-                    .expect("Already checked for detached buffer")
-                    .clone(),
-                o.array_length(),
-            )
-        };
+                (
+                    o.viewed_array_buffer()
+                        .expect("Already checked for detached buffer")
+                        .clone(),
+                    o.array_length(),
+                )
+            };
 
         // 4. Let items be a new empty List.
         let mut items = Vec::with_capacity(len as usize);
@@ -2641,8 +2719,9 @@ impl TypedArray {
                     .expect("Must be array buffer")
                     .is_detached_buffer()
                 {
-                    return context
-                        .throw_type_error("Cannot sort typed array with detached buffer");
+                    return Err(JsNativeError::typ()
+                        .with_message("Cannot sort typed array with detached buffer")
+                        .into());
                 }
 
                 // c. If v is NaN, return +0𝔽.
@@ -2778,13 +2857,13 @@ impl TypedArray {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
-        let obj = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let obj = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         let obj_borrow = obj.borrow();
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
 
         // 4. Let buffer be O.[[ViewedArrayBuffer]].
         let buffer = o
@@ -2862,15 +2941,17 @@ impl TypedArray {
     fn values(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
-        let o = this
-            .as_object()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.borrow()
             .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?
+            .ok_or_else(|| JsNativeError::typ().with_message("Value is not a typed array object"))?
             .is_detached()
         {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. Return CreateArrayIterator(O, value).
@@ -2948,8 +3029,9 @@ impl TypedArray {
             .content_type()
             != typed_array_name.content_type()
         {
-            return context
-                .throw_type_error("New typed array has different context type than exemplar");
+            return Err(JsNativeError::typ()
+                .with_message("New typed array has different context type than exemplar")
+                .into());
         }
 
         // 6. Return result.
@@ -2972,11 +3054,13 @@ impl TypedArray {
 
         let obj_borrow = new_typed_array.borrow();
         // 2. Perform ? ValidateTypedArray(newTypedArray).
-        let o = obj_borrow
-            .as_typed_array()
-            .ok_or_else(|| context.construct_type_error("Value is not a typed array object"))?;
+        let o = obj_borrow.as_typed_array().ok_or_else(|| {
+            JsNativeError::typ().with_message("Value is not a typed array object")
+        })?;
         if o.is_detached() {
-            return context.throw_type_error("Buffer of the typed array is detached");
+            return Err(JsNativeError::typ()
+                .with_message("Buffer of the typed array is detached")
+                .into());
         }
 
         // 3. If argumentList is a List of a single Number, then
@@ -2984,8 +3068,9 @@ impl TypedArray {
             if let Some(number) = args[0].as_number() {
                 // a. If newTypedArray.[[ArrayLength]] < ℝ(argumentList[0]), throw a TypeError exception.
                 if (o.array_length() as f64) < number {
-                    return context
-                        .throw_type_error("New typed array length is smaller than expected");
+                    return Err(JsNativeError::typ()
+                        .with_message("New typed array length is smaller than expected")
+                        .into());
                 }
             }
         }
@@ -3133,7 +3218,9 @@ impl TypedArray {
         // 1. Let srcData be srcArray.[[ViewedArrayBuffer]].
         // 2. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
         if src_array.is_detached() {
-            return context.throw_type_error("Cannot initialize typed array from detached buffer");
+            return Err(JsNativeError::typ()
+                .with_message("Cannot initialize typed array from detached buffer")
+                .into());
         }
         let src_data_obj = src_array
             .viewed_array_buffer()
@@ -3191,14 +3278,16 @@ impl TypedArray {
 
             // b. If IsDetachedBuffer(srcData) is true, throw a TypeError exception.
             if src_data.is_detached_buffer() {
-                return context
-                    .throw_type_error("Cannot initialize typed array from detached buffer");
+                return Err(JsNativeError::typ()
+                    .with_message("Cannot initialize typed array from detached buffer")
+                    .into());
             }
 
             // c. If srcArray.[[ContentType]] ≠ O.[[ContentType]], throw a TypeError exception.
             if src_name.content_type() != constructor_name.content_type() {
-                return context
-                    .throw_type_error("Cannot initialize typed array from different content type");
+                return Err(JsNativeError::typ()
+                    .with_message("Cannot initialize typed array from different content type")
+                    .into());
             }
 
             // d. Let srcByteIndex be srcByteOffset.
@@ -3283,7 +3372,9 @@ impl TypedArray {
 
         // 4. If offset modulo elementSize ≠ 0, throw a RangeError exception.
         if offset % constructor_name.element_size() != 0 {
-            return context.throw_range_error("Invalid length for typed array");
+            return Err(JsNativeError::range()
+                .with_message("Invalid length for typed array")
+                .into());
         }
 
         let buffer_byte_length = {
@@ -3294,8 +3385,9 @@ impl TypedArray {
 
             // 6. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
             if buffer_array.is_detached_buffer() {
-                return context
-                    .throw_type_error("Cannot construct typed array from detached buffer");
+                return Err(JsNativeError::typ()
+                    .with_message("Cannot construct typed array from detached buffer")
+                    .into());
             }
 
             // 7. Let bufferByteLength be buffer.[[ArrayBufferByteLength]].
@@ -3306,7 +3398,9 @@ impl TypedArray {
         let new_byte_length = if length.is_undefined() {
             // a. If bufferByteLength modulo elementSize ≠ 0, throw a RangeError exception.
             if buffer_byte_length % constructor_name.element_size() != 0 {
-                return context.throw_range_error("Invalid length for typed array");
+                return Err(JsNativeError::range()
+                    .with_message("Invalid length for typed array")
+                    .into());
             }
 
             // b. Let newByteLength be bufferByteLength - offset.
@@ -3314,7 +3408,9 @@ impl TypedArray {
 
             // c. If newByteLength < 0, throw a RangeError exception.
             if new_byte_length < 0 {
-                return context.throw_range_error("Invalid length for typed array");
+                return Err(JsNativeError::range()
+                    .with_message("Invalid length for typed array")
+                    .into());
             }
 
             new_byte_length as u64
@@ -3328,7 +3424,9 @@ impl TypedArray {
 
             // b. If offset + newByteLength > bufferByteLength, throw a RangeError exception.
             if offset + new_byte_length > buffer_byte_length {
-                return context.throw_range_error("Invalid length for typed array");
+                return Err(JsNativeError::range()
+                    .with_message("Invalid length for typed array")
+                    .into());
             }
 
             new_byte_length

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -63,6 +63,7 @@
 
 use crate::{
     builtins::function::NativeFunctionSignature,
+    error::JsNativeError,
     object::{ConstructorBuilder, JsFunction, JsObject, NativeObject, ObjectData, PROTOTYPE},
     property::{Attribute, PropertyDescriptor, PropertyKey},
     Context, JsResult, JsValue,
@@ -104,29 +105,35 @@ impl<T: Class> ClassConstructor for T {
         Self: Sized,
     {
         if this.is_undefined() {
-            return context.throw_type_error(format!(
-                "cannot call constructor of native class `{}` without new",
-                T::NAME
-            ));
+            return Err(JsNativeError::typ()
+                .with_message(format!(
+                    "cannot call constructor of native class `{}` without new",
+                    T::NAME
+                ))
+                .into());
         }
 
         let class_constructor = context.global_object().clone().get(T::NAME, context)?;
         let class_constructor = if let JsValue::Object(ref obj) = class_constructor {
             obj
         } else {
-            return context.throw_type_error(format!(
-                "invalid constructor for native class `{}` ",
-                T::NAME
-            ));
+            return Err(JsNativeError::typ()
+                .with_message(format!(
+                    "invalid constructor for native class `{}` ",
+                    T::NAME
+                ))
+                .into());
         };
         let class_prototype =
             if let JsValue::Object(ref obj) = class_constructor.get(PROTOTYPE, context)? {
                 obj.clone()
             } else {
-                return context.throw_type_error(format!(
-                    "invalid default prototype for native class `{}`",
-                    T::NAME
-                ));
+                return Err(JsNativeError::typ()
+                    .with_message(format!(
+                        "invalid default prototype for native class `{}`",
+                        T::NAME
+                    ))
+                    .into());
             };
 
         let prototype = this

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -2,14 +2,14 @@
 //!
 //! Native classes are implemented through the [`Class`][class-trait] trait.
 //! ```
-//!# use boa_engine::{
-//!#    property::Attribute,
-//!#    class::{Class, ClassBuilder},
-//!#    Context, JsResult, JsValue,
-//!#    builtins::JsArgs,
-//!# };
-//!# use boa_gc::{Finalize, Trace};
-//!#
+//! # use boa_engine::{
+//! #    property::Attribute,
+//! #    class::{Class, ClassBuilder},
+//! #    Context, JsResult, JsValue,
+//! #    builtins::JsArgs,
+//! # };
+//! # use boa_gc::{Finalize, Trace};
+//! #
 //! // This does not have to be an enum it can also be a struct.
 //! #[derive(Debug, Trace, Finalize)]
 //! enum Animal {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -48,9 +48,9 @@ pub use icu::BoaProvider;
 ///
 /// ```rust
 /// use boa_engine::{
-///     Context,
 ///     object::ObjectInitializer,
-///     property::{Attribute, PropertyDescriptor}
+///     property::{Attribute, PropertyDescriptor},
+///     Context,
 /// };
 ///
 /// let script = r#"
@@ -71,11 +71,7 @@ pub use icu::BoaProvider;
 /// let arg = ObjectInitializer::new(&mut context)
 ///     .property("x", 12, Attribute::READONLY)
 ///     .build();
-/// context.register_global_property(
-///     "arg",
-///     arg,
-///     Attribute::all()
-/// );
+/// context.register_global_property("arg", arg, Attribute::all());
 ///
 /// let value = context.eval("test(arg)").unwrap();
 ///
@@ -422,36 +418,20 @@ impl Context {
     /// # Example
     /// ```
     /// use boa_engine::{
-    ///     Context,
+    ///     object::ObjectInitializer,
     ///     property::{Attribute, PropertyDescriptor},
-    ///     object::ObjectInitializer
+    ///     Context,
     /// };
     ///
     /// let mut context = Context::default();
     ///
-    /// context.register_global_property(
-    ///     "myPrimitiveProperty",
-    ///     10,
-    ///     Attribute::all()
-    /// );
+    /// context.register_global_property("myPrimitiveProperty", 10, Attribute::all());
     ///
     /// let object = ObjectInitializer::new(&mut context)
-    ///    .property(
-    ///         "x",
-    ///         0,
-    ///         Attribute::all()
-    ///     )
-    ///     .property(
-    ///         "y",
-    ///         1,
-    ///         Attribute::all()
-    ///     )
-    ///    .build();
-    /// context.register_global_property(
-    ///     "myObjectProperty",
-    ///     object,
-    ///     Attribute::all()
-    /// );
+    ///     .property("x", 0, Attribute::all())
+    ///     .property("y", 1, Attribute::all())
+    ///     .build();
+    /// context.register_global_property("myObjectProperty", object, Attribute::all());
     /// ```
     #[inline]
     pub fn register_global_property<K, V>(&mut self, key: K, value: V, attribute: Attribute)
@@ -474,7 +454,7 @@ impl Context {
     ///
     /// # Examples
     /// ```
-    ///# use boa_engine::Context;
+    /// # use boa_engine::Context;
     /// let mut context = Context::default();
     ///
     /// let value = context.eval("1 + 3").unwrap();
@@ -610,7 +590,6 @@ impl Context {
 /// Additionally, if the `intl` feature is enabled, [`ContextBuilder`] becomes
 /// the only way to create a new [`Context`], since now it requires a
 /// valid data provider for the `Intl` functionality.
-///
 #[cfg_attr(
     feature = "intl",
     doc = "The required data in a valid provider is specified in [`BoaProvider`]"

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -1,6 +1,6 @@
 use crate::{
-    environments::CompileTimeEnvironment, object::JsObject, syntax::ast::expression::Identifier,
-    Context, JsResult, JsValue,
+    environments::CompileTimeEnvironment, error::JsNativeError, object::JsObject,
+    syntax::ast::expression::Identifier, Context, JsResult, JsValue,
 };
 use boa_gc::{Cell, Finalize, Gc, Trace};
 
@@ -798,10 +798,12 @@ impl BindingLocator {
     #[inline]
     pub(crate) fn throw_mutate_immutable(&self, context: &mut Context) -> JsResult<()> {
         if self.mutate_immutable {
-            context.throw_type_error(format!(
-                "cannot mutate an immutable binding '{}'",
-                context.interner().resolve_expect(self.name.sym())
-            ))
+            Err(JsNativeError::typ()
+                .with_message(format!(
+                    "cannot mutate an immutable binding '{}'",
+                    context.interner().resolve_expect(self.name.sym())
+                ))
+                .into())
         } else {
             Ok(())
         }

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -504,7 +504,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Uri, Box::default(), None)
     }
 
-    /// Appends a message to this error.
+    /// Sets the message of this error.
     ///
     /// # Examples
     ///
@@ -523,7 +523,7 @@ impl JsNativeError {
         self
     }
 
-    /// Appends a cause to this error.
+    /// Sets the cause of this error.
     ///
     /// # Examples
     ///

--- a/boa_engine/src/error/mod.rs
+++ b/boa_engine/src/error/mod.rs
@@ -375,8 +375,7 @@ pub struct JsNativeError {
 }
 
 impl JsNativeError {
-    /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally)
-    /// its `cause`.
+    /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally) its `cause`.
     fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<Box<JsError>>) -> Self {
         Self {
             kind,
@@ -385,8 +384,8 @@ impl JsNativeError {
         }
     }
 
-    /// Creates a new `JsNativeError` of kind `AggregateError` from
-    /// a list of [`JsError`]s, with empty `message` and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `AggregateError` from a list of [`JsError`]s, with
+    /// empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -407,8 +406,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Aggregate(errors), Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `Error`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `Error`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -422,8 +420,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Error, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `EvalError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `EvalError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -437,8 +434,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Eval, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `RangeError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `RangeError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -452,8 +448,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Range, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `ReferenceError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `ReferenceError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -467,8 +462,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Reference, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `SyntaxError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `SyntaxError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -482,8 +476,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Syntax, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `TypeError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `TypeError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -497,8 +490,7 @@ impl JsNativeError {
         Self::new(JsNativeErrorKind::Type, Box::default(), None)
     }
 
-    /// Creates a new `JsNativeError` of kind `UriError`, with empty `message`
-    /// and undefined `cause`.
+    /// Creates a new `JsNativeError` of kind `UriError`, with empty `message` and undefined `cause`.
     ///
     /// # Examples
     ///
@@ -590,8 +582,7 @@ impl JsNativeError {
         self.cause.as_deref()
     }
 
-    /// Converts this native error to its opaque representation as a
-    /// [`JsObject`].
+    /// Converts this native error to its opaque representation as a [`JsObject`].
     ///
     /// # Examples
     ///
@@ -745,8 +736,8 @@ pub enum JsNativeErrorKind {
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
     Type,
-    /// An error thrown when the [`encodeURI()`][e_uri] and [`decodeURI()`][d_uri]
-    /// functions receive invalid parameters.
+    /// An error thrown when the [`encodeURI()`][e_uri] and [`decodeURI()`][d_uri] functions receive
+    /// invalid parameters.
     ///
     /// More information:
     /// - [ECMAScript reference][spec]

--- a/boa_engine/src/error/mod.rs
+++ b/boa_engine/src/error/mod.rs
@@ -1,0 +1,332 @@
+use boa_gc::{Finalize, Trace};
+
+use crate::{
+    builtins::{error::ErrorKind, Array},
+    object::JsObject,
+    object::ObjectData,
+    property::PropertyDescriptor,
+    syntax::parser,
+    Context, JsResult, JsString, JsValue,
+};
+
+#[derive(Debug, Clone, Trace, Finalize)]
+pub struct JsError {
+    inner: Repr,
+}
+
+#[derive(Debug, Clone, Trace, Finalize)]
+enum Repr {
+    Native(JsNativeError),
+    Opaque(JsValue),
+}
+
+impl JsError {
+    pub fn to_value(&self, context: &mut Context) -> JsValue {
+        match &self.inner {
+            Repr::Native(e) => e.to_value(context),
+            Repr::Opaque(v) => v.clone(),
+        }
+    }
+
+    // TODO: Should probably change this to return a custom error instead
+    pub fn try_native(&self, context: &mut Context) -> JsResult<JsNativeError> {
+        match &self.inner {
+            Repr::Native(e) => Ok(e.clone()),
+            Repr::Opaque(val) => {
+                if let Some(obj) = val.as_object() {
+                    if let Some(error) = obj.borrow().as_error() {
+                        let message = if obj.has_property("message", context)? {
+                            obj.get("message", context)?
+                                .as_string()
+                                .map(JsString::to_std_string)
+                                .transpose()
+                                .map_err(|_| {
+                                    JsNativeError::typ().with_message(
+                                        "field `message` cannot have unpaired surrogates",
+                                    )
+                                })?
+                                .ok_or_else(|| {
+                                    JsNativeError::typ()
+                                        .with_message("invalid type for field `message`")
+                                })?
+                                .into()
+                        } else {
+                            "".into()
+                        };
+
+                        let cause = if obj.has_property("cause", context)? {
+                            Some(obj.get("cause", context)?)
+                        } else {
+                            None
+                        };
+
+                        let kind = match error {
+                            ErrorKind::Error => JsNativeErrorKind::Error,
+                            ErrorKind::Eval => JsNativeErrorKind::Eval,
+                            ErrorKind::Type => JsNativeErrorKind::Type,
+                            ErrorKind::Range => JsNativeErrorKind::Range,
+                            ErrorKind::Reference => JsNativeErrorKind::Reference,
+                            ErrorKind::Syntax => JsNativeErrorKind::Syntax,
+                            ErrorKind::Uri => JsNativeErrorKind::Uri,
+                            ErrorKind::Aggregate => {
+                                let errors = obj.get("errors", context)?;
+                                let mut error_list = Vec::new();
+                                match errors.as_object() {
+                                    Some(errors) if errors.is_array() => {
+                                        let length = errors.length_of_array_like(context)?;
+                                        for i in 0..length {
+                                            error_list.push(errors.get(i, context)?.into());
+                                        }
+                                    }
+                                    _ => {
+                                        return Err(JsNativeError::typ()
+                                            .with_message(
+                                                "field `errors` must be a valid Array object",
+                                            )
+                                            .into())
+                                    }
+                                }
+
+                                JsNativeErrorKind::Aggregate(error_list)
+                            }
+                        };
+
+                        return Ok(JsNativeError {
+                            kind,
+                            message,
+                            cause,
+                        });
+                    }
+                }
+                Err(JsNativeError::typ()
+                    .with_message("failed to convert value to native error")
+                    .with_cause(val)
+                    .into())
+            }
+        }
+    }
+
+    pub fn as_opaque(&self) -> Option<&JsValue> {
+        match self.inner {
+            Repr::Native(_) => None,
+            Repr::Opaque(ref v) => Some(v),
+        }
+    }
+
+    pub fn as_native(&self) -> Option<&JsNativeError> {
+        match self.inner {
+            Repr::Native(ref e) => Some(e),
+            Repr::Opaque(_) => None,
+        }
+    }
+}
+
+impl From<parser::ParseError> for JsError {
+    fn from(err: parser::ParseError) -> Self {
+        Self::from(JsNativeError::from(err))
+    }
+}
+
+impl From<JsNativeError> for JsError {
+    fn from(error: JsNativeError) -> Self {
+        Self {
+            inner: Repr::Native(error),
+        }
+    }
+}
+
+impl From<JsValue> for JsError {
+    fn from(value: JsValue) -> Self {
+        Self {
+            inner: Repr::Opaque(value),
+        }
+    }
+}
+
+impl From<JsObject> for JsError {
+    fn from(object: JsObject) -> Self {
+        Self {
+            inner: Repr::Opaque(object.into()),
+        }
+    }
+}
+
+impl std::fmt::Display for JsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.inner {
+            Repr::Native(e) => e.fmt(f),
+            Repr::Opaque(v) => v.display().fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Trace, Finalize)]
+pub struct JsNativeError {
+    pub kind: JsNativeErrorKind,
+    message: Box<str>,
+    cause: Option<JsValue>,
+}
+
+impl JsNativeError {
+    fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<JsValue>) -> Self {
+        Self {
+            kind,
+            message,
+            cause,
+        }
+    }
+
+    pub fn aggregate(errors: Vec<JsError>) -> Self {
+        Self::new(JsNativeErrorKind::Aggregate(errors), Box::default(), None)
+    }
+    pub fn error() -> Self {
+        Self::new(JsNativeErrorKind::Error, Box::default(), None)
+    }
+    pub fn eval() -> Self {
+        Self::new(JsNativeErrorKind::Eval, Box::default(), None)
+    }
+    pub fn range() -> Self {
+        Self::new(JsNativeErrorKind::Range, Box::default(), None)
+    }
+    pub fn reference() -> Self {
+        Self::new(JsNativeErrorKind::Reference, Box::default(), None)
+    }
+    pub fn syntax() -> Self {
+        Self::new(JsNativeErrorKind::Syntax, Box::default(), None)
+    }
+    pub fn typ() -> Self {
+        Self::new(JsNativeErrorKind::Type, Box::default(), None)
+    }
+    pub fn uri() -> Self {
+        Self::new(JsNativeErrorKind::Uri, Box::default(), None)
+    }
+
+    #[must_use]
+    pub fn with_message<S>(mut self, message: S) -> Self
+    where
+        S: Into<Box<str>>,
+    {
+        self.message = message.into();
+        self
+    }
+
+    #[must_use]
+    pub fn with_cause<V>(mut self, cause: V) -> Self
+    where
+        V: Into<JsValue>,
+    {
+        self.cause = Some(cause.into());
+        self
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn cause(&self) -> Option<&JsValue> {
+        self.cause.as_ref()
+    }
+
+    pub fn to_value(&self, context: &mut Context) -> JsValue {
+        let Self {
+            kind,
+            message,
+            cause,
+        } = self;
+        let constructors = context.intrinsics().constructors();
+        let prototype = match kind {
+            JsNativeErrorKind::Aggregate(_) => constructors.aggregate_error().prototype(),
+            JsNativeErrorKind::Error => constructors.error().prototype(),
+            JsNativeErrorKind::Eval => constructors.eval_error().prototype(),
+            JsNativeErrorKind::Range => constructors.range_error().prototype(),
+            JsNativeErrorKind::Reference => constructors.reference_error().prototype(),
+            JsNativeErrorKind::Syntax => constructors.syntax_error().prototype(),
+            JsNativeErrorKind::Type => constructors.type_error().prototype(),
+            JsNativeErrorKind::Uri => constructors.uri_error().prototype(),
+        };
+
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(kind.as_error_kind()));
+
+        o.create_non_enumerable_data_property_or_throw("message", &**message, context);
+
+        if let Some(cause) = cause {
+            o.create_non_enumerable_data_property_or_throw("cause", cause.clone(), context);
+        }
+
+        if let JsNativeErrorKind::Aggregate(errors) = kind {
+            let errors = errors
+                .iter()
+                .map(|e| e.to_value(context))
+                .collect::<Vec<_>>();
+            let errors = Array::create_array_from_list(errors, context);
+            o.define_property_or_throw(
+                "errors",
+                PropertyDescriptor::builder()
+                    .configurable(true)
+                    .enumerable(false)
+                    .writable(true)
+                    .value(errors),
+                context,
+            )
+            .expect("The spec guarantees this succeeds for a newly created object ");
+        }
+        o.into()
+    }
+}
+
+impl std::fmt::Display for JsNativeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self { kind, message, .. } = self;
+        write!(f, "{kind}: {message}")
+    }
+}
+
+impl From<parser::ParseError> for JsNativeError {
+    fn from(err: parser::ParseError) -> Self {
+        Self::syntax().with_message(err.to_string())
+    }
+}
+
+#[derive(Debug, Clone, Trace, Finalize)]
+#[non_exhaustive]
+pub enum JsNativeErrorKind {
+    Aggregate(Vec<JsError>),
+    Error,
+    Eval,
+    Range,
+    Reference,
+    Syntax,
+    Type,
+    Uri,
+}
+
+impl JsNativeErrorKind {
+    fn as_error_kind(&self) -> ErrorKind {
+        match self {
+            JsNativeErrorKind::Aggregate(_) => ErrorKind::Aggregate,
+            JsNativeErrorKind::Error => ErrorKind::Error,
+            JsNativeErrorKind::Eval => ErrorKind::Eval,
+            JsNativeErrorKind::Range => ErrorKind::Range,
+            JsNativeErrorKind::Reference => ErrorKind::Reference,
+            JsNativeErrorKind::Syntax => ErrorKind::Syntax,
+            JsNativeErrorKind::Type => ErrorKind::Type,
+            JsNativeErrorKind::Uri => ErrorKind::Uri,
+        }
+    }
+}
+
+impl std::fmt::Display for JsNativeErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            JsNativeErrorKind::Aggregate(_) => "AggregateError",
+            JsNativeErrorKind::Error => "Error",
+            JsNativeErrorKind::Eval => "EvalError",
+            JsNativeErrorKind::Range => "RangeError",
+            JsNativeErrorKind::Reference => "ReferenceError",
+            JsNativeErrorKind::Syntax => "SyntaxError",
+            JsNativeErrorKind::Type => "TypeError",
+            JsNativeErrorKind::Uri => "UriError",
+        }
+        .fmt(f)
+    }
+}

--- a/boa_engine/src/error/mod.rs
+++ b/boa_engine/src/error/mod.rs
@@ -1,5 +1,3 @@
-use boa_gc::{Finalize, Trace};
-
 use crate::{
     builtins::{error::ErrorKind, Array},
     object::JsObject,
@@ -8,26 +6,156 @@ use crate::{
     syntax::parser,
     Context, JsResult, JsString, JsValue,
 };
+use boa_gc::{Finalize, Trace};
+use thiserror::Error;
 
+/// The error type returned by all operations related
+/// to the execution of Javascript code.
+///
+/// This is essentially an enum that can store either [`JsNativeError`]s (for ideal
+/// native errors)  or opaque [`JsValue`]s, since Javascript allows throwing any valid
+/// `JsValue`.
+///
+/// The implementation doesn't provide a [`From`] conversion
+/// for `JsValue`. This is with the intent of encouraging the usage of proper
+/// `JsNativeError`s instead of plain `JsValue`s. However, if you
+/// do need a proper opaque error, you can construct one using the
+/// [`JsError::from_opaque`] method.
+///
+/// # Examples
+///
+/// ```rust
+/// # use boa_engine::{JsError, JsNativeError, JsNativeErrorKind, JsValue};
+/// let cause = JsError::from_opaque("error!".into());
+///
+/// assert!(cause.as_opaque().is_some());
+/// assert_eq!(cause.as_opaque().unwrap(), &JsValue::from("error!"));
+///
+/// let native_error: JsError = JsNativeError::typ()
+///     .with_message("invalid type!")
+///     .with_cause(cause)
+///     .into();
+///
+/// assert!(native_error.as_native().is_some());
+///
+/// let kind = &native_error.as_native().unwrap().kind;
+/// assert!(matches!(kind, JsNativeErrorKind::Type));
+/// ```
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct JsError {
     inner: Repr,
 }
 
+// hiding the enum makes it a bit more difficult
+// to treat `JsError` as a proper enum, which should
+// make it a bit harder to try to match against a native error
+// without calling `try_native` first.
 #[derive(Debug, Clone, Trace, Finalize)]
 enum Repr {
     Native(JsNativeError),
     Opaque(JsValue),
 }
 
-impl JsError {
-    pub fn to_value(&self, context: &mut Context) -> JsValue {
+impl std::error::Error for JsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match &self.inner {
-            Repr::Native(e) => e.to_value(context),
+            Repr::Native(err) => err.source(),
+            Repr::Opaque(_) => None,
+        }
+    }
+}
+
+impl JsError {
+    /// Creates a new `JsError` from a native error `err`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsError, JsNativeError};
+    /// let error = JsError::from_native(JsNativeError::syntax());
+    ///
+    /// assert!(error.as_native().is_some());
+    /// ```
+    pub fn from_native(err: JsNativeError) -> Self {
+        Self {
+            inner: Repr::Native(err),
+        }
+    }
+
+    /// Creates a new `JsError` from an opaque error `value`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::JsError;
+    /// let error = JsError::from_opaque(5.0f64.into());
+    ///
+    /// assert!(error.as_opaque().is_some());
+    /// ```
+    pub fn from_opaque(value: JsValue) -> Self {
+        Self {
+            inner: Repr::Opaque(value),
+        }
+    }
+
+    /// Converts the error to an opaque `JsValue` error
+    ///
+    /// Unwraps the inner `JsValue` if the error is already an opaque error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{Context, JsError, JsNativeError};
+    /// let context = &mut Context::default();
+    /// let error: JsError = JsNativeError::eval().with_message("invalid script").into();
+    /// let error_val = error.to_opaque(context);
+    ///
+    /// assert!(error_val.as_object().unwrap().borrow().is_error());
+    /// ```
+    pub fn to_opaque(&self, context: &mut Context) -> JsValue {
+        match &self.inner {
+            Repr::Native(e) => e.to_opaque(context).into(),
             Repr::Opaque(v) => v.clone(),
         }
     }
 
+    /// Unwraps the inner error if this contains a native error.
+    /// Otherwise, it will inspect the opaque error and try to extract the
+    /// necessary information to construct a native error similar to the provided
+    /// opaque error.
+    ///
+    /// # Note 1
+    ///
+    /// This method won't try to make any conversions between JS types.
+    /// In other words, for this conversion to succeed:
+    /// - `message` **MUST** be a `JsString` value.
+    /// - `errors` (in the case of `AggregateError`s) **MUST** be an `Array` object.
+    ///
+    /// # Note 2
+    ///
+    /// This operation should be considered a lossy conversion, since it
+    /// won't store any additional properties of the opaque
+    /// error, other than `message`, `cause` and `errors` (in the case of
+    /// `AggregateError`s). If you cannot affort a lossy conversion, clone
+    /// the object before calling [`from_opaque`][JsError::from_opaque]
+    /// to preserve its original properties.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{Context, JsError, JsNativeError, JsNativeErrorKind};
+    /// let context = &mut Context::default();
+    ///
+    /// // create a new, opaque Error object
+    /// let error: JsError = JsNativeError::typ().with_message("type error!").into();
+    /// let error_val = error.to_opaque(context);
+    ///
+    /// // then, try to recover the original
+    /// let error = JsError::from_opaque(error_val).try_native(context).unwrap();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Type));
+    /// assert_eq!(error.message(), "type error!");
+    /// ```
     // TODO: Should probably change this to return a custom error instead
     pub fn try_native(&self, context: &mut Context) -> JsResult<JsNativeError> {
         match &self.inner {
@@ -54,11 +182,10 @@ impl JsError {
                             "".into()
                         };
 
-                        let cause = if obj.has_property("cause", context)? {
-                            Some(obj.get("cause", context)?)
-                        } else {
-                            None
-                        };
+                        let cause = obj
+                            .has_property("cause", context)?
+                            .then(|| obj.get("cause", context))
+                            .transpose()?;
 
                         let kind = match error {
                             ErrorKind::Error => JsNativeErrorKind::Error,
@@ -75,7 +202,9 @@ impl JsError {
                                     Some(errors) if errors.is_array() => {
                                         let length = errors.length_of_array_like(context)?;
                                         for i in 0..length {
-                                            error_list.push(errors.get(i, context)?.into());
+                                            error_list.push(JsError::from_opaque(
+                                                errors.get(i, context)?,
+                                            ));
                                         }
                                     }
                                     _ => {
@@ -94,18 +223,34 @@ impl JsError {
                         return Ok(JsNativeError {
                             kind,
                             message,
-                            cause,
+                            cause: cause.map(|v| Box::new(JsError::from_opaque(v))),
                         });
                     }
                 }
                 Err(JsNativeError::typ()
                     .with_message("failed to convert value to native error")
-                    .with_cause(val)
                     .into())
             }
         }
     }
 
+    /// Gets the inner [`JsValue`] if the error is an opaque error,
+    /// or `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsError, JsNativeError};
+    /// let error: JsError = JsNativeError::reference()
+    ///     .with_message("variable not found!")
+    ///     .into();
+    ///
+    /// assert!(error.as_opaque().is_none());
+    ///
+    /// let error = JsError::from_opaque(256u32.into());
+    ///
+    /// assert!(error.as_opaque().is_some());
+    /// ```
     pub fn as_opaque(&self) -> Option<&JsValue> {
         match self.inner {
             Repr::Native(_) => None,
@@ -113,6 +258,21 @@ impl JsError {
         }
     }
 
+    /// Gets the inner [`JsNativeError`] if the error is a native
+    /// error, or `None` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsError, JsNativeError, JsValue};
+    /// let error: JsError = JsNativeError::error().with_message("Unknown error").into();
+    ///
+    /// assert!(error.as_native().is_some());
+    ///
+    /// let error = JsError::from_opaque(JsValue::undefined().into());
+    ///
+    /// assert!(error.as_native().is_none());
+    /// ```
     pub fn as_native(&self) -> Option<&JsNativeError> {
         match self.inner {
             Repr::Native(ref e) => Some(e),
@@ -135,22 +295,6 @@ impl From<JsNativeError> for JsError {
     }
 }
 
-impl From<JsValue> for JsError {
-    fn from(value: JsValue) -> Self {
-        Self {
-            inner: Repr::Opaque(value),
-        }
-    }
-}
-
-impl From<JsObject> for JsError {
-    fn from(object: JsObject) -> Self {
-        Self {
-            inner: Repr::Opaque(object.into()),
-        }
-    }
-}
-
 impl std::fmt::Display for JsError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.inner {
@@ -160,15 +304,41 @@ impl std::fmt::Display for JsError {
     }
 }
 
-#[derive(Debug, Clone, Trace, Finalize)]
+/// Native representation of an ideal `Error` object from Javascript.
+///
+/// This representation is more space efficient than its [`JsObject`] equivalent,
+/// since it doesn't need to create a whole new `JsObject` to be instantiated.
+/// Prefer using this over [`JsError`] when you don't need to throw
+/// plain [`JsValue`]s as errors, or when you need to inspect the error type
+/// of a `JsError`.
+///
+/// # Examples
+///
+/// ```rust
+/// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+/// let native_error = JsNativeError::uri().with_message("cannot decode uri");
+///
+/// match native_error.kind {
+///     JsNativeErrorKind::Uri => { /* handle URI error*/ }
+///     _ => unreachable!(),
+/// }
+///
+/// assert_eq!(native_error.message(), "cannot decode uri");
+/// ```
+#[derive(Debug, Clone, Trace, Finalize, Error)]
+#[error("{kind}: {message}")]
 pub struct JsNativeError {
+    /// The kind of native error (e.g. `TypeError`, `SyntaxError`, etc.)
     pub kind: JsNativeErrorKind,
     message: Box<str>,
-    cause: Option<JsValue>,
+    #[source]
+    cause: Option<Box<JsError>>,
 }
 
 impl JsNativeError {
-    fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<JsValue>) -> Self {
+    /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally)
+    /// its `cause`.
+    fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<Box<JsError>>) -> Self {
         Self {
             kind,
             message,
@@ -176,31 +346,150 @@ impl JsNativeError {
         }
     }
 
+    /// Creates a new `JsNativeError` of kind `AggregateError` from
+    /// a list of [`JsError`]s, with empty `message` and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let inner_errors = vec![
+    ///     JsNativeError::typ().into(),
+    ///     JsNativeError::syntax().into()
+    /// ];
+    /// let error = JsNativeError::aggregate(inner_errors);
+    ///
+    /// assert!(matches!(
+    ///     error.kind,
+    ///     JsNativeErrorKind::Aggregate(ref errors) if errors.len() == 2
+    /// ));
+    /// ```
     pub fn aggregate(errors: Vec<JsError>) -> Self {
         Self::new(JsNativeErrorKind::Aggregate(errors), Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `Error`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::error();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Error));
+    /// ```
     pub fn error() -> Self {
         Self::new(JsNativeErrorKind::Error, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `EvalError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::eval();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Eval));
+    /// ```
     pub fn eval() -> Self {
         Self::new(JsNativeErrorKind::Eval, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `RangeError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::range();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Range));
+    /// ```
     pub fn range() -> Self {
         Self::new(JsNativeErrorKind::Range, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `ReferenceError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::reference();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Reference));
+    /// ```
     pub fn reference() -> Self {
         Self::new(JsNativeErrorKind::Reference, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `SyntaxError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::syntax();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Syntax));
+    /// ```
     pub fn syntax() -> Self {
         Self::new(JsNativeErrorKind::Syntax, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `TypeError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::typ();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Type));
+    /// ```
     pub fn typ() -> Self {
         Self::new(JsNativeErrorKind::Type, Box::default(), None)
     }
+
+    /// Creates a new `JsNativeError` of kind `UriError`, with empty `message`
+    /// and undefined `cause`.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{JsNativeError, JsNativeErrorKind};
+    /// let error = JsNativeError::uri();
+    ///
+    /// assert!(matches!(error.kind, JsNativeErrorKind::Uri));
+    /// ```
     pub fn uri() -> Self {
         Self::new(JsNativeErrorKind::Uri, Box::default(), None)
     }
 
+    /// Appends a message to this error.
+    ///
+    /// # Note
+    ///
+    /// A static [`str`] will be stored as a simple pointer,
+    /// while a [`String`] will be converted to a [`Rc<str>`][std::rc::Rc<str>] in order
+    /// to make clones more efficient. Prefer static `str`s if you want
+    /// efficiency, and [`String`] s if you prefer descriptive error messages.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::JsNativeError;
+    /// let error = JsNativeError::range().with_message("number too large");
+    ///
+    /// assert_eq!(error.message(), "number too large");
+    /// ```
     #[must_use]
     pub fn with_message<S>(mut self, message: S) -> Self
     where
@@ -210,53 +499,122 @@ impl JsNativeError {
         self
     }
 
+    /// Appends a cause to this error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::JsNativeError;
+    /// let cause = JsNativeError::syntax();
+    /// let error = JsNativeError::error().with_cause(cause);
+    ///
+    /// assert!(error.cause().unwrap().as_native().is_some());
+    /// ```
     #[must_use]
     pub fn with_cause<V>(mut self, cause: V) -> Self
     where
-        V: Into<JsValue>,
+        V: Into<JsError>,
     {
-        self.cause = Some(cause.into());
+        self.cause = Some(Box::new(cause.into()));
         self
     }
 
+    /// Gets the `message` of this error.
+    ///
+    /// This is equivalent to the [`NativeError.prototype.message`][spec]
+    /// property.
+    ///
+    /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::JsNativeError;
+    /// let error = JsNativeError::range().with_message("number too large");
+    ///
+    /// assert_eq!(error.message(), "number too large");
+    /// ```
     pub fn message(&self) -> &str {
         &self.message
     }
 
-    pub fn cause(&self) -> Option<&JsValue> {
-        self.cause.as_ref()
+    /// Gets the `cause` of this error.
+    ///
+    /// This is equivalent to the [`NativeError.prototype.cause`][spec]
+    /// property.
+    ///
+    /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::JsNativeError;
+    /// let cause = JsNativeError::syntax();
+    /// let error = JsNativeError::error().with_cause(cause);
+    ///
+    /// assert!(error.cause().unwrap().as_native().is_some());
+    /// ```
+    pub fn cause(&self) -> Option<&JsError> {
+        self.cause.as_deref()
     }
 
-    pub fn to_value(&self, context: &mut Context) -> JsValue {
+    /// Converts this native error to its opaque representation as a
+    /// [`JsObject`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use boa_engine::{Context, JsError, JsNativeError};
+    /// let context = &mut Context::default();
+    ///
+    /// let error = JsNativeError::error().with_message("error!");
+    /// let error_obj = error.to_opaque(context);
+    ///
+    /// assert!(error_obj.borrow().is_error());
+    /// assert_eq!(error_obj.get("message", context).unwrap(), "error!".into())
+    /// ```
+    pub fn to_opaque(&self, context: &mut Context) -> JsObject {
         let Self {
             kind,
             message,
             cause,
         } = self;
         let constructors = context.intrinsics().constructors();
-        let prototype = match kind {
-            JsNativeErrorKind::Aggregate(_) => constructors.aggregate_error().prototype(),
-            JsNativeErrorKind::Error => constructors.error().prototype(),
-            JsNativeErrorKind::Eval => constructors.eval_error().prototype(),
-            JsNativeErrorKind::Range => constructors.range_error().prototype(),
-            JsNativeErrorKind::Reference => constructors.reference_error().prototype(),
-            JsNativeErrorKind::Syntax => constructors.syntax_error().prototype(),
-            JsNativeErrorKind::Type => constructors.type_error().prototype(),
-            JsNativeErrorKind::Uri => constructors.uri_error().prototype(),
+        let (prototype, tag) = match kind {
+            JsNativeErrorKind::Aggregate(_) => (
+                constructors.aggregate_error().prototype(),
+                ErrorKind::Aggregate,
+            ),
+            JsNativeErrorKind::Error => (constructors.error().prototype(), ErrorKind::Error),
+            JsNativeErrorKind::Eval => (constructors.eval_error().prototype(), ErrorKind::Eval),
+            JsNativeErrorKind::Range => (constructors.range_error().prototype(), ErrorKind::Range),
+            JsNativeErrorKind::Reference => (
+                constructors.reference_error().prototype(),
+                ErrorKind::Reference,
+            ),
+            JsNativeErrorKind::Syntax => {
+                (constructors.syntax_error().prototype(), ErrorKind::Syntax)
+            }
+            JsNativeErrorKind::Type => (constructors.type_error().prototype(), ErrorKind::Type),
+            JsNativeErrorKind::Uri => (constructors.uri_error().prototype(), ErrorKind::Uri),
         };
 
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(kind.as_error_kind()));
+        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(tag));
 
         o.create_non_enumerable_data_property_or_throw("message", &**message, context);
 
         if let Some(cause) = cause {
-            o.create_non_enumerable_data_property_or_throw("cause", cause.clone(), context);
+            o.create_non_enumerable_data_property_or_throw(
+                "cause",
+                cause.to_opaque(context),
+                context,
+            );
         }
 
         if let JsNativeErrorKind::Aggregate(errors) = kind {
             let errors = errors
                 .iter()
-                .map(|e| e.to_value(context))
+                .map(|e| e.to_opaque(context))
                 .collect::<Vec<_>>();
             let errors = Array::create_array_from_list(errors, context);
             o.define_property_or_throw(
@@ -270,14 +628,7 @@ impl JsNativeError {
             )
             .expect("The spec guarantees this succeeds for a newly created object ");
         }
-        o.into()
-    }
-}
-
-impl std::fmt::Display for JsNativeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self { kind, message, .. } = self;
-        write!(f, "{kind}: {message}")
+        o
     }
 }
 
@@ -287,32 +638,93 @@ impl From<parser::ParseError> for JsNativeError {
     }
 }
 
+/// The list of possible error types a [`JsNativeError`] can be.
+///
+/// More information:
+/// - [ECMAScript reference][spec]
+/// - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-error-objects
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
 #[derive(Debug, Clone, Trace, Finalize)]
 #[non_exhaustive]
 pub enum JsNativeErrorKind {
+    /// A collection of errors wrapped in a single error.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-aggregate-error-objects
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError
     Aggregate(Vec<JsError>),
+    /// A generic error. Commonly used as the base for custom exceptions.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-error-constructor
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
     Error,
+    /// An error related to the global function [`eval()`][eval].
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/EvalError
+    /// [eval]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
     Eval,
+    /// An error thrown when a value is outside its valid range.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RangeError
     Range,
+    /// An error representing an invalid de-reference of a variable.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ReferenceError
     Reference,
+    /// An error representing an invalid syntax in the Javascript language.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError
     Syntax,
+    /// An error thrown when a variable or argument is not of a valid type.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError
     Type,
+    /// An error thrown when the [`encodeURI()`][e_uri] and [`decodeURI()`][d_uri]
+    /// functions receive invalid parameters.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    /// - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/URIError
+    /// [e_uri]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
+    /// [d_uri]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURI
     Uri,
-}
-
-impl JsNativeErrorKind {
-    fn as_error_kind(&self) -> ErrorKind {
-        match self {
-            JsNativeErrorKind::Aggregate(_) => ErrorKind::Aggregate,
-            JsNativeErrorKind::Error => ErrorKind::Error,
-            JsNativeErrorKind::Eval => ErrorKind::Eval,
-            JsNativeErrorKind::Range => ErrorKind::Range,
-            JsNativeErrorKind::Reference => ErrorKind::Reference,
-            JsNativeErrorKind::Syntax => ErrorKind::Syntax,
-            JsNativeErrorKind::Type => ErrorKind::Type,
-            JsNativeErrorKind::Uri => ErrorKind::Uri,
-        }
-    }
 }
 
 impl std::fmt::Display for JsNativeErrorKind {

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::Array,
+    error::JsNativeError,
     object::{JsFunction, JsObject, JsObjectType},
     value::IntoOrUndefined,
     Context, JsResult, JsString, JsValue,
@@ -38,11 +39,13 @@ impl JsArray {
     ///
     /// This does not clone the fields of the array, it only does a shallow clone of the object.
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_array() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not an Array")
+            Err(JsNativeError::typ()
+                .with_message("object is not an Array")
+                .into())
         }
     }
 
@@ -112,7 +115,7 @@ impl JsArray {
             .cloned()
             .expect("Array.prototype.filter should always return object");
 
-        Self::from_object(object, context)
+        Self::from_object(object)
     }
 
     #[inline]
@@ -234,7 +237,7 @@ impl JsArray {
         .cloned()
         .expect("Array.prototype.filter should always return object");
 
-        Self::from_object(object, context)
+        Self::from_object(object)
     }
 
     #[inline]
@@ -253,7 +256,7 @@ impl JsArray {
         .cloned()
         .expect("Array.prototype.map should always return object");
 
-        Self::from_object(object, context)
+        Self::from_object(object)
     }
 
     #[inline]
@@ -319,7 +322,7 @@ impl JsArray {
         .cloned()
         .expect("Array.prototype.slice should always return object");
 
-        Self::from_object(object, context)
+        Self::from_object(object)
     }
 
     #[inline]

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -1,6 +1,7 @@
 use crate::{
     builtins::array_buffer::ArrayBuffer,
     context::intrinsics::StandardConstructors,
+    error::JsNativeError,
     object::{
         internal_methods::get_prototype_from_constructor, JsObject, JsObjectType, ObjectData,
     },
@@ -79,11 +80,13 @@ impl JsArrayBuffer {
     ///
     /// This does not clone the fields of the array buffer, it only does a shallow clone of the object.
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_array_buffer() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not an ArrayBuffer")
+            Err(JsNativeError::typ()
+                .with_message("object is not an ArrayBuffer")
+                .into())
         }
     }
 

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -32,7 +32,6 @@ use std::ops::Deref;
 /// map.set("Key-2", 10, context).unwrap();
 ///
 /// assert_eq!(map.get_size(context).unwrap(), 2.into());
-///
 /// ```
 ///
 /// Create a `JsMap` from a `JsArray`
@@ -52,15 +51,18 @@ use std::ops::Deref;
 /// let vec_one: Vec<JsValue> = vec![JsValue::new("first-key"), JsValue::new("first-value")];
 ///
 /// // We create an push our `[key, value]` pair onto our array as a `JsArray`
-/// js_array.push(JsArray::from_iter(vec_one, context), context).unwrap();
+/// js_array
+///     .push(JsArray::from_iter(vec_one, context), context)
+///     .unwrap();
 ///
 /// // Create a `JsMap` from the `JsArray` using it's iterable property.
 /// let js_iterable_map = JsMap::from_js_iterable(&js_array.into(), context).unwrap();
 ///
-/// assert_eq!(js_iterable_map.get("first-key", context).unwrap(), "first-value".into());
-///
+/// assert_eq!(
+///     js_iterable_map.get("first-key", context).unwrap(),
+///     "first-value".into()
+/// );
 /// ```
-///
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct JsMap {
     inner: JsObject,
@@ -82,7 +84,6 @@ impl JsMap {
     ///
     /// // Create a new empty `JsMap`.
     /// let map = JsMap::new(context);
-    ///
     /// ```
     #[inline]
     pub fn new(context: &mut Context) -> Self {
@@ -107,13 +108,13 @@ impl JsMap {
     ///
     /// // Create a `[key, value]` pair of JsValues and add it to the `JsArray` as a `JsArray`
     /// let vec_one: Vec<JsValue> = vec![JsValue::new("first-key"), JsValue::new("first-value")];
-    /// js_array.push(JsArray::from_iter(vec_one, context), context).unwrap();
+    /// js_array
+    ///     .push(JsArray::from_iter(vec_one, context), context)
+    ///     .unwrap();
     ///
     /// // Create a `JsMap` from the `JsArray` using it's iterable property.
     /// let js_iterable_map = JsMap::from_js_iterable(&js_array.into(), context).unwrap();
-    ///
     /// ```
-    ///
     #[inline]
     pub fn from_js_iterable(iterable: &JsValue, context: &mut Context) -> JsResult<Self> {
         // Create a new map object.
@@ -146,12 +147,11 @@ impl JsMap {
     /// // `some_object` can be any JavaScript `Map` object.
     /// let some_object = JsObject::from_proto_and_data(
     ///     context.intrinsics().constructors().map().prototype(),
-    ///     ObjectData::map(OrderedMap::new())
+    ///     ObjectData::map(OrderedMap::new()),
     /// );
     ///
     /// // Create `JsMap` object with incoming object.
     /// let js_map = JsMap::from_object(some_object).unwrap();
-    ///
     /// ```
     ///
     /// Invalid Example - returns a `TypeError` with the message "object is not a Map"
@@ -167,7 +167,6 @@ impl JsMap {
     ///
     /// // `some_object` is an Array object, not a map object
     /// assert!(JsMap::from_object(some_object.into()).is_err());
-    ///
     /// ```
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
@@ -226,7 +225,6 @@ impl JsMap {
     ///
     /// assert_eq!(js_map.get("foo", context).unwrap(), "bar".into());
     /// assert_eq!(js_map.get(2, context).unwrap(), 4.into())
-    ///
     /// ```
     #[inline]
     pub fn set<K, V>(&self, key: K, value: V, context: &mut Context) -> JsResult<JsValue>
@@ -260,7 +258,6 @@ impl JsMap {
     /// let map_size = js_map.get_size(context).unwrap();
     ///
     /// assert_eq!(map_size, 1.into());
-    ///
     /// ```
     #[inline]
     pub fn get_size(&self, context: &mut Context) -> JsResult<JsValue> {
@@ -287,7 +284,6 @@ impl JsMap {
     ///
     /// assert_eq!(js_map.get_size(context).unwrap(), 1.into());
     /// assert_eq!(js_map.get("foo", context).unwrap(), JsValue::undefined());
-    ///
     /// ```
     #[inline]
     pub fn delete<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
@@ -314,7 +310,6 @@ impl JsMap {
     /// let retrieved_value = js_map.get("foo", context).unwrap();
     ///
     /// assert_eq!(retrieved_value, "bar".into());
-    ///
     /// ```
     #[inline]
     pub fn get<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
@@ -343,7 +338,6 @@ impl JsMap {
     /// js_map.clear(context).unwrap();
     ///
     /// assert_eq!(js_map.get_size(context).unwrap(), 0.into());
-    ///
     /// ```
     #[inline]
     pub fn clear(&self, context: &mut Context) -> JsResult<JsValue> {
@@ -368,7 +362,6 @@ impl JsMap {
     /// let has_key = js_map.has("foo", context).unwrap();
     ///
     /// assert_eq!(has_key, true.into());
-    ///
     /// ```
     #[inline]
     pub fn has<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -2,6 +2,7 @@
 use crate::{
     builtins::map::{add_entries_from_iterable, ordered_map::OrderedMap},
     builtins::Map,
+    error::JsNativeError,
     object::{JsFunction, JsMapIterator, JsObject, JsObjectType, ObjectData},
     Context, JsResult, JsValue,
 };
@@ -149,7 +150,7 @@ impl JsMap {
     /// );
     ///
     /// // Create `JsMap` object with incoming object.
-    /// let js_map = JsMap::from_object(some_object, context).unwrap();
+    /// let js_map = JsMap::from_object(some_object).unwrap();
     ///
     /// ```
     ///
@@ -164,16 +165,18 @@ impl JsMap {
     ///
     /// let some_object = JsArray::new(context);
     ///
-    /// // Some object is an Array object, not a map object
-    /// assert!(JsMap::from_object(some_object.into(), context).is_err());
+    /// // `some_object` is an Array object, not a map object
+    /// assert!(JsMap::from_object(some_object.into()).is_err());
     ///
     /// ```
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_map() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not a Map")
+            Err(JsNativeError::typ()
+                .with_message("object is not a Map")
+                .into())
         }
     }
 
@@ -192,7 +195,7 @@ impl JsMap {
         let iterator_record = Map::entries(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
-        JsMapIterator::from_object(map_iterator_object.clone(), context)
+        JsMapIterator::from_object(map_iterator_object.clone())
     }
 
     /// Returns a new [`JsMapIterator`] object that yields the `key` for each element within the [`JsMap`] in insertion order.
@@ -201,7 +204,7 @@ impl JsMap {
         let iterator_record = Map::keys(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
-        JsMapIterator::from_object(map_iterator_object.clone(), context)
+        JsMapIterator::from_object(map_iterator_object.clone())
     }
 
     /// Inserts a new entry into the [`JsMap`] object
@@ -396,7 +399,7 @@ impl JsMap {
         let iterator_record = Map::values(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
-        JsMapIterator::from_object(map_iterator_object.clone(), context)
+        JsMapIterator::from_object(map_iterator_object.clone())
     }
 }
 

--- a/boa_engine/src/object/builtins/jsmap_iterator.rs
+++ b/boa_engine/src/object/builtins/jsmap_iterator.rs
@@ -1,6 +1,7 @@
 //! This module implements a wrapper for the `MapIterator` object
 use crate::{
     builtins::map::map_iterator::MapIterator,
+    error::JsNativeError,
     object::{JsObject, JsObjectType},
     Context, JsResult, JsValue,
 };
@@ -17,11 +18,13 @@ pub struct JsMapIterator {
 impl JsMapIterator {
     /// Create a [`JsMapIterator`] from a [`JsObject`]. If object is not a `MapIterator`, throw `TypeError`
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_map_iterator() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not a MapIterator")
+            Err(JsNativeError::typ()
+                .with_message("object is not a MapIterator")
+                .into())
         }
     }
 

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -2,7 +2,7 @@
 use crate::{
     builtins::RegExp,
     object::{JsArray, JsObject, JsObjectType},
-    Context, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue,
 };
 
 use boa_gc::{Finalize, Trace};
@@ -75,11 +75,13 @@ impl JsRegExp {
 
     /// Create a `JsRegExp` from a regular expression `JsObject`
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_regexp() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not a RegExp")
+            Err(JsNativeError::typ()
+                .with_message("object is not a RegExp")
+                .into())
         }
     }
 
@@ -210,11 +212,8 @@ impl JsRegExp {
                 None
             } else {
                 Some(
-                    JsArray::from_object(
-                        v.to_object(context).expect("v must be an array"),
-                        context,
-                    )
-                    .expect("from_object must not fail if v is an array object"),
+                    JsArray::from_object(v.to_object(context).expect("v must be an array"))
+                        .expect("from_object must not fail if v is an array object"),
                 )
             }
         })

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -75,9 +75,9 @@ impl JsSet {
     where
         T: Into<JsValue>,
     {
+        // TODO: Make `delete` return a native `bool`
         match Set::delete(&self.inner.clone().into(), &[value.into()], context)? {
             JsValue::Boolean(bool) => Ok(bool),
-            // TODO: find a better solution to this, without impacting perf
             _ => unreachable!("`delete` must always return a bool"),
         }
     }
@@ -91,9 +91,9 @@ impl JsSet {
     where
         T: Into<JsValue>,
     {
+        // TODO: Make `has` return a native `bool`
         match Set::has(&self.inner.clone().into(), &[value.into()], context)? {
             JsValue::Boolean(bool) => Ok(bool),
-            // TODO: find a better solution to this, without impacting perf
             _ => unreachable!("`has` must always return a bool"),
         }
     }

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -4,6 +4,7 @@ use boa_gc::{Finalize, Trace};
 
 use crate::{
     builtins::Set,
+    error::JsNativeError,
     object::{JsFunction, JsObject, JsObjectType, JsSetIterator},
     Context, JsResult, JsValue,
 };
@@ -30,8 +31,8 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.size`.
     #[inline]
-    pub fn size(&self, context: &mut Context) -> JsResult<usize> {
-        Set::get_size(&self.inner.clone().into(), context)
+    pub fn size(&self) -> JsResult<usize> {
+        Set::get_size(&self.inner.clone().into())
     }
 
     /// Appends value to the Set object.
@@ -76,7 +77,8 @@ impl JsSet {
     {
         match Set::delete(&self.inner.clone().into(), &[value.into()], context)? {
             JsValue::Boolean(bool) => Ok(bool),
-            _ => Err(JsValue::Undefined),
+            // TODO: find a better solution to this, without impacting perf
+            _ => unreachable!("`delete` must always return a bool"),
         }
     }
 
@@ -91,7 +93,8 @@ impl JsSet {
     {
         match Set::has(&self.inner.clone().into(), &[value.into()], context)? {
             JsValue::Boolean(bool) => Ok(bool),
-            _ => Err(JsValue::Undefined),
+            // TODO: find a better solution to this, without impacting perf
+            _ => unreachable!("`has` must always return a bool"),
         }
     }
 
@@ -104,7 +107,7 @@ impl JsSet {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
-        JsSetIterator::from_object(iterator_object.iterator().clone(), context)
+        JsSetIterator::from_object(iterator_object.iterator().clone())
     }
 
     /// Alias for `Set.prototype.values()`
@@ -117,7 +120,7 @@ impl JsSet {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
-        JsSetIterator::from_object(iterator_object.iterator().clone(), context)
+        JsSetIterator::from_object(iterator_object.iterator().clone())
     }
 
     /// Calls callbackFn once for each value present in the Set object,
@@ -141,11 +144,13 @@ impl JsSet {
 
     /// Utility: Creates `JsSet` from `JsObject`, if not a Set throw `TypeError`.
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_set() {
             Ok(Self { inner: object })
         } else {
-            context.throw_error("Object is not a Set")
+            Err(JsNativeError::typ()
+                .with_message("Object is not a Set")
+                .into())
         }
     }
 

--- a/boa_engine/src/object/builtins/jsset_iterator.rs
+++ b/boa_engine/src/object/builtins/jsset_iterator.rs
@@ -4,6 +4,7 @@ use boa_gc::{Finalize, Trace};
 
 use crate::{
     builtins::SetIterator,
+    error::JsNativeError,
     object::{JsObject, JsObjectType},
     Context, JsResult, JsValue,
 };
@@ -17,11 +18,13 @@ pub struct JsSetIterator {
 impl JsSetIterator {
     /// Create a `JsSetIterator` from a `JsObject`.
     /// If object is not a `SetIterator`, throw `TypeError`.
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_set_iterator() {
             Ok(Self { inner: object })
         } else {
-            context.throw_type_error("object is not a SetIterator")
+            Err(JsNativeError::typ()
+                .with_message("object is not a SetIterator")
+                .into())
         }
     }
     /// Advances the `JsSetIterator` and gets the next result in the `JsSet`.

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::typed_array::TypedArray,
+    error::JsNativeError,
     object::{JsArrayBuffer, JsFunction, JsObject, JsObjectType},
     value::IntoOrUndefined,
     Context, JsResult, JsString, JsValue,
@@ -18,13 +19,15 @@ impl JsTypedArray {
     ///
     /// This does not clone the fields of the typed array, it only does a shallow clone of the object.
     #[inline]
-    pub fn from_object(object: JsObject, context: &mut Context) -> JsResult<Self> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.borrow().is_typed_array() {
             Ok(Self {
                 inner: object.into(),
             })
         } else {
-            context.throw_type_error("object is not a TypedArray")
+            Err(JsNativeError::typ()
+                .with_message("object is not a TypedArray")
+                .into())
         }
     }
 

--- a/boa_engine/src/object/internal_methods/array.rs
+++ b/boa_engine/src/object/internal_methods/array.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::JsNativeError,
     object::JsObject,
     property::{PropertyDescriptor, PropertyKey},
     string::utf16,
@@ -127,7 +128,9 @@ fn array_set_length(
     // 5. If SameValueZero(newLen, numberLen) is false, throw a RangeError exception.
     #[allow(clippy::float_cmp)]
     if f64::from(new_len) != number_len {
-        return context.throw_range_error("bad length for array");
+        return Err(JsNativeError::range()
+            .with_message("bad length for array")
+            .into());
     }
 
     // 2. Let newLenDesc be a copy of Desc.

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::{array, object::Object},
+    error::JsNativeError,
     object::{InternalObjectMethods, JsObject, JsPrototype},
     property::{PropertyDescriptor, PropertyKey},
     value::Type,
@@ -61,7 +62,7 @@ pub(crate) fn proxy_exotic_get_prototype_of(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "getPrototypeOf").
     let trap = if let Some(trap) = handler.get_method("getPrototypeOf", context)? {
@@ -79,7 +80,11 @@ pub(crate) fn proxy_exotic_get_prototype_of(
     let handler_proto = match &handler_proto {
         JsValue::Object(obj) => Some(obj.clone()),
         JsValue::Null => None,
-        _ => return context.throw_type_error("Proxy trap result is neither object nor null"),
+        _ => {
+            return Err(JsNativeError::typ()
+                .with_message("Proxy trap result is neither object nor null")
+                .into())
+        }
     };
 
     // 9. Let extensibleTarget be ? IsExtensible(target).
@@ -93,7 +98,9 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 
     // 12. If SameValue(handlerProto, targetProto) is false, throw a TypeError exception.
     if handler_proto != target_proto {
-        return context.throw_type_error("Proxy trap returned unexpected prototype");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap returned unexpected prototype")
+            .into());
     }
 
     // 13. Return handlerProto.
@@ -120,7 +127,7 @@ pub(crate) fn proxy_exotic_set_prototype_of(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "setPrototypeOf").
     let trap = if let Some(trap) = handler.get_method("setPrototypeOf", context)? {
@@ -158,7 +165,9 @@ pub(crate) fn proxy_exotic_set_prototype_of(
 
     // 12. If SameValue(V, targetProto) is false, throw a TypeError exception.
     if val != target_proto {
-        return context.throw_type_error("Proxy trap failed to set prototype");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap failed to set prototype")
+            .into());
     }
 
     // 13. Return true.
@@ -181,7 +190,7 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "isExtensible").
     let trap = if let Some(trap) = handler.get_method("isExtensible", context)? {
@@ -202,7 +211,9 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
 
     // 9. If SameValue(booleanTrapResult, targetResult) is false, throw a TypeError exception.
     if boolean_trap_result != target_result {
-        return context.throw_type_error("Proxy trap returned unexpected extensible value");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap returned unexpected extensible value")
+            .into());
     }
 
     // 10. Return booleanTrapResult.
@@ -228,7 +239,7 @@ pub(crate) fn proxy_exotic_prevent_extensions(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "preventExtensions").
     let trap = if let Some(trap) = handler.get_method("preventExtensions", context)? {
@@ -248,7 +259,9 @@ pub(crate) fn proxy_exotic_prevent_extensions(
     if boolean_trap_result && target.is_extensible(context)? {
         // a. Let extensibleTarget be ? IsExtensible(target).
         // b. If extensibleTarget is true, throw a TypeError exception.
-        return context.throw_type_error("Proxy trap failed to set extensible");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap failed to set extensible")
+            .into());
     }
 
     // 9. Return booleanTrapResult.
@@ -275,7 +288,7 @@ pub(crate) fn proxy_exotic_get_own_property(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "getOwnPropertyDescriptor").
     let trap = if let Some(trap) = handler.get_method("getOwnPropertyDescriptor", context)? {
@@ -295,7 +308,9 @@ pub(crate) fn proxy_exotic_get_own_property(
 
     // 8. If Type(trapResultObj) is neither Object nor Undefined, throw a TypeError exception.
     if !trap_result_obj.is_object() && !trap_result_obj.is_undefined() {
-        return context.throw_type_error("Proxy trap result is neither object nor undefined");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap result is neither object nor undefined")
+            .into());
     }
 
     // 9. Let targetDesc be ? target.[[GetOwnProperty]](P).
@@ -306,17 +321,19 @@ pub(crate) fn proxy_exotic_get_own_property(
         if let Some(desc) = target_desc {
             // b. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
             if !desc.expect_configurable() {
-                return context.throw_type_error(
-                    "Proxy trap result is undefined adn target result is not configurable",
-                );
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "Proxy trap result is undefined adn target result is not configurable",
+                    )
+                    .into());
             }
 
             // c. Let extensibleTarget be ? IsExtensible(target).
             // d. If extensibleTarget is false, throw a TypeError exception.
             if !target.is_extensible(context)? {
-                return context.throw_type_error(
-                    "Proxy trap result is undefined and target is not extensible",
-                );
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap result is undefined and target is not extensible")
+                    .into());
             }
             // e. Return undefined.
             return Ok(None);
@@ -342,7 +359,9 @@ pub(crate) fn proxy_exotic_get_own_property(
         result_desc.clone(),
         target_desc.clone(),
     ) {
-        return context.throw_type_error("Proxy trap returned unexpected property");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap returned unexpected property")
+            .into());
     }
 
     // 16. If resultDesc.[[Configurable]] is false, then
@@ -355,16 +374,18 @@ pub(crate) fn proxy_exotic_get_own_property(
                     // i. If targetDesc.[[Writable]] is true, throw a TypeError exception.
                     if desc.expect_writable() {
                         return
-                            context.throw_type_error("Proxy trap result is writable and not configurable while target result is not configurable")
+                            Err(JsNativeError::typ().with_message("Proxy trap result is writable and not configurable while target result is not configurable").into())
                         ;
                     }
                 }
             }
             // i. Throw a TypeError exception.
             _ => {
-                return context.throw_type_error(
-                    "Proxy trap result is not configurable and target result is undefined",
-                )
+                return Err(JsNativeError::typ()
+                    .with_message(
+                        "Proxy trap result is not configurable and target result is undefined",
+                    )
+                    .into())
             }
         }
     }
@@ -394,7 +415,7 @@ pub(crate) fn proxy_exotic_define_own_property(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "defineProperty").
     let trap = if let Some(trap) = handler.get_method("defineProperty", context)? {
@@ -435,12 +456,16 @@ pub(crate) fn proxy_exotic_define_own_property(
         None => {
             // a. If extensibleTarget is false, throw a TypeError exception.
             if !extensible_target {
-                return context.throw_type_error("Proxy trap failed to set property");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap failed to set property")
+                    .into());
             }
 
             // b. If settingConfigFalse is true, throw a TypeError exception.
             if setting_config_false {
-                return context.throw_type_error("Proxy trap failed to set property");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap failed to set property")
+                    .into());
             }
         }
         // 15. Else,
@@ -451,14 +476,16 @@ pub(crate) fn proxy_exotic_define_own_property(
                 desc.clone(),
                 Some(target_desc.clone()),
             ) {
-                return context.throw_type_error("Proxy trap set property to unexpected value");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap set property to unexpected value")
+                    .into());
             }
 
             // b. If settingConfigFalse is true and targetDesc.[[Configurable]] is true, throw a TypeError exception.
             if setting_config_false && target_desc.expect_configurable() {
-                return context.throw_type_error(
-                    "Proxy trap set property with unexpected configurable field",
-                );
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap set property with unexpected configurable field")
+                    .into());
             }
 
             // c. If IsDataDescriptor(targetDesc) is true, targetDesc.[[Configurable]] is false, and targetDesc.[[Writable]] is true, then
@@ -469,9 +496,9 @@ pub(crate) fn proxy_exotic_define_own_property(
                 // i. If Desc has a [[Writable]] field and Desc.[[Writable]] is false, throw a TypeError exception.
                 if let Some(writable) = desc.writable() {
                     if !writable {
-                        return context.throw_type_error(
-                            "Proxy trap set property with unexpected writable field",
-                        );
+                        return Err(JsNativeError::typ()
+                            .with_message("Proxy trap set property with unexpected writable field")
+                            .into());
                     }
                 }
             }
@@ -502,7 +529,7 @@ pub(crate) fn proxy_exotic_has_property(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "has").
     let trap = if let Some(trap) = handler.get_method("has", context)? {
@@ -531,13 +558,17 @@ pub(crate) fn proxy_exotic_has_property(
         if let Some(target_desc) = target_desc {
             // i. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
             if !target_desc.expect_configurable() {
-                return context.throw_type_error("Proxy trap returned unexpected property");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap returned unexpected property")
+                    .into());
             }
 
             // ii. Let extensibleTarget be ? IsExtensible(target).
             // iii. If extensibleTarget is false, throw a TypeError exception.
             if !target.is_extensible(context)? {
-                return context.throw_type_error("Proxy trap returned unexpected property");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap returned unexpected property")
+                    .into());
             }
         }
     }
@@ -567,7 +598,7 @@ pub(crate) fn proxy_exotic_get(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "get").
     let trap = if let Some(trap) = handler.get_method("get", context)? {
@@ -595,8 +626,9 @@ pub(crate) fn proxy_exotic_get(
             if target_desc.is_data_descriptor() && !target_desc.expect_writable() {
                 // i. If SameValue(trapResult, targetDesc.[[Value]]) is false, throw a TypeError exception.
                 if !JsValue::same_value(&trap_result, target_desc.expect_value()) {
-                    return context
-                        .throw_type_error("Proxy trap returned unexpected data descriptor");
+                    return Err(JsNativeError::typ()
+                        .with_message("Proxy trap returned unexpected data descriptor")
+                        .into());
                 }
             }
 
@@ -604,8 +636,9 @@ pub(crate) fn proxy_exotic_get(
             if target_desc.is_accessor_descriptor() && target_desc.expect_get().is_undefined() {
                 // i. If trapResult is not undefined, throw a TypeError exception.
                 if !trap_result.is_undefined() {
-                    return context
-                        .throw_type_error("Proxy trap returned unexpected accessor descriptor");
+                    return Err(JsNativeError::typ()
+                        .with_message("Proxy trap returned unexpected accessor descriptor")
+                        .into());
                 }
             }
         }
@@ -637,7 +670,7 @@ pub(crate) fn proxy_exotic_set(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "set").
     let trap = if let Some(trap) = handler.get_method("set", context)? {
@@ -671,7 +704,9 @@ pub(crate) fn proxy_exotic_set(
             if target_desc.is_data_descriptor() && !target_desc.expect_writable() {
                 // i. If SameValue(V, targetDesc.[[Value]]) is false, throw a TypeError exception.
                 if !JsValue::same_value(&value, target_desc.expect_value()) {
-                    return context.throw_type_error("Proxy trap set unexpected data descriptor");
+                    return Err(JsNativeError::typ()
+                        .with_message("Proxy trap set unexpected data descriptor")
+                        .into());
                 }
             }
 
@@ -680,8 +715,9 @@ pub(crate) fn proxy_exotic_set(
                 // i. If targetDesc.[[Set]] is undefined, throw a TypeError exception.
                 match target_desc.set() {
                     None | Some(&JsValue::Undefined) => {
-                        return context
-                            .throw_type_error("Proxy trap set unexpected accessor descriptor");
+                        return Err(JsNativeError::typ()
+                            .with_message("Proxy trap set unexpected accessor descriptor")
+                            .into());
                     }
                     _ => {}
                 }
@@ -713,7 +749,7 @@ pub(crate) fn proxy_exotic_delete(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "deleteProperty").
     let trap = if let Some(trap) = handler.get_method("deleteProperty", context)? {
@@ -744,7 +780,9 @@ pub(crate) fn proxy_exotic_delete(
         // 11. If targetDesc.[[Configurable]] is false, throw a TypeError exception.
         Some(target_desc) => {
             if !target_desc.expect_configurable() {
-                return context.throw_type_error("Proxy trap failed to delete property");
+                return Err(JsNativeError::typ()
+                    .with_message("Proxy trap failed to delete property")
+                    .into());
             }
         }
     }
@@ -752,7 +790,9 @@ pub(crate) fn proxy_exotic_delete(
     // 12. Let extensibleTarget be ? IsExtensible(target).
     // 13. If extensibleTarget is false, throw a TypeError exception.
     if !target.is_extensible(context)? {
-        return context.throw_type_error("Proxy trap failed to delete property");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap failed to delete property")
+            .into());
     }
 
     // 14. Return true.
@@ -778,7 +818,7 @@ pub(crate) fn proxy_exotic_own_property_keys(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "ownKeys").
     let trap = if let Some(trap) = handler.get_method("ownKeys", context)? {
@@ -803,17 +843,17 @@ pub(crate) fn proxy_exotic_own_property_keys(
         match value {
             JsValue::String(s) => {
                 if !unchecked_result_keys.insert(s.clone().into()) {
-                    return context.throw_type_error(
-                        "Proxy trap result contains duplicate string property keys",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("Proxy trap result contains duplicate string property keys")
+                        .into());
                 }
                 trap_result.push(s.clone().into());
             }
             JsValue::Symbol(s) => {
                 if !unchecked_result_keys.insert(s.clone().into()) {
-                    return context.throw_type_error(
-                        "Proxy trap result contains duplicate symbol property keys",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("Proxy trap result contains duplicate symbol property keys")
+                        .into());
                 }
                 trap_result.push(s.clone().into());
             }
@@ -863,9 +903,9 @@ pub(crate) fn proxy_exotic_own_property_keys(
         // a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
         // b. Remove key from uncheckedResultKeys.
         if !unchecked_result_keys.remove(&key) {
-            return context.throw_type_error(
-                "Proxy trap failed to return all non-configurable property keys",
-            );
+            return Err(JsNativeError::typ()
+                .with_message("Proxy trap failed to return all non-configurable property keys")
+                .into());
         }
     }
 
@@ -879,14 +919,17 @@ pub(crate) fn proxy_exotic_own_property_keys(
         // a. If key is not an element of uncheckedResultKeys, throw a TypeError exception.
         // b. Remove key from uncheckedResultKeys.
         if !unchecked_result_keys.remove(&key) {
-            return context
-                .throw_type_error("Proxy trap failed to return all configurable property keys");
+            return Err(JsNativeError::typ()
+                .with_message("Proxy trap failed to return all configurable property keys")
+                .into());
         }
     }
 
     // 22. If uncheckedResultKeys is not empty, throw a TypeError exception.
     if !unchecked_result_keys.is_empty() {
-        return context.throw_type_error("Proxy trap failed to return all property keys");
+        return Err(JsNativeError::typ()
+            .with_message("Proxy trap failed to return all property keys")
+            .into());
     }
 
     // 23. Return trapResult.
@@ -913,7 +956,7 @@ fn proxy_exotic_call(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "apply").
     let trap = if let Some(trap) = handler.get_method("apply", context)? {
@@ -955,7 +998,7 @@ fn proxy_exotic_construct(
         .borrow()
         .as_proxy()
         .expect("Proxy object internal internal method called on non-proxy object")
-        .try_data(context)?;
+        .try_data()?;
 
     // 5. Assert: IsConstructor(target) is true.
     assert!(target.is_constructor());
@@ -985,7 +1028,7 @@ fn proxy_exotic_construct(
 
     // 10. If Type(newObj) is not Object, throw a TypeError exception.
     let new_obj = new_obj.as_object().cloned().ok_or_else(|| {
-        context.construct_type_error("Proxy trap constructor returned non-object value")
+        JsNativeError::typ().with_message("Proxy trap constructor returned non-object value")
     })?;
 
     // 11. Return newObj.

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -4,6 +4,7 @@
 
 use super::{JsPrototype, NativeObject, Object, PropertyMap};
 use crate::{
+    error::JsNativeError,
     object::{ObjectData, ObjectKind},
     property::{PropertyDescriptor, PropertyKey},
     value::PreferredType,
@@ -186,7 +187,9 @@ impl JsObject {
         }
 
         // 6. Throw a TypeError exception.
-        context.throw_type_error("cannot convert object to primitive value")
+        Err(JsNativeError::typ()
+            .with_message("cannot convert object to primitive value")
+            .into())
     }
 
     /// Return `true` if it is a native object and the native type is `T`.
@@ -546,7 +549,9 @@ impl JsObject {
             // b. If IsCallable(getter) is false and getter is not undefined, throw a TypeError exception.
             // todo: extract IsCallable to be callable from Value
             if !getter.is_undefined() && getter.as_object().map_or(true, |o| !o.is_callable()) {
-                return context.throw_type_error("Property descriptor getter must be callable");
+                return Err(JsNativeError::typ()
+                    .with_message("Property descriptor getter must be callable")
+                    .into());
             }
             // c. Set desc.[[Get]] to getter.
             Some(getter)
@@ -562,7 +567,9 @@ impl JsObject {
             // 14.b. If IsCallable(setter) is false and setter is not undefined, throw a TypeError exception.
             // todo: extract IsCallable to be callable from Value
             if !setter.is_undefined() && setter.as_object().map_or(true, |o| !o.is_callable()) {
-                return context.throw_type_error("Property descriptor setter must be callable");
+                return Err(JsNativeError::typ()
+                    .with_message("Property descriptor setter must be callable")
+                    .into());
             }
             // 14.c. Set desc.[[Set]] to setter.
             Some(setter)
@@ -573,10 +580,12 @@ impl JsObject {
         // 15. If desc.[[Get]] is present or desc.[[Set]] is present, then ...
         // a. If desc.[[Value]] is present or desc.[[Writable]] is present, throw a TypeError exception.
         if get.as_ref().or(set.as_ref()).is_some() && desc.inner().is_data_descriptor() {
-            return context.throw_type_error(
-                "Invalid property descriptor.\
+            return Err(JsNativeError::typ()
+                .with_message(
+                    "Invalid property descriptor.\
 Cannot both specify accessors and a value or writable attribute",
-            );
+                )
+                .into());
         }
 
         desc = desc.maybe_get(get).maybe_set(set);

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -455,7 +455,7 @@ impl ObjectData {
     }
 
     /// Create the `Error` object data
-    pub fn error(error: ErrorKind) -> Self {
+    pub(crate) fn error(error: ErrorKind) -> Self {
         Self {
             kind: ObjectKind::Error(error),
             internal_methods: &ORDINARY_INTERNAL_METHODS,
@@ -1075,6 +1075,7 @@ impl Object {
         )
     }
 
+    #[inline]
     pub fn as_error(&self) -> Option<ErrorKind> {
         match self.data {
             ObjectData {

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -30,6 +30,7 @@ use crate::{
         array::array_iterator::ArrayIterator,
         array_buffer::ArrayBuffer,
         async_generator::AsyncGenerator,
+        error::ErrorKind,
         function::arguments::Arguments,
         function::{
             arguments::ParameterMap, BoundFunction, Captures, ConstructorKind, Function,
@@ -49,6 +50,7 @@ use crate::{
         DataView, Date, Promise, RegExp,
     },
     context::intrinsics::StandardConstructor,
+    error::JsNativeError,
     js_string,
     property::{Attribute, PropertyDescriptor, PropertyKey},
     Context, JsBigInt, JsResult, JsString, JsSymbol, JsValue,
@@ -182,7 +184,7 @@ pub enum ObjectKind {
     StringIterator(StringIterator),
     Number(f64),
     Symbol(JsSymbol),
-    Error,
+    Error(ErrorKind),
     Ordinary,
     Proxy(Proxy),
     Date(Date),
@@ -226,7 +228,7 @@ unsafe impl Trace for ObjectKind {
             | Self::String(_)
             | Self::Date(_)
             | Self::Array
-            | Self::Error
+            | Self::Error(_)
             | Self::Ordinary
             | Self::Global
             | Self::Number(_)
@@ -453,9 +455,9 @@ impl ObjectData {
     }
 
     /// Create the `Error` object data
-    pub fn error() -> Self {
+    pub fn error(error: ErrorKind) -> Self {
         Self {
-            kind: ObjectKind::Error,
+            kind: ObjectKind::Error(error),
             internal_methods: &ORDINARY_INTERNAL_METHODS,
         }
     }
@@ -559,7 +561,7 @@ impl Display for ObjectKind {
             Self::String(_) => "String",
             Self::StringIterator(_) => "StringIterator",
             Self::Symbol(_) => "Symbol",
-            Self::Error => "Error",
+            Self::Error(_) => "Error",
             Self::Ordinary => "Ordinary",
             Self::Proxy(_) => "Proxy",
             Self::Boolean(_) => "Boolean",
@@ -1067,10 +1069,20 @@ impl Object {
         matches!(
             self.data,
             ObjectData {
-                kind: ObjectKind::Error,
+                kind: ObjectKind::Error(_),
                 ..
             }
         )
+    }
+
+    pub fn as_error(&self) -> Option<ErrorKind> {
+        match self.data {
+            ObjectData {
+                kind: ObjectKind::Error(e),
+                ..
+            } => Some(e),
+            _ => None,
+        }
     }
 
     /// Checks if it a Boolean object.
@@ -1675,7 +1687,8 @@ impl<'context> FunctionBuilder<'context> {
                 function: Box::new(move |this, args, captures: Captures, context| {
                     let mut captures = captures.as_mut_any();
                     let captures = captures.downcast_mut::<C>().ok_or_else(|| {
-                        context.construct_type_error("cannot downcast `Captures` to given type")
+                        JsNativeError::typ()
+                            .with_message("cannot downcast `Captures` to given type")
                     })?;
                     function(this, args, captures, context)
                 }),

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1802,16 +1802,8 @@ impl<'context> FunctionBuilder<'context> {
 /// # use boa_engine::{Context, JsValue, object::ObjectInitializer, property::Attribute};
 /// let mut context = Context::default();
 /// let object = ObjectInitializer::new(&mut context)
-///     .property(
-///         "hello",
-///         "world",
-///         Attribute::all()
-///     )
-///     .property(
-///         1,
-///         1,
-///         Attribute::all()
-///     )
+///     .property("hello", "world", Attribute::all())
+///     .property(1, 1, Attribute::all())
 ///     .function(|_, _, _| Ok(JsValue::undefined()), "func", 0)
 ///     .build();
 /// ```

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -55,7 +55,7 @@ use self::common::{COMMON_STRINGS, COMMON_STRINGS_CACHE, MAX_COMMON_STRING_LENGT
 ///
 ///
 /// You can create a `JsString` from a string literal, which completely skips the runtime
-/// conversion from [`&str`] to [`&\[u16\]`]:
+/// conversion from [`&str`] to <code>[&\[u16\]][slice]</code>:
 ///
 /// ```
 /// # use boa_engine::js_string;
@@ -255,7 +255,7 @@ impl TaggedJsString {
 }
 
 /// Enum representing either a reference to a heap allocated [`RawJsString`] or a static reference to
-/// a [`\[u16\]`][std::slice] inside [`COMMON_STRINGS`].
+/// a [`\[u16\]`][slice] inside [`COMMON_STRINGS`].
 enum JsStringPtrKind<'a> {
     // A string allocated on the heap.
     Heap(&'a mut RawJsString),
@@ -265,8 +265,8 @@ enum JsStringPtrKind<'a> {
 
 /// A UTF-16–encoded, reference counted, immutable string.
 ///
-/// This is pretty similar to a <code>[Rc][std::rc::Rc]\<[\[u16\]][std::slice]\></code>, but without
-/// the length metadata associated with the [`Rc`][std::rc::Rc] fat pointer. Instead, the length of
+/// This is pretty similar to a <code>[Rc][std::rc::Rc]\<[\[u16\]][slice]\></code>, but without
+/// the length metadata associated with the `Rc` fat pointer. Instead, the length of
 /// every string is stored on the heap, along with its reference counter and its data.
 ///
 /// We define some commonly used string constants in an interner. For these strings, we don't allocate
@@ -274,8 +274,8 @@ enum JsStringPtrKind<'a> {
 ///
 /// # Deref
 ///
-/// [`JsString`] implements <code>[Deref]<Target = [\[u16\]][std::slice]></code>, inheriting all of
-/// [`\[u16\]`][std::slice]'s methods.
+/// [`JsString`] implements <code>[Deref]<Target = \[u16\]></code>, inheriting all of
+/// <code>\[u16\]</code>'s methods.
 #[derive(Finalize)]
 pub struct JsString {
     ptr: TaggedJsString,
@@ -287,7 +287,7 @@ unsafe impl Trace for JsString {
 }
 
 impl JsString {
-    /// Obtains the underlying [`&[u16]`][std::slice] slice of a [`JsString`]
+    /// Obtains the underlying [`&[u16]`][slice] slice of a [`JsString`]
     pub fn as_slice(&self) -> &[u16] {
         self
     }
@@ -874,8 +874,7 @@ impl Utf16Trim for [u16] {
     }
 }
 
-/// Utility trait that adds a `UTF-16` escaped representation to every
-/// [`[u16]`][std::slice].
+/// Utility trait that adds a `UTF-16` escaped representation to every [`[u16]`][slice].
 pub(crate) trait ToStringEscaped {
     /// Decodes `self` as an `UTF-16` encoded string, escaping any unpaired surrogates by its
     /// codepoint value.

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -805,6 +805,30 @@ impl<const N: usize> PartialEq<[u16; N]> for JsString {
     }
 }
 
+impl PartialEq<str> for JsString {
+    fn eq(&self, other: &str) -> bool {
+        let utf16 = self.code_points();
+        let mut utf8 = other.chars();
+
+        for lhs in utf16 {
+            if let Some(rhs) = utf8.next() {
+                match lhs {
+                    CodePoint::Unicode(lhs) if lhs == rhs => continue,
+                    _ => return false,
+                }
+            }
+            return false;
+        }
+        utf8.next().is_none()
+    }
+}
+
+impl PartialEq<JsString> for str {
+    fn eq(&self, other: &JsString) -> bool {
+        other == self
+    }
+}
+
 impl PartialOrd for JsString {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self[..].partial_cmp(other)

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -27,7 +27,7 @@ use std::{
 ///
 /// # Examples
 /// ```
-///# use boa_engine::symbol::WellKnownSymbols;
+/// # use boa_engine::symbol::WellKnownSymbols;
 ///
 /// let iterator = WellKnownSymbols::iterator();
 /// assert_eq!(iterator.description().unwrap().to_std_string_escaped(), "Symbol.iterator");

--- a/boa_engine/src/syntax/ast/function/parameters.rs
+++ b/boa_engine/src/syntax/ast/function/parameters.rs
@@ -237,10 +237,10 @@ impl Default for FormalParameterListFlags {
 ///
 /// In the declaration of a function, the parameters must be identifiers,
 /// not any value like numbers, strings, or objects.
-///```text
-///function foo(formalParameter1, formalParameter2) {
-///}
-///```
+/// ```text
+/// function foo(formalParameter1, formalParameter2) {
+/// }
+/// ```
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]

--- a/boa_engine/src/syntax/ast/statement/switch/mod.rs
+++ b/boa_engine/src/syntax/ast/statement/switch/mod.rs
@@ -1,9 +1,7 @@
 //! Switch node.
 //!
-use crate::syntax::ast::{expression::Expression, statement::Statement};
+use crate::syntax::ast::{expression::Expression, statement::Statement, StatementList};
 use boa_interner::{Interner, ToInternedString};
-
-use crate::syntax::ast::StatementList;
 
 use super::ContainsSymbol;
 

--- a/boa_engine/src/syntax/parser/expression/identifiers.rs
+++ b/boa_engine/src/syntax/parser/expression/identifiers.rs
@@ -4,7 +4,6 @@
 //!  - [ECMAScript specification][spec]
 //!
 //! [spec]: https://tc39.es/ecma262/#sec-identifiers
-//!
 
 use crate::syntax::{
     ast::{expression::Identifier, Keyword},

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -467,7 +467,7 @@ fn test_invalid_break() {
     let string = forward(&mut context, src);
     assert_eq!(
         string,
-        "Uncaught \"SyntaxError\": \"unlabeled break must be inside loop or switch\""
+        "Uncaught SyntaxError: unlabeled break must be inside loop or switch"
     );
 }
 
@@ -482,7 +482,7 @@ fn test_invalid_continue_target() {
     let string = forward(&mut context, src);
     assert_eq!(
         string,
-        "Uncaught \"SyntaxError\": \"Cannot use the undeclared label 'nonexistent'\""
+        "Uncaught SyntaxError: Cannot use the undeclared label 'nonexistent'"
     );
 }
 
@@ -490,10 +490,7 @@ fn test_invalid_continue_target() {
 fn test_invalid_continue() {
     let mut context = Context::default();
     let string = forward(&mut context, r"continue;");
-    assert_eq!(
-        string,
-        "Uncaught \"SyntaxError\": \"continue must be inside loop\""
-    );
+    assert_eq!(string, "Uncaught SyntaxError: continue must be inside loop");
 }
 
 #[test]
@@ -542,10 +539,10 @@ fn unary_pre() {
 #[test]
 fn invalid_unary_access() {
     check_output(&[
-        TestAction::TestStartsWith("++[];", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("[]++;", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("--[];", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("[]--;", "Uncaught \"SyntaxError\": "),
+        TestAction::TestStartsWith("++[];", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("[]++;", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("--[];", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("[]--;", "Uncaught SyntaxError: "),
     ]);
 }
 
@@ -851,7 +848,7 @@ mod in_operator {
 
         check_output(&[TestAction::TestEq(
             scenario,
-            "Uncaught \"TypeError\": \"not a constructor\"",
+            "Uncaught TypeError: not a constructor",
         )]);
     }
 
@@ -1238,20 +1235,6 @@ fn calling_function_with_unspecified_arguments() {
 }
 
 #[test]
-fn to_object() {
-    let mut context = Context::default();
-
-    assert!(JsValue::undefined()
-        .to_object(&mut context)
-        .unwrap_err()
-        .is_object());
-    assert!(JsValue::null()
-        .to_object(&mut context)
-        .unwrap_err()
-        .is_object());
-}
-
-#[test]
 fn check_this_binding_in_object_literal() {
     let mut context = Context::default();
     let init = r#"
@@ -1404,7 +1387,7 @@ fn assignment_to_non_assignable() {
     for case in &test_cases {
         let string = forward(&mut context, case);
 
-        assert!(string.starts_with("Uncaught \"SyntaxError\": "));
+        assert!(string.starts_with("Uncaught SyntaxError: "));
         assert!(string.contains("1:3"));
     }
 }
@@ -1412,15 +1395,15 @@ fn assignment_to_non_assignable() {
 #[test]
 fn assignment_to_non_assignable_ctd() {
     check_output(&[
-        TestAction::TestStartsWith("(()=>{})() -= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() *= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() /= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() %= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() &= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() ^= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() |= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() += 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() = 5", "Uncaught \"SyntaxError\": "),
+        TestAction::TestStartsWith("(()=>{})() -= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() *= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() /= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() %= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() &= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() ^= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() |= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() += 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() = 5", "Uncaught SyntaxError: "),
     ]);
 }
 
@@ -1435,7 +1418,7 @@ fn multicharacter_assignment_to_non_assignable() {
     for case in &test_cases {
         let string = forward(&mut context, case);
 
-        assert!(string.starts_with("Uncaught \"SyntaxError\": "));
+        assert!(string.starts_with("Uncaught SyntaxError: "));
         assert!(string.contains("1:3"));
     }
 }
@@ -1443,9 +1426,9 @@ fn multicharacter_assignment_to_non_assignable() {
 #[test]
 fn multicharacter_assignment_to_non_assignable_ctd() {
     check_output(&[
-        TestAction::TestStartsWith("(()=>{})() **= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() <<= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() >>= 5", "Uncaught \"SyntaxError\": "),
+        TestAction::TestStartsWith("(()=>{})() **= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() <<= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() >>= 5", "Uncaught SyntaxError: "),
     ]);
 }
 
@@ -1459,7 +1442,7 @@ fn multicharacter_bitwise_assignment_to_non_assignable() {
     for case in &test_cases {
         let string = forward(&mut context, case);
 
-        assert!(string.starts_with("Uncaught \"SyntaxError\": "));
+        assert!(string.starts_with("Uncaught SyntaxError: "));
         assert!(string.contains("1:3"));
     }
 }
@@ -1467,27 +1450,27 @@ fn multicharacter_bitwise_assignment_to_non_assignable() {
 #[test]
 fn multicharacter_bitwise_assignment_to_non_assignable_ctd() {
     check_output(&[
-        TestAction::TestStartsWith("(()=>{})() >>>= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() &&= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() ||= 5", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("(()=>{})() ??= 5", "Uncaught \"SyntaxError\": "),
+        TestAction::TestStartsWith("(()=>{})() >>>= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() &&= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() ||= 5", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("(()=>{})() ??= 5", "Uncaught SyntaxError: "),
     ]);
 }
 
 #[test]
 fn assign_to_array_decl() {
     check_output(&[
-        TestAction::TestStartsWith("[1] = [2]", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("[3, 5] = [7, 8]", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("[6, 8] = [2]", "Uncaught \"SyntaxError\": "),
-        TestAction::TestStartsWith("[6] = [2, 9]", "Uncaught \"SyntaxError\": "),
+        TestAction::TestStartsWith("[1] = [2]", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("[3, 5] = [7, 8]", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("[6, 8] = [2]", "Uncaught SyntaxError: "),
+        TestAction::TestStartsWith("[6] = [2, 9]", "Uncaught SyntaxError: "),
     ]);
 }
 
 #[test]
 fn assign_to_object_decl() {
     const ERR_MSG: &str =
-        "Uncaught \"SyntaxError\": \"unexpected token '=', primary expression at line 1, col 8\"";
+        "Uncaught SyntaxError: unexpected token '=', primary expression at line 1, col 8";
 
     let mut context = Context::default();
 
@@ -1531,7 +1514,7 @@ fn test_conditional_op() {
 #[test]
 fn test_identifier_op() {
     let scenario = "break = 1";
-    assert_eq!(&exec(scenario), "\"SyntaxError\": \"expected token \'identifier\', got \'=\' in binding identifier at line 1, col 7\"");
+    assert_eq!(&exec(scenario), "SyntaxError: expected token \'identifier\', got \'=\' in binding identifier at line 1, col 7");
 }
 
 #[test]
@@ -1546,7 +1529,7 @@ fn test_strict_mode_octal() {
 
     check_output(&[TestAction::TestStartsWith(
         scenario,
-        "Uncaught \"SyntaxError\": ",
+        "Uncaught SyntaxError: ",
     )]);
 }
 
@@ -1566,7 +1549,7 @@ fn test_strict_mode_with() {
 
     check_output(&[TestAction::TestStartsWith(
         scenario,
-        "Uncaught \"SyntaxError\": ",
+        "Uncaught SyntaxError: ",
     )]);
 }
 
@@ -1583,7 +1566,7 @@ fn test_strict_mode_delete() {
 
     check_output(&[TestAction::TestStartsWith(
         scenario,
-        "Uncaught \"SyntaxError\": ",
+        "Uncaught SyntaxError: ",
     )]);
 }
 
@@ -1612,7 +1595,7 @@ fn test_strict_mode_reserved_name() {
 
         let string = forward(&mut context, &scenario);
 
-        assert!(string.starts_with("Uncaught \"SyntaxError\": "));
+        assert!(string.starts_with("Uncaught SyntaxError: "));
     }
 }
 
@@ -1628,7 +1611,7 @@ fn test_strict_mode_dup_func_parameters() {
 
     check_output(&[TestAction::TestStartsWith(
         scenario,
-        "Uncaught \"SyntaxError\": ",
+        "Uncaught SyntaxError: ",
     )]);
 }
 

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -3,10 +3,11 @@ use crate::{
         number::{f64_to_int32, f64_to_uint32},
         Number,
     },
+    error::JsNativeError,
     js_string,
+    value::{Numeric, PreferredType, WellKnownSymbols},
+    Context, JsBigInt, JsResult, JsValue,
 };
-
-use super::{Context, JsBigInt, JsResult, JsValue, Numeric, PreferredType, WellKnownSymbols};
 
 impl JsValue {
     #[inline]
@@ -40,9 +41,11 @@ impl JsValue {
                         Self::new(JsBigInt::add(x, y))
                     }
                     (_, _) => {
-                        return context.throw_type_error(
-                            "cannot mix BigInt and other types, use explicit conversions",
-                        )
+                        return Err(JsNativeError::typ()
+                            .with_message(
+                                "cannot mix BigInt and other types, use explicit conversions",
+                            )
+                            .into())
                     }
                 },
             },
@@ -67,9 +70,9 @@ impl JsValue {
                 (Numeric::Number(a), Numeric::Number(b)) => Self::new(a - b),
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => Self::new(JsBigInt::sub(x, y)),
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -93,9 +96,9 @@ impl JsValue {
                 (Numeric::Number(a), Numeric::Number(b)) => Self::new(a * b),
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => Self::new(JsBigInt::mul(x, y)),
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -115,7 +118,9 @@ impl JsValue {
 
             (Self::BigInt(ref x), Self::BigInt(ref y)) => {
                 if y.is_zero() {
-                    return context.throw_range_error("BigInt division by zero");
+                    return Err(JsNativeError::range()
+                        .with_message("BigInt division by zero")
+                        .into());
                 }
                 Self::new(JsBigInt::div(x, y))
             }
@@ -125,14 +130,16 @@ impl JsValue {
                 (Numeric::Number(a), Numeric::Number(b)) => Self::new(a / b),
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
                     if y.is_zero() {
-                        return context.throw_range_error("BigInt division by zero");
+                        return Err(JsNativeError::range()
+                            .with_message("BigInt division by zero")
+                            .into());
                     }
                     Self::new(JsBigInt::div(x, y))
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -162,7 +169,9 @@ impl JsValue {
 
             (Self::BigInt(ref x), Self::BigInt(ref y)) => {
                 if y.is_zero() {
-                    return context.throw_range_error("BigInt division by zero");
+                    return Err(JsNativeError::range()
+                        .with_message("BigInt division by zero")
+                        .into());
                 }
                 Self::new(JsBigInt::rem(x, y))
             }
@@ -172,14 +181,16 @@ impl JsValue {
                 (Numeric::Number(a), Numeric::Number(b)) => Self::new(a % b),
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
                     if y.is_zero() {
-                        return context.throw_range_error("BigInt division by zero");
+                        return Err(JsNativeError::range()
+                            .with_message("BigInt division by zero")
+                            .into());
                     }
                     Self::new(JsBigInt::rem(x, y))
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -197,18 +208,16 @@ impl JsValue {
             (Self::Integer(x), Self::Rational(y)) => Self::new(f64::from(*x).powf(*y)),
             (Self::Rational(x), Self::Integer(y)) => Self::new(x.powi(*y)),
 
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::new(JsBigInt::pow(a, b, context)?),
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::new(JsBigInt::pow(a, b)?),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
                 (Numeric::Number(a), Numeric::Number(b)) => Self::new(a.powf(b)),
-                (Numeric::BigInt(ref a), Numeric::BigInt(ref b)) => {
-                    Self::new(JsBigInt::pow(a, b, context)?)
-                }
+                (Numeric::BigInt(ref a), Numeric::BigInt(ref b)) => Self::new(JsBigInt::pow(a, b)?),
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -236,9 +245,9 @@ impl JsValue {
                     Self::new(JsBigInt::bitand(x, y))
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -266,9 +275,9 @@ impl JsValue {
                     Self::new(JsBigInt::bitor(x, y))
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -296,9 +305,9 @@ impl JsValue {
                     Self::new(JsBigInt::bitxor(x, y))
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -317,9 +326,7 @@ impl JsValue {
                 Self::new(f64_to_int32(*x).wrapping_shl(*y as u32))
             }
 
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
-                Self::new(JsBigInt::shift_left(a, b, context)?)
-            }
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::new(JsBigInt::shift_left(a, b)?),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -327,12 +334,12 @@ impl JsValue {
                     Self::new(f64_to_int32(x).wrapping_shl(f64_to_uint32(y)))
                 }
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
-                    Self::new(JsBigInt::shift_left(x, y, context)?)
+                    Self::new(JsBigInt::shift_left(x, y)?)
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -351,9 +358,7 @@ impl JsValue {
                 Self::new(f64_to_int32(*x).wrapping_shr(*y as u32))
             }
 
-            (Self::BigInt(ref a), Self::BigInt(ref b)) => {
-                Self::new(JsBigInt::shift_right(a, b, context)?)
-            }
+            (Self::BigInt(ref a), Self::BigInt(ref b)) => Self::new(JsBigInt::shift_right(a, b)?),
 
             // Slow path:
             (_, _) => match (self.to_numeric(context)?, other.to_numeric(context)?) {
@@ -361,12 +366,12 @@ impl JsValue {
                     Self::new(f64_to_int32(x).wrapping_shr(f64_to_uint32(y)))
                 }
                 (Numeric::BigInt(ref x), Numeric::BigInt(ref y)) => {
-                    Self::new(JsBigInt::shift_right(x, y, context)?)
+                    Self::new(JsBigInt::shift_right(x, y)?)
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -393,13 +398,14 @@ impl JsValue {
                     Self::new(f64_to_uint32(x).wrapping_shr(f64_to_uint32(y)))
                 }
                 (Numeric::BigInt(_), Numeric::BigInt(_)) => {
-                    return context
-                        .throw_type_error("BigInts have no unsigned right shift, use >> instead");
+                    return Err(JsNativeError::typ()
+                        .with_message("BigInts have no unsigned right shift, use >> instead")
+                        .into());
                 }
                 (_, _) => {
-                    return context.throw_type_error(
-                        "cannot mix BigInt and other types, use explicit conversions",
-                    );
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot mix BigInt and other types, use explicit conversions")
+                        .into());
                 }
             },
         })
@@ -415,10 +421,12 @@ impl JsValue {
     pub fn instance_of(&self, target: &Self, context: &mut Context) -> JsResult<bool> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         if !target.is_object() {
-            return context.throw_type_error(format!(
-                "right-hand side of 'instanceof' should be an object, got {}",
-                target.type_of().to_std_string_escaped()
-            ));
+            return Err(JsNativeError::typ()
+                .with_message(format!(
+                    "right-hand side of 'instanceof' should be an object, got {}",
+                    target.type_of().to_std_string_escaped()
+                ))
+                .into());
         }
 
         // 2. Let instOfHandler be ? GetMethod(target, @@hasInstance).
@@ -436,7 +444,9 @@ impl JsValue {
             }
             None => {
                 // 4. If IsCallable(target) is false, throw a TypeError exception.
-                context.throw_type_error("right-hand side of 'instanceof' is not callable")
+                Err(JsNativeError::typ()
+                    .with_message("right-hand side of 'instanceof' is not callable")
+                    .into())
             }
         }
     }

--- a/boa_engine/src/value/tests.rs
+++ b/boa_engine/src/value/tests.rs
@@ -539,46 +539,64 @@ fn to_integer_or_infinity() {
     let mut context = Context::default();
 
     assert_eq!(
-        JsValue::undefined().to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(0))
+        JsValue::undefined()
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(0)
     );
     assert_eq!(
-        JsValue::nan().to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(0))
+        JsValue::nan().to_integer_or_infinity(&mut context).unwrap(),
+        IntegerOrInfinity::Integer(0)
     );
     assert_eq!(
-        JsValue::new(0.0).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(0))
+        JsValue::new(0.0)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(0)
     );
     assert_eq!(
-        JsValue::new(-0.0).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(0))
-    );
-
-    assert_eq!(
-        JsValue::new(f64::INFINITY).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::PositiveInfinity)
-    );
-    assert_eq!(
-        JsValue::new(f64::NEG_INFINITY).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::NegativeInfinity)
+        JsValue::new(-0.0)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(0)
     );
 
     assert_eq!(
-        JsValue::new(10).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(10))
+        JsValue::new(f64::INFINITY)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::PositiveInfinity
     );
     assert_eq!(
-        JsValue::new(11.0).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(11))
+        JsValue::new(f64::NEG_INFINITY)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::NegativeInfinity
+    );
+
+    assert_eq!(
+        JsValue::new(10)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(10)
     );
     assert_eq!(
-        JsValue::new("12").to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(12))
+        JsValue::new(11.0)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(11)
     );
     assert_eq!(
-        JsValue::new(true).to_integer_or_infinity(&mut context),
-        Ok(IntegerOrInfinity::Integer(1))
+        JsValue::new("12")
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(12)
+    );
+    assert_eq!(
+        JsValue::new(true)
+            .to_integer_or_infinity(&mut context)
+            .unwrap(),
+        IntegerOrInfinity::Integer(1)
     );
 }
 
@@ -679,7 +697,7 @@ mod cyclic_conversions {
 
         assert_eq!(
             forward(&mut context, src),
-            r#"Uncaught "TypeError": "cyclic object value""#,
+            "Uncaught TypeError: cyclic object value",
         );
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1454,15 +1454,12 @@ impl JsObject {
                         .expect("must be function environment")
                         .as_function_slots()
                         .expect("must be function environment");
-                    if let Some(this_binding) = function_env.borrow().get_this_binding() {
-                        Ok(this_binding
-                            .as_object()
-                            .expect("this binding must be object")
-                            .clone())
-                    } else {
-                        //Err(JsNativeError::typ().with_message("Function constructor must not return non-object").into())
-                        Err(JsNativeError::reference().with_message("Must call super constructor in derived class before accessing 'this' or returning from derived constructor").into())
-                    }
+                    Ok(function_env
+                        .borrow()
+                        .get_this_binding()?
+                        .as_object()
+                        .expect("this binding must be object")
+                        .clone())
                 }
             }
             Function::Generator { .. }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -10,6 +10,7 @@ use crate::{
         Array, ForInIterator, JsArgs, Number, Promise,
     },
     environments::EnvironmentSlots,
+    error::JsNativeError,
     object::{FunctionBuilder, JsFunction, JsObject, ObjectData, PrivateElement},
     property::{DescriptorKind, PropertyDescriptor, PropertyDescriptorBuilder, PropertyKey},
     value::Numeric,
@@ -205,8 +206,9 @@ impl Context {
                 if let Some(superclass) = superclass.as_constructor() {
                     let proto = superclass.get("prototype", self)?;
                     if !proto.is_object() && !proto.is_null() {
-                        return self
-                            .throw_type_error("superclass prototype must be an object or null");
+                        return Err(JsNativeError::typ()
+                            .with_message("superclass prototype must be an object or null")
+                            .into());
                     }
 
                     let class = self.vm.pop();
@@ -231,7 +233,9 @@ impl Context {
                 } else if superclass.is_null() {
                     self.vm.push(JsValue::Null);
                 } else {
-                    return self.throw_type_error("superclass must be a constructor");
+                    return Err(JsNativeError::typ()
+                        .with_message("superclass must be a constructor")
+                        .into());
                 }
             }
             Opcode::SetClassPrototype => {
@@ -386,10 +390,12 @@ impl Context {
                 let lhs = self.vm.pop();
 
                 if !rhs.is_object() {
-                    return self.throw_type_error(format!(
-                        "right-hand side of 'in' should be an object, got {}",
-                        rhs.type_of().to_std_string_escaped()
-                    ));
+                    return Err(JsNativeError::typ()
+                        .with_message(format!(
+                            "right-hand side of 'in' should be an object, got {}",
+                            rhs.type_of().to_std_string_escaped()
+                        ))
+                        .into());
                 }
                 let key = lhs.to_property_key(self)?;
                 let value = self.has_property(&rhs, &key)?;
@@ -569,17 +575,21 @@ impl Context {
                                     self.call(&get, &self.global_object().clone().into(), &[])?
                                 }
                                 _ => {
-                                    return self.throw_reference_error(format!(
-                                        "{} is not defined",
-                                        key.to_std_string_escaped()
-                                    ))
+                                    return Err(JsNativeError::reference()
+                                        .with_message(format!(
+                                            "{} is not defined",
+                                            key.to_std_string_escaped()
+                                        ))
+                                        .into())
                                 }
                             },
                             _ => {
-                                return self.throw_reference_error(format!(
-                                    "{} is not defined",
-                                    key.to_std_string_escaped()
-                                ))
+                                return Err(JsNativeError::reference()
+                                    .with_message(format!(
+                                        "{} is not defined",
+                                        key.to_std_string_escaped()
+                                    ))
+                                    .into())
                             }
                         }
                     }
@@ -594,7 +604,9 @@ impl Context {
                         .interner()
                         .resolve_expect(binding_locator.name().sym())
                         .to_string();
-                    return self.throw_reference_error(format!("{name} is not initialized",));
+                    return Err(JsNativeError::reference()
+                        .with_message(format!("{name} is not initialized"))
+                        .into());
                 };
 
                 self.vm.push(value);
@@ -662,10 +674,12 @@ impl Context {
                         let exists = self.global_bindings_mut().contains_key(&key);
 
                         if !exists && self.vm.frame().code.strict {
-                            return self.throw_reference_error(format!(
-                                "assignment to undeclared variable {}",
-                                key.to_std_string_escaped()
-                            ));
+                            return Err(JsNativeError::reference()
+                                .with_message(format!(
+                                    "assignment to undeclared variable {}",
+                                    key.to_std_string_escaped()
+                                ))
+                                .into());
                         }
 
                         let success =
@@ -676,10 +690,12 @@ impl Context {
                             )?;
 
                         if !success && self.vm.frame().code.strict {
-                            return self.throw_type_error(format!(
-                                "cannot set non-writable property: {}",
-                                key.to_std_string_escaped()
-                            ));
+                            return Err(JsNativeError::typ()
+                                .with_message(format!(
+                                    "cannot set non-writable property: {}",
+                                    key.to_std_string_escaped()
+                                ))
+                                .into());
                         }
                     }
                 } else if !self.realm.environments.put_value_if_initialized(
@@ -688,10 +704,12 @@ impl Context {
                     binding_locator.name(),
                     value,
                 ) {
-                    self.throw_reference_error(format!(
-                        "cannot access '{}' before initialization",
-                        self.interner().resolve_expect(binding_locator.name().sym())
-                    ))?;
+                    return Err(JsNativeError::reference()
+                        .with_message(format!(
+                            "cannot access '{}' before initialization",
+                            self.interner().resolve_expect(binding_locator.name().sym())
+                        ))
+                        .into());
                 }
             }
             Opcode::Jump => {
@@ -1162,7 +1180,9 @@ impl Context {
                                 .set_private_element(name.sym(), PrivateElement::Field(value));
                         }
                         Some(PrivateElement::Method(_)) => {
-                            return self.throw_type_error("private method is not writable");
+                            return Err(JsNativeError::typ()
+                                .with_message("private method is not writable")
+                                .into());
                         }
                         Some(PrivateElement::Accessor {
                             setter: Some(setter),
@@ -1173,14 +1193,20 @@ impl Context {
                             setter.call(&object.clone().into(), &[value], self)?;
                         }
                         None => {
-                            return self.throw_type_error("private field not defined");
+                            return Err(JsNativeError::typ()
+                                .with_message("private field not defined")
+                                .into());
                         }
                         _ => {
-                            return self.throw_type_error("private field defined without a setter");
+                            return Err(JsNativeError::typ()
+                                .with_message("private field defined without a setter")
+                                .into());
                         }
                     }
                 } else {
-                    return self.throw_type_error("cannot set private property on non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot set private property on non-object")
+                        .into());
                 }
             }
             Opcode::SetPrivateField => {
@@ -1203,7 +1229,9 @@ impl Context {
                             .set_private_element(name.sym(), PrivateElement::Field(value));
                     }
                 } else {
-                    return self.throw_type_error("cannot set private property on non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot set private property on non-object")
+                        .into());
                 }
             }
             Opcode::SetPrivateMethod => {
@@ -1217,7 +1245,9 @@ impl Context {
                     object_borrow_mut
                         .set_private_element(name.sym(), PrivateElement::Method(value.clone()));
                 } else {
-                    return self.throw_type_error("cannot set private setter on non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot set private setter on non-object")
+                        .into());
                 }
             }
             Opcode::SetPrivateSetter => {
@@ -1230,7 +1260,9 @@ impl Context {
                     let mut object_borrow_mut = object.borrow_mut();
                     object_borrow_mut.set_private_element_setter(name.sym(), value.clone());
                 } else {
-                    return self.throw_type_error("cannot set private setter on non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot set private setter on non-object")
+                        .into());
                 }
             }
             Opcode::SetPrivateGetter => {
@@ -1243,7 +1275,9 @@ impl Context {
                     let mut object_borrow_mut = object.borrow_mut();
                     object_borrow_mut.set_private_element_getter(name.sym(), value.clone());
                 } else {
-                    return self.throw_type_error("cannot set private getter on non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot set private getter on non-object")
+                        .into());
                 }
             }
             Opcode::GetPrivateField => {
@@ -1264,16 +1298,20 @@ impl Context {
                                 self.vm.push(value);
                             }
                             PrivateElement::Accessor { .. } => {
-                                return self.throw_type_error(
-                                    "private property was defined without a getter",
-                                );
+                                return Err(JsNativeError::typ()
+                                    .with_message("private property was defined without a getter")
+                                    .into());
                             }
                         }
                     } else {
-                        return self.throw_type_error("private property does not exist");
+                        return Err(JsNativeError::typ()
+                            .with_message("private property does not exist")
+                            .into());
                     }
                 } else {
-                    return self.throw_type_error("cannot read private property from non-object");
+                    return Err(JsNativeError::typ()
+                        .with_message("cannot read private property from non-object")
+                        .into());
                 }
             }
             Opcode::PushClassField => {
@@ -1393,7 +1431,9 @@ impl Context {
                 let object = self.vm.pop();
                 let result = object.to_object(self)?.__delete__(&key, self)?;
                 if !result && self.vm.frame().code.strict {
-                    return Err(self.construct_type_error("Cannot delete property"));
+                    return Err(JsNativeError::typ()
+                        .with_message("Cannot delete property")
+                        .into());
                 }
                 self.vm.push(result);
             }
@@ -1404,7 +1444,9 @@ impl Context {
                     .to_object(self)?
                     .__delete__(&key.to_property_key(self)?, self)?;
                 if !result && self.vm.frame().code.strict {
-                    return Err(self.construct_type_error("Cannot delete property"));
+                    return Err(JsNativeError::typ()
+                        .with_message("Cannot delete property")
+                        .into());
                 }
                 self.vm.push(result);
             }
@@ -1435,7 +1477,7 @@ impl Context {
             }
             Opcode::Throw => {
                 let value = self.vm.pop();
-                return Err(value);
+                return Err(value.into());
             }
             Opcode::TryStart => {
                 let next = self.vm.read::<u32>();
@@ -1518,7 +1560,7 @@ impl Context {
                         return Ok(ShouldExit::True);
                     }
                     FinallyReturn::Err => {
-                        return Err(self.vm.pop());
+                        return Err(self.vm.pop().into());
                     }
                 }
             }
@@ -1540,7 +1582,7 @@ impl Context {
                             self.vm.push(this);
                         } else {
                             drop(env_b);
-                            return self.throw_reference_error("Must call super constructor in derived class before accessing 'this' or returning from derived constructor");
+                            return Err(JsNativeError::reference().with_message("Must call super constructor in derived class before accessing 'this' or returning from derived constructor").into());
                         }
                     }
                     EnvironmentSlots::Global => {
@@ -1575,7 +1617,7 @@ impl Context {
 
                     home_object
                 } else {
-                    return self.throw_range_error("Must call super constructor in derived class before accessing 'this' or returning from derived constructor");
+                    return Err(JsNativeError::range().with_message("Must call super constructor in derived class before accessing 'this' or returning from derived constructor").into());
                 };
 
                 if let Some(home) = home {
@@ -1617,7 +1659,9 @@ impl Context {
                     .expect("function object must have prototype");
 
                 if !super_constructor.is_constructor() {
-                    return self.throw_type_error("super constructor object must be constructor");
+                    return Err(JsNativeError::typ()
+                        .with_message("super constructor object must be constructor")
+                        .into());
                 }
 
                 let result = super_constructor.__construct__(&arguments, &new_target, self)?;
@@ -1632,7 +1676,9 @@ impl Context {
                     .expect("super call must be in function environment");
 
                 if !this_env.borrow_mut().bind_this_value(&result) {
-                    return self.throw_reference_error("this already initialized");
+                    return Err(JsNativeError::reference()
+                        .with_message("this already initialized")
+                        .into());
                 }
                 self.vm.push(result);
             }
@@ -1670,7 +1716,9 @@ impl Context {
                     .expect("function object must have prototype");
 
                 if !super_constructor.is_constructor() {
-                    return self.throw_type_error("super constructor object must be constructor");
+                    return Err(JsNativeError::typ()
+                        .with_message("super constructor object must be constructor")
+                        .into());
                 }
 
                 let result = super_constructor.__construct__(&arguments, &new_target, self)?;
@@ -1685,7 +1733,9 @@ impl Context {
                     .expect("super call must be in function environment");
 
                 if !this_env.borrow_mut().bind_this_value(&result) {
-                    return self.throw_reference_error("this already initialized");
+                    return Err(JsNativeError::reference()
+                        .with_message("this already initialized")
+                        .into());
                 }
                 self.vm.push(result);
             }
@@ -1718,7 +1768,9 @@ impl Context {
                     .expect("function object must have prototype");
 
                 if !super_constructor.is_constructor() {
-                    return self.throw_type_error("super constructor object must be constructor");
+                    return Err(JsNativeError::typ()
+                        .with_message("super constructor object must be constructor")
+                        .into());
                 }
 
                 let result = super_constructor.__construct__(&arguments, &new_target, self)?;
@@ -1732,7 +1784,9 @@ impl Context {
                     .as_function_slots()
                     .expect("super call must be in function environment");
                 if !this_env.borrow_mut().bind_this_value(&result) {
-                    return self.throw_reference_error("this already initialized");
+                    return Err(JsNativeError::reference()
+                        .with_message("this already initialized")
+                        .into());
                 }
 
                 self.vm.push(result);
@@ -1779,7 +1833,9 @@ impl Context {
             }
             Opcode::CallEval => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
                 let argument_count = self.vm.read::<u32>();
                 let mut arguments = Vec::with_capacity(argument_count as usize);
@@ -1793,7 +1849,11 @@ impl Context {
 
                 let object = match func {
                     JsValue::Object(ref object) if object.is_callable() => object.clone(),
-                    _ => return self.throw_type_error("not a callable function"),
+                    _ => {
+                        return Err(JsNativeError::typ()
+                            .with_message("not a callable function")
+                            .into())
+                    }
                 };
 
                 // A native function with the name "eval" implies, that is this the built-in eval function.
@@ -1816,7 +1876,9 @@ impl Context {
             }
             Opcode::CallEvalSpread => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
 
                 // Get the arguments that are stored as an array object on the stack.
@@ -1836,7 +1898,11 @@ impl Context {
 
                 let object = match func {
                     JsValue::Object(ref object) if object.is_callable() => object.clone(),
-                    _ => return self.throw_type_error("not a callable function"),
+                    _ => {
+                        return Err(JsNativeError::typ()
+                            .with_message("not a callable function")
+                            .into())
+                    }
                 };
 
                 // A native function with the name "eval" implies, that is this the built-in eval function.
@@ -1859,7 +1925,9 @@ impl Context {
             }
             Opcode::Call => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
                 let argument_count = self.vm.read::<u32>();
                 let mut arguments = Vec::with_capacity(argument_count as usize);
@@ -1873,7 +1941,11 @@ impl Context {
 
                 let object = match func {
                     JsValue::Object(ref object) if object.is_callable() => object.clone(),
-                    _ => return self.throw_type_error("not a callable function"),
+                    _ => {
+                        return Err(JsNativeError::typ()
+                            .with_message("not a callable function")
+                            .into())
+                    }
                 };
 
                 let result = object.__call__(&this, &arguments, self)?;
@@ -1882,7 +1954,9 @@ impl Context {
             }
             Opcode::CallSpread => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
 
                 // Get the arguments that are stored as an array object on the stack.
@@ -1902,7 +1976,11 @@ impl Context {
 
                 let object = match func {
                     JsValue::Object(ref object) if object.is_callable() => object.clone(),
-                    _ => return self.throw_type_error("not a callable function"),
+                    _ => {
+                        return Err(JsNativeError::typ()
+                            .with_message("not a callable function")
+                            .into())
+                    }
                 };
 
                 let result = object.__call__(&this, &arguments, self)?;
@@ -1911,7 +1989,9 @@ impl Context {
             }
             Opcode::New => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
                 let argument_count = self.vm.read::<u32>();
                 let mut arguments = Vec::with_capacity(argument_count as usize);
@@ -1923,14 +2003,20 @@ impl Context {
 
                 let result = func
                     .as_constructor()
-                    .ok_or_else(|| self.construct_type_error("not a constructor"))
+                    .ok_or_else(|| {
+                        JsNativeError::typ()
+                            .with_message("not a constructor")
+                            .into()
+                    })
                     .and_then(|cons| cons.__construct__(&arguments, cons, self))?;
 
                 self.vm.push(result);
             }
             Opcode::NewSpread => {
                 if self.vm.stack_size_limit <= self.vm.stack.len() {
-                    return self.throw_range_error("Maximum call stack size exceeded");
+                    return Err(JsNativeError::range()
+                        .with_message("Maximum call stack size exceeded")
+                        .into());
                 }
                 // Get the arguments that are stored as an array object on the stack.
                 let arguments_array = self.vm.pop();
@@ -1948,9 +2034,12 @@ impl Context {
 
                 let result = func
                     .as_constructor()
-                    .ok_or_else(|| self.construct_type_error("not a constructor"))
+                    .ok_or_else(|| {
+                        JsNativeError::typ()
+                            .with_message("not a constructor")
+                            .into()
+                    })
                     .and_then(|cons| cons.__construct__(&arguments, cons, self))?;
-
                 self.vm.push(result);
             }
             Opcode::Return => {
@@ -2057,7 +2146,9 @@ impl Context {
                     .as_ref()
                     .map(PropertyDescriptor::expect_value)
                     .cloned()
-                    .ok_or_else(|| self.construct_type_error("Could not find property `next`"))?;
+                    .ok_or_else(|| {
+                        JsNativeError::typ().with_message("Could not find property `next`")
+                    })?;
 
                 self.vm.push(iterator);
                 self.vm.push(next_method);
@@ -2181,7 +2272,9 @@ impl Context {
                 let next_method_object = if let Some(object) = next_method.as_callable() {
                     object
                 } else {
-                    return self.throw_type_error("iterable next method not a function");
+                    return Err(JsNativeError::typ()
+                        .with_message("iterable next method not a function")
+                        .into());
                 };
                 let iterator = self.vm.pop();
                 let next_result = next_method_object.call(&iterator, &[], self)?;
@@ -2196,7 +2289,9 @@ impl Context {
                 let next_result = if let Some(next_result) = next_result.as_object() {
                     IteratorResult::new(next_result.clone())
                 } else {
-                    return self.throw_type_error("next value should be an object");
+                    return Err(JsNativeError::typ()
+                        .with_message("next value should be an object")
+                        .into());
                 };
 
                 if next_result.complete(self)? {
@@ -2228,16 +2323,20 @@ impl Context {
             }
             Opcode::RequireObjectCoercible => {
                 let value = self.vm.pop();
-                let value = value.require_object_coercible(self)?;
+                let value = value.require_object_coercible()?;
                 self.vm.push(value);
             }
             Opcode::ValueNotNullOrUndefined => {
                 let value = self.vm.pop();
                 if value.is_null() {
-                    return self.throw_type_error("Cannot destructure 'null' value");
+                    return Err(JsNativeError::typ()
+                        .with_message("Cannot destructure 'null' value")
+                        .into());
                 }
                 if value.is_undefined() {
-                    return self.throw_type_error("Cannot destructure 'undefined' value");
+                    return Err(JsNativeError::typ()
+                        .with_message("Cannot destructure 'undefined' value")
+                        .into());
                 }
                 self.vm.push(value);
             }
@@ -2281,7 +2380,7 @@ impl Context {
                 GeneratorResumeKind::Normal => return Ok(ShouldExit::False),
                 GeneratorResumeKind::Throw => {
                     let received = self.vm.pop();
-                    return Err(received);
+                    return Err(received.into());
                 }
                 GeneratorResumeKind::Return => {
                     let mut finally_left = false;
@@ -2308,7 +2407,7 @@ impl Context {
                 let value = self.vm.pop();
 
                 if self.vm.frame().generator_resume_kind == GeneratorResumeKind::Throw {
-                    return Err(value);
+                    return Err(value.into());
                 }
 
                 let completion = Ok(value);
@@ -2336,9 +2435,11 @@ impl Context {
                 if let Some(next) = gen.queue.front() {
                     let (completion, r#return) = &next.completion;
                     if *r#return {
-                        match completion {
-                            Ok(value) | Err(value) => self.vm.push(value),
-                        }
+                        let value = match completion {
+                            Ok(value) => value.clone(),
+                            Err(e) => e.clone().to_value(self),
+                        };
+                        self.vm.push(value);
                         self.vm.push(true);
                     } else {
                         self.vm.push(completion.clone()?);
@@ -2369,7 +2470,8 @@ impl Context {
                         let result =
                             self.call(&next_method, &iterator.clone().into(), &[received])?;
                         let result_object = result.as_object().ok_or_else(|| {
-                            self.construct_type_error("generator next method returned non-object")
+                            JsNativeError::typ()
+                                .with_message("generator next method returned non-object")
                         })?;
                         let done = result_object.get("done", self)?.to_boolean();
                         if done {
@@ -2390,9 +2492,8 @@ impl Context {
                         if let Some(throw) = throw {
                             let result = throw.call(&iterator.clone().into(), &[received], self)?;
                             let result_object = result.as_object().ok_or_else(|| {
-                                self.construct_type_error(
-                                    "generator throw method returned non-object",
-                                )
+                                JsNativeError::typ()
+                                    .with_message("generator throw method returned non-object")
                             })?;
                             let done = result_object.get("done", self)?.to_boolean();
                             if done {
@@ -2412,9 +2513,9 @@ impl Context {
                         let iterator_record =
                             IteratorRecord::new(iterator.clone(), next_method, done);
                         iterator_record.close(Ok(JsValue::Undefined), self)?;
-                        let error =
-                            self.construct_type_error("iterator does not have a throw method");
-                        return Err(error);
+                        return Err(JsNativeError::typ()
+                            .with_message("iterator does not have a throw method")
+                            .into());
                     }
                     GeneratorResumeKind::Return => {
                         let r#return = iterator.get_method("return", self)?;
@@ -2422,9 +2523,8 @@ impl Context {
                             let result =
                                 r#return.call(&iterator.clone().into(), &[received], self)?;
                             let result_object = result.as_object().ok_or_else(|| {
-                                self.construct_type_error(
-                                    "generator return method returned non-object",
-                                )
+                                JsNativeError::typ()
+                                    .with_message("generator return method returned non-object")
                             })?;
                             let done = result_object.get("done", self)?.to_boolean();
                             if done {
@@ -2742,12 +2842,14 @@ impl Context {
                         self.vm.frame_mut().catch.pop();
                         self.vm.frame_mut().finally_return = FinallyReturn::Err;
                         self.vm.frame_mut().thrown = true;
+                        let e = e.to_value(self);
                         self.vm.push(e);
                     } else {
                         self.vm.stack.truncate(start_stack_size);
 
                         // Step 3.f in [AsyncBlockStart](https://tc39.es/ecma262/#sec-asyncblockstart).
                         if let Some(promise_capability) = promise_capability {
+                            let e = e.to_value(self);
                             promise_capability
                                 .reject()
                                 .call(&JsValue::undefined(), &[e.clone()], self)

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -43,7 +43,14 @@ fn try_catch_finally_from_init() {
         }
     "#;
 
-    assert_eq!(Context::default().eval(source.as_bytes()), Err("h".into()));
+    assert_eq!(
+        Context::default()
+            .eval(source.as_bytes())
+            .unwrap_err()
+            .as_opaque()
+            .unwrap(),
+        &"h".into()
+    );
 }
 
 #[test]
@@ -61,8 +68,8 @@ fn multiple_catches() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::Undefined)
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::Undefined
     );
 }
 
@@ -80,8 +87,8 @@ fn use_last_expr_try_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::from("Hello!"))
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::from("Hello!")
     );
 }
 #[test]
@@ -98,8 +105,8 @@ fn use_last_expr_catch_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::from("Hello!"))
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::from("Hello!")
     );
 }
 
@@ -114,8 +121,8 @@ fn no_use_last_expr_finally_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::undefined())
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::undefined()
     );
 }
 
@@ -133,8 +140,8 @@ fn finally_block_binding_env() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::from("Hey hey people"))
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::from("Hey hey people")
     );
 }
 
@@ -152,8 +159,8 @@ fn run_super_method_in_object() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::from("super"))
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::from("super")
     );
 }
 
@@ -178,7 +185,7 @@ fn get_reference_by_super() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()),
-        Ok(JsValue::from("ab"))
+        Context::default().eval(source.as_bytes()).unwrap(),
+        JsValue::from("ab")
     );
 }

--- a/boa_examples/src/bin/classes.rs
+++ b/boa_examples/src/bin/classes.rs
@@ -2,6 +2,7 @@
 use boa_engine::{
     builtins::JsArgs,
     class::{Class, ClassBuilder},
+    error::JsNativeError,
     property::Attribute,
     Context, JsResult, JsString, JsValue,
 };
@@ -29,7 +30,7 @@ struct Person {
 // or any function that matches the required signature.
 impl Person {
     /// Says hello if `this` is a `Person`
-    fn say_hello(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn say_hello(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // We check if this is an object.
         if let Some(object) = this.as_object() {
             // If it is we downcast the type to type `Person`.
@@ -45,7 +46,9 @@ impl Person {
         }
         // If `this` was not an object or the type of `this` was not a native object `Person`,
         // we throw a `TypeError`.
-        context.throw_type_error("'this' is not a Person object")
+        Err(JsNativeError::typ()
+            .with_message("'this' is not a Person object")
+            .into())
     }
 }
 

--- a/boa_examples/src/bin/closures.rs
+++ b/boa_examples/src/bin/closures.rs
@@ -6,11 +6,11 @@ use boa_engine::{
     object::{FunctionBuilder, JsObject},
     property::{Attribute, PropertyDescriptor},
     string::utf16,
-    Context, JsString, JsValue,
+    Context, JsError, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
 
-fn main() -> Result<(), JsValue> {
+fn main() -> Result<(), JsError> {
     // We create a new `Context` to create a new Javascript executor.
     let mut context = Context::default();
 

--- a/boa_examples/src/bin/jsset.rs
+++ b/boa_examples/src/bin/jsset.rs
@@ -1,21 +1,21 @@
 // This example shows how to manipulate a Javascript Set using Rust code.
 #![allow(clippy::bool_assert_comparison)]
-use boa_engine::{object::builtins::JsSet, Context, JsValue};
+use boa_engine::{object::builtins::JsSet, Context, JsError, JsValue};
 
-fn main() -> Result<(), JsValue> {
+fn main() -> Result<(), JsError> {
     // New `Context` for a new Javascript executor.
     let context = &mut Context::default();
 
     // Create an empty set.
     let set = JsSet::new(context);
 
-    assert_eq!(set.size(context)?, 0);
+    assert_eq!(set.size()?, 0);
     set.add(5, context)?;
-    assert_eq!(set.size(context)?, 1);
+    assert_eq!(set.size()?, 1);
     set.add(10, context)?;
-    assert_eq!(set.size(context)?, 2);
+    assert_eq!(set.size()?, 2);
     set.clear(context)?;
-    assert_eq!(set.size(context)?, 0);
+    assert_eq!(set.size()?, 0);
 
     set.add("one", context)?;
     set.add("two", context)?;
@@ -32,7 +32,7 @@ fn main() -> Result<(), JsValue> {
 
     assert_eq!(set.has("one", context)?, false);
     assert_eq!(set.has("three", context)?, false);
-    assert_eq!(set.size(context)?, 0);
+    assert_eq!(set.size()?, 0);
 
     // Add a slice into a set;
     set.add_items(
@@ -40,12 +40,12 @@ fn main() -> Result<(), JsValue> {
         context,
     )?;
     // Will return 1, as one slice was added.
-    assert_eq!(set.size(context)?, 1);
+    assert_eq!(set.size()?, 1);
 
     // Make a new set from a slice
     let slice_set = JsSet::from_iter([JsValue::new(1), JsValue::new(2), JsValue::new(3)], context);
     // Will return 3, as each element of slice was added into the set.
-    assert_eq!(slice_set.size(context)?, 3);
+    assert_eq!(slice_set.size()?, 3);
 
     set.clear(context)?;
 

--- a/boa_examples/src/bin/loadfile.rs
+++ b/boa_examples/src/bin/loadfile.rs
@@ -22,7 +22,7 @@ fn main() {
                 }
                 Err(e) => {
                     // Pretty print the error
-                    eprintln!("Uncaught {}", e.display());
+                    eprintln!("Uncaught {e}");
                 }
             };
         }

--- a/boa_examples/src/bin/loadstring.rs
+++ b/boa_examples/src/bin/loadstring.rs
@@ -18,7 +18,7 @@ fn main() {
         }
         Err(e) => {
             // Pretty print the error
-            eprintln!("Uncaught {}", e.display());
+            eprintln!("Uncaught {e}");
         }
     };
 }

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -2,7 +2,7 @@ use boa_engine::{
     builtins::JsArgs,
     object::{JsObject, ObjectInitializer},
     property::Attribute,
-    Context, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue,
 };
 
 /// Initializes the object in the context.
@@ -40,24 +40,18 @@ fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsRes
 /// The `$262.detachArrayBuffer()` function.
 ///
 /// Implements the `DetachArrayBuffer` abstract operation.
-fn detach_array_buffer(
-    _this: &JsValue,
-    args: &[JsValue],
-    context: &mut Context,
-) -> JsResult<JsValue> {
+fn detach_array_buffer(_this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
     #[inline]
-    fn type_err(context: &mut Context) -> JsValue {
-        context.construct_type_error("The provided object was not an ArrayBuffer")
+    fn type_err() -> JsNativeError {
+        JsNativeError::typ().with_message("The provided object was not an ArrayBuffer")
     }
 
     let array_buffer = args
         .get(0)
         .and_then(JsValue::as_object)
-        .ok_or_else(|| type_err(context))?;
+        .ok_or_else(type_err)?;
     let mut array_buffer = array_buffer.borrow_mut();
-    let array_buffer = array_buffer
-        .as_array_buffer_mut()
-        .ok_or_else(|| type_err(context))?;
+    let array_buffer = array_buffer.as_array_buffer_mut().ok_or_else(type_err)?;
 
     // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false. TODO
     // 2. If key is not present, set key to undefined.
@@ -65,7 +59,9 @@ fn detach_array_buffer(
 
     // 3. If SameValue(arrayBuffer.[[ArrayBufferDetachKey]], key) is false, throw a TypeError exception.
     if !JsValue::same_value(&array_buffer.array_buffer_detach_key, key) {
-        return context.throw_type_error("Cannot detach array buffer with different key");
+        return Err(JsNativeError::typ()
+            .with_message("Cannot detach array buffer with different key")
+            .into());
     }
 
     // 4. Set arrayBuffer.[[ArrayBufferData]] to null.
@@ -85,7 +81,9 @@ fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
     if let Some(source_text) = args.get(0).and_then(JsValue::as_string) {
         match context.parse(source_text.to_std_string_escaped()) {
             // TODO: check strict
-            Err(e) => context.throw_type_error(format!("Uncaught Syntax Error: {e}")),
+            Err(e) => Err(JsNativeError::typ()
+                .with_message(format!("Uncaught Syntax Error: {e}"))
+                .into()),
             // Calling eval here parses the code a second time.
             // TODO: We can fix this after we have have defined the public api for the vm executer.
             Ok(_) => context.eval(source_text.to_std_string_escaped()),

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -2,13 +2,15 @@
 
 mod js262;
 
+use crate::read::ErrorType;
+
 use super::{
     Harness, Outcome, Phase, SuiteResult, Test, TestFlags, TestOutcomeResult, TestResult,
     TestSuite, IGNORED,
 };
 use boa_engine::{
     builtins::JsArgs, object::FunctionBuilder, property::Attribute, syntax::Parser, Context,
-    JsResult, JsValue,
+    JsNativeErrorKind, JsResult, JsValue,
 };
 use boa_gc::{Cell, Finalize, Gc, Trace};
 use colored::Colorize;
@@ -181,7 +183,7 @@ impl Test {
                                 && matches!(*callback_obj.result.borrow(), Some(true) | None);
                             let text = match res {
                                 Ok(val) => val.display().to_string(),
-                                Err(e) => format!("Uncaught {}", e.display()),
+                                Err(e) => format!("Uncaught {e}",),
                             };
 
                             (passed, text)
@@ -191,11 +193,11 @@ impl Test {
                 }
                 Outcome::Negative {
                     phase: Phase::Parse | Phase::Early,
-                    ref error_type,
+                    error_type,
                 } => {
                     assert_eq!(
-                        error_type.as_ref(),
-                        "SyntaxError",
+                        error_type,
+                        ErrorType::SyntaxError,
                         "non-SyntaxError parsing/early error found in {}",
                         self.name
                     );
@@ -215,7 +217,7 @@ impl Test {
                 } => todo!("check module resolution errors"),
                 Outcome::Negative {
                     phase: Phase::Runtime,
-                    ref error_type,
+                    error_type,
                 } => {
                     let mut context = Context::default();
                     if let Err(e) = Parser::new(test_content.as_bytes()).parse_all(&mut context) {
@@ -226,13 +228,45 @@ impl Test {
                             Ok(_) => match context.eval(&test_content) {
                                 Ok(res) => (false, res.display().to_string()),
                                 Err(e) => {
-                                    let passed = e
-                                        .display()
-                                        .internals(true)
-                                        .to_string()
-                                        .contains(error_type.as_ref());
+                                    let passed = if let Ok(e) = e.try_native(&mut context) {
+                                        match &e.kind {
+                                            JsNativeErrorKind::Syntax
+                                                if error_type == ErrorType::SyntaxError =>
+                                            {
+                                                true
+                                            }
+                                            JsNativeErrorKind::Reference
+                                                if error_type == ErrorType::ReferenceError =>
+                                            {
+                                                true
+                                            }
+                                            JsNativeErrorKind::Range
+                                                if error_type == ErrorType::RangeError =>
+                                            {
+                                                true
+                                            }
+                                            JsNativeErrorKind::Type
+                                                if error_type == ErrorType::TypeError =>
+                                            {
+                                                true
+                                            }
+                                            _ => false,
+                                        }
+                                    } else {
+                                        e.as_opaque()
+                                            .expect("try_native cannot fail if e is not opaque")
+                                            .as_object()
+                                            .and_then(|o| o.get("constructor", &mut context).ok())
+                                            .as_ref()
+                                            .and_then(JsValue::as_object)
+                                            .and_then(|o| o.get("name", &mut context).ok())
+                                            .as_ref()
+                                            .and_then(JsValue::as_string)
+                                            .map(|s| s == error_type.as_str())
+                                            .unwrap_or_default()
+                                    };
 
-                                    (passed, format!("Uncaught {}", e.display()))
+                                    (passed, format!("Uncaught {e}"))
                                 }
                             },
                             Err(e) => (false, e),
@@ -331,15 +365,15 @@ impl Test {
 
         context
             .eval(harness.assert.as_ref())
-            .map_err(|e| format!("could not run assert.js:\n{}", e.display()))?;
+            .map_err(|e| format!("could not run assert.js:\n{e}"))?;
         context
             .eval(harness.sta.as_ref())
-            .map_err(|e| format!("could not run sta.js:\n{}", e.display()))?;
+            .map_err(|e| format!("could not run sta.js:\n{e}"))?;
 
         if self.flags.contains(TestFlags::ASYNC) {
             context
                 .eval(harness.doneprint_handle.as_ref())
-                .map_err(|e| format!("could not run doneprintHandle.js:\n{}", e.display()))?;
+                .map_err(|e| format!("could not run doneprintHandle.js:\n{e}"))?;
         }
 
         for include in self.includes.iter() {
@@ -351,12 +385,7 @@ impl Test {
                         .ok_or_else(|| format!("could not find the {include} include file."))?
                         .as_ref(),
                 )
-                .map_err(|e| {
-                    format!(
-                        "could not run the {include} include file:\nUncaught {}",
-                        e.display()
-                    )
-                })?;
+                .map_err(|e| format!("could not run the {include} include file:\nUncaught {e}"))?;
         }
 
         Ok(())

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -77,6 +77,7 @@ use clap::{ArgAction, Parser, ValueHint};
 use colored::Colorize;
 use fxhash::{FxHashMap, FxHashSet};
 use once_cell::sync::Lazy;
+use read::ErrorType;
 use serde::{Deserialize, Serialize};
 use std::{
     fs,
@@ -456,7 +457,7 @@ impl Test {
 #[derive(Debug, Clone)]
 enum Outcome {
     Positive,
-    Negative { phase: Phase, error_type: Box<str> },
+    Negative { phase: Phase, error_type: ErrorType },
 }
 
 impl Default for Outcome {

--- a/boa_tester/src/read.rs
+++ b/boa_tester/src/read.rs
@@ -33,7 +33,30 @@ pub(super) struct MetaData {
 pub(super) struct Negative {
     pub(super) phase: Phase,
     #[serde(rename = "type")]
-    pub(super) error_type: Box<str>,
+    pub(super) error_type: ErrorType,
+}
+
+/// All possible error types
+#[derive(Debug, Copy, Clone, Deserialize, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)] // Better than appending `rename` to all variants
+pub(super) enum ErrorType {
+    Test262Error,
+    SyntaxError,
+    ReferenceError,
+    RangeError,
+    TypeError,
+}
+
+impl ErrorType {
+    pub(super) fn as_str(self) -> &'static str {
+        match self {
+            ErrorType::Test262Error => "Test262Error",
+            ErrorType::SyntaxError => "SyntaxError",
+            ErrorType::ReferenceError => "ReferenceError",
+            ErrorType::RangeError => "RangeError",
+            ErrorType::TypeError => "TypeError",
+        }
+    }
 }
 
 /// Individual test flag.

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -67,6 +67,6 @@ pub fn evaluate(src: &str) -> Result<String, JsValue> {
     // Setup executor
     Context::default()
         .eval(src)
-        .map_err(|e| JsValue::from(format!("Uncaught {}", e.display())))
+        .map_err(|e| JsValue::from(format!("Uncaught {e}")))
         .map(|v| v.display().to_string())
 }


### PR DESCRIPTION
This is an experiment that tries to migrate the codebase from eager `Error` objects to lazy ones.

In short words, this redefines `JsResult = Result<JsValue, JsError>`, where `JsError` is a brand new type that stores only the essential part of an error type, and only transforms those errors to `JsObject`s on demand (when having to pass them as arguments to functions or store them inside async/generators).

This change is pretty big, because it unblocks a LOT of code from having to take a `&mut Context` on each call. It also paves the road for possibly making `JsError` a proper variant of `JsValue`, which can be a pretty big optimization for try/catch.

A downside of this is that it exposes some brand new error types to our public API. However, we can now implement `Error` on `JsError`, making our `JsResult` type a bit more inline with Rust's best practices.

~Will mark this as draft, since it's missing some documentation and a lot of examples, but~ it's pretty much feature complete. As always, any comments about the design are very much appreciated!

Note: Since there are a lot of changes which are essentially just rewriting `context.throw` to `JsNativeError::%type%`, I'll leave an "index" of the most important changes here:

- [boa_engine/src/error.rs](https://github.com/boa-dev/boa/pull/2283/files#diff-f15f2715655440626eefda5c46193d29856f4949ad37380c129a8debc6b82f26)
- [boa_engine/src/builtins/error/mod.rs](https://github.com/boa-dev/boa/pull/2283/files#diff-3eb1e4b4b5c7210eb98192a5277f5a239148423c6b970c4ae05d1b267f8f1084)
- [boa_tester/src/exec/mod.rs](https://github.com/boa-dev/boa/pull/2283/files#diff-fc3d7ad7b5e64574258c9febbe56171f3309b74e0c8da35238a76002f3ee34d9)