### PR TITLE
[Merged by Bors] - Switch to workspace inherited properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,22 @@ members = [
     "boa_examples",
 ]
 
+[workspace.package]
+edition = "2021"
+version = "0.16.0"
+rust-version = "1.60"
+authors = ["boa-dev"]
+repository = "https://github.com/boa-dev/boa"
+license = "Unlicense/MIT"
+description = "Boa is a Javascript lexer, parser and Just-in-Time compiler written in Rust. Currently, it has support for some of the language."
+
+[workspace.dependencies]
+boa_engine = { version = "0.16.0", path = "boa_engine" }
+boa_interner = { version = "0.16.0", path = "boa_interner" }
+boa_gc = { version = "0.16.0", path = "boa_gc" }
+boa_profiler = { version = "0.16.0", path = "boa_profiler" }
+boa_unicode = { version = "0.16.0", path = "boa_unicode" }
+
 [workspace.metadata.workspaces]
 allow_branch = "main"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 [workspace.package]
 edition = "2021"
 version = "0.16.0"
-rust-version = "1.60"
+rust-version = "1.64"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
 license = "Unlicense/MIT"

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "boa_cli"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "Boa is a Javascript lexer, parser and Just-in-Time compiler written in Rust. Currently, it has support for some of the language."
-repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "compiler", "js", "cli"]
 categories = ["command-line-utilities"]
-license = "Unlicense/MIT"
 default-run = "boa"
+description.workspace = true
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-boa_engine = { path = "../boa_engine", features = ["deser", "console"], version = "0.16.0" }
-boa_interner = { path = "../boa_interner", version = "0.16.0" }
+boa_engine = { workspace = true, features = ["deser", "console"] }
+boa_interner.workspace = true
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
 clap = { version = "3.2.22", features = ["derive"] }

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "boa_engine"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "Boa is a Javascript lexer, parser and Just-in-Time compiler written in Rust. Currently, it has support for some of the language."
-repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "js", "compiler", "lexer", "parser"]
 categories = ["parser-implementations", "compilers"]
-license = "Unlicense/MIT"
 readme = "../README.md"
+description.workspace = true
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [features]
 profiler = ["boa_profiler/profiler"]
@@ -28,11 +28,11 @@ intl = [
 console = []
 
 [dependencies]
-boa_unicode = { path = "../boa_unicode", version = "0.16.0" }
-boa_interner = { path = "../boa_interner", version = "0.16.0" }
-boa_gc = { path = "../boa_gc", version = "0.16.0" }
+boa_unicode.workspace = true
+boa_interner.workspace = true
+boa_gc.workspace = true
+boa_profiler.workspace = true
 gc = "0.4.1"
-boa_profiler = { path = "../boa_profiler", version = "0.16.0" }
 serde = { version = "1.0.145", features = ["derive", "rc"] }
 serde_json = "1.0.85"
 rand = "0.8.5"

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1735,7 +1735,7 @@ impl<'context> FunctionBuilder<'context> {
                 ref mut constructor,
                 ..
             } => {
-                *constructor = yes.then(|| ConstructorKind::Base);
+                *constructor = yes.then_some(ConstructorKind::Base);
             }
             Function::Ordinary { .. }
             | Function::Generator { .. }
@@ -2146,7 +2146,7 @@ impl<'context> ConstructorBuilder<'context> {
     /// Default is `true`
     #[inline]
     pub fn constructor(&mut self, constructor: bool) -> &mut Self {
-        self.constructor = constructor.then(|| ConstructorKind::Base);
+        self.constructor = constructor.then_some(ConstructorKind::Base);
         self
     }
 

--- a/boa_examples/Cargo.toml
+++ b/boa_examples/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
 name = "boa_examples"
-version = "0.16.0"
-authors = ["boa-dev"]
-repository = "https://github.com/boa-dev/boa"
-license = "Unlicense/MIT"
-edition = "2021"
+description = "Usage examples of the Boa JavaScript engine."
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-boa_engine = { path = "../boa_engine", features = ["console"], version = "0.16.0" }
-boa_gc = { path = "../boa_gc", version = "0.16.0" }
+boa_engine = { workspace = true, features = ["console"] }
+boa_gc.workspace = true
 gc = "0.4.1"

--- a/boa_gc/Cargo.toml
+++ b/boa_gc/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "boa_gc"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "Garbage collector used in Boa."
-repository = "https://github.com/boa-dev/boa"
+description = "Garbage collector for the Boa JavaScript engine."
 keywords = ["javascript", "js", "garbage", "memory"]
 categories = ["command-line-utilities"]
-license = "Unlicense/MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 gc = { version = "0.4.1", features = ["derive"] }

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "boa_interner"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "String interner used in Boa."
-repository = "https://github.com/boa-dev/boa"
+description = "String interner for the Boa JavaScript engine."
 keywords = ["javascript", "js", "string", "interner"]
 categories = ["data-structures"]
-license = "Unlicense/MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 serde = { version = "1.0.145", features = ["derive"], optional = true }

--- a/boa_profiler/Cargo.toml
+++ b/boa_profiler/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "boa_profiler"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "Profiler used in Boa."
-repository = "https://github.com/boa-dev/boa"
+description = "Profiler for the Boa JavaScript engine."
 keywords = ["javascript", "js", "compiler", "profiler"]
 categories = ["development-tools::profiling"]
-license = "Unlicense/MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [features]
 profiler = ["measureme", "once_cell"]

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "boa_tester"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "Test runner for the Boa JavaScript engine."
-repository = "https://github.com/boa-dev/boa"
+description = "ECMA-262 tests runner for the Boa JavaScript engine."
 keywords = ["javascript", "ECMASCript", "compiler", "test262", "tester"]
 categories = ["command-line-utilites"]
-license = "Unlicense/MIT"
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-boa_engine = { path = "../boa_engine", features = ["intl"], version = "0.16.0" }
-boa_interner = { path = "../boa_interner", version = "0.16.0" }
-boa_gc = { path = "../boa_gc", version = "0.16.0" }
+boa_engine = { workspace = true, features = ["intl"] }
+boa_interner.workspace = true
+boa_gc.workspace = true
 clap = { version = "3.2.22", features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_yaml = "0.9.13"

--- a/boa_unicode/Cargo.toml
+++ b/boa_unicode/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "boa_unicode"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
 description = "Unicode support for the Boa JavaScript engine."
-repository = "https://github.com/boa-dev/boa"
 keywords = ["javascript", "compiler", "lexer", "parser", "unicode"]
 categories = ["parsing"]
-license = "Unlicense/MIT"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 unicode-general-category = "0.6.0"

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "boa_wasm"
-version = "0.16.0"
-edition = "2021"
-rust-version = "1.60"
-authors = ["boa-dev"]
-description = "WASM package for the Boa JavaScript engine."
-repository = "https://github.com/boa-dev/boa"
+description = "WASM compatibility layer for the Boa JavaScript engine."
 keywords = ["javascript", "compiler", "lexer", "parser", "js"]
 categories = ["parser-implementations", "wasm", "compilers"]
-license = "Unlicense/MIT"
 publish = false
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
-boa_engine = { path = "../boa_engine", features = ["console"], version = "0.16.0" }
+boa_engine = { workspace = true, features = ["console"] }
 wasm-bindgen = "0.2.83"
 getrandom = { version = "0.2.7", features = ["js"] }
 


### PR DESCRIPTION
This Pull Request switches our codebase to the brand new [workspace inherited keys](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table), which allows us to define common package options that are usable within each crate's Cargo.toml file.

It also allows to share dependency versions between crates, but I defined only shared versions for our workspace members. It would be a good follow-up to lift all the shared dependencies between crates into the global Cargo.toml.