### PR TITLE
[Merged by Bors] - Add unicode terminator to line comment

### DIFF
--- a/boa_engine/src/syntax/lexer/comment.rs
+++ b/boa_engine/src/syntax/lexer/comment.rs
@@ -34,12 +34,14 @@ impl<R> Tokenizer<R> for SingleLineComment {
         let _timer = Profiler::global().start_event("SingleLineComment", "Lexing");
 
         // Skip either to the end of the line or to the end of the input
-        while let Some(ch) = cursor.peek()? {
-            if ch == b'\n' || ch == b'\r' {
-                break;
-            }
-            // Consume char.
-            cursor.next_byte()?.expect("Comment character vanished");
+        while let Some(ch) = cursor.next_char()? {
+            let tried_ch = char::try_from(ch);
+            match tried_ch {
+                Ok(c) if c == '\r' || c == '\n' || c == '\u{2028}' || c == '\u{2029}' => {
+                   break;
+                }
+                _ => {}
+            };
         }
         Ok(Token::new(
             TokenKind::Comment,

--- a/boa_engine/src/syntax/lexer/comment.rs
+++ b/boa_engine/src/syntax/lexer/comment.rs
@@ -34,12 +34,13 @@ impl<R> Tokenizer<R> for SingleLineComment {
         let _timer = Profiler::global().start_event("SingleLineComment", "Lexing");
 
         // Skip either to the end of the line or to the end of the input
-        while let Some(ch) = cursor.next_char()? {
+        while let Some(ch) = cursor.peek_char()? {
             let tried_ch = char::try_from(ch);
             match tried_ch {
                 Ok(c) if c == '\r' || c == '\n' || c == '\u{2028}' || c == '\u{2029}' => break,
                 _ => {}
             };
+            cursor.next_char().expect("Comment character vanished");
         }
         Ok(Token::new(
             TokenKind::Comment,

--- a/boa_engine/src/syntax/lexer/comment.rs
+++ b/boa_engine/src/syntax/lexer/comment.rs
@@ -37,9 +37,7 @@ impl<R> Tokenizer<R> for SingleLineComment {
         while let Some(ch) = cursor.next_char()? {
             let tried_ch = char::try_from(ch);
             match tried_ch {
-                Ok(c) if c == '\r' || c == '\n' || c == '\u{2028}' || c == '\u{2029}' => {
-                   break;
-                }
+                Ok(c) if c == '\r' || c == '\n' || c == '\u{2028}' || c == '\u{2029}' => break,
                 _ => {}
             };
         }


### PR DESCRIPTION
This PR sloves the unicode terminator to single line comment
+ [{u+2028}](https://unicode-table.com/en/2028/)
+ [{u+2029}](https://unicode-table.com/en/2029/)
+ [related test](https://github.com/tc39/test262/blob/9215420deee3e5887d29f95822bf6a474c1bf728/test/language/line-terminators/comment-single-ps.js)
+ [related test set](https://github.com/tc39/test262/tree/9215420deee3e5887d29f95822bf6a474c1bf728/test/language/line-terminators)
