### PR TITLE
[Merged by Bors] - Fixing the output for the test diffs in PRs

### DIFF
--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -264,7 +264,13 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             format!(
                 "{}{}{}{}",
                 if diff == 0 { "" } else { "**" },
-                if diff.is_positive() { "+" } else { "-" },
+                if diff.is_positive() {
+                    "+"
+                } else if diff.is_negative() {
+                    "-"
+                } else {
+                    ""
+                },
                 pretty_int(diff),
                 if diff == 0 { "" } else { "**" }
             )

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -250,7 +250,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
         fn pretty_int(i: isize) -> String {
             let mut res = String::new();
 
-            for (idx, val) in i.to_string().chars().rev().enumerate() {
+            for (idx, val) in i.abs().to_string().chars().rev().enumerate() {
                 if idx != 0 && idx % 3 == 0 {
                     res.insert(0, ',');
                 }
@@ -264,7 +264,7 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             format!(
                 "{}{}{}{}",
                 if diff == 0 { "" } else { "**" },
-                if diff > 0 { "+" } else { "" },
+                if diff.is_positive() { "+" } else { "-" },
                 pretty_int(diff),
                 if diff == 0 { "" } else { "**" }
             )


### PR DESCRIPTION
This PR fixes PR comments where negative numbers from 100 to 999 would be shown as `-,999` instead of `-999`
