### PR TITLE
Fixed a documentation link

### DIFF
--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1,4 +1,5 @@
-//! This module implements the Rust representation of a JavaScript object, see object::[builtins] for implementors.
+//! This module implements the Rust representation of a JavaScript object, see
+//! [`object::builtins`][builtins] for implementors.
 //!
 //! This module also provides helper objects for working with JavaScript objects.
 


### PR DESCRIPTION
We were getting warnings because this link was not properly back-ticked. This fixes it.

