### PR TITLE
[Merged by Bors] - Bump serde_json from 1.0.85 to 1.0.86

### DIFF
--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -17,7 +17,7 @@ boa_interner.workspace = true
 rustyline = "10.0.0"
 rustyline-derive = "0.7.0"
 clap = { version = "3.2.22", features = ["derive"] }
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 colored = "2.0.0"
 regex = "1.6.0"
 phf = { version = "0.11.1", features = ["macros"] }

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -35,7 +35,7 @@ boa_profiler.workspace = true
 boa_macros.workspace = true
 gc = "0.4.1"
 serde = { version = "1.0.145", features = ["derive", "rc"] }
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 rand = "0.8.5"
 num-traits = "0.2.15"
 regress = "0.4.1"

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -18,7 +18,7 @@ boa_gc.workspace = true
 clap = { version = "3.2.22", features = ["derive"] }
 serde = { version = "1.0.145", features = ["derive"] }
 serde_yaml = "0.9.13"
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 bitflags = "1.3.2"
 regex = "1.6.0"
 once_cell = "1.15.0"


### PR DESCRIPTION
Replaces #2339 since dependabot has a small bug.