### PR TITLE
[Merged by Bors] - Modified the `loadfile` example to show how Boa can read bytes

### DIFF
--- a/boa_examples/src/bin/loadfile.rs
+++ b/boa_examples/src/bin/loadfile.rs
@@ -1,14 +1,14 @@
 // This example shows how to load, parse and execute JS code from a source file
 // (./scripts/helloworld.js)
 
-use std::fs::read_to_string;
+use std::fs;
 
 use boa_engine::Context;
 
 fn main() {
     let js_file_path = "./scripts/helloworld.js";
 
-    match read_to_string(js_file_path) {
+    match fs::read(js_file_path) {
         Ok(src) => {
             // Instantiate the execution context
             let mut context = Context::default();


### PR DESCRIPTION
Boa's `Context::eval()` and `Context::parse()` functions allow reading a byte slice directly, apart from a string. We were not showing this properly in our examples, so this modifies the `loadfile.rs` example to use a byte vector instead of a string, which allows us to use UTF-16 files, if I'm not mistaken.