### PR TITLE
[Merged by Bors] - Removed the "VM Implementation" headline for Test262

### DIFF
--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -276,8 +276,6 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) {
             )
         }
 
-        println!("#### VM implementation");
-
         println!("| Test result | main count | PR count | difference |");
         println!("| :---------: | :----------: | :------: | :--------: |");
         println!(


### PR DESCRIPTION
We were always getting a "VM Implementation" headline in Test262 results for PRs. This was a leftover from the time when we had 2 distinct implementations for the execution. This is no longer the case, so we can remove it to reduce clutter.