### PR TITLE
[Merged by Bors] - Removed some duplicate code, added `ToIndentedString`

### DIFF
--- a/boa_engine/src/syntax/ast/declaration/mod.rs
+++ b/boa_engine/src/syntax/ast/declaration/mod.rs
@@ -1,11 +1,10 @@
-use boa_interner::{Interner, ToInternedString};
-use tap::Tap;
-
 use super::{
     expression::Identifier,
     function::{AsyncFunction, AsyncGenerator, Class, Function, Generator},
     ContainsSymbol,
 };
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
+use tap::Tap;
 
 mod variable;
 
@@ -34,17 +33,6 @@ pub enum Declaration {
 }
 
 impl Declaration {
-    pub(super) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        match self {
-            Declaration::Function(f) => f.to_indented_string(interner, indentation),
-            Declaration::Generator(g) => g.to_indented_string(interner, indentation),
-            Declaration::AsyncFunction(af) => af.to_indented_string(interner, indentation),
-            Declaration::AsyncGenerator(ag) => ag.to_indented_string(interner, indentation),
-            Declaration::Class(c) => c.to_indented_string(interner, indentation),
-            Declaration::Lexical(l) => l.to_interned_string(interner).tap_mut(|s| s.push(';')),
-        }
-    }
-
     /// Return the lexically declared names of a `Declaration`.
     ///
     /// The returned list may contain duplicates.
@@ -146,8 +134,15 @@ impl Declaration {
     }
 }
 
-impl ToInternedString for Declaration {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for Declaration {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        match self {
+            Declaration::Function(f) => f.to_indented_string(interner, indentation),
+            Declaration::Generator(g) => g.to_indented_string(interner, indentation),
+            Declaration::AsyncFunction(af) => af.to_indented_string(interner, indentation),
+            Declaration::AsyncGenerator(ag) => ag.to_indented_string(interner, indentation),
+            Declaration::Class(c) => c.to_indented_string(interner, indentation),
+            Declaration::Lexical(l) => l.to_interned_string(interner).tap_mut(|s| s.push(';')),
+        }
     }
 }

--- a/boa_engine/src/syntax/ast/expression/await.rs
+++ b/boa_engine/src/syntax/ast/expression/await.rs
@@ -3,7 +3,7 @@
 use crate::syntax::ast::ContainsSymbol;
 
 use super::Expression;
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 /// An await expression is used within an async function to pause execution and wait for a
 /// promise to resolve.

--- a/boa_engine/src/syntax/ast/expression/literal/object/mod.rs
+++ b/boa_engine/src/syntax/ast/expression/literal/object/mod.rs
@@ -10,7 +10,7 @@ use crate::syntax::ast::{
     property::{MethodDefinition, PropertyDefinition},
     ContainsSymbol,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 /// Objects in JavaScript may be defined as an unordered collection of related data, of
 /// primitive or reference types, in the form of “key: value” pairs.
@@ -39,13 +39,27 @@ pub struct ObjectLiteral {
 }
 
 impl ObjectLiteral {
+    /// Gets the object literal properties
     #[inline]
     pub fn properties(&self) -> &[PropertyDefinition] {
         &self.properties
     }
 
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indent_n: usize) -> String {
+    #[inline]
+    pub(crate) fn contains_arguments(&self) -> bool {
+        self.properties
+            .iter()
+            .any(PropertyDefinition::contains_arguments)
+    }
+
+    #[inline]
+    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
+        self.properties.iter().any(|prop| prop.contains(symbol))
+    }
+}
+
+impl ToIndentedString for ObjectLiteral {
+    fn to_indented_string(&self, interner: &Interner, indent_n: usize) -> String {
         let mut buf = "{\n".to_owned();
         let indentation = "    ".repeat(indent_n + 1);
         for property in self.properties().iter() {
@@ -118,25 +132,6 @@ impl ObjectLiteral {
         buf.push_str(&format!("{}}}", "    ".repeat(indent_n)));
 
         buf
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.properties
-            .iter()
-            .any(PropertyDefinition::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.properties.iter().any(|prop| prop.contains(symbol))
-    }
-}
-
-impl ToInternedString for ObjectLiteral {
-    #[inline]
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
     }
 }
 

--- a/boa_engine/src/syntax/ast/expression/mod.rs
+++ b/boa_engine/src/syntax/ast/expression/mod.rs
@@ -1,4 +1,4 @@
-use boa_interner::{Interner, Sym, ToInternedString};
+use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 
 use self::{
     access::{PrivatePropertyAccess, PropertyAccess, SuperPropertyAccess},
@@ -142,12 +142,6 @@ pub enum Expression {
 }
 
 impl Expression {
-    /// Creates a string of the value of the expression with the given indentation.
-    #[inline]
-    pub fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        self.to_no_indent_string(interner, indentation)
-    }
-
     /// Implements the display formatting with indentation.
     ///
     /// This will not prefix the value with any indentation. If you want to prefix this with proper
@@ -281,9 +275,9 @@ impl From<Expression> for Statement {
     }
 }
 
-impl ToInternedString for Expression {
+impl ToIndentedString for Expression {
     #[inline]
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        self.to_no_indent_string(interner, indentation)
     }
 }

--- a/boa_engine/src/syntax/ast/function/arrow_function.rs
+++ b/boa_engine/src/syntax/ast/function/arrow_function.rs
@@ -2,7 +2,7 @@ use crate::syntax::ast::{
     expression::{Expression, Identifier},
     join_nodes, ContainsSymbol, StatementList,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString};
 
 use super::FormalParameterList;
 
@@ -29,6 +29,7 @@ pub struct ArrowFunction {
 
 impl ArrowFunction {
     /// Creates a new `ArrowFunctionDecl` AST Expression.
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         params: FormalParameterList,
@@ -42,38 +43,27 @@ impl ArrowFunction {
     }
 
     /// Gets the name of the function declaration.
+    #[inline]
     pub fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Sets the name of the function declaration.
+    #[inline]
     pub fn set_name(&mut self, name: Option<Identifier>) {
         self.name = name;
     }
 
     /// Gets the list of parameters of the arrow function.
+    #[inline]
     pub(crate) fn parameters(&self) -> &FormalParameterList {
         &self.parameters
     }
 
     /// Gets the body of the arrow function.
+    #[inline]
     pub(crate) fn body(&self) -> &StatementList {
         &self.body
-    }
-
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        let mut buf = format!("({}", join_nodes(interner, &self.parameters.parameters));
-        if self.body().statements().is_empty() {
-            buf.push_str(") => {}");
-        } else {
-            buf.push_str(&format!(
-                ") => {{\n{}{}}}",
-                self.body.to_indented_string(interner, indentation + 1),
-                "    ".repeat(indentation)
-            ));
-        }
-        buf
     }
 
     #[inline]
@@ -97,9 +87,19 @@ impl ArrowFunction {
     }
 }
 
-impl ToInternedString for ArrowFunction {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for ArrowFunction {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        let mut buf = format!("({}", join_nodes(interner, &self.parameters.parameters));
+        if self.body().statements().is_empty() {
+            buf.push_str(") => {}");
+        } else {
+            buf.push_str(&format!(
+                ") => {{\n{}{}}}",
+                self.body.to_indented_string(interner, indentation + 1),
+                "    ".repeat(indentation)
+            ));
+        }
+        buf
     }
 }
 

--- a/boa_engine/src/syntax/ast/function/async_function.rs
+++ b/boa_engine/src/syntax/ast/function/async_function.rs
@@ -4,7 +4,7 @@ use crate::syntax::ast::{
     expression::{Expression, Identifier},
     join_nodes, Declaration, StatementList,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString};
 
 use super::FormalParameterList;
 
@@ -27,6 +27,7 @@ pub struct AsyncFunction {
 
 impl AsyncFunction {
     /// Creates a new function expression
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         parameters: FormalParameterList,
@@ -40,22 +41,26 @@ impl AsyncFunction {
     }
 
     /// Gets the name of the function declaration.
+    #[inline]
     pub fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Gets the list of parameters of the function declaration.
+    #[inline]
     pub fn parameters(&self) -> &FormalParameterList {
         &self.parameters
     }
 
     /// Gets the body of the function declaration.
+    #[inline]
     pub fn body(&self) -> &StatementList {
         &self.body
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for AsyncFunction {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = "async function".to_owned();
         if let Some(name) = self.name {
             buf.push_str(&format!(" {}", interner.resolve_expect(name.sym())));
@@ -77,19 +82,15 @@ impl AsyncFunction {
     }
 }
 
-impl ToInternedString for AsyncFunction {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 impl From<AsyncFunction> for Expression {
+    #[inline]
     fn from(expr: AsyncFunction) -> Self {
         Self::AsyncFunction(expr)
     }
 }
 
 impl From<AsyncFunction> for Declaration {
+    #[inline]
     fn from(f: AsyncFunction) -> Self {
         Self::AsyncFunction(f)
     }

--- a/boa_engine/src/syntax/ast/function/async_generator.rs
+++ b/boa_engine/src/syntax/ast/function/async_generator.rs
@@ -4,7 +4,7 @@ use crate::syntax::ast::{
     expression::{Expression, Identifier},
     join_nodes, Declaration, StatementList,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString};
 
 use super::FormalParameterList;
 
@@ -24,6 +24,7 @@ pub struct AsyncGenerator {
 
 impl AsyncGenerator {
     /// Creates a new async generator expression
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         parameters: FormalParameterList,
@@ -37,21 +38,26 @@ impl AsyncGenerator {
     }
 
     /// Gets the name of the async generator expression
+    #[inline]
     pub fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Gets the list of parameters of the async generator expression
+    #[inline]
     pub fn parameters(&self) -> &FormalParameterList {
         &self.parameters
     }
 
     /// Gets the body of the async generator expression
+    #[inline]
     pub fn body(&self) -> &StatementList {
         &self.body
     }
+}
 
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for AsyncGenerator {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = "async function*".to_owned();
         if let Some(name) = self.name {
             buf.push_str(&format!(" {}", interner.resolve_expect(name.sym())));
@@ -66,19 +72,15 @@ impl AsyncGenerator {
     }
 }
 
-impl ToInternedString for AsyncGenerator {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 impl From<AsyncGenerator> for Expression {
+    #[inline]
     fn from(expr: AsyncGenerator) -> Self {
         Self::AsyncGenerator(expr)
     }
 }
 
 impl From<AsyncGenerator> for Declaration {
+    #[inline]
     fn from(f: AsyncGenerator) -> Self {
         Self::AsyncGenerator(f)
     }

--- a/boa_engine/src/syntax/ast/function/class.rs
+++ b/boa_engine/src/syntax/ast/function/class.rs
@@ -11,7 +11,7 @@ use crate::{
         ContainsSymbol, Declaration, StatementList,
     },
 };
-use boa_interner::{Interner, Sym, ToInternedString};
+use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 
 use super::Function;
 
@@ -36,6 +36,7 @@ pub struct Class {
 
 impl Class {
     /// Creates a new class declaration.
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         super_ref: Option<Expression>,
@@ -51,25 +52,30 @@ impl Class {
     }
 
     /// Returns the name of the class.
+    #[inline]
     pub(crate) fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Returns the super class ref of the class.
+    #[inline]
     pub(crate) fn super_ref(&self) -> Option<&Expression> {
         self.super_ref.as_ref()
     }
 
     /// Returns the constructor of the class.
+    #[inline]
     pub(crate) fn constructor(&self) -> Option<&Function> {
         self.constructor.as_ref()
     }
 
     /// Gets the list of all fields defined on the class.
+    #[inline]
     pub(crate) fn elements(&self) -> &[ClassElement] {
         &self.elements
     }
 
+    #[inline]
     pub(crate) fn contains_arguments(&self) -> bool {
         matches!(self.name, Some(ref ident) if *ident == Sym::ARGUMENTS)
             || matches!(self.super_ref, Some(ref expr) if expr.contains_arguments())
@@ -88,9 +94,10 @@ impl Class {
         matches!(self.super_ref, Some(ref expr) if expr.contains(symbol))
             || self.elements.iter().any(|elem| elem.contains(symbol))
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indent_n: usize) -> String {
+impl ToIndentedString for Class {
+    fn to_indented_string(&self, interner: &Interner, indent_n: usize) -> String {
         let class_name = self.name.map_or(Cow::Borrowed(""), |s| {
             interner.resolve_expect(s.sym()).join(
                 Cow::Borrowed,
@@ -359,12 +366,6 @@ impl Class {
         }
         buf.push('}');
         buf
-    }
-}
-
-impl ToInternedString for Class {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
     }
 }
 

--- a/boa_engine/src/syntax/ast/function/generator.rs
+++ b/boa_engine/src/syntax/ast/function/generator.rs
@@ -4,7 +4,7 @@ use crate::syntax::ast::{
     join_nodes, Declaration, StatementList,
 };
 
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString};
 
 use super::FormalParameterList;
 
@@ -26,6 +26,7 @@ pub struct Generator {
 
 impl Generator {
     /// Creates a new generator expression
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         parameters: FormalParameterList,
@@ -39,22 +40,26 @@ impl Generator {
     }
 
     /// Gets the name of the generator declaration.
+    #[inline]
     pub fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Gets the list of parameters of the generator declaration.
+    #[inline]
     pub fn parameters(&self) -> &FormalParameterList {
         &self.parameters
     }
 
     /// Gets the body of the generator declaration.
+    #[inline]
     pub fn body(&self) -> &StatementList {
         &self.body
     }
+}
 
-    /// Converts the generator expresion Expression to a string with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for Generator {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = "function*".to_owned();
         if let Some(name) = self.name {
             buf.push_str(&format!(" {}", interner.resolve_expect(name.sym())));
@@ -69,19 +74,15 @@ impl Generator {
     }
 }
 
-impl ToInternedString for Generator {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 impl From<Generator> for Expression {
+    #[inline]
     fn from(expr: Generator) -> Self {
         Self::Generator(expr)
     }
 }
 
 impl From<Generator> for Declaration {
+    #[inline]
     fn from(f: Generator) -> Self {
         Self::Generator(f)
     }

--- a/boa_engine/src/syntax/ast/function/mod.rs
+++ b/boa_engine/src/syntax/ast/function/mod.rs
@@ -15,7 +15,7 @@ pub use parameters::{FormalParameter, FormalParameterList};
 pub(crate) use parameters::FormalParameterListFlags;
 
 use crate::syntax::ast::{block_to_string, join_nodes, StatementList};
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString};
 
 use super::expression::{Expression, Identifier};
 use super::{ContainsSymbol, Declaration};
@@ -46,6 +46,7 @@ pub struct Function {
 
 impl Function {
     /// Creates a new function expression
+    #[inline]
     pub(in crate::syntax) fn new(
         name: Option<Identifier>,
         parameters: FormalParameterList,
@@ -59,22 +60,26 @@ impl Function {
     }
 
     /// Gets the name of the function declaration.
+    #[inline]
     pub fn name(&self) -> Option<Identifier> {
         self.name
     }
 
     /// Gets the list of parameters of the function declaration.
+    #[inline]
     pub fn parameters(&self) -> &FormalParameterList {
         &self.parameters
     }
 
     /// Gets the body of the function declaration.
+    #[inline]
     pub fn body(&self) -> &StatementList {
         &self.body
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for Function {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = "function".to_owned();
         if let Some(name) = self.name {
             buf.push_str(&format!(" {}", interner.resolve_expect(name.sym())));
@@ -89,19 +94,15 @@ impl Function {
     }
 }
 
-impl ToInternedString for Function {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 impl From<Function> for Expression {
+    #[inline]
     fn from(expr: Function) -> Self {
         Self::Function(expr)
     }
 }
 
 impl From<Function> for Declaration {
+    #[inline]
     fn from(f: Function) -> Self {
         Self::Function(f)
     }

--- a/boa_engine/src/syntax/ast/mod.rs
+++ b/boa_engine/src/syntax/ast/mod.rs
@@ -11,7 +11,7 @@ pub mod punctuator;
 pub mod statement;
 pub mod statement_list;
 
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 pub use self::{
     declaration::Declaration,

--- a/boa_engine/src/syntax/ast/statement/block.rs
+++ b/boa_engine/src/syntax/ast/statement/block.rs
@@ -1,9 +1,8 @@
 //! Block AST node.
 
-use crate::syntax::ast::{expression::Identifier, ContainsSymbol, StatementList};
-
 use super::Statement;
-use boa_interner::{Interner, ToInternedString};
+use crate::syntax::ast::{expression::Identifier, ContainsSymbol, StatementList};
+use boa_interner::{Interner, ToIndentedString};
 
 /// A `block` statement (or compound statement in other languages) is used to group zero or
 /// more statements.
@@ -29,23 +28,15 @@ pub struct Block {
 
 impl Block {
     /// Gets the list of statements and declarations in this block.
+    #[inline]
     pub(crate) fn statement_list(&self) -> &StatementList {
         &self.statements
     }
 
     /// Get the lexically declared names of the block.
+    #[inline]
     pub(crate) fn lexically_declared_names(&self) -> Vec<(Identifier, bool)> {
         self.statements.lexically_declared_names()
-    }
-
-    /// Implements the display formatting with indentation.
-    pub(super) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        format!(
-            "{{\n{}{}}}",
-            self.statements
-                .to_indented_string(interner, indentation + 1),
-            "    ".repeat(indentation)
-        )
     }
 
     #[inline]
@@ -63,6 +54,7 @@ impl<T> From<T> for Block
 where
     T: Into<StatementList>,
 {
+    #[inline]
     fn from(list: T) -> Self {
         Self {
             statements: list.into(),
@@ -70,13 +62,19 @@ where
     }
 }
 
-impl ToInternedString for Block {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for Block {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        format!(
+            "{{\n{}{}}}",
+            self.statements
+                .to_indented_string(interner, indentation + 1),
+            "    ".repeat(indentation)
+        )
     }
 }
 
 impl From<Block> for Statement {
+    #[inline]
     fn from(block: Block) -> Self {
         Self::Block(block)
     }

--- a/boa_engine/src/syntax/ast/statement/if.rs
+++ b/boa_engine/src/syntax/ast/statement/if.rs
@@ -1,7 +1,7 @@
 //! If statement
 
 use crate::syntax::ast::{expression::Expression, statement::Statement, ContainsSymbol};
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 /// The `if` statement executes a statement if a specified condition is [`truthy`][truthy]. If
 /// the condition is [`falsy`][falsy], another statement can be executed.
@@ -28,14 +28,20 @@ pub struct If {
 }
 
 impl If {
+    /// Gets the condition of the if statement.
+    #[inline]
     pub fn cond(&self) -> &Expression {
         &self.condition
     }
 
+    /// Gets the body to execute if the condition is true.
+    #[inline]
     pub fn body(&self) -> &Statement {
         &self.body
     }
 
+    /// Gets the `else` node, if it has one.
+    #[inline]
     pub fn else_node(&self) -> Option<&Statement> {
         self.else_node.as_ref().map(Box::as_ref)
     }
@@ -47,23 +53,6 @@ impl If {
             body: body.into(),
             else_node: else_node.map(Box::new),
         }
-    }
-
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indent: usize) -> String {
-        let mut buf = format!("if ({}) ", self.cond().to_interned_string(interner));
-        match self.else_node() {
-            Some(else_e) => {
-                buf.push_str(&format!(
-                    "{} else {}",
-                    self.body().to_indented_string(interner, indent),
-                    else_e.to_indented_string(interner, indent)
-                ));
-            }
-            None => {
-                buf.push_str(&self.body().to_indented_string(interner, indent));
-            }
-        }
-        buf
     }
 
     #[inline]
@@ -81,9 +70,22 @@ impl If {
     }
 }
 
-impl ToInternedString for If {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for If {
+    fn to_indented_string(&self, interner: &Interner, indent: usize) -> String {
+        let mut buf = format!("if ({}) ", self.cond().to_interned_string(interner));
+        match self.else_node() {
+            Some(else_e) => {
+                buf.push_str(&format!(
+                    "{} else {}",
+                    self.body().to_indented_string(interner, indent),
+                    else_e.to_indented_string(interner, indent)
+                ));
+            }
+            None => {
+                buf.push_str(&self.body().to_indented_string(interner, indent));
+            }
+        }
+        buf
     }
 }
 

--- a/boa_engine/src/syntax/ast/statement/iteration/do_while_loop.rs
+++ b/boa_engine/src/syntax/ast/statement/iteration/do_while_loop.rs
@@ -1,5 +1,5 @@
 use crate::syntax::ast::{expression::Expression, statement::Statement, ContainsSymbol};
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 /// The `do...while` statement creates a loop that executes a specified statement until the
 /// test condition evaluates to false.
@@ -21,28 +21,24 @@ pub struct DoWhileLoop {
 }
 
 impl DoWhileLoop {
+    /// Gets the body of the do-while loop.
+    #[inline]
     pub fn body(&self) -> &Statement {
         &self.body
     }
 
+    /// Gets the condition of the do-while loop.
+    #[inline]
     pub fn cond(&self) -> &Expression {
         &self.condition
     }
     /// Creates a `DoWhileLoop` AST node.
+    #[inline]
     pub fn new(body: Statement, condition: Expression) -> Self {
         Self {
             body: body.into(),
             condition,
         }
-    }
-
-    /// Converts the "do while" loop to a string with the given indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        format!(
-            "do {} while ({})",
-            self.body().to_indented_string(interner, indentation),
-            self.cond().to_interned_string(interner)
-        )
     }
 
     #[inline]
@@ -56,9 +52,13 @@ impl DoWhileLoop {
     }
 }
 
-impl ToInternedString for DoWhileLoop {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for DoWhileLoop {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        format!(
+            "do {} while ({})",
+            self.body().to_indented_string(interner, indentation),
+            self.cond().to_interned_string(interner)
+        )
     }
 }
 

--- a/boa_engine/src/syntax/ast/statement/iteration/for_in_loop.rs
+++ b/boa_engine/src/syntax/ast/statement/iteration/for_in_loop.rs
@@ -3,7 +3,8 @@ use crate::syntax::ast::{
     statement::{iteration::IterableLoopInitializer, Statement},
     ContainsSymbol,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
+
 #[cfg_attr(feature = "deser", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForInLoop {
@@ -13,6 +14,8 @@ pub struct ForInLoop {
 }
 
 impl ForInLoop {
+    /// Creates a new `ForInLoop`.
+    #[inline]
     pub fn new(init: IterableLoopInitializer, expr: Expression, body: Statement) -> Self {
         Self {
             init,
@@ -21,28 +24,22 @@ impl ForInLoop {
         }
     }
 
+    /// Gets the initializer of the for...in loop.
+    #[inline]
     pub fn init(&self) -> &IterableLoopInitializer {
         &self.init
     }
 
+    /// Gets the for...in loop expression.
+    #[inline]
     pub fn expr(&self) -> &Expression {
         &self.expr
     }
 
+    /// Gets the body of the for...in loop.
+    #[inline]
     pub fn body(&self) -> &Statement {
         &self.body
-    }
-
-    /// Converts the "for in" loop to a string with the given indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        let mut buf = format!(
-            "for ({} in {}) ",
-            self.init.to_interned_string(interner),
-            self.expr.to_interned_string(interner)
-        );
-        buf.push_str(&self.body().to_indented_string(interner, indentation));
-
-        buf
     }
 
     #[inline]
@@ -58,13 +55,21 @@ impl ForInLoop {
     }
 }
 
-impl ToInternedString for ForInLoop {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for ForInLoop {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        let mut buf = format!(
+            "for ({} in {}) ",
+            self.init.to_interned_string(interner),
+            self.expr.to_interned_string(interner)
+        );
+        buf.push_str(&self.body().to_indented_string(interner, indentation));
+
+        buf
     }
 }
 
 impl From<ForInLoop> for Statement {
+    #[inline]
     fn from(for_in: ForInLoop) -> Self {
         Self::ForInLoop(for_in)
     }

--- a/boa_engine/src/syntax/ast/statement/iteration/for_loop.rs
+++ b/boa_engine/src/syntax/ast/statement/iteration/for_loop.rs
@@ -4,7 +4,7 @@ use crate::syntax::ast::{
     statement::Statement,
     ContainsSymbol, Expression,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 /// The `for` statement creates a loop that consists of three optional expressions.
 ///
@@ -26,6 +26,7 @@ pub struct ForLoop {
 
 impl ForLoop {
     /// Creates a new for loop AST node.
+    #[inline]
     pub(in crate::syntax) fn new(
         init: Option<ForLoopInitializer>,
         condition: Option<Expression>,
@@ -38,45 +39,27 @@ impl ForLoop {
     }
 
     /// Gets the initialization node.
+    #[inline]
     pub fn init(&self) -> Option<&ForLoopInitializer> {
         self.inner.init()
     }
 
     /// Gets the loop condition node.
+    #[inline]
     pub fn condition(&self) -> Option<&Expression> {
         self.inner.condition()
     }
 
     /// Gets the final expression node.
+    #[inline]
     pub fn final_expr(&self) -> Option<&Expression> {
         self.inner.final_expr()
     }
 
     /// Gets the body of the for loop.
+    #[inline]
     pub fn body(&self) -> &Statement {
         self.inner.body()
-    }
-
-    /// Converts the for loop to a string with the given indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        let mut buf = String::from("for (");
-        if let Some(init) = self.init() {
-            buf.push_str(&init.to_interned_string(interner));
-        }
-        buf.push_str("; ");
-        if let Some(condition) = self.condition() {
-            buf.push_str(&condition.to_interned_string(interner));
-        }
-        buf.push_str("; ");
-        if let Some(final_expr) = self.final_expr() {
-            buf.push_str(&final_expr.to_interned_string(interner));
-        }
-        buf.push_str(&format!(
-            ") {}",
-            self.inner.body().to_indented_string(interner, indentation)
-        ));
-
-        buf
     }
 
     #[inline]
@@ -98,13 +81,31 @@ impl ForLoop {
     }
 }
 
-impl ToInternedString for ForLoop {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for ForLoop {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        let mut buf = String::from("for (");
+        if let Some(init) = self.init() {
+            buf.push_str(&init.to_interned_string(interner));
+        }
+        buf.push_str("; ");
+        if let Some(condition) = self.condition() {
+            buf.push_str(&condition.to_interned_string(interner));
+        }
+        buf.push_str("; ");
+        if let Some(final_expr) = self.final_expr() {
+            buf.push_str(&final_expr.to_interned_string(interner));
+        }
+        buf.push_str(&format!(
+            ") {}",
+            self.inner.body().to_indented_string(interner, indentation)
+        ));
+
+        buf
     }
 }
 
 impl From<ForLoop> for Statement {
+    #[inline]
     fn from(for_loop: ForLoop) -> Self {
         Self::ForLoop(for_loop)
     }
@@ -122,6 +123,7 @@ struct InnerForLoop {
 
 impl InnerForLoop {
     /// Creates a new inner for loop.
+    #[inline]
     fn new(
         init: Option<ForLoopInitializer>,
         condition: Option<Expression>,
@@ -137,21 +139,25 @@ impl InnerForLoop {
     }
 
     /// Gets the initialization node.
+    #[inline]
     fn init(&self) -> Option<&ForLoopInitializer> {
         self.init.as_ref()
     }
 
     /// Gets the loop condition node.
+    #[inline]
     fn condition(&self) -> Option<&Expression> {
         self.condition.as_ref()
     }
 
     /// Gets the final expression node.
+    #[inline]
     fn final_expr(&self) -> Option<&Expression> {
         self.final_expr.as_ref()
     }
 
     /// Gets the body of the for loop.
+    #[inline]
     fn body(&self) -> &Statement {
         &self.body
     }
@@ -213,18 +219,21 @@ impl ToInternedString for ForLoopInitializer {
 }
 
 impl From<Expression> for ForLoopInitializer {
+    #[inline]
     fn from(expr: Expression) -> Self {
         ForLoopInitializer::Expression(expr)
     }
 }
 
 impl From<LexicalDeclaration> for ForLoopInitializer {
+    #[inline]
     fn from(list: LexicalDeclaration) -> Self {
         ForLoopInitializer::Lexical(list)
     }
 }
 
 impl From<VarDeclaration> for ForLoopInitializer {
+    #[inline]
     fn from(list: VarDeclaration) -> Self {
         ForLoopInitializer::Var(list)
     }

--- a/boa_engine/src/syntax/ast/statement/iteration/for_of_loop.rs
+++ b/boa_engine/src/syntax/ast/statement/iteration/for_of_loop.rs
@@ -3,7 +3,7 @@ use crate::syntax::ast::{
     statement::{iteration::IterableLoopInitializer, Statement},
     ContainsSymbol,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 #[cfg(feature = "deser")]
 use serde::{Deserialize, Serialize};
@@ -19,6 +19,7 @@ pub struct ForOfLoop {
 
 impl ForOfLoop {
     /// Creates a new "for of" loop AST node.
+    #[inline]
     pub fn new(
         init: IterableLoopInitializer,
         iterable: Expression,
@@ -33,31 +34,28 @@ impl ForOfLoop {
         }
     }
 
+    /// Gets the initializer of the for...of loop.
+    #[inline]
     pub fn init(&self) -> &IterableLoopInitializer {
         &self.init
     }
 
+    /// Gets the iterable expression of the for...of loop.
+    #[inline]
     pub fn iterable(&self) -> &Expression {
         &self.iterable
     }
 
+    /// Gets the body to execute in the for...of loop.
+    #[inline]
     pub fn body(&self) -> &Statement {
         &self.body
     }
 
     /// Returns true if this "for...of" loop is an "for await...of" loop.
+    #[inline]
     pub(crate) fn r#await(&self) -> bool {
         self.r#await
-    }
-
-    /// Converts the "for of" loop to a string with the given indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        format!(
-            "for ({} of {}) {}",
-            self.init.to_interned_string(interner),
-            self.iterable.to_interned_string(interner),
-            self.body().to_indented_string(interner, indentation)
-        )
     }
 
     #[inline]
@@ -73,13 +71,19 @@ impl ForOfLoop {
     }
 }
 
-impl ToInternedString for ForOfLoop {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for ForOfLoop {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        format!(
+            "for ({} of {}) {}",
+            self.init.to_interned_string(interner),
+            self.iterable.to_interned_string(interner),
+            self.body().to_indented_string(interner, indentation)
+        )
     }
 }
 
 impl From<ForOfLoop> for Statement {
+    #[inline]
     fn from(for_of: ForOfLoop) -> Self {
         Self::ForOfLoop(for_of)
     }

--- a/boa_engine/src/syntax/ast/statement/iteration/while_loop.rs
+++ b/boa_engine/src/syntax/ast/statement/iteration/while_loop.rs
@@ -1,5 +1,6 @@
 use crate::syntax::ast::{expression::Expression, statement::Statement, ContainsSymbol};
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
+
 /// The `while` statement creates a loop that executes a specified statement as long as the
 /// test condition evaluates to `true`.
 ///
@@ -19,14 +20,8 @@ pub struct WhileLoop {
 }
 
 impl WhileLoop {
-    pub fn condition(&self) -> &Expression {
-        &self.condition
-    }
-
-    pub fn body(&self) -> &Statement {
-        &self.body
-    }
     /// Creates a `WhileLoop` AST node.
+    #[inline]
     pub fn new(condition: Expression, body: Statement) -> Self {
         Self {
             condition,
@@ -34,15 +29,19 @@ impl WhileLoop {
         }
     }
 
-    /// Converts the while loop to a string with the given indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        format!(
-            "while ({}) {}",
-            self.condition().to_interned_string(interner),
-            self.body().to_indented_string(interner, indentation)
-        )
+    /// Gets the condition of the while loop.
+    #[inline]
+    pub fn condition(&self) -> &Expression {
+        &self.condition
     }
 
+    /// Gets the body of the while loop.
+    #[inline]
+    pub fn body(&self) -> &Statement {
+        &self.body
+    }
+
+    #[inline]
     pub(crate) fn contains_arguments(&self) -> bool {
         self.condition.contains_arguments() || self.body.contains_arguments()
     }
@@ -53,13 +52,18 @@ impl WhileLoop {
     }
 }
 
-impl ToInternedString for WhileLoop {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for WhileLoop {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        format!(
+            "while ({}) {}",
+            self.condition().to_interned_string(interner),
+            self.body().to_indented_string(interner, indentation)
+        )
     }
 }
 
 impl From<WhileLoop> for Statement {
+    #[inline]
     fn from(while_loop: WhileLoop) -> Self {
         Self::WhileLoop(while_loop)
     }

--- a/boa_engine/src/syntax/ast/statement/labelled.rs
+++ b/boa_engine/src/syntax/ast/statement/labelled.rs
@@ -1,8 +1,6 @@
-use boa_interner::{Interner, Sym, ToInternedString};
-
-use crate::syntax::ast::{function::Function, ContainsSymbol};
-
 use super::Statement;
+use crate::syntax::ast::{function::Function, ContainsSymbol};
+use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 
 /// The set of AST nodes that can be preceded by a label, as defined by the [spec].
 ///

--- a/boa_engine/src/syntax/ast/statement/mod.rs
+++ b/boa_engine/src/syntax/ast/statement/mod.rs
@@ -22,7 +22,7 @@ pub use self::{
     throw::Throw,
 };
 
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use rustc_hash::FxHashSet;
 use tap::Tap;
 
@@ -98,27 +98,6 @@ pub enum Statement {
 }
 
 impl Statement {
-    /// Creates a string of the value of the node with the given indentation. For example, an
-    /// indent level of 2 would produce this:
-    ///
-    /// ```js
-    ///         function hello() {
-    ///             console.log("hello");
-    ///         }
-    ///         hello();
-    ///         a = 2;
-    /// ```
-    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
-        let mut buf = match *self {
-            Self::Block(_) => String::new(),
-            _ => "    ".repeat(indentation),
-        };
-
-        buf.push_str(&self.to_no_indent_string(interner, indentation));
-
-        buf
-    }
-
     /// Implements the display formatting with indentation.
     ///
     /// This will not prefix the value with any indentation. If you want to prefix this with proper
@@ -302,8 +281,25 @@ impl Statement {
     }
 }
 
-impl ToInternedString for Statement {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
+impl ToIndentedString for Statement {
+    /// Creates a string of the value of the node with the given indentation. For example, an
+    /// indent level of 2 would produce this:
+    ///
+    /// ```js
+    ///         function hello() {
+    ///             console.log("hello");
+    ///         }
+    ///         hello();
+    ///         a = 2;
+    /// ```
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+        let mut buf = match *self {
+            Self::Block(_) => String::new(),
+            _ => "    ".repeat(indentation),
+        };
+
+        buf.push_str(&self.to_no_indent_string(interner, indentation));
+
+        buf
     }
 }

--- a/boa_engine/src/syntax/ast/statement/try/mod.rs
+++ b/boa_engine/src/syntax/ast/statement/try/mod.rs
@@ -3,7 +3,7 @@ use crate::syntax::ast::{
     statement::{Block, Statement},
     statement_list::StatementListItem,
 };
-use boa_interner::{Interner, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 
 use super::ContainsSymbol;
 
@@ -33,6 +33,7 @@ pub struct Try {
 
 impl Try {
     /// Creates a new `Try` AST node.
+    #[inline]
     pub(in crate::syntax) fn new(
         block: Block,
         catch: Option<Catch>,
@@ -51,16 +52,19 @@ impl Try {
     }
 
     /// Gets the `try` block.
+    #[inline]
     pub fn block(&self) -> &Block {
         &self.block
     }
 
     /// Gets the `catch` block, if any.
+    #[inline]
     pub fn catch(&self) -> Option<&Catch> {
         self.catch.as_ref()
     }
 
     /// Gets the `finally` block, if any.
+    #[inline]
     pub fn finally(&self) -> Option<&Block> {
         self.finally.as_ref().map(Finally::block)
     }
@@ -78,9 +82,10 @@ impl Try {
             || matches!(self.catch, Some(ref catch) if catch.contains(symbol))
             || matches!(self.finally, Some(ref finally) if finally.contains(symbol))
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(crate) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for Try {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = format!(
             "{}try {}",
             "    ".repeat(indentation),
@@ -98,13 +103,8 @@ impl Try {
     }
 }
 
-impl ToInternedString for Try {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 impl From<Try> for Statement {
+    #[inline]
     fn from(try_catch: Try) -> Self {
         Self::Try(try_catch)
     }
@@ -120,16 +120,19 @@ pub struct Catch {
 
 impl Catch {
     /// Creates a new catch block.
+    #[inline]
     pub(in crate::syntax) fn new(parameter: Option<Binding>, block: Block) -> Self {
         Self { parameter, block }
     }
 
     /// Gets the parameter of the catch block.
+    #[inline]
     pub fn parameter(&self) -> Option<&Binding> {
         self.parameter.as_ref()
     }
 
     /// Retrieves the catch execution block.
+    #[inline]
     pub fn block(&self) -> &Block {
         &self.block
     }
@@ -151,9 +154,10 @@ impl Catch {
             .iter()
             .any(|stmt| stmt.contains(symbol))
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(super) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for Catch {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = " catch".to_owned();
         if let Some(ref param) = self.parameter {
             buf.push_str(&format!("({})", param.to_interned_string(interner)));
@@ -167,12 +171,6 @@ impl Catch {
     }
 }
 
-impl ToInternedString for Catch {
-    fn to_interned_string(&self, interner: &Interner) -> String {
-        self.to_indented_string(interner, 0)
-    }
-}
-
 /// Finally block.
 #[cfg_attr(feature = "deser", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug, PartialEq)]
@@ -182,6 +180,7 @@ pub struct Finally {
 
 impl Finally {
     /// Gets the finally block.
+    #[inline]
     pub fn block(&self) -> &Block {
         &self.block
     }
@@ -203,9 +202,10 @@ impl Finally {
             .iter()
             .any(|stmt| stmt.contains(symbol))
     }
+}
 
-    /// Implements the display formatting with indentation.
-    pub(super) fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
+impl ToIndentedString for Finally {
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         format!(
             " finally {}",
             self.block.to_indented_string(interner, indentation)
@@ -214,6 +214,7 @@ impl Finally {
 }
 
 impl From<Block> for Finally {
+    #[inline]
     fn from(block: Block) -> Self {
         Self { block }
     }

--- a/boa_engine/src/syntax/parser/expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/tests.rs
@@ -148,8 +148,7 @@ fn check_numeric_operations() {
                 ArithmeticOp::Div.into(),
                 Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
                 Identifier::new(interner.get_or_intern_static("b", utf16!("b"))).into(),
-            ))
-            .into()]
+            ))]
             .into(),
         )))
         .into()],

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -421,15 +421,6 @@ pub trait ToInternedString {
     fn to_interned_string(&self, interner: &Interner) -> String;
 }
 
-// impl<T> ToInternedString for T
-// where
-//     T: std::fmt::Display,
-// {
-//     fn to_interned_string(&self, _interner: &Interner) -> String {
-//         self.to_string()
-//     }
-// }
-
 impl<T> ToInternedString for T
 where
     T: ToIndentedString,

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -409,17 +409,32 @@ impl Interner {
     }
 }
 
+/// Implements the display formatting with indentation.
+pub trait ToIndentedString {
+    /// Converts the element to a string using an interner, with the given indentation.
+    fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String;
+}
+
 /// Converts a given element to a string using an interner.
 pub trait ToInternedString {
     /// Converts a given element to a string using an interner.
     fn to_interned_string(&self, interner: &Interner) -> String;
 }
 
+// impl<T> ToInternedString for T
+// where
+//     T: std::fmt::Display,
+// {
+//     fn to_interned_string(&self, _interner: &Interner) -> String {
+//         self.to_string()
+//     }
+// }
+
 impl<T> ToInternedString for T
 where
-    T: std::fmt::Display,
+    T: ToIndentedString,
 {
-    fn to_interned_string(&self, _interner: &Interner) -> String {
-        self.to_string()
+    fn to_interned_string(&self, interner: &Interner) -> String {
+        self.to_indented_string(interner, 0)
     }
 }


### PR DESCRIPTION
In most cases, the `ToInternedString` was just calling `self.to_indented_string(interner, 0)`. This avoids all this duplicate code by adding a new trait, `ToIndentedString`. Any type implementing that automatically implements `ToInternedString`.

I have also added a bunch of `#[inline]` in one-liners, and some one-line documentations for some functions.

I have noticed that we also use `contains()` and `contains_arguments()` a lot. Would it make sense to create traits for this?