### PR TITLE
[Merged by Bors] - Allow LineTerminator before Semicolon in `continue`

### DIFF
--- a/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
@@ -66,7 +66,7 @@ where
                 if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                     cursor.next(interner)?;
                 } else if token.kind() == &TokenKind::LineTerminator {
-                    if let SemicolonResult::Found(Some(token)) = cursor.peek_semicolon(interner)? {
+                    if let Some(token) = cursor.peek(0, interner)? {
                         if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                             cursor.next(interner)?;
                         }

--- a/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
@@ -62,11 +62,17 @@ where
         cursor.expect((Keyword::Continue, false), "continue statement", interner)?;
 
         let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
-            match tok {
-                Some(tok) if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
-                    let _next = cursor.next(interner)?;
+            if let Some(token) = tok {
+                if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
+                    cursor.next(interner)?;
+                } else if token.kind() == &TokenKind::LineTerminator {
+                    cursor.next(interner)?;
+                    if let SemicolonResult::Found(Some(token)) = cursor.peek_semicolon(interner)? {
+                        if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
+                            cursor.next(interner)?;
+                        }
+                    }
                 }
-                _ => {}
             }
 
             None

--- a/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
@@ -66,7 +66,6 @@ where
                 if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                     cursor.next(interner)?;
                 } else if token.kind() == &TokenKind::LineTerminator {
-                    cursor.next(interner)?;
                     if let SemicolonResult::Found(Some(token)) = cursor.peek_semicolon(interner)? {
                         if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
                             cursor.next(interner)?;


### PR DESCRIPTION
This Pull Request changes the following:

- Check if there is a Semicolon after a LineTerminator is found in a `continue` statement.

