### PR TITLE
[Merged by Bors] - Implement member accessors in initializer of for loops

### DIFF
--- a/boa_engine/src/syntax/ast/expression/mod.rs
+++ b/boa_engine/src/syntax/ast/expression/mod.rs
@@ -12,7 +12,7 @@
 use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 
 use self::{
-    access::{PrivatePropertyAccess, PropertyAccess, SuperPropertyAccess},
+    access::PropertyAccess,
     literal::{ArrayLiteral, Literal, ObjectLiteral, TemplateLiteral},
     operator::{Assign, Binary, Conditional, Unary},
 };
@@ -104,12 +104,6 @@ pub enum Expression {
     /// See [`PropertyAccess`].
     PropertyAccess(PropertyAccess),
 
-    /// See [`SuperPropertyAccess`]
-    SuperPropertyAccess(SuperPropertyAccess),
-
-    /// See [`PrivatePropertyAccess].
-    PrivatePropertyAccess(PrivatePropertyAccess),
-
     /// See [`New`].
     New(New),
 
@@ -176,8 +170,6 @@ impl Expression {
             Self::AsyncGenerator(asgen) => asgen.to_indented_string(interner, indentation),
             Self::TemplateLiteral(tem) => tem.to_interned_string(interner),
             Self::PropertyAccess(prop) => prop.to_interned_string(interner),
-            Self::SuperPropertyAccess(supp) => supp.to_interned_string(interner),
-            Self::PrivatePropertyAccess(private) => private.to_interned_string(interner),
             Self::New(new) => new.to_interned_string(interner),
             Self::Call(call) => call.to_interned_string(interner),
             Self::SuperCall(supc) => supc.to_interned_string(interner),
@@ -218,8 +210,6 @@ impl Expression {
             Expression::Class(class) => class.contains_arguments(),
             Expression::TemplateLiteral(template) => template.contains_arguments(),
             Expression::PropertyAccess(access) => access.contains_arguments(),
-            Expression::SuperPropertyAccess(access) => access.contains_arguments(),
-            Expression::PrivatePropertyAccess(access) => access.contains_arguments(),
             Expression::New(new) => new.contains_arguments(),
             Expression::Call(call) => call.contains_arguments(),
             Expression::SuperCall(call) => call.contains_arguments(),
@@ -257,12 +247,7 @@ impl Expression {
             Expression::ArrowFunction(arrow) => arrow.contains(symbol),
             Expression::Class(class) => class.contains(symbol),
             Expression::TemplateLiteral(temp) => temp.contains(symbol),
-            Expression::PropertyAccess(access) => access.contains(symbol),
-            Expression::SuperPropertyAccess(_access) if symbol == ContainsSymbol::SuperProperty => {
-                true
-            }
-            Expression::SuperPropertyAccess(access) => access.contains(symbol),
-            Expression::PrivatePropertyAccess(access) => access.contains(symbol),
+            Expression::PropertyAccess(prop) => prop.contains(symbol),
             Expression::New(new) => new.contains(symbol),
             Expression::Call(call) => call.contains(symbol),
             Expression::SuperCall(_) if symbol == ContainsSymbol::SuperCall => true,

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/tests.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
     ast::{
-        expression::{access::PropertyAccess, Call, Identifier},
+        expression::{access::SimplePropertyAccess, Call, Identifier},
         Expression, Statement,
     },
     parser::tests::check_parser,
@@ -13,14 +13,17 @@ macro_rules! check_call_property_identifier {
         let mut interner = Interner::default();
         check_parser(
             format!("a().{}", $property).as_str(),
-            vec![Statement::Expression(Expression::from(PropertyAccess::new(
-                Call::new(
-                    Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
-                    Box::default(),
+            vec![Statement::Expression(Expression::PropertyAccess(
+                SimplePropertyAccess::new(
+                    Call::new(
+                        Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
+                        Box::default(),
+                    )
+                    .into(),
+                    interner.get_or_intern_static($property, utf16!($property)),
                 )
                 .into(),
-                interner.get_or_intern_static($property, utf16!($property)),
-            )))
+            ))
             .into()],
             interner,
         );
@@ -41,10 +44,13 @@ macro_rules! check_member_property_identifier {
         let mut interner = Interner::default();
         check_parser(
             format!("a.{}", $property).as_str(),
-            vec![Statement::Expression(Expression::from(PropertyAccess::new(
-                Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
-                interner.get_or_intern_static($property, utf16!($property)),
-            )))
+            vec![Statement::Expression(Expression::PropertyAccess(
+                SimplePropertyAccess::new(
+                    Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
+                    interner.get_or_intern_static($property, utf16!($property)),
+                )
+                .into(),
+            ))
             .into()],
             interner,
         );

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -541,7 +541,7 @@ fn expression_to_formal_parameters(
                     ));
                 }
             },
-            _ => {
+            AssignTarget::Access(_) => {
                 return Err(ParseError::general(
                     "invalid initialization expression in formal parameter list",
                     span.start(),

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -10,6 +10,7 @@
 use crate::syntax::{
     ast::{
         expression::{
+            access::PropertyAccess,
             operator::{unary::UnaryOp, Unary},
             Identifier,
         },
@@ -87,7 +88,7 @@ where
                             token_start,
                         )));
                     }
-                    Expression::PrivatePropertyAccess(_) => {
+                    Expression::PropertyAccess(PropertyAccess::Private(_)) => {
                         return Err(ParseError::general(
                             "private fields can not be deleted",
                             position,

--- a/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
@@ -377,13 +377,7 @@ fn initializer_to_iterable_loop_initializer(
                     })
                     .map(|obj| IterableLoopInitializer::Pattern(obj.into()))
             }
-            // TODO: implement member initializers
-            ast::Expression::PropertyAccess(_)
-            | ast::Expression::SuperPropertyAccess(_)
-            | ast::Expression::PrivatePropertyAccess(_) => Err(ParseError::Unimplemented {
-                message: "using a property access as iterable loop initializer is not implemented",
-                position,
-            }),
+            ast::Expression::PropertyAccess(access) => Ok(IterableLoopInitializer::Access(access)),
             _ => Err(ParseError::lex(LexError::Syntax(
                 "invalid variable for iterable loop".into(),
                 position,

--- a/boa_engine/src/syntax/parser/statement/iteration/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/tests.rs
@@ -2,7 +2,7 @@ use crate::syntax::{
     ast::{
         declaration::{VarDeclaration, Variable},
         expression::{
-            access::PropertyAccess,
+            access::SimplePropertyAccess,
             literal::Literal,
             operator::{
                 assign::AssignOp, binary::RelationalOp, unary::UnaryOp, Assign, Binary, Unary,
@@ -64,14 +64,16 @@ fn check_do_while_semicolon_insertion() {
                 Statement::Block(
                     vec![StatementListItem::Statement(Statement::Expression(
                         Expression::from(Call::new(
-                            PropertyAccess::new(
-                                Identifier::new(
-                                    interner.get_or_intern_static("console", utf16!("console")),
+                            Expression::PropertyAccess(
+                                SimplePropertyAccess::new(
+                                    Identifier::new(
+                                        interner.get_or_intern_static("console", utf16!("console")),
+                                    )
+                                    .into(),
+                                    interner.get_or_intern_static("log", utf16!("log")),
                                 )
                                 .into(),
-                                interner.get_or_intern_static("log", utf16!("log")),
-                            )
-                            .into(),
+                            ),
                             vec![Literal::from(
                                 interner.get_or_intern_static("hello", utf16!("hello")),
                             )
@@ -94,12 +96,16 @@ fn check_do_while_semicolon_insertion() {
             ))
             .into(),
             Statement::Expression(Expression::from(Call::new(
-                PropertyAccess::new(
-                    Identifier::new(interner.get_or_intern_static("console", utf16!("console")))
+                Expression::PropertyAccess(
+                    SimplePropertyAccess::new(
+                        Identifier::new(
+                            interner.get_or_intern_static("console", utf16!("console")),
+                        )
                         .into(),
-                    interner.get_or_intern_static("log", utf16!("log")),
-                )
-                .into(),
+                        interner.get_or_intern_static("log", utf16!("log")),
+                    )
+                    .into(),
+                ),
                 vec![Literal::from(interner.get_or_intern_static("end", utf16!("end"))).into()]
                     .into(),
             )))
@@ -131,14 +137,16 @@ fn check_do_while_semicolon_insertion_no_space() {
                 Statement::Block(
                     vec![StatementListItem::Statement(Statement::Expression(
                         Expression::from(Call::new(
-                            PropertyAccess::new(
-                                Identifier::new(
-                                    interner.get_or_intern_static("console", utf16!("console")),
+                            Expression::PropertyAccess(
+                                SimplePropertyAccess::new(
+                                    Identifier::new(
+                                        interner.get_or_intern_static("console", utf16!("console")),
+                                    )
+                                    .into(),
+                                    interner.get_or_intern_static("log", utf16!("log")),
                                 )
                                 .into(),
-                                interner.get_or_intern_static("log", utf16!("log")),
-                            )
-                            .into(),
+                            ),
                             vec![Literal::from(
                                 interner.get_or_intern_static("hello", utf16!("hello")),
                             )
@@ -161,12 +169,16 @@ fn check_do_while_semicolon_insertion_no_space() {
             ))
             .into(),
             Statement::Expression(Expression::from(Call::new(
-                PropertyAccess::new(
-                    Identifier::new(interner.get_or_intern_static("console", utf16!("console")))
+                Expression::PropertyAccess(
+                    SimplePropertyAccess::new(
+                        Identifier::new(
+                            interner.get_or_intern_static("console", utf16!("console")),
+                        )
                         .into(),
-                    interner.get_or_intern_static("log", utf16!("log")),
-                )
-                .into(),
+                        interner.get_or_intern_static("log", utf16!("log")),
+                    )
+                    .into(),
+                ),
                 vec![Literal::from(interner.get_or_intern_static("end", utf16!("end"))).into()]
                     .into(),
             )))

--- a/boa_engine/src/syntax/parser/statement/switch/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/switch/tests.rs
@@ -1,7 +1,7 @@
 use crate::syntax::{
     ast::{
         declaration::{LexicalDeclaration, Variable},
-        expression::{access::PropertyAccess, literal::Literal, Call, Identifier},
+        expression::{access::SimplePropertyAccess, literal::Literal, Call, Identifier},
         statement::{Break, Case, Switch},
         Declaration, Expression, Statement,
     },
@@ -173,7 +173,10 @@ fn check_separated_switch() {
                         Literal::from(5).into(),
                         vec![
                             Statement::Expression(Expression::from(Call::new(
-                                PropertyAccess::new(Identifier::new(console).into(), log).into(),
+                                Expression::PropertyAccess(
+                                    SimplePropertyAccess::new(Identifier::new(console).into(), log)
+                                        .into(),
+                                ),
                                 vec![Literal::from(5).into()].into(),
                             )))
                             .into(),
@@ -185,7 +188,10 @@ fn check_separated_switch() {
                         Literal::from(10).into(),
                         vec![
                             Statement::Expression(Expression::from(Call::new(
-                                PropertyAccess::new(Identifier::new(console).into(), log).into(),
+                                Expression::PropertyAccess(
+                                    SimplePropertyAccess::new(Identifier::new(console).into(), log)
+                                        .into(),
+                                ),
                                 vec![Literal::from(10).into()].into(),
                             )))
                             .into(),
@@ -197,7 +203,9 @@ fn check_separated_switch() {
                 .into(),
                 Some(
                     vec![Statement::Expression(Expression::from(Call::new(
-                        PropertyAccess::new(Identifier::new(console).into(), log).into(),
+                        Expression::PropertyAccess(
+                            SimplePropertyAccess::new(Identifier::new(console).into(), log).into(),
+                        ),
                         vec![Literal::from(
                             interner.get_or_intern_static("Default", utf16!("Default")),
                         )

--- a/boa_engine/src/syntax/parser/tests.rs
+++ b/boa_engine/src/syntax/parser/tests.rs
@@ -9,7 +9,7 @@ use crate::{
     syntax::ast::{
         declaration::{Declaration, LexicalDeclaration, VarDeclaration, Variable},
         expression::{
-            access::PropertyAccess,
+            access::SimplePropertyAccess,
             literal::{Literal, ObjectLiteral},
             operator::{
                 assign::AssignOp,
@@ -60,15 +60,18 @@ fn check_construct_call_precedence() {
     check_parser(
         "new Date().getTime()",
         vec![Statement::Expression(Expression::from(Call::new(
-            PropertyAccess::new(
-                New::from(Call::new(
-                    Identifier::new(interner.get_or_intern_static("Date", utf16!("Date"))).into(),
-                    Box::default(),
-                ))
+            Expression::PropertyAccess(
+                SimplePropertyAccess::new(
+                    New::from(Call::new(
+                        Identifier::new(interner.get_or_intern_static("Date", utf16!("Date")))
+                            .into(),
+                        Box::default(),
+                    ))
+                    .into(),
+                    interner.get_or_intern_static("getTime", utf16!("getTime")),
+                )
                 .into(),
-                interner.get_or_intern_static("getTime", utf16!("getTime")),
-            )
-            .into(),
+            ),
             Box::default(),
         )))
         .into()],

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -845,7 +845,7 @@ pub enum Opcode {
 
     /// Deletes a property by name of an object.
     ///
-    /// Like `delete object.key.`
+    /// Like `delete object.key`
     ///
     /// Operands: name_index: `u32`
     ///
@@ -1068,7 +1068,7 @@ pub enum Opcode {
     ///
     /// Operands: argument_count: `u32`
     ///
-    /// Stack: func, this, argument_1, ... argument_n **=>** result
+    /// Stack: this, func, argument_1, ... argument_n **=>** result
     Call,
 
     /// Call a function where the arguments contain spreads.


### PR DESCRIPTION
This Pull Request implements member accessors in `for ... in` and `for ... of` loops. This unlocks patterns like:

```Javascript
let obj = {a: 0, b: 1};

for (obj.a of [1,2,3]) {
}

console.log(obj.a) // 3
```
