### PR TITLE
[Merged by Bors] - Fix var collisions in strict eval calls

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -148,7 +148,11 @@ impl Eval {
 
         // Compile and execute the eval statement list.
         let code_block = context.compile_with_new_declarative(&body, strict)?;
-        if direct {
+        // Indirect calls don't need extensions, because a non-strict indirect call modifies only
+        // the global object.
+        // Strict direct calls also don't need extensions, since all strict eval calls push a new
+        // function environment before evaluating.
+        if direct && !strict {
             context
                 .realm
                 .environments

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -501,11 +501,7 @@ impl Context {
     ) -> JsResult<Gc<CodeBlock>> {
         let _timer = Profiler::global().start_event("Compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), self);
-        compiler.compile_statement_list_with_new_declarative(
-            statement_list,
-            true,
-            strict || statement_list.strict(),
-        )?;
+        compiler.compile_statement_list_with_new_declarative(statement_list, true, strict)?;
         Ok(Gc::new(compiler.finish()))
     }
 

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -84,15 +84,15 @@ where
                 match val {
                     Expression::Identifier(_) if cursor.strict_mode() => {
                         return Err(ParseError::lex(LexError::Syntax(
-                            "Delete <variable> statements not allowed in strict mode".into(),
+                            "cannot delete variables in strict mode".into(),
                             token_start,
                         )));
                     }
                     Expression::PropertyAccess(PropertyAccess::Private(_)) => {
-                        return Err(ParseError::general(
-                            "private fields can not be deleted",
+                        return Err(ParseError::lex(LexError::Syntax(
+                            "cannot delete private fields".into(),
                             position,
-                        ));
+                        )));
                     }
                     _ => {}
                 }


### PR DESCRIPTION
This Pull Request allows collisions of var declarations with already existing lexical bindings if the `eval` call is strict or occurs within strict code. In short, it allows:

```Javascript
{
  let x;
  {
    eval('"use strict"; var x;');
  }
}
```

and

```Javascript
"use strict";
{
  let x;
  {
    eval('var x;');
  }
}
```

This is valid since in strict code all `eval` calls get their own function environment, making it impossible to declare a new var in the outer function environment. This change also skips poisoning environments on strict code, because `eval` cannot add new declarations for the current environment in that situation.