### PR TITLE
Reduce documentation size in blog

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: doc
-          args: -v --document-private-items --all-features
+          args: -v --document-private-items --all-features --workspace --no-deps --exclude boa_examples
       - run: echo "<meta http-equiv=refresh content=0;url=boa_engine/index.html>" > target/doc/index.html
       - run: |
           if [ -d target/doc_upload ]; then rm -rf target/doc_upload; fi


### PR DESCRIPTION
The documentation page of our blog is a whooping 532 MB in size. This is because we're uploading the whole documentation of all our deps instead of only our crates. This PR modifies our CI to only upload a lightweight version of our documentation, which excludes all deps (replaces all hyperlinks with crates.io links) and only builds our crates docs. This brings the total size of our docs down to 87 MB.