### PR TITLE
Improve performance of conformance page

### DIFF
--- a/test262/index.html
+++ b/test262/index.html
@@ -98,7 +98,10 @@
           id="old-versions"
         ></section>
       </div>
-      <div class="row accordion col-md-12 collapse" id="info"></div>
+      <div class="row col-md-12 collapse" id="infoContainer">
+        <div class="card-body accordion" id="info">
+        </div>
+      </div>
       <div
         id="graph-modal"
         class="modal fade"

--- a/test262/results.js
+++ b/test262/results.js
@@ -166,18 +166,19 @@
 
   // Shows the full test data.
   function showData(data, infoIcon) {
-    let infoContainer = $("#info");
+    let infoContainer = $("#infoContainer");
+    let info = $("#info");
     $(infoIcon).attr("class", "spinner-border text-primary small");
 
     setTimeout(
       function () {
-        infoContainer.empty();
+        info.empty();
         let totalTests = data.r.c;
         let passedTests = data.r.o;
         let ignoredTests = data.r.i;
         let failedTests = totalTests - passedTests - ignoredTests;
 
-        infoContainer.append(
+        infoContainer.prepend(
           $('<div class="progress g-0"></div>')
             .append(
               $(
@@ -221,7 +222,7 @@
         );
 
         for (let suite of data.r.s) {
-          addSuite(infoContainer, suite, "info", "test/" + suite.n, data.u);
+          addSuite(info, suite, "info", "test/" + suite.n, data.u);
         }
         infoContainer.collapse("show");
         $(infoIcon).attr("class", "bi-info-square");
@@ -328,7 +329,13 @@
       }
 
       info.attr("aria-controls", newID).attr("data-bs-target", "#" + newID);
-      inner.append(innerInner);
+      inner.on('show.bs.collapse', {elem: innerInner}, function(event){
+        event.data.elem.appendTo(inner);
+      });
+      inner.on('hidden.bs.collapse', {elem: innerInner}, function(event){
+        event.stopPropagation();
+        event.data.elem.detach();
+      });
       li.append(inner);
 
       elm.append(li);


### PR DESCRIPTION
This Pull Request improves the performance of our conformance page.

Basically, we were creating the whole DOM structure for all our test data, which is pretty inefficient considering the size of our data and that only one suite can be displayed at once. This changes our load algorithm so that we append the required elements just before displaying them, and we remove them after hiding them.

Though, this can be further optimized by lazily initializing the DOM elements on display, and also removing them completely, which should be more memory efficient, but I'll leave that for another PR.