### PR TITLE
[Merged by Bors] - Implement async arrow functions

### DIFF
--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -19,8 +19,8 @@ use self::{
 };
 
 use super::{
-    function::FormalParameterList,
     function::{ArrowFunction, AsyncFunction, AsyncGenerator, Class, Function, Generator},
+    function::{AsyncArrowFunction, FormalParameterList},
     Statement,
 };
 
@@ -87,6 +87,9 @@ pub enum Expression {
 
     /// See [`ArrowFunction`].
     ArrowFunction(ArrowFunction),
+
+    /// See [`AsyncArrowFunction`].
+    AsyncArrowFunction(AsyncArrowFunction),
 
     /// See [`Generator`].
     Generator(Generator),
@@ -168,6 +171,7 @@ impl Expression {
             Self::ObjectLiteral(o) => o.to_indented_string(interner, indentation),
             Self::Spread(sp) => sp.to_interned_string(interner),
             Self::Function(f) => f.to_indented_string(interner, indentation),
+            Self::AsyncArrowFunction(f) => f.to_indented_string(interner, indentation),
             Self::ArrowFunction(arrf) => arrf.to_indented_string(interner, indentation),
             Self::Class(cl) => cl.to_indented_string(interner, indentation),
             Self::Generator(gen) => gen.to_indented_string(interner, indentation),
@@ -219,6 +223,7 @@ impl VisitWith for Expression {
             Expression::Spread(sp) => visitor.visit_spread(sp),
             Expression::Function(f) => visitor.visit_function(f),
             Expression::ArrowFunction(af) => visitor.visit_arrow_function(af),
+            Expression::AsyncArrowFunction(af) => visitor.visit_async_arrow_function(af),
             Expression::Generator(g) => visitor.visit_generator(g),
             Expression::AsyncFunction(af) => visitor.visit_async_function(af),
             Expression::AsyncGenerator(ag) => visitor.visit_async_generator(ag),
@@ -256,6 +261,7 @@ impl VisitWith for Expression {
             Expression::Spread(sp) => visitor.visit_spread_mut(sp),
             Expression::Function(f) => visitor.visit_function_mut(f),
             Expression::ArrowFunction(af) => visitor.visit_arrow_function_mut(af),
+            Expression::AsyncArrowFunction(af) => visitor.visit_async_arrow_function_mut(af),
             Expression::Generator(g) => visitor.visit_generator_mut(g),
             Expression::AsyncFunction(af) => visitor.visit_async_function_mut(af),
             Expression::AsyncGenerator(ag) => visitor.visit_async_generator_mut(ag),

--- a/boa_ast/src/function/async_generator.rs
+++ b/boa_ast/src/function/async_generator.rs
@@ -24,6 +24,7 @@ pub struct AsyncGenerator {
     name: Option<Identifier>,
     parameters: FormalParameterList,
     body: StatementList,
+    has_binding_identifier: bool,
 }
 
 impl AsyncGenerator {
@@ -34,11 +35,13 @@ impl AsyncGenerator {
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: StatementList,
+        has_binding_identifier: bool,
     ) -> Self {
         Self {
             name,
             parameters,
             body,
+            has_binding_identifier,
         }
     }
 
@@ -61,6 +64,13 @@ impl AsyncGenerator {
     #[must_use]
     pub fn body(&self) -> &StatementList {
         &self.body
+    }
+
+    /// Returns whether the function expression has a binding identifier.
+    #[inline]
+    #[must_use]
+    pub fn has_binding_identifier(&self) -> bool {
+        self.has_binding_identifier
     }
 }
 

--- a/boa_ast/src/function/generator.rs
+++ b/boa_ast/src/function/generator.rs
@@ -26,6 +26,7 @@ pub struct Generator {
     name: Option<Identifier>,
     parameters: FormalParameterList,
     body: StatementList,
+    has_binding_identifier: bool,
 }
 
 impl Generator {
@@ -36,11 +37,13 @@ impl Generator {
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: StatementList,
+        has_binding_identifier: bool,
     ) -> Self {
         Self {
             name,
             parameters,
             body,
+            has_binding_identifier,
         }
     }
 
@@ -63,6 +66,13 @@ impl Generator {
     #[must_use]
     pub fn body(&self) -> &StatementList {
         &self.body
+    }
+
+    /// Returns whether the function expression has a binding identifier.
+    #[inline]
+    #[must_use]
+    pub fn has_binding_identifier(&self) -> bool {
+        self.has_binding_identifier
     }
 }
 

--- a/boa_ast/src/function/mod.rs
+++ b/boa_ast/src/function/mod.rs
@@ -5,12 +5,13 @@
 //!
 //! - [`Function`]s.
 //! - [`ArrowFunction`]s.
+//! - [`AsyncArrowFunction`]s.
 //! - [`Generator`]s.
 //! - [`AsyncFunction`]s.
 //! - [`AsyncGenerator`]s.
 //!
 //! All of them can be declared in either [declaration][decl] form or [expression][expr] form,
-//! except from `ArrowFunction`s, which can only be declared in expression form.
+//! except from `ArrowFunction`s and `AsyncArrowFunction`s, which can only be declared in expression form.
 //!
 //! This module also contains [`Class`]es, which are templates for creating objects. Classes
 //! can also be declared in either declaration or expression form.
@@ -21,6 +22,7 @@
 //! [expr]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/function
 
 mod arrow_function;
+mod async_arrow_function;
 mod async_function;
 mod async_generator;
 mod class;
@@ -28,6 +30,7 @@ mod generator;
 mod parameters;
 
 pub use arrow_function::ArrowFunction;
+pub use async_arrow_function::AsyncArrowFunction;
 pub use async_function::AsyncFunction;
 pub use async_generator::AsyncGenerator;
 pub use class::{Class, ClassElement};
@@ -59,10 +62,11 @@ pub struct Function {
     name: Option<Identifier>,
     parameters: FormalParameterList,
     body: StatementList,
+    has_binding_identifier: bool,
 }
 
 impl Function {
-    /// Creates a new function expression
+    /// Creates a new function expression.
     #[inline]
     #[must_use]
     pub fn new(
@@ -74,6 +78,24 @@ impl Function {
             name,
             parameters,
             body,
+            has_binding_identifier: false,
+        }
+    }
+
+    /// Creates a new function expression with an expression binding identifier.
+    #[inline]
+    #[must_use]
+    pub fn new_with_binding_identifier(
+        name: Option<Identifier>,
+        parameters: FormalParameterList,
+        body: StatementList,
+        has_binding_identifier: bool,
+    ) -> Self {
+        Self {
+            name,
+            parameters,
+            body,
+            has_binding_identifier,
         }
     }
 
@@ -96,6 +118,13 @@ impl Function {
     #[must_use]
     pub fn body(&self) -> &StatementList {
         &self.body
+    }
+
+    /// Returns whether the function expression has a binding identifier.
+    #[inline]
+    #[must_use]
+    pub fn has_binding_identifier(&self) -> bool {
+        self.has_binding_identifier
     }
 }
 

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -9,7 +9,8 @@ use boa_interner::Sym;
 use crate::{
     expression::{access::SuperPropertyAccess, Await, Identifier, SuperCall, Yield},
     function::{
-        ArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement, Function, Generator,
+        ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
+        Function, Generator,
     },
     property::{MethodDefinition, PropertyDefinition},
     visitor::{VisitWith, Visitor},
@@ -117,6 +118,25 @@ where
         fn visit_arrow_function(
             &mut self,
             node: &'ast ArrowFunction,
+        ) -> ControlFlow<Self::BreakTy> {
+            if ![
+                ContainsSymbol::NewTarget,
+                ContainsSymbol::SuperProperty,
+                ContainsSymbol::SuperCall,
+                ContainsSymbol::Super,
+                ContainsSymbol::This,
+            ]
+            .contains(&self.0)
+            {
+                return ControlFlow::Continue(());
+            }
+
+            node.visit_with(self)
+        }
+
+        fn visit_async_arrow_function(
+            &mut self,
+            node: &'ast AsyncArrowFunction,
         ) -> ControlFlow<Self::BreakTy> {
             if ![
                 ContainsSymbol::NewTarget,

--- a/boa_ast/src/visitor.rs
+++ b/boa_ast/src/visitor.rs
@@ -31,8 +31,8 @@ use crate::expression::{
     Spread, SuperCall, TaggedTemplate, Yield,
 };
 use crate::function::{
-    ArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement, FormalParameter,
-    FormalParameterList, Function, Generator,
+    ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
+    FormalParameter, FormalParameterList, Function, Generator,
 };
 use crate::pattern::{
     ArrayPattern, ArrayPatternElement, ObjectPattern, ObjectPatternElement, Pattern,
@@ -119,6 +119,7 @@ pub trait Visitor<'ast>: Sized {
     define_visit!(visit_object_literal, ObjectLiteral);
     define_visit!(visit_spread, Spread);
     define_visit!(visit_arrow_function, ArrowFunction);
+    define_visit!(visit_async_arrow_function, AsyncArrowFunction);
     define_visit!(visit_template_literal, TemplateLiteral);
     define_visit!(visit_property_access, PropertyAccess);
     define_visit!(visit_new, New);
@@ -203,6 +204,7 @@ pub trait VisitorMut<'ast>: Sized {
     define_visit_mut!(visit_object_literal_mut, ObjectLiteral);
     define_visit_mut!(visit_spread_mut, Spread);
     define_visit_mut!(visit_arrow_function_mut, ArrowFunction);
+    define_visit_mut!(visit_async_arrow_function_mut, AsyncArrowFunction);
     define_visit_mut!(visit_template_literal_mut, TemplateLiteral);
     define_visit_mut!(visit_property_access_mut, PropertyAccess);
     define_visit_mut!(visit_new_mut, New);

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -841,31 +841,29 @@ impl BuiltInFunctionObject {
             }
         };
 
-        match (function, name) {
-            (
-                Function::Native {
-                    function: _,
-                    constructor: _,
-                },
-                Some(name),
-            ) => Ok(js_string!(
-                utf16!("function "),
-                &name,
-                utf16!("() {{\n  [native Code]\n}}")
-            )
-            .into()),
-            (Function::Ordinary { .. }, Some(name)) if name.is_empty() => {
-                Ok(js_string!("[Function (anonymous)]").into())
+        let name = if let Some(name) = name {
+            if name.is_empty() {
+                "anonymous".into()
+            } else {
+                name
             }
-            (Function::Ordinary { .. }, Some(name)) => {
+        } else {
+            "anonymous".into()
+        };
+
+        match function {
+            Function::Native { .. } | Function::Closure { .. } | Function::Ordinary { .. } => {
                 Ok(js_string!(utf16!("[Function: "), &name, utf16!("]")).into())
             }
-            (Function::Ordinary { .. }, None) => Ok(js_string!("[Function (anonymous)]").into()),
-            (Function::Generator { .. }, Some(name)) => {
-                Ok(js_string!(utf16!("[Function*: "), &name, utf16!("]")).into())
+            Function::Async { .. } => {
+                Ok(js_string!(utf16!("[AsyncFunction: "), &name, utf16!("]")).into())
             }
-            (Function::Generator { .. }, None) => Ok(js_string!("[Function* (anonymous)]").into()),
-            _ => Ok("TODO".into()),
+            Function::Generator { .. } => {
+                Ok(js_string!(utf16!("[GeneratorFunction: "), &name, utf16!("]")).into())
+            }
+            Function::AsyncGenerator { .. } => {
+                Ok(js_string!(utf16!("[AsyncGeneratorFunction: "), &name, utf16!("]")).into())
+            }
         }
     }
 

--- a/boa_engine/src/syntax/parser/expression/assignment/async_arrow_function.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/async_arrow_function.rs
@@ -1,102 +1,98 @@
-//! Arrow function parsing.
+//! Async arrow function parsing.
 //!
 //! More information:
 //!  - [MDN documentation][mdn]
 //!  - [ECMAScript specification][spec]
 //!
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
-//! [spec]: https://tc39.es/ecma262/#sec-arrow-function-definitions
+//! [spec]: https://tc39.es/ecma262/#sec-async-arrow-function-definitions
 
-use super::AssignmentExpression;
+use super::arrow_function::ExpressionBody;
 use crate::syntax::{
     lexer::{Error as LexError, TokenKind},
     parser::{
         error::{ErrorContext, ParseError, ParseResult},
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, AllowAwait, AllowIn, AllowYield, Cursor, TokenParser,
+        name_in_lexically_declared_names, AllowIn, AllowYield, Cursor, TokenParser,
     },
+};
+use ast::{
+    operations::{contains, ContainsSymbol},
+    Keyword,
 };
 use boa_ast::{
     self as ast,
     declaration::Variable,
     expression::Identifier,
     function::{FormalParameter, FormalParameterList},
-    operations::{contains, ContainsSymbol},
     statement::Return,
-    Expression, Punctuator, StatementList,
+    Punctuator, StatementList,
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
 use std::io::Read;
 
-/// Arrow function parsing.
+/// Async arrow function parsing.
 ///
 /// More information:
 ///  - [MDN documentation][mdn]
 ///  - [ECMAScript specification][spec]
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
-/// [spec]: https://tc39.es/ecma262/#prod-ArrowFunction
+/// [spec]: https://tc39.es/ecma262/#prod-AsyncArrowFunction
 #[derive(Debug, Clone, Copy)]
-pub(in crate::syntax::parser) struct ArrowFunction {
+pub(in crate::syntax::parser) struct AsyncArrowFunction {
     name: Option<Identifier>,
     allow_in: AllowIn,
     allow_yield: AllowYield,
-    allow_await: AllowAwait,
 }
 
-impl ArrowFunction {
-    /// Creates a new `ArrowFunction` parser.
-    pub(in crate::syntax::parser) fn new<N, I, Y, A>(
-        name: N,
-        allow_in: I,
-        allow_yield: Y,
-        allow_await: A,
-    ) -> Self
+impl AsyncArrowFunction {
+    /// Creates a new `AsyncArrowFunction` parser.
+    pub(in crate::syntax::parser) fn new<N, I, Y>(name: N, allow_in: I, allow_yield: Y) -> Self
     where
         N: Into<Option<Identifier>>,
         I: Into<AllowIn>,
         Y: Into<AllowYield>,
-        A: Into<AllowAwait>,
     {
         Self {
             name: name.into(),
             allow_in: allow_in.into(),
             allow_yield: allow_yield.into(),
-            allow_await: allow_await.into(),
         }
     }
 }
 
-impl<R> TokenParser<R> for ArrowFunction
+impl<R> TokenParser<R> for AsyncArrowFunction
 where
     R: Read,
 {
-    type Output = ast::function::ArrowFunction;
+    type Output = ast::function::AsyncArrowFunction;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
-        let _timer = Profiler::global().start_event("ArrowFunction", "Parsing");
-        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let _timer = Profiler::global().start_event("AsyncArrowFunction", "Parsing");
 
+        cursor.expect((Keyword::Async, false), "async arrow function", interner)?;
+        cursor.peek_expect_no_lineterminator(0, "async arrow function", interner)?;
+
+        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
         let (params, params_start_position) = if let TokenKind::Punctuator(Punctuator::OpenParen) =
             &next_token.kind()
         {
-            // CoverParenthesizedExpressionAndArrowParameterList
             let params_start_position = cursor
-                .expect(Punctuator::OpenParen, "arrow function", interner)?
+                .expect(Punctuator::OpenParen, "async arrow function", interner)?
                 .span()
                 .end();
 
-            let params = FormalParameters::new(self.allow_yield, self.allow_await)
-                .parse(cursor, interner)?;
-            cursor.expect(Punctuator::CloseParen, "arrow function", interner)?;
+            let params = FormalParameters::new(false, true).parse(cursor, interner)?;
+            cursor.expect(Punctuator::CloseParen, "async arrow function", interner)?;
             (params, params_start_position)
         } else {
             let params_start_position = next_token.span().start();
-            let param = BindingIdentifier::new(self.allow_yield, self.allow_await)
+            let param = BindingIdentifier::new(self.allow_yield, true)
                 .parse(cursor, interner)
-                .context("arrow function")?;
+                .context("async arrow function")?;
             (
                 FormalParameterList::try_from(FormalParameter::new(
                     Variable::from_identifier(param, None),
@@ -107,17 +103,10 @@ where
             )
         };
 
-        cursor.peek_expect_no_lineterminator(0, "arrow function", interner)?;
+        cursor.peek_expect_no_lineterminator(0, "async arrow function", interner)?;
+        cursor.expect(Punctuator::Arrow, "async arrow function", interner)?;
 
-        cursor.expect(
-            TokenKind::Punctuator(Punctuator::Arrow),
-            "arrow function",
-            interner,
-        )?;
-        let arrow = cursor.arrow();
-        cursor.set_arrow(true);
-        let body = ConciseBody::new(self.allow_in).parse(cursor, interner)?;
-        cursor.set_arrow(arrow);
+        let body = AsyncConciseBody::new(self.allow_in).parse(cursor, interner)?;
 
         // Early Error: ArrowFormalParameters are UniqueFormalParameters.
         if params.has_duplicates() {
@@ -127,7 +116,7 @@ where
             )));
         }
 
-        // Early Error: It is a Syntax Error if ArrowParameters Contains YieldExpression is true.
+        // Early Error: It is a Syntax Error if CoverCallExpressionAndAsyncArrowHead Contains YieldExpression is true.
         if contains(&params, ContainsSymbol::YieldExpression) {
             return Err(ParseError::lex(LexError::Syntax(
                 "Yield expression not allowed in this context".into(),
@@ -135,7 +124,7 @@ where
             )));
         }
 
-        // Early Error: It is a Syntax Error if ArrowParameters Contains AwaitExpression is true.
+        // Early Error: It is a Syntax Error if CoverCallExpressionAndAsyncArrowHead Contains AwaitExpression is true.
         if contains(&params, ContainsSymbol::AwaitExpression) {
             return Err(ParseError::lex(LexError::Syntax(
                 "Await expression not allowed in this context".into(),
@@ -143,8 +132,8 @@ where
             )));
         }
 
-        // Early Error: It is a Syntax Error if ConciseBodyContainsUseStrict of ConciseBody is true
-        // and IsSimpleParameterList of ArrowParameters is false.
+        // Early Error: It is a Syntax Error if AsyncConciseBodyContainsUseStrict of AsyncConciseBody is true and
+        // IsSimpleParameterList of CoverCallExpressionAndAsyncArrowHead is false.
         if body.strict() && !params.is_simple() {
             return Err(ParseError::lex(LexError::Syntax(
                 "Illegal 'use strict' directive in function with non-simple parameter list".into(),
@@ -152,27 +141,28 @@ where
             )));
         }
 
-        // It is a Syntax Error if any element of the BoundNames of ArrowParameters
-        // also occurs in the LexicallyDeclaredNames of ConciseBody.
-        // https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-early-errors
+        // Early Error: It is a Syntax Error if any element of the BoundNames of CoverCallExpressionAndAsyncArrowHead
+        // also occurs in the LexicallyDeclaredNames of AsyncConciseBody.
         name_in_lexically_declared_names(
             &params,
             &body.lexically_declared_names_top_level(),
             params_start_position,
         )?;
 
-        Ok(ast::function::ArrowFunction::new(self.name, params, body))
+        Ok(ast::function::AsyncArrowFunction::new(
+            self.name, params, body,
+        ))
     }
 }
 
-/// <https://tc39.es/ecma262/#prod-ConciseBody>
+/// <https://tc39.es/ecma262/#prod-AsyncConciseBody>
 #[derive(Debug, Clone, Copy)]
-pub(in crate::syntax::parser) struct ConciseBody {
+pub(in crate::syntax::parser) struct AsyncConciseBody {
     allow_in: AllowIn,
 }
 
-impl ConciseBody {
-    /// Creates a new `ConciseBody` parser.
+impl AsyncConciseBody {
+    /// Creates a new `AsyncConciseBody` parser.
     pub(in crate::syntax::parser) fn new<I>(allow_in: I) -> Self
     where
         I: Into<AllowIn>,
@@ -183,7 +173,7 @@ impl ConciseBody {
     }
 }
 
-impl<R> TokenParser<R> for ConciseBody
+impl<R> TokenParser<R> for AsyncConciseBody
 where
     R: Read,
 {
@@ -196,52 +186,19 @@ where
             .kind()
         {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {
-                let _next = cursor.next(interner)?;
-                let body = FunctionBody::new(false, false).parse(cursor, interner)?;
-                cursor.expect(Punctuator::CloseBlock, "arrow function", interner)?;
+                cursor.next(interner)?;
+                let body = FunctionBody::new(false, true).parse(cursor, interner)?;
+                cursor.expect(Punctuator::CloseBlock, "async arrow function", interner)?;
                 Ok(body)
             }
             _ => Ok(StatementList::from(vec![ast::Statement::Return(
                 Return::new(
-                    ExpressionBody::new(self.allow_in, false)
+                    ExpressionBody::new(self.allow_in, true)
                         .parse(cursor, interner)?
                         .into(),
                 ),
             )
             .into()])),
         }
-    }
-}
-
-/// <https://tc39.es/ecma262/#prod-ExpressionBody>
-#[derive(Debug, Clone, Copy)]
-pub(super) struct ExpressionBody {
-    allow_in: AllowIn,
-    allow_await: AllowAwait,
-}
-
-impl ExpressionBody {
-    /// Creates a new `ExpressionBody` parser.
-    pub(super) fn new<I, A>(allow_in: I, allow_await: A) -> Self
-    where
-        I: Into<AllowIn>,
-        A: Into<AllowAwait>,
-    {
-        Self {
-            allow_in: allow_in.into(),
-            allow_await: allow_await.into(),
-        }
-    }
-}
-
-impl<R> TokenParser<R> for ExpressionBody
-where
-    R: Read,
-{
-    type Output = Expression;
-
-    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
-        AssignmentExpression::new(None, self.allow_in, false, self.allow_await)
-            .parse(cursor, interner)
     }
 }

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -62,13 +62,16 @@ where
             interner,
         )?;
 
-        let name = match cursor
+        let (name, has_binding_identifier) = match cursor
             .peek(0, interner)?
             .ok_or(ParseError::AbruptEnd)?
             .kind()
         {
-            TokenKind::Punctuator(Punctuator::OpenParen) => self.name,
-            _ => Some(BindingIdentifier::new(self.allow_yield, true).parse(cursor, interner)?),
+            TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
+            _ => (
+                Some(BindingIdentifier::new(self.allow_yield, true).parse(cursor, interner)?),
+                true,
+            ),
         };
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
@@ -134,7 +137,7 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncFunction::new(name, params, body);
+        let function = AsyncFunction::new(name, params, body, has_binding_identifier);
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/tests.rs
@@ -30,6 +30,7 @@ fn check_async_expression() {
                             Return::new(Some(Literal::from(1).into())),
                         ))]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),
@@ -73,6 +74,7 @@ fn check_nested_async_expression() {
                                         )))
                                         .into()]
                                         .into(),
+                                        false,
                                     )
                                     .into(),
                                 ),
@@ -82,6 +84,7 @@ fn check_nested_async_expression() {
                         ))
                         .into()]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
@@ -71,13 +71,16 @@ where
             interner,
         )?;
 
-        let name = match cursor
+        let (name, has_binding_identifier) = match cursor
             .peek(0, interner)?
             .ok_or(ParseError::AbruptEnd)?
             .kind()
         {
-            TokenKind::Punctuator(Punctuator::OpenParen) => self.name,
-            _ => Some(BindingIdentifier::new(true, true).parse(cursor, interner)?),
+            TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
+            _ => (
+                Some(BindingIdentifier::new(true, true).parse(cursor, interner)?),
+                true,
+            ),
         };
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict
@@ -166,7 +169,7 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncGenerator::new(name, params, body);
+        let function = AsyncGenerator::new(name, params, body, has_binding_identifier);
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
@@ -175,7 +178,6 @@ where
             )));
         }
 
-        //implement the below AsyncGeneratorExpr in ast::node
         Ok(function)
     }
 }

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/tests.rs
@@ -33,6 +33,7 @@ fn check_async_generator_expr() {
                             Return::new(Some(Literal::from(1).into())),
                         ))]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),
@@ -75,6 +76,7 @@ fn check_nested_async_generator_expr() {
                                             Return::new(Some(Literal::from(1).into())),
                                         ))]
                                         .into(),
+                                        false,
                                     )
                                     .into(),
                                 ),
@@ -84,6 +86,7 @@ fn check_nested_async_generator_expr() {
                         ))
                         .into()]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/tests.rs
@@ -101,10 +101,11 @@ fn check_function_non_reserved_keyword() {
                 vec![Variable::from_identifier(
                     $interner.get_or_intern_static("add", utf16!("add")).into(),
                     Some(
-                        Function::new(
+                        Function::new_with_binding_identifier(
                             Some($interner.get_or_intern_static($keyword, utf16!($keyword)).into()),
                             FormalParameterList::default(),
                             vec![StatementListItem::Statement(Statement::Return(Return::new(Some(Literal::from(1).into()))))].into(),
+                            true,
                         )
                         .into(),
                     ),

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
@@ -66,13 +66,16 @@ where
             interner,
         )?;
 
-        let name = match cursor
+        let (name, has_binding_identifier) = match cursor
             .peek(0, interner)?
             .ok_or(ParseError::AbruptEnd)?
             .kind()
         {
-            TokenKind::Punctuator(Punctuator::OpenParen) => self.name,
-            _ => Some(BindingIdentifier::new(true, false).parse(cursor, interner)?),
+            TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
+            _ => (
+                Some(BindingIdentifier::new(true, false).parse(cursor, interner)?),
+                true,
+            ),
         };
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
@@ -130,7 +133,7 @@ where
             params_start_position,
         )?;
 
-        let function = Generator::new(name, params, body);
+        let function = Generator::new(name, params, body, has_binding_identifier);
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/tests.rs
@@ -28,6 +28,7 @@ fn check_generator_function_expression() {
                             Expression::from(Yield::new(Some(Literal::from(1).into()), false)),
                         ))]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),
@@ -60,6 +61,7 @@ fn check_generator_function_delegate_yield_expression() {
                             Expression::from(Yield::new(Some(Literal::from(1).into()), true)),
                         ))]
                         .into(),
+                        false,
                     )
                     .into(),
                 ),

--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -729,7 +729,7 @@ where
             body_start,
         )?;
 
-        let method = MethodDefinition::Generator(Generator::new(None, params, body));
+        let method = MethodDefinition::Generator(Generator::new(None, params, body, false));
 
         if contains(&method, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
@@ -843,7 +843,8 @@ where
             body_start,
         )?;
 
-        let method = MethodDefinition::AsyncGenerator(AsyncGenerator::new(None, params, body));
+        let method =
+            MethodDefinition::AsyncGenerator(AsyncGenerator::new(None, params, body, false));
 
         if contains(&method, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
@@ -928,7 +929,7 @@ where
             body_start,
         )?;
 
-        let method = MethodDefinition::Async(AsyncFunction::new(None, params, body));
+        let method = MethodDefinition::Async(AsyncFunction::new(None, params, body, false));
 
         if contains(&method, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(

--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/tests.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/tests.rs
@@ -410,6 +410,7 @@ fn check_async_method() {
             None,
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         )),
     )];
 
@@ -443,6 +444,7 @@ fn check_async_generator_method() {
             None,
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         )),
     )];
 

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -88,6 +88,11 @@ where
 
         let result = parse_callable_declaration(&self, cursor, interner)?;
 
-        Ok(AsyncFunction::new(Some(result.0), result.1, result.2))
+        Ok(AsyncFunction::new(
+            Some(result.0),
+            result.1,
+            result.2,
+            false,
+        ))
     }
 }

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_function_decl/tests.rs
@@ -20,6 +20,7 @@ fn async_function_declaration() {
             ),
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         ))
         .into()],
         interner,
@@ -40,6 +41,7 @@ fn async_function_declaration_keywords() {
             ),
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         ))
         .into()],
         interner,
@@ -56,6 +58,7 @@ fn async_function_declaration_keywords() {
             ),
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         ))
         .into()],
         interner,

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -107,6 +107,11 @@ where
 
         let result = parse_callable_declaration(&self, cursor, interner)?;
 
-        Ok(AsyncGenerator::new(Some(result.0), result.1, result.2))
+        Ok(AsyncGenerator::new(
+            Some(result.0),
+            result.1,
+            result.2,
+            false,
+        ))
     }
 }

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
@@ -15,6 +15,7 @@ fn async_generator_function_declaration() {
             Some(interner.get_or_intern_static("gen", utf16!("gen")).into()),
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         ))
         .into()],
         interner,

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -83,6 +83,6 @@ where
 
         let result = parse_callable_declaration(&self, cursor, interner)?;
 
-        Ok(Generator::new(Some(result.0), result.1, result.2))
+        Ok(Generator::new(Some(result.0), result.1, result.2, false))
     }
 }

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/generator_decl/tests.rs
@@ -15,6 +15,7 @@ fn generator_function_declaration() {
             Some(interner.get_or_intern_static("gen", utf16!("gen")).into()),
             FormalParameterList::default(),
             StatementList::default(),
+            false,
         ))
         .into()],
         interner,

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -167,7 +167,7 @@ impl Context {
         let promise_capability = self
             .realm
             .environments
-            .get_this_environment()
+            .current_function_slots()
             .as_function_slots()
             .and_then(|slots| {
                 let slots_borrow = slots.borrow();

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -64,6 +64,9 @@ impl Operation for DefInitVar {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
+        if binding_locator.is_silent() {
+            return Ok(ShouldExit::False);
+        }
         binding_locator.throw_mutate_immutable(context)?;
 
         if binding_locator.is_global() {

--- a/boa_engine/src/vm/opcode/get/function.rs
+++ b/boa_engine/src/vm/opcode/get/function.rs
@@ -23,6 +23,26 @@ impl Operation for GetArrowFunction {
     }
 }
 
+/// `GetAsyncArrowFunction` implements the Opcode Operation for `Opcode::GetAsyncArrowFunction`
+///
+/// Operation:
+///  - Get async arrow function from the pre-compiled inner functions.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetAsyncArrowFunction;
+
+impl Operation for GetAsyncArrowFunction {
+    const NAME: &'static str = "GetAsyncArrowFunction";
+    const INSTRUCTION: &'static str = "INST - GetAsyncArrowFunction";
+
+    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+        let index = context.vm.read::<u32>();
+        let code = context.vm.frame().code.functions[index as usize].clone();
+        let function = create_function_object(code, true, true, None, context);
+        context.vm.push(function);
+        Ok(ShouldExit::False)
+    }
+}
+
 /// `GetFunction` implements the Opcode Operation for `Opcode::GetFunction`
 ///
 /// Operation:

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1130,6 +1130,13 @@ generate_impl! {
         /// Stack: **=>** func
         GetArrowFunction,
 
+        /// Get async arrow function from the pre-compiled inner functions.
+        ///
+        /// Operands: address: `u32`
+        ///
+        /// Stack: **=>** func
+        GetAsyncArrowFunction,
+
         /// Get function from the pre-compiled inner functions.
         ///
         /// Operands: address: `u32`

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -19,6 +19,9 @@ impl Operation for SetName {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         let value = context.vm.pop();
+        if binding_locator.is_silent() {
+            return Ok(ShouldExit::False);
+        }
         binding_locator.throw_mutate_immutable(context)?;
 
         if binding_locator.is_global() {


### PR DESCRIPTION
This Pull Request fixes #1805.

It changes the following:

- Implement async arrow function parsing and execution.
- Handle special case when a function expressions binding identifier need to be bound in the function body.
- Implement special silent ignored assignment for the above case.
- Fix issue with getting the correct promise capability for function returns.
- Complete function object `toString` todo.

I will fix the two failing assignmenttargettype tests in a follow up PR.