### PR TITLE
[Merged by Bors] - Replace `contains` and friends with visitors

### DIFF
--- a/boa_ast/src/declaration/mod.rs
+++ b/boa_ast/src/declaration/mod.rs
@@ -17,7 +17,6 @@
 use super::{
     expression::Identifier,
     function::{AsyncFunction, AsyncGenerator, Class, Function, Generator},
-    ContainsSymbol,
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
@@ -114,42 +113,6 @@ impl Declaration {
                 }
                 names
             }
-        }
-    }
-
-    /// Returns true if the node contains a identifier reference named 'arguments'.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
-    // TODO: replace with a visitor
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            Self::Function(_)
-            | Self::Generator(_)
-            | Self::AsyncGenerator(_)
-            | Self::AsyncFunction(_) => false,
-            Self::Lexical(decl) => decl.contains_arguments(),
-            Self::Class(class) => class.contains_arguments(),
-        }
-    }
-
-    /// Returns `true` if the node contains the given token.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
-    // TODO: replace with a visitor
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            Self::Function(_)
-            | Self::Generator(_)
-            | Self::AsyncGenerator(_)
-            | Self::AsyncFunction(_) => false,
-            Self::Class(class) => class.contains(symbol),
-            Self::Lexical(decl) => decl.contains(symbol),
         }
     }
 }

--- a/boa_ast/src/expression/await.rs
+++ b/boa_ast/src/expression/await.rs
@@ -1,6 +1,5 @@
 //! Await expression Expression.
 
-use crate::ContainsSymbol;
 use core::ops::ControlFlow;
 
 use super::Expression;
@@ -28,16 +27,6 @@ impl Await {
     #[must_use]
     pub fn target(&self) -> &Expression {
         &self.target
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.target.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.target.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/call.rs
+++ b/boa_ast/src/expression/call.rs
@@ -1,6 +1,6 @@
+use crate::join_nodes;
 use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{join_nodes, ContainsSymbol};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -50,16 +50,6 @@ impl Call {
     #[must_use]
     pub fn args(&self) -> &[Expression] {
         &self.args
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.function.contains_arguments() || self.args.iter().any(Expression::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.function.contains(symbol) || self.args.iter().any(|expr| expr.contains(symbol))
     }
 }
 
@@ -132,16 +122,6 @@ impl SuperCall {
     #[must_use]
     pub fn arguments(&self) -> &[Expression] {
         &self.args
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.args.iter().any(Expression::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.args.iter().any(|expr| expr.contains(symbol))
     }
 }
 

--- a/boa_ast/src/expression/literal/array.rs
+++ b/boa_ast/src/expression/literal/array.rs
@@ -1,10 +1,10 @@
 //! Array declaration Expression.
 
 use crate::expression::operator::assign::AssignTarget;
+use crate::expression::Expression;
 use crate::pattern::{ArrayPattern, ArrayPatternElement, Pattern};
 use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, ContainsSymbol};
 use boa_interner::{Interner, Sym, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -150,19 +150,6 @@ impl ArrayLiteral {
             }
         }
         Some(ArrayPattern::new(bindings.into()))
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.arr
-            .iter()
-            .flatten()
-            .any(Expression::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.arr.iter().flatten().any(|expr| expr.contains(symbol))
     }
 }
 

--- a/boa_ast/src/expression/literal/object.rs
+++ b/boa_ast/src/expression/literal/object.rs
@@ -8,7 +8,6 @@ use crate::{
     property::{MethodDefinition, PropertyDefinition, PropertyName},
     try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
-    ContainsSymbol,
 };
 use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
@@ -204,18 +203,6 @@ impl ObjectLiteral {
         }
 
         Some(ObjectPattern::new(bindings.into()))
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.properties
-            .iter()
-            .any(PropertyDefinition::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.properties.iter().any(|prop| prop.contains(symbol))
     }
 }
 

--- a/boa_ast/src/expression/literal/template.rs
+++ b/boa_ast/src/expression/literal/template.rs
@@ -9,7 +9,7 @@ use crate::{
     expression::Expression,
     try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
-    ContainsSymbol, ToStringEscaped,
+    ToStringEscaped,
 };
 
 /// Template literals are string literals allowing embedded expressions.
@@ -60,22 +60,6 @@ impl TemplateLiteral {
     #[must_use]
     pub fn elements(&self) -> &[TemplateElement] {
         &self.elements
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.elements.iter().any(|e| match e {
-            TemplateElement::String(_) => false,
-            TemplateElement::Expr(expr) => expr.contains_arguments(),
-        })
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.elements.iter().any(|e| match e {
-            TemplateElement::String(_) => false,
-            TemplateElement::Expr(expr) => expr.contains(symbol),
-        })
     }
 }
 

--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -9,7 +9,7 @@
 //! [primary]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#primary_expressions
 //! [lhs]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#left-hand-side_expressions
 
-use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
+use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
 use self::{
@@ -21,7 +21,7 @@ use self::{
 use super::{
     function::FormalParameterList,
     function::{ArrowFunction, AsyncFunction, AsyncGenerator, Class, Function, Generator},
-    ContainsSymbol, Statement,
+    Statement,
 };
 
 mod r#await;
@@ -188,91 +188,6 @@ impl Expression {
             Self::Await(aw) => aw.to_interned_string(interner),
             Self::Yield(yi) => yi.to_interned_string(interner),
             Self::FormalParameterList(_) => unreachable!(),
-        }
-    }
-
-    /// Returns true if the expression contains a identifier reference named 'arguments'.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
-    // TODO: replace with a visitor
-    #[inline]
-    #[must_use]
-    pub fn contains_arguments(&self) -> bool {
-        match self {
-            Expression::Identifier(ident) => *ident == Sym::ARGUMENTS,
-            Expression::Function(_)
-            | Expression::Generator(_)
-            | Expression::AsyncFunction(_)
-            | Expression::AsyncGenerator(_)
-            | Expression::Literal(_)
-            | Expression::This
-            | Expression::NewTarget => false,
-            Expression::ArrayLiteral(array) => array.contains_arguments(),
-            Expression::ObjectLiteral(object) => object.contains_arguments(),
-            Expression::Spread(spread) => spread.contains_arguments(),
-            Expression::ArrowFunction(arrow) => arrow.contains_arguments(),
-            Expression::Class(class) => class.contains_arguments(),
-            Expression::TemplateLiteral(template) => template.contains_arguments(),
-            Expression::PropertyAccess(access) => access.contains_arguments(),
-            Expression::New(new) => new.contains_arguments(),
-            Expression::Call(call) => call.contains_arguments(),
-            Expression::SuperCall(call) => call.contains_arguments(),
-            Expression::Optional(opt) => opt.contains_arguments(),
-            Expression::TaggedTemplate(tag) => tag.contains_arguments(),
-            Expression::Assign(assign) => assign.contains_arguments(),
-            Expression::Unary(unary) => unary.contains_arguments(),
-            Expression::Binary(binary) => binary.contains_arguments(),
-            Expression::Conditional(cond) => cond.contains_arguments(),
-            Expression::Await(r#await) => r#await.contains_arguments(),
-            Expression::Yield(r#yield) => r#yield.contains_arguments(),
-            // TODO: remove variant
-            Expression::FormalParameterList(_) => unreachable!(),
-        }
-    }
-
-    /// Returns `true` if the node contains the given token.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
-    // TODO: replace with a visitor
-    #[must_use]
-    pub fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            Expression::This => symbol == ContainsSymbol::This,
-            Expression::Identifier(_)
-            | Expression::Literal(_)
-            | Expression::Function(_)
-            | Expression::Generator(_)
-            | Expression::AsyncFunction(_)
-            | Expression::AsyncGenerator(_) => false,
-            Expression::ArrayLiteral(array) => array.contains(symbol),
-            Expression::ObjectLiteral(obj) => obj.contains(symbol),
-            Expression::Spread(spread) => spread.contains(symbol),
-            Expression::ArrowFunction(arrow) => arrow.contains(symbol),
-            Expression::Class(class) => class.contains(symbol),
-            Expression::TemplateLiteral(temp) => temp.contains(symbol),
-            Expression::PropertyAccess(prop) => prop.contains(symbol),
-            Expression::New(new) => new.contains(symbol),
-            Expression::Call(call) => call.contains(symbol),
-            Expression::SuperCall(_) if symbol == ContainsSymbol::SuperCall => true,
-            Expression::SuperCall(expr) => expr.contains(symbol),
-            Expression::Optional(opt) => opt.contains(symbol),
-            Expression::TaggedTemplate(temp) => temp.contains(symbol),
-            Expression::NewTarget => symbol == ContainsSymbol::NewTarget,
-            Expression::Assign(assign) => assign.contains(symbol),
-            Expression::Unary(unary) => unary.contains(symbol),
-            Expression::Binary(binary) => binary.contains(symbol),
-            Expression::Conditional(cond) => cond.contains(symbol),
-            Expression::Await(_) if symbol == ContainsSymbol::AwaitExpression => true,
-            Expression::Await(r#await) => r#await.contains(symbol),
-            Expression::Yield(_) if symbol == ContainsSymbol::YieldExpression => true,
-            Expression::Yield(r#yield) => r#yield.contains(symbol),
-            Expression::FormalParameterList(_) => unreachable!(),
         }
     }
 }

--- a/boa_ast/src/expression/new.rs
+++ b/boa_ast/src/expression/new.rs
@@ -1,5 +1,5 @@
+use crate::expression::Call;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Call, ContainsSymbol};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -45,16 +45,6 @@ impl New {
     #[must_use]
     pub fn call(&self) -> &Call {
         &self.call
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.call.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.call.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/operator/assign/mod.rs
+++ b/boa_ast/src/expression/operator/assign/mod.rs
@@ -15,14 +15,13 @@ mod op;
 use core::ops::ControlFlow;
 pub use op::*;
 
-use boa_interner::{Interner, Sym, ToInternedString};
+use boa_interner::{Interner, ToInternedString};
 
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::{access::PropertyAccess, identifier::Identifier, Expression},
     pattern::Pattern,
-    ContainsSymbol,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
 };
 
 /// An assignment operator expression.
@@ -66,24 +65,6 @@ impl Assign {
     #[must_use]
     pub fn rhs(&self) -> &Expression {
         &self.rhs
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        (match &*self.lhs {
-            AssignTarget::Identifier(ident) => *ident == Sym::ARGUMENTS,
-            AssignTarget::Access(access) => access.contains_arguments(),
-            AssignTarget::Pattern(pattern) => pattern.contains_arguments(),
-        } || self.rhs.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        (match &*self.lhs {
-            AssignTarget::Identifier(_) => false,
-            AssignTarget::Access(access) => access.contains(symbol),
-            AssignTarget::Pattern(pattern) => pattern.contains(symbol),
-        } || self.rhs.contains(symbol))
     }
 }
 

--- a/boa_ast/src/expression/operator/binary/mod.rs
+++ b/boa_ast/src/expression/operator/binary/mod.rs
@@ -21,9 +21,11 @@ pub use op::*;
 
 use boa_interner::{Interner, ToInternedString};
 
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 
 /// Binary operations require two operands, one before the operator and one after the operator.
 ///
@@ -66,16 +68,6 @@ impl Binary {
     #[must_use]
     pub fn rhs(&self) -> &Expression {
         &self.rhs
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.lhs.contains_arguments() || self.rhs.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.lhs.contains(symbol) || self.rhs.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/operator/conditional.rs
+++ b/boa_ast/src/expression/operator/conditional.rs
@@ -1,6 +1,8 @@
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -57,20 +59,6 @@ impl Conditional {
             if_true: Box::new(if_true),
             if_false: Box::new(if_false),
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.condition.contains_arguments()
-            || self.if_true.contains_arguments()
-            || self.if_false.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.condition.contains(symbol)
-            || self.if_true.contains(symbol)
-            || self.if_false.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/operator/unary/mod.rs
+++ b/boa_ast/src/expression/operator/unary/mod.rs
@@ -18,8 +18,8 @@ pub use op::*;
 
 use boa_interner::{Interner, ToInternedString};
 
+use crate::expression::Expression;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, ContainsSymbol};
 
 /// A unary expression is an operation with only one operand.
 ///
@@ -58,16 +58,6 @@ impl Unary {
     #[must_use]
     pub fn target(&self) -> &Expression {
         self.target.as_ref()
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.target.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.target.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/spread.rs
+++ b/boa_ast/src/expression/spread.rs
@@ -2,7 +2,6 @@ use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::ContainsSymbol;
 
 use super::Expression;
 
@@ -44,16 +43,6 @@ impl Spread {
         Self {
             target: Box::new(target),
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.target.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.target.contains(symbol)
     }
 }
 

--- a/boa_ast/src/expression/tagged_template.rs
+++ b/boa_ast/src/expression/tagged_template.rs
@@ -3,7 +3,6 @@ use core::ops::ControlFlow;
 
 use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::ContainsSymbol;
 
 use super::Expression;
 
@@ -68,16 +67,6 @@ impl TaggedTemplate {
     #[must_use]
     pub fn exprs(&self) -> &[Expression] {
         &self.exprs
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.tag.contains_arguments() || self.exprs.iter().any(Expression::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.tag.contains(symbol) || self.exprs.iter().any(|expr| expr.contains(symbol))
     }
 }
 

--- a/boa_ast/src/expression/yield.rs
+++ b/boa_ast/src/expression/yield.rs
@@ -2,7 +2,6 @@ use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::ContainsSymbol;
 
 use super::Expression;
 
@@ -43,16 +42,6 @@ impl Yield {
             target: expr.map(Box::new),
             delegate,
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        matches!(self.target, Some(ref expr) if expr.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        matches!(self.target, Some(ref expr) if expr.contains(symbol))
     }
 }
 

--- a/boa_ast/src/function/arrow_function.rs
+++ b/boa_ast/src/function/arrow_function.rs
@@ -2,7 +2,7 @@ use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::{Expression, Identifier},
-    join_nodes, ContainsSymbol, StatementList,
+    join_nodes, StatementList,
 };
 use boa_interner::{Interner, ToIndentedString};
 use core::ops::ControlFlow;
@@ -63,26 +63,6 @@ impl ArrowFunction {
     #[must_use]
     pub fn body(&self) -> &StatementList {
         &self.body
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.parameters.contains_arguments() || self.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        if ![
-            ContainsSymbol::NewTarget,
-            ContainsSymbol::SuperProperty,
-            ContainsSymbol::SuperCall,
-            ContainsSymbol::This,
-        ]
-        .contains(&symbol)
-        {
-            return false;
-        }
-        self.parameters.contains(symbol) || self.body.contains(symbol)
     }
 }
 

--- a/boa_ast/src/function/class.rs
+++ b/boa_ast/src/function/class.rs
@@ -8,7 +8,7 @@ use crate::{
     property::{MethodDefinition, PropertyName},
     try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
-    ContainsSymbol, Declaration, StatementList, StatementListItem, ToStringEscaped,
+    Declaration, StatementList, ToStringEscaped,
 };
 use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 
@@ -74,26 +74,6 @@ impl Class {
     #[must_use]
     pub fn elements(&self) -> &[ClassElement] {
         &self.elements
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        matches!(self.name, Some(ref ident) if *ident == Sym::ARGUMENTS)
-            || matches!(self.super_ref, Some(ref expr) if expr.contains_arguments())
-            || self.elements.iter().any(ClassElement::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        if symbol == ContainsSymbol::ClassBody && !self.elements.is_empty() {
-            return true;
-        }
-        if symbol == ContainsSymbol::ClassHeritage {
-            return self.super_ref.is_some();
-        }
-
-        matches!(self.super_ref, Some(ref expr) if expr.contains(symbol))
-            || self.elements.iter().any(|elem| elem.contains(symbol))
     }
 }
 
@@ -448,47 +428,6 @@ pub enum ClassElement {
     PrivateStaticFieldDefinition(Sym, Option<Expression>),
     /// A static block, where a class can have initialization logic for its static fields.
     StaticBlock(StatementList),
-}
-
-impl ClassElement {
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            // Skipping function since they must not have names
-            Self::MethodDefinition(name, _) | Self::StaticMethodDefinition(name, _) => {
-                name.contains_arguments()
-            }
-            Self::FieldDefinition(name, Some(init))
-            | Self::StaticFieldDefinition(name, Some(init)) => {
-                name.contains_arguments() || init.contains_arguments()
-            }
-            Self::PrivateFieldDefinition(_, Some(init))
-            | Self::PrivateStaticFieldDefinition(_, Some(init)) => init.contains_arguments(),
-            Self::StaticBlock(statement_list) => statement_list
-                .statements()
-                .iter()
-                .any(StatementListItem::contains_arguments),
-            _ => false,
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            // Skipping function since they must not have names
-            Self::MethodDefinition(name, _) | Self::StaticMethodDefinition(name, _) => {
-                name.contains(symbol)
-            }
-            Self::FieldDefinition(name, Some(init))
-            | Self::StaticFieldDefinition(name, Some(init)) => {
-                name.contains(symbol) || init.contains(symbol)
-            }
-            Self::PrivateFieldDefinition(_, Some(init))
-            | Self::PrivateStaticFieldDefinition(_, Some(init)) => init.contains(symbol),
-            Self::StaticBlock(_statement_list) => false,
-            _ => false,
-        }
-    }
 }
 
 impl VisitWith for ClassElement {

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -4,7 +4,6 @@ use crate::{
     pattern::Pattern,
     try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
-    ContainsSymbol,
 };
 use bitflags::bitflags;
 use boa_interner::{Interner, Sym, ToInternedString};
@@ -123,46 +122,6 @@ impl FormalParameterList {
     #[must_use]
     pub fn has_arguments(&self) -> bool {
         self.flags.contains(FormalParameterListFlags::HAS_ARGUMENTS)
-    }
-
-    /// Check if the any of the parameters contains a yield expression.
-    #[must_use]
-    pub fn contains_yield_expression(&self) -> bool {
-        for parameter in self.parameters.iter() {
-            if parameter
-                .variable()
-                .contains(ContainsSymbol::YieldExpression)
-            {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Check if the any of the parameters contains a await expression.
-    #[must_use]
-    pub fn contains_await_expression(&self) -> bool {
-        for parameter in self.parameters.iter() {
-            if parameter
-                .variable()
-                .contains(ContainsSymbol::AwaitExpression)
-            {
-                return true;
-            }
-        }
-        false
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.parameters
-            .iter()
-            .any(FormalParameter::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.parameters.iter().any(|param| param.contains(symbol))
     }
 }
 
@@ -300,15 +259,6 @@ impl FormalParameter {
     #[must_use]
     pub fn is_identifier(&self) -> bool {
         matches!(&self.variable.binding(), Binding::Identifier(_))
-    }
-
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.variable.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.variable.contains(symbol)
     }
 }
 

--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -63,6 +63,7 @@ pub mod declaration;
 pub mod expression;
 pub mod function;
 pub mod keyword;
+pub mod operations;
 pub mod pattern;
 pub mod property;
 pub mod statement;
@@ -79,32 +80,6 @@ pub use self::{
     statement::Statement,
     statement_list::{StatementList, StatementListItem},
 };
-
-/// Represents all the possible symbols searched for by the [`Contains`][contains] operation.
-///
-/// [contains]: https://tc39.es/ecma262/#sec-syntax-directed-operations-contains
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ContainsSymbol {
-    /// A super property access (`super.prop`).
-    SuperProperty,
-    /// A super constructor call (`super(args)`).
-    SuperCall,
-    /// A yield expression (`yield 5`).
-    YieldExpression,
-    /// An await expression (`await 4`).
-    AwaitExpression,
-    /// The new target expression (`new.target`).
-    NewTarget,
-    /// The body of a class definition.
-    ClassBody,
-    /// The super class of a class definition.
-    ClassHeritage,
-    /// A this expression (`this`).
-    This,
-    /// A method definition.
-    MethodDefinition,
-}
 
 /// Utility to join multiple Nodes into a single string.
 fn join_nodes<N>(interner: &Interner, nodes: &[N]) -> String

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -1,0 +1,261 @@
+//! Definitions of various **Syntax-Directed Operations** used in the [spec].
+//!
+//! [spec]: https://tc39.es/ecma262/#sec-syntax-directed-operations
+
+use core::ops::ControlFlow;
+
+use boa_interner::Sym;
+
+use crate::{
+    expression::{access::SuperPropertyAccess, Await, Identifier, SuperCall, Yield},
+    function::{
+        ArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement, Function, Generator,
+    },
+    property::{MethodDefinition, PropertyDefinition},
+    visitor::{VisitWith, Visitor},
+    Expression,
+};
+
+/// Represents all the possible symbols searched for by the [`Contains`][contains] operation.
+///
+/// [contains]: https://tc39.es/ecma262/#sec-syntax-directed-operations-contains
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ContainsSymbol {
+    /// A node with the `super` keyword (`super(args)` or `super.prop`).
+    Super,
+    /// A super property access (`super.prop`).
+    SuperProperty,
+    /// A super constructor call (`super(args)`).
+    SuperCall,
+    /// A yield expression (`yield 5`).
+    YieldExpression,
+    /// An await expression (`await 4`).
+    AwaitExpression,
+    /// The new target expression (`new.target`).
+    NewTarget,
+    /// The body of a class definition.
+    ClassBody,
+    /// The super class of a class definition.
+    ClassHeritage,
+    /// A this expression (`this`).
+    This,
+    /// A method definition.
+    MethodDefinition,
+}
+
+/// Returns `true` if the node contains the given symbol.
+///
+/// More information:
+///  - [ECMAScript specification][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
+#[must_use]
+pub fn contains<N>(node: &N, symbol: ContainsSymbol) -> bool
+where
+    N: VisitWith,
+{
+    struct ContainsVisitor(ContainsSymbol);
+    impl<'ast> Visitor<'ast> for ContainsVisitor {
+        type BreakTy = ();
+
+        fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
+            if !node.elements().is_empty() && self.0 == ContainsSymbol::ClassBody {
+                return ControlFlow::Break(());
+            }
+
+            if node.super_ref().is_some() && self.0 == ContainsSymbol::ClassHeritage {
+                return ControlFlow::Break(());
+            }
+
+            node.visit_with(self)
+        }
+
+        // `ComputedPropertyContains`: https://tc39.es/ecma262/#sec-static-semantics-computedpropertycontains
+        fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
+            match node {
+                ClassElement::MethodDefinition(name, _)
+                | ClassElement::StaticMethodDefinition(name, _)
+                | ClassElement::FieldDefinition(name, _)
+                | ClassElement::StaticFieldDefinition(name, _) => name.visit_with(self),
+                _ => ControlFlow::Continue(()),
+            }
+        }
+
+        fn visit_property_definition(
+            &mut self,
+            node: &'ast PropertyDefinition,
+        ) -> ControlFlow<Self::BreakTy> {
+            if let PropertyDefinition::MethodDefinition(name, _) = node {
+                if self.0 == ContainsSymbol::MethodDefinition {
+                    return ControlFlow::Break(());
+                }
+                return name.visit_with(self);
+            }
+
+            node.visit_with(self)
+        }
+
+        fn visit_arrow_function(
+            &mut self,
+            node: &'ast ArrowFunction,
+        ) -> ControlFlow<Self::BreakTy> {
+            if ![
+                ContainsSymbol::NewTarget,
+                ContainsSymbol::SuperProperty,
+                ContainsSymbol::SuperCall,
+                ContainsSymbol::Super,
+                ContainsSymbol::This,
+            ]
+            .contains(&self.0)
+            {
+                return ControlFlow::Continue(());
+            }
+
+            node.visit_with(self)
+        }
+
+        fn visit_super_property_access(
+            &mut self,
+            node: &'ast SuperPropertyAccess,
+        ) -> ControlFlow<Self::BreakTy> {
+            if [ContainsSymbol::SuperProperty, ContainsSymbol::Super].contains(&self.0) {
+                return ControlFlow::Break(());
+            }
+            node.visit_with(self)
+        }
+
+        fn visit_super_call(&mut self, node: &'ast SuperCall) -> ControlFlow<Self::BreakTy> {
+            if [ContainsSymbol::SuperCall, ContainsSymbol::Super].contains(&self.0) {
+                return ControlFlow::Break(());
+            }
+            node.visit_with(self)
+        }
+
+        fn visit_yield(&mut self, node: &'ast Yield) -> ControlFlow<Self::BreakTy> {
+            if self.0 == ContainsSymbol::YieldExpression {
+                return ControlFlow::Break(());
+            }
+
+            node.visit_with(self)
+        }
+
+        fn visit_await(&mut self, node: &'ast Await) -> ControlFlow<Self::BreakTy> {
+            if self.0 == ContainsSymbol::AwaitExpression {
+                return ControlFlow::Break(());
+            }
+
+            node.visit_with(self)
+        }
+
+        fn visit_expression(&mut self, node: &'ast Expression) -> ControlFlow<Self::BreakTy> {
+            if node == &Expression::This && self.0 == ContainsSymbol::This {
+                return ControlFlow::Break(());
+            }
+            if node == &Expression::NewTarget && self.0 == ContainsSymbol::NewTarget {
+                return ControlFlow::Break(());
+            }
+            node.visit_with(self)
+        }
+    }
+
+    match node.visit_with(&mut ContainsVisitor(symbol)) {
+        ControlFlow::Continue(_) => false,
+        ControlFlow::Break(_) => true,
+    }
+}
+
+/// Returns true if the node contains an identifier reference with name `arguments`.
+///
+/// More information:
+///  - [ECMAScript specification][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
+#[must_use]
+pub fn contains_arguments<N>(node: &N) -> bool
+where
+    N: VisitWith,
+{
+    struct ContainsArgsVisitor;
+
+    impl<'ast> Visitor<'ast> for ContainsArgsVisitor {
+        type BreakTy = ();
+
+        fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
+            if node.sym() == Sym::ARGUMENTS {
+                ControlFlow::Break(())
+            } else {
+                ControlFlow::Continue(())
+            }
+        }
+
+        fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
+            ControlFlow::Continue(())
+        }
+
+        fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
+            match node {
+                ClassElement::MethodDefinition(name, _)
+                | ClassElement::StaticMethodDefinition(name, _) => return name.visit_with(self),
+                _ => {}
+            }
+            node.visit_with(self)
+        }
+
+        fn visit_property_definition(
+            &mut self,
+            node: &'ast PropertyDefinition,
+        ) -> ControlFlow<Self::BreakTy> {
+            if let PropertyDefinition::MethodDefinition(name, _) = node {
+                name.visit_with(self)
+            } else {
+                node.visit_with(self)
+            }
+        }
+    }
+    match node.visit_with(&mut ContainsArgsVisitor) {
+        ControlFlow::Continue(_) => false,
+        ControlFlow::Break(_) => true,
+    }
+}
+
+/// Returns `true` if `method` has a super call in its parameters or body.
+#[must_use]
+pub fn has_direct_super(method: &MethodDefinition) -> bool {
+    match method {
+        MethodDefinition::Get(f) | MethodDefinition::Set(f) | MethodDefinition::Ordinary(f) => {
+            contains(f, ContainsSymbol::SuperCall)
+        }
+        MethodDefinition::Generator(f) => contains(f, ContainsSymbol::SuperCall),
+        MethodDefinition::AsyncGenerator(f) => contains(f, ContainsSymbol::SuperCall),
+        MethodDefinition::Async(f) => contains(f, ContainsSymbol::SuperCall),
+    }
+}

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -46,8 +46,7 @@ pub enum ContainsSymbol {
 
 /// Returns `true` if the node contains the given symbol.
 ///
-/// More information:
-///  - [ECMAScript specification][spec]
+/// This is equivalent to the [`Contains`][spec] syntax operation in the spec.
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
 #[must_use]
@@ -55,7 +54,10 @@ pub fn contains<N>(node: &N, symbol: ContainsSymbol) -> bool
 where
     N: VisitWith,
 {
+    /// Visitor used by the function to search for a specific symbol in a node.
+    #[derive(Debug, Clone, Copy)]
     struct ContainsVisitor(ContainsSymbol);
+
     impl<'ast> Visitor<'ast> for ContainsVisitor {
         type BreakTy = ();
 
@@ -175,16 +177,12 @@ where
         }
     }
 
-    match node.visit_with(&mut ContainsVisitor(symbol)) {
-        ControlFlow::Continue(_) => false,
-        ControlFlow::Break(_) => true,
-    }
+    node.visit_with(&mut ContainsVisitor(symbol)).is_break()
 }
 
 /// Returns true if the node contains an identifier reference with name `arguments`.
 ///
-/// More information:
-///  - [ECMAScript specification][spec]
+/// This is equivalent to the [`ContainsArguments`][spec] syntax operation in the spec.
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
 #[must_use]
@@ -192,6 +190,8 @@ pub fn contains_arguments<N>(node: &N) -> bool
 where
     N: VisitWith,
 {
+    /// Visitor used by the function to search for an identifier with the name `arguments`.
+    #[derive(Debug, Clone, Copy)]
     struct ContainsArgsVisitor;
 
     impl<'ast> Visitor<'ast> for ContainsArgsVisitor {
@@ -241,13 +241,14 @@ where
             }
         }
     }
-    match node.visit_with(&mut ContainsArgsVisitor) {
-        ControlFlow::Continue(_) => false,
-        ControlFlow::Break(_) => true,
-    }
+    node.visit_with(&mut ContainsArgsVisitor).is_break()
 }
 
 /// Returns `true` if `method` has a super call in its parameters or body.
+///
+/// This is equivalent to the [`HasDirectSuper`][spec] syntax operation in the spec.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-hasdirectsuper
 #[must_use]
 pub fn has_direct_super(method: &MethodDefinition) -> bool {
     match method {

--- a/boa_ast/src/property.rs
+++ b/boa_ast/src/property.rs
@@ -7,8 +7,8 @@ use core::ops::ControlFlow;
 
 use super::{
     expression::{literal::Literal, Identifier},
-    function::{AsyncFunction, AsyncGenerator, FormalParameterList, Function, Generator},
-    ContainsSymbol, Expression, StatementList,
+    function::{AsyncFunction, AsyncGenerator, Function, Generator},
+    Expression,
 };
 
 /// Describes the definition of a property within an object literal.
@@ -77,43 +77,6 @@ pub enum PropertyDefinition {
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-CoverInitializedName
     CoverInitializedName(Identifier, Expression),
-}
-
-impl PropertyDefinition {
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            PropertyDefinition::IdentifierReference(ident) => *ident == Sym::ARGUMENTS,
-            PropertyDefinition::Property(name, expr) => {
-                name.contains_arguments() || expr.contains_arguments()
-            }
-            // Skipping definition since functions are excluded from the search
-            PropertyDefinition::MethodDefinition(name, _) => name.contains_arguments(),
-            PropertyDefinition::SpreadObject(expr) => expr.contains_arguments(),
-            PropertyDefinition::CoverInitializedName(ident, expr) => {
-                *ident == Sym::ARGUMENTS || expr.contains_arguments()
-            }
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            PropertyDefinition::IdentifierReference(_) => false,
-            PropertyDefinition::Property(name, expr) => {
-                name.contains(symbol) || expr.contains(symbol)
-            }
-            // Skipping definition since functions are excluded from the search
-            PropertyDefinition::MethodDefinition(_, _)
-                if symbol == ContainsSymbol::MethodDefinition =>
-            {
-                true
-            }
-            PropertyDefinition::MethodDefinition(name, _) => name.contains(symbol),
-            PropertyDefinition::SpreadObject(expr) => expr.contains(symbol),
-            PropertyDefinition::CoverInitializedName(_ident, expr) => expr.contains(symbol),
-        }
-    }
 }
 
 impl VisitWith for PropertyDefinition {
@@ -248,34 +211,6 @@ pub enum MethodDefinition {
     Async(AsyncFunction),
 }
 
-impl MethodDefinition {
-    /// Gets the body of the method.
-    #[must_use]
-    pub fn body(&self) -> &StatementList {
-        match self {
-            MethodDefinition::Get(expr)
-            | MethodDefinition::Set(expr)
-            | MethodDefinition::Ordinary(expr) => expr.body(),
-            MethodDefinition::Generator(expr) => expr.body(),
-            MethodDefinition::AsyncGenerator(expr) => expr.body(),
-            MethodDefinition::Async(expr) => expr.body(),
-        }
-    }
-
-    /// Gets the parameters of the method.
-    #[must_use]
-    pub fn parameters(&self) -> &FormalParameterList {
-        match self {
-            MethodDefinition::Get(expr)
-            | MethodDefinition::Set(expr)
-            | MethodDefinition::Ordinary(expr) => expr.parameters(),
-            MethodDefinition::Generator(expr) => expr.parameters(),
-            MethodDefinition::AsyncGenerator(expr) => expr.parameters(),
-            MethodDefinition::Async(expr) => expr.parameters(),
-        }
-    }
-}
-
 impl VisitWith for MethodDefinition {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
@@ -360,22 +295,6 @@ impl PropertyName {
             PropertyName::Literal(sym)
             | PropertyName::Computed(Expression::Literal(Literal::String(sym))) => Some(*sym),
             PropertyName::Computed(_) => None,
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            PropertyName::Literal(_) => false,
-            PropertyName::Computed(expr) => expr.contains_arguments(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            PropertyName::Literal(_) => false,
-            PropertyName::Computed(expr) => expr.contains(symbol),
         }
     }
 }

--- a/boa_ast/src/statement/block.rs
+++ b/boa_ast/src/statement/block.rs
@@ -1,8 +1,10 @@
 //! Block AST node.
 
-use super::Statement;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Identifier, ContainsSymbol, StatementList};
+use crate::{
+    expression::Identifier,
+    visitor::{VisitWith, Visitor, VisitorMut},
+    Statement, StatementList,
+};
 use boa_interner::{Interner, ToIndentedString};
 use core::ops::ControlFlow;
 
@@ -41,16 +43,6 @@ impl Block {
     #[must_use]
     pub fn lexically_declared_names(&self) -> Vec<(Identifier, bool)> {
         self.statements.lexically_declared_names()
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.statements.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.statements.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/if.rs
+++ b/boa_ast/src/statement/if.rs
@@ -1,8 +1,11 @@
 //! If statement
 
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, statement::Statement, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    statement::Statement,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -59,20 +62,6 @@ impl If {
             body: body.into(),
             else_node: else_node.map(Box::new),
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.condition.contains_arguments()
-            || self.body.contains_arguments()
-            || matches!(self.else_node, Some(ref stmt) if stmt.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.condition.contains(symbol)
-            || self.body.contains(symbol)
-            || matches!(self.else_node, Some(ref stmt) if stmt.contains(symbol))
     }
 }
 

--- a/boa_ast/src/statement/iteration/break.rs
+++ b/boa_ast/src/statement/iteration/break.rs
@@ -36,11 +36,6 @@ impl Break {
     pub fn label(&self) -> Option<Sym> {
         self.label
     }
-
-    #[inline]
-    pub(crate) fn contains_arguments(self) -> bool {
-        matches!(self.label, Some(label) if label == Sym::ARGUMENTS)
-    }
 }
 
 impl ToInternedString for Break {

--- a/boa_ast/src/statement/iteration/continue.rs
+++ b/boa_ast/src/statement/iteration/continue.rs
@@ -34,11 +34,6 @@ impl Continue {
     pub fn label(&self) -> Option<Sym> {
         self.label
     }
-
-    #[inline]
-    pub(crate) fn contains_arguments(self) -> bool {
-        matches!(self.label, Some(label) if label == Sym::ARGUMENTS)
-    }
 }
 
 impl ToInternedString for Continue {

--- a/boa_ast/src/statement/iteration/do_while_loop.rs
+++ b/boa_ast/src/statement/iteration/do_while_loop.rs
@@ -1,6 +1,9 @@
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, statement::Statement, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    statement::Statement,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -45,16 +48,6 @@ impl DoWhileLoop {
             body: body.into(),
             condition,
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.body.contains_arguments() || self.condition.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.body.contains(symbol) || self.condition.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/iteration/for_in_loop.rs
+++ b/boa_ast/src/statement/iteration/for_in_loop.rs
@@ -3,7 +3,6 @@ use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::Expression,
     statement::{iteration::IterableLoopInitializer, Statement},
-    ContainsSymbol,
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
@@ -54,20 +53,6 @@ impl ForInLoop {
     #[must_use]
     pub fn body(&self) -> &Statement {
         &self.body
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.initializer.contains_arguments()
-            || self.target.contains_arguments()
-            || self.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.initializer.contains(symbol)
-            || self.target.contains(symbol)
-            || self.body.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/iteration/for_loop.rs
+++ b/boa_ast/src/statement/iteration/for_loop.rs
@@ -4,7 +4,7 @@ use crate::{
     declaration::{LexicalDeclaration, VarDeclaration, Variable},
     expression::Identifier,
     statement::Statement,
-    ContainsSymbol, Expression,
+    Expression,
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
@@ -67,24 +67,6 @@ impl ForLoop {
     #[must_use]
     pub fn body(&self) -> &Statement {
         self.inner.body()
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        let inner = &self.inner;
-        matches!(inner.init, Some(ref init) if init.contains_arguments())
-            || matches!(inner.condition, Some(ref expr) if expr.contains_arguments())
-            || matches!(inner.final_expr, Some(ref expr) if expr.contains_arguments())
-            || inner.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        let inner = &self.inner;
-        matches!(inner.init, Some(ref init) if init.contains(symbol))
-            || matches!(inner.condition, Some(ref expr) if expr.contains(symbol))
-            || matches!(inner.final_expr, Some(ref expr) if expr.contains(symbol))
-            || inner.body.contains(symbol)
     }
 }
 
@@ -240,23 +222,6 @@ impl ForLoopInitializer {
                 .flat_map(Variable::idents)
                 .collect(),
             _ => Vec::new(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            Self::Var(var) => var.contains_arguments(),
-            Self::Lexical(lex) => lex.contains_arguments(),
-            Self::Expression(expr) => expr.contains_arguments(),
-        }
-    }
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            Self::Var(var) => var.contains(symbol),
-            Self::Lexical(lex) => lex.contains(symbol),
-            Self::Expression(expr) => expr.contains(symbol),
         }
     }
 }

--- a/boa_ast/src/statement/iteration/for_of_loop.rs
+++ b/boa_ast/src/statement/iteration/for_of_loop.rs
@@ -3,7 +3,6 @@ use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::Expression,
     statement::{iteration::IterableLoopInitializer, Statement},
-    ContainsSymbol,
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
@@ -73,18 +72,6 @@ impl ForOfLoop {
     #[must_use]
     pub fn r#await(&self) -> bool {
         self.r#await
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.init.contains_arguments()
-            || self.iterable.contains_arguments()
-            || self.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.init.contains(symbol) || self.iterable.contains(symbol) || self.body.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/iteration/mod.rs
+++ b/boa_ast/src/statement/iteration/mod.rs
@@ -25,9 +25,7 @@ pub use self::{
     while_loop::WhileLoop,
 };
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use boa_interner::{Interner, Sym, ToInternedString};
-
-use super::ContainsSymbol;
+use boa_interner::{Interner, ToInternedString};
 
 /// A `for-in`, `for-of` and `for-await-of` loop initializer.
 ///
@@ -67,28 +65,6 @@ impl IterableLoopInitializer {
         match self {
             Self::Let(binding) | Self::Const(binding) => binding.idents(),
             _ => Vec::new(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            Self::Identifier(ident) => *ident == Sym::ARGUMENTS,
-            Self::Access(access) => access.contains_arguments(),
-            Self::Var(bind) | Self::Let(bind) | Self::Const(bind) => bind.contains_arguments(),
-            Self::Pattern(pattern) => pattern.contains_arguments(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            Self::Var(declaration) | Self::Let(declaration) | Self::Const(declaration) => {
-                declaration.contains(symbol)
-            }
-            Self::Pattern(pattern) => pattern.contains(symbol),
-            Self::Access(access) => access.contains(symbol),
-            Self::Identifier(_) => false,
         }
     }
 }

--- a/boa_ast/src/statement/iteration/while_loop.rs
+++ b/boa_ast/src/statement/iteration/while_loop.rs
@@ -1,6 +1,9 @@
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, statement::Statement, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    statement::Statement,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -45,16 +48,6 @@ impl WhileLoop {
     #[must_use]
     pub fn body(&self) -> &Statement {
         &self.body
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.condition.contains_arguments() || self.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.condition.contains(symbol) || self.body.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/labelled.rs
+++ b/boa_ast/src/statement/labelled.rs
@@ -1,7 +1,9 @@
-use super::Statement;
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{function::Function, ContainsSymbol};
+use crate::{
+    function::Function,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+    Statement,
+};
 use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -28,22 +30,6 @@ impl LabelledItem {
         match self {
             LabelledItem::Function(f) => f.to_indented_string(interner, indentation),
             LabelledItem::Statement(stmt) => stmt.to_indented_string(interner, indentation),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            LabelledItem::Function(_) => false,
-            LabelledItem::Statement(stmt) => stmt.contains_arguments(),
-        }
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            LabelledItem::Function(_) => false,
-            LabelledItem::Statement(stmt) => stmt.contains(symbol),
         }
     }
 }
@@ -129,16 +115,6 @@ impl Labelled {
             interner.resolve_expect(self.label),
             self.item.to_indented_string(interner, indentation)
         )
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.label == Sym::ARGUMENTS || self.item.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.item.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -37,7 +37,6 @@ use rustc_hash::FxHashSet;
 use super::{
     declaration::{Binding, VarDeclaration},
     expression::{Expression, Identifier},
-    ContainsSymbol,
 };
 
 /// The `Statement` Parse Node.
@@ -226,69 +225,20 @@ impl Statement {
         }
     }
 
-    /// Returns true if the node contains a identifier reference named 'arguments'.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
-    // TODO: replace with a visitor
-    pub(crate) fn contains_arguments(&self) -> bool {
-        match self {
-            Self::Empty => false,
-            Self::Block(block) => block.contains_arguments(),
-            Self::Var(var) => var.contains_arguments(),
-            Self::Expression(expr) => expr.contains_arguments(),
-            Self::If(r#if) => r#if.contains_arguments(),
-            Self::DoWhileLoop(dowhile) => dowhile.contains_arguments(),
-            Self::WhileLoop(whileloop) => whileloop.contains_arguments(),
-            Self::ForLoop(forloop) => forloop.contains_arguments(),
-            Self::ForInLoop(forin) => forin.contains_arguments(),
-            Self::ForOfLoop(forof) => forof.contains_arguments(),
-            Self::Switch(switch) => switch.contains_arguments(),
-            Self::Continue(r#continue) => r#continue.contains_arguments(),
-            Self::Break(r#break) => r#break.contains_arguments(),
-            Self::Return(r#return) => r#return.contains_arguments(),
-            Self::Labelled(labelled) => labelled.contains_arguments(),
-            Self::Throw(throw) => throw.contains_arguments(),
-            Self::Try(r#try) => r#try.contains_arguments(),
-        }
-    }
-
-    /// Returns `true` if the node contains the given token.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
-    // TODO: replace with a visitor
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            Self::Empty | Self::Continue(_) | Self::Break(_) => false,
-            Self::Block(block) => block.contains(symbol),
-            Self::Var(var) => var.contains(symbol),
-            Self::Expression(expr) => expr.contains(symbol),
-            Self::If(r#if) => r#if.contains(symbol),
-            Self::DoWhileLoop(dowhile) => dowhile.contains(symbol),
-            Self::WhileLoop(whileloop) => whileloop.contains(symbol),
-            Self::ForLoop(forloop) => forloop.contains(symbol),
-            Self::ForInLoop(forin) => forin.contains(symbol),
-            Self::ForOfLoop(forof) => forof.contains(symbol),
-            Self::Switch(switch) => switch.contains(symbol),
-            Self::Return(r#return) => r#return.contains(symbol),
-            Self::Labelled(labelled) => labelled.contains(symbol),
-            Self::Throw(throw) => throw.contains(symbol),
-            Self::Try(r#try) => r#try.contains(symbol),
-        }
-    }
-
-    /// `IsLabelledFunction` static operation, as defined by the [spec].
-    ///
-    /// Returns `true` if this `Statement` is a labelled function.
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-islabelledfunction
     #[inline]
     #[must_use]
+    /// Abstract operation [`IsLabelledFunction`][spec].
+    ///
+    /// This recursively checks if this `Statement` is a labelled function, since adding
+    /// several labels in a function should not change the return value of the abstract operation:
+    ///
+    /// ```Javascript
+    /// l1: l2: l3: l4: function f(){ }
+    /// ```
+    ///
+    /// This should return `true` for that snippet.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-islabelledfunction
     pub fn is_labelled_function(&self) -> bool {
         match self {
             Self::Labelled(stmt) => match stmt.item() {

--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -225,8 +225,6 @@ impl Statement {
         }
     }
 
-    #[inline]
-    #[must_use]
     /// Abstract operation [`IsLabelledFunction`][spec].
     ///
     /// This recursively checks if this `Statement` is a labelled function, since adding
@@ -239,6 +237,8 @@ impl Statement {
     /// This should return `true` for that snippet.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-islabelledfunction
+    #[inline]
+    #[must_use]
     pub fn is_labelled_function(&self) -> bool {
         match self {
             Self::Labelled(stmt) => match stmt.item() {

--- a/boa_ast/src/statement/return.rs
+++ b/boa_ast/src/statement/return.rs
@@ -1,5 +1,8 @@
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, statement::Statement, ContainsSymbol};
+use crate::{
+    expression::Expression,
+    statement::Statement,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -37,15 +40,6 @@ impl Return {
     #[must_use]
     pub fn new(expression: Option<Expression>) -> Self {
         Self { target: expression }
-    }
-
-    pub(crate) fn contains_arguments(&self) -> bool {
-        matches!(self.target, Some(ref expr) if expr.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        matches!(self.target, Some(ref expr) if expr.contains(symbol))
     }
 }
 

--- a/boa_ast/src/statement/switch.rs
+++ b/boa_ast/src/statement/switch.rs
@@ -1,12 +1,14 @@
 //! Switch node.
 //!
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Expression, statement::Statement, StatementList};
+use crate::{
+    expression::Expression,
+    statement::Statement,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+    StatementList,
+};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
-
-use super::ContainsSymbol;
 
 /// A case clause inside a [`Switch`] statement, as defined by the [spec].
 ///
@@ -43,21 +45,6 @@ impl Case {
     #[must_use]
     pub fn body(&self) -> &StatementList {
         &self.body
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.condition.contains_arguments() || self.body.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.condition.contains(symbol)
-            || self
-                .body
-                .statements()
-                .iter()
-                .any(|stmt| stmt.contains(symbol))
     }
 }
 
@@ -134,18 +121,6 @@ impl Switch {
     #[must_use]
     pub fn default(&self) -> Option<&StatementList> {
         self.default.as_ref()
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.val.contains_arguments()
-            || self.cases.iter().any(Case::contains_arguments)
-            || matches!(self.default, Some(ref stmts) if stmts.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.val.contains(symbol) || self.cases.iter().any(|case| case.contains(symbol))
     }
 }
 

--- a/boa_ast/src/statement/throw.rs
+++ b/boa_ast/src/statement/throw.rs
@@ -1,5 +1,8 @@
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{statement::Statement, ContainsSymbol, Expression};
+use crate::{
+    statement::Statement,
+    visitor::{VisitWith, Visitor, VisitorMut},
+    Expression,
+};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -34,16 +37,6 @@ impl Throw {
     #[must_use]
     pub fn new(target: Expression) -> Self {
         Self { target }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.target.contains_arguments()
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.target.contains(symbol)
     }
 }
 

--- a/boa_ast/src/statement/try.rs
+++ b/boa_ast/src/statement/try.rs
@@ -5,12 +5,9 @@ use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     declaration::Binding,
     statement::{Block, Statement},
-    StatementListItem,
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
-
-use super::ContainsSymbol;
 
 /// The `try...catch` statement marks a block of statements to try and specifies a response
 /// should an exception be thrown.
@@ -77,20 +74,6 @@ impl Try {
             ErrorHandler::Finally(f) | ErrorHandler::Full(_, f) => Some(f),
             ErrorHandler::Catch(_) => None,
         }
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.block.contains_arguments()
-            || matches!(self.catch(), Some(catch) if catch.contains_arguments())
-            || matches!(self.finally(), Some(finally) if finally.contains_arguments())
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.block.contains(symbol)
-            || matches!(self.catch(), Some(catch) if catch.contains(symbol))
-            || matches!(self.finally(), Some(finally) if finally.contains(symbol))
     }
 }
 
@@ -181,24 +164,6 @@ impl Catch {
     pub fn block(&self) -> &Block {
         &self.block
     }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.block
-            .statement_list()
-            .statements()
-            .iter()
-            .any(StatementListItem::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.block
-            .statement_list()
-            .statements()
-            .iter()
-            .any(|stmt| stmt.contains(symbol))
-    }
 }
 
 impl ToIndentedString for Catch {
@@ -251,24 +216,6 @@ impl Finally {
     #[must_use]
     pub fn block(&self) -> &Block {
         &self.block
-    }
-
-    #[inline]
-    pub(crate) fn contains_arguments(&self) -> bool {
-        self.block
-            .statement_list()
-            .statements()
-            .iter()
-            .any(StatementListItem::contains_arguments)
-    }
-
-    #[inline]
-    pub(crate) fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.block
-            .statement_list()
-            .statements()
-            .iter()
-            .any(|stmt| stmt.contains(symbol))
     }
 }
 

--- a/boa_ast/src/statement_list.rs
+++ b/boa_ast/src/statement_list.rs
@@ -1,9 +1,12 @@
 //! Statement list node.
 
 use super::{declaration::Binding, Declaration};
-use crate::try_break;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
-use crate::{expression::Identifier, statement::Statement, ContainsSymbol};
+use crate::{
+    expression::Identifier,
+    statement::Statement,
+    try_break,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToIndentedString};
 use core::ops::ControlFlow;
 use rustc_hash::FxHashSet;
@@ -46,36 +49,6 @@ impl StatementListItem {
         match self {
             StatementListItem::Statement(stmt) => stmt.var_declared_names(vars),
             StatementListItem::Declaration(_) => {}
-        }
-    }
-
-    /// Returns true if the node contains a identifier reference named 'arguments'.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
-    #[inline]
-    #[must_use]
-    pub fn contains_arguments(&self) -> bool {
-        match self {
-            StatementListItem::Statement(stmt) => stmt.contains_arguments(),
-            StatementListItem::Declaration(decl) => decl.contains_arguments(),
-        }
-    }
-
-    /// Returns `true` if the node contains the given token.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
-    #[inline]
-    #[must_use]
-    pub fn contains(&self, symbol: ContainsSymbol) -> bool {
-        match self {
-            StatementListItem::Statement(stmt) => stmt.contains(symbol),
-            StatementListItem::Declaration(decl) => decl.contains(symbol),
         }
     }
 }
@@ -251,31 +224,6 @@ impl StatementList {
         }
 
         names
-    }
-
-    /// Returns true if the node contains a identifier reference named 'arguments'.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-containsarguments
-    #[inline]
-    pub fn contains_arguments(&self) -> bool {
-        self.statements
-            .iter()
-            .any(StatementListItem::contains_arguments)
-    }
-
-    /// Returns `true` if the node contains the given token.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
-    #[inline]
-    #[must_use]
-    pub fn contains(&self, symbol: ContainsSymbol) -> bool {
-        self.statements.iter().any(|stmt| stmt.contains(symbol))
     }
 }
 

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -315,7 +315,7 @@ impl Array {
         }
 
         // 4. Return ? IsArray(O).
-        o.is_array_abstract(context)
+        o.is_array_abstract()
     }
 
     /// `get Array [ @@species ]`
@@ -345,7 +345,7 @@ impl Array {
     ) -> JsResult<JsObject> {
         // 1. Let isArray be ? IsArray(originalArray).
         // 2. If isArray is false, return ? ArrayCreate(length).
-        if !original_array.is_array_abstract(context)? {
+        if !original_array.is_array_abstract()? {
             return Self::array_create(length, None, context);
         }
         // 3. Let C be ? Get(originalArray, "constructor").
@@ -566,10 +566,10 @@ impl Array {
     pub(crate) fn is_array(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        _context: &mut Context,
     ) -> JsResult<JsValue> {
         // 1. Return ? IsArray(arg).
-        args.get_or_undefined(0).is_array(context).map(Into::into)
+        args.get_or_undefined(0).is_array().map(Into::into)
     }
 
     /// `Array.of(...items)`
@@ -1788,7 +1788,7 @@ impl Array {
                 // iv. If depth > 0, then
                 if depth > 0 {
                     // 1. Set shouldFlatten to ? IsArray(element).
-                    should_flatten = element.is_array(context)?;
+                    should_flatten = element.is_array()?;
                 }
 
                 // v. If shouldFlatten is true

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -184,7 +184,7 @@ fn lookup_matcher(
             // Assignment deferred. See return statement below.
             // ii. If locale and noExtensionsLocale are not the same String value, then
             let maybe_ext = if locale_str.eq(&no_extensions_locale) {
-                "".into()
+                String::new()
             } else {
                 // 1. Let extension be the String value consisting of the substring of the Unicode
                 //    locale extension sequence within locale.
@@ -205,7 +205,7 @@ fn lookup_matcher(
     // 5. Return result.
     MatcherRecord {
         locale: default_locale(canonicalizer).to_string(),
-        extension: "".into(),
+        extension: String::new(),
     }
 }
 
@@ -312,7 +312,7 @@ fn unicode_extension_components(extension: &str) -> UniExtRecord {
             // ii. Set keyword to the Record { [[Key]]: subtag, [[Value]]: "" }.
             keyword = Some(Keyword {
                 key: subtag.into(),
-                value: "".into(),
+                value: String::new(),
             });
         // f. Else,
         } else {
@@ -562,9 +562,9 @@ fn resolve_locale(
 
     // 5. Let result be a new Record.
     let mut result = ResolveLocaleRecord {
-        locale: "".into(),
+        locale: String::new(),
         properties: FxHashMap::default(),
-        data_locale: "".into(),
+        data_locale: String::new(),
     };
 
     // 6. Set result.[[dataLocale]] to foundLocale.
@@ -607,7 +607,7 @@ fn resolve_locale(
         };
 
         // g. Let supportedExtensionAddition be "".
-        let mut supported_extension_addition = "".into();
+        let mut supported_extension_addition = String::new();
 
         // h. If r has an [[extension]] field, then
         if !r.extension.is_empty() {
@@ -682,7 +682,7 @@ fn resolve_locale(
                     value = options_value;
 
                     // b. Let supportedExtensionAddition be "".
-                    supported_extension_addition = "".into();
+                    supported_extension_addition = String::new();
                 }
             }
         }

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -234,7 +234,7 @@ impl Json {
         if let Some(obj) = val.as_object() {
             // a. Let isArray be ? IsArray(val).
             // b. If isArray is true, then
-            if obj.is_array_abstract(context)? {
+            if obj.is_array_abstract()? {
                 // i. Let I be 0.
                 // ii. Let len be ? LengthOfArrayLike(val).
                 // iii. Repeat, while I < len,
@@ -339,7 +339,7 @@ impl Json {
             } else {
                 // i. Let isArray be ? IsArray(replacer).
                 // ii. If isArray is true, then
-                if replacer_obj.is_array_abstract(context)? {
+                if replacer_obj.is_array_abstract()? {
                     // 1. Set PropertyList to a new empty List.
                     let mut property_set = indexmap::IndexSet::new();
 
@@ -562,7 +562,7 @@ impl Json {
                 // a. Let isArray be ? IsArray(value).
                 // b. If isArray is true, return ? SerializeJSONArray(state, value).
                 // c. Return ? SerializeJSONObject(state, value).
-                return if obj.is_array_abstract(context)? {
+                return if obj.is_array_abstract()? {
                     Ok(Some(Self::serialize_json_array(state, obj, context)?))
                 } else {
                     Ok(Some(Self::serialize_json_object(state, obj, context)?))

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -780,7 +780,7 @@ impl Object {
 
         //  4. Let isArray be ? IsArray(O).
         //  5. If isArray is true, let builtinTag be "Array".
-        let builtin_tag = if o.is_array_abstract(context)? {
+        let builtin_tag = if o.is_array_abstract()? {
             utf16!("Array")
         } else {
             // 6. Else if O has a [[ParameterMap]] internal slot, let builtinTag be "Arguments".

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -345,7 +345,7 @@ where
             k += 2;
 
             // vi. Let n be the number of leading 1 bits in B.
-            let n = leading_one_bits(b);
+            let n = b.leading_ones() as usize;
 
             // vii. If n = 0, then
             if n == 0 {
@@ -453,62 +453,9 @@ fn decode_hex_byte(high: u16, low: u16) -> Option<u8> {
     }
 }
 
-/// Counts the number of leading 1 bits in a given byte.
-#[inline]
-fn leading_one_bits(byte: u8) -> usize {
-    // This uses a value table for speed
-    if byte == u8::MAX {
-        8
-    } else if byte == 0b1111_1110 {
-        7
-    } else if byte & 0b1111_1100 == 0b1111_1100 {
-        6
-    } else if byte & 0b1111_1000 == 0b1111_1000 {
-        5
-    } else if byte & 0b1111_0000 == 0b1111_0000 {
-        4
-    } else if byte & 0b1110_0000 == 0b1110_0000 {
-        3
-    } else if byte & 0b1100_0000 == 0b1100_0000 {
-        2
-    } else if byte & 0b1000_0000 == 0b1000_0000 {
-        1
-    } else {
-        0
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Checks if the `leading_one_bits()` function works as expected.
-    #[test]
-    fn ut_leading_one_bits() {
-        assert_eq!(leading_one_bits(0b1111_1111), 8);
-        assert_eq!(leading_one_bits(0b1111_1110), 7);
-
-        assert_eq!(leading_one_bits(0b1111_1100), 6);
-        assert_eq!(leading_one_bits(0b1111_1101), 6);
-
-        assert_eq!(leading_one_bits(0b1111_1011), 5);
-        assert_eq!(leading_one_bits(0b1111_1000), 5);
-
-        assert_eq!(leading_one_bits(0b1111_0000), 4);
-        assert_eq!(leading_one_bits(0b1111_0111), 4);
-
-        assert_eq!(leading_one_bits(0b1110_0000), 3);
-        assert_eq!(leading_one_bits(0b1110_1111), 3);
-
-        assert_eq!(leading_one_bits(0b1100_0000), 2);
-        assert_eq!(leading_one_bits(0b1101_1111), 2);
-
-        assert_eq!(leading_one_bits(0b1000_0000), 1);
-        assert_eq!(leading_one_bits(0b1011_1111), 1);
-
-        assert_eq!(leading_one_bits(0b0000_0000), 0);
-        assert_eq!(leading_one_bits(0b0111_1111), 0);
-    }
 
     /// Checks that the `decode_byte()` function works as expected.
     #[test]

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -346,17 +346,17 @@ impl<'b> ByteCompiler<'b> {
 
     #[inline]
     fn emit_u64(&mut self, value: u64) {
-        self.code_block.code.extend(&value.to_ne_bytes());
+        self.code_block.code.extend(value.to_ne_bytes());
     }
 
     #[inline]
     fn emit_u32(&mut self, value: u32) {
-        self.code_block.code.extend(&value.to_ne_bytes());
+        self.code_block.code.extend(value.to_ne_bytes());
     }
 
     #[inline]
     fn emit_u16(&mut self, value: u16) {
-        self.code_block.code.extend(&value.to_ne_bytes());
+        self.code_block.code.extend(value.to_ne_bytes());
     }
 
     #[inline]
@@ -696,7 +696,7 @@ impl<'b> ByteCompiler<'b> {
                     }
                     PropertyAccessField::Expr(expr) => {
                         self.emit_opcode(Opcode::Super);
-                        self.compile_expr(&**expr, true)?;
+                        self.compile_expr(expr, true)?;
                         self.emit_opcode(Opcode::GetPropertyByValue);
                     }
                 },

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -728,7 +728,7 @@ Cannot both specify accessors and a value or writable attribute",
 impl AsRef<boa_gc::Cell<Object>> for JsObject {
     #[inline]
     fn as_ref(&self) -> &boa_gc::Cell<Object> {
-        &*self.inner
+        &self.inner
     }
 }
 

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -627,7 +627,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isarray
-    pub(crate) fn is_array_abstract(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn is_array_abstract(&self) -> JsResult<bool> {
         // Note: The spec specifies this function for JsValue.
         // It is implemented for JsObject for convenience.
 
@@ -644,7 +644,7 @@ impl JsObject {
             let (target, _) = proxy.try_data()?;
 
             // c. Return ? IsArray(target).
-            return target.is_array_abstract(context);
+            return target.is_array_abstract();
         }
 
         // 4. Return false.

--- a/boa_engine/src/syntax/lexer/cursor.rs
+++ b/boa_engine/src/syntax/lexer/cursor.rs
@@ -338,7 +338,7 @@ where
     #[inline]
     fn increment(&mut self, n: u32) -> Result<(), Error> {
         for _ in 0..n {
-            if None == self.next_byte()? {
+            if (self.next_byte()?).is_none() {
                 break;
             }
         }

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -6,11 +6,15 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        function_contains_super, name_in_lexically_declared_names, AllowYield, Cursor, ParseError,
-        ParseResult, TokenParser,
+        name_in_lexically_declared_names, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
     },
 };
-use boa_ast::{expression::Identifier, function::AsyncFunction, Keyword, Position, Punctuator};
+use boa_ast::{
+    expression::Identifier,
+    function::AsyncFunction,
+    operations::{contains, ContainsSymbol},
+    Keyword, Position, Punctuator,
+};
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use std::io::Read;
@@ -130,13 +134,15 @@ where
             params_start_position,
         )?;
 
-        if function_contains_super(&body, &params) {
+        let function = AsyncFunction::new(name, params, body);
+
+        if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
                 "invalid super usage".into(),
                 params_start_position,
             )));
         }
 
-        Ok(AsyncFunction::new(name, params, body))
+        Ok(function)
     }
 }

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -15,11 +15,15 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        function_contains_super, name_in_lexically_declared_names, Cursor, ParseError, ParseResult,
-        TokenParser,
+        name_in_lexically_declared_names, Cursor, ParseError, ParseResult, TokenParser,
     },
 };
-use boa_ast::{expression::Identifier, function::Function, Keyword, Position, Punctuator};
+use boa_ast::{
+    expression::Identifier,
+    function::Function,
+    operations::{contains, ContainsSymbol},
+    Keyword, Position, Punctuator,
+};
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use std::io::Read;
@@ -124,13 +128,15 @@ where
             params_start_position,
         )?;
 
-        if function_contains_super(&body, &params) {
+        let function = Function::new(name, params, body);
+
+        if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
                 "invalid super usage".into(),
                 params_start_position,
             )));
         }
 
-        Ok(Function::new(name, params, body))
+        Ok(function)
     }
 }

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
@@ -15,11 +15,15 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        function_contains_super, name_in_lexically_declared_names, Cursor, ParseError, ParseResult,
-        TokenParser,
+        name_in_lexically_declared_names, Cursor, ParseError, ParseResult, TokenParser,
     },
 };
-use boa_ast::{expression::Identifier, function::Generator, Position, Punctuator};
+use boa_ast::{
+    expression::Identifier,
+    function::Generator,
+    operations::{contains, ContainsSymbol},
+    Position, Punctuator,
+};
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use std::io::Read;
@@ -126,13 +130,15 @@ where
             params_start_position,
         )?;
 
-        if function_contains_super(&body, &params) {
+        let function = Generator::new(name, params, body);
+
+        if contains(&function, ContainsSymbol::Super) {
             return Err(ParseError::lex(LexError::Syntax(
                 "invalid super usage".into(),
                 params_start_position,
             )));
         }
 
-        Ok(Generator::new(name, params, body))
+        Ok(function)
     }
 }

--- a/boa_engine/src/syntax/parser/expression/primary/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/mod.rs
@@ -46,6 +46,7 @@ use boa_ast::{
         Call, Identifier, New,
     },
     function::{FormalParameter, FormalParameterList},
+    operations::{contains, ContainsSymbol},
     pattern::{ArrayPatternElement, ObjectPatternElement, Pattern},
     Keyword, Punctuator, Span,
 };
@@ -467,7 +468,7 @@ where
             }
         }
 
-        if parameters.contains_yield_expression() {
+        if contains(&parameters, ContainsSymbol::YieldExpression) {
             return Err(ParseError::general(
                 "yield expression is not allowed in formal parameter list of arrow function",
                 start_span.start(),

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -992,13 +992,13 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isarray
-    pub(crate) fn is_array(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn is_array(&self) -> JsResult<bool> {
         // Note: The spec specifies this function for JsValue.
         // The main part of the function is implemented for JsObject.
 
         // 1. If Type(argument) is not Object, return false.
         if let Some(object) = self.as_object() {
-            object.is_array_abstract(context)
+            object.is_array_abstract()
         }
         // 4. Return false.
         else {

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -521,6 +521,7 @@ pub(crate) fn create_function_object(
         Function::Async {
             code,
             environments: context.realm.environments.clone(),
+            home_object: None,
             promise_capability,
         }
     } else {
@@ -626,6 +627,7 @@ pub(crate) fn create_generator_function_object(
         let function = Function::AsyncGenerator {
             code,
             environments: context.realm.environments.clone(),
+            home_object: None,
         };
         JsObject::from_proto_and_data(
             function_prototype,
@@ -635,6 +637,7 @@ pub(crate) fn create_generator_function_object(
         let function = Function::Generator {
             code,
             environments: context.realm.environments.clone(),
+            home_object: None,
         };
         JsObject::from_proto_and_data(function_prototype, ObjectData::generator_function(function))
     };
@@ -831,6 +834,7 @@ impl JsObject {
                 code,
                 environments,
                 promise_capability,
+                ..
             } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
@@ -949,7 +953,9 @@ impl JsObject {
 
                 Ok(promise.into())
             }
-            Function::Generator { code, environments } => {
+            Function::Generator {
+                code, environments, ..
+            } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
                 drop(object);
@@ -1084,7 +1090,9 @@ impl JsObject {
 
                 Ok(generator.into())
             }
-            Function::AsyncGenerator { code, environments } => {
+            Function::AsyncGenerator {
+                code, environments, ..
+            } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
                 drop(object);

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -379,7 +379,7 @@ impl Test {
         for include in self.includes.iter() {
             context
                 .eval(
-                    &harness
+                    harness
                         .includes
                         .get(include)
                         .ok_or_else(|| format!("could not find the {include} include file."))?

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -187,7 +187,7 @@ fn update_gh_pages_repo(path: &Path, verbose: u8) {
 
         // We run the command to pull the gh-pages branch: git -C ../gh-pages/ pull origin
         Command::new("git")
-            .args(&["-C", "../gh-pages", "pull", "--ff-only"])
+            .args(["-C", "../gh-pages", "pull", "--ff-only"])
             .output()
             .expect("could not update GitHub Pages");
 


### PR DESCRIPTION
This Pull Request replaces `contains`, `contains_arguments`, `has_direct_super` and `function_contains_super` with visitors. (~1000 removed lines!)

Also, the new visitor implementation caught a bug where we weren't setting the home object of async functions, generators and async generators for methods of classes, which caused a stack overflow on `super` calls, and I think that's pretty cool!

Next is `var_declared_names`, `lexically_declared_names` and friends, which will be on another PR.