### PR TITLE
[Merged by Bors] - Rewrite some patterns with let-else and ok_or_else

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 [workspace.package]
 edition = "2021"
 version = "0.16.0"
-rust-version = "1.64"
+rust-version = "1.65"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
 license = "Unlicense/MIT"

--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -49,11 +49,7 @@
     nonstandard_style,
     missing_docs
 )]
-#![allow(
-    clippy::module_name_repetitions,
-    clippy::too_many_lines,
-    rustdoc::missing_doc_code_examples
-)]
+#![allow(clippy::module_name_repetitions, clippy::too_many_lines)]
 
 mod position;
 mod punctuator;

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -149,13 +149,10 @@ impl JsBigInt {
 
     #[inline]
     pub fn pow(x: &Self, y: &Self) -> JsResult<Self> {
-        let y = if let Some(y) = y.inner.to_biguint() {
-            y
-        } else {
-            return Err(JsNativeError::range()
-                .with_message("BigInt negative exponent")
-                .into());
-        };
+        let y = y
+            .inner
+            .to_biguint()
+            .ok_or_else(|| JsNativeError::range().with_message("BigInt negative exponent"))?;
 
         let num_bits = (x.inner.bits() as f64
             * y.to_f64().expect("Unable to convert from BigUInt to f64"))

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -300,9 +300,7 @@ impl Array {
     /// by `Array.prototype.concat`.
     fn is_concat_spreadable(o: &JsValue, context: &mut Context) -> JsResult<bool> {
         // 1. If Type(O) is not Object, return false.
-        let o = if let Some(o) = o.as_object() {
-            o
-        } else {
+        let Some(o) = o.as_object() else {
             return Ok(false);
         };
 
@@ -461,9 +459,7 @@ impl Array {
                 let next = iterator_record.step(context)?;
 
                 // iv. If next is false, then
-                let next = if let Some(next) = next {
-                    next
-                } else {
+                let Some(next) = next else {
                     // 1. Perform ? Set(A, "length", 𝔽(k), true).
                     a.set("length", k, true, context)?;
 

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -508,13 +508,9 @@ impl Date {
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, throw a TypeError exception.
-        let o = if let Some(o) = this.as_object() {
-            o
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message("Date.prototype[@@toPrimitive] called on non object")
-                .into());
-        };
+        let o = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message("Date.prototype[@@toPrimitive] called on non object")
+        })?;
 
         let hint = args.get_or_undefined(0);
 
@@ -908,25 +904,13 @@ impl Date {
         }
 
         // 3. Let y be ? ToNumber(year).
-        let y = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
+        let y = args.get_or_undefined(0).to_number(context)?;
 
         // 4. If month is not present, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-        let m = if let Some(m) = args.get(1) {
-            Some(m.to_number(context)?)
-        } else {
-            None
-        };
+        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 5. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = if let Some(dt) = args.get(2) {
-            Some(dt.to_number(context)?)
-        } else {
-            None
-        };
+        let dt = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
         t.set_components(false, Some(y), m, dt, None, None, None, None);
@@ -965,25 +949,13 @@ impl Date {
             .to_number(context)?;
 
         // 3. If min is not present, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-        let m = if let Some(m) = args.get(1) {
-            Some(m.to_number(context)?)
-        } else {
-            None
-        };
+        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 4. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let sec = if let Some(sec) = args.get(2) {
-            Some(sec.to_number(context)?)
-        } else {
-            None
-        };
+        let sec = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 5. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = if let Some(milli) = args.get(3) {
-            Some(milli.to_number(context)?)
-        } else {
-            None
-        };
+        let milli = args.get(3).map(|v| v.to_number(context)).transpose()?;
 
         // 6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
         t.set_components(false, None, None, None, Some(h), m, sec, milli);
@@ -1062,18 +1034,10 @@ impl Date {
             .to_number(context)?;
 
         // 3. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let s = if let Some(s) = args.get(1) {
-            Some(s.to_number(context)?)
-        } else {
-            None
-        };
+        let s = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 4. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = if let Some(milli) = args.get(2) {
-            Some(milli.to_number(context)?)
-        } else {
-            None
-        };
+        let milli = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
         t.set_components(false, None, None, None, None, Some(m), s, milli);
@@ -1110,11 +1074,7 @@ impl Date {
             .to_number(context)?;
 
         // 3. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = if let Some(date) = args.get(1) {
-            Some(date.to_number(context)?)
-        } else {
-            None
-        };
+        let dt = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
         t.set_components(false, None, Some(m), dt, None, None, None, None);
@@ -1155,11 +1115,7 @@ impl Date {
             .to_number(context)?;
 
         // 3. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = if let Some(milli) = args.get(1) {
-            Some(milli.to_number(context)?)
-        } else {
-            None
-        };
+        let milli = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
         t.set_components(false, None, None, None, None, None, Some(s), milli);
@@ -1341,18 +1297,10 @@ impl Date {
             .to_number(context)?;
 
         // 4. If month is not present, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-        let m = if let Some(m) = args.get(1) {
-            Some(m.to_number(context)?)
-        } else {
-            None
-        };
+        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 5. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = if let Some(dt) = args.get(2) {
-            Some(dt.to_number(context)?)
-        } else {
-            None
-        };
+        let dt = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
         t.set_components(true, Some(y), m, dt, None, None, None, None);
@@ -1395,25 +1343,13 @@ impl Date {
             .to_number(context)?;
 
         // 3. If min is not present, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-        let m = if let Some(m) = args.get(1) {
-            Some(m.to_number(context)?)
-        } else {
-            None
-        };
+        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 4. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let sec = if let Some(s) = args.get(2) {
-            Some(s.to_number(context)?)
-        } else {
-            None
-        };
+        let sec = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 5. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let ms = if let Some(ms) = args.get(3) {
-            Some(ms.to_number(context)?)
-        } else {
-            None
-        };
+        let ms = args.get(3).map(|v| v.to_number(context)).transpose()?;
 
         // 6. Let newDate be MakeDate(Day(t), MakeTime(h, m, s, milli)).
         t.set_components(true, None, None, None, Some(h), m, sec, ms);
@@ -1493,21 +1429,13 @@ impl Date {
 
         // 3. If sec is not present, let s be SecFromTime(t).
         // 4. Else,
-        let s = if let Some(s) = args.get(1) {
-            // a. Let s be ? ToNumber(sec).
-            Some(s.to_number(context)?)
-        } else {
-            None
-        };
+        // a. Let s be ? ToNumber(sec).
+        let s = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 5. If ms is not present, let milli be msFromTime(t).
         // 6. Else,
-        let milli = if let Some(ms) = args.get(2) {
-            // a. Let milli be ? ToNumber(ms).
-            Some(ms.to_number(context)?)
-        } else {
-            None
-        };
+        // a. Let milli be ? ToNumber(ms).
+        let milli = args.get(2).map(|v| v.to_number(context)).transpose()?;
 
         // 7. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
         t.set_components(true, None, None, None, None, Some(m), s, milli);
@@ -1549,12 +1477,8 @@ impl Date {
 
         // 3. If date is not present, let dt be DateFromTime(t).
         // 4. Else,
-        let dt = if let Some(dt) = args.get(1) {
-            // a. Let dt be ? ToNumber(date).
-            Some(dt.to_number(context)?)
-        } else {
-            None
-        };
+        // a. Let dt be ? ToNumber(date).
+        let dt = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 5. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
         t.set_components(true, None, Some(m), dt, None, None, None, None);
@@ -1596,12 +1520,8 @@ impl Date {
 
         // 3. If ms is not present, let milli be msFromTime(t).
         // 4. Else,
-        let milli = if let Some(milli) = args.get(1) {
-            // a. Let milli be ? ToNumber(ms).
-            Some(milli.to_number(context)?)
-        } else {
-            None
-        };
+        // a. Let milli be ? ToNumber(ms).
+        let milli = args.get(1).map(|v| v.to_number(context)).transpose()?;
 
         // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
         t.set_components(true, None, None, None, None, None, Some(s), milli);
@@ -1841,9 +1761,7 @@ impl Date {
         // This method is implementation-defined and discouraged, so we just require the same format as the string
         // constructor.
 
-        let date = if let Some(arg) = args.get(0) {
-            arg
-        } else {
+        let Some(date) = args.get(0) else {
             return Ok(JsValue::nan());
         };
 

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -170,14 +170,10 @@ impl Error {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
-        let o = if let Some(o) = this.as_object() {
-            o
         // 2. If Type(O) is not Object, throw a TypeError exception.
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message("'this' is not an Object")
-                .into());
-        };
+        let o = this
+            .as_object()
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not an Object"))?;
 
         // 3. Let name be ? Get(O, "name").
         let name = o.get(js_string!("name"), context)?;

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -77,9 +77,7 @@ impl Eval {
         debug_assert!(direct || !strict);
 
         // 2. If Type(x) is not String, return x.
-        let x = if let Some(x) = x.as_string() {
-            x.clone()
-        } else {
+        let Some(x) = x.as_string() else {
             return Ok(x.clone());
         };
 

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -841,15 +841,9 @@ impl BuiltInFunctionObject {
             }
         };
 
-        let name = if let Some(name) = name {
-            if name.is_empty() {
-                "anonymous".into()
-            } else {
-                name
-            }
-        } else {
-            "anonymous".into()
-        };
+        let name = name
+            .filter(|n| !n.is_empty())
+            .unwrap_or_else(|| "anonymous".into());
 
         match function {
             Function::Native { .. } | Function::Closure { .. } | Function::Ordinary { .. } => {

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -233,10 +233,8 @@ impl AsyncFromSyncIterator {
         // 10. IfAbruptRejectPromise(result, promiseCapability).
         if_abrupt_reject_promise!(result, promise_capability, context);
 
-        // 11. If Type(result) is not Object, then
-        let result = if let Some(result) = result.as_object() {
-            result
-        } else {
+        let Some(result) = result.as_object() else {
+            // 11. If Type(result) is not Object, then
             // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
             promise_capability
                 .reject()
@@ -333,10 +331,8 @@ impl AsyncFromSyncIterator {
         // 10. IfAbruptRejectPromise(result, promiseCapability).
         if_abrupt_reject_promise!(result, promise_capability, context);
 
-        // 11. If Type(result) is not Object, then
-        let result = if let Some(result) = result.as_object() {
-            result
-        } else {
+        let Some(result) = result.as_object() else {
+            // 11. If Type(result) is not Object, then
             // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
             promise_capability
                 .reject()

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -540,16 +540,14 @@ pub(crate) fn add_entries_from_iterable(
 
         // b. If next is false, return target.
         // c. Let nextItem be ? IteratorValue(next).
-        let next_item = if let Some(next) = next {
-            next.value(context)?
-        } else {
+        let Some(next_item) = next else {
             return Ok(target.clone().into());
         };
 
-        let next_item = if let Some(obj) = next_item.as_object() {
-            obj
-        // d. If Type(nextItem) is not Object, then
-        } else {
+        let next_item = next_item.value(context)?;
+
+        let Some(next_item) = next_item.as_object() else {
+            // d. If Type(nextItem) is not Object, then
             // i. Let error be ThrowCompletion(a newly created TypeError object).
             let err = Err(JsNativeError::typ()
                 .with_message("cannot get key and value from primitive item of `iterable`")

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -635,9 +635,7 @@ impl Object {
             }
         };
 
-        let obj = if let Some(obj) = o.as_object() {
-            obj
-        } else {
+        let Some(obj) = o.as_object() else {
             // 3. If Type(O) is not Object, return O.
             return Ok(o);
         };

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -1268,23 +1268,21 @@ impl Promise {
                     return Ok(JsValue::Undefined);
                 }
 
-                let then = if let Some(resolution) = resolution.as_object() {
-                    // 9. Let then be Completion(Get(resolution, "then")).
-                    resolution.get("then", context)
-                } else {
+                let Some(then) = resolution.as_object() else {
                     // 8. If Type(resolution) is not Object, then
                     //   a. Perform FulfillPromise(promise, resolution).
                     promise
-                        .borrow_mut()
-                        .as_promise_mut()
-                        .expect("Expected promise to be a Promise")
-                        .fulfill_promise(resolution, context)?;
+                    .borrow_mut()
+                    .as_promise_mut()
+                    .expect("Expected promise to be a Promise")
+                    .fulfill_promise(resolution, context)?;
 
                     //   b. Return undefined.
                     return Ok(JsValue::Undefined);
                 };
 
-                let then_action = match then {
+                // 9. Let then be Completion(Get(resolution, "then")).
+                let then_action = match then.get("then", context) {
                     // 10. If then is an abrupt completion, then
                     Err(e) => {
                         //   a. Perform RejectPromise(promise, then.[[Value]]).
@@ -1741,9 +1739,7 @@ impl Promise {
         let promise = this;
 
         // 2. If Type(promise) is not Object, throw a TypeError exception.
-        let promise_obj = if let Some(p) = promise.as_object() {
-            p
-        } else {
+        let Some(promise_obj) = promise.as_object() else {
             return Err(JsNativeError::typ()
                 .with_message("finally called with a non-object promise")
                 .into());

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1045,13 +1045,10 @@ impl RegExp {
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
-        let rx = if let Some(rx) = this.as_object() {
-            rx
-        } else {
-            return Err(JsNativeError::typ()
+        let rx = this.as_object().ok_or_else(|| {
+            JsNativeError::typ()
                 .with_message("RegExp.prototype.match method called on incompatible value")
-                .into());
-        };
+        })?;
 
         // 3. Let S be ? ToString(string).
         let arg_str = args.get_or_undefined(0).to_string(context)?;
@@ -1235,15 +1232,11 @@ impl RegExp {
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
-        let rx = if let Some(rx) = this.as_object() {
-            rx
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message(
-                    "RegExp.prototype[Symbol.replace] method called on incompatible value",
-                )
-                .into());
-        };
+        let rx = this.as_object().ok_or_else(|| {
+            JsNativeError::typ().with_message(
+                "RegExp.prototype[Symbol.replace] method called on incompatible value",
+            )
+        })?;
 
         // 3. Let S be ? ToString(string).
         let arg_str = args.get_or_undefined(0).to_string(context)?;
@@ -1457,13 +1450,10 @@ impl RegExp {
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
-        let rx = if let Some(rx) = this.as_object() {
-            rx
-        } else {
-            return Err(JsNativeError::typ()
+        let rx = this.as_object().ok_or_else(|| {
+            JsNativeError::typ()
                 .with_message("RegExp.prototype[Symbol.search] method called on incompatible value")
-                .into());
-        };
+        })?;
 
         // 3. Let S be ? ToString(string).
         let arg_str = args.get_or_undefined(0).to_string(context)?;
@@ -1515,13 +1505,10 @@ impl RegExp {
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
-        let rx = if let Some(rx) = this.as_object() {
-            rx
-        } else {
-            return Err(JsNativeError::typ()
+        let rx = this.as_object().ok_or_else(|| {
+            JsNativeError::typ()
                 .with_message("RegExp.prototype.split method called on incompatible value")
-                .into());
-        };
+        })?;
 
         // 3. Let S be ? ToString(string).
         let arg_str = args.get_or_undefined(0).to_string(context)?;

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -281,21 +281,16 @@ impl Set {
     pub(crate) fn delete(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let value = args.get_or_undefined(0);
 
-        let res = if let Some(object) = this.as_object() {
-            if let Some(set) = object.borrow_mut().as_set_mut() {
-                set.delete(value)
-            } else {
-                return Err(JsNativeError::typ()
-                    .with_message("'this' is not a Set")
-                    .into());
-            }
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message("'this' is not a Set")
-                .into());
-        };
+        let mut object = this
+            .as_object()
+            .map(JsObject::borrow_mut)
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
 
-        Ok(res.into())
+        let set = object
+            .as_set_mut()
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
+
+        Ok(set.delete(value).into())
     }
 
     /// `Set.prototype.entries( )`

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -952,9 +952,7 @@ impl String {
 
         // 8. Let position be ! StringIndexOf(string, searchString, 0).
         // 9. If position is -1, return string.
-        let position = if let Some(p) = this_str.index_of(&search_str, 0) {
-            p
-        } else {
+        let Some(position) = this_str.index_of(&search_str, 0) else {
             return Ok(this_str.into());
         };
 

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -253,9 +253,7 @@ where
             let cp = string.code_point_at(k);
 
             // ii. If cp.[[IsUnpairedSurrogate]] is true, throw a URIError exception.
-            let ch = if let CodePoint::Unicode(ch) = cp {
-                ch
-            } else {
+            let CodePoint::Unicode(ch) = cp else {
                 return Err(JsNativeError::uri()
                     .with_message("trying to encode an invalid string")
                     .into());

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -72,7 +72,6 @@
     // Ignore because `write!(string, ...)` instead of `string.push_str(&format!(...))` can fail.
     // We only use it in `ToInternedString` where performance is not an issue.
     clippy::format_push_string,
-    rustdoc::missing_doc_code_examples
 )]
 
 extern crate static_assertions as sa;

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -30,9 +30,7 @@ pub(crate) fn arguments_exotic_get_own_property(
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let desc be OrdinaryGetOwnProperty(args, P).
     // 2. If desc is undefined, return desc.
-    let desc = if let Some(desc) = super::ordinary_get_own_property(obj, key, context)? {
-        desc
-    } else {
+    let Some(desc) = super::ordinary_get_own_property(obj, key, context)? else {
         return Ok(None);
     };
 

--- a/boa_engine/src/object/internal_methods/global.rs
+++ b/boa_engine/src/object/internal_methods/global.rs
@@ -501,11 +501,8 @@ pub(crate) fn validate_and_apply_property_descriptor(
     );
     // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.
 
-    let mut current = if let Some(own) = current {
-        own
-    }
-    // 2. If current is undefined, then
-    else {
+    let Some(mut current) = current else {
+        // 2. If current is undefined, then
         // a. If extensible is false, return false.
         if !extensible {
             return false;

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -794,11 +794,8 @@ pub(crate) fn validate_and_apply_property_descriptor(
         Profiler::global().start_event("Object::validate_and_apply_property_descriptor", "object");
     // 1. Assert: If O is not undefined, then IsPropertyKey(P) is true.
 
-    let mut current = if let Some(own) = current {
-        own
-    }
-    // 2. If current is undefined, then
-    else {
+    let Some(mut current) = current else {
+        // 2. If current is undefined, then
         // a. If extensible is false, return false.
         if !extensible {
             return false;

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -65,10 +65,8 @@ pub(crate) fn proxy_exotic_get_prototype_of(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "getPrototypeOf").
-    let trap = if let Some(trap) = handler.get_method("getPrototypeOf", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("getPrototypeOf", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[GetPrototypeOf]]().
         return target.__get_prototype_of__(context);
     };
@@ -130,10 +128,8 @@ pub(crate) fn proxy_exotic_set_prototype_of(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "setPrototypeOf").
-    let trap = if let Some(trap) = handler.get_method("setPrototypeOf", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("setPrototypeOf", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[SetPrototypeOf]](V).
         return target.__set_prototype_of__(val, context);
     };
@@ -193,10 +189,8 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "isExtensible").
-    let trap = if let Some(trap) = handler.get_method("isExtensible", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("isExtensible", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? IsExtensible(target).
         return target.is_extensible(context);
     };
@@ -242,10 +236,8 @@ pub(crate) fn proxy_exotic_prevent_extensions(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "preventExtensions").
-    let trap = if let Some(trap) = handler.get_method("preventExtensions", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("preventExtensions", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[PreventExtensions]]().
         return target.__prevent_extensions__(context);
     };
@@ -291,10 +283,8 @@ pub(crate) fn proxy_exotic_get_own_property(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "getOwnPropertyDescriptor").
-    let trap = if let Some(trap) = handler.get_method("getOwnPropertyDescriptor", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("getOwnPropertyDescriptor", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[GetOwnProperty]](P).
         return target.__get_own_property__(key, context);
     };
@@ -418,10 +408,8 @@ pub(crate) fn proxy_exotic_define_own_property(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "defineProperty").
-    let trap = if let Some(trap) = handler.get_method("defineProperty", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("defineProperty", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[DefineOwnProperty]](P, Desc).
         return target.__define_own_property__(key, desc, context);
     };
@@ -532,10 +520,8 @@ pub(crate) fn proxy_exotic_has_property(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "has").
-    let trap = if let Some(trap) = handler.get_method("has", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("has", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[HasProperty]](P).
         return target.has_property(key.clone(), context);
     };
@@ -601,10 +587,8 @@ pub(crate) fn proxy_exotic_get(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "get").
-    let trap = if let Some(trap) = handler.get_method("get", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("get", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[Get]](P, Receiver).
         return target.__get__(key, receiver, context);
     };
@@ -673,10 +657,8 @@ pub(crate) fn proxy_exotic_set(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "set").
-    let trap = if let Some(trap) = handler.get_method("set", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("set", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[Set]](P, V, Receiver).
         return target.__set__(key, value, receiver, context);
     };
@@ -757,10 +739,8 @@ pub(crate) fn proxy_exotic_delete(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "deleteProperty").
-    let trap = if let Some(trap) = handler.get_method("deleteProperty", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("deleteProperty", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[Delete]](P).
         return target.__delete__(key, context);
     };
@@ -826,10 +806,8 @@ pub(crate) fn proxy_exotic_own_property_keys(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "ownKeys").
-    let trap = if let Some(trap) = handler.get_method("ownKeys", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("ownKeys", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? target.[[OwnPropertyKeys]]().
         return target.__own_property_keys__(context);
     };
@@ -964,10 +942,8 @@ fn proxy_exotic_call(
         .try_data()?;
 
     // 5. Let trap be ? GetMethod(handler, "apply").
-    let trap = if let Some(trap) = handler.get_method("apply", context)? {
-        trap
-    // 6. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("apply", context)? else {
+        // 6. If trap is undefined, then
         // a. Return ? Call(target, thisArgument, argumentsList).
         return target.call(this, args, context);
     };
@@ -1009,10 +985,8 @@ fn proxy_exotic_construct(
     assert!(target.is_constructor());
 
     // 6. Let trap be ? GetMethod(handler, "construct").
-    let trap = if let Some(trap) = handler.get_method("construct", context)? {
-        trap
-    // 7. If trap is undefined, then
-    } else {
+    let Some(trap) = handler.get_method("construct", context)? else {
+        // 7. If trap is undefined, then
         // a. Return ? Construct(target, argumentsList, newTarget).
         return target.construct(args, Some(new_target), context);
     };

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -452,9 +452,7 @@ impl JsString {
     pub(crate) fn to_number(&self) -> f64 {
         // 1. Let text be ! StringToCodePoints(str).
         // 2. Let literal be ParseText(text, StringNumericLiteral).
-        let string = if let Ok(string) = self.to_std_string() {
-            string
-        } else {
+        let Ok(string) = self.to_std_string() else {
             // 3. If literal is a List of errors, return NaN.
             return f64::NAN;
         };

--- a/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/object_initializer/mod.rs
@@ -216,11 +216,7 @@ where
                 let (class_element_name, method) =
                     AsyncMethod::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
-                let property_name = if let property::ClassElementName::PropertyName(property_name) =
-                    class_element_name
-                {
-                    property_name
-                } else {
+                let property::ClassElementName::PropertyName(property_name) = class_element_name else {
                     return Err(ParseError::general(
                         "private identifiers not allowed in object literal",
                         position,

--- a/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
@@ -261,20 +261,15 @@ where
                 let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(
-                                None,
-                                self.allow_in,
-                                self.allow_yield,
-                                self.allow_await,
-                            )
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(None, self.allow_in, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
-                        )
-                    } else {
-                        None
-                    }
+                    )
                 } else {
                     None
                 };
@@ -294,20 +289,15 @@ where
                 let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(
-                                None,
-                                self.allow_in,
-                                self.allow_yield,
-                                self.allow_await,
-                            )
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(None, self.allow_in, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
-                        )
-                    } else {
-                        None
-                    }
+                    )
                 } else {
                     None
                 };
@@ -334,20 +324,20 @@ where
                     )));
                 }
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(
-                                Some(ident),
-                                self.allow_in,
-                                self.allow_yield,
-                                self.allow_await,
-                            )
-                            .parse(cursor, interner)?,
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(
+                            Some(ident),
+                            self.allow_in,
+                            self.allow_yield,
+                            self.allow_await,
                         )
-                    } else {
-                        None
-                    }
+                        .parse(cursor, interner)?,
+                    )
                 } else {
                     None
                 };

--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -170,20 +170,15 @@ where
                 let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(
-                                None,
-                                self.allow_in,
-                                self.allow_yield,
-                                self.allow_await,
-                            )
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(None, self.allow_in, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
-                        )
-                    } else {
-                        None
-                    }
+                    )
                 } else {
                     None
                 };
@@ -194,20 +189,15 @@ where
                 let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(
-                                None,
-                                self.allow_in,
-                                self.allow_yield,
-                                self.allow_await,
-                            )
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(None, self.allow_in, self.allow_yield, self.allow_await)
                             .parse(cursor, interner)?,
-                        )
-                    } else {
-                        None
-                    }
+                    )
                 } else {
                     None
                 };
@@ -218,15 +208,15 @@ where
                 let ident = BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
 
-                let init = if let Some(t) = cursor.peek(0, interner)? {
-                    if *t.kind() == TokenKind::Punctuator(Punctuator::Assign) {
-                        Some(
-                            Initializer::new(Some(ident), true, self.allow_yield, self.allow_await)
-                                .parse(cursor, interner)?,
-                        )
-                    } else {
-                        None
-                    }
+                let init = if cursor
+                    .peek(0, interner)?
+                    .filter(|t| *t.kind() == TokenKind::Punctuator(Punctuator::Assign))
+                    .is_some()
+                {
+                    Some(
+                        Initializer::new(Some(ident), true, self.allow_yield, self.allow_await)
+                            .parse(cursor, interner)?,
+                    )
                 } else {
                     None
                 };

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -69,7 +69,6 @@
     clippy::let_unit_value,
     // TODO deny once false positive is fixed (https://github.com/rust-lang/rust-clippy/issues/9626).
     clippy::trait_duplication_in_bounds,
-    rustdoc::missing_doc_code_examples,
 )]
 
 extern crate static_assertions as sa;

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -60,7 +60,6 @@
     clippy::missing_errors_doc,
     clippy::as_conversions,
     clippy::let_unit_value,
-    rustdoc::missing_doc_code_examples
 )]
 
 mod exec;

--- a/boa_unicode/src/lib.rs
+++ b/boa_unicode/src/lib.rs
@@ -63,8 +63,7 @@
     clippy::must_use_candidate,
     clippy::missing_errors_doc,
     clippy::as_conversions,
-    clippy::let_unit_value,
-    rustdoc::missing_doc_code_examples
+    clippy::let_unit_value
 )]
 
 mod tables;

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -55,8 +55,7 @@
     clippy::must_use_candidate,
     clippy::missing_errors_doc,
     clippy::as_conversions,
-    clippy::let_unit_value,
-    rustdoc::missing_doc_code_examples
+    clippy::let_unit_value
 )]
 
 use boa_engine::Context;


### PR DESCRIPTION
This Pull Request updates the codebase to the newest version of rustc (1.65.0).

It changes the following:

- Bumps `rust-version` to 1.65.0.
- Rewrites some snippets to use the new let else, ok_or_else and some other utils.
- Removes the `rustdoc::missing_doc_code_examples` allow lint from our codebase. (Context: https://github.com/rust-lang/rust/pull/101732)
