### PR TITLE
[Merged by Bors] - Fix async tests result values

### DIFF
--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -380,12 +380,13 @@ impl Test {
     }
 
     /// Registers the print function in the context.
-    fn register_print_fn(context: &mut Context, helper: AsyncResult) {
+    fn register_print_fn(context: &mut Context, async_result: AsyncResult) {
         // We use `FunctionBuilder` to define a closure with additional captures.
-        let js_function = FunctionBuilder::closure_with_captures(context, test262_print, helper)
-            .name("print")
-            .length(1)
-            .build();
+        let js_function =
+            FunctionBuilder::closure_with_captures(context, test262_print, async_result)
+                .name("print")
+                .length(1)
+                .build();
 
         context.register_global_property(
             "print",

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -244,22 +244,22 @@ impl Test {
                             JsNativeErrorKind::Type if error_type == ErrorType::TypeError => {}
                             _ => return (false, format!("Uncaught {e}")),
                         }
-                    } else if !e
-                        .as_opaque()
-                        .expect("try_native cannot fail if e is not opaque")
-                        .as_object()
-                        .and_then(|o| o.get("constructor", &mut context).ok())
-                        .as_ref()
-                        .and_then(JsValue::as_object)
-                        .and_then(|o| o.get("name", &mut context).ok())
-                        .as_ref()
-                        .and_then(JsValue::as_string)
-                        .map(|s| s == error_type.as_str())
-                        .unwrap_or_default()
-                    {
-                        return (false, format!("Uncaught {e}"));
-                    };
-                    (true, format!("Uncaught {e}"))
+                        (true, format!("Uncaught {e}"))
+                    } else {
+                        let passed = e
+                            .as_opaque()
+                            .expect("try_native cannot fail if e is not opaque")
+                            .as_object()
+                            .and_then(|o| o.get("constructor", &mut context).ok())
+                            .as_ref()
+                            .and_then(JsValue::as_object)
+                            .and_then(|o| o.get("name", &mut context).ok())
+                            .as_ref()
+                            .and_then(JsValue::as_string)
+                            .map(|s| s == error_type.as_str())
+                            .unwrap_or_default();
+                        (passed, format!("Uncaught {e}"))
+                    }
                 }
             });
 

--- a/test_ignore.txt
+++ b/test_ignore.txt
@@ -13,6 +13,7 @@ feature:Atomics
 feature:dynamic_import
 feature:decorators
 feature:array-grouping
+feature:IsHTMLDDA
 
 // Non-implemented Intl features
 feature:intl-normative-optional


### PR DESCRIPTION
So, there were some tests that weren't reporting the result of async evaluations correctly. This PR fixes this. It also ignores tests with the `IsHTMLDDA` feature, since we haven't implemented it.

On another note, this also changes the symbols of the test suite to 'F' (failed) and '-' (ignored), which is clearer for colorless terminals.
