### PR TITLE
[Merged by Bors] - Pretty print promise objects

### DIFF
--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -665,6 +665,19 @@ Cannot both specify accessors and a value or writable attribute",
         Ok(())
     }
 
+    #[inline]
+    pub(crate) fn get_property(&self, key: &PropertyKey) -> Option<PropertyDescriptor> {
+        let mut obj = Some(self.clone());
+
+        while let Some(o) = obj {
+            if let Some(v) = o.borrow().properties.get(key) {
+                return Some(v);
+            }
+            obj = o.borrow().prototype().clone();
+        }
+        None
+    }
+
     /// Helper function for property insertion.
     #[inline]
     #[track_caller]

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -192,9 +192,9 @@ pub enum ObjectKind {
     Arguments(Arguments),
     NativeObject(Box<dyn NativeObject>),
     IntegerIndexed(IntegerIndexed),
+    Promise(Promise),
     #[cfg(feature = "intl")]
     DateTimeFormat(Box<DateTimeFormat>),
-    Promise(Promise),
 }
 
 unsafe impl Trace for ObjectKind {

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2645,7 +2645,7 @@ fn spread_getters_in_object() {
         var a = { x: 42 };
         var aWithXGetter = { ...a, ... { get x() { throw new Error('not thrown yet') } } };
     "#;
-    assert_eq!(&exec(scenario), "\"Error\": \"not thrown yet\"");
+    assert_eq!(&exec(scenario), "Error: not thrown yet");
 }
 
 #[test]


### PR DESCRIPTION
Right now our promises print `{ }` on display. This PR improves a bit the display and ergonomics of promises in general. Now, promises will print...
- When pending: `Promise { <pending> }`
- When fulfilled: `Promise { "hi" }`
- When rejected: `Promise { <rejected> ReferenceError: x is not initialized }`
