### PR TITLE
[Merged by Bors] - Rewrite scope analysis operations using visitors

### DIFF
--- a/boa_ast/src/declaration/mod.rs
+++ b/boa_ast/src/declaration/mod.rs
@@ -14,10 +14,7 @@
 //! [class]: https://tc39.es/ecma262/#prod-ClassDeclaration
 //! [diff]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements#difference_between_statements_and_declarations
 
-use super::{
-    expression::Identifier,
-    function::{AsyncFunction, AsyncGenerator, Class, Function, Generator},
-};
+use super::function::{AsyncFunction, AsyncGenerator, Class, Function, Generator};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
 use core::ops::ControlFlow;
 
@@ -49,72 +46,6 @@ pub enum Declaration {
 
     /// See [`LexicalDeclaration`]
     Lexical(LexicalDeclaration),
-}
-
-impl Declaration {
-    /// Return the lexically declared names of a `Declaration`.
-    ///
-    /// The returned list may contain duplicates.
-    ///
-    /// If a declared name originates from a function declaration it is flagged as `true` in the returned list.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
-    pub(crate) fn lexically_declared_names(&self) -> Vec<(Identifier, bool)> {
-        match self {
-            Declaration::Function(f) => {
-                if let Some(name) = f.name() {
-                    vec![(name, true)]
-                } else {
-                    Vec::new()
-                }
-            }
-            Declaration::Generator(g) => {
-                if let Some(name) = g.name() {
-                    vec![(name, false)]
-                } else {
-                    Vec::new()
-                }
-            }
-            Declaration::AsyncFunction(af) => {
-                if let Some(name) = af.name() {
-                    vec![(name, false)]
-                } else {
-                    Vec::new()
-                }
-            }
-            Declaration::AsyncGenerator(ag) => {
-                if let Some(name) = ag.name() {
-                    vec![(name, false)]
-                } else {
-                    Vec::new()
-                }
-            }
-            Declaration::Class(cl) => {
-                if let Some(name) = cl.name() {
-                    vec![(name, false)]
-                } else {
-                    Vec::new()
-                }
-            }
-            Declaration::Lexical(lexical) => {
-                let mut names = Vec::new();
-                for decl in lexical.variable_list().as_ref() {
-                    match decl.binding() {
-                        Binding::Identifier(ident) => {
-                            names.push((*ident, false));
-                        }
-                        Binding::Pattern(pattern) => {
-                            names.extend(pattern.idents().into_iter().map(|name| (name, false)));
-                        }
-                    }
-                }
-                names
-            }
-        }
-    }
 }
 
 impl ToIndentedString for Declaration {

--- a/boa_ast/src/declaration/variable.rs
+++ b/boa_ast/src/declaration/variable.rs
@@ -299,12 +299,6 @@ impl Variable {
     pub fn init(&self) -> Option<&Expression> {
         self.init.as_ref()
     }
-
-    /// Gets the list of declared identifiers.
-    #[must_use]
-    pub fn idents(&self) -> Vec<Identifier> {
-        self.binding.idents()
-    }
 }
 
 impl VisitWith for Variable {
@@ -355,16 +349,6 @@ impl From<Identifier> for Binding {
 impl From<Pattern> for Binding {
     fn from(pat: Pattern) -> Self {
         Self::Pattern(pat)
-    }
-}
-
-impl Binding {
-    /// Gets the list of declared identifiers.
-    pub(crate) fn idents(&self) -> Vec<Identifier> {
-        match self {
-            Binding::Identifier(id) => vec![*id],
-            Binding::Pattern(ref pat) => pat.idents(),
-        }
     }
 }
 

--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -152,7 +152,7 @@ pub enum Expression {
     /// A FormalParameterList.
     ///
     /// This is only used in the parser itself.
-    /// It is not a valid AST node.
+    /// It is not a valid expression node.
     #[doc(hidden)]
     FormalParameterList(FormalParameterList),
 }

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -242,7 +242,7 @@ impl FormalParameter {
         self.is_rest_param
     }
 
-    /// Returns `true` if the parameter is a simple [`Identifier`].
+    /// Returns `true` if the parameter is an identifier.
     #[must_use]
     pub fn is_identifier(&self) -> bool {
         matches!(&self.variable.binding(), Binding::Identifier(_))

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -1,7 +1,7 @@
 use crate::{
     declaration::{Binding, Variable},
-    expression::{Expression, Identifier},
-    pattern::Pattern,
+    expression::Expression,
+    operations::bound_names,
     try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
@@ -40,7 +40,7 @@ impl FormalParameterList {
         let mut names = FxHashSet::default();
 
         for parameter in &parameters {
-            let parameter_names = parameter.names();
+            let parameter_names = bound_names(parameter);
 
             for name in parameter_names {
                 if name == Sym::ARGUMENTS {
@@ -221,19 +221,6 @@ impl FormalParameter {
         Self {
             variable: variable.into(),
             is_rest_param,
-        }
-    }
-
-    /// Gets the name of the formal parameter.
-    #[must_use]
-    pub fn names(&self) -> Vec<Identifier> {
-        match self.variable.binding() {
-            Binding::Identifier(ident) => vec![*ident],
-            Binding::Pattern(pattern) => match pattern {
-                Pattern::Object(object_pattern) => object_pattern.idents(),
-
-                Pattern::Array(array_pattern) => array_pattern.idents(),
-            },
         }
     }
 

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -6,18 +6,19 @@ use core::ops::ControlFlow;
 use std::convert::Infallible;
 
 use boa_interner::Sym;
+use rustc_hash::FxHashSet;
 
 use crate::{
-    declaration::{Binding, Variable},
+    declaration::VarDeclaration,
     expression::{access::SuperPropertyAccess, Await, Identifier, SuperCall, Yield},
     function::{
         ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
         Function, Generator,
     },
     property::{MethodDefinition, PropertyDefinition},
-    statement::iteration::{ForLoopInitializer, IterableLoopInitializer},
+    statement::LabelledItem,
     visitor::{NodeRef, VisitWith, Visitor},
-    Declaration, Expression,
+    Declaration, Expression, Statement, StatementList, StatementListItem,
 };
 
 /// Represents all the possible symbols searched for by the [`Contains`][contains] operation.
@@ -284,6 +285,76 @@ pub fn has_direct_super(method: &MethodDefinition) -> bool {
     }
 }
 
+/// A container that [`BoundNamesVisitor`] can use to push the found identifiers.
+trait IdentList {
+    fn add(&mut self, value: Identifier, function: bool);
+}
+
+impl IdentList for Vec<Identifier> {
+    fn add(&mut self, value: Identifier, _function: bool) {
+        self.push(value);
+    }
+}
+
+impl IdentList for Vec<(Identifier, bool)> {
+    fn add(&mut self, value: Identifier, function: bool) {
+        self.push((value, function));
+    }
+}
+
+impl IdentList for FxHashSet<Identifier> {
+    fn add(&mut self, value: Identifier, _function: bool) {
+        self.insert(value);
+    }
+}
+
+/// The [`Visitor`] used to obtain the bound names of a node.
+#[derive(Debug)]
+struct BoundNamesVisitor<'a, T: IdentList>(&'a mut T);
+
+impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
+    type BreakTy = Infallible;
+
+    fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
+        self.0.add(*node, false);
+        ControlFlow::Continue(())
+    }
+    fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
+        ControlFlow::Continue(())
+    }
+    // TODO: add "*default" for module default functions without name
+    fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
+        if let Some(ident) = node.name() {
+            self.0.add(ident, true);
+        }
+        ControlFlow::Continue(())
+    }
+    fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
+        if let Some(ident) = node.name() {
+            self.0.add(ident, false);
+        }
+        ControlFlow::Continue(())
+    }
+    fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
+        if let Some(ident) = node.name() {
+            self.0.add(ident, false);
+        }
+        ControlFlow::Continue(())
+    }
+    fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
+        if let Some(ident) = node.name() {
+            self.0.add(ident, false);
+        }
+        ControlFlow::Continue(())
+    }
+    fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
+        if let Some(ident) = node.name() {
+            self.0.add(ident, false);
+        }
+        ControlFlow::Continue(())
+    }
+}
+
 /// Returns a list with the bound names of an AST node, which may contain duplicates.
 ///
 /// This is equivalent to the [`BoundNames`][spec] syntax operation in the spec.
@@ -294,83 +365,268 @@ pub fn bound_names<'a, N>(node: &'a N) -> Vec<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
 {
-    struct BoundNamesVisitor(Vec<Identifier>);
+    let mut names = Vec::new();
+    BoundNamesVisitor(&mut names).visit(node.into());
 
-    impl<'ast> Visitor<'ast> for BoundNamesVisitor {
-        type BreakTy = Infallible;
+    names
+}
 
-        fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
-            self.0.push(*node);
-            ControlFlow::Continue(())
-        }
-        fn visit_binding(&mut self, _: &'ast Binding) -> ControlFlow<Self::BreakTy> {
-            ControlFlow::Continue(())
-        }
-        fn visit_variable(&mut self, node: &'ast Variable) -> ControlFlow<Self::BreakTy> {
-            node.binding().visit_with(self)
-        }
-        fn visit_iterable_loop_initializer(
-            &mut self,
-            node: &'ast IterableLoopInitializer,
-        ) -> ControlFlow<Self::BreakTy> {
-            match node {
-                IterableLoopInitializer::Var(b)
-                | IterableLoopInitializer::Let(b)
-                | IterableLoopInitializer::Const(b) => b.visit_with(self),
-                _ => ControlFlow::Continue(()),
-            }
-        }
+/// The [`Visitor`] used to obtain the lexically declared names of a node.
+#[derive(Debug)]
+struct LexicallyDeclaredNamesVisitor<'a, T: IdentList>(&'a mut T);
 
-        fn visit_for_loop_initializer(
-            &mut self,
-            node: &'ast ForLoopInitializer,
-        ) -> ControlFlow<Self::BreakTy> {
-            match node {
-                ForLoopInitializer::Expression(_) => ControlFlow::Continue(()),
-                ForLoopInitializer::Var(decl) => decl.visit_with(self),
-                ForLoopInitializer::Lexical(decl) => decl.visit_with(self),
-            }
+impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> {
+    type BreakTy = Infallible;
+    fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
+        ControlFlow::Continue(())
+    }
+    fn visit_statement(&mut self, node: &'ast Statement) -> ControlFlow<Self::BreakTy> {
+        if let Statement::Labelled(labelled) = node {
+            return self.visit_labelled(labelled);
         }
-
-        fn visit_declaration(&mut self, node: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
-            // TODO: add "*default" for module default functions without name
-            match node {
-                Declaration::Function(f) => {
-                    if let Some(ident) = f.name() {
-                        self.0.push(ident);
-                    }
-                }
-                Declaration::Generator(f) => {
-                    if let Some(ident) = f.name() {
-                        self.0.push(ident);
-                    }
-                }
-                Declaration::AsyncFunction(f) => {
-                    if let Some(ident) = f.name() {
-                        self.0.push(ident);
-                    }
-                }
-                Declaration::AsyncGenerator(f) => {
-                    if let Some(ident) = f.name() {
-                        self.0.push(ident);
-                    }
-                }
-                Declaration::Class(f) => {
-                    if let Some(ident) = f.name() {
-                        self.0.push(ident);
-                    }
-                }
-                Declaration::Lexical(decl) => {
-                    decl.visit_with(self);
-                }
-            }
-            ControlFlow::Continue(())
+        ControlFlow::Continue(())
+    }
+    fn visit_declaration(&mut self, node: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
+        BoundNamesVisitor(self.0).visit_declaration(node)
+    }
+    fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
+        match node {
+            LabelledItem::Function(f) => BoundNamesVisitor(self.0).visit_function(f),
+            LabelledItem::Statement(_) => ControlFlow::Continue(()),
         }
     }
+    fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_arrow_function(
+        &mut self,
+        node: &'ast AsyncArrowFunction,
+    ) -> ControlFlow<Self::BreakTy> {
+        top_level_lexicals(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
+        if let ClassElement::StaticBlock(stmts) = node {
+            top_level_lexicals(stmts, self.0);
+        }
+        ControlFlow::Continue(())
+    }
 
-    let mut visitor = BoundNamesVisitor(Vec::new());
+    // TODO:  ScriptBody : StatementList
+    // 1. Return TopLevelLexicallyDeclaredNames of StatementList.
+    // But we don't have that node yet. In the meantime, use `top_level_lexically_declared_names` directly.
+}
 
-    visitor.visit(node.into());
+/// Returns a list with the lexical bindings of a node, which may contain duplicates.
+///
+/// This is equivalent to the [`LexicallyDeclaredNames`][spec] syntax operation in the spec.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
+#[must_use]
+pub fn lexically_declared_names<'a, N>(node: &'a N) -> Vec<Identifier>
+where
+    &'a N: Into<NodeRef<'a>>,
+{
+    let mut names = Vec::new();
+    LexicallyDeclaredNamesVisitor(&mut names).visit(node.into());
+    names
+}
 
-    visitor.0
+/// Returns a list with the lexical bindings of a node, which may contain duplicates.
+///
+/// If a declared name originates from a function declaration it is flagged as `true` in the returned
+/// list. (See [B.3.2.4 Changes to Block Static Semantics: Early Errors])
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
+/// [changes]: https://tc39.es/ecma262/#sec-block-duplicates-allowed-static-semantics
+#[must_use]
+pub fn lexically_declared_names_legacy<'a, N>(node: &'a N) -> Vec<(Identifier, bool)>
+where
+    &'a N: Into<NodeRef<'a>>,
+{
+    let mut names = Vec::new();
+    LexicallyDeclaredNamesVisitor(&mut names).visit(node.into());
+    names
+}
+
+/// The [`Visitor`] used to obtain the var declared names of a node.
+#[derive(Debug)]
+struct VarDeclaredNamesVisitor<'a>(&'a mut FxHashSet<Identifier>);
+
+impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
+    type BreakTy = Infallible;
+    fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
+        ControlFlow::Continue(())
+    }
+    fn visit_declaration(&mut self, _: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
+        ControlFlow::Continue(())
+    }
+    fn visit_var_declaration(&mut self, node: &'ast VarDeclaration) -> ControlFlow<Self::BreakTy> {
+        BoundNamesVisitor(self.0).visit_var_declaration(node)
+    }
+    fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
+        match node {
+            LabelledItem::Function(_) => ControlFlow::Continue(()),
+            LabelledItem::Statement(stmt) => stmt.visit_with(self),
+        }
+    }
+    fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_async_arrow_function(
+        &mut self,
+        node: &'ast AsyncArrowFunction,
+    ) -> ControlFlow<Self::BreakTy> {
+        top_level_vars(node.body(), self.0);
+        ControlFlow::Continue(())
+    }
+    fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
+        if let ClassElement::StaticBlock(stmts) = node {
+            top_level_vars(stmts, self.0);
+        }
+        node.visit_with(self)
+    }
+
+    // TODO:  ScriptBody : StatementList
+    // 1. Return TopLevelVarDeclaredNames of StatementList.
+    // But we don't have that node yet. In the meantime, use `top_level_var_declared_names` directly.
+}
+
+/// Returns a set with the var bindings of a node, with no duplicates.
+///
+/// This is equivalent to the [`VarDeclaredNames`][spec] syntax operation in the spec.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames
+#[must_use]
+pub fn var_declared_names<'a, N>(node: &'a N) -> FxHashSet<Identifier>
+where
+    &'a N: Into<NodeRef<'a>>,
+{
+    let mut names = FxHashSet::default();
+    VarDeclaredNamesVisitor(&mut names).visit(node.into());
+    names
+}
+
+/// Utility function that collects the top level lexicals of a statement list into `names`.
+fn top_level_lexicals<T: IdentList>(stmts: &StatementList, names: &mut T) {
+    for stmt in stmts.statements() {
+        if let StatementListItem::Declaration(decl) = stmt {
+            match decl {
+                // Note
+                // At the top level of a function, or script, function declarations are treated like
+                // var declarations rather than like lexical declarations.
+                Declaration::Function(_)
+                | Declaration::Generator(_)
+                | Declaration::AsyncFunction(_)
+                | Declaration::AsyncGenerator(_) => {}
+                Declaration::Class(class) => {
+                    BoundNamesVisitor(names).visit_class(class);
+                }
+                Declaration::Lexical(decl) => {
+                    BoundNamesVisitor(names).visit_lexical_declaration(decl);
+                }
+            }
+        }
+    }
+}
+
+/// Returns a list with the lexical bindings of a top-level statement list, which may contain duplicates.
+///
+/// This is equivalent to the [`TopLevelLexicallyDeclaredNames`][spec] syntax operation in the spec.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallydeclarednames
+#[must_use]
+pub fn top_level_lexically_declared_names(stmts: &StatementList) -> Vec<Identifier> {
+    let mut names = Vec::new();
+    top_level_lexicals(stmts, &mut names);
+    names
+}
+
+/// Utility function that collects the top level vars of a statement list into `names`.
+fn top_level_vars(stmts: &StatementList, names: &mut FxHashSet<Identifier>) {
+    for stmt in stmts.statements() {
+        match stmt {
+            StatementListItem::Declaration(decl) => {
+                match decl {
+                    // Note
+                    // At the top level of a function, or script, function declarations are treated like
+                    // var declarations rather than like lexical declarations.
+                    Declaration::Function(f) => {
+                        BoundNamesVisitor(names).visit_function(f);
+                    }
+                    Declaration::Generator(f) => {
+                        BoundNamesVisitor(names).visit_generator(f);
+                    }
+                    Declaration::AsyncFunction(f) => {
+                        BoundNamesVisitor(names).visit_async_function(f);
+                    }
+                    Declaration::AsyncGenerator(f) => {
+                        BoundNamesVisitor(names).visit_async_generator(f);
+                    }
+                    Declaration::Class(_) | Declaration::Lexical(_) => {}
+                }
+            }
+            StatementListItem::Statement(stmt) => {
+                let mut stmt = Some(stmt);
+                while let Some(Statement::Labelled(labelled)) = stmt {
+                    match labelled.item() {
+                        LabelledItem::Function(f) => {
+                            BoundNamesVisitor(names).visit_function(f);
+                            stmt = None;
+                        }
+                        LabelledItem::Statement(s) => stmt = Some(s),
+                    }
+                }
+                if let Some(stmt) = stmt {
+                    VarDeclaredNamesVisitor(names).visit(stmt);
+                }
+            }
+        }
+    }
+}
+
+/// Returns a list with the var bindings of a top-level statement list, with no duplicates.
+///
+/// This is equivalent to the [`TopLevelVarDeclaredNames`][spec] syntax operation in the spec.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-static-semantics-toplevelvardeclarednames
+#[must_use]
+pub fn top_level_var_declared_names(stmts: &StatementList) -> FxHashSet<Identifier> {
+    let mut names = FxHashSet::default();
+    top_level_vars(stmts, &mut names);
+    names
 }

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -55,6 +55,7 @@ pub enum ContainsSymbol {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
 #[must_use]
+#[inline]
 pub fn contains<N>(node: &N, symbol: ContainsSymbol) -> bool
 where
     N: VisitWith,
@@ -295,6 +296,7 @@ where
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-hasdirectsuper
 #[must_use]
+#[inline]
 pub fn has_direct_super(method: &MethodDefinition) -> bool {
     match method {
         MethodDefinition::Get(f) | MethodDefinition::Set(f) | MethodDefinition::Ordinary(f) => {
@@ -392,6 +394,7 @@ impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-boundnames
 #[must_use]
+#[inline]
 pub fn bound_names<'a, N>(node: &'a N) -> Vec<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -482,6 +485,7 @@ impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> 
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
 #[must_use]
+#[inline]
 pub fn lexically_declared_names<'a, N>(node: &'a N) -> Vec<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -499,6 +503,7 @@ where
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
 /// [changes]: https://tc39.es/ecma262/#sec-block-duplicates-allowed-static-semantics
 #[must_use]
+#[inline]
 pub fn lexically_declared_names_legacy<'a, N>(node: &'a N) -> Vec<(Identifier, bool)>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -585,6 +590,7 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames
 #[must_use]
+#[inline]
 pub fn var_declared_names<'a, N>(node: &'a N) -> FxHashSet<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -595,6 +601,7 @@ where
 }
 
 /// Utility function that collects the top level lexicals of a statement list into `names`.
+#[inline]
 fn top_level_lexicals<T: IdentList>(stmts: &StatementList, names: &mut T) {
     for stmt in stmts.statements() {
         if let StatementListItem::Declaration(decl) = stmt {
@@ -623,6 +630,7 @@ fn top_level_lexicals<T: IdentList>(stmts: &StatementList, names: &mut T) {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-toplevellexicallydeclarednames
 #[must_use]
+#[inline]
 pub fn top_level_lexically_declared_names(stmts: &StatementList) -> Vec<Identifier> {
     let mut names = Vec::new();
     top_level_lexicals(stmts, &mut names);
@@ -630,6 +638,7 @@ pub fn top_level_lexically_declared_names(stmts: &StatementList) -> Vec<Identifi
 }
 
 /// Utility function that collects the top level vars of a statement list into `names`.
+#[inline]
 fn top_level_vars(stmts: &StatementList, names: &mut FxHashSet<Identifier>) {
     for stmt in stmts.statements() {
         match stmt {
@@ -678,6 +687,7 @@ fn top_level_vars(stmts: &StatementList, names: &mut FxHashSet<Identifier>) {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-toplevelvardeclarednames
 #[must_use]
+#[inline]
 pub fn top_level_var_declared_names(stmts: &StatementList) -> FxHashSet<Identifier> {
     let mut names = FxHashSet::default();
     top_level_vars(stmts, &mut names);

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -66,22 +66,27 @@ where
     impl<'ast> Visitor<'ast> for ContainsVisitor {
         type BreakTy = ();
 
+        #[inline]
         fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
             if !node.elements().is_empty() && self.0 == ContainsSymbol::ClassBody {
                 return ControlFlow::Break(());
@@ -95,6 +100,7 @@ where
         }
 
         // `ComputedPropertyContains`: https://tc39.es/ecma262/#sec-static-semantics-computedpropertycontains
+        #[inline]
         fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
             match node {
                 ClassElement::MethodDefinition(name, _)
@@ -105,6 +111,7 @@ where
             }
         }
 
+        #[inline]
         fn visit_property_definition(
             &mut self,
             node: &'ast PropertyDefinition,
@@ -119,6 +126,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_arrow_function(
             &mut self,
             node: &'ast ArrowFunction,
@@ -138,6 +146,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_async_arrow_function(
             &mut self,
             node: &'ast AsyncArrowFunction,
@@ -157,6 +166,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_super_property_access(
             &mut self,
             node: &'ast SuperPropertyAccess,
@@ -167,6 +177,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_super_call(&mut self, node: &'ast SuperCall) -> ControlFlow<Self::BreakTy> {
             if [ContainsSymbol::SuperCall, ContainsSymbol::Super].contains(&self.0) {
                 return ControlFlow::Break(());
@@ -174,6 +185,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_yield(&mut self, node: &'ast Yield) -> ControlFlow<Self::BreakTy> {
             if self.0 == ContainsSymbol::YieldExpression {
                 return ControlFlow::Break(());
@@ -182,6 +194,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_await(&mut self, node: &'ast Await) -> ControlFlow<Self::BreakTy> {
             if self.0 == ContainsSymbol::AwaitExpression {
                 return ControlFlow::Break(());
@@ -190,6 +203,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_expression(&mut self, node: &'ast Expression) -> ControlFlow<Self::BreakTy> {
             if node == &Expression::This && self.0 == ContainsSymbol::This {
                 return ControlFlow::Break(());
@@ -221,6 +235,7 @@ where
     impl<'ast> Visitor<'ast> for ContainsArgsVisitor {
         type BreakTy = ();
 
+        #[inline]
         fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
             if node.sym() == Sym::ARGUMENTS {
                 ControlFlow::Break(())
@@ -229,22 +244,27 @@ where
             }
         }
 
+        #[inline]
         fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
+        #[inline]
         fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
             match node {
                 ClassElement::MethodDefinition(name, _)
@@ -254,6 +274,7 @@ where
             node.visit_with(self)
         }
 
+        #[inline]
         fn visit_property_definition(
             &mut self,
             node: &'ast PropertyDefinition,
@@ -291,18 +312,21 @@ trait IdentList {
 }
 
 impl IdentList for Vec<Identifier> {
+    #[inline]
     fn add(&mut self, value: Identifier, _function: bool) {
         self.push(value);
     }
 }
 
 impl IdentList for Vec<(Identifier, bool)> {
+    #[inline]
     fn add(&mut self, value: Identifier, function: bool) {
         self.push((value, function));
     }
 }
 
 impl IdentList for FxHashSet<Identifier> {
+    #[inline]
     fn add(&mut self, value: Identifier, _function: bool) {
         self.insert(value);
     }
@@ -315,38 +339,45 @@ struct BoundNamesVisitor<'a, T: IdentList>(&'a mut T);
 impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
     type BreakTy = Infallible;
 
+    #[inline]
     fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
         self.0.add(*node, false);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
     // TODO: add "*default" for module default functions without name
+    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, true);
         }
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
@@ -377,44 +408,54 @@ struct LexicallyDeclaredNamesVisitor<'a, T: IdentList>(&'a mut T);
 
 impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> {
     type BreakTy = Infallible;
+    #[inline]
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_statement(&mut self, node: &'ast Statement) -> ControlFlow<Self::BreakTy> {
         if let Statement::Labelled(labelled) = node {
             return self.visit_labelled(labelled);
         }
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_declaration(&mut self, node: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
         BoundNamesVisitor(self.0).visit_declaration(node)
     }
+    #[inline]
     fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
         match node {
             LabelledItem::Function(f) => BoundNamesVisitor(self.0).visit_function(f),
             LabelledItem::Statement(_) => ControlFlow::Continue(()),
         }
     }
+    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_arrow_function(
         &mut self,
         node: &'ast AsyncArrowFunction,
@@ -422,6 +463,7 @@ impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> 
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
         if let ClassElement::StaticBlock(stmts) = node {
             top_level_lexicals(stmts, self.0);
@@ -472,41 +514,51 @@ struct VarDeclaredNamesVisitor<'a>(&'a mut FxHashSet<Identifier>);
 
 impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
     type BreakTy = Infallible;
+    #[inline]
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_declaration(&mut self, _: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_var_declaration(&mut self, node: &'ast VarDeclaration) -> ControlFlow<Self::BreakTy> {
         BoundNamesVisitor(self.0).visit_var_declaration(node)
     }
+    #[inline]
     fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
         match node {
             LabelledItem::Function(_) => ControlFlow::Continue(()),
             LabelledItem::Statement(stmt) => stmt.visit_with(self),
         }
     }
+    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_async_arrow_function(
         &mut self,
         node: &'ast AsyncArrowFunction,
@@ -514,6 +566,7 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+    #[inline]
     fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
         if let ClassElement::StaticBlock(stmts) = node {
             top_level_vars(stmts, self.0);

--- a/boa_ast/src/statement/block.rs
+++ b/boa_ast/src/statement/block.rs
@@ -1,7 +1,6 @@
 //! Block AST node.
 
 use crate::{
-    expression::Identifier,
     visitor::{VisitWith, Visitor, VisitorMut},
     Statement, StatementList,
 };
@@ -36,13 +35,6 @@ impl Block {
     #[must_use]
     pub fn statement_list(&self) -> &StatementList {
         &self.statements
-    }
-
-    /// Get the lexically declared names of the block.
-    #[inline]
-    #[must_use]
-    pub fn lexically_declared_names(&self) -> Vec<(Identifier, bool)> {
-        self.statements.lexically_declared_names()
     }
 }
 

--- a/boa_ast/src/statement/iteration/for_loop.rs
+++ b/boa_ast/src/statement/iteration/for_loop.rs
@@ -1,8 +1,7 @@
 use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
-    declaration::{LexicalDeclaration, VarDeclaration, Variable},
-    expression::Identifier,
+    declaration::{LexicalDeclaration, VarDeclaration},
     statement::Statement,
     Expression,
 };
@@ -203,27 +202,6 @@ pub enum ForLoopInitializer {
     Var(VarDeclaration),
     /// A lexical declaration initializer.
     Lexical(LexicalDeclaration),
-}
-
-impl ForLoopInitializer {
-    /// Return the bound names of a for loop initializer.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-boundnames
-    #[must_use]
-    pub fn bound_names(&self) -> Vec<Identifier> {
-        match self {
-            ForLoopInitializer::Lexical(lex) => lex
-                .variable_list()
-                .as_ref()
-                .iter()
-                .flat_map(Variable::idents)
-                .collect(),
-            _ => Vec::new(),
-        }
-    }
 }
 
 impl ToInternedString for ForLoopInitializer {

--- a/boa_ast/src/statement/iteration/for_of_loop.rs
+++ b/boa_ast/src/statement/iteration/for_of_loop.rs
@@ -49,7 +49,7 @@ impl ForOfLoop {
     /// Gets the initializer of the for...of loop.
     #[inline]
     #[must_use]
-    pub fn init(&self) -> &IterableLoopInitializer {
+    pub fn initializer(&self) -> &IterableLoopInitializer {
         &self.init
     }
 

--- a/boa_ast/src/statement/iteration/mod.rs
+++ b/boa_ast/src/statement/iteration/mod.rs
@@ -51,24 +51,6 @@ pub enum IterableLoopInitializer {
     Pattern(Pattern),
 }
 
-impl IterableLoopInitializer {
-    /// Return the bound names of a for loop initializer.
-    ///
-    /// The returned list may contain duplicates.
-    ///
-    /// More information:
-    ///  - [ECMAScript specification][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-boundnames
-    #[must_use]
-    pub fn bound_names(&self) -> Vec<Identifier> {
-        match self {
-            Self::Let(binding) | Self::Const(binding) => binding.idents(),
-            _ => Vec::new(),
-        }
-    }
-}
-
 impl ToInternedString for IterableLoopInitializer {
     fn to_interned_string(&self, interner: &Interner) -> String {
         let (binding, pre) = match self {

--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -17,7 +17,6 @@ mod r#try;
 
 pub mod iteration;
 
-use self::iteration::{ForLoopInitializer, IterableLoopInitializer};
 pub use self::{
     block::Block,
     iteration::{Break, Continue, DoWhileLoop, ForInLoop, ForLoop, ForOfLoop, WhileLoop},
@@ -32,12 +31,8 @@ use core::ops::ControlFlow;
 
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
-use rustc_hash::FxHashSet;
 
-use super::{
-    declaration::{Binding, VarDeclaration},
-    expression::{Expression, Identifier},
-};
+use super::{declaration::VarDeclaration, expression::Expression};
 
 /// The `Statement` Parse Node.
 ///
@@ -136,93 +131,6 @@ impl Statement {
         };
         s.push(';');
         s
-    }
-
-    /// Gets the var declared names of this `Statement`.
-    pub fn var_declared_names(&self, vars: &mut FxHashSet<Identifier>) {
-        match self {
-            Self::Var(VarDeclaration(list)) => {
-                for decl in list.as_ref() {
-                    vars.extend(decl.idents());
-                }
-            }
-            Self::Block(block) => {
-                for node in block.statement_list().statements() {
-                    node.var_declared_names(vars);
-                }
-            }
-            Self::If(if_statement) => {
-                if_statement.body().var_declared_names(vars);
-                if let Some(node) = if_statement.else_node() {
-                    node.var_declared_names(vars);
-                }
-            }
-            Self::DoWhileLoop(do_while_loop) => {
-                do_while_loop.body().var_declared_names(vars);
-            }
-            Self::WhileLoop(while_loop) => {
-                while_loop.body().var_declared_names(vars);
-            }
-            Self::ForLoop(for_loop) => {
-                if let Some(ForLoopInitializer::Var(VarDeclaration(list))) = for_loop.init() {
-                    for variable in list.as_ref() {
-                        match variable.binding() {
-                            Binding::Identifier(ident) => {
-                                vars.insert(*ident);
-                            }
-                            Binding::Pattern(pattern) => {
-                                for ident in pattern.idents() {
-                                    vars.insert(ident);
-                                }
-                            }
-                        }
-                    }
-                }
-                for_loop.body().var_declared_names(vars);
-            }
-            Self::ForInLoop(for_in_loop) => {
-                if let IterableLoopInitializer::Var(bind) = for_in_loop.initializer() {
-                    vars.extend(bind.idents());
-                }
-                for_in_loop.body().var_declared_names(vars);
-            }
-            Self::ForOfLoop(for_of_loop) => {
-                if let IterableLoopInitializer::Var(bind) = for_of_loop.initializer() {
-                    vars.extend(bind.idents());
-                }
-                for_of_loop.body().var_declared_names(vars);
-            }
-            Self::Switch(switch) => {
-                for case in switch.cases() {
-                    for node in case.body().statements() {
-                        node.var_declared_names(vars);
-                    }
-                }
-                if let Some(stmts) = switch.default() {
-                    stmts.var_declared_names(vars);
-                }
-            }
-            Self::Try(try_statement) => {
-                for node in try_statement.block().statement_list().statements() {
-                    node.var_declared_names(vars);
-                }
-                if let Some(catch) = try_statement.catch() {
-                    for node in catch.block().statement_list().statements() {
-                        node.var_declared_names(vars);
-                    }
-                }
-                if let Some(finally) = try_statement.finally() {
-                    for node in finally.block().statement_list().statements() {
-                        node.var_declared_names(vars);
-                    }
-                }
-            }
-            Self::Labelled(labelled) => match labelled.item() {
-                LabelledItem::Function(_) => {}
-                LabelledItem::Statement(stmt) => stmt.var_declared_names(vars),
-            },
-            _ => {}
-        }
     }
 
     /// Abstract operation [`IsLabelledFunction`][spec].

--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -187,7 +187,7 @@ impl Statement {
                 for_in_loop.body().var_declared_names(vars);
             }
             Self::ForOfLoop(for_of_loop) => {
-                if let IterableLoopInitializer::Var(bind) = for_of_loop.init() {
+                if let IterableLoopInitializer::Var(bind) = for_of_loop.initializer() {
                     vars.extend(bind.idents());
                 }
                 for_of_loop.body().var_declared_names(vars);

--- a/boa_ast/src/visitor.rs
+++ b/boa_ast/src/visitor.rs
@@ -55,7 +55,6 @@ macro_rules! try_break {
 macro_rules! define_visit {
     ($fn_name:ident, $type_name:ident) => {
         #[doc = concat!("Visits a `", stringify!($type_name), "` with this visitor")]
-        #[must_use]
         fn $fn_name(&mut self, node: &'ast $type_name) -> ControlFlow<Self::BreakTy> {
             node.visit_with(self)
         }
@@ -66,7 +65,6 @@ macro_rules! define_visit {
 macro_rules! define_visit_mut {
     ($fn_name:ident, $type_name:ident) => {
         #[doc = concat!("Visits a `", stringify!($type_name), "` with this visitor, mutably")]
-        #[must_use]
         fn $fn_name(&mut self, node: &'ast mut $type_name) -> ControlFlow<Self::BreakTy> {
             node.visit_with_mut(self)
         }

--- a/boa_ast/src/visitor.rs
+++ b/boa_ast/src/visitor.rs
@@ -3,6 +3,43 @@
 //! This module contains visitors which can be used to inspect or modify AST nodes. This allows for
 //! fine-grained manipulation of ASTs for analysis, rewriting, or instrumentation.
 
+use std::ops::ControlFlow;
+
+use crate::{
+    declaration::{
+        Binding, Declaration, LexicalDeclaration, VarDeclaration, Variable, VariableList,
+    },
+    expression::{
+        access::{
+            PrivatePropertyAccess, PropertyAccess, PropertyAccessField, SimplePropertyAccess,
+            SuperPropertyAccess,
+        },
+        literal::{ArrayLiteral, Literal, ObjectLiteral, TemplateElement, TemplateLiteral},
+        operator::{
+            assign::{Assign, AssignTarget},
+            Binary, Conditional, Unary,
+        },
+        Await, Call, Expression, Identifier, New, Optional, OptionalOperation,
+        OptionalOperationKind, Spread, SuperCall, TaggedTemplate, Yield,
+    },
+    function::{
+        ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
+        FormalParameter, FormalParameterList, Function, Generator,
+    },
+    pattern::{ArrayPattern, ArrayPatternElement, ObjectPattern, ObjectPatternElement, Pattern},
+    property::{MethodDefinition, PropertyDefinition, PropertyName},
+    statement::{
+        iteration::{
+            Break, Continue, DoWhileLoop, ForInLoop, ForLoop, ForLoopInitializer, ForOfLoop,
+            IterableLoopInitializer, WhileLoop,
+        },
+        Block, Case, Catch, Finally, If, Labelled, LabelledItem, Return, Statement, Switch, Throw,
+        Try,
+    },
+    StatementList, StatementListItem,
+};
+use boa_interner::Sym;
+
 /// `Try`-like conditional unwrapping of `ControlFlow`.
 #[macro_export]
 macro_rules! try_break {
@@ -14,46 +51,12 @@ macro_rules! try_break {
     };
 }
 
-use crate::declaration::{
-    Binding, Declaration, LexicalDeclaration, VarDeclaration, Variable, VariableList,
-};
-use crate::expression::access::{
-    PrivatePropertyAccess, PropertyAccess, PropertyAccessField, SimplePropertyAccess,
-    SuperPropertyAccess,
-};
-use crate::expression::literal::{
-    ArrayLiteral, Literal, ObjectLiteral, TemplateElement, TemplateLiteral,
-};
-use crate::expression::operator::assign::{Assign, AssignTarget};
-use crate::expression::operator::{Binary, Conditional, Unary};
-use crate::expression::{
-    Await, Call, Expression, Identifier, New, Optional, OptionalOperation, OptionalOperationKind,
-    Spread, SuperCall, TaggedTemplate, Yield,
-};
-use crate::function::{
-    ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
-    FormalParameter, FormalParameterList, Function, Generator,
-};
-use crate::pattern::{
-    ArrayPattern, ArrayPatternElement, ObjectPattern, ObjectPatternElement, Pattern,
-};
-use crate::property::{MethodDefinition, PropertyDefinition, PropertyName};
-use crate::statement::iteration::{
-    Break, Continue, DoWhileLoop, ForInLoop, ForLoop, ForLoopInitializer, ForOfLoop,
-    IterableLoopInitializer, WhileLoop,
-};
-use crate::statement::{
-    Block, Case, Catch, Finally, If, Labelled, LabelledItem, Return, Statement, Switch, Throw, Try,
-};
-use crate::{StatementList, StatementListItem};
-use boa_interner::Sym;
-
 /// Creates the default visit function implementation for a particular type
 macro_rules! define_visit {
     ($fn_name:ident, $type_name:ident) => {
         #[doc = concat!("Visits a `", stringify!($type_name), "` with this visitor")]
         #[must_use]
-        fn $fn_name(&mut self, node: &'ast $type_name) -> core::ops::ControlFlow<Self::BreakTy> {
+        fn $fn_name(&mut self, node: &'ast $type_name) -> ControlFlow<Self::BreakTy> {
             node.visit_with(self)
         }
     };
@@ -64,13 +67,132 @@ macro_rules! define_visit_mut {
     ($fn_name:ident, $type_name:ident) => {
         #[doc = concat!("Visits a `", stringify!($type_name), "` with this visitor, mutably")]
         #[must_use]
-        fn $fn_name(
-            &mut self,
-            node: &'ast mut $type_name,
-        ) -> core::ops::ControlFlow<Self::BreakTy> {
+        fn $fn_name(&mut self, node: &'ast mut $type_name) -> ControlFlow<Self::BreakTy> {
             node.visit_with_mut(self)
         }
     };
+}
+
+/// Generates the `NodeRef` and `NodeMutRef` enums from a list of variants.
+macro_rules! node_ref {
+    (
+        $(
+            $Variant:ident
+        ),*
+        $(,)?
+    ) => {
+        /// A reference to a node visitable by a [`Visitor`].
+        #[derive(Debug, Clone, Copy)]
+        #[allow(missing_docs)]
+        pub enum NodeRef<'a> {
+            $(
+                $Variant(&'a $Variant)
+            ),*
+        }
+
+        $(
+            impl<'a> From<&'a $Variant> for NodeRef<'a> {
+                fn from(node: &'a $Variant) -> NodeRef<'a> {
+                    Self::$Variant(node)
+                }
+            }
+        )*
+
+        /// A mutable reference to a node visitable by a [`VisitorMut`].
+        #[derive(Debug)]
+        #[allow(missing_docs)]
+        pub enum NodeRefMut<'a> {
+            $(
+                $Variant(&'a mut $Variant)
+            ),*
+        }
+
+        $(
+            impl<'a> From<&'a mut $Variant> for NodeRefMut<'a> {
+                fn from(node: &'a mut $Variant) -> NodeRefMut<'a> {
+                    Self::$Variant(node)
+                }
+            }
+        )*
+    }
+}
+
+node_ref! {
+    StatementList,
+    StatementListItem,
+    Statement,
+    Declaration,
+    Function,
+    Generator,
+    AsyncFunction,
+    AsyncGenerator,
+    Class,
+    LexicalDeclaration,
+    Block,
+    VarDeclaration,
+    Expression,
+    If,
+    DoWhileLoop,
+    WhileLoop,
+    ForLoop,
+    ForInLoop,
+    ForOfLoop,
+    Switch,
+    Continue,
+    Break,
+    Return,
+    Labelled,
+    Throw,
+    Try,
+    Identifier,
+    FormalParameterList,
+    ClassElement,
+    VariableList,
+    Variable,
+    Binding,
+    Pattern,
+    Literal,
+    ArrayLiteral,
+    ObjectLiteral,
+    Spread,
+    ArrowFunction,
+    AsyncArrowFunction,
+    TemplateLiteral,
+    PropertyAccess,
+    New,
+    Call,
+    SuperCall,
+    Optional,
+    TaggedTemplate,
+    Assign,
+    Unary,
+    Binary,
+    Conditional,
+    Await,
+    Yield,
+    ForLoopInitializer,
+    IterableLoopInitializer,
+    Case,
+    Sym,
+    LabelledItem,
+    Catch,
+    Finally,
+    FormalParameter,
+    PropertyName,
+    MethodDefinition,
+    ObjectPattern,
+    ArrayPattern,
+    PropertyDefinition,
+    TemplateElement,
+    SimplePropertyAccess,
+    PrivatePropertyAccess,
+    SuperPropertyAccess,
+    OptionalOperation,
+    AssignTarget,
+    ObjectPatternElement,
+    ArrayPatternElement,
+    PropertyAccessField,
+    OptionalOperationKind,
 }
 
 /// Represents an AST visitor.
@@ -156,6 +278,90 @@ pub trait Visitor<'ast>: Sized {
     define_visit!(visit_array_pattern_element, ArrayPatternElement);
     define_visit!(visit_property_access_field, PropertyAccessField);
     define_visit!(visit_optional_operation_kind, OptionalOperationKind);
+
+    /// Generic entry point for a node that is visitable by a `Visitor`.
+    ///
+    /// This is usually used for generic functions that need to visit an unnamed AST node.
+    fn visit<N: Into<NodeRef<'ast>>>(&mut self, node: N) -> ControlFlow<Self::BreakTy> {
+        let node = node.into();
+        match node {
+            NodeRef::StatementList(n) => self.visit_statement_list(n),
+            NodeRef::StatementListItem(n) => self.visit_statement_list_item(n),
+            NodeRef::Statement(n) => self.visit_statement(n),
+            NodeRef::Declaration(n) => self.visit_declaration(n),
+            NodeRef::Function(n) => self.visit_function(n),
+            NodeRef::Generator(n) => self.visit_generator(n),
+            NodeRef::AsyncFunction(n) => self.visit_async_function(n),
+            NodeRef::AsyncGenerator(n) => self.visit_async_generator(n),
+            NodeRef::Class(n) => self.visit_class(n),
+            NodeRef::LexicalDeclaration(n) => self.visit_lexical_declaration(n),
+            NodeRef::Block(n) => self.visit_block(n),
+            NodeRef::VarDeclaration(n) => self.visit_var_declaration(n),
+            NodeRef::Expression(n) => self.visit_expression(n),
+            NodeRef::If(n) => self.visit_if(n),
+            NodeRef::DoWhileLoop(n) => self.visit_do_while_loop(n),
+            NodeRef::WhileLoop(n) => self.visit_while_loop(n),
+            NodeRef::ForLoop(n) => self.visit_for_loop(n),
+            NodeRef::ForInLoop(n) => self.visit_for_in_loop(n),
+            NodeRef::ForOfLoop(n) => self.visit_for_of_loop(n),
+            NodeRef::Switch(n) => self.visit_switch(n),
+            NodeRef::Continue(n) => self.visit_continue(n),
+            NodeRef::Break(n) => self.visit_break(n),
+            NodeRef::Return(n) => self.visit_return(n),
+            NodeRef::Labelled(n) => self.visit_labelled(n),
+            NodeRef::Throw(n) => self.visit_throw(n),
+            NodeRef::Try(n) => self.visit_try(n),
+            NodeRef::Identifier(n) => self.visit_identifier(n),
+            NodeRef::FormalParameterList(n) => self.visit_formal_parameter_list(n),
+            NodeRef::ClassElement(n) => self.visit_class_element(n),
+            NodeRef::VariableList(n) => self.visit_variable_list(n),
+            NodeRef::Variable(n) => self.visit_variable(n),
+            NodeRef::Binding(n) => self.visit_binding(n),
+            NodeRef::Pattern(n) => self.visit_pattern(n),
+            NodeRef::Literal(n) => self.visit_literal(n),
+            NodeRef::ArrayLiteral(n) => self.visit_array_literal(n),
+            NodeRef::ObjectLiteral(n) => self.visit_object_literal(n),
+            NodeRef::Spread(n) => self.visit_spread(n),
+            NodeRef::ArrowFunction(n) => self.visit_arrow_function(n),
+            NodeRef::AsyncArrowFunction(n) => self.visit_async_arrow_function(n),
+            NodeRef::TemplateLiteral(n) => self.visit_template_literal(n),
+            NodeRef::PropertyAccess(n) => self.visit_property_access(n),
+            NodeRef::New(n) => self.visit_new(n),
+            NodeRef::Call(n) => self.visit_call(n),
+            NodeRef::SuperCall(n) => self.visit_super_call(n),
+            NodeRef::Optional(n) => self.visit_optional(n),
+            NodeRef::TaggedTemplate(n) => self.visit_tagged_template(n),
+            NodeRef::Assign(n) => self.visit_assign(n),
+            NodeRef::Unary(n) => self.visit_unary(n),
+            NodeRef::Binary(n) => self.visit_binary(n),
+            NodeRef::Conditional(n) => self.visit_conditional(n),
+            NodeRef::Await(n) => self.visit_await(n),
+            NodeRef::Yield(n) => self.visit_yield(n),
+            NodeRef::ForLoopInitializer(n) => self.visit_for_loop_initializer(n),
+            NodeRef::IterableLoopInitializer(n) => self.visit_iterable_loop_initializer(n),
+            NodeRef::Case(n) => self.visit_case(n),
+            NodeRef::Sym(n) => self.visit_sym(n),
+            NodeRef::LabelledItem(n) => self.visit_labelled_item(n),
+            NodeRef::Catch(n) => self.visit_catch(n),
+            NodeRef::Finally(n) => self.visit_finally(n),
+            NodeRef::FormalParameter(n) => self.visit_formal_parameter(n),
+            NodeRef::PropertyName(n) => self.visit_property_name(n),
+            NodeRef::MethodDefinition(n) => self.visit_method_definition(n),
+            NodeRef::ObjectPattern(n) => self.visit_object_pattern(n),
+            NodeRef::ArrayPattern(n) => self.visit_array_pattern(n),
+            NodeRef::PropertyDefinition(n) => self.visit_property_definition(n),
+            NodeRef::TemplateElement(n) => self.visit_template_element(n),
+            NodeRef::SimplePropertyAccess(n) => self.visit_simple_property_access(n),
+            NodeRef::PrivatePropertyAccess(n) => self.visit_private_property_access(n),
+            NodeRef::SuperPropertyAccess(n) => self.visit_super_property_access(n),
+            NodeRef::OptionalOperation(n) => self.visit_optional_operation(n),
+            NodeRef::AssignTarget(n) => self.visit_assign_target(n),
+            NodeRef::ObjectPatternElement(n) => self.visit_object_pattern_element(n),
+            NodeRef::ArrayPatternElement(n) => self.visit_array_pattern_element(n),
+            NodeRef::PropertyAccessField(n) => self.visit_property_access_field(n),
+            NodeRef::OptionalOperationKind(n) => self.visit_optional_operation_kind(n),
+        }
+    }
 }
 
 /// Represents an AST visitor which can modify AST content.
@@ -241,33 +447,117 @@ pub trait VisitorMut<'ast>: Sized {
     define_visit_mut!(visit_array_pattern_element_mut, ArrayPatternElement);
     define_visit_mut!(visit_property_access_field_mut, PropertyAccessField);
     define_visit_mut!(visit_optional_operation_kind_mut, OptionalOperationKind);
+
+    /// Generic entry point for a node that is visitable by a `VisitorMut`.
+    ///
+    /// This is usually used for generic functions that need to visit an unnamed AST node.
+    fn visit<N: Into<NodeRefMut<'ast>>>(&mut self, node: N) -> ControlFlow<Self::BreakTy> {
+        let node = node.into();
+        match node {
+            NodeRefMut::StatementList(n) => self.visit_statement_list_mut(n),
+            NodeRefMut::StatementListItem(n) => self.visit_statement_list_item_mut(n),
+            NodeRefMut::Statement(n) => self.visit_statement_mut(n),
+            NodeRefMut::Declaration(n) => self.visit_declaration_mut(n),
+            NodeRefMut::Function(n) => self.visit_function_mut(n),
+            NodeRefMut::Generator(n) => self.visit_generator_mut(n),
+            NodeRefMut::AsyncFunction(n) => self.visit_async_function_mut(n),
+            NodeRefMut::AsyncGenerator(n) => self.visit_async_generator_mut(n),
+            NodeRefMut::Class(n) => self.visit_class_mut(n),
+            NodeRefMut::LexicalDeclaration(n) => self.visit_lexical_declaration_mut(n),
+            NodeRefMut::Block(n) => self.visit_block_mut(n),
+            NodeRefMut::VarDeclaration(n) => self.visit_var_declaration_mut(n),
+            NodeRefMut::Expression(n) => self.visit_expression_mut(n),
+            NodeRefMut::If(n) => self.visit_if_mut(n),
+            NodeRefMut::DoWhileLoop(n) => self.visit_do_while_loop_mut(n),
+            NodeRefMut::WhileLoop(n) => self.visit_while_loop_mut(n),
+            NodeRefMut::ForLoop(n) => self.visit_for_loop_mut(n),
+            NodeRefMut::ForInLoop(n) => self.visit_for_in_loop_mut(n),
+            NodeRefMut::ForOfLoop(n) => self.visit_for_of_loop_mut(n),
+            NodeRefMut::Switch(n) => self.visit_switch_mut(n),
+            NodeRefMut::Continue(n) => self.visit_continue_mut(n),
+            NodeRefMut::Break(n) => self.visit_break_mut(n),
+            NodeRefMut::Return(n) => self.visit_return_mut(n),
+            NodeRefMut::Labelled(n) => self.visit_labelled_mut(n),
+            NodeRefMut::Throw(n) => self.visit_throw_mut(n),
+            NodeRefMut::Try(n) => self.visit_try_mut(n),
+            NodeRefMut::Identifier(n) => self.visit_identifier_mut(n),
+            NodeRefMut::FormalParameterList(n) => self.visit_formal_parameter_list_mut(n),
+            NodeRefMut::ClassElement(n) => self.visit_class_element_mut(n),
+            NodeRefMut::VariableList(n) => self.visit_variable_list_mut(n),
+            NodeRefMut::Variable(n) => self.visit_variable_mut(n),
+            NodeRefMut::Binding(n) => self.visit_binding_mut(n),
+            NodeRefMut::Pattern(n) => self.visit_pattern_mut(n),
+            NodeRefMut::Literal(n) => self.visit_literal_mut(n),
+            NodeRefMut::ArrayLiteral(n) => self.visit_array_literal_mut(n),
+            NodeRefMut::ObjectLiteral(n) => self.visit_object_literal_mut(n),
+            NodeRefMut::Spread(n) => self.visit_spread_mut(n),
+            NodeRefMut::ArrowFunction(n) => self.visit_arrow_function_mut(n),
+            NodeRefMut::AsyncArrowFunction(n) => self.visit_async_arrow_function_mut(n),
+            NodeRefMut::TemplateLiteral(n) => self.visit_template_literal_mut(n),
+            NodeRefMut::PropertyAccess(n) => self.visit_property_access_mut(n),
+            NodeRefMut::New(n) => self.visit_new_mut(n),
+            NodeRefMut::Call(n) => self.visit_call_mut(n),
+            NodeRefMut::SuperCall(n) => self.visit_super_call_mut(n),
+            NodeRefMut::Optional(n) => self.visit_optional_mut(n),
+            NodeRefMut::TaggedTemplate(n) => self.visit_tagged_template_mut(n),
+            NodeRefMut::Assign(n) => self.visit_assign_mut(n),
+            NodeRefMut::Unary(n) => self.visit_unary_mut(n),
+            NodeRefMut::Binary(n) => self.visit_binary_mut(n),
+            NodeRefMut::Conditional(n) => self.visit_conditional_mut(n),
+            NodeRefMut::Await(n) => self.visit_await_mut(n),
+            NodeRefMut::Yield(n) => self.visit_yield_mut(n),
+            NodeRefMut::ForLoopInitializer(n) => self.visit_for_loop_initializer_mut(n),
+            NodeRefMut::IterableLoopInitializer(n) => self.visit_iterable_loop_initializer_mut(n),
+            NodeRefMut::Case(n) => self.visit_case_mut(n),
+            NodeRefMut::Sym(n) => self.visit_sym_mut(n),
+            NodeRefMut::LabelledItem(n) => self.visit_labelled_item_mut(n),
+            NodeRefMut::Catch(n) => self.visit_catch_mut(n),
+            NodeRefMut::Finally(n) => self.visit_finally_mut(n),
+            NodeRefMut::FormalParameter(n) => self.visit_formal_parameter_mut(n),
+            NodeRefMut::PropertyName(n) => self.visit_property_name_mut(n),
+            NodeRefMut::MethodDefinition(n) => self.visit_method_definition_mut(n),
+            NodeRefMut::ObjectPattern(n) => self.visit_object_pattern_mut(n),
+            NodeRefMut::ArrayPattern(n) => self.visit_array_pattern_mut(n),
+            NodeRefMut::PropertyDefinition(n) => self.visit_property_definition_mut(n),
+            NodeRefMut::TemplateElement(n) => self.visit_template_element_mut(n),
+            NodeRefMut::SimplePropertyAccess(n) => self.visit_simple_property_access_mut(n),
+            NodeRefMut::PrivatePropertyAccess(n) => self.visit_private_property_access_mut(n),
+            NodeRefMut::SuperPropertyAccess(n) => self.visit_super_property_access_mut(n),
+            NodeRefMut::OptionalOperation(n) => self.visit_optional_operation_mut(n),
+            NodeRefMut::AssignTarget(n) => self.visit_assign_target_mut(n),
+            NodeRefMut::ObjectPatternElement(n) => self.visit_object_pattern_element_mut(n),
+            NodeRefMut::ArrayPatternElement(n) => self.visit_array_pattern_element_mut(n),
+            NodeRefMut::PropertyAccessField(n) => self.visit_property_access_field_mut(n),
+            NodeRefMut::OptionalOperationKind(n) => self.visit_optional_operation_kind_mut(n),
+        }
+    }
 }
 
 /// Denotes that a type may be visited, providing a method which allows a visitor to traverse its
 /// private fields.
 pub trait VisitWith {
     /// Visit this node with the provided visitor.
-    fn visit_with<'a, V>(&'a self, visitor: &mut V) -> core::ops::ControlFlow<V::BreakTy>
+    fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
         V: Visitor<'a>;
 
     /// Visit this node with the provided visitor mutably, allowing the visitor to modify private
     /// fields.
-    fn visit_with_mut<'a, V>(&'a mut self, visitor: &mut V) -> core::ops::ControlFlow<V::BreakTy>
+    fn visit_with_mut<'a, V>(&'a mut self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
         V: VisitorMut<'a>;
 }
 
 // implementation for Sym as it is out-of-crate
 impl VisitWith for Sym {
-    fn visit_with<'a, V>(&'a self, _visitor: &mut V) -> core::ops::ControlFlow<V::BreakTy>
+    fn visit_with<'a, V>(&'a self, _visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
         V: Visitor<'a>,
     {
         core::ops::ControlFlow::Continue(())
     }
 
-    fn visit_with_mut<'a, V>(&'a mut self, _visitor: &mut V) -> core::ops::ControlFlow<V::BreakTy>
+    fn visit_with_mut<'a, V>(&'a mut self, _visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
         V: VisitorMut<'a>,
     {

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -70,6 +70,7 @@ impl Eval {
     ) -> JsResult<JsValue> {
         /// Possible actions that can be executed after exiting this function to restore the environment to its
         /// original state.
+        #[derive(Debug)]
         enum EnvStackAction {
             Truncate(usize),
             Restore(Vec<Gc<DeclarativeEnvironment>>),

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -5,7 +5,7 @@ use crate::{
     symbol::{self, WellKnownSymbols},
     Context, JsValue,
 };
-use boa_ast::function::FormalParameterList;
+use boa_ast::{function::FormalParameterList, operations::bound_names};
 use boa_gc::{Finalize, Gc, Trace};
 use rustc_hash::FxHashMap;
 
@@ -199,18 +199,16 @@ impl Arguments {
 
         let mut bindings = FxHashMap::default();
         let mut property_index = 0;
-        'outer: for formal in formals.as_ref() {
-            for name in formal.names() {
-                if property_index >= len {
-                    break 'outer;
-                }
-                let binding_index = bindings.len() + 1;
-                let entry = bindings
-                    .entry(name)
-                    .or_insert((binding_index, property_index));
-                entry.1 = property_index;
-                property_index += 1;
+        for name in bound_names(formals) {
+            if property_index >= len {
+                break;
             }
+            let binding_index = bindings.len() + 1;
+            let entry = bindings
+                .entry(name)
+                .or_insert((binding_index, property_index));
+            entry.1 = property_index;
+            property_index += 1;
         }
 
         let mut map = ParameterMap {

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -4,7 +4,9 @@ use crate::{
     vm::{BindingOpcode, CodeBlock, Opcode},
     Context, JsResult,
 };
-use boa_ast::{declaration::Binding, function::FormalParameterList, StatementList};
+use boa_ast::{
+    declaration::Binding, function::FormalParameterList, operations::bound_names, StatementList,
+};
 use boa_gc::Gc;
 use boa_interner::Sym;
 use rustc_hash::FxHashMap;
@@ -153,7 +155,7 @@ impl FunctionCompiler {
                     compiler.emit_binding(BindingOpcode::InitArg, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         compiler.context.create_mutable_binding(ident, false, false);
                     }
                     // TODO: throw custom error if ident is in init

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -21,6 +21,7 @@ use boa_ast::{
         ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
         FormalParameterList, Function, Generator,
     },
+    operations::bound_names,
     pattern::{ArrayPatternElement, ObjectPatternElement, Pattern},
     property::{MethodDefinition, PropertyDefinition, PropertyName},
     statement::{
@@ -1920,7 +1921,7 @@ impl<'b> ByteCompiler<'b> {
         label: Option<Sym>,
         configurable_globals: bool,
     ) -> JsResult<()> {
-        let init_bound_names = for_in_loop.initializer().bound_names();
+        let init_bound_names = bound_names(for_in_loop.initializer());
         if init_bound_names.is_empty() {
             self.compile_expr(for_in_loop.target(), true)?;
         } else {
@@ -2035,7 +2036,7 @@ impl<'b> ByteCompiler<'b> {
         label: Option<Sym>,
         configurable_globals: bool,
     ) -> JsResult<()> {
-        let init_bound_names = for_of_loop.init().bound_names();
+        let init_bound_names = bound_names(for_of_loop.initializer());
         if init_bound_names.is_empty() {
             self.compile_expr(for_of_loop.iterable(), true)?;
         } else {
@@ -2077,7 +2078,7 @@ impl<'b> ByteCompiler<'b> {
             self.emit_opcode_with_operand(Opcode::ForInLoopNext)
         };
 
-        match for_of_loop.init() {
+        match for_of_loop.initializer() {
             IterableLoopInitializer::Identifier(ref ident) => {
                 self.context.create_mutable_binding(*ident, true, true);
                 let binding = self.context.set_mutable_binding(*ident);

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -1972,7 +1972,7 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitVar, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_mutable_binding(ident, true, false);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitVar)?;
@@ -1984,7 +1984,7 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitLet, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_mutable_binding(ident, false, false);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitLet)?;
@@ -1996,14 +1996,14 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitConst, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_immutable_binding(ident, true);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitConst)?;
                 }
             },
             IterableLoopInitializer::Pattern(pattern) => {
-                for ident in pattern.idents() {
+                for ident in bound_names(pattern) {
                     self.context.create_mutable_binding(ident, true, true);
                 }
                 self.compile_declaration_pattern(pattern, BindingOpcode::InitVar)?;
@@ -2098,7 +2098,7 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitVar, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_mutable_binding(ident, true, false);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitVar)?;
@@ -2110,7 +2110,7 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitLet, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_mutable_binding(ident, false, false);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitLet)?;
@@ -2122,14 +2122,14 @@ impl<'b> ByteCompiler<'b> {
                     self.emit_binding(BindingOpcode::InitConst, *ident);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         self.context.create_immutable_binding(ident, true);
                     }
                     self.compile_declaration_pattern(pattern, BindingOpcode::InitConst)?;
                 }
             },
             IterableLoopInitializer::Pattern(pattern) => {
-                for ident in pattern.idents() {
+                for ident in bound_names(pattern) {
                     self.context.create_mutable_binding(ident, true, true);
                 }
                 self.compile_declaration_pattern(pattern, BindingOpcode::InitVar)?;
@@ -2567,7 +2567,7 @@ impl<'b> ByteCompiler<'b> {
                                 self.emit_binding(BindingOpcode::InitLet, *ident);
                             }
                             Binding::Pattern(pattern) => {
-                                for ident in pattern.idents() {
+                                for ident in bound_names(pattern) {
                                     self.context.create_mutable_binding(ident, false, false);
                                 }
                                 self.compile_declaration_pattern(pattern, BindingOpcode::InitLet)?;
@@ -3053,7 +3053,7 @@ impl<'b> ByteCompiler<'b> {
                         .create_mutable_binding(*ident, true, configurable_globals);
                 }
                 Binding::Pattern(pattern) => {
-                    for ident in pattern.idents() {
+                    for ident in bound_names(pattern) {
                         if ident == Sym::ARGUMENTS {
                             has_identifier_argument = true;
                         }
@@ -3080,7 +3080,7 @@ impl<'b> ByteCompiler<'b> {
                             self.context.create_mutable_binding(*ident, false, false);
                         }
                         Binding::Pattern(pattern) => {
-                            for ident in pattern.idents() {
+                            for ident in bound_names(pattern) {
                                 if ident == Sym::ARGUMENTS {
                                     has_identifier_argument = true;
                                 }
@@ -3101,7 +3101,7 @@ impl<'b> ByteCompiler<'b> {
                             self.context.create_immutable_binding(*ident, true);
                         }
                         Binding::Pattern(pattern) => {
-                            for ident in pattern.idents() {
+                            for ident in bound_names(pattern) {
                                 if ident == Sym::ARGUMENTS {
                                     has_identifier_argument = true;
                                 }
@@ -3259,7 +3259,7 @@ impl<'b> ByteCompiler<'b> {
                         compiler.emit_binding(BindingOpcode::InitArg, *ident);
                     }
                     Binding::Pattern(pattern) => {
-                        for ident in pattern.idents() {
+                        for ident in bound_names(pattern) {
                             compiler.context.create_mutable_binding(ident, false, false);
                         }
                         compiler.compile_declaration_pattern(pattern, BindingOpcode::InitArg)?;

--- a/boa_engine/src/syntax/parser/expression/assignment/arrow_function.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/arrow_function.rs
@@ -17,6 +17,7 @@ use crate::syntax::{
         name_in_lexically_declared_names, AllowAwait, AllowIn, AllowYield, Cursor, TokenParser,
     },
 };
+use ast::operations::{bound_names, top_level_lexically_declared_names};
 use boa_ast::{
     self as ast,
     declaration::Variable,
@@ -150,14 +151,14 @@ where
                 "Illegal 'use strict' directive in function with non-simple parameter list".into(),
                 params_start_position,
             )));
-        }
+        };
 
         // It is a Syntax Error if any element of the BoundNames of ArrowParameters
         // also occurs in the LexicallyDeclaredNames of ConciseBody.
         // https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-early-errors
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/expression/assignment/async_arrow_function.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/async_arrow_function.rs
@@ -18,7 +18,7 @@ use crate::syntax::{
     },
 };
 use ast::{
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Keyword,
 };
 use boa_ast::{
@@ -144,8 +144,8 @@ where
         // Early Error: It is a Syntax Error if any element of the BoundNames of CoverCallExpressionAndAsyncArrowHead
         // also occurs in the LexicallyDeclaredNames of AsyncConciseBody.
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/expression/assignment/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/mod.rs
@@ -26,7 +26,7 @@ use crate::syntax::{
         ParseResult, TokenParser,
     },
 };
-use ast::operations::{contains, ContainsSymbol};
+use ast::operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol};
 use boa_ast::{
     self as ast,
     expression::{
@@ -242,8 +242,8 @@ where
             // also occurs in the LexicallyDeclaredNames of ConciseBody.
             // https://tc39.es/ecma262/#sec-arrow-function-definitions-static-semantics-early-errors
             name_in_lexically_declared_names(
-                &parameters,
-                &body.lexically_declared_names_top_level(),
+                &bound_names(&parameters),
+                &top_level_lexically_declared_names(&body),
                 position,
             )?;
 

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -12,7 +12,7 @@ use crate::syntax::{
 use boa_ast::{
     expression::Identifier,
     function::AsyncFunction,
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Keyword, Position, Punctuator,
 };
 use boa_interner::{Interner, Sym};
@@ -132,8 +132,8 @@ where
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
@@ -21,7 +21,7 @@ use crate::syntax::{
 use boa_ast::{
     expression::Identifier,
     function::AsyncGenerator,
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Keyword, Position, Punctuator,
 };
 use boa_interner::{Interner, Sym};
@@ -164,8 +164,8 @@ where
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -21,7 +21,7 @@ use crate::syntax::{
 use boa_ast::{
     expression::Identifier,
     function::Function,
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Keyword, Position, Punctuator,
 };
 use boa_interner::{Interner, Sym};
@@ -126,8 +126,8 @@ where
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
@@ -21,7 +21,7 @@ use crate::syntax::{
 use boa_ast::{
     expression::Identifier,
     function::Generator,
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Position, Punctuator,
 };
 use boa_interner::{Interner, Sym};
@@ -128,8 +128,8 @@ where
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
         name_in_lexically_declared_names(
-            &params,
-            &body.lexically_declared_names_top_level(),
+            &bound_names(&params),
+            &top_level_lexically_declared_names(&body),
             params_start_position,
         )?;
 

--- a/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/hoistable/mod.rs
@@ -32,7 +32,7 @@ use crate::syntax::{
 use boa_ast::{
     expression::Identifier,
     function::FormalParameterList,
-    operations::{contains, ContainsSymbol},
+    operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
     Declaration, Keyword, Position, Punctuator, StatementList,
 };
 use boa_interner::{Interner, Sym};
@@ -209,8 +209,8 @@ fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
     // also occurs in the LexicallyDeclaredNames of FunctionBody.
     // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
     name_in_lexically_declared_names(
-        &params,
-        &body.lexically_declared_names_top_level(),
+        &bound_names(&params),
+        &top_level_lexically_declared_names(&body),
         params_start_position,
     )?;
 

--- a/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/lexical.rs
@@ -16,6 +16,7 @@ use crate::syntax::{
         AllowAwait, AllowIn, AllowYield, ParseError, ParseResult, TokenParser,
     },
 };
+use ast::operations::bound_names;
 use boa_ast::{self as ast, declaration::Variable, pattern::Pattern, Keyword, Punctuator};
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
@@ -276,7 +277,7 @@ where
 
                 let declaration = Pattern::Object(bindings.into());
 
-                if declaration.idents().contains(&Sym::LET.into()) {
+                if bound_names(&declaration).contains(&Sym::LET.into()) {
                     return Err(ParseError::lex(LexError::Syntax(
                         "'let' is disallowed as a lexically bound name".into(),
                         position,
@@ -304,7 +305,7 @@ where
 
                 let declaration = Pattern::Array(bindings.into());
 
-                if declaration.idents().contains(&Sym::LET.into()) {
+                if bound_names(&declaration).contains(&Sym::LET.into()) {
                     return Err(ParseError::lex(LexError::Syntax(
                         "'let' is disallowed as a lexically bound name".into(),
                         position,

--- a/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/for_statement.rs
@@ -16,6 +16,7 @@ use crate::syntax::{
         AllowAwait, AllowReturn, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
     },
 };
+use ast::operations::bound_names;
 use boa_ast::{
     self as ast,
     statement::{
@@ -185,8 +186,8 @@ where
                 // It is a Syntax Error if the BoundNames of ForDeclaration contains any duplicate entries.
                 let mut vars = FxHashSet::default();
                 body.var_declared_names(&mut vars);
-                let mut bound_names = FxHashSet::default();
-                for name in init.bound_names() {
+                let mut names = FxHashSet::default();
+                for name in bound_names(&init) {
                     if name == Sym::LET {
                         return Err(ParseError::general(
                             "Cannot use 'let' as a lexically bound name",
@@ -199,7 +200,7 @@ where
                             position,
                         ));
                     }
-                    if !bound_names.insert(name) {
+                    if !names.insert(name) {
                         return Err(ParseError::general(
                             "For loop initializer cannot contain duplicate identifiers",
                             position,
@@ -238,8 +239,8 @@ where
                 // It is a Syntax Error if the BoundNames of ForDeclaration contains any duplicate entries.
                 let mut vars = FxHashSet::default();
                 body.var_declared_names(&mut vars);
-                let mut bound_names = FxHashSet::default();
-                for name in init.bound_names() {
+                let mut names = FxHashSet::default();
+                for name in bound_names(&init) {
                     if name == Sym::LET {
                         return Err(ParseError::general(
                             "Cannot use 'let' as a lexically bound name",
@@ -252,7 +253,7 @@ where
                             position,
                         ));
                     }
-                    if !bound_names.insert(name) {
+                    if !names.insert(name) {
                         return Err(ParseError::general(
                             "For loop initializer cannot contain duplicate identifiers",
                             position,
@@ -322,7 +323,7 @@ where
         let mut vars = FxHashSet::default();
         body.var_declared_names(&mut vars);
         if let Some(ref init) = init {
-            for name in init.bound_names() {
+            for name in bound_names(init) {
                 if vars.contains(&name) {
                     return Err(ParseError::general(
                         "For loop initializer declared in loop body",

--- a/boa_engine/src/syntax/parser/statement/iteration/tests.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/tests.rs
@@ -244,3 +244,9 @@ fn do_while_spaces() {
 fn reject_const_no_init_for_loop() {
     check_invalid("for (const h;;);");
 }
+
+/// Checks rejection of for await .. in loops
+#[test]
+fn reject_for_await_in_loop() {
+    check_invalid("for await (x in [1,2,3]);");
+}

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1396,19 +1396,7 @@ impl JsObject {
                     false,
                 );
 
-                let mut arguments_in_parameter_names = false;
-                let mut is_simple_parameter_list = true;
-                let mut has_parameter_expressions = false;
-
-                for param in code.params.as_ref().iter() {
-                    has_parameter_expressions = has_parameter_expressions || param.init().is_some();
-                    arguments_in_parameter_names = arguments_in_parameter_names
-                        || param.names().contains(&Sym::ARGUMENTS.into());
-                    is_simple_parameter_list = is_simple_parameter_list
-                        && !param.is_rest_param()
-                        && param.is_identifier()
-                        && param.init().is_none();
-                }
+                let has_expressions = code.params.has_expressions();
 
                 if let Some(binding) = code.arguments_binding {
                     let arguments_obj = if code.strict || !code.params.is_simple() {
@@ -1475,7 +1463,7 @@ impl JsObject {
                 context.vm.pop_frame();
 
                 let mut environment = context.realm.environments.pop();
-                if has_parameter_expressions {
+                if has_expressions {
                     environment = context.realm.environments.pop();
                 }
 


### PR DESCRIPTION
This PR rewrites all syntax-directed operations that find declared names and variables using visitors.

Hopefully, this should be the last step before finally being able to separate the parser from the engine.

I checked the failing [tests](https://github.com/tc39/test262/blob/85373b4ce12a908f8fc517093d95cf2ed2f5ee6a/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-target-yield-expr.js#L49) and they're apparently false positives, since they return `Promise { <rejected> ReferenceError: x is not initialized }` on the main branch.