### PR TITLE
[Merged by Bors] - Reduced boilerplate code in the parser

### DIFF
--- a/boa_engine/src/syntax/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_engine/src/syntax/parser/cursor/buffered_lexer/mod.rs
@@ -1,6 +1,6 @@
 use crate::syntax::{
     lexer::{InputElement, Lexer, Token, TokenKind},
-    parser::error::ParseError,
+    parser::{error::ParseError, ParseResult},
 };
 use boa_ast::Position;
 use boa_interner::Interner;
@@ -83,7 +83,7 @@ where
         &mut self,
         start: Position,
         interner: &mut Interner,
-    ) -> Result<Token, ParseError> {
+    ) -> ParseResult<Token> {
         let _timer = Profiler::global().start_event("cursor::lex_regex()", "Parsing");
         self.set_goal(InputElement::RegExp);
         self.lexer
@@ -97,7 +97,7 @@ where
         &mut self,
         start: Position,
         interner: &mut Interner,
-    ) -> Result<Token, ParseError> {
+    ) -> ParseResult<Token> {
         self.lexer
             .lex_template(start, interner)
             .map_err(ParseError::from)
@@ -116,7 +116,7 @@ where
     /// Fills the peeking buffer with the next token.
     ///
     /// It will not fill two line terminators one after the other.
-    fn fill(&mut self, interner: &mut Interner) -> Result<(), ParseError> {
+    fn fill(&mut self, interner: &mut Interner) -> ParseResult<()> {
         debug_assert!(
             self.write_index < PEEK_BUF_SIZE,
             "write index went out of bounds"
@@ -166,12 +166,12 @@ where
     ///
     /// This follows iterator semantics in that a `peek(0, false)` followed by a `next(false)` will
     /// return the same value. Note that because a `peek(n, false)` may return a line terminator a
-    // subsequent `next(true)` may not return the same value.
+    /// subsequent `next(true)` may not return the same value.
     pub(super) fn next(
         &mut self,
         skip_line_terminators: bool,
         interner: &mut Interner,
-    ) -> Result<Option<Token>, ParseError> {
+    ) -> ParseResult<Option<Token>> {
         if self.read_index == self.write_index {
             self.fill(interner)?;
         }
@@ -217,7 +217,7 @@ where
         skip_n: usize,
         skip_line_terminators: bool,
         interner: &mut Interner,
-    ) -> Result<Option<&Token>, ParseError> {
+    ) -> ParseResult<Option<&Token>> {
         assert!(
             skip_n <= MAX_PEEK_SKIP,
             "you cannot skip more than {} elements",

--- a/boa_engine/src/syntax/parser/error.rs
+++ b/boa_engine/src/syntax/parser/error.rs
@@ -12,13 +12,15 @@ pub(crate) trait ErrorContext {
     fn context(self, context: &'static str) -> Self;
 }
 
-impl<T> ErrorContext for Result<T, ParseError> {
+impl<T> ErrorContext for ParseResult<T> {
+    #[inline]
     fn context(self, context: &'static str) -> Self {
         self.map_err(|e| e.context(context))
     }
 }
 
 impl From<LexError> for ParseError {
+    #[inline]
     fn from(e: LexError) -> Self {
         Self::lex(e)
     }

--- a/boa_engine/src/syntax/parser/expression/assignment/conditional.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/conditional.rs
@@ -79,7 +79,7 @@ where
 
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Question) {
-                cursor.next(interner)?.expect("? character vanished"); // Consume the token.
+                cursor.advance(interner);
                 let then_clause =
                     AssignmentExpression::new(None, true, self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;

--- a/boa_engine/src/syntax/parser/expression/assignment/yield.rs
+++ b/boa_engine/src/syntax/parser/expression/assignment/yield.rs
@@ -10,7 +10,7 @@
 use super::AssignmentExpression;
 use crate::syntax::{
     lexer::TokenKind,
-    parser::{AllowAwait, AllowIn, Cursor, ParseError, ParseResult, TokenParser},
+    parser::{AllowAwait, AllowIn, Cursor, OrAbrupt, ParseResult, TokenParser},
 };
 use boa_ast::{expression::Yield, Expression, Keyword, Punctuator};
 use boa_interner::Interner;
@@ -67,10 +67,10 @@ where
             return Ok(Yield::new(None, false).into());
         }
 
-        let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let token = cursor.peek(0, interner).or_abrupt()?;
         match token.kind() {
             TokenKind::Punctuator(Punctuator::Mul) => {
-                cursor.next(interner)?.expect("token disappeared");
+                cursor.advance(interner);
                 let expr = AssignmentExpression::new(None, self.allow_in, true, self.allow_await)
                     .parse(cursor, interner)?;
                 Ok(Yield::new(Some(expr), true).into())

--- a/boa_engine/src/syntax/parser/expression/identifiers.rs
+++ b/boa_engine/src/syntax/parser/expression/identifiers.rs
@@ -7,7 +7,9 @@
 
 use crate::syntax::{
     lexer::{Error as LexError, TokenKind},
-    parser::{cursor::Cursor, AllowAwait, AllowYield, ParseError, ParseResult, TokenParser},
+    parser::{
+        cursor::Cursor, AllowAwait, AllowYield, OrAbrupt, ParseError, ParseResult, TokenParser,
+    },
 };
 use boa_ast::{expression::Identifier, Keyword};
 use boa_interner::{Interner, Sym};
@@ -61,7 +63,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("IdentifierReference", "Parsing");
 
-        let token = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
+        let token = cursor.next(interner).or_abrupt()?;
 
         match token.kind() {
             TokenKind::Identifier(ident)
@@ -153,7 +155,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("BindingIdentifier", "Parsing");
 
-        let next_token = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = cursor.next(interner).or_abrupt()?;
 
         match next_token.kind() {
             TokenKind::Identifier(Sym::ARGUMENTS) if cursor.strict_mode() => {

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/arguments.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/arguments.rs
@@ -10,8 +10,8 @@
 use crate::syntax::{
     lexer::{InputElement, TokenKind},
     parser::{
-        expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, ParseError, ParseResult,
-        TokenParser,
+        expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, OrAbrupt, ParseError,
+        ParseResult, TokenParser,
     },
 };
 use boa_ast::{expression::Spread, Expression, Punctuator};
@@ -60,11 +60,11 @@ where
         let mut args = Vec::new();
         loop {
             cursor.set_goal(InputElement::RegExp);
-            let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+            let next_token = cursor.peek(0, interner).or_abrupt()?;
 
             match next_token.kind() {
                 TokenKind::Punctuator(Punctuator::CloseParen) => {
-                    cursor.next(interner)?.expect(") token vanished"); // Consume the token.
+                    cursor.advance(interner);
                     break;
                 }
                 TokenKind::Punctuator(Punctuator::Comma) => {

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/mod.rs
@@ -101,7 +101,7 @@ where
         cursor.set_goal(InputElement::TemplateTail);
 
         let mut lhs = if is_super_call(cursor, interner)? {
-            cursor.next(interner).expect("token disappeared");
+            cursor.advance(interner);
             let args =
                 Arguments::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
             SuperCall::new(args).into()

--- a/boa_engine/src/syntax/parser/expression/left_hand_side/template.rs
+++ b/boa_engine/src/syntax/parser/expression/left_hand_side/template.rs
@@ -1,8 +1,8 @@
 use crate::syntax::{
     lexer::TokenKind,
     parser::{
-        cursor::Cursor, expression::Expression, AllowAwait, AllowYield, ParseError, ParseResult,
-        TokenParser,
+        cursor::Cursor, expression::Expression, AllowAwait, AllowYield, OrAbrupt, ParseError,
+        ParseResult, TokenParser,
     },
 };
 use boa_ast::{self as ast, expression::TaggedTemplate, Position, Punctuator};
@@ -58,7 +58,7 @@ where
         let mut cookeds = Vec::new();
         let mut exprs = Vec::new();
 
-        let mut token = cursor.next(interner)?.ok_or(ParseError::AbruptEnd)?;
+        let mut token = cursor.next(interner).or_abrupt()?;
 
         loop {
             match token.kind() {

--- a/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_function_expression/mod.rs
@@ -6,7 +6,8 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
+        name_in_lexically_declared_names, AllowYield, Cursor, OrAbrupt, ParseError, ParseResult,
+        TokenParser,
     },
 };
 use boa_ast::{
@@ -62,11 +63,7 @@ where
             interner,
         )?;
 
-        let (name, has_binding_identifier) = match cursor
-            .peek(0, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .kind()
-        {
+        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
             TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
             _ => (
                 Some(BindingIdentifier::new(self.allow_yield, true).parse(cursor, interner)?),

--- a/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/async_generator_expression/mod.rs
@@ -15,7 +15,7 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, Cursor, ParseError, ParseResult, TokenParser,
+        name_in_lexically_declared_names, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -71,11 +71,7 @@ where
             interner,
         )?;
 
-        let (name, has_binding_identifier) = match cursor
-            .peek(0, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .kind()
-        {
+        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
             TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
             _ => (
                 Some(BindingIdentifier::new(true, true).parse(cursor, interner)?),

--- a/boa_engine/src/syntax/parser/expression/primary/class_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/class_expression/mod.rs
@@ -2,7 +2,7 @@ use crate::syntax::{
     lexer::TokenKind,
     parser::{
         expression::BindingIdentifier, statement::ClassTail, AllowAwait, AllowYield, Cursor,
-        ParseError, ParseResult, TokenParser,
+        OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{expression::Identifier, function::Class, Keyword};
@@ -50,7 +50,7 @@ where
         let strict = cursor.strict_mode();
         cursor.set_strict_mode(true);
 
-        let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let token = cursor.peek(0, interner).or_abrupt()?;
         let name = match token.kind() {
             TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 BindingIdentifier::new(self.allow_yield, self.allow_await)

--- a/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/function_expression/mod.rs
@@ -15,7 +15,7 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, Cursor, ParseError, ParseResult, TokenParser,
+        name_in_lexically_declared_names, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -60,11 +60,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("FunctionExpression", "Parsing");
 
-        let (name, has_binding_identifier) = match cursor
-            .peek(0, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .kind()
-        {
+        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
             TokenKind::Identifier(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,

--- a/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_engine/src/syntax/parser/expression/primary/generator_expression/mod.rs
@@ -15,7 +15,7 @@ use crate::syntax::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, Cursor, ParseError, ParseResult, TokenParser,
+        name_in_lexically_declared_names, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -66,11 +66,7 @@ where
             interner,
         )?;
 
-        let (name, has_binding_identifier) = match cursor
-            .peek(0, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .kind()
-        {
+        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
             TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
             _ => (
                 Some(BindingIdentifier::new(true, false).parse(cursor, interner)?),

--- a/boa_engine/src/syntax/parser/expression/unary.rs
+++ b/boa_engine/src/syntax/parser/expression/unary.rs
@@ -11,7 +11,7 @@ use crate::syntax::{
     lexer::{Error as LexError, TokenKind},
     parser::{
         expression::{await_expr::AwaitExpression, update::UpdateExpression},
-        AllowAwait, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
+        AllowAwait, AllowYield, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -66,19 +66,15 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("UnaryExpression", "Parsing");
 
-        let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let tok = cursor.peek(0, interner).or_abrupt()?;
         let token_start = tok.span().start();
         match tok.kind() {
             TokenKind::Keyword((Keyword::Delete | Keyword::Void | Keyword::TypeOf, true)) => Err(
                 ParseError::general("Keyword must not contain escaped characters", token_start),
             ),
             TokenKind::Keyword((Keyword::Delete, false)) => {
-                cursor.next(interner)?.expect("Delete keyword vanished");
-                let position = cursor
-                    .peek(0, interner)?
-                    .ok_or(ParseError::AbruptEnd)?
-                    .span()
-                    .start();
+                cursor.advance(interner);
+                let position = cursor.peek(0, interner).or_abrupt()?.span().start();
                 let val = self.parse(cursor, interner)?;
 
                 match val {
@@ -100,27 +96,27 @@ where
                 Ok(Unary::new(UnaryOp::Delete, val).into())
             }
             TokenKind::Keyword((Keyword::Void, false)) => {
-                cursor.next(interner)?.expect("Void keyword vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::Void, self.parse(cursor, interner)?).into())
             }
             TokenKind::Keyword((Keyword::TypeOf, false)) => {
-                cursor.next(interner)?.expect("TypeOf keyword vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::TypeOf, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Add) => {
-                cursor.next(interner)?.expect("+ token vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::Plus, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Sub) => {
-                cursor.next(interner)?.expect("- token vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::Minus, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Neg) => {
-                cursor.next(interner)?.expect("~ token vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::Tilde, self.parse(cursor, interner)?).into())
             }
             TokenKind::Punctuator(Punctuator::Not) => {
-                cursor.next(interner)?.expect("! token vanished"); // Consume the token.
+                cursor.advance(interner);
                 Ok(Unary::new(UnaryOp::Not, self.parse(cursor, interner)?).into())
             }
             TokenKind::Keyword((Keyword::Await, true)) if self.allow_await.0 => {

--- a/boa_engine/src/syntax/parser/expression/update.rs
+++ b/boa_engine/src/syntax/parser/expression/update.rs
@@ -9,7 +9,7 @@ use super::{check_strict_arguments_or_eval, left_hand_side::LeftHandSideExpressi
 use crate::syntax::{
     lexer::{Error as LexError, TokenKind},
     parser::{
-        expression::unary::UnaryExpression, AllowAwait, AllowYield, Cursor, ParseError,
+        expression::unary::UnaryExpression, AllowAwait, AllowYield, Cursor, OrAbrupt, ParseError,
         ParseResult, TokenParser,
     },
 };
@@ -62,7 +62,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("UpdateExpression", "Parsing");
 
-        let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let tok = cursor.peek(0, interner).or_abrupt()?;
         let position = tok.span().start();
         match tok.kind() {
             TokenKind::Punctuator(Punctuator::Inc) => {

--- a/boa_engine/src/syntax/parser/function/mod.rs
+++ b/boa_engine/src/syntax/parser/function/mod.rs
@@ -29,7 +29,7 @@ use boa_macros::utf16;
 use boa_profiler::Profiler;
 use std::io::Read;
 
-use super::ParseResult;
+use super::{OrAbrupt, ParseResult};
 
 /// Formal parameters parsing.
 ///
@@ -71,7 +71,7 @@ where
 
         let mut params = Vec::new();
 
-        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = cursor.peek(0, interner).or_abrupt()?;
         if next_token.kind() == &TokenKind::Punctuator(Punctuator::CloseParen) {
             return Ok(FormalParameterList::default());
         }
@@ -99,10 +99,7 @@ where
 
             params.push(next_param);
 
-            if cursor
-                .peek(0, interner)?
-                .ok_or(ParseError::AbruptEnd)?
-                .kind()
+            if cursor.peek(0, interner).or_abrupt()?.kind()
                 == &TokenKind::Punctuator(Punctuator::CloseParen)
             {
                 break;
@@ -118,10 +115,7 @@ where
             }
 
             cursor.expect(Punctuator::Comma, "parameter list", interner)?;
-            if cursor
-                .peek(0, interner)?
-                .ok_or(ParseError::AbruptEnd)?
-                .kind()
+            if cursor.peek(0, interner).or_abrupt()?.kind()
                 == &TokenKind::Punctuator(Punctuator::CloseParen)
             {
                 break;
@@ -353,10 +347,7 @@ where
                 TokenKind::Punctuator(Punctuator::OpenBlock) => {
                     let bindings = ObjectBindingPattern::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
-                    let init = if *cursor
-                        .peek(0, interner)?
-                        .ok_or(ParseError::AbruptEnd)?
-                        .kind()
+                    let init = if *cursor.peek(0, interner).or_abrupt()?.kind()
                         == TokenKind::Punctuator(Punctuator::Assign)
                     {
                         Some(
@@ -372,10 +363,7 @@ where
                 TokenKind::Punctuator(Punctuator::OpenBracket) => {
                     let bindings = ArrayBindingPattern::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
-                    let init = if *cursor
-                        .peek(0, interner)?
-                        .ok_or(ParseError::AbruptEnd)?
-                        .kind()
+                    let init = if *cursor.peek(0, interner).or_abrupt()?.kind()
                         == TokenKind::Punctuator(Punctuator::Assign)
                     {
                         Some(
@@ -391,10 +379,7 @@ where
                 _ => {
                     let ident = BindingIdentifier::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
-                    let init = if *cursor
-                        .peek(0, interner)?
-                        .ok_or(ParseError::AbruptEnd)?
-                        .kind()
+                    let init = if *cursor.peek(0, interner).or_abrupt()?.kind()
                         == TokenKind::Punctuator(Punctuator::Assign)
                     {
                         Some(

--- a/boa_engine/src/syntax/parser/statement/break_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/break_stm/mod.rs
@@ -64,7 +64,7 @@ where
         let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {
                 Some(tok) if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
-                    let _next = cursor.next(interner)?;
+                    cursor.advance(interner);
                 }
                 _ => {}
             }

--- a/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/continue_stm/mod.rs
@@ -64,11 +64,11 @@ where
         let label = if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             if let Some(token) = tok {
                 if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
-                    cursor.next(interner)?;
+                    cursor.advance(interner);
                 } else if token.kind() == &TokenKind::LineTerminator {
                     if let Some(token) = cursor.peek(0, interner)? {
                         if token.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
-                            cursor.next(interner)?;
+                            cursor.advance(interner);
                         }
                     }
                 }

--- a/boa_engine/src/syntax/parser/statement/declaration/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/declaration/mod.rs
@@ -20,7 +20,7 @@ pub(in crate::syntax::parser) use lexical::LexicalDeclaration;
 
 use crate::syntax::{
     lexer::TokenKind,
-    parser::{AllowAwait, AllowYield, Cursor, ParseError, ParseResult, TokenParser},
+    parser::{AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser},
 };
 use boa_ast::{self as ast, Keyword};
 use boa_interner::Interner;
@@ -60,7 +60,7 @@ where
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("Declaration", "Parsing");
-        let tok = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let tok = cursor.peek(0, interner).or_abrupt()?;
 
         match tok.kind() {
             TokenKind::Keyword((Keyword::Function | Keyword::Async | Keyword::Class, _)) => {

--- a/boa_engine/src/syntax/parser/statement/if_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/if_stm/mod.rs
@@ -5,7 +5,7 @@ use crate::syntax::{
     lexer::TokenKind,
     parser::{
         expression::Expression, statement::declaration::FunctionDeclaration, AllowAwait,
-        AllowReturn, AllowYield, Cursor, ParseError, ParseResult, TokenParser,
+        AllowReturn, AllowYield, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -72,7 +72,7 @@ where
             .end();
 
         let strict = cursor.strict_mode();
-        let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let token = cursor.peek(0, interner).or_abrupt()?;
         let then_node = match token.kind() {
             TokenKind::Keyword((Keyword::Function, _)) => {
                 // FunctionDeclarations in IfStatement Statement Clauses
@@ -108,10 +108,10 @@ where
                     ));
                 }
                 TokenKind::Keyword((Keyword::Else, false)) => {
-                    cursor.next(interner)?.expect("token disappeared");
+                    cursor.advance(interner);
 
                     let strict = cursor.strict_mode();
-                    let token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+                    let token = cursor.peek(0, interner).or_abrupt()?;
                     let position = token.span().start();
                     let stmt = match token.kind() {
                         TokenKind::Keyword((Keyword::Function, _)) => {

--- a/boa_engine/src/syntax/parser/statement/iteration/while_statement.rs
+++ b/boa_engine/src/syntax/parser/statement/iteration/while_statement.rs
@@ -1,6 +1,6 @@
 use crate::syntax::parser::{
     expression::Expression, statement::Statement, AllowAwait, AllowReturn, AllowYield, Cursor,
-    ParseError, ParseResult, TokenParser,
+    OrAbrupt, ParseError, ParseResult, TokenParser,
 };
 use boa_ast::{statement::WhileLoop, Keyword, Punctuator};
 use boa_interner::Interner;
@@ -59,11 +59,7 @@ where
 
         cursor.expect(Punctuator::CloseParen, "while statement", interner)?;
 
-        let position = cursor
-            .peek(0, interner)?
-            .ok_or(ParseError::AbruptEnd)?
-            .span()
-            .start();
+        let position = cursor.peek(0, interner).or_abrupt()?.span().start();
 
         let body = Statement::new(self.allow_yield, self.allow_await, self.allow_return)
             .parse(cursor, interner)?;

--- a/boa_engine/src/syntax/parser/statement/labelled_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/labelled_stm/mod.rs
@@ -5,7 +5,7 @@ use crate::syntax::{
         error::ParseError,
         expression::LabelIdentifier,
         statement::{AllowAwait, AllowReturn, Statement},
-        AllowYield, ParseResult, TokenParser,
+        AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
 };
 use boa_ast::{self as ast, Keyword, Punctuator};
@@ -61,7 +61,7 @@ where
         cursor.expect(Punctuator::Colon, "Labelled Statement", interner)?;
 
         let strict = cursor.strict_mode();
-        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = cursor.peek(0, interner).or_abrupt()?;
 
         let labelled_item = match next_token.kind() {
             // Early Error: It is a Syntax Error if any strict mode source code matches this rule.

--- a/boa_engine/src/syntax/parser/statement/return_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/return_stm/mod.rs
@@ -52,7 +52,7 @@ where
         if let SemicolonResult::Found(tok) = cursor.peek_semicolon(interner)? {
             match tok {
                 Some(tok) if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) => {
-                    let _next = cursor.next(interner)?;
+                    cursor.advance(interner);
                 }
                 _ => {}
             }

--- a/boa_engine/src/syntax/parser/statement/throw/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/throw/mod.rs
@@ -54,7 +54,7 @@ where
             .parse(cursor, interner)?;
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Semicolon) {
-                let _next = cursor.next(interner).expect("token disappeared");
+                cursor.advance(interner);
             }
         }
 

--- a/boa_engine/src/syntax/parser/statement/try_stm/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/try_stm/mod.rs
@@ -8,7 +8,9 @@ use self::{catch::Catch, finally::Finally};
 use super::block::Block;
 use crate::syntax::{
     lexer::TokenKind,
-    parser::{AllowAwait, AllowReturn, AllowYield, Cursor, ParseError, ParseResult, TokenParser},
+    parser::{
+        AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseError, ParseResult, TokenParser,
+    },
 };
 use boa_ast::{
     statement::{ErrorHandler, Try},
@@ -63,7 +65,7 @@ where
         let try_clause = Block::new(self.allow_yield, self.allow_await, self.allow_return)
             .parse(cursor, interner)?;
 
-        let next_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let next_token = cursor.peek(0, interner).or_abrupt()?;
         match next_token.kind() {
             TokenKind::Keyword((Keyword::Catch | Keyword::Finally, true)) => {
                 return Err(ParseError::general(

--- a/boa_engine/src/syntax/parser/statement/variable/mod.rs
+++ b/boa_engine/src/syntax/parser/statement/variable/mod.rs
@@ -6,7 +6,7 @@ use crate::syntax::{
         cursor::Cursor,
         expression::Initializer,
         statement::{ArrayBindingPattern, BindingIdentifier, ObjectBindingPattern},
-        AllowAwait, AllowIn, AllowYield, ParseError, ParseResult, TokenParser,
+        AllowAwait, AllowIn, AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
 };
 use boa_ast::{
@@ -163,7 +163,7 @@ where
     type Output = Variable;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
-        let peek_token = cursor.peek(0, interner)?.ok_or(ParseError::AbruptEnd)?;
+        let peek_token = cursor.peek(0, interner).or_abrupt()?;
 
         match peek_token.kind() {
             TokenKind::Punctuator(Punctuator::OpenBlock) => {


### PR DESCRIPTION
This PR adds an `OrAbrupt` trait, with the `or_abrupt()` function. This function is equivalent to the previous `?.ok_or(ParseError::AbruptEnd)`, but it's cleaner. It's implemented for the parser cursor results types.

It also adds an `advance()` function to the parser cursor (which might be possible to optimize further), that just advances the cursor without returning any token. This shows a clearer intent in many places where it's being used.

I also used `ParseResult` in more places, since we were not using it in many places.