### PR TITLE
Deny warnings and add miri to CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,6 @@ permissions:
 
 env:
   RUSTFLAGS: -Dwarnings
-  MIRIFLAGS: -Zmiri-strict-provenance
 
 jobs:
   coverage:
@@ -48,8 +47,6 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v3
-        if: matrix.os == 'macOS-latest'
-        - uses: dtolnay/rust-toolchain@miri
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -65,8 +62,17 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
-      - name: Test with miri
-        run: cargo miri test
+
+  miri:
+    name: Miri
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
+      - run: cargo miri test
+        env:
+          MIRIFLAGS: -Zmiri-strict-provenance
   
   misc:
     name: Misc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -48,7 +48,8 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@miri
+        if: matrix.os == 'macOS-latest'
+        - uses: dtolnay/rust-toolchain@miri
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -65,7 +66,6 @@ jobs:
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
       - name: Test with miri
-        if: matrix.os == 'macOS-latest'
         run: cargo miri test
   
   misc:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
-      - uses: dtolnay/rust-toolchain@miri
         with:
           toolchain: stable
           override: true
@@ -61,14 +60,13 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
-      - name: Miri Test
-        run: cargo miri test
 
   misc:
     name: Misc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -91,3 +89,5 @@ jobs:
         run: cargo build --quiet --profile ci
       - name: Run example classes
         run: cargo run --bin classes --profile ci
+      - name: Miri Test
+        run: cargo miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
       - staging # bors
       - trying # bors
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   coverage:
     name: Coverage
@@ -42,6 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
+      - uses: dtolnay/rust-toolchain@miri
         with:
           toolchain: stable
           override: true
@@ -56,6 +60,10 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
+      - name: Miri Test
+        run: cargo miri test
+          env:
+            MIRIFLAGS: -Zmiri-strict-provenance
 
   misc:
     name: Misc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
       - staging # bors
       - trying # bors
 
+permissions:
+  contents: read
+
 env:
   RUSTFLAGS: -Dwarnings
   MIRIFLAGS: -Zmiri-strict-provenance

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -65,8 +65,9 @@ jobs:
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
       - name: Test with miri
+        if: matrix.os == 'macOS-latest'
         run: cargo miri test
-
+  
   misc:
     name: Misc
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,7 @@ jobs:
           - windows-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -60,13 +61,14 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
+      - name: Test with miri
+        run: cargo miri test
 
   misc:
     name: Misc
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@miri
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -89,5 +91,3 @@ jobs:
         run: cargo build --quiet --profile ci
       - name: Run example classes
         run: cargo run --bin classes --profile ci
-      - name: Miri Test
-        run: cargo miri test

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,7 +73,7 @@ jobs:
       - run: cargo miri test
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
-  
+
   misc:
     name: Misc
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
+  MIRIFLAGS: -Zmiri-strict-provenance
 
 jobs:
   coverage:
@@ -62,8 +63,6 @@ jobs:
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
       - name: Miri Test
         run: cargo miri test
-          env:
-            MIRIFLAGS: -Zmiri-strict-provenance
 
   misc:
     name: Misc

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@miri
-      - run: cargo miri test
+      - run: cargo miri test miri
         env:
           MIRIFLAGS: -Zmiri-strict-provenance
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2366 

It changes the following:

- Denies Warnings in `cargo build`
- Enables miri as a seperate step running on ubuntu (miri has limited support on windows)

Note that this will cause previously passing builds to fail.
