### PR TITLE
[Merged by Bors] - Refactor the `Date` builtin

### DIFF
--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -34,8 +34,6 @@ macro_rules! some_or_nan {
 
 /// Gets a mutable reference to the inner `Date` object of `val` and stores it on `var`, or returns
 /// a `TypeError` if `val` is not a `Date` object.
-///
-/// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
 macro_rules! get_mut_date {
     (let $var:ident = $val:expr) => {
         let mut $var = $val
@@ -64,14 +62,17 @@ pub(super) fn this_time_value(value: &JsValue) -> JsResult<Option<NaiveDateTime>
 pub struct Date(Option<NaiveDateTime>);
 
 impl Date {
+    #[inline]
+    /// Creates a new `Date`.
     pub(crate) fn new(dt: Option<NaiveDateTime>) -> Self {
         Self(dt)
     }
+
+    /// Converts the `Date` into a `JsValue`, mapping `None` to `NaN` and `Some(datetime)` to
+    /// `JsValue::from(datetime.timestamp_millis())`.
     fn as_value(&self) -> JsValue {
-        match self.0 {
-            Some(dt) => JsValue::from(dt.timestamp_millis()),
-            None => JsValue::from(f64::NAN),
-        }
+        self.0
+            .map_or_else(|| f64::NAN.into(), |dt| dt.timestamp_millis().into())
     }
 }
 

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -1,3 +1,5 @@
+mod utils;
+use utils::{make_date, make_day, make_time, replace_params, time_clip, DateParameters};
 #[cfg(test)]
 mod tests;
 
@@ -12,44 +14,66 @@ use crate::{
     },
     string::utf16,
     symbol::WellKnownSymbols,
-    value::{IntegerOrInfinity, JsValue, PreferredType},
+    value::{IntegerOrNan, JsValue, PreferredType},
     Context, JsError, JsResult,
 };
 use boa_profiler::Profiler;
-use chrono::{prelude::*, Duration, LocalResult};
+use chrono::prelude::*;
 use std::fmt::Display;
 use tap::{Conv, Pipe};
 
-/// The number of nanoseconds in a millisecond.
-const NANOS_PER_MS: i64 = 1_000_000;
-/// The number of milliseconds in an hour.
-const MILLIS_PER_HOUR: i64 = 3_600_000;
-/// The number of milliseconds in a minute.
-const MILLIS_PER_MINUTE: i64 = 60_000;
-/// The number of milliseconds in a second.
-const MILLIS_PER_SECOND: i64 = 1000;
-
-#[inline]
-fn is_zero_or_normal_opt(value: Option<f64>) -> bool {
-    value.map_or(true, |value| value == 0f64 || value.is_normal())
-}
-
-macro_rules! check_normal_opt {
-    ($($v:expr),+) => {
-        $(is_zero_or_normal_opt($v.into()) &&)+ true
+/// Extracts `Some` from an `Option<T>` or returns `NaN` if the object contains `None`.
+macro_rules! some_or_nan {
+    ($v:expr) => {
+        match $v {
+            Some(dt) => dt,
+            None => return Ok(JsValue::from(f64::NAN)),
+        }
     };
 }
 
+/// Gets a mutable reference to the inner `Date` object of `val` and stores it on `var`, or returns
+/// a `TypeError` if `val` is not a `Date` object.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
+macro_rules! get_mut_date {
+    (let $var:ident = $val:expr) => {
+        let mut $var = $val
+            .as_object()
+            .map(JsObject::borrow_mut)
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+        let $var = $var
+            .as_date_mut()
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?;
+    };
+}
+
+/// Abstract operation [`thisTimeValue`][spec].
+///
+/// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
 #[inline]
-fn ignore_ambiguity<T>(result: LocalResult<T>) -> Option<T> {
-    match result {
-        LocalResult::Ambiguous(v, _) | LocalResult::Single(v) => Some(v),
-        LocalResult::None => None,
-    }
+pub(super) fn this_time_value(value: &JsValue) -> JsResult<Option<NaiveDateTime>> {
+    Ok(value
+        .as_object()
+        .and_then(|obj| obj.borrow().as_date().copied())
+        .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Date"))?
+        .0)
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Date(Option<NaiveDateTime>);
+
+impl Date {
+    pub(crate) fn new(dt: Option<NaiveDateTime>) -> Self {
+        Self(dt)
+    }
+    fn as_value(&self) -> JsValue {
+        match self.0 {
+            Some(dt) => JsValue::from(dt.timestamp_millis()),
+            None => JsValue::from(f64::NAN),
+        }
+    }
+}
 
 impl Display for Date {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -101,21 +125,21 @@ impl BuiltIn for Date {
         .method(Self::get_year, "getYear", 0)
         .static_method(Self::now, "now", 0)
         .static_method(Self::parse, "parse", 1)
-        .method(Self::set_date, "setDate", 1)
-        .method(Self::set_full_year, "setFullYear", 3)
-        .method(Self::set_hours, "setHours", 4)
-        .method(Self::set_milliseconds, "setMilliseconds", 1)
-        .method(Self::set_minutes, "setMinutes", 3)
-        .method(Self::set_month, "setMonth", 2)
-        .method(Self::set_seconds, "setSeconds", 2)
+        .method(Self::set_date::<true>, "setDate", 1)
+        .method(Self::set_full_year::<true>, "setFullYear", 3)
+        .method(Self::set_hours::<true>, "setHours", 4)
+        .method(Self::set_milliseconds::<true>, "setMilliseconds", 1)
+        .method(Self::set_minutes::<true>, "setMinutes", 3)
+        .method(Self::set_month::<true>, "setMonth", 2)
+        .method(Self::set_seconds::<true>, "setSeconds", 2)
         .method(Self::set_time, "setTime", 1)
-        .method(Self::set_utc_date, "setUTCDate", 1)
-        .method(Self::set_utc_full_year, "setUTCFullYear", 3)
-        .method(Self::set_utc_hours, "setUTCHours", 4)
-        .method(Self::set_utc_milliseconds, "setUTCMilliseconds", 1)
-        .method(Self::set_utc_minutes, "setUTCMinutes", 3)
-        .method(Self::set_utc_month, "setUTCMonth", 2)
-        .method(Self::set_utc_seconds, "setUTCSeconds", 2)
+        .method(Self::set_date::<false>, "setUTCDate", 1)
+        .method(Self::set_full_year::<false>, "setUTCFullYear", 3)
+        .method(Self::set_hours::<false>, "setUTCHours", 4)
+        .method(Self::set_milliseconds::<false>, "setUTCMilliseconds", 1)
+        .method(Self::set_minutes::<false>, "setUTCMinutes", 3)
+        .method(Self::set_month::<false>, "setUTCMonth", 2)
+        .method(Self::set_seconds::<false>, "setUTCSeconds", 2)
         .method(Self::set_year, "setYear", 1)
         .method(Self::to_date_string, "toDateString", 0)
         .method(Self::to_gmt_string, "toGMTString", 0)
@@ -144,176 +168,12 @@ impl Date {
     /// The amount of arguments this function object takes.
     pub(crate) const LENGTH: usize = 7;
 
-    /// Check if the time (number of milliseconds) is in the expected range.
-    /// Returns None if the time is not in the range, otherwise returns the time itself in option.
+    /// [`Date ( ...values )`][spec]
     ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-timeclip
-    #[inline]
-    pub fn time_clip(time: f64) -> Option<i64> {
-        // 1. If time is not finite, return NaN.
-        // 2. If abs(ℝ(time)) > 8.64 × 1015, return NaN.
-        // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
-        if time.is_nan() {
-            return None;
-        }
-        match IntegerOrInfinity::from(time) {
-            IntegerOrInfinity::Integer(i) if i.abs() <= 864i64 * 10i64.pow(13) => Some(i),
-            _ => None,
-        }
-    }
-
-    /// Converts the `Date` to a local `DateTime`.
-    ///
-    /// If the `Date` is invalid (i.e. NAN), this function will return `None`.
-    #[inline]
-    pub fn to_local(self) -> Option<DateTime<Local>> {
-        self.0
-            .map(|utc| Local::now().timezone().from_utc_datetime(&utc))
-    }
-
-    /// Converts the `Date` to a UTC `DateTime`.
-    ///
-    /// If the `Date` is invalid (i.e. NAN), this function will return `None`.
-    pub fn to_utc(self) -> Option<DateTime<Utc>> {
-        self.0
-            .map(|utc| Utc::now().timezone().from_utc_datetime(&utc))
-    }
-
-    /// Optionally sets the individual components of the `Date`.
-    ///
-    /// Each component does not have to be within the range of valid values. For example, if `month` is too large
-    /// then `year` will be incremented by the required amount.
-    #[allow(clippy::too_many_arguments)]
-    pub fn set_components(
-        &mut self,
-        utc: bool,
-        year: Option<f64>,
-        month: Option<f64>,
-        day: Option<f64>,
-        hour: Option<f64>,
-        minute: Option<f64>,
-        second: Option<f64>,
-        millisecond: Option<f64>,
-    ) {
-        #[inline]
-        fn num_days_in(year: i32, month: u32) -> Option<u32> {
-            let month = month + 1; // zero-based for calculations
-
-            Some(
-                NaiveDate::from_ymd_opt(
-                    match month {
-                        12 => year.checked_add(1)?,
-                        _ => year,
-                    },
-                    match month {
-                        12 => 1,
-                        _ => month + 1,
-                    },
-                    1,
-                )?
-                .signed_duration_since(NaiveDate::from_ymd_opt(year, month, 1)?)
-                .num_days() as u32,
-            )
-        }
-
-        #[inline]
-        fn fix_month(year: i32, month: i32) -> Option<(i32, u32)> {
-            let year = year.checked_add(month / 12)?;
-
-            if month < 0 {
-                let year = year.checked_sub(1)?;
-                let month = (11 + (month + 1) % 12) as u32;
-                Some((year, month))
-            } else {
-                let month = (month % 12) as u32;
-                Some((year, month))
-            }
-        }
-
-        #[inline]
-        fn fix_day(mut year: i32, mut month: i32, mut day: i32) -> Option<(i32, u32, u32)> {
-            loop {
-                if day < 0 {
-                    let (fixed_year, fixed_month) = fix_month(year, month.checked_sub(1)?)?;
-
-                    year = fixed_year;
-                    month = fixed_month as i32;
-                    day += num_days_in(fixed_year, fixed_month)? as i32;
-                } else {
-                    let (fixed_year, fixed_month) = fix_month(year, month)?;
-                    let num_days = num_days_in(fixed_year, fixed_month)? as i32;
-
-                    if day >= num_days {
-                        day -= num_days;
-                        month = month.checked_add(1)?;
-                    } else {
-                        break;
-                    }
-                }
-            }
-
-            let (fixed_year, fixed_month) = fix_month(year, month)?;
-            Some((fixed_year, fixed_month, day as u32))
-        }
-
-        // If any of the args are infinity or NaN, return an invalid date.
-        if !check_normal_opt!(year, month, day, hour, minute, second, millisecond) {
-            self.0 = None;
-            return;
-        }
-
-        let naive = if utc {
-            self.to_utc().map(|dt| dt.naive_utc())
-        } else {
-            self.to_local().map(|dt| dt.naive_local())
-        };
-
-        self.0 = naive.and_then(|naive| {
-            let year = year.unwrap_or_else(|| f64::from(naive.year())) as i32;
-            let month = month.unwrap_or_else(|| f64::from(naive.month0())) as i32;
-            let day = (day.unwrap_or_else(|| f64::from(naive.day())) as i32).checked_sub(1)?;
-            let hour = hour.unwrap_or_else(|| f64::from(naive.hour())) as i64;
-            let minute = minute.unwrap_or_else(|| f64::from(naive.minute())) as i64;
-            let second = second.unwrap_or_else(|| f64::from(naive.second())) as i64;
-            let millisecond = millisecond
-                .unwrap_or_else(|| f64::from(naive.nanosecond()) / NANOS_PER_MS as f64)
-                as i64;
-
-            let (year, month, day) = fix_day(year, month, day)?;
-
-            let duration_hour = Duration::milliseconds(hour.checked_mul(MILLIS_PER_HOUR)?);
-            let duration_minute = Duration::milliseconds(minute.checked_mul(MILLIS_PER_MINUTE)?);
-            let duration_second = Duration::milliseconds(second.checked_mul(MILLIS_PER_SECOND)?);
-            let duration_millisecond = Duration::milliseconds(millisecond);
-
-            let duration = duration_hour
-                .checked_add(&duration_minute)?
-                .checked_add(&duration_second)?
-                .checked_add(&duration_millisecond)?;
-
-            NaiveDate::from_ymd_opt(year, month + 1, day + 1)
-                .and_then(|dt| dt.and_hms(0, 0, 0).checked_add_signed(duration))
-                .and_then(|dt| {
-                    if utc {
-                        Some(Utc.from_utc_datetime(&dt).naive_utc())
-                    } else {
-                        ignore_ambiguity(Local.from_local_datetime(&dt)).map(|dt| dt.naive_utc())
-                    }
-                })
-                .filter(|dt| Self::time_clip(dt.timestamp_millis() as f64).is_some())
-        });
-    }
-
-    /// `Date()`
-    ///
-    /// Creates a JavaScript `Date` instance that represents a single moment in time in a platform-independent format.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
+    /// - When called as a function, returns a string displaying the current time in the UTC timezone.
+    /// - When called as a constructor, it returns a new `Date` object from the provided arguments.
+    /// The [MDN documentation][mdn] has a more extensive explanation on the usages and return
+    /// values for all possible arguments.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
@@ -322,182 +182,1421 @@ impl Date {
         args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
+        // 1. If NewTarget is undefined, then
         if new_target.is_undefined() {
-            Ok(Self::make_date_string())
-        } else {
-            let prototype =
-                get_prototype_from_constructor(new_target, StandardConstructors::date, context)?;
-            Ok(if args.is_empty() {
-                Self::make_date_now(prototype)
-            } else if args.len() == 1 {
-                Self::make_date_single(prototype, args, context)?
-            } else {
-                Self::make_date_multiple(prototype, args, context)?
-            }
-            .into())
+            // a. Let now be the time value (UTC) identifying the current time.
+            // b. Return ToDateString(now).
+            return Ok(JsValue::new(
+                Local::now()
+                    .format("%a %b %d %Y %H:%M:%S GMT%:z")
+                    .to_string(),
+            ));
         }
-    }
-
-    /// Utility: Returns `Date` object with current datetime
-    pub(crate) fn date_create(prototype: Option<JsObject>, context: &mut Context) -> JsObject {
-        let prototype =
-            prototype.unwrap_or_else(|| context.intrinsics().constructors().date().prototype());
-
-        Self::make_date_now(prototype)
-    }
-
-    /// `Date()`
-    ///
-    /// The `Date()` function is used to create a string that represent the current date and time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
-    pub(crate) fn make_date_string() -> JsValue {
-        JsValue::new(Local::now().to_rfc3339())
-    }
-
-    /// `Date()`
-    ///
-    /// The newly-created `Date` object represents the current date and time as of the time of instantiation.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
-    pub(crate) fn make_date_now(prototype: JsObject) -> JsObject {
-        JsObject::from_proto_and_data(prototype, ObjectData::date(Self::default()))
-    }
-
-    /// `Date(value)`
-    ///
-    /// The newly-created `Date` object represents the value provided to the constructor.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
-    pub(crate) fn make_date_single(
-        prototype: JsObject,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsObject> {
-        let value = &args[0];
-        let tv = match this_time_value(value) {
-            Ok(dt) => dt.0,
-            _ => match value.to_primitive(context, PreferredType::Default)? {
-                JsValue::String(ref str) => str
-                    .to_std_string()
-                    .ok()
-                    .and_then(|s| chrono::DateTime::parse_from_rfc3339(s.as_str()).ok())
-                    .map(|dt| dt.naive_utc()),
-                tv => {
-                    let tv = tv.to_number(context)?;
-                    if tv.is_nan() {
-                        None
-                    } else {
-                        let secs = (tv / 1_000f64) as i64;
-                        let nano_secs = ((tv % 1_000f64) * 1_000_000f64) as u32;
-                        NaiveDateTime::from_timestamp_opt(secs, nano_secs)
+        // 2. Let numberOfArgs be the number of elements in values.
+        let dv = match args {
+            // 3. If numberOfArgs = 0, then
+            [] => {
+                // a. Let dv be the time value (UTC) identifying the current time.
+                Date::default()
+            }
+            // 4. Else if numberOfArgs = 1, then
+            // a. Let value be values[0].
+            [value] => match value
+                .as_object()
+                .and_then(|obj| obj.borrow().as_date().copied())
+            {
+                // b. If value is an Object and value has a [[DateValue]] internal slot, then
+                Some(dt) => {
+                    // i. Let tv be ! thisTimeValue(value).
+                    dt
+                }
+                // c. Else,
+                None => {
+                    // i. Let v be ? ToPrimitive(value).
+                    match value.to_primitive(context, PreferredType::Default)? {
+                        // ii. If v is a String, then
+                        JsValue::String(ref str) => {
+                            // 1. Assert: The next step never returns an abrupt completion because v is a String.
+                            // 2. Let tv be the result of parsing v as a date, in exactly the same manner as for the
+                            // parse method (21.4.3.2).
+                            Date(
+                                str.to_std_string()
+                                    .ok()
+                                    .and_then(|s| {
+                                        chrono::DateTime::parse_from_rfc3339(s.as_str()).ok()
+                                    })
+                                    .map(|dt| dt.naive_utc()),
+                            )
+                        }
+                        // iii. Else,
+                        v => {
+                            // Directly convert to integer
+                            // 1. Let tv be ? ToNumber(v).
+                            Date(
+                                v.to_integer_or_nan(context)?
+                                    .as_integer()
+                                    // d. Let dv be TimeClip(tv).
+                                    .and_then(time_clip)
+                                    .and_then(NaiveDateTime::from_timestamp_millis),
+                            )
+                        }
                     }
                 }
             },
+            // 5. Else,
+            _ => {
+                // Separating this into its own function to simplify the logic.
+                Date(
+                    Self::construct_date(args, context)?
+                        .and_then(|dt| Local.from_local_datetime(&dt).earliest())
+                        .map(|dt| dt.naive_utc()),
+                )
+            }
         };
 
-        let tv = tv.filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
-        Ok(JsObject::from_proto_and_data(
-            prototype,
-            ObjectData::date(Self(tv)),
-        ))
+        // 6. Let O be ? OrdinaryCreateFromConstructor(NewTarget, "%Date.prototype%", « [[DateValue]] »).
+        let prototype =
+            get_prototype_from_constructor(new_target, StandardConstructors::date, context)?;
+
+        // 7. Set O.[[DateValue]] to dv.
+        let obj = JsObject::from_proto_and_data(prototype, ObjectData::date(dv));
+
+        // 8. Return O.
+        Ok(obj.into())
     }
 
-    /// `Date(year, month [ , date [ , hours [ , minutes [ , seconds [ , ms ] ] ] ] ])`
+    /// Gets the timestamp from a list of component values.
+    fn construct_date(
+        values: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<Option<NaiveDateTime>> {
+        // 1. Let y be ? ToNumber(year).
+        let Some(mut year) = values.get_or_undefined(0).to_integer_or_nan(context)?.as_integer() else {
+            return Ok(None);
+        };
+
+        // 2. If month is present, let m be ? ToNumber(month); else let m be +0𝔽.
+        let Some(month) = values.get(1).map_or(Ok(Some(0)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 3. If date is present, let dt be ? ToNumber(date); else let dt be 1𝔽.
+        let Some(date) = values.get(2).map_or(Ok(Some(1)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 4. If hours is present, let h be ? ToNumber(hours); else let h be +0𝔽.
+        let Some(hour) = values.get(3).map_or(Ok(Some(0)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 5. If minutes is present, let min be ? ToNumber(minutes); else let min be +0𝔽.
+        let Some(min) = values.get(4).map_or(Ok(Some(0)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 6. If seconds is present, let s be ? ToNumber(seconds); else let s be +0𝔽.
+        let Some(sec) = values.get(5).map_or(Ok(Some(0)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 7. If ms is present, let milli be ? ToNumber(ms); else let milli be +0𝔽.
+        let Some(ms) = values.get(6).map_or(Ok(Some(0)), |value| {
+            value
+            .to_integer_or_nan(context)
+            .map(IntegerOrNan::as_integer)
+        })? else {
+            return Ok(None);
+        };
+
+        // 8. If y is NaN, let yr be NaN.
+        // 9. Else,
+        //     a. Let yi be ! ToIntegerOrInfinity(y).
+        //     b. If 0 ≤ yi ≤ 99, let yr be 1900𝔽 + 𝔽(yi); otherwise, let yr be y.
+        if (0..=99).contains(&year) {
+            year += 1900;
+        }
+
+        // 10. Return TimeClip(MakeDate(MakeDay(yr, m, dt), MakeTime(h, min, s, milli))).
+        // PLEASE RUST TEAM GIVE US TRY BLOCKS ;-;
+        let timestamp = (move || {
+            let day = make_day(year, month, date)?;
+            let time = make_time(hour, min, sec, ms)?;
+            make_date(day, time)
+        })();
+
+        Ok(timestamp
+            .and_then(time_clip)
+            .and_then(NaiveDateTime::from_timestamp_millis))
+    }
+
+    /// `Date.now()`
     ///
-    /// The newly-created `Date` object represents the date components provided to the constructor.
+    /// The static `Date.now()` method returns the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date
-    pub(crate) fn make_date_multiple(
-        prototype: JsObject,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsObject> {
-        let mut year = args[0].to_number(context)?;
-        let month = args[1].to_number(context)?;
-        let day = args
-            .get(2)
-            .map_or(Ok(1f64), |value| value.to_number(context))?;
-        let hour = args
-            .get(3)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let min = args
-            .get(4)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let sec = args
-            .get(5)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let milli = args
-            .get(6)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-
-        // If any of the args are infinity or NaN, return an invalid date.
-        if !check_normal_opt!(year, month, day, hour, min, sec, milli) {
-            return Ok(JsObject::from_proto_and_data(
-                prototype,
-                ObjectData::date(Self(None)),
-            ));
-        }
-
-        if (0.0..=99.0).contains(&year) {
-            year += 1900.0;
-        }
-
-        let mut date = Self(
-            NaiveDateTime::from_timestamp_opt(0, 0)
-                .and_then(|local| ignore_ambiguity(Local.from_local_datetime(&local)))
-                .map(|local| local.naive_utc())
-                .filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some()),
-        );
-
-        date.set_components(
-            false,
-            Some(year),
-            Some(month),
-            Some(day),
-            Some(hour),
-            Some(min),
-            Some(sec),
-            Some(milli),
-        );
-
-        Ok(JsObject::from_proto_and_data(
-            prototype,
-            ObjectData::date(date),
-        ))
+    /// [spec]: https://tc39.es/ecma262/#sec-date.now
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
+    #[allow(clippy::unnecessary_wraps)]
+    pub(crate) fn now(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Ok(JsValue::new(Utc::now().timestamp_millis()))
     }
 
-    /// `Date.prototype[@@toPrimitive]`
+    /// `Date.parse()`
     ///
-    /// The [@@toPrimitive]() method converts a Date object to a primitive value.
+    /// The `Date.parse()` method parses a string representation of a date, and returns the number of milliseconds since
+    /// January 1, 1970, 00:00:00 UTC or `NaN` if the string is unrecognized or, in some cases, contains illegal date
+    /// values.
     ///
     /// More information:
     ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.parse
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
+    pub(crate) fn parse(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // This method is implementation-defined and discouraged, so we just require the same format as the string
+        // constructor.
+
+        let date = some_or_nan!(args.get(0));
+
+        let date = date.to_string(context)?;
+
+        Ok(date
+            .to_std_string()
+            .ok()
+            .and_then(|s| DateTime::parse_from_rfc3339(s.as_str()).ok())
+            .and_then(|date| time_clip(date.naive_utc().timestamp_millis()))
+            .map_or_else(|| JsValue::from(f64::NAN), JsValue::from))
+    }
+
+    /// `Date.UTC()`
+    ///
+    /// The `Date.UTC()` method accepts parameters similar to the `Date` constructor, but treats them as UTC.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.utc
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC
+    pub(crate) fn utc(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let t = some_or_nan!(Self::construct_date(args, context)?);
+
+        Ok(JsValue::from(t.timestamp_millis()))
+    }
+
+    /// `Date.prototype.getDate()`.
+    ///
+    /// The `getDate()` method returns the day of the month for the specified date according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getdate
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate
+    pub(crate) fn get_date(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return DateFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.day()))
+    }
+
+    /// `Date.prototype.getDay()`.
+    ///
+    /// The `getDay()` method returns the day of the week for the specified date according to local time, where 0
+    /// represents Sunday.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getday
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay
+    pub(crate) fn get_day(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return WeekDay(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.weekday().num_days_from_sunday()))
+    }
+
+    /// `Date.prototype.getYear()`.
+    ///
+    /// The `getYear()` method returns the year in the specified date according to local time.
+    /// Because `getYear()` does not return full years ("year 2000 problem"), it is no longer used
+    /// and has been replaced by the `getFullYear()` method.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getyear
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear
+    pub(crate) fn get_year(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return YearFromTime(LocalTime(t)) - 1900𝔽.
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::from(local.year() - 1900))
+    }
+
+    /// `Date.prototype.getFullYear()`.
+    ///
+    /// The `getFullYear()` method returns the year of the specified date according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getfullyear
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear
+    pub(crate) fn get_full_year(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return YearFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.year()))
+    }
+
+    /// `Date.prototype.getHours()`.
+    ///
+    /// The `getHours()` method returns the hour for the specified date, according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gethours
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours
+    pub(crate) fn get_hours(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return HourFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.hour()))
+    }
+
+    /// `Date.prototype.getMilliseconds()`.
+    ///
+    /// The `getMilliseconds()` method returns the milliseconds in the specified date according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
+    pub(crate) fn get_milliseconds(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return msFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.timestamp_subsec_millis()))
+    }
+
+    /// `Date.prototype.getMinutes()`.
+    ///
+    /// The `getMinutes()` method returns the minutes in the specified date according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getminutes
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes
+    pub(crate) fn get_minutes(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return MinFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.minute()))
+    }
+
+    /// `Date.prototype.getMonth()`.
+    ///
+    /// The `getMonth()` method returns the month in the specified date according to local time, as a zero-based value
+    /// (where zero indicates the first month of the year).
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getmonth
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
+    pub(crate) fn get_month(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return MonthFromTime(LocalTime(t)).
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.month0()))
+    }
+
+    /// `Date.prototype.getSeconds()`.
+    ///
+    /// The `getSeconds()` method returns the seconds in the specified date according to local time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getseconds
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds
+    pub(crate) fn get_seconds(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return SecFromTime(LocalTime(t))
+        let local = Local.from_utc_datetime(&t);
+        Ok(JsValue::new(local.second()))
+    }
+
+    /// `Date.prototype.getTime()`.
+    ///
+    /// The `getTime()` method returns the number of milliseconds since the Unix Epoch.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gettime
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime
+    pub(crate) fn get_time(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Return ? thisTimeValue(this value).
+        let t = some_or_nan!(this_time_value(this)?);
+        Ok(JsValue::from(t.timestamp_millis()))
+    }
+
+    /// `Date.prototype.getTimeZoneOffset()`.
+    ///
+    /// The `getTimezoneOffset()` method returns the time zone difference, in minutes, from current locale (host system
+    /// settings) to UTC.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
+    #[inline]
+    pub(crate) fn get_timezone_offset(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        some_or_nan!(this_time_value(this)?);
+
+        // 3. Return (t - LocalTime(t)) / msPerMinute.
+        Ok(JsValue::from(-Local::now().offset().local_minus_utc() / 60))
+    }
+
+    /// `Date.prototype.getUTCDate()`.
+    ///
+    /// The `getUTCDate()` method returns the day (date) of the month in the specified date according to universal time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcdate
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate
+    pub(crate) fn get_utc_date(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return DateFromTime(t).
+        Ok(JsValue::new(t.day()))
+    }
+
+    /// `Date.prototype.getUTCDay()`.
+    ///
+    /// The `getUTCDay()` method returns the day of the week in the specified date according to universal time, where 0
+    /// represents Sunday.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcday
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay
+    pub(crate) fn get_utc_day(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return WeekDay(t).
+        Ok(JsValue::new(t.weekday().num_days_from_sunday()))
+    }
+
+    /// `Date.prototype.getUTCFullYear()`.
+    ///
+    /// The `getUTCFullYear()` method returns the year in the specified date according to universal time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear
+    pub(crate) fn get_utc_full_year(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return YearFromTime(t).
+        Ok(JsValue::new(t.year()))
+    }
+
+    /// `Date.prototype.getUTCHours()`.
+    ///
+    /// The `getUTCHours()` method returns the hours in the specified date according to universal time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutchours
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours
+    pub(crate) fn get_utc_hours(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return HourFromTime(t).
+        Ok(JsValue::new(t.hour()))
+    }
+
+    /// `Date.prototype.getUTCMilliseconds()`.
+    ///
+    /// The `getUTCMilliseconds()` method returns the milliseconds portion of the time object's value.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds
+    pub(crate) fn get_utc_milliseconds(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return msFromTime(t).
+        Ok(JsValue::new(t.timestamp_subsec_millis()))
+    }
+
+    /// `Date.prototype.getUTCMinutes()`.
+    ///
+    /// The `getUTCMinutes()` method returns the minutes in the specified date according to universal time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcminutes
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes
+    pub(crate) fn get_utc_minutes(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return MinFromTime(t).
+        Ok(JsValue::new(t.minute()))
+    }
+
+    /// `Date.prototype.getUTCMonth()`.
+    ///
+    /// The `getUTCMonth()` returns the month of the specified date according to universal time, as a zero-based value
+    /// (where zero indicates the first month of the year).
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcmonth
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth
+    pub(crate) fn get_utc_month(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return MonthFromTime(t).
+        Ok(JsValue::new(t.month0()))
+    }
+
+    /// `Date.prototype.getUTCSeconds()`
+    ///
+    /// The `getUTCSeconds()` method returns the seconds in the specified date according to universal
+    /// time.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcseconds
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds
+    pub(crate) fn get_utc_seconds(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 2. If t is NaN, return NaN.
+        let t = some_or_nan!(this_time_value(this)?);
+
+        // 3. Return SecFromTime(t).
+        Ok(JsValue::new(t.second()))
+    }
+
+    /// [`Date.prototype.setDate ( date )`][local] and
+    /// [`Date.prototype.setUTCDate ( date )`][utc].
+    ///
+    /// The `setDate()` method sets the day of the `Date` object relative to the beginning of the
+    /// currently set month.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setdate
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcdate
+    pub(crate) fn set_date<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be LocalTime(? thisTimeValue(this value)).
+        get_mut_date!(let t = this);
+
+        // 2. Let dt be ? ToNumber(date).
+        let date = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 4. Set t to LocalTime(t).
+        // 5. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
+        // 6. Let u be TimeClip(UTC(newDate)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                date: Some(date),
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 7. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 8. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setFullYear ( year [ , month [ , date ] ] )`][local] and
+    /// [Date.prototype.setUTCFullYear ( year [ , month [ , date ] ] )][utc].
+    ///
+    /// The `setFullYear()` method sets the full year for a specified date and returns the new
+    /// timestamp.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setfullyear
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear
+    pub(crate) fn set_full_year<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+        let datetime = match t.0 {
+            Some(dt) => dt,
+            None if LOCAL => {
+                let Some(datetime) = Local
+                    .from_local_datetime(&NaiveDateTime::default())
+                    .earliest()
+                    .as_ref()
+                    .map(DateTime::naive_utc) else {
+                        *t = Date(None);
+                        return Ok(t.as_value())
+                    };
+                datetime
+            }
+            None => NaiveDateTime::default(),
+        };
+
+        // 3. Let y be ? ToNumber(year).
+        let year = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 4. If month is not present, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
+        let month = args
+            .get(1)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 5. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
+        let date = args
+            .get(2)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
+        // 7. Let u be TimeClip(UTC(newDate)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                year: Some(year),
+                month,
+                date,
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 8. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 9. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setHours ( hour [ , min [ , sec [ , ms ] ] ] )`][local] and
+    /// [`Date.prototype.setUTCHours ( hour [ , min [ , sec [ , ms ] ] ] )`][utc].
+    ///
+    /// The `setHours()` method sets the hours for a specified date, and returns the number
+    /// of milliseconds since January 1, 1970 00:00:00 UTC until the time represented by the
+    /// updated `Date` instance.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.sethours
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutchours
+    pub(crate) fn set_hours<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let h be ? ToNumber(hour).
+        let hour = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If min is present, let m be ? ToNumber(min).
+        let minute = args
+            .get(1)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 4. If sec is present, let s be ? ToNumber(sec).
+        let second = args
+            .get(2)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 5. If ms is present, let milli be ? ToNumber(ms).
+        let millisecond = args
+            .get(3)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 6. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 7. Set t to LocalTime(t).
+        // 8. If min is not present, let m be MinFromTime(t).
+        // 9. If sec is not present, let s be SecFromTime(t).
+        // 10. If ms is not present, let milli be msFromTime(t).
+        // 11. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
+        // 12. Let u be TimeClip(UTC(date)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                hour: Some(hour),
+                minute,
+                second,
+                millisecond,
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 13. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 14. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setMilliseconds ( ms )`[local] and
+    /// [`Date.prototype.setUTCMilliseconds ( ms )`][utc].
+    ///
+    /// The `setMilliseconds()` method sets the milliseconds for a specified date according to local time.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds
+    pub(crate) fn set_milliseconds<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        // 1. Let t be LocalTime(? thisTimeValue(this value)).
+        get_mut_date!(let t = this);
+
+        // 2. Set ms to ? ToNumber(ms).
+        let ms = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 4. Set t to LocalTime(t).
+        // 5. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), ms).
+        // 6. Let u be TimeClip(UTC(MakeDate(Day(t), time))).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                millisecond: Some(ms),
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 7. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 8. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setMinutes ( min [ , sec [ , ms ] ] )`][local] and
+    /// [`Date.prototype.setUTCMinutes ( min [ , sec [ , ms ] ] )`][utc].
+    ///
+    /// The `setMinutes()` method sets the minutes for a specified date.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setminutes
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcminutes
+    pub(crate) fn set_minutes<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let m be ? ToNumber(min).
+        let minute = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If sec is present, let s be ? ToNumber(sec).
+        let second = args
+            .get(1)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 4. If ms is present, let milli be ? ToNumber(ms).
+        let millisecond = args
+            .get(2)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 5. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 6. Set t to LocalTime(t).
+        // 7. If sec is not present, let s be SecFromTime(t).
+        // 8. If ms is not present, let milli be msFromTime(t).
+        // 9. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
+        // 10. Let u be TimeClip(UTC(date)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                minute: Some(minute),
+                second,
+                millisecond,
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 11. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 12. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setMonth ( month [ , date ] )`][local] and
+    /// [`Date.prototype.setUTCMonth ( month [ , date ] )`][utc].
+    ///
+    /// The `setMonth()` method sets the month for a specified date according to the currently set
+    /// year.
+    ///
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setmonth
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcmonth
+    pub(crate) fn set_month<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let m be ? ToNumber(month).
+        let month = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If date is present, let dt be ? ToNumber(date).
+        let date = args
+            .get(1)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 4. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 5. Set t to LocalTime(t).
+        // 6. If date is not present, let dt be DateFromTime(t).
+        // 7. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
+        // 8. Let u be TimeClip(UTC(newDate)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                month: Some(month),
+                date,
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 9. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 10. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setSeconds ( sec [ , ms ] )`[local] and
+    /// [`Date.prototype.setUTCSeconds ( sec [ , ms ] )`][utc]
+    ///
+    /// The `setSeconds()` method sets the seconds for a specified date.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setseconds
+    /// [mdn]: https://tc39.es/ecma262/#sec-date.prototype.setutcseconds
+    pub(crate) fn set_seconds<const LOCAL: bool>(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let s be ? ToNumber(sec).
+        let second = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If ms is present, let milli be ? ToNumber(ms).
+        let millisecond = args
+            .get(1)
+            .map(|v| v.to_integer_or_nan(context))
+            .transpose()?;
+
+        // 4. If t is NaN, return NaN.
+        let datetime = some_or_nan!(t.0);
+
+        // 5. Set t to LocalTime(t).
+        // 6. If ms is not present, let milli be msFromTime(t).
+        // 7. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
+        // 8. Let u be TimeClip(UTC(date)).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                second: Some(second),
+                millisecond,
+                ..Default::default()
+            },
+            LOCAL,
+        );
+
+        // 9. Set the [[DateValue]] internal slot of this Date object to u.
+        *t = Date(datetime);
+
+        // 10. Return u.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setYear()`][spec]
+    ///
+    /// The `setYear()` method sets the year for a specified date according to local time.
+    ///
+    /// # Note
+    ///
+    ///
+    /// The [`Self::set_full_year`] method is preferred for nearly all purposes, because it avoids
+    /// the “year 2000 problem.”
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear
+    pub(crate) fn set_year(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let t be ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let y be ? ToNumber(year).
+        // 5. Let yi be ! ToIntegerOrInfinity(y).
+        let year = args.get_or_undefined(0).to_integer_or_nan(context)?;
+
+        // 3. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
+        let Some(datetime) = t.0.or_else(|| {
+            Local
+                .from_local_datetime(&NaiveDateTime::default())
+                .earliest()
+                .as_ref()
+                .map(DateTime::naive_utc)
+        }) else {
+            *t = Date(None);
+            return Ok(t.as_value());
+        };
+
+        // 4. If y is NaN, then
+        let Some(mut year) = year.as_integer() else {
+            // a. Set the [[DateValue]] internal slot of this Date object to NaN.
+            *t = Date(None);
+
+            // b. Return NaN.
+            return Ok(t.as_value());
+        };
+
+        // 6. If 0 ≤ yi ≤ 99, let yyyy be 1900𝔽 + 𝔽(yi).
+        // 7. Else, let yyyy be y.
+        if (0..=99).contains(&year) {
+            year += 1900;
+        }
+
+        // 8. Let d be MakeDay(yyyy, MonthFromTime(t), DateFromTime(t)).
+        // 9. Let date be UTC(MakeDate(d, TimeWithinDay(t))).
+        let datetime = replace_params(
+            datetime,
+            DateParameters {
+                year: Some(IntegerOrNan::Integer(year)),
+                ..Default::default()
+            },
+            true,
+        );
+
+        // 10. Set the [[DateValue]] internal slot of this Date object to TimeClip(date).
+        *t = Date(datetime);
+
+        // 11. Return the value of the [[DateValue]] internal slot of this Date object.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.setTime()`][spec]
+    ///
+    /// The `setTime()` method sets the Date object to the time represented by a number of milliseconds
+    /// since January 1, 1970, 00:00:00 UTC.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.settime
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime
+    pub(crate) fn set_time(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Perform ? thisTimeValue(this value).
+        get_mut_date!(let t = this);
+
+        // 2. Let t be ? ToNumber(time).
+        // 3. Let v be TimeClip(t).
+        let timestamp = args
+            .get_or_undefined(0)
+            .to_integer_or_nan(context)?
+            .as_integer()
+            .and_then(time_clip)
+            .and_then(NaiveDateTime::from_timestamp_millis);
+
+        // 4. Set the [[DateValue]] internal slot of this Date object to v.
+        *t = Date(timestamp);
+
+        // 5. Return v.
+        Ok(t.as_value())
+    }
+
+    /// [`Date.prototype.toDateString()`][spec]
+    ///
+    /// The `toDateString()` method returns the date portion of a Date object in English.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.todatestring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString
+    pub(crate) fn to_date_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be this Date object.
+        // 2. Let tv be ? thisTimeValue(O).
+        let Some(tv) = this_time_value(this)? else {
+            // 3. If tv is NaN, return "Invalid Date".
+            return Ok(js_string!("Invalid Date").into());
+        };
+
+        // 4. Let t be LocalTime(tv).
+        // 5. Return DateString(t).
+        Ok(Local::now()
+            .timezone()
+            .from_utc_datetime(&tv)
+            .format("%a %b %d %Y")
+            .to_string()
+            .into())
+    }
+
+    /// [`Date.prototype.toISOString()`][spec]
+    ///
+    /// The `toISOString()` method returns a string in simplified extended ISO format
+    /// ([ISO 8601][iso8601]).
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [iso8601]: http://en.wikipedia.org/wiki/ISO_8601
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.toisostring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
+    pub(crate) fn to_iso_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        let t = this_time_value(this)?
+            .ok_or_else(|| JsNativeError::range().with_message("Invalid time value"))?;
+        Ok(Utc::now()
+            .timezone()
+            .from_utc_datetime(&t)
+            .format("%Y-%m-%dT%H:%M:%S.%3fZ")
+            .to_string()
+            .into())
+    }
+
+    /// [`Date.prototype.toJSON()`][spec]
+    ///
+    /// The `toJSON()` method returns a string representation of the `Date` object.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tojson
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON
+    pub(crate) fn to_json(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be ? ToObject(this value).
+        let o = this.to_object(context)?;
+
+        // 2. Let tv be ? ToPrimitive(O, number).
+        let tv = this.to_primitive(context, PreferredType::Number)?;
+
+        // 3. If Type(tv) is Number and tv is not finite, return null.
+        if let Some(number) = tv.as_number() {
+            if !number.is_finite() {
+                return Ok(JsValue::null());
+            }
+        }
+
+        // 4. Return ? Invoke(O, "toISOString").
+        let func = o.get("toISOString", context)?;
+        context.call(&func, &o.into(), &[])
+    }
+
+    /// [`Date.prototype.toLocaleDateString()`][spec]
+    ///
+    /// The `toLocaleDateString()` method returns the date portion of the given Date instance according
+    /// to language-specific conventions.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
+    pub(crate) fn to_locale_date_string(
+        _this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        Err(JsError::from_opaque(JsValue::new("Function Unimplemented")))
+    }
+
+    /// [`Date.prototype.toLocaleString()`][spec]
+    ///
+    /// The `toLocaleString()` method returns a string representing the specified Date object.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
+    pub(crate) fn to_locale_string(
+        _this: &JsValue,
+        _: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        Err(JsError::from_opaque(JsValue::new(
+            "Function Unimplemented]",
+        )))
+    }
+
+    /// [`Date.prototype.toLocaleTimeString()`][spec]
+    ///
+    /// The `toLocaleTimeString()` method returns the time portion of a Date object in human readable
+    /// form in American English.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
+    pub(crate) fn to_locale_time_string(
+        _this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        Err(JsError::from_opaque(JsValue::new(
+            "Function Unimplemented]",
+        )))
+    }
+
+    /// [`Date.prototype.toString()`][spec]
+    ///
+    /// The `toString()` method returns a string representing the specified Date object.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tostring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString
+    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        // 1. Let tv be ? thisTimeValue(this value).
+        // 2. Return ToDateString(tv).
+        let Some(t) = this_time_value(this)? else {
+            return Ok(js_string!("Invalid Date").into());
+        };
+        Ok(Local::now()
+            .timezone()
+            .from_utc_datetime(&t)
+            .format("%a %b %d %Y %H:%M:%S GMT%z")
+            .to_string()
+            .into())
+    }
+
+    /// [`Date.prototype.toTimeString()`][spec]
+    ///
+    /// The `toTimeString()` method returns the time portion of a Date object in human readable form
+    /// in American English.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.totimestring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString
+    pub(crate) fn to_time_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be this Date object.
+        // 2. Let tv be ? thisTimeValue(O).
+        let Some(t) = this_time_value(this)? else {
+            // 3. If tv is NaN, return "Invalid Date".
+            return Ok(js_string!("Invalid Date").into());
+        };
+
+        // 4. Let t be LocalTime(tv).
+        // 5. Return the string-concatenation of TimeString(t) and TimeZoneString(tv).
+        Ok(Local::now()
+            .timezone()
+            .from_utc_datetime(&t)
+            .format("%H:%M:%S GMT%z")
+            .to_string()
+            .into())
+    }
+
+    /// [`Date.prototype.toUTCString()`][spec]
+    ///
+    /// The `toUTCString()` method returns a string representing the specified Date object.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.toutcstring
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
+    pub(crate) fn to_utc_string(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let O be this Date object.
+        let Some(t) = this_time_value(this)? else {
+            // 3. If tv is NaN, return "Invalid Date".
+            return Ok(js_string!("Invalid Date").into())
+        };
+
+        // 2. Let tv be ? thisTimeValue(O).
+        // 4. Let weekday be the Name of the entry in Table 60 with the Number WeekDay(tv).
+        // 5. Let month be the Name of the entry in Table 61 with the Number MonthFromTime(tv).
+        // 6. Let day be ToZeroPaddedDecimalString(ℝ(DateFromTime(tv)), 2).
+        // 7. Let yv be YearFromTime(tv).
+        // 8. If yv is +0𝔽 or yv > +0𝔽, let yearSign be the empty String; otherwise, let yearSign be "-".
+        // 9. Let paddedYear be ToZeroPaddedDecimalString(abs(ℝ(yv)), 4).
+        // 10. Return the string-concatenation of weekday, ",", the code unit 0x0020 (SPACE), day, the
+        // code unit 0x0020 (SPACE), month, the code unit 0x0020 (SPACE), yearSign, paddedYear, the code
+        // unit 0x0020 (SPACE), and TimeString(tv)
+        let utc_string = t.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
+        Ok(JsValue::new(utc_string))
+    }
+
+    /// [`Date.prototype.valueOf()`][spec]
+    ///
+    /// The `valueOf()` method returns the primitive value of a `Date` object.
+    ///
+    /// More information:
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.valueof
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _args: &[JsValue],
+        _context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Return ? thisTimeValue(this value).
+        Ok(Date(this_time_value(this)?).as_value())
+    }
+
+    /// [`Date.prototype [ @@toPrimitive ] ( hint )`][spec]
+    ///
+    /// The <code>\[@@toPrimitive\]()</code> method converts a Date object to a primitive value.
+    ///
+    /// More information:
     ///  - [MDN documentation][mdn]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.prototype-@@toprimitive
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/@@toPrimitive
-    #[allow(clippy::wrong_self_convention)]
     pub(crate) fn to_primitive(
         this: &JsValue,
         args: &[JsValue],
@@ -532,1539 +1631,30 @@ impl Date {
         o.ordinary_to_primitive(context, try_first)
     }
 
-    /// `Date.prototype.getDate()`
+    /// [`Date.prototype.toGMTString ( )`][spec]
     ///
-    /// The `getDate()` method returns the day of the month for the specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getdate
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDate
-    pub fn get_date(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.day()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getDay()`
-    ///
-    /// The `getDay()` method returns the day of the week for the specified date according to local time, where 0
-    /// represents Sunday.
+    /// The `toGMTString()` method converts a date to a string, using Internet Greenwich Mean Time
+    /// (GMT) conventions.
     ///
     /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getday
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay
-    pub fn get_day(this: &JsValue, _args: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.weekday().num_days_from_sunday()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getFullYear()`
-    ///
-    /// The `getFullYear()` method returns the year of the specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getfullyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear
-    pub fn get_full_year(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.year()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getHours()`
-    ///
-    /// The `getHours()` method returns the hour for the specified date, according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gethours
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getHours
-    pub fn get_hours(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.hour()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getMilliseconds()`
-    ///
-    /// The `getMilliseconds()` method returns the milliseconds in the specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getmilliseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMilliseconds
-    pub fn get_milliseconds(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.timestamp_subsec_millis()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getMinutes()`
-    ///
-    /// The `getMinutes()` method returns the minutes in the specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getminutes
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMinutes
-    pub fn get_minutes(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.minute()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getMonth()`
-    ///
-    /// The `getMonth()` method returns the month in the specified date according to local time, as a zero-based value
-    /// (where zero indicates the first month of the year).
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getmonth
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
-    pub fn get_month(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.month0()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getSeconds()`
-    ///
-    /// The `getSeconds()` method returns the seconds in the specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getSeconds
-    pub fn get_seconds(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            Ok(JsValue::new(local.second()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getYear()`
-    ///
-    /// The `getYear()` method returns the year in the specified date according to local time.
-    /// Because `getYear()` does not return full years ("year 2000 problem"), it is no longer used
-    /// and has been replaced by the `getFullYear()` method.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear
-    pub fn get_year(this: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let local = Local::now().timezone().from_utc_datetime(&t);
-            let year = JsValue::Integer(local.year());
-            year.sub(&JsValue::from(1900), context)
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getTime()`
-    ///
-    /// The `getTime()` method returns the number of milliseconds since the Unix Epoch.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gettime
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime
-    pub fn get_time(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.timestamp_millis()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// Utility: Internal `get_time()`
-    fn int_get_time(&self) -> f64 {
-        self.to_utc()
-            .map_or(f64::NAN, |dt| dt.timestamp_millis() as f64)
-    }
-
-    /// `Date.prototype.getTimeZoneOffset()`
-    ///
-    /// The `getTimezoneOffset()` method returns the time zone difference, in minutes, from current locale (host system
-    /// settings) to UTC.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
-    #[inline]
-    pub fn get_timezone_offset(
-        this: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let t = this_time_value(this)?;
-
-        // 2. If t is NaN, return NaN.
-        if t.0.is_none() {
-            return Ok(JsValue::nan());
-        }
-
-        // 3. Return (t - LocalTime(t)) / msPerMinute.
-        Ok(JsValue::new(
-            f64::from(-Local::now().offset().local_minus_utc()) / 60f64,
-        ))
-    }
-
-    /// `Date.prototype.getUTCDate()`
-    ///
-    /// The `getUTCDate()` method returns the day (date) of the month in the specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcdate
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDate
-    pub fn get_utc_date(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.day()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCDay()`
-    ///
-    /// The `getUTCDay()` method returns the day of the week in the specified date according to universal time, where 0
-    /// represents Sunday.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcday
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCDay
-    pub fn get_utc_day(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.weekday().num_days_from_sunday()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCFullYear()`
-    ///
-    /// The `getUTCFullYear()` method returns the year in the specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcfullyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCFullYear
-    pub fn get_utc_full_year(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.year()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCHours()`
-    ///
-    /// The `getUTCHours()` method returns the hours in the specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutchours
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCHours
-    pub fn get_utc_hours(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.hour()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCMilliseconds()`
-    ///
-    /// The `getUTCMilliseconds()` method returns the milliseconds portion of the time object's value.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcmilliseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMilliseconds
-    pub fn get_utc_milliseconds(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.timestamp_subsec_millis()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCMinutes()`
-    ///
-    /// The `getUTCMinutes()` method returns the minutes in the specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcminutes
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMinutes
-    pub fn get_utc_minutes(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.minute()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCMonth()`
-    ///
-    /// The `getUTCMonth()` returns the month of the specified date according to universal time, as a zero-based value
-    /// (where zero indicates the first month of the year).
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcmonth
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCMonth
-    pub fn get_utc_month(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.month0()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.getUTCSeconds()`
-    ///
-    /// The `getUTCSeconds()` method returns the seconds in the specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.getutcseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getUTCSeconds
-    pub fn get_utc_seconds(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.second()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.prototype.setDate()`
-    ///
-    /// The `setDate()` method sets the day of the `Date` object relative to the beginning of the currently set
-    /// month.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setdate
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setDate
-    pub fn set_date(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let dt be ? ToNumber(date).
-        let dt = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
-        t.set_components(false, None, None, Some(dt), None, None, None, None);
-
-        // 4. Let u be TimeClip(UTC(newDate)).
-        let u = t.int_get_time();
-
-        // 5. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 6. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setFullYear()`
-    ///
-    /// The `setFullYear()` method sets the full year for a specified date according to local time. Returns new
-    /// timestamp.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setfullyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setFullYear
-    pub fn set_full_year(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
-        if t.0.is_none() {
-            t.0 = NaiveDateTime::from_timestamp_opt(0, 0)
-                .and_then(|local| ignore_ambiguity(Local.from_local_datetime(&local)))
-                .map(|local| local.naive_utc())
-                .filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
-        }
-
-        // 3. Let y be ? ToNumber(year).
-        let y = args.get_or_undefined(0).to_number(context)?;
-
-        // 4. If month is not present, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
-        t.set_components(false, Some(y), m, dt, None, None, None, None);
-
-        // 7. Let u be TimeClip(UTC(newDate)).
-        let u = t.int_get_time();
-
-        // 8. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 9. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setHours()`
-    ///
-    /// The `setHours()` method sets the hours for a specified date according to local time, and returns the number
-    /// of milliseconds since January 1, 1970 00:00:00 UTC until the time represented by the updated `Date`
-    /// instance.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.sethours
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setHours
-    pub fn set_hours(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let h be ? ToNumber(hour).
-        let h = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If min is not present, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 4. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let sec = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = args.get(3).map(|v| v.to_number(context)).transpose()?;
-
-        // 6. Let date be MakeDate(Day(t), MakeTime(h, m, s, milli)).
-        t.set_components(false, None, None, None, Some(h), m, sec, milli);
-
-        // 7. Let u be TimeClip(UTC(date)).
-        let u = t.int_get_time();
-
-        // 8. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 9. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setMilliseconds()`
-    ///
-    /// The `setMilliseconds()` method sets the milliseconds for a specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setmilliseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMilliseconds
-    pub fn set_milliseconds(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Set ms to ? ToNumber(ms).
-        let ms = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), ms).
-        t.set_components(false, None, None, None, None, None, None, Some(ms));
-
-        // 4. Let u be TimeClip(UTC(MakeDate(Day(t), time))).
-        let u = t.int_get_time();
-
-        // 5. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 6. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setMinutes()`
-    ///
-    /// The `setMinutes()` method sets the minutes for a specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setminutes
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMinutes
-    pub fn set_minutes(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let m be ? ToNumber(min).
-        let m = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let s = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 4. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
-        t.set_components(false, None, None, None, None, Some(m), s, milli);
-
-        // 6. Let u be TimeClip(UTC(date)).
-        let u = t.int_get_time();
-
-        // 7. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 8. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setMonth()`
-    ///
-    /// The `setMonth()` method sets the month for a specified date according to the currently set year.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setmonth
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setMonth
-    pub fn set_month(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let m be ? ToNumber(month).
-        let m = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 4. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
-        t.set_components(false, None, Some(m), dt, None, None, None, None);
-
-        // 5. Let u be TimeClip(UTC(newDate)).
-        let u = t.int_get_time();
-
-        // 6. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 7. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setSeconds()`
-    ///
-    /// The `setSeconds()` method sets the seconds for a specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setSeconds
-    pub fn set_seconds(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be LocalTime(? thisTimeValue(this value)).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let s be ? ToNumber(sec).
-        let s = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let milli = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 4. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
-        t.set_components(false, None, None, None, None, None, Some(s), milli);
-
-        // 5. Let u be TimeClip(UTC(date)).
-        let u = t.int_get_time();
-
-        // 6. Set the [[DateValue]] internal slot of this Date object to u.
-        this.set_data(ObjectData::date(t));
-
-        // 7. Return u.
-        Ok(u.into())
-    }
-
-    /// `Date.prototype.setYear()`
-    ///
-    /// The `setYear()` method sets the year for a specified date according to local time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear
-    pub fn set_year(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. If t is NaN, set t to +0𝔽; otherwise, set t to LocalTime(t).
-        if t.0.is_none() {
-            t.0 = NaiveDateTime::from_timestamp_opt(0, 0)
-                .and_then(|local| ignore_ambiguity(Local.from_local_datetime(&local)))
-                .map(|local| local.naive_utc())
-                .filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
-        }
-
-        // 3. Let y be ? ToNumber(year).
-        let mut y = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 4. If y is NaN, then
-        if y.is_nan() {
-            // a. Set the [[DateValue]] internal slot of this Date object to NaN.
-            this.set_data(ObjectData::date(Self(None)));
-
-            // b. Return NaN.
-            return Ok(JsValue::nan());
-        }
-
-        // 5. Let yi be ! ToIntegerOrInfinity(y).
-        // 6. If 0 ≤ yi ≤ 99, let yyyy be 1900𝔽 + 𝔽(yi).
-        // 7. Else, let yyyy be y.
-        if (0f64..=99f64).contains(&y) {
-            y += 1900f64;
-        }
-
-        // 8. Let d be MakeDay(yyyy, MonthFromTime(t), DateFromTime(t)).
-        // 9. Let date be UTC(MakeDate(d, TimeWithinDay(t))).
-        t.set_components(false, Some(y), None, None, None, None, None, None);
-
-        // 10. Set the [[DateValue]] internal slot of this Date object to TimeClip(date).
-        this.set_data(ObjectData::date(t));
-
-        // 11. Return the value of the [[DateValue]] internal slot of this Date object.
-        Ok(t.int_get_time().into())
-    }
-
-    /// `Date.prototype.setTime()`
-    ///
-    /// The `setTime()` method sets the Date object to the time represented by a number of milliseconds since
-    /// January 1, 1970, 00:00:00 UTC.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.settime
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setTime
-    pub fn set_time(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Perform ? thisTimeValue(this value).
-        this_time_value(this)?;
-
-        // 2. Let t be ? ToNumber(time).
-        let t = args.get_or_undefined(0).to_number(context)?;
-
-        // 3. Let v be TimeClip(t).
-        let v_int = Self::time_clip(t);
-        let v = v_int.map(|t| Local.timestamp_millis(t).naive_utc());
-
-        // 4. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(Date(v)));
-
-        // 5. Return v.
-        Ok(v_int.map_or(JsValue::Rational(f64::NAN), JsValue::from))
-    }
-
-    /// `Date.prototype.setUTCDate()`
-    ///
-    /// The `setUTCDate()` method sets the day of the month for a specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcdate
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCDate
-    pub fn set_utc_date(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let dt be ? ToNumber(date).
-        let dt = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. Let newDate be MakeDate(MakeDay(YearFromTime(t), MonthFromTime(t), dt), TimeWithinDay(t)).
-        t.set_components(true, None, None, Some(dt), None, None, None, None);
-
-        // 4. Let v be TimeClip(newDate).
-        let v = Self::get_time(this, args, context)?;
-
-        // 5. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 6. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setFullYear()`
-    ///
-    /// The `setFullYear()` method sets the full year for a specified date according to local time. Returns new
-    /// timestamp.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcfullyear
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCFullYear
-    pub fn set_utc_full_year(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. If t is NaN, set t to +0𝔽.
-        if t.0.is_none() {
-            t.0 = NaiveDateTime::from_timestamp_opt(0, 0)
-                .and_then(|local| ignore_ambiguity(Local.from_local_datetime(&local)))
-                .map(|local| local.naive_utc())
-                .filter(|time| Self::time_clip(time.timestamp_millis() as f64).is_some());
-        }
-
-        // 3. Let y be ? ToNumber(year).
-        let y = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 4. If month is not present, let m be MonthFromTime(t); otherwise, let m be ? ToNumber(month).
-        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. If date is not present, let dt be DateFromTime(t); otherwise, let dt be ? ToNumber(date).
-        let dt = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 6. Let newDate be MakeDate(MakeDay(y, m, dt), TimeWithinDay(t)).
-        t.set_components(true, Some(y), m, dt, None, None, None, None);
-
-        // 7. Let v be TimeClip(newDate).
-        let v = Self::get_time(this, args, context)?;
-
-        // 8. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 9. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setUTCHours()`
-    ///
-    /// The `setUTCHours()` method sets the hour for a specified date according to universal time, and returns the
-    /// number of milliseconds since  January 1, 1970 00:00:00 UTC until the time represented by the updated `Date`
-    /// instance.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutchours
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCHours
-    pub fn set_utc_hours(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let h be ? ToNumber(hour).
-        let h = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If min is not present, let m be MinFromTime(t); otherwise, let m be ? ToNumber(min).
-        let m = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 4. If sec is not present, let s be SecFromTime(t); otherwise, let s be ? ToNumber(sec).
-        let sec = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. If ms is not present, let milli be msFromTime(t); otherwise, let milli be ? ToNumber(ms).
-        let ms = args.get(3).map(|v| v.to_number(context)).transpose()?;
-
-        // 6. Let newDate be MakeDate(Day(t), MakeTime(h, m, s, milli)).
-        t.set_components(true, None, None, None, Some(h), m, sec, ms);
-
-        // 7. Let v be TimeClip(newDate).
-        let v = Self::get_time(this, args, context)?;
-
-        // 8. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 9. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setUTCMilliseconds()`
-    ///
-    /// The `setUTCMilliseconds()` method sets the milliseconds for a specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcmilliseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMilliseconds
-    pub fn set_utc_milliseconds(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let milli be ? ToNumber(ms).
-        let ms = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. Let time be MakeTime(HourFromTime(t), MinFromTime(t), SecFromTime(t), milli).
-        t.set_components(true, None, None, None, None, None, None, Some(ms));
-
-        // 4. Let v be TimeClip(MakeDate(Day(t), time)).
-        let v = Self::get_time(this, args, context)?;
-
-        // 5. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 6. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setUTCMinutes()`
-    ///
-    /// The `setUTCMinutes()` method sets the minutes for a specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcminutes
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMinutes
-    pub fn set_utc_minutes(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let m be ? ToNumber(min).
-        let m = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If sec is not present, let s be SecFromTime(t).
-        // 4. Else,
-        // a. Let s be ? ToNumber(sec).
-        let s = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. If ms is not present, let milli be msFromTime(t).
-        // 6. Else,
-        // a. Let milli be ? ToNumber(ms).
-        let milli = args.get(2).map(|v| v.to_number(context)).transpose()?;
-
-        // 7. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), m, s, milli)).
-        t.set_components(true, None, None, None, None, Some(m), s, milli);
-
-        // 8. Let v be TimeClip(date).
-        let v = Self::get_time(this, args, context)?;
-
-        // 9. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 10. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setUTCMonth()`
-    ///
-    /// The `setUTCMonth()` method sets the month for a specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcmonth
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCMonth
-    pub fn set_utc_month(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let m be ? ToNumber(month).
-        let m = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If date is not present, let dt be DateFromTime(t).
-        // 4. Else,
-        // a. Let dt be ? ToNumber(date).
-        let dt = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. Let newDate be MakeDate(MakeDay(YearFromTime(t), m, dt), TimeWithinDay(t)).
-        t.set_components(true, None, Some(m), dt, None, None, None, None);
-
-        // 6. Let v be TimeClip(newDate).
-        let v = Self::get_time(this, args, context)?;
-
-        // 7. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 8. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.setUTCSeconds()`
-    ///
-    /// The `setUTCSeconds()` method sets the seconds for a specified date according to universal time.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setutcseconds
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setUTCSeconds
-    pub fn set_utc_seconds(
-        this: &JsValue,
-        args: &[JsValue],
-        context: &mut Context,
-    ) -> JsResult<JsValue> {
-        // 1. Let t be ? thisTimeValue(this value).
-        let mut t = this_time_value(this)?;
-
-        // 2. Let s be ? ToNumber(sec).
-        let s = args
-            .get(0)
-            .cloned()
-            .unwrap_or_default()
-            .to_number(context)?;
-
-        // 3. If ms is not present, let milli be msFromTime(t).
-        // 4. Else,
-        // a. Let milli be ? ToNumber(ms).
-        let milli = args.get(1).map(|v| v.to_number(context)).transpose()?;
-
-        // 5. Let date be MakeDate(Day(t), MakeTime(HourFromTime(t), MinFromTime(t), s, milli)).
-        t.set_components(true, None, None, None, None, None, Some(s), milli);
-
-        // 6. Let v be TimeClip(date).
-        let v = Self::get_time(this, args, context)?;
-
-        // 7. Set the [[DateValue]] internal slot of this Date object to v.
-        this.set_data(ObjectData::date(t));
-
-        // 8. Return v.
-        Ok(v)
-    }
-
-    /// `Date.prototype.toDateString()`
-    ///
-    /// The `toDateString()` method returns the date portion of a Date object in English.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.todatestring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toDateString
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_date_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        // 1. Let O be this Date object.
-        // 2. Let tv be ? thisTimeValue(O).
-        let tv = this_time_value(this)?;
-
-        // 3. If tv is NaN, return "Invalid Date".
-        // 4. Let t be LocalTime(tv).
-        // 5. Return DateString(t).
-        if let Some(t) = tv.0 {
-            Ok(Local::now()
-                .timezone()
-                .from_utc_datetime(&t)
-                .format("%a %b %d %Y")
-                .to_string()
-                .into())
-        } else {
-            Ok(js_string!("Invalid Date").into())
-        }
-    }
-
-    /// `Date.prototype.toLocaleDateString()`
-    ///
-    /// The `toLocaleDateString()` method returns the date portion of the given Date instance
-    /// according to language-specific conventions.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
-    pub fn to_locale_date_string(
-        _this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        Err(JsError::from_opaque(JsValue::new("Function Unimplemented")))
-    }
-
-    /// `Date.prototype.toGMTString()`
-    ///
-    /// The `toGMTString()` method converts a date to a string, using Internet Greenwich Mean Time (GMT) conventions.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
     ///  - [MDN documentation][mdn]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.togmtstring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toGMTString
-    pub fn to_gmt_string(
+    pub(crate) fn to_gmt_string(
         this: &JsValue,
         _args: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
+        // The initial value of the "toGMTString" property is %Date.prototype.toUTCString%
         Self::to_utc_string(this, &[], context)
     }
 
-    /// `Date.prototype.toISOString()`
+    /// Converts the `Date` to a local `DateTime`.
     ///
-    /// The `toISOString()` method returns a string in simplified extended ISO format (ISO 8601).
-    ///
-    /// More information:
-    ///  - [ISO 8601][iso8601]
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [iso8601]: http://en.wikipedia.org/wiki/ISO_8601
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.toisostring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_iso_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(Utc::now()
-                .timezone()
-                .from_utc_datetime(&t)
-                .format("%Y-%m-%dT%H:%M:%S.%3fZ")
-                .to_string()
-                .into())
-        } else {
-            Err(JsNativeError::range()
-                .with_message("Invalid time value")
-                .into())
-        }
+    /// If the `Date` is invalid (i.e. NAN), this function will return `None`.
+    #[inline]
+    pub(crate) fn to_local(self) -> Option<DateTime<Local>> {
+        self.0.map(|utc| Local.from_utc_datetime(&utc))
     }
-
-    /// `Date.prototype.toJSON()`
-    ///
-    /// The `toJSON()` method returns a string representation of the `Date` object.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tojson
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toJSON
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let O be ? ToObject(this value).
-        let o = this.to_object(context)?;
-
-        // 2. Let tv be ? ToPrimitive(O, number).
-        let tv = this.to_primitive(context, PreferredType::Number)?;
-
-        // 3. If Type(tv) is Number and tv is not finite, return null.
-        if let Some(number) = tv.as_number() {
-            if !number.is_finite() {
-                return Ok(JsValue::null());
-            }
-        }
-
-        // 4. Return ? Invoke(O, "toISOString").
-        let func = o.get("toISOString", context)?;
-        context.call(&func, &o.into(), &[])
-    }
-
-    /// `Date.prototype.toString()`
-    ///
-    /// The `toString()` method returns a string representing the specified Date object.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tostring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        // 1. Let tv be ? thisTimeValue(this value).
-        let tv = this_time_value(this)?;
-
-        // 2. Return ToDateString(tv).
-        if let Some(t) = tv.0 {
-            Ok(Local::now()
-                .timezone()
-                .from_utc_datetime(&t)
-                .format("%a %b %d %Y %H:%M:%S GMT%z")
-                .to_string()
-                .into())
-        } else {
-            Ok(js_string!("Invalid Date").into())
-        }
-    }
-
-    /// `Date.prototype.toLocaleString()`
-    ///
-    /// The `toLocaleString()` method returns a string representing the specified Date object.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocalestring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString
-    pub fn to_locale_string(
-        _this: &JsValue,
-        _: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        Err(JsError::from_opaque(JsValue::new(
-            "Function Unimplemented]",
-        )))
-    }
-
-    /// `Date.prototype.toTimeString()`
-    ///
-    /// The `toTimeString()` method returns the time portion of a Date object in human readable form in American
-    /// English.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.totimestring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toTimeString
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_time_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        // 1. Let O be this Date object.
-        // 2. Let tv be ? thisTimeValue(O).
-        let tv = this_time_value(this)?;
-
-        // 3. If tv is NaN, return "Invalid Date".
-        // 4. Let t be LocalTime(tv).
-        // 5. Return the string-concatenation of TimeString(t) and TimeZoneString(tv).
-        if let Some(t) = tv.0 {
-            Ok(Local::now()
-                .timezone()
-                .from_utc_datetime(&t)
-                .format("%H:%M:%S GMT%z")
-                .to_string()
-                .into())
-        } else {
-            Ok(js_string!("Invalid Date").into())
-        }
-    }
-
-    /// `Date.prototype.toLocaleTimeString()`
-    ///
-    /// The `toLocaleTimeString()` method returns the time portion of a Date object in human readable form in American
-    /// English.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tolocaletimestring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString
-    pub fn to_locale_time_string(
-        _this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        Err(JsError::from_opaque(JsValue::new(
-            "Function Unimplemented]",
-        )))
-    }
-
-    /// `Date.prototype.toUTCString()`
-    ///
-    /// The `toUTCString()` method returns a string representing the specified Date object.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.toutcstring
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toUTCString
-    pub fn to_utc_string(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            let utc_string = t.format("%a, %d %b %Y %H:%M:%S GMT").to_string();
-            Ok(JsValue::new(utc_string))
-        } else {
-            Ok(js_string!("Invalid Date").into())
-        }
-    }
-
-    /// `Date.prototype.valueOf()`
-    ///
-    /// The `valueOf()` method returns the primitive value of a `Date` object.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.valueof
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf
-    pub fn value_of(
-        this: &JsValue,
-        _args: &[JsValue],
-        _context: &mut Context,
-    ) -> JsResult<JsValue> {
-        if let Some(t) = this_time_value(this)?.0 {
-            Ok(JsValue::new(t.timestamp_millis()))
-        } else {
-            Ok(JsValue::nan())
-        }
-    }
-
-    /// `Date.now()`
-    ///
-    /// The static `Date.now()` method returns the number of milliseconds elapsed since January 1, 1970 00:00:00 UTC.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.now
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
-    #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn now(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Ok(JsValue::new(Utc::now().timestamp_millis() as f64))
-    }
-
-    /// `Date.parse()`
-    ///
-    /// The `Date.parse()` method parses a string representation of a date, and returns the number of milliseconds since
-    /// January 1, 1970, 00:00:00 UTC or `NaN` if the string is unrecognized or, in some cases, contains illegal date
-    /// values.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.parse
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
-    pub(crate) fn parse(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // This method is implementation-defined and discouraged, so we just require the same format as the string
-        // constructor.
-
-        let Some(date) = args.get(0) else {
-            return Ok(JsValue::nan());
-        };
-
-        let date = date.to_string(context)?;
-
-        Ok(JsValue::new(
-            date.to_std_string()
-                .ok()
-                .and_then(|s| DateTime::parse_from_rfc3339(s.as_str()).ok())
-                .map_or(f64::NAN, |v| v.naive_utc().timestamp_millis() as f64),
-        ))
-    }
-
-    /// `Date.UTC()`
-    ///
-    /// The `Date.UTC()` method accepts parameters similar to the `Date` constructor, but treats them as UTC.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.utc
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC
-    pub(crate) fn utc(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let year = args
-            .get(0)
-            .map_or(Ok(f64::NAN), |value| value.to_number(context))?;
-        let month = args
-            .get(1)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let day = args
-            .get(2)
-            .map_or(Ok(1f64), |value| value.to_number(context))?;
-        let hour = args
-            .get(3)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let min = args
-            .get(4)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let sec = args
-            .get(5)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-        let milli = args
-            .get(6)
-            .map_or(Ok(0f64), |value| value.to_number(context))?;
-
-        if !check_normal_opt!(year, month, day, hour, min, sec, milli) {
-            return Ok(JsValue::nan());
-        }
-
-        let year = year as i32;
-        let month = month as u32;
-        let day = day as u32;
-        let hour = hour as u32;
-        let min = min as u32;
-        let sec = sec as u32;
-        let milli = milli as u32;
-
-        let year = if (0..=99).contains(&year) {
-            1900 + year
-        } else {
-            year
-        };
-
-        NaiveDate::from_ymd_opt(year, month + 1, day)
-            .and_then(|f| f.and_hms_milli_opt(hour, min, sec, milli))
-            .and_then(|f| Self::time_clip(f.timestamp_millis() as f64))
-            .map_or(Ok(JsValue::nan()), |time| Ok(JsValue::new(time)))
-    }
-
-    /// Utility: Returns an `Object` representing `Date` from string in RFC3339
-    pub(crate) fn create_obj(value: &JsValue, context: &mut Context) -> JsObject {
-        let prototype = context.intrinsics().constructors().date().prototype();
-        let date_time = DateTime::parse_from_rfc3339(&value.to_string(context).expect(
-            "Utility: Date's string conversion used in limited(internal) area shouldn't fail",
-        ).to_std_string().expect("Utility: Conversion of confirmed JsString to std string"))
-        .expect("Utility: Parse RFC3339 is used in limited(internal) areas shouldn't fail");
-        let internal_date = Date(Some(date_time.naive_local()));
-        JsObject::from_proto_and_data(prototype, ObjectData::date(internal_date))
-    }
-}
-
-/// The abstract operation `thisTimeValue` takes argument value.
-///
-/// In following descriptions of functions that are properties of the Date prototype object, the phrase “this
-/// Date object” refers to the object that is the this value for the invocation of the function. If the `Type` of
-/// the this value is not `Object`, a `TypeError` exception is thrown. The phrase “this time value” within the
-/// specification of a method refers to the result returned by calling the abstract operation `thisTimeValue` with
-/// the this value of the method invocation passed as the argument.
-///
-/// More information:
-///  - [ECMAScript reference][spec]
-///
-/// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
-#[inline]
-pub fn this_time_value(value: &JsValue) -> JsResult<Date> {
-    value
-        .as_object()
-        .and_then(|obj| obj.borrow().as_date().copied())
-        .ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("'this' is not a Date")
-                .into()
-        })
 }

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -62,14 +62,15 @@ pub(super) fn this_time_value(value: &JsValue) -> JsResult<Option<NaiveDateTime>
 pub struct Date(Option<NaiveDateTime>);
 
 impl Date {
-    #[inline]
     /// Creates a new `Date`.
+    #[inline]
     pub(crate) fn new(dt: Option<NaiveDateTime>) -> Self {
         Self(dt)
     }
 
     /// Converts the `Date` into a `JsValue`, mapping `None` to `NaN` and `Some(datetime)` to
     /// `JsValue::from(datetime.timestamp_millis())`.
+    #[inline]
     fn as_value(&self) -> JsValue {
         self.0
             .map_or_else(|| f64::NAN.into(), |dt| dt.timestamp_millis().into())

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -1183,12 +1183,12 @@ impl Date {
     }
 
     /// [`Date.prototype.setSeconds ( sec [ , ms ] )`[local] and
-    /// [`Date.prototype.setUTCSeconds ( sec [ , ms ] )`][utc]
+    /// [`Date.prototype.setUTCSeconds ( sec [ , ms ] )`][utc].
     ///
     /// The `setSeconds()` method sets the seconds for a specified date.
     ///
-    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setseconds
-    /// [mdn]: https://tc39.es/ecma262/#sec-date.prototype.setutcseconds
+    /// [local]: https://tc39.es/ecma262/#sec-date.prototype.setseconds
+    /// [utc]: https://tc39.es/ecma262/#sec-date.prototype.setutcseconds
     pub(crate) fn set_seconds<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
@@ -1230,12 +1230,11 @@ impl Date {
         Ok(t.as_value())
     }
 
-    /// [`Date.prototype.setYear()`][spec]
+    /// [`Date.prototype.setYear()`][spec].
     ///
     /// The `setYear()` method sets the year for a specified date according to local time.
     ///
     /// # Note
-    ///
     ///
     /// The [`Self::set_full_year`] method is preferred for nearly all purposes, because it avoids
     /// the “year 2000 problem.”
@@ -1244,6 +1243,7 @@ impl Date {
     ///  - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/setYear
+    /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.setyear
     pub(crate) fn set_year(
         this: &JsValue,
         args: &[JsValue],
@@ -1301,7 +1301,7 @@ impl Date {
         Ok(t.as_value())
     }
 
-    /// [`Date.prototype.setTime()`][spec]
+    /// [`Date.prototype.setTime()`][spec].
     ///
     /// The `setTime()` method sets the Date object to the time represented by a number of milliseconds
     /// since January 1, 1970, 00:00:00 UTC.
@@ -1335,7 +1335,7 @@ impl Date {
         Ok(t.as_value())
     }
 
-    /// [`Date.prototype.toDateString()`][spec]
+    /// [`Date.prototype.toDateString()`][spec].
     ///
     /// The `toDateString()` method returns the date portion of a Date object in English.
     ///
@@ -1366,7 +1366,7 @@ impl Date {
             .into())
     }
 
-    /// [`Date.prototype.toISOString()`][spec]
+    /// [`Date.prototype.toISOString()`][spec].
     ///
     /// The `toISOString()` method returns a string in simplified extended ISO format
     /// ([ISO 8601][iso8601]).
@@ -1392,7 +1392,7 @@ impl Date {
             .into())
     }
 
-    /// [`Date.prototype.toJSON()`][spec]
+    /// [`Date.prototype.toJSON()`][spec].
     ///
     /// The `toJSON()` method returns a string representation of the `Date` object.
     ///
@@ -1424,7 +1424,7 @@ impl Date {
         context.call(&func, &o.into(), &[])
     }
 
-    /// [`Date.prototype.toLocaleDateString()`][spec]
+    /// [`Date.prototype.toLocaleDateString()`][spec].
     ///
     /// The `toLocaleDateString()` method returns the date portion of the given Date instance according
     /// to language-specific conventions.
@@ -1442,7 +1442,7 @@ impl Date {
         Err(JsError::from_opaque(JsValue::new("Function Unimplemented")))
     }
 
-    /// [`Date.prototype.toLocaleString()`][spec]
+    /// [`Date.prototype.toLocaleString()`][spec].
     ///
     /// The `toLocaleString()` method returns a string representing the specified Date object.
     ///
@@ -1461,7 +1461,7 @@ impl Date {
         )))
     }
 
-    /// [`Date.prototype.toLocaleTimeString()`][spec]
+    /// [`Date.prototype.toLocaleTimeString()`][spec].
     ///
     /// The `toLocaleTimeString()` method returns the time portion of a Date object in human readable
     /// form in American English.
@@ -1481,7 +1481,7 @@ impl Date {
         )))
     }
 
-    /// [`Date.prototype.toString()`][spec]
+    /// [`Date.prototype.toString()`][spec].
     ///
     /// The `toString()` method returns a string representing the specified Date object.
     ///
@@ -1504,7 +1504,7 @@ impl Date {
             .into())
     }
 
-    /// [`Date.prototype.toTimeString()`][spec]
+    /// [`Date.prototype.toTimeString()`][spec].
     ///
     /// The `toTimeString()` method returns the time portion of a Date object in human readable form
     /// in American English.
@@ -1536,7 +1536,7 @@ impl Date {
             .into())
     }
 
-    /// [`Date.prototype.toUTCString()`][spec]
+    /// [`Date.prototype.toUTCString()`][spec].
     ///
     /// The `toUTCString()` method returns a string representing the specified Date object.
     ///
@@ -1570,7 +1570,7 @@ impl Date {
         Ok(JsValue::new(utc_string))
     }
 
-    /// [`Date.prototype.valueOf()`][spec]
+    /// [`Date.prototype.valueOf()`][spec].
     ///
     /// The `valueOf()` method returns the primitive value of a `Date` object.
     ///
@@ -1588,7 +1588,7 @@ impl Date {
         Ok(Date(this_time_value(this)?).as_value())
     }
 
-    /// [`Date.prototype [ @@toPrimitive ] ( hint )`][spec]
+    /// [`Date.prototype [ @@toPrimitive ] ( hint )`][spec].
     ///
     /// The <code>\[@@toPrimitive\]()</code> method converts a Date object to a primitive value.
     ///
@@ -1631,7 +1631,7 @@ impl Date {
         o.ordinary_to_primitive(context, try_first)
     }
 
-    /// [`Date.prototype.toGMTString ( )`][spec]
+    /// [`Date.prototype.toGMTString ( )`][spec].
     ///
     /// The `toGMTString()` method converts a date to a string, using Internet Greenwich Mean Time
     /// (GMT) conventions.

--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -1267,7 +1267,7 @@ fn date_proto_to_date_string() {
         "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.toDateString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed Jul 8 2020"), actual);
+    assert_eq!(JsValue::new("Wed Jul 08 2020"), actual);
 }
 
 #[test]
@@ -1279,7 +1279,7 @@ fn date_proto_to_gmt_string() {
         "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toGMTString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed, 8 Jul 2020 9:16:15 GMT"), actual);
+    assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
 }
 
 #[test]
@@ -1325,7 +1325,7 @@ fn date_proto_to_string() {
                 ))
                 .earliest()
                 .unwrap()
-                .format("Wed Jul 8 2020 9:16:15 GMT%z")
+                .format("Wed Jul 08 2020 09:16:15 GMT%z")
                 .to_string()
         )),
         actual
@@ -1367,7 +1367,7 @@ fn date_proto_to_utc_string() {
         "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toUTCString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed, 8 Jul 2020 9:16:15 GMT"), actual);
+    assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
 }
 
 #[test]

--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -82,7 +82,7 @@ fn date_ctor_call_string() {
     // Internal date is expressed as UTC
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 06, 08)
+            NaiveDate::from_ymd_opt(2020, 6, 8)
                 .unwrap()
                 .and_hms_milli_opt(15, 46, 15, 779)
                 .unwrap()
@@ -106,9 +106,9 @@ fn date_ctor_call_number() {
     let date_time = forward_dt(&mut context, "new Date(1594199775779)");
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         date_time
@@ -123,9 +123,9 @@ fn date_ctor_call_date() {
 
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         date_time
@@ -136,10 +136,10 @@ fn date_ctor_call_date() {
 fn date_ctor_call_multiple() {
     let mut context = Context::default();
 
-    let date_time = forward_dt(&mut context, "new Date(2020, 06, 08, 09, 16, 15, 779)");
+    let date_time = forward_dt(&mut context, "new Date(2020, 6, 8, 9, 16, 15, 779)");
 
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 15, 779)),
         date_time
     );
 }
@@ -148,10 +148,10 @@ fn date_ctor_call_multiple() {
 fn date_ctor_call_multiple_90s() {
     let mut context = Context::default();
 
-    let date_time = forward_dt(&mut context, "new Date(99, 06, 08, 09, 16, 15, 779)");
+    let date_time = forward_dt(&mut context, "new Date(99, 6, 8, 9, 16, 15, 779)");
 
     assert_eq!(
-        Some(datetime_from_local(1999, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(1999, 7, 8, 9, 16, 15, 779)),
         date_time
     );
 }
@@ -164,13 +164,13 @@ fn date_ctor_call_multiple_nan() {
         assert_eq!(None, date_time);
     }
 
-    check("new Date(1/0, 06, 08, 09, 16, 15, 779)");
-    check("new Date(2020, 1/0, 08, 09, 16, 15, 779)");
-    check("new Date(2020, 06, 1/0, 09, 16, 15, 779)");
-    check("new Date(2020, 06, 08, 1/0, 16, 15, 779)");
-    check("new Date(2020, 06, 08, 09, 1/0, 15, 779)");
-    check("new Date(2020, 06, 08, 09, 16, 1/0, 779)");
-    check("new Date(2020, 06, 08, 09, 16, 15, 1/0)");
+    check("new Date(1/0, 6, 8, 9, 16, 15, 779)");
+    check("new Date(2020, 1/0, 8, 9, 16, 15, 779)");
+    check("new Date(2020, 6, 1/0, 9, 16, 15, 779)");
+    check("new Date(2020, 6, 8, 1/0, 16, 15, 779)");
+    check("new Date(2020, 6, 8, 9, 1/0, 15, 779)");
+    check("new Date(2020, 6, 8, 9, 16, 1/0, 779)");
+    check("new Date(2020, 6, 8, 9, 16, 15, 1/0)");
 }
 
 #[test]
@@ -201,7 +201,7 @@ fn date_ctor_parse_call() {
 fn date_ctor_utc_call() {
     let mut context = Context::default();
 
-    let date_time = forward_val(&mut context, "Date.UTC(2020, 06, 08, 09, 16, 15, 779)");
+    let date_time = forward_val(&mut context, "Date.UTC(2020, 6, 8, 9, 16, 15, 779)");
 
     assert_eq!(JsValue::new(1594199775779i64), date_time.unwrap());
 }
@@ -214,13 +214,13 @@ fn date_ctor_utc_call_nan() {
         assert_eq!(JsValue::nan(), date_time);
     }
 
-    check("Date.UTC(1/0, 06, 08, 09, 16, 15, 779)");
-    check("Date.UTC(2020, 1/0, 08, 09, 16, 15, 779)");
-    check("Date.UTC(2020, 06, 1/0, 09, 16, 15, 779)");
-    check("Date.UTC(2020, 06, 08, 1/0, 16, 15, 779)");
-    check("Date.UTC(2020, 06, 08, 09, 1/0, 15, 779)");
-    check("Date.UTC(2020, 06, 08, 09, 16, 1/0, 779)");
-    check("Date.UTC(2020, 06, 08, 09, 16, 15, 1/0)");
+    check("Date.UTC(1/0, 6, 8, 9, 16, 15, 779)");
+    check("Date.UTC(2020, 1/0, 8, 9, 16, 15, 779)");
+    check("Date.UTC(2020, 6, 1/0, 9, 16, 15, 779)");
+    check("Date.UTC(2020, 6, 8, 1/0, 16, 15, 779)");
+    check("Date.UTC(2020, 6, 8, 9, 1/0, 15, 779)");
+    check("Date.UTC(2020, 6, 8, 9, 16, 1/0, 779)");
+    check("Date.UTC(2020, 6, 8, 9, 16, 15, 1/0)");
 }
 
 #[test]
@@ -229,7 +229,7 @@ fn date_proto_get_date_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getDate()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getDate()",
     );
     assert_eq!(JsValue::new(8), actual.unwrap());
 
@@ -243,7 +243,7 @@ fn date_proto_get_day_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getDay()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getDay()",
     );
     assert_eq!(JsValue::new(3), actual.unwrap());
 
@@ -257,7 +257,7 @@ fn date_proto_get_full_year_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getFullYear()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getFullYear()",
     );
     assert_eq!(JsValue::new(2020), actual.unwrap());
 
@@ -271,7 +271,7 @@ fn date_proto_get_hours_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getHours()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getHours()",
     );
     assert_eq!(JsValue::new(9), actual.unwrap());
 
@@ -285,7 +285,7 @@ fn date_proto_get_milliseconds_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getMilliseconds()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getMilliseconds()",
     );
     assert_eq!(JsValue::new(779), actual.unwrap());
 
@@ -299,7 +299,7 @@ fn date_proto_get_minutes_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getMinutes()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getMinutes()",
     );
     assert_eq!(JsValue::new(16), actual.unwrap());
 
@@ -313,9 +313,9 @@ fn date_proto_get_month() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getMonth()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getMonth()",
     );
-    assert_eq!(JsValue::new(06), actual.unwrap());
+    assert_eq!(JsValue::new(6), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getMonth()");
     assert_eq!(JsValue::nan(), actual.unwrap());
@@ -327,7 +327,7 @@ fn date_proto_get_seconds() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getSeconds()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getSeconds()",
     );
     assert_eq!(JsValue::new(15), actual.unwrap());
 
@@ -341,11 +341,10 @@ fn date_proto_get_time() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getTime()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getTime()",
     );
 
-    let ts =
-        Local.with_ymd_and_hms(2020, 07, 08, 09, 16, 15).unwrap() + Duration::milliseconds(779);
+    let ts = Local.with_ymd_and_hms(2020, 7, 8, 9, 16, 15).unwrap() + Duration::milliseconds(779);
 
     assert_eq!(JsValue::new(ts.timestamp_millis()), actual.unwrap());
 
@@ -359,7 +358,7 @@ fn date_proto_get_year() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(2020, 06, 08, 09, 16, 15, 779).getYear()",
+        "new Date(2020, 6, 8, 9, 16, 15, 779).getYear()",
     );
     assert_eq!(JsValue::new(120), actual.unwrap());
 
@@ -402,9 +401,9 @@ fn date_proto_get_utc_date_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCDate()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCDate()",
     );
-    assert_eq!(JsValue::new(08), actual.unwrap());
+    assert_eq!(JsValue::new(8), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCDate()");
     assert_eq!(JsValue::nan(), actual.unwrap());
@@ -416,7 +415,7 @@ fn date_proto_get_utc_day_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCDay()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCDay()",
     );
     assert_eq!(JsValue::new(3), actual.unwrap());
 
@@ -430,7 +429,7 @@ fn date_proto_get_utc_full_year_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCFullYear()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCFullYear()",
     );
     assert_eq!(JsValue::new(2020), actual.unwrap());
 
@@ -444,9 +443,9 @@ fn date_proto_get_utc_hours_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCHours()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCHours()",
     );
-    assert_eq!(JsValue::new(09), actual.unwrap());
+    assert_eq!(JsValue::new(9), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCHours()");
     assert_eq!(JsValue::nan(), actual.unwrap());
@@ -458,7 +457,7 @@ fn date_proto_get_utc_milliseconds_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMilliseconds()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCMilliseconds()",
     );
     assert_eq!(JsValue::new(779), actual.unwrap());
 
@@ -472,7 +471,7 @@ fn date_proto_get_utc_minutes_call() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMinutes()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCMinutes()",
     );
     assert_eq!(JsValue::new(16), actual.unwrap());
 
@@ -486,9 +485,9 @@ fn date_proto_get_utc_month() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCMonth()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCMonth()",
     );
-    assert_eq!(JsValue::new(06), actual.unwrap());
+    assert_eq!(JsValue::new(6), actual.unwrap());
 
     let actual = forward_val(&mut context, "new Date(1/0).getUTCMonth()");
     assert_eq!(JsValue::nan(), actual.unwrap());
@@ -500,7 +499,7 @@ fn date_proto_get_utc_seconds() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).getUTCSeconds()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).getUTCSeconds()",
     );
     assert_eq!(JsValue::new(15), actual.unwrap());
 
@@ -514,26 +513,26 @@ fn date_proto_set_date() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setDate(21); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setDate(21); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 21, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 7, 21, 9, 16, 15, 779)),
         actual
     );
 
     // Date wraps to previous month for 0.
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setDate(0); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setDate(0); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 06, 30, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 6, 30, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setDate(1/0); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setDate(1/0); dt",
     );
     assert_eq!(None, actual);
 }
@@ -544,28 +543,28 @@ fn date_proto_set_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setFullYear(2012); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setFullYear(2012); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2012, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2012, 7, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setFullYear(2012, 8); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setFullYear(2012, 8); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2012, 09, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2012, 9, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setFullYear(2012, 8, 10); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setFullYear(2012, 8, 10); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2012, 09, 10, 09, 16, 15, 779)),
+        Some(datetime_from_local(2012, 9, 10, 9, 16, 15, 779)),
         actual
     );
 
@@ -573,37 +572,37 @@ fn date_proto_set_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setFullYear(2012, 35); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setFullYear(2012, 35); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2014, 12, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2014, 12, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setFullYear(2012, -35); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setFullYear(2012, -35); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2009, 02, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2009, 2, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setFullYear(2012, 9, 950); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setFullYear(2012, 9, 950); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2015, 05, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2015, 5, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setFullYear(2012, 9, -950); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setFullYear(2012, 9, -950); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2010, 02, 23, 09, 16, 15, 779)),
+        Some(datetime_from_local(2010, 2, 23, 9, 16, 15, 779)),
         actual
     );
 }
@@ -614,37 +613,37 @@ fn date_proto_set_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setHours(11); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setHours(11); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 11, 16, 15, 779)),
+        Some(datetime_from_local(2020, 7, 8, 11, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setHours(11, 35); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setHours(11, 35); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 11, 35, 15, 779)),
+        Some(datetime_from_local(2020, 7, 8, 11, 35, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setHours(11, 35, 23); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setHours(11, 35, 23); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 11, 35, 23, 779)),
+        Some(datetime_from_local(2020, 7, 8, 11, 35, 23, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setHours(11, 35, 23, 537); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setHours(11, 35, 23, 537); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 11, 35, 23, 537)),
+        Some(datetime_from_local(2020, 7, 8, 11, 35, 23, 537)),
         actual
     );
 
@@ -652,10 +651,10 @@ fn date_proto_set_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setHours(10000, 20000, 30000, 40123); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setHours(10000, 20000, 30000, 40123); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2021, 09, 11, 21, 40, 40, 123)),
+        Some(datetime_from_local(2021, 9, 11, 21, 40, 40, 123)),
         actual
     );
 }
@@ -666,10 +665,10 @@ fn date_proto_set_milliseconds() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMilliseconds(597); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMilliseconds(597); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 15, 597)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 15, 597)),
         actual
     );
 
@@ -678,10 +677,10 @@ fn date_proto_set_milliseconds() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMilliseconds(40123); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMilliseconds(40123); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 55, 123)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 55, 123)),
         actual
     );
 }
@@ -692,28 +691,28 @@ fn date_proto_set_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMinutes(11); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMinutes(11); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 11, 15, 779)),
+        Some(datetime_from_local(2020, 7, 8, 9, 11, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMinutes(11, 35); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMinutes(11, 35); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 11, 35, 779)),
+        Some(datetime_from_local(2020, 7, 8, 9, 11, 35, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMinutes(11, 35, 537); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMinutes(11, 35, 537); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 11, 35, 537)),
+        Some(datetime_from_local(2020, 7, 8, 9, 11, 35, 537)),
         actual
     );
 
@@ -722,10 +721,10 @@ fn date_proto_set_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMinutes(600000, 30000, 40123); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMinutes(600000, 30000, 40123); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2021, 08, 29, 09, 20, 40, 123)),
+        Some(datetime_from_local(2021, 8, 29, 9, 20, 40, 123)),
         actual
     );
 }
@@ -736,19 +735,19 @@ fn date_proto_set_month() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMonth(11); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMonth(11); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 12, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 12, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setMonth(11, 16); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setMonth(11, 16); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 12, 16, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 12, 16, 9, 16, 15, 779)),
         actual
     );
 
@@ -757,10 +756,10 @@ fn date_proto_set_month() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setMonth(40, 83); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setMonth(40, 83); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2023, 07, 22, 09, 16, 15, 779)),
+        Some(datetime_from_local(2023, 7, 22, 9, 16, 15, 779)),
         actual
     );
 }
@@ -771,19 +770,19 @@ fn date_proto_set_seconds() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setSeconds(11); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setSeconds(11); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 11, 779)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 11, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setSeconds(11, 487); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setSeconds(11, 487); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 11, 487)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 11, 487)),
         actual
     );
 
@@ -792,10 +791,10 @@ fn date_proto_set_seconds() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 07, 08, 09, 16, 15, 779); dt.setSeconds(40000000, 40123); dt",
+        "dt = new Date(2020, 7, 8, 9, 16, 15, 779); dt.setSeconds(40000000, 40123); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2021, 11, 14, 08, 23, 20, 123)),
+        Some(datetime_from_local(2021, 11, 14, 8, 23, 20, 123)),
         actual
     );
 }
@@ -806,19 +805,19 @@ fn set_year() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setYear(98); dt",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setYear(98); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(1998, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(1998, 7, 8, 9, 16, 15, 779)),
         actual
     );
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.setYear(2001); dt",
+        "dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.setYear(2001); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2001, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2001, 7, 8, 9, 16, 15, 779)),
         actual
     );
 }
@@ -829,10 +828,10 @@ fn date_proto_set_time() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(); dt.setTime(new Date(2020, 06, 08, 09, 16, 15, 779).getTime()); dt",
+        "let dt = new Date(); dt.setTime(new Date(2020, 6, 8, 9, 16, 15, 779).getTime()); dt",
     );
     assert_eq!(
-        Some(datetime_from_local(2020, 07, 08, 09, 16, 15, 779)),
+        Some(datetime_from_local(2020, 7, 8, 9, 16, 15, 779)),
         actual
     );
 }
@@ -843,13 +842,13 @@ fn date_proto_set_utc_date() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCDate(21); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCDate(21); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 21)
+            NaiveDate::from_ymd_opt(2020, 7, 21)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -858,13 +857,13 @@ fn date_proto_set_utc_date() {
     // Date wraps to previous month for 0.
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCDate(0); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCDate(0); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 06, 30)
+            NaiveDate::from_ymd_opt(2020, 6, 30)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -872,7 +871,7 @@ fn date_proto_set_utc_date() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCDate(1/0); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCDate(1/0); dt",
     );
     assert_eq!(None, actual);
 }
@@ -883,13 +882,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2012, 07, 08)
+            NaiveDate::from_ymd_opt(2012, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -897,13 +896,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, 8); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, 8); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2012, 09, 08)
+            NaiveDate::from_ymd_opt(2012, 9, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -911,13 +910,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, 8, 10); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, 8, 10); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2012, 09, 10)
+            NaiveDate::from_ymd_opt(2012, 9, 10)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -927,13 +926,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, 35); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, 35); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2014, 12, 08)
+            NaiveDate::from_ymd_opt(2014, 12, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -941,13 +940,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, -35); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, -35); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2009, 02, 08)
+            NaiveDate::from_ymd_opt(2009, 2, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -955,13 +954,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, 9, 950); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, 9, 950); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2015, 05, 08)
+            NaiveDate::from_ymd_opt(2015, 5, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -969,13 +968,13 @@ fn date_proto_set_utc_full_year() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCFullYear(2012, 9, -950); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCFullYear(2012, 9, -950); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2010, 02, 23)
+            NaiveDate::from_ymd_opt(2010, 2, 23)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -988,11 +987,11 @@ fn date_proto_set_utc_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCHours(11); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCHours(11); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
                 .and_hms_milli_opt(11, 16, 15, 779)
                 .unwrap()
@@ -1002,11 +1001,11 @@ fn date_proto_set_utc_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCHours(11, 35); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCHours(11, 35); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
                 .and_hms_milli_opt(11, 35, 15, 779)
                 .unwrap()
@@ -1016,11 +1015,11 @@ fn date_proto_set_utc_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCHours(11, 35, 23); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCHours(11, 35, 23); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
                 .and_hms_milli_opt(11, 35, 23, 779)
                 .unwrap()
@@ -1030,11 +1029,11 @@ fn date_proto_set_utc_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCHours(11, 35, 23, 537); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCHours(11, 35, 23, 537); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
                 .and_hms_milli_opt(11, 35, 23, 537)
                 .unwrap()
@@ -1046,11 +1045,11 @@ fn date_proto_set_utc_hours() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCHours(10000, 20000, 30000, 40123); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCHours(10000, 20000, 30000, 40123); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2021, 09, 11)
+            NaiveDate::from_ymd_opt(2021, 9, 11)
                 .unwrap()
                 .and_hms_milli_opt(21, 40, 40, 123)
                 .unwrap()
@@ -1065,13 +1064,13 @@ fn date_proto_set_utc_milliseconds() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMilliseconds(597); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMilliseconds(597); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 597)
+                .and_hms_milli_opt(9, 16, 15, 597)
                 .unwrap()
         ),
         actual
@@ -1082,13 +1081,13 @@ fn date_proto_set_utc_milliseconds() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMilliseconds(40123); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMilliseconds(40123); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 55, 123)
+                .and_hms_milli_opt(9, 16, 55, 123)
                 .unwrap()
         ),
         actual
@@ -1101,13 +1100,13 @@ fn date_proto_set_utc_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMinutes(11); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMinutes(11); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 11, 15, 779)
+                .and_hms_milli_opt(9, 11, 15, 779)
                 .unwrap()
         ),
         actual
@@ -1115,13 +1114,13 @@ fn date_proto_set_utc_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMinutes(11, 35); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMinutes(11, 35); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 11, 35, 779)
+                .and_hms_milli_opt(9, 11, 35, 779)
                 .unwrap()
         ),
         actual
@@ -1129,13 +1128,13 @@ fn date_proto_set_utc_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMinutes(11, 35, 537); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMinutes(11, 35, 537); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 11, 35, 537)
+                .and_hms_milli_opt(9, 11, 35, 537)
                 .unwrap()
         ),
         actual
@@ -1146,13 +1145,13 @@ fn date_proto_set_utc_minutes() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMinutes(600000, 30000, 40123); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMinutes(600000, 30000, 40123); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2021, 08, 29)
+            NaiveDate::from_ymd_opt(2021, 8, 29)
                 .unwrap()
-                .and_hms_milli_opt(09, 20, 40, 123)
+                .and_hms_milli_opt(9, 20, 40, 123)
                 .unwrap()
         ),
         actual
@@ -1165,13 +1164,13 @@ fn date_proto_set_utc_month() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMonth(11); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMonth(11); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 12, 08)
+            NaiveDate::from_ymd_opt(2020, 12, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -1179,13 +1178,13 @@ fn date_proto_set_utc_month() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCMonth(11, 16); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCMonth(11, 16); dt",
     );
     assert_eq!(
         Some(
             NaiveDate::from_ymd_opt(2020, 12, 16)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -1196,13 +1195,13 @@ fn date_proto_set_utc_month() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCMonth(40, 83); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCMonth(40, 83); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2023, 07, 22)
+            NaiveDate::from_ymd_opt(2023, 7, 22)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 15, 779)
+                .and_hms_milli_opt(9, 16, 15, 779)
                 .unwrap()
         ),
         actual
@@ -1215,13 +1214,13 @@ fn date_proto_set_utc_seconds() {
 
     let actual = forward_dt(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCSeconds(11); dt",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCSeconds(11); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 11, 779)
+                .and_hms_milli_opt(9, 16, 11, 779)
                 .unwrap()
         ),
         actual
@@ -1229,13 +1228,13 @@ fn date_proto_set_utc_seconds() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.setUTCSeconds(11, 487); dt",
+        "dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.setUTCSeconds(11, 487); dt",
     );
     assert_eq!(
         Some(
-            NaiveDate::from_ymd_opt(2020, 07, 08)
+            NaiveDate::from_ymd_opt(2020, 7, 8)
                 .unwrap()
-                .and_hms_milli_opt(09, 16, 11, 487)
+                .and_hms_milli_opt(9, 16, 11, 487)
                 .unwrap()
         ),
         actual
@@ -1246,13 +1245,13 @@ fn date_proto_set_utc_seconds() {
 
     let actual = forward_dt(
         &mut context,
-        "dt = new Date(Date.UTC(2020, 07, 08, 09, 16, 15, 779)); dt.setUTCSeconds(40000000, 40123); dt",
+        "dt = new Date(Date.UTC(2020, 7, 8, 9, 16, 15, 779)); dt.setUTCSeconds(40000000, 40123); dt",
     );
     assert_eq!(
         Some(
             NaiveDate::from_ymd_opt(2021, 11, 14)
                 .unwrap()
-                .and_hms_milli_opt(08, 23, 20, 123)
+                .and_hms_milli_opt(8, 23, 20, 123)
                 .unwrap()
         ),
         actual
@@ -1265,10 +1264,10 @@ fn date_proto_to_date_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.toDateString()",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.toDateString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed Jul 08 2020"), actual);
+    assert_eq!(JsValue::new("Wed Jul 8 2020"), actual);
 }
 
 #[test]
@@ -1277,10 +1276,10 @@ fn date_proto_to_gmt_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toGMTString()",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toGMTString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
+    assert_eq!(JsValue::new("Wed, 8 Jul 2020 9:16:15 GMT"), actual);
 }
 
 #[test]
@@ -1289,7 +1288,7 @@ fn date_proto_to_iso_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toISOString()",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toISOString()",
     )
     .unwrap();
     assert_eq!(JsValue::new("2020-07-08T09:16:15.779Z"), actual);
@@ -1301,7 +1300,7 @@ fn date_proto_to_json() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toJSON()",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toJSON()",
     )
     .unwrap();
     assert_eq!(JsValue::new("2020-07-08T09:16:15.779Z"), actual);
@@ -1313,7 +1312,7 @@ fn date_proto_to_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.toString()",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.toString()",
     )
     .ok();
 
@@ -1326,7 +1325,7 @@ fn date_proto_to_string() {
                 ))
                 .earliest()
                 .unwrap()
-                .format("Wed Jul 08 2020 09:16:15 GMT%z")
+                .format("Wed Jul 8 2020 9:16:15 GMT%z")
                 .to_string()
         )),
         actual
@@ -1339,7 +1338,7 @@ fn date_proto_to_time_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(2020, 06, 08, 09, 16, 15, 779); dt.toTimeString()",
+        "let dt = new Date(2020, 6, 8, 9, 16, 15, 779); dt.toTimeString()",
     )
     .ok();
 
@@ -1365,10 +1364,10 @@ fn date_proto_to_utc_string() {
 
     let actual = forward_val(
         &mut context,
-        "let dt = new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)); dt.toUTCString()",
+        "let dt = new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)); dt.toUTCString()",
     )
     .unwrap();
-    assert_eq!(JsValue::new("Wed, 08 Jul 2020 09:16:15 GMT"), actual);
+    assert_eq!(JsValue::new("Wed, 8 Jul 2020 9:16:15 GMT"), actual);
 }
 
 #[test]
@@ -1377,7 +1376,7 @@ fn date_proto_value_of() {
 
     let actual = forward_val(
         &mut context,
-        "new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)).valueOf()",
+        "new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)).valueOf()",
     )
     .unwrap();
     assert_eq!(JsValue::new(1594199775779i64), actual);
@@ -1389,7 +1388,7 @@ fn date_neg() {
 
     let actual = forward_val(
         &mut context,
-        "-new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779))",
+        "-new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779))",
     )
     .unwrap();
     assert_eq!(JsValue::new(-1594199775779i64), actual);
@@ -1401,7 +1400,7 @@ fn date_json() {
 
     let actual = forward_val(
         &mut context,
-        "JSON.stringify({ date: new Date(Date.UTC(2020, 06, 08, 09, 16, 15, 779)) })",
+        "JSON.stringify({ date: new Date(Date.UTC(2020, 6, 8, 9, 16, 15, 779)) })",
     )
     .unwrap();
     assert_eq!(

--- a/boa_engine/src/builtins/date/utils.rs
+++ b/boa_engine/src/builtins/date/utils.rs
@@ -1,0 +1,200 @@
+use chrono::{Datelike, Local, NaiveDateTime, TimeZone, Timelike};
+
+use crate::value::IntegerOrNan;
+
+/// The absolute maximum value of a timestamp
+pub(super) const MAX_TIMESTAMP: i64 = 864 * 10i64.pow(13);
+/// The number of milliseconds in a second.
+pub(super) const MILLIS_PER_SECOND: i64 = 1000;
+/// The number of milliseconds in a minute.
+pub(super) const MILLIS_PER_MINUTE: i64 = MILLIS_PER_SECOND * 60;
+/// The number of milliseconds in an hour.
+pub(super) const MILLIS_PER_HOUR: i64 = MILLIS_PER_MINUTE * 60;
+/// The number of milliseconds in a day.
+pub(super) const MILLIS_PER_DAY: i64 = MILLIS_PER_HOUR * 24;
+
+// https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-values-and-time-range
+//
+// The smaller range supported by a time value as specified in this section is approximately -273,790 to 273,790
+// years relative to 1970.
+pub(super) const MIN_YEAR: i64 = -300_000;
+pub(super) const MAX_YEAR: i64 = -MIN_YEAR;
+pub(super) const MIN_MONTH: i64 = MIN_YEAR * 12;
+pub(super) const MAX_MONTH: i64 = MAX_YEAR * 12;
+
+/// Calculates the absolute day number from the year number.
+pub(super) const fn day_from_year(year: i64) -> i64 {
+    // Taken from https://chromium.googlesource.com/v8/v8/+/refs/heads/main/src/date/date.cc#496
+    // Useful to avoid negative divisions and overflows on 32-bit platforms (if we plan to support them).
+    const YEAR_DELTA: i64 = 399_999;
+    const fn day(year: i64) -> i64 {
+        let year = year + YEAR_DELTA;
+        365 * year + year / 4 - year / 100 + year / 400
+    }
+
+    assert!(MIN_YEAR <= year && year <= MAX_YEAR);
+    day(year) - day(1970)
+}
+
+/// Abstract operation [`MakeTime`][spec].
+///
+/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-maketime
+pub(super) fn make_time(hour: i64, min: i64, sec: i64, ms: i64) -> Option<i64> {
+    // 1. If hour is not finite or min is not finite or sec is not finite or ms is not finite, return NaN.
+    // 2. Let h be 𝔽(! ToIntegerOrInfinity(hour)).
+    // 3. Let m be 𝔽(! ToIntegerOrInfinity(min)).
+    // 4. Let s be 𝔽(! ToIntegerOrInfinity(sec)).
+    // 5. Let milli be 𝔽(! ToIntegerOrInfinity(ms)).
+
+    // 6. Let t be ((h * msPerHour + m * msPerMinute) + s * msPerSecond) + milli, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators * and +).
+    // 7. Return t.
+
+    let h_ms = hour.checked_mul(MILLIS_PER_HOUR)?;
+    let m_ms = min.checked_mul(MILLIS_PER_MINUTE)?;
+    let s_ms = sec.checked_mul(MILLIS_PER_SECOND)?;
+
+    h_ms.checked_add(m_ms)?.checked_add(s_ms)?.checked_add(ms)
+}
+
+/// Abstract operation [`MakeDay`][spec].
+///
+/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-makeday
+pub(super) fn make_day(mut year: i64, mut month: i64, date: i64) -> Option<i64> {
+    // 1. If year is not finite or month is not finite or date is not finite, return NaN.
+    // 2. Let y be 𝔽(! ToIntegerOrInfinity(year)).
+    // 3. Let m be 𝔽(! ToIntegerOrInfinity(month)).
+    // 4. Let dt be 𝔽(! ToIntegerOrInfinity(date)).
+    if !(MIN_YEAR..=MAX_YEAR).contains(&year) || !(MIN_MONTH..=MAX_MONTH).contains(&month) {
+        return None;
+    }
+
+    // At this point, we've already asserted that year and month are much less than its theoretical
+    // maximum and minimum values (i64::MAX/MIN), so we don't need to do checked operations.
+
+    // 5. Let ym be y + 𝔽(floor(ℝ(m) / 12)).
+    // 6. If ym is not finite, return NaN.
+    year += month / 12;
+    // 7. Let mn be 𝔽(ℝ(m) modulo 12).
+    month %= 12;
+    if month < 0 {
+        month += 12;
+        year -= 1;
+    }
+
+    // 8. Find a finite time value t such that YearFromTime(t) is ym and MonthFromTime(t) is mn and DateFromTime(t) is
+    // 1𝔽; but if this is not possible (because some argument is out of range), return NaN.
+    let month = usize::try_from(month).expect("month must be between 0 and 11 at this point");
+
+    let mut day = day_from_year(year);
+
+    // Consider leap years when calculating the cumulative days added to the year from the input month
+    if (year % 4 != 0) || (year % 100 == 0 && year % 400 != 0) {
+        day += [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][month];
+    } else {
+        day += [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335][month];
+    }
+
+    // 9. Return Day(t) + dt - 1𝔽.
+    (day - 1).checked_add(date)
+}
+
+/// Abstract operation [`MakeDate`][spec].
+///
+/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-makedate
+pub(super) fn make_date(day: i64, time: i64) -> Option<i64> {
+    // 1. If day is not finite or time is not finite, return NaN.
+    // 2. Let tv be day × msPerDay + time.
+    // 3. If tv is not finite, return NaN.
+    // 4. Return tv.
+    day.checked_mul(MILLIS_PER_DAY)?.checked_add(time)
+}
+
+/// Abstract operation [`TimeClip`][spec]
+/// Returns the timestamp (number of milliseconds) if it is in the expected range.
+/// Otherwise, returns `None`.
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timeclip
+#[inline]
+pub(super) fn time_clip(time: i64) -> Option<i64> {
+    // 1. If time is not finite, return NaN.
+    // 2. If abs(ℝ(time)) > 8.64 × 10^15, return NaN.
+    // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
+    (time.checked_abs()? <= MAX_TIMESTAMP).then_some(time)
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub(super) struct DateParameters {
+    pub(super) year: Option<IntegerOrNan>,
+    pub(super) month: Option<IntegerOrNan>,
+    pub(super) date: Option<IntegerOrNan>,
+    pub(super) hour: Option<IntegerOrNan>,
+    pub(super) minute: Option<IntegerOrNan>,
+    pub(super) second: Option<IntegerOrNan>,
+    pub(super) millisecond: Option<IntegerOrNan>,
+}
+
+/// Replaces some (or all) parameters of `date` with the specified parameters
+pub(super) fn replace_params(
+    datetime: NaiveDateTime,
+    params: DateParameters,
+    local: bool,
+) -> Option<NaiveDateTime> {
+    let DateParameters {
+        year,
+        month,
+        date,
+        hour,
+        minute,
+        second,
+        millisecond,
+    } = params;
+
+    let datetime = if local {
+        Local.from_utc_datetime(&datetime).naive_local()
+    } else {
+        datetime
+    };
+
+    let year = match year {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.year()),
+    };
+    let month = match month {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.month() - 1),
+    };
+    let date = match date {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.day()),
+    };
+    let hour = match hour {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.hour()),
+    };
+    let minute = match minute {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.minute()),
+    };
+    let second = match second {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.second()),
+    };
+    let millisecond = match millisecond {
+        Some(i) => i.as_integer()?,
+        None => i64::from(datetime.timestamp_subsec_millis()),
+    };
+
+    let new_day = make_day(year, month, date)?;
+    let new_time = make_time(hour, minute, second, millisecond)?;
+    let mut ts = make_date(new_day, new_time)?;
+
+    if local {
+        ts = Local
+            .from_local_datetime(&NaiveDateTime::from_timestamp_millis(ts)?)
+            .earliest()?
+            .naive_utc()
+            .timestamp_millis();
+    }
+
+    NaiveDateTime::from_timestamp_millis(time_clip(ts)?)
+}

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -251,20 +251,18 @@ impl Set {
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
     pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        if let Some(object) = this.as_object() {
-            if object.borrow().is_set() {
-                this.set_data(ObjectData::set(OrderedSet::new()));
-                Ok(JsValue::undefined())
-            } else {
-                Err(JsNativeError::typ()
-                    .with_message("'this' is not a Set")
-                    .into())
-            }
-        } else {
-            Err(JsNativeError::typ()
-                .with_message("'this' is not a Set")
-                .into())
-        }
+        let mut object = this
+            .as_object()
+            .map(JsObject::borrow_mut)
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
+
+        let set = object
+            .as_set_mut()
+            .ok_or_else(|| JsNativeError::typ().with_message("'this' is not a Set"))?;
+
+        set.clear();
+
+        Ok(JsValue::undefined())
     }
 
     /// `Set.prototype.delete( value )`

--- a/boa_engine/src/builtins/set/ordered_set.rs
+++ b/boa_engine/src/builtins/set/ordered_set.rs
@@ -91,6 +91,7 @@ where
     }
 
     /// Removes all elements in the set, while preserving its capacity.
+    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
     }

--- a/boa_engine/src/builtins/set/ordered_set.rs
+++ b/boa_engine/src/builtins/set/ordered_set.rs
@@ -90,6 +90,11 @@ where
         self.inner.shift_remove(value)
     }
 
+    /// Removes all elements in the set, while preserving its capacity.
+    pub fn clear(&mut self) {
+        self.inner.clear();
+    }
+
     /// Checks if a given value is present in the set
     ///
     /// Return `true` if `value` is present in set, false otherwise.

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -161,6 +161,6 @@ mod tests {
                 )
                 .unwrap(),
             JsValue::undefined()
-        )
+        );
     }
 }

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -641,6 +641,7 @@ impl ContextBuilder {
     ///
     /// This function is only available if the `fuzz` feature is enabled.
     #[cfg(feature = "fuzz")]
+    #[must_use]
     pub fn instructions_remaining(mut self, instructions_remaining: usize) -> Self {
         self.instructions_remaining = instructions_remaining;
         self

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -81,7 +81,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getDate()`.
     #[inline]
     pub fn get_date(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_date(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_date::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the day of the week (0–6) for the specified date
@@ -90,7 +90,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getDay()`.
     #[inline]
     pub fn get_day(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_day(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_day::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the year (4 digits for 4-digit years) of the specified date
@@ -99,7 +99,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getFullYear()`.
     #[inline]
     pub fn get_full_year(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_full_year(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_full_year::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the hour (0–23) in the specified date according to local time.
@@ -107,7 +107,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getHours()`.
     #[inline]
     pub fn get_hours(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_hours(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_hours::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the milliseconds (0–999) in the specified date according
@@ -116,7 +116,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getMilliseconds()`.
     #[inline]
     pub fn get_milliseconds(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_milliseconds(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_milliseconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the minutes (0–59) in the specified date according to local time.
@@ -124,7 +124,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getMinutes()`.
     #[inline]
     pub fn get_minutes(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_minutes(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_minutes::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the month (0–11) in the specified date according to local time.
@@ -132,7 +132,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getMonth()`.
     #[inline]
     pub fn get_month(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_month(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_month::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the seconds (0–59) in the specified date according to local time.
@@ -140,7 +140,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getSeconds()`.
     #[inline]
     pub fn get_seconds(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_seconds(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_seconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the numeric value of the specified date as the number
@@ -167,7 +167,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCDate()`.
     #[inline]
     pub fn get_utc_date(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_date(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_date::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the day of the week (0–6) in the specified
@@ -176,7 +176,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCDay()`.
     #[inline]
     pub fn get_utc_day(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_day(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_day::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the year (4 digits for 4-digit years) in the specified
@@ -185,7 +185,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCFullYear()`.
     #[inline]
     pub fn get_utc_full_year(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_full_year(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_full_year::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the hours (0–23) in the specified date according
@@ -194,7 +194,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCHours()`.
     #[inline]
     pub fn get_utc_hours(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_hours(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_hours::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the milliseconds (0–999) in the specified date
@@ -203,7 +203,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCMilliseconds()`.
     #[inline]
     pub fn get_utc_milliseconds(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_milliseconds(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_milliseconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the minutes (0–59) in the specified date according
@@ -212,7 +212,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCMinutes()`.
     #[inline]
     pub fn get_utc_minutes(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_minutes(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_minutes::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the month (0–11) in the specified date according
@@ -221,7 +221,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCMonth()`.
     #[inline]
     pub fn get_utc_month(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_month(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_month::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Returns the seconds (0–59) in the specified date according
@@ -230,7 +230,7 @@ impl JsDate {
     /// Same as JavaScript's `Date.prototype.getUTCSeconds()`.
     #[inline]
     pub fn get_utc_seconds(&self, context: &mut Context) -> JsResult<JsValue> {
-        Date::get_utc_seconds(&self.inner.clone().into(), &[JsValue::null()], context)
+        Date::get_seconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
     /// Sets the day of the month for a specified date according

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1188,6 +1188,17 @@ impl Object {
         }
     }
 
+    #[inline]
+    pub fn as_date_mut(&mut self) -> Option<&mut Date> {
+        match self.data {
+            ObjectData {
+                kind: ObjectKind::Date(ref mut date),
+                ..
+            } => Some(date),
+            _ => None,
+        }
+    }
+
     /// Checks if it a `RegExp` object.
     #[inline]
     pub fn is_regexp(&self) -> bool {

--- a/boa_engine/src/value/integer.rs
+++ b/boa_engine/src/value/integer.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-/// Represents the result of `ToIntegerOrInfinity` operation
+/// Represents the result of the `ToIntegerOrInfinity` operation
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum IntegerOrInfinity {
     PositiveInfinity,
@@ -88,5 +88,29 @@ impl PartialOrd<IntegerOrInfinity> for i64 {
             IntegerOrInfinity::Integer(i) => self.partial_cmp(i),
             IntegerOrInfinity::NegativeInfinity => Some(Ordering::Greater),
         }
+    }
+}
+
+/// Represents the result of the `to_integer_or_nan` method.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum IntegerOrNan {
+    Integer(i64),
+    Nan,
+}
+
+impl IntegerOrNan {
+    /// Gets the wrapped `i64` if the variant is an `Integer`.
+    pub(crate) fn as_integer(self) -> Option<i64> {
+        match self {
+            Self::Integer(i) => Some(i),
+            Self::Nan => None,
+        }
+    }
+}
+
+impl From<IntegerOrInfinity> for IntegerOrNan {
+    fn from(ior: IntegerOrInfinity) -> Self {
+        ior.as_integer()
+            .map_or(IntegerOrNan::Nan, IntegerOrNan::Integer)
     }
 }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -182,10 +182,10 @@ impl Context {
 
         while self.vm.frame().pc < self.vm.frame().code.code.len() {
             #[cfg(feature = "fuzz")]
-            #[allow(clippy::redundant_else)]
-            if self.instructions_remaining == 0 {
-                return Err(JsError::from_native(JsNativeError::no_instructions_remain()));
-            } else {
+            {
+                if self.instructions_remaining == 0 {
+                    return Err(JsError::from_native(JsNativeError::no_instructions_remain()));
+                }
                 self.instructions_remaining -= 1;
             }
 

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -182,6 +182,7 @@ impl Context {
 
         while self.vm.frame().pc < self.vm.frame().code.code.len() {
             #[cfg(feature = "fuzz")]
+            #[allow(clippy::redundant_else)]
             if self.instructions_remaining == 0 {
                 return Err(JsError::from_native(JsNativeError::no_instructions_remain()));
             } else {


### PR DESCRIPTION
Just a general cleanup of the `Date` builtin to use slightly better patterns and to fix our warnings about deprecated functions.

About the regressed tests. It seems to be a `chrono` bug, so I opened up an issue (https://github.com/chronotope/chrono/issues/884) for it and they've already opened a PR fixing it (https://github.com/chronotope/chrono/pull/885).

However, while checking out the remaining failing tests, I realized there's a more fundamental limitation with the library. Currently, [`chrono`](https://github.com/chronotope/chrono) specifies:

> Date types are limited in about +/- 262,000 years from the common epoch.

While the [ECMAScript spec](https://tc39.es/ecma262/#sec-time-values-and-time-range) says:

> The smaller range supported by a time value as specified in this section is approximately -273,790 to 273,790 years relative to 1970.

The range allowed by the spec is barely outside of the range supported by `chrono`! This is why the remaining `Date` tests fail.
Seeing that, I would like to ping @djc and @esheppa (the maintainers of `chrono`) to ask if it would be feasible to add a feature, akin to the `large-dates` feature from the `time` crate, that expands the supported range of `chrono`.

EDIT: Filed https://github.com/chronotope/chrono/issues/886
