### PR TITLE
[Merged by Bors] - `JsArrayBuffer` take method and docs

### DIFF
--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -31,7 +31,7 @@ impl JsArrayBuffer {
     /// let array_buffer = JsArrayBuffer::new(4, context).unwrap();
     ///
     /// assert_eq!(array_buffer.take().unwrap(), vec![0_u8; 4]);
-    /// 
+    ///
     /// ```
     #[inline]
     pub fn new(byte_length: usize, context: &mut Context) -> JsResult<Self> {
@@ -60,16 +60,16 @@ impl JsArrayBuffer {
     /// # object::builtins::JsArrayBuffer,
     /// # Context,
     /// # };
-    /// 
+    ///
     /// # // Initialize context
     /// # let context = &mut Context::default();
-    /// 
+    ///
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context).unwrap();
-    /// 
-/// assert_eq!(array_buffer.take().unwrap(), (0..5).collect::<Vec<u8>>());
-    /// 
+    ///
+    /// assert_eq!(array_buffer.take().unwrap(), (0..5).collect::<Vec<u8>>());
+    ///
     /// ```
     #[inline]
     pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
@@ -123,7 +123,7 @@ impl JsArrayBuffer {
     }
 
     /// Returns the byte length of the array buffer.
-    /// 
+    ///
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
@@ -137,7 +137,7 @@ impl JsArrayBuffer {
     ///
     /// // Take the inner buffer
     /// let buffer_length = array_buffer.byte_length(context);
-    /// 
+    ///
     /// assert_eq!(buffer_length, 5_usize);
     /// ```
     #[inline]
@@ -149,9 +149,9 @@ impl JsArrayBuffer {
     }
 
     /// Take the inner `ArrayBuffer`'s `array_buffer_data` field and replace it with `None`
-    /// 
-    /// Note: This causes the pre-existing JsArrayBuffer to become detached.
-    /// 
+    ///
+    /// Note: This causes the pre-existing `JsArrayBuffer` to become detached.
+    ///
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
@@ -165,13 +165,13 @@ impl JsArrayBuffer {
     ///
     /// // Take the inner buffer
     /// let internal_buffer = array_buffer.take().unwrap();
-    /// 
+    ///
     /// assert_eq!(internal_buffer, (0..5).collect::<Vec<u8>>());
-    /// 
+    ///
     /// // Anymore interaction with the buffer will return an error
     /// let detached_err = array_buffer.take();
     /// assert!(detached_err.is_err());
-    /// 
+    ///
     /// ```
     #[inline]
     pub fn take(&self) -> JsResult<Vec<u8>> {
@@ -181,7 +181,11 @@ impl JsArrayBuffer {
             .expect("inner must be an ArrayBuffer")
             .array_buffer_data
             .take()
-            .ok_or(JsNativeError::typ().with_message("ArrayBuffer is detached").into())
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("ArrayBuffer is detached")
+                    .into()
+            })
     }
 }
 

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -23,15 +23,18 @@ impl JsArrayBuffer {
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
-    /// # Context,
+    /// # Context, JsResult
     /// # };
+    /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Creates a blank array buffer of n bytes
-    /// let array_buffer = JsArrayBuffer::new(4, context).unwrap();
+    /// let array_buffer = JsArrayBuffer::new(4, context)?;
     ///
-    /// assert_eq!(array_buffer.take().unwrap(), vec![0_u8; 4]);
+    /// assert_eq!(array_buffer.take()?, vec![0_u8; 4]);
     ///
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn new(byte_length: usize, context: &mut Context) -> JsResult<Self> {
@@ -58,18 +61,19 @@ impl JsArrayBuffer {
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
-    /// # Context,
+    /// # Context, JsResult,
     /// # };
-    ///
+    /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     ///
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
-    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context).unwrap();
+    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
-    /// assert_eq!(array_buffer.take().unwrap(), (0..5).collect::<Vec<u8>>());
-    ///
+    /// assert_eq!(array_buffer.take()?, (0..5).collect::<Vec<u8>>());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
@@ -127,19 +131,22 @@ impl JsArrayBuffer {
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
-    /// # Context,
+    /// # Context, JsResult,
     /// # };
+    /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
-    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context).unwrap();
+    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Take the inner buffer
     /// let buffer_length = array_buffer.byte_length(context);
     ///
-    /// assert_eq!(buffer_length, 5_usize);
-    /// ```
+    /// assert_eq!(buffer_length, 5);
+    /// # Ok(())
+    /// # }
+    ///  ```
     #[inline]
     pub fn byte_length(&self, context: &mut Context) -> usize {
         ArrayBuffer::get_byte_length(&self.inner.clone().into(), &[], context)
@@ -155,23 +162,25 @@ impl JsArrayBuffer {
     /// ```
     /// # use boa_engine::{
     /// # object::builtins::JsArrayBuffer,
-    /// # Context,
+    /// # Context, JsResult,
     /// # };
+    /// # fn main() -> JsResult<()> {
     /// # // Initialize context
     /// # let context = &mut Context::default();
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
-    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context).unwrap();
+    /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
     ///
     /// // Take the inner buffer
-    /// let internal_buffer = array_buffer.take().unwrap();
+    /// let internal_buffer = array_buffer.take()?;
     ///
     /// assert_eq!(internal_buffer, (0..5).collect::<Vec<u8>>());
     ///
     /// // Anymore interaction with the buffer will return an error
     /// let detached_err = array_buffer.take();
     /// assert!(detached_err.is_err());
-    ///
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn take(&self) -> JsResult<Vec<u8>> {

--- a/boa_examples/src/bin/jsarraybuffer.rs
+++ b/boa_examples/src/bin/jsarraybuffer.rs
@@ -56,5 +56,15 @@ fn main() -> JsResult<()> {
         Attribute::WRITABLE | Attribute::ENUMERABLE | Attribute::CONFIGURABLE,
     );
 
+    // We can also take the inner data from a JsArrayBuffer
+    let data_block: Vec<u8> = (0..5).collect();
+    let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
+
+    let internal_buffer = array_buffer.take()?;
+
+    assert_eq!(internal_buffer, (0..5).collect::<Vec<u8>>());
+    let detached_err = array_buffer.take();
+    assert!(detached_err.is_err());
+
     Ok(())
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the #2058 and the discussion in the discord chat.

It changes the following:

- Adds a `take` method to `JsArrayBuffer`
- Builds out `JsArrayBuffer` docs
- Adds a `JsArrayBuffer::take()` example to `jsarraybuffer.rs` in `boa_examples`
