### PR TITLE
Fix built-ins/Array/prototype/toString/non-callable-join-string-tag.js test case

### DIFF
--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -790,10 +790,9 @@ impl Object {
             // 12. Else if O has a [[DateValue]] internal slot, let builtinTag be "Date".
             // 13. Else if O has a [[RegExpMatcher]] internal slot, let builtinTag be "RegExp".
             // 14. Else, let builtinTag be "Object".
-            let o = o.borrow();
-            match o.kind() {
+            match o.borrow().kind() {
                 ObjectKind::Arguments(_) => utf16!("Arguments"),
-                ObjectKind::Function(_) => utf16!("Function"),
+                _ if o.is_callable() => utf16!("Function"),
                 ObjectKind::Error(_) => utf16!("Error"),
                 ObjectKind::Boolean(_) => utf16!("Boolean"),
                 ObjectKind::Number(_) => utf16!("Number"),


### PR DESCRIPTION
This Pull Request fixes [built-ins/Array/prototype/toString/non-callable-join-string-tag.js](https://github.com/tc39/test262/blob/main/test/built-ins/Array/prototype/toString/non-callable-join-string-tag.js)

Previously:
```
Array.prototype.toString.call(new Proxy(() => {}, {})) => "[object Object]"
```

With this change:
```
Array.prototype.toString.call(new Proxy(() => {}, {})) => "[object Function]"
```

Reasoning:
1) [23.1.3.33 Array.prototype.toString](https://tc39.es/ecma262/#sec-array.prototype.tostring): Assuming `this` does not have a callable `join` property, delegate to `Object.prototype.toString`.
2) [20.1.3.6 Object.prototype.toString](https://tc39.es/ecma262/#sec-object.prototype.tostring): if `O` has a `[[Call]]` internal method set, `builtinTag` should be "Function"
3) [10.5.14 ProxyCreate](https://tc39.es/ecma262/#sec-proxycreate): If the `target` passed isCallable, set the `[[Call]]` internal method