### PR TITLE
[Merged by Bors] - Fix `PartialEq` for `JsBigInt` and `f64`

### DIFF
--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -453,21 +453,15 @@ impl PartialEq<JsBigInt> for i32 {
 impl PartialEq<f64> for JsBigInt {
     #[inline]
     fn eq(&self, other: &f64) -> bool {
-        if other.fract().is_zero() {
-            RawBigInt::from_f64(*other).map_or(false, |bigint| self.inner.as_ref() == &bigint)
-        } else {
-            false
-        }
+        other.fract().is_zero()
+            && RawBigInt::from_f64(*other).map_or(false, |bigint| self.inner.as_ref() == &bigint)
     }
 }
 
 impl PartialEq<JsBigInt> for f64 {
     #[inline]
     fn eq(&self, other: &JsBigInt) -> bool {
-        if self.fract().is_zero() {
-            RawBigInt::from_f64(*self).map_or(false, |bigint| other.inner.as_ref() == &bigint)
-        } else {
-            false
-        }
+        self.fract().is_zero()
+            && RawBigInt::from_f64(*self).map_or(false, |bigint| other.inner.as_ref() == &bigint)
     }
 }

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -453,21 +453,21 @@ impl PartialEq<JsBigInt> for i32 {
 impl PartialEq<f64> for JsBigInt {
     #[inline]
     fn eq(&self, other: &f64) -> bool {
-        if other.fract() != 0.0 {
-            return false;
+        if other.fract().is_zero() {
+            RawBigInt::from_f64(*other).map_or(false, |bigint| self.inner.as_ref() == &bigint)
+        } else {
+            false
         }
-
-        self.inner.as_ref() == &RawBigInt::from(*other as i64)
     }
 }
 
 impl PartialEq<JsBigInt> for f64 {
     #[inline]
     fn eq(&self, other: &JsBigInt) -> bool {
-        if self.fract() != 0.0 {
-            return false;
+        if self.fract().is_zero() {
+            RawBigInt::from_f64(*self).map_or(false, |bigint| other.inner.as_ref() == &bigint)
+        } else {
+            false
         }
-
-        &RawBigInt::from(*self as i64) == other.inner.as_ref()
     }
 }


### PR DESCRIPTION
This Pull Request changes the following:

- Use the `BigInt::from_f64` function when checking `JsBigInt` and `f64` for eqality.
