### PR TITLE
[Merged by Bors] - Fix to weak_trace for `boa_tester`

### DIFF
--- a/boa_gc/src/internals/gc_box.rs
+++ b/boa_gc/src/internals/gc_box.rs
@@ -157,13 +157,16 @@ impl<T: Trace + ?Sized> GcBox<T> {
         }
     }
 
-    /// Trace inner data
+    /// Trace inner data and search for ephemerons to add to the ephemeron queue.
     #[inline]
     pub(crate) fn weak_trace_inner(&self) {
-        // SAFETY: if a `GcBox` has `weak_trace_inner` called, then the inner.
-        // value must have been deemed as reachable.
-        unsafe {
-            self.value.weak_trace();
+        if !self.header.is_marked() && !self.header.is_ephemeron() {
+            self.header.mark();
+            // SAFETY: if a `GcBox` has `weak_trace_inner` called, then the inner.
+            // value must have been deemed as reachable.
+            unsafe {
+                self.value.weak_trace();
+            }
         }
     }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes the current issue with the `boa_gc` when running `boa_tester` in parallel on Ubuntu. It looks like since we are running the `gc` in parallel something may not being cleaned up correctly that creates a reference cycle. The below changes should account for that.

It changes the following:

- Updates `weak_trace` to account for `Gc` reference cycles.
