### PR TITLE
[Merged by Bors] - Cleanup inline annotations

### DIFF
--- a/boa_ast/src/expression/access.rs
+++ b/boa_ast/src/expression/access.rs
@@ -151,7 +151,6 @@ impl SimplePropertyAccess {
     }
 
     /// Creates a `PropertyAccess` AST Expression.
-    #[inline]
     pub fn new<F>(target: Expression, field: F) -> Self
     where
         F: Into<PropertyAccessField>,

--- a/boa_ast/src/expression/await.rs
+++ b/boa_ast/src/expression/await.rs
@@ -35,7 +35,6 @@ impl<T> From<T> for Await
 where
     T: Into<Box<Expression>>,
 {
-    #[inline]
     fn from(e: T) -> Self {
         Self { target: e.into() }
     }

--- a/boa_ast/src/expression/literal/array.rs
+++ b/boa_ast/src/expression/literal/array.rs
@@ -165,7 +165,6 @@ impl<T> From<T> for ArrayLiteral
 where
     T: Into<Box<[Option<Expression>]>>,
 {
-    #[inline]
     fn from(decl: T) -> Self {
         Self {
             arr: decl.into(),

--- a/boa_ast/src/expression/literal/object.rs
+++ b/boa_ast/src/expression/literal/object.rs
@@ -289,7 +289,6 @@ impl<T> From<T> for ObjectLiteral
 where
     T: Into<Box<[PropertyDefinition]>>,
 {
-    #[inline]
     fn from(props: T) -> Self {
         Self {
             properties: props.into(),

--- a/boa_ast/src/expression/operator/assign/mod.rs
+++ b/boa_ast/src/expression/operator/assign/mod.rs
@@ -38,6 +38,7 @@ pub struct Assign {
 
 impl Assign {
     /// Creates an `Assign` AST Expression.
+    #[inline]
     #[must_use]
     pub fn new(op: AssignOp, lhs: AssignTarget, rhs: Expression) -> Self {
         Self {

--- a/boa_ast/src/expression/operator/binary/mod.rs
+++ b/boa_ast/src/expression/operator/binary/mod.rs
@@ -41,6 +41,7 @@ pub struct Binary {
 
 impl Binary {
     /// Creates a `BinOp` AST Expression.
+    #[inline]
     #[must_use]
     pub fn new(op: BinaryOp, lhs: Expression, rhs: Expression) -> Self {
         Self {

--- a/boa_ast/src/expression/operator/unary/mod.rs
+++ b/boa_ast/src/expression/operator/unary/mod.rs
@@ -39,6 +39,7 @@ pub struct Unary {
 
 impl Unary {
     /// Creates a new `UnaryOp` AST Expression.
+    #[inline]
     #[must_use]
     pub fn new(op: UnaryOp, target: Expression) -> Self {
         Self {

--- a/boa_ast/src/function/async_arrow_function.rs
+++ b/boa_ast/src/function/async_arrow_function.rs
@@ -51,11 +51,10 @@ impl AsyncArrowFunction {
     }
 
     /// Sets the name of the function declaration.
-    //#[inline]
-    //#[must_use]
-    //pub fn set_name(&mut self, name: Option<Identifier>) {
-    //    self.name = name;
-    //}
+    #[inline]
+    pub fn set_name(&mut self, name: Option<Identifier>) {
+        self.name = name;
+    }
 
     /// Gets the list of parameters of the arrow function.
     #[inline]

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -320,9 +320,11 @@ impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
         self.0.add(*node, false);
         ControlFlow::Continue(())
     }
+
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+
     // TODO: add "*default" for module default functions without name
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
@@ -330,24 +332,28 @@ impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
         }
         ControlFlow::Continue(())
     }
+
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
+
     fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
@@ -474,41 +480,51 @@ struct VarDeclaredNamesVisitor<'a>(&'a mut FxHashSet<Identifier>);
 
 impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
     type BreakTy = Infallible;
+
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+
     fn visit_declaration(&mut self, _: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
+
     fn visit_var_declaration(&mut self, node: &'ast VarDeclaration) -> ControlFlow<Self::BreakTy> {
         BoundNamesVisitor(self.0).visit_var_declaration(node)
     }
+
     fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
         match node {
             LabelledItem::Function(_) => ControlFlow::Continue(()),
             LabelledItem::Statement(stmt) => stmt.visit_with(self),
         }
     }
+
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_async_arrow_function(
         &mut self,
         node: &'ast AsyncArrowFunction,
@@ -516,6 +532,7 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
+
     fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
         if let ClassElement::StaticBlock(stmts) = node {
             top_level_vars(stmts, self.0);

--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -55,7 +55,6 @@ pub enum ContainsSymbol {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-contains
 #[must_use]
-#[inline]
 pub fn contains<N>(node: &N, symbol: ContainsSymbol) -> bool
 where
     N: VisitWith,
@@ -67,27 +66,22 @@ where
     impl<'ast> Visitor<'ast> for ContainsVisitor {
         type BreakTy = ();
 
-        #[inline]
         fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
             if !node.elements().is_empty() && self.0 == ContainsSymbol::ClassBody {
                 return ControlFlow::Break(());
@@ -101,7 +95,6 @@ where
         }
 
         // `ComputedPropertyContains`: https://tc39.es/ecma262/#sec-static-semantics-computedpropertycontains
-        #[inline]
         fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
             match node {
                 ClassElement::MethodDefinition(name, _)
@@ -112,7 +105,6 @@ where
             }
         }
 
-        #[inline]
         fn visit_property_definition(
             &mut self,
             node: &'ast PropertyDefinition,
@@ -127,7 +119,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_arrow_function(
             &mut self,
             node: &'ast ArrowFunction,
@@ -147,7 +138,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_async_arrow_function(
             &mut self,
             node: &'ast AsyncArrowFunction,
@@ -167,7 +157,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_super_property_access(
             &mut self,
             node: &'ast SuperPropertyAccess,
@@ -178,7 +167,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_super_call(&mut self, node: &'ast SuperCall) -> ControlFlow<Self::BreakTy> {
             if [ContainsSymbol::SuperCall, ContainsSymbol::Super].contains(&self.0) {
                 return ControlFlow::Break(());
@@ -186,7 +174,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_yield(&mut self, node: &'ast Yield) -> ControlFlow<Self::BreakTy> {
             if self.0 == ContainsSymbol::YieldExpression {
                 return ControlFlow::Break(());
@@ -195,7 +182,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_await(&mut self, node: &'ast Await) -> ControlFlow<Self::BreakTy> {
             if self.0 == ContainsSymbol::AwaitExpression {
                 return ControlFlow::Break(());
@@ -204,7 +190,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_expression(&mut self, node: &'ast Expression) -> ControlFlow<Self::BreakTy> {
             if node == &Expression::This && self.0 == ContainsSymbol::This {
                 return ControlFlow::Break(());
@@ -236,7 +221,6 @@ where
     impl<'ast> Visitor<'ast> for ContainsArgsVisitor {
         type BreakTy = ();
 
-        #[inline]
         fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
             if node.sym() == Sym::ARGUMENTS {
                 ControlFlow::Break(())
@@ -245,27 +229,22 @@ where
             }
         }
 
-        #[inline]
         fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_async_function(&mut self, _: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_generator(&mut self, _: &'ast Generator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_async_generator(&mut self, _: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())
         }
 
-        #[inline]
         fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
             match node {
                 ClassElement::MethodDefinition(name, _)
@@ -275,7 +254,6 @@ where
             node.visit_with(self)
         }
 
-        #[inline]
         fn visit_property_definition(
             &mut self,
             node: &'ast PropertyDefinition,
@@ -314,21 +292,18 @@ trait IdentList {
 }
 
 impl IdentList for Vec<Identifier> {
-    #[inline]
     fn add(&mut self, value: Identifier, _function: bool) {
         self.push(value);
     }
 }
 
 impl IdentList for Vec<(Identifier, bool)> {
-    #[inline]
     fn add(&mut self, value: Identifier, function: bool) {
         self.push((value, function));
     }
 }
 
 impl IdentList for FxHashSet<Identifier> {
-    #[inline]
     fn add(&mut self, value: Identifier, _function: bool) {
         self.insert(value);
     }
@@ -341,45 +316,38 @@ struct BoundNamesVisitor<'a, T: IdentList>(&'a mut T);
 impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
     type BreakTy = Infallible;
 
-    #[inline]
     fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
         self.0.add(*node, false);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
     // TODO: add "*default" for module default functions without name
-    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, true);
         }
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
         }
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_class(&mut self, node: &'ast Class) -> ControlFlow<Self::BreakTy> {
         if let Some(ident) = node.name() {
             self.0.add(ident, false);
@@ -394,7 +362,6 @@ impl<'ast, T: IdentList> Visitor<'ast> for BoundNamesVisitor<'_, T> {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-boundnames
 #[must_use]
-#[inline]
 pub fn bound_names<'a, N>(node: &'a N) -> Vec<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -411,54 +378,45 @@ struct LexicallyDeclaredNamesVisitor<'a, T: IdentList>(&'a mut T);
 
 impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> {
     type BreakTy = Infallible;
-    #[inline]
+
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_statement(&mut self, node: &'ast Statement) -> ControlFlow<Self::BreakTy> {
         if let Statement::Labelled(labelled) = node {
             return self.visit_labelled(labelled);
         }
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_declaration(&mut self, node: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
         BoundNamesVisitor(self.0).visit_declaration(node)
     }
-    #[inline]
     fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
         match node {
             LabelledItem::Function(f) => BoundNamesVisitor(self.0).visit_function(f),
             LabelledItem::Statement(_) => ControlFlow::Continue(()),
         }
     }
-    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_arrow_function(
         &mut self,
         node: &'ast AsyncArrowFunction,
@@ -466,7 +424,6 @@ impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> 
         top_level_lexicals(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
         if let ClassElement::StaticBlock(stmts) = node {
             top_level_lexicals(stmts, self.0);
@@ -485,7 +442,6 @@ impl<'ast, T: IdentList> Visitor<'ast> for LexicallyDeclaredNamesVisitor<'_, T> 
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
 #[must_use]
-#[inline]
 pub fn lexically_declared_names<'a, N>(node: &'a N) -> Vec<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -503,7 +459,6 @@ where
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames
 /// [changes]: https://tc39.es/ecma262/#sec-block-duplicates-allowed-static-semantics
 #[must_use]
-#[inline]
 pub fn lexically_declared_names_legacy<'a, N>(node: &'a N) -> Vec<(Identifier, bool)>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -519,51 +474,41 @@ struct VarDeclaredNamesVisitor<'a>(&'a mut FxHashSet<Identifier>);
 
 impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
     type BreakTy = Infallible;
-    #[inline]
     fn visit_expression(&mut self, _: &'ast Expression) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_declaration(&mut self, _: &'ast Declaration) -> ControlFlow<Self::BreakTy> {
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_var_declaration(&mut self, node: &'ast VarDeclaration) -> ControlFlow<Self::BreakTy> {
         BoundNamesVisitor(self.0).visit_var_declaration(node)
     }
-    #[inline]
     fn visit_labelled_item(&mut self, node: &'ast LabelledItem) -> ControlFlow<Self::BreakTy> {
         match node {
             LabelledItem::Function(_) => ControlFlow::Continue(()),
             LabelledItem::Statement(stmt) => stmt.visit_with(self),
         }
     }
-    #[inline]
     fn visit_function(&mut self, node: &'ast Function) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_function(&mut self, node: &'ast AsyncFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_generator(&mut self, node: &'ast Generator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_generator(&mut self, node: &'ast AsyncGenerator) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_arrow_function(&mut self, node: &'ast ArrowFunction) -> ControlFlow<Self::BreakTy> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_async_arrow_function(
         &mut self,
         node: &'ast AsyncArrowFunction,
@@ -571,7 +516,6 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
         top_level_vars(node.body(), self.0);
         ControlFlow::Continue(())
     }
-    #[inline]
     fn visit_class_element(&mut self, node: &'ast ClassElement) -> ControlFlow<Self::BreakTy> {
         if let ClassElement::StaticBlock(stmts) = node {
             top_level_vars(stmts, self.0);
@@ -590,7 +534,6 @@ impl<'ast> Visitor<'ast> for VarDeclaredNamesVisitor<'_> {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-vardeclarednames
 #[must_use]
-#[inline]
 pub fn var_declared_names<'a, N>(node: &'a N) -> FxHashSet<Identifier>
 where
     &'a N: Into<NodeRef<'a>>,
@@ -601,7 +544,6 @@ where
 }
 
 /// Utility function that collects the top level lexicals of a statement list into `names`.
-#[inline]
 fn top_level_lexicals<T: IdentList>(stmts: &StatementList, names: &mut T) {
     for stmt in stmts.statements() {
         if let StatementListItem::Declaration(decl) = stmt {
@@ -638,7 +580,6 @@ pub fn top_level_lexically_declared_names(stmts: &StatementList) -> Vec<Identifi
 }
 
 /// Utility function that collects the top level vars of a statement list into `names`.
-#[inline]
 fn top_level_vars(stmts: &StatementList, names: &mut FxHashSet<Identifier>) {
     for stmt in stmts.statements() {
         match stmt {

--- a/boa_ast/src/position.rs
+++ b/boa_ast/src/position.rs
@@ -91,7 +91,6 @@ impl Span {
     }
 
     /// Checks if this span inclusively contains another span or position.
-    #[inline]
     pub fn contains<S>(self, other: S) -> bool
     where
         S: Into<Self>,

--- a/boa_ast/src/statement/block.rs
+++ b/boa_ast/src/statement/block.rs
@@ -43,7 +43,6 @@ impl<T> From<T> for Block
 where
     T: Into<StatementList>,
 {
-    #[inline]
     fn from(list: T) -> Self {
         Self {
             statements: list.into(),

--- a/boa_ast/src/statement/if.rs
+++ b/boa_ast/src/statement/if.rs
@@ -56,6 +56,7 @@ impl If {
     }
 
     /// Creates an `If` AST node.
+    #[inline]
     #[must_use]
     pub fn new(condition: Expression, body: Statement, else_node: Option<Statement>) -> Self {
         Self {

--- a/boa_ast/src/statement/labelled.rs
+++ b/boa_ast/src/statement/labelled.rs
@@ -91,6 +91,7 @@ pub struct Labelled {
 
 impl Labelled {
     /// Creates a new `Labelled` statement.
+    #[inline]
     #[must_use]
     pub fn new(item: LabelledItem, label: Sym) -> Self {
         Self {
@@ -100,11 +101,13 @@ impl Labelled {
     }
 
     /// Gets the labelled item.
+    #[inline]
     #[must_use]
     pub const fn item(&self) -> &LabelledItem {
         &self.item
     }
 
+    #[inline]
     /// Gets the label name.
     #[must_use]
     pub const fn label(&self) -> Sym {

--- a/boa_ast/src/statement/labelled.rs
+++ b/boa_ast/src/statement/labelled.rs
@@ -107,8 +107,8 @@ impl Labelled {
         &self.item
     }
 
-    #[inline]
     /// Gets the label name.
+    #[inline]
     #[must_use]
     pub const fn label(&self) -> Sym {
         self.label

--- a/boa_cli/src/helper.rs
+++ b/boa_cli/src/helper.rs
@@ -41,7 +41,6 @@ pub(crate) struct RLHelper {
 }
 
 impl RLHelper {
-    #[inline]
     pub(crate) fn new() -> Self {
         Self {
             highlighter: LineHighlighter,

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -24,7 +24,6 @@ pub struct JsBigInt {
 
 impl JsBigInt {
     /// Create a new [`JsBigInt`].
-    #[inline]
     #[must_use]
     pub fn new<T: Into<Self>>(value: T) -> Self {
         value.into()
@@ -289,7 +288,6 @@ impl JsBigInt {
         Self::new(!x.as_inner())
     }
 
-    #[inline]
     pub(crate) fn as_inner(&self) -> &RawBigInt {
         &self.inner
     }

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -166,7 +166,7 @@ impl Array {
             let int_len = if !len.is_number() {
                 // i. Perform ! CreateDataPropertyOrThrow(array, "0", len).
                 array
-                    .create_data_property_or_throw(0, len, context)
+                    .create_data_property_or_throw(0, len.clone(), context)
                     .expect("this CreateDataPropertyOrThrow call must not fail");
                 // ii. Let intLen be 1𝔽.
                 1
@@ -595,7 +595,7 @@ impl Array {
             // a. Let kValue be items[k].
             // b. Let Pk be ! ToString(𝔽(k)).
             // c. Perform ? CreateDataPropertyOrThrow(A, Pk, kValue).
-            a.create_data_property_or_throw(k, value, context)?;
+            a.create_data_property_or_throw(k, value.clone(), context)?;
             // d. Set k to k + 1.
         }
 
@@ -714,7 +714,7 @@ impl Array {
                         .into());
                 }
                 // iii. Perform ? CreateDataPropertyOrThrow(A, ! ToString(𝔽(n)), E).
-                arr.create_data_property_or_throw(n, item, context)?;
+                arr.create_data_property_or_throw(n, item.clone(), context)?;
                 // iv. Set n to n + 1.
                 n += 1;
             }
@@ -1137,7 +1137,7 @@ impl Array {
             // e. For each element E of items, do
             for (j, e) in args.iter().enumerate() {
                 // i. Perform ? Set(O, ! ToString(j), E, true).
-                o.set(j, e, true, context)?;
+                o.set(j, e.clone(), true, context)?;
                 // ii. Set j to j + 1𝔽.
             }
         }
@@ -2189,7 +2189,7 @@ impl Array {
                 .map(|(i, val)| (i as u64 + actual_start, val))
             {
                 // a. Perform ? Set(O, ! ToString(𝔽(k)), E, true).
-                o.set(k, item, true, context)?;
+                o.set(k, item.clone(), true, context)?;
                 // b. Set k to k + 1.
             }
         }

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -110,7 +110,6 @@ impl BigInt {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-numbertobigint
-    #[inline]
     fn number_to_bigint(number: f64) -> JsResult<JsValue> {
         // 1. If IsIntegralNumber(number) is false, throw a RangeError exception.
         if number.is_nan() || number.is_infinite() || number.fract() != 0.0 {
@@ -133,7 +132,6 @@ impl BigInt {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-thisbigintvalue
-    #[inline]
     fn this_bigint_value(value: &JsValue) -> JsResult<JsBigInt> {
         value
             // 1. If Type(value) is BigInt, return value.

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -113,7 +113,6 @@ impl Boolean {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-boolean.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
-    #[inline]
     pub(crate) fn value_of(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_boolean_value(this)?))
     }

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -59,7 +59,6 @@ macro_rules! get_mut_date {
 /// Abstract operation [`thisTimeValue`][spec].
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-thistimevalue
-#[inline]
 pub(super) fn this_time_value(value: &JsValue) -> JsResult<Option<NaiveDateTime>> {
     Ok(value
         .as_object()
@@ -74,14 +73,12 @@ pub struct Date(Option<NaiveDateTime>);
 
 impl Date {
     /// Creates a new `Date`.
-    #[inline]
     pub(crate) const fn new(dt: Option<NaiveDateTime>) -> Self {
         Self(dt)
     }
 
     /// Converts the `Date` into a `JsValue`, mapping `None` to `NaN` and `Some(datetime)` to
     /// `JsValue::from(datetime.timestamp_millis())`.
-    #[inline]
     fn as_value(&self) -> JsValue {
         self.0
             .map_or_else(|| f64::NAN.into(), |dt| dt.timestamp_millis().into())
@@ -664,7 +661,6 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.gettimezoneoffset
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTimezoneOffset
-    #[inline]
     pub(crate) fn get_timezone_offset(
         this: &JsValue,
         _: &[JsValue],
@@ -1470,7 +1466,6 @@ impl Date {
     /// Converts the `Date` to a local `DateTime`.
     ///
     /// If the `Date` is invalid (i.e. NAN), this function will return `None`.
-    #[inline]
     pub(crate) fn to_local(self) -> Option<DateTime<Local>> {
         self.0.map(|utc| Local.from_utc_datetime(&utc))
     }

--- a/boa_engine/src/builtins/date/utils.rs
+++ b/boa_engine/src/builtins/date/utils.rs
@@ -114,7 +114,6 @@ pub(super) fn make_date(day: i64, time: i64) -> Option<i64> {
 /// Otherwise, returns `None`.
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-timeclip
-#[inline]
 pub(super) fn time_clip(time: i64) -> Option<i64> {
     // 1. If time is not finite, return NaN.
     // 2. If abs(ℝ(time)) > 8.64 × 10^15, return NaN.

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -265,7 +265,7 @@ impl Generator {
         std::mem::swap(&mut context.vm.stack, &mut generator_context.stack);
         context.vm.push_frame(generator_context.call_frame.clone());
         if !first_execution {
-            context.vm.push(value);
+            context.vm.push(value.clone());
         }
 
         context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Normal;

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -131,7 +131,6 @@ impl IteratorPrototypes {
 /// `CreateIterResultObject( value, done )`
 ///
 /// Generates an object supporting the `IteratorResult` interface.
-#[inline]
 pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Context) -> JsValue {
     let _timer = Profiler::global().start_event("create_iter_result_object", "init");
 
@@ -166,7 +165,6 @@ impl JsValue {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getiterator
-    #[inline]
     pub fn get_iterator(
         &self,
         context: &mut Context,
@@ -235,7 +233,6 @@ impl JsValue {
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-%iteratorprototype%-object
-#[inline]
 fn create_iterator_prototype(context: &mut Context) -> JsObject {
     let _timer = Profiler::global().start_event("Iterator Prototype", "init");
 
@@ -333,25 +330,21 @@ impl IteratorRecord {
     }
 
     /// Get the `[[Iterator]]` field of the `IteratorRecord`.
-    #[inline]
     pub(crate) const fn iterator(&self) -> &JsObject {
         &self.iterator
     }
 
     /// Get the `[[NextMethod]]` field of the `IteratorRecord`.
-    #[inline]
     pub(crate) const fn next_method(&self) -> &JsValue {
         &self.next_method
     }
 
     /// Get the `[[Done]]` field of the `IteratorRecord`.
-    #[inline]
     pub(crate) const fn done(&self) -> bool {
         self.done
     }
 
     /// Sets the `[[Done]]` field of the `IteratorRecord`.
-    #[inline]
     pub(crate) fn set_done(&mut self, done: bool) {
         self.done = done;
     }
@@ -366,7 +359,6 @@ impl IteratorRecord {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratornext
-    #[inline]
     pub(crate) fn next(
         &self,
         value: Option<JsValue>,
@@ -443,7 +435,6 @@ impl IteratorRecord {
     ///  - [ECMA reference][spec]
     ///
     ///  [spec]: https://tc39.es/ecma262/#sec-iteratorclose
-    #[inline]
     pub(crate) fn close(
         &self,
         completion: JsResult<JsValue>,
@@ -571,7 +562,6 @@ pub(crate) use if_abrupt_close_iterator;
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-asynciteratorprototype
-#[inline]
 fn create_async_iterator_prototype(context: &mut Context) -> JsObject {
     let _timer = Profiler::global().start_event("AsyncIteratorPrototype", "init");
 

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -67,7 +67,6 @@ where
     I::Item: Clone,
 {
     type Item = I::Item;
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.peek.is_some() {
             self.peek.take()

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -121,7 +121,6 @@ pub(crate) trait BuiltIn {
 
 /// Utility function that checks if a type implements `BuiltIn` before initializing it as a global
 /// built-in.
-#[inline]
 fn init_builtin<B: BuiltIn>(context: &mut Context) {
     if let Some(value) = B::init(context) {
         let property = PropertyDescriptor::builder()
@@ -137,7 +136,6 @@ fn init_builtin<B: BuiltIn>(context: &mut Context) {
 }
 
 /// Initializes built-in objects and functions
-#[inline]
 pub fn init(context: &mut Context) {
     macro_rules! globals {
         ($( $builtin:ty ),*) => {

--- a/boa_engine/src/builtins/number/conversions.rs
+++ b/boa_engine/src/builtins/number/conversions.rs
@@ -1,7 +1,6 @@
 /// Converts a 64-bit floating point number to an `i32` according to the [`ToInt32`][ToInt32] algorithm.
 ///
 /// [ToInt32]: https://tc39.es/ecma262/#sec-toint32
-#[inline]
 #[allow(clippy::float_cmp)]
 pub(crate) fn f64_to_int32(number: f64) -> i32 {
     const SIGN_MASK: u64 = 0x8000_0000_0000_0000;
@@ -14,12 +13,10 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
     const EXPONENT_BIAS: i32 = 0x3FF + PHYSICAL_SIGNIFICAND_SIZE;
     const DENORMAL_EXPONENT: i32 = -EXPONENT_BIAS + 1;
 
-    #[inline]
     fn is_denormal(number: f64) -> bool {
         (number.to_bits() & EXPONENT_MASK) == 0
     }
 
-    #[inline]
     fn exponent(number: f64) -> i32 {
         if is_denormal(number) {
             return DENORMAL_EXPONENT;
@@ -31,7 +28,6 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
         biased_e - EXPONENT_BIAS
     }
 
-    #[inline]
     fn significand(number: f64) -> u64 {
         let d64 = number.to_bits();
         let significand = d64 & SIGNIFICAND_MASK;
@@ -43,7 +39,6 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
         }
     }
 
-    #[inline]
     fn sign(number: f64) -> i64 {
         if (number.to_bits() & SIGN_MASK) == 0 {
             1
@@ -80,7 +75,6 @@ pub(crate) fn f64_to_int32(number: f64) -> i32 {
 /// Converts a 64-bit floating point number to an `u32` according to the [`ToUint32`][ToUint32] algorithm.
 ///
 /// [ToUint32]: https://tc39.es/ecma262/#sec-touint32
-#[inline]
 pub(crate) fn f64_to_uint32(number: f64) -> u32 {
     f64_to_int32(number) as u32
 }

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -530,7 +530,6 @@ impl Number {
     }
 
     // https://golang.org/src/math/nextafter.go
-    #[inline]
     fn next_after(x: f64, y: f64) -> f64 {
         if x.is_nan() || y.is_nan() {
             f64::NAN
@@ -1085,7 +1084,6 @@ impl Number {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isinteger
-    #[inline]
     pub(crate) fn is_integer(val: &JsValue) -> bool {
         match val {
             JsValue::Integer(_) => true,
@@ -1095,7 +1093,6 @@ impl Number {
     }
 
     /// Checks if the float argument is an integer.
-    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn is_float_integer(number: f64) -> bool {
         number.is_finite() && number.abs().floor() == number.abs()
@@ -1105,7 +1102,6 @@ impl Number {
     /// x (a Number) and y (a Number). It performs the following steps when called:
     ///
     /// <https://tc39.es/ecma262/#sec-numeric-types-number-equal>
-    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn equal(x: f64, y: f64) -> bool {
         x == y
@@ -1127,7 +1123,6 @@ impl Number {
     /// x (a Number) and y (a Number). It performs the following steps when called:
     ///
     /// <https://tc39.es/ecma262/#sec-numeric-types-number-sameValueZero>
-    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn same_value_zero(x: f64, y: f64) -> bool {
         if x.is_nan() && y.is_nan() {
@@ -1137,7 +1132,6 @@ impl Number {
         x == y
     }
 
-    #[inline]
     #[allow(clippy::float_cmp)]
     pub(crate) fn less_than(x: f64, y: f64) -> AbstractRelation {
         if x.is_nan() || y.is_nan() {
@@ -1161,7 +1155,6 @@ impl Number {
         (x < y).into()
     }
 
-    #[inline]
     pub(crate) fn not(x: f64) -> i32 {
         let x = f64_to_int32(x);
         !x

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -238,7 +238,7 @@ impl Object {
 
         // 3. Let desc be PropertyDescriptor { [[Get]]: getter, [[Enumerable]]: true, [[Configurable]]: true }.
         let desc = PropertyDescriptor::builder()
-            .get(getter)
+            .get(getter.clone())
             .enumerable(true)
             .configurable(true);
 
@@ -281,7 +281,7 @@ impl Object {
 
         // 3. Let desc be PropertyDescriptor { [[Set]]: setter, [[Enumerable]]: true, [[Configurable]]: true }.
         let desc = PropertyDescriptor::builder()
-            .set(setter)
+            .set(setter.clone())
             .enumerable(true)
             .configurable(true);
 
@@ -325,7 +325,7 @@ impl Object {
             if let Some(current_desc) = desc {
                 // i. If IsAccessorDescriptor(desc) is true, return desc.[[Get]].
                 return if current_desc.is_accessor_descriptor() {
-                    Ok(current_desc.expect_get().into())
+                    Ok(current_desc.expect_get().clone())
                 } else {
                     // ii. Return undefined.
                     Ok(JsValue::undefined())
@@ -369,7 +369,7 @@ impl Object {
             if let Some(current_desc) = desc {
                 // i. If IsAccessorDescriptor(desc) is true, return desc.[[Set]].
                 return if current_desc.is_accessor_descriptor() {
-                    Ok(current_desc.expect_set().into())
+                    Ok(current_desc.expect_set().clone())
                 } else {
                     // ii. Return undefined.
                     Ok(JsValue::undefined())
@@ -517,7 +517,7 @@ impl Object {
         // 4. If Desc has a [[Value]] field, then
         if let Some(value) = desc.value() {
             // a. Perform ! CreateDataPropertyOrThrow(obj, "value", Desc.[[Value]]).
-            obj.create_data_property_or_throw("value", value, context)
+            obj.create_data_property_or_throw("value", value.clone(), context)
                 .expect("CreateDataPropertyOrThrow cannot fail here");
         }
 
@@ -531,14 +531,14 @@ impl Object {
         // 6. If Desc has a [[Get]] field, then
         if let Some(get) = desc.get() {
             // a. Perform ! CreateDataPropertyOrThrow(obj, "get", Desc.[[Get]]).
-            obj.create_data_property_or_throw("get", get, context)
+            obj.create_data_property_or_throw("get", get.clone(), context)
                 .expect("CreateDataPropertyOrThrow cannot fail here");
         }
 
         // 7. If Desc has a [[Set]] field, then
         if let Some(set) = desc.set() {
             // a. Perform ! CreateDataPropertyOrThrow(obj, "set", Desc.[[Set]]).
-            obj.create_data_property_or_throw("set", set, context)
+            obj.create_data_property_or_throw("set", set.clone(), context)
                 .expect("CreateDataPropertyOrThrow cannot fail here");
         }
 
@@ -1256,7 +1256,7 @@ impl Object {
                 let property_key = key.to_property_key(context)?;
 
                 // b. Perform ! CreateDataPropertyOrThrow(obj, propertyKey, value).
-                obj.create_data_property_or_throw(property_key, value, context)?;
+                obj.create_data_property_or_throw(property_key, value.clone(), context)?;
 
                 // c. Return undefined.
                 Ok(JsValue::undefined())
@@ -1278,7 +1278,6 @@ impl Object {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-object.defineproperties
-#[inline]
 fn object_define_properties(
     object: &JsObject,
     props: &JsValue,

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -816,8 +816,12 @@ impl Promise {
                         .expect("cannot fail per spec");
 
                     // 11. Perform ! CreateDataPropertyOrThrow(obj, "value", x).
-                    obj.create_data_property_or_throw("value", args.get_or_undefined(0), context)
-                        .expect("cannot fail per spec");
+                    obj.create_data_property_or_throw(
+                        "value",
+                        args.get_or_undefined(0).clone(),
+                        context,
+                    )
+                    .expect("cannot fail per spec");
 
                     // 12. Set values[index] to obj.
                     captures.values.borrow_mut()[captures.index] = obj.into();
@@ -896,8 +900,12 @@ impl Promise {
                         .expect("cannot fail per spec");
 
                     // 11. Perform ! CreateDataPropertyOrThrow(obj, "reason", x).
-                    obj.create_data_property_or_throw("reason", args.get_or_undefined(0), context)
-                        .expect("cannot fail per spec");
+                    obj.create_data_property_or_throw(
+                        "reason",
+                        args.get_or_undefined(0).clone(),
+                        context,
+                    )
+                    .expect("cannot fail per spec");
 
                     // 12. Set values[index] to obj.
                     captures.values.borrow_mut()[captures.index] = obj.into();

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -358,7 +358,6 @@ impl RegExp {
         Ok(this.clone())
     }
 
-    #[inline]
     fn regexp_has_flag(this: &JsValue, flag: u8, context: &mut Context) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             if let Some(regexp) = object.borrow().as_regexp() {

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -40,7 +40,6 @@ pub(crate) enum Placement {
 }
 
 /// Helper function to check if a `char` is trimmable.
-#[inline]
 pub(crate) const fn is_trimmable_whitespace(c: char) -> bool {
     // The rust implementation of `trim` does not regard the same characters whitespace as ecma standard does
     //
@@ -383,7 +382,6 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.tostring
     #[allow(clippy::wrong_self_convention)]
-    #[inline]
     pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Return ? thisStringValue(this value).
         Ok(Self::this_string_value(this)?.into())
@@ -1050,7 +1048,7 @@ impl String {
             // d. If replacer is not undefined, then
             if let Some(replacer) = replacer {
                 // i. Return ? Call(replacer, searchValue, « O, replaceValue »).
-                return replacer.call(search_value, &[o.into(), replace_value.clone()], context);
+                return replacer.call(search_value, &[o.clone(), replace_value.clone()], context);
             }
         }
 

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -529,7 +529,7 @@ impl TypedArray {
             // a. Let kValue be items[k].
             // b. Let Pk be ! ToString(𝔽(k)).
             // c. Perform ? Set(newObj, Pk, kValue, true).
-            new_obj.set(k, k_value, true, context)?;
+            new_obj.set(k, k_value.clone(), true, context)?;
         }
 
         // 7. Return newObj.
@@ -3502,7 +3502,6 @@ impl TypedArrayKind {
     /// Gets the element size of the given typed array name, as per the [spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#table-the-typedarray-constructors
-    #[inline]
     pub(crate) const fn element_size(self) -> u64 {
         match self {
             Self::Int8 | Self::Uint8 | Self::Uint8Clamped => 1,
@@ -3513,7 +3512,6 @@ impl TypedArrayKind {
     }
 
     /// Gets the content type of this typed array name.
-    #[inline]
     pub(crate) const fn content_type(self) -> ContentType {
         match self {
             Self::BigInt64 | Self::BigUint64 => ContentType::BigInt,
@@ -3522,7 +3520,6 @@ impl TypedArrayKind {
     }
 
     /// Gets the name of this typed array name.
-    #[inline]
     pub(crate) const fn name(&self) -> &str {
         match self {
             Self::Int8 => "Int8Array",

--- a/boa_engine/src/builtins/uri/consts.rs
+++ b/boa_engine/src/builtins/uri/consts.rs
@@ -77,7 +77,6 @@ const NUMBER_SIGN: u16 = b'#' as u16;
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-uriUnescaped
-#[inline]
 pub(super) fn is_uri_unescaped(code_point: u16) -> bool {
     URI_ALPHA_LOWER.contains(&code_point)
         || URI_ALPHA_UPPER.contains(&code_point)
@@ -91,7 +90,6 @@ pub(super) fn is_uri_unescaped(code_point: u16) -> bool {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-uriReserved
-#[inline]
 pub(super) fn is_uri_reserved_or_number_sign(code_point: u16) -> bool {
     code_point == NUMBER_SIGN || URI_RESERVED.contains(&code_point)
 }
@@ -104,7 +102,6 @@ pub(super) fn is_uri_reserved_or_number_sign(code_point: u16) -> bool {
 ///
 /// [uri_reserved]: https://tc39.es/ecma262/#prod-uriReserved
 /// [uri_unescaped]: https://tc39.es/ecma262/#prod-uriUnescaped
-#[inline]
 pub(super) fn is_uri_reserved_or_uri_unescaped_or_number_sign(code_point: u16) -> bool {
     code_point == NUMBER_SIGN || is_uri_unescaped(code_point) || URI_RESERVED.contains(&code_point)
 }

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -25,7 +25,6 @@ pub(crate) struct FunctionCompiler {
 
 impl FunctionCompiler {
     /// Create a new `FunctionCompiler`.
-    #[inline]
     pub(crate) const fn new() -> Self {
         Self {
             name: Sym::EMPTY_STRING,
@@ -38,7 +37,6 @@ impl FunctionCompiler {
     }
 
     /// Set the name of the function.
-    #[inline]
     pub(crate) fn name<N>(mut self, name: N) -> Self
     where
         N: Into<Option<Sym>>,
@@ -51,34 +49,29 @@ impl FunctionCompiler {
     }
 
     /// Indicate if the function is an arrow function.
-    #[inline]
     pub(crate) const fn arrow(mut self, arrow: bool) -> Self {
         self.arrow = arrow;
         self
     }
     /// Indicate if the function is a generator function.
-    #[inline]
     pub(crate) const fn generator(mut self, generator: bool) -> Self {
         self.generator = generator;
         self
     }
 
     /// Indicate if the function is an async function.
-    #[inline]
     pub(crate) const fn r#async(mut self, r#async: bool) -> Self {
         self.r#async = r#async;
         self
     }
 
     /// Indicate if the function is in a strict context.
-    #[inline]
     pub(crate) const fn strict(mut self, strict: bool) -> Self {
         self.strict = strict;
         self
     }
 
     /// Indicate if the function has a binding identifier.
-    #[inline]
     pub(crate) const fn has_binding_identifier(mut self, has_binding_identifier: bool) -> Self {
         self.has_binding_identifier = has_binding_identifier;
         self

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -257,7 +257,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Push a compile time environment to the current `CodeBlock` and return it's index.
-
     fn push_compile_environment(
         &mut self,
         environment: Gc<GcCell<CompileTimeEnvironment>>,
@@ -446,7 +445,6 @@ impl<'b> ByteCompiler<'b> {
 
     /// Emit an opcode with a dummy operand.
     /// Return the `Label` of the operand.
-
     fn emit_opcode_with_operand(&mut self, opcode: Opcode) -> Label {
         let index = self.next_opcode_location();
         self.emit(opcode, &[Self::DUMMY_ADDRESS]);
@@ -455,7 +453,6 @@ impl<'b> ByteCompiler<'b> {
 
     /// Emit an opcode with two dummy operands.
     /// Return the `Label`s of the two operands.
-
     fn emit_opcode_with_two_operands(&mut self, opcode: Opcode) -> (Label, Label) {
         let index = self.next_opcode_location();
         self.emit(opcode, &[Self::DUMMY_ADDRESS, Self::DUMMY_ADDRESS]);
@@ -828,7 +825,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`StatementList`].
-
     pub fn compile_statement_list(
         &mut self,
         list: &StatementList,
@@ -845,7 +841,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a statement list in a new declarative environment.
-
     pub(crate) fn compile_statement_list_with_new_declarative(
         &mut self,
         list: &StatementList,
@@ -1137,7 +1132,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`StatementListItem`].
-
     fn compile_stmt_list_item(
         &mut self,
         item: &StatementListItem,
@@ -1153,7 +1147,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`Declaration`].
-
     pub fn compile_decl(&mut self, decl: &Declaration) -> JsResult<()> {
         match decl {
             Declaration::Function(function) => {
@@ -1174,7 +1167,6 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compiles a [`Statement`]
-
     pub fn compile_stmt(
         &mut self,
         node: &Statement,

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -63,12 +63,10 @@ struct FunctionSpec<'a> {
 }
 
 impl FunctionSpec<'_> {
-    #[inline]
     const fn is_arrow(&self) -> bool {
         matches!(self.kind, FunctionKind::Arrow | FunctionKind::AsyncArrow)
     }
 
-    #[inline]
     const fn is_async(&self) -> bool {
         matches!(
             self.kind,
@@ -76,7 +74,6 @@ impl FunctionSpec<'_> {
         )
     }
 
-    #[inline]
     const fn is_generator(&self) -> bool {
         matches!(
             self.kind,
@@ -255,13 +252,12 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn interner(&self) -> &Interner {
         self.context.interner()
     }
 
     /// Push a compile time environment to the current `CodeBlock` and return it's index.
-    #[inline]
+
     fn push_compile_environment(
         &mut self,
         environment: Gc<GcCell<CompileTimeEnvironment>>,
@@ -271,7 +267,6 @@ impl<'b> ByteCompiler<'b> {
         index
     }
 
-    #[inline]
     fn get_or_insert_literal(&mut self, literal: Literal) -> u32 {
         if let Some(index) = self.literals_map.get(&literal) {
             return *index;
@@ -288,7 +283,6 @@ impl<'b> ByteCompiler<'b> {
         index
     }
 
-    #[inline]
     fn get_or_insert_name(&mut self, name: Identifier) -> u32 {
         if let Some(index) = self.names_map.get(&name) {
             return *index;
@@ -300,7 +294,6 @@ impl<'b> ByteCompiler<'b> {
         index
     }
 
-    #[inline]
     fn get_or_insert_binding(&mut self, binding: BindingLocator) -> u32 {
         if let Some(index) = self.bindings_map.get(&binding) {
             return *index;
@@ -312,7 +305,6 @@ impl<'b> ByteCompiler<'b> {
         index
     }
 
-    #[inline]
     fn emit_binding(&mut self, opcode: BindingOpcode, name: Identifier) {
         match opcode {
             BindingOpcode::Var => {
@@ -357,13 +349,11 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn next_opcode_location(&mut self) -> u32 {
         assert!(self.code_block.code.len() < u32::MAX as usize);
         self.code_block.code.len() as u32
     }
 
-    #[inline]
     fn emit(&mut self, opcode: Opcode, operands: &[u32]) {
         self.emit_opcode(opcode);
         for operand in operands {
@@ -371,32 +361,26 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn emit_u64(&mut self, value: u64) {
         self.code_block.code.extend(value.to_ne_bytes());
     }
 
-    #[inline]
     fn emit_u32(&mut self, value: u32) {
         self.code_block.code.extend(value.to_ne_bytes());
     }
 
-    #[inline]
     fn emit_u16(&mut self, value: u16) {
         self.code_block.code.extend(value.to_ne_bytes());
     }
 
-    #[inline]
     fn emit_opcode(&mut self, opcode: Opcode) {
         self.emit_u8(opcode as u8);
     }
 
-    #[inline]
     fn emit_u8(&mut self, value: u8) {
         self.code_block.code.push(value);
     }
 
-    #[inline]
     fn emit_push_integer(&mut self, value: i32) {
         match value {
             0 => self.emit_opcode(Opcode::PushZero),
@@ -413,13 +397,11 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn emit_push_literal(&mut self, literal: Literal) {
         let index = self.get_or_insert_literal(literal);
         self.emit(Opcode::PushLiteral, &[index]);
     }
 
-    #[inline]
     fn emit_push_rational(&mut self, value: f64) {
         if value.is_nan() {
             return self.emit_opcode(Opcode::PushNaN);
@@ -442,14 +424,12 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn jump(&mut self) -> Label {
         let index = self.next_opcode_location();
         self.emit(Opcode::Jump, &[Self::DUMMY_ADDRESS]);
         Label { index }
     }
 
-    #[inline]
     fn jump_if_false(&mut self) -> Label {
         let index = self.next_opcode_location();
         self.emit(Opcode::JumpIfFalse, &[Self::DUMMY_ADDRESS]);
@@ -457,7 +437,6 @@ impl<'b> ByteCompiler<'b> {
         Label { index }
     }
 
-    #[inline]
     fn jump_if_null_or_undefined(&mut self) -> Label {
         let index = self.next_opcode_location();
         self.emit(Opcode::JumpIfNullOrUndefined, &[Self::DUMMY_ADDRESS]);
@@ -467,7 +446,7 @@ impl<'b> ByteCompiler<'b> {
 
     /// Emit an opcode with a dummy operand.
     /// Return the `Label` of the operand.
-    #[inline]
+
     fn emit_opcode_with_operand(&mut self, opcode: Opcode) -> Label {
         let index = self.next_opcode_location();
         self.emit(opcode, &[Self::DUMMY_ADDRESS]);
@@ -476,14 +455,13 @@ impl<'b> ByteCompiler<'b> {
 
     /// Emit an opcode with two dummy operands.
     /// Return the `Label`s of the two operands.
-    #[inline]
+
     fn emit_opcode_with_two_operands(&mut self, opcode: Opcode) -> (Label, Label) {
         let index = self.next_opcode_location();
         self.emit(opcode, &[Self::DUMMY_ADDRESS, Self::DUMMY_ADDRESS]);
         (Label { index }, Label { index: index + 4 })
     }
 
-    #[inline]
     fn patch_jump_with_target(&mut self, label: Label, target: u32) {
         let Label { index } = label;
 
@@ -496,13 +474,11 @@ impl<'b> ByteCompiler<'b> {
         self.code_block.code[index + 4] = bytes[3];
     }
 
-    #[inline]
     fn patch_jump(&mut self, label: Label) {
         let target = self.next_opcode_location();
         self.patch_jump_with_target(label, target);
     }
 
-    #[inline]
     fn push_loop_control_info(&mut self, label: Option<Sym>, start_address: u32) {
         self.jump_info.push(JumpControlInfo {
             label,
@@ -517,7 +493,6 @@ impl<'b> ByteCompiler<'b> {
         });
     }
 
-    #[inline]
     fn push_loop_control_info_for_of_in_loop(&mut self, label: Option<Sym>, start_address: u32) {
         self.jump_info.push(JumpControlInfo {
             label,
@@ -532,7 +507,6 @@ impl<'b> ByteCompiler<'b> {
         });
     }
 
-    #[inline]
     fn pop_loop_control_info(&mut self) {
         let loop_info = self.jump_info.pop().expect("no jump information found");
 
@@ -547,7 +521,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn push_switch_control_info(&mut self, label: Option<Sym>, start_address: u32) {
         self.jump_info.push(JumpControlInfo {
             label,
@@ -562,7 +535,6 @@ impl<'b> ByteCompiler<'b> {
         });
     }
 
-    #[inline]
     fn pop_switch_control_info(&mut self) {
         let info = self.jump_info.pop().expect("no jump information found");
 
@@ -573,7 +545,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn push_try_control_info(&mut self, has_finally: bool) {
         if !self.jump_info.is_empty() {
             let start_address = self
@@ -596,7 +567,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn push_try_control_info_catch_start(&mut self) {
         if !self.jump_info.is_empty() {
             let mut info = self
@@ -608,7 +578,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn push_try_control_info_finally_start(&mut self, start: Label) {
         if !self.jump_info.is_empty() {
             let mut info = self
@@ -620,7 +589,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn pop_try_control_info(&mut self, finally_start_address: Option<u32>) {
         if !self.jump_info.is_empty() {
             let mut info = self.jump_info.pop().expect("no jump information found");
@@ -659,7 +627,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn push_labelled_block_control_info(&mut self, label: Sym, start_address: u32) {
         self.jump_info.push(JumpControlInfo {
             label: Some(label),
@@ -674,7 +641,6 @@ impl<'b> ByteCompiler<'b> {
         });
     }
 
-    #[inline]
     fn pop_labelled_block_control_info(&mut self) {
         let info = self.jump_info.pop().expect("no jump information found");
 
@@ -689,7 +655,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn access_get(&mut self, access: Access<'_>, use_expr: bool) -> JsResult<()> {
         match access {
             Access::Variable { name } => {
@@ -753,7 +718,6 @@ impl<'b> ByteCompiler<'b> {
         Ok(())
     }
 
-    #[inline]
     fn access_set<F, R>(&mut self, access: Access<'_>, use_expr: bool, expr_fn: F) -> JsResult<R>
     where
         F: FnOnce(&mut ByteCompiler<'_>, u8) -> JsResult<R>,
@@ -830,7 +794,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     fn access_delete(&mut self, access: Access<'_>) -> JsResult<()> {
         match access {
             Access::Property { access } => match access {
@@ -865,7 +828,7 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`StatementList`].
-    #[inline]
+
     pub fn compile_statement_list(
         &mut self,
         list: &StatementList,
@@ -882,7 +845,7 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a statement list in a new declarative environment.
-    #[inline]
+
     pub(crate) fn compile_statement_list_with_new_declarative(
         &mut self,
         list: &StatementList,
@@ -1174,7 +1137,7 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`StatementListItem`].
-    #[inline]
+
     fn compile_stmt_list_item(
         &mut self,
         item: &StatementListItem,
@@ -1190,7 +1153,7 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compile a [`Declaration`].
-    #[inline]
+
     pub fn compile_decl(&mut self, decl: &Declaration) -> JsResult<()> {
         match decl {
             Declaration::Function(function) => {
@@ -1211,7 +1174,7 @@ impl<'b> ByteCompiler<'b> {
     }
 
     /// Compiles a [`Statement`]
-    #[inline]
+
     pub fn compile_stmt(
         &mut self,
         node: &Statement,
@@ -1407,7 +1370,6 @@ impl<'b> ByteCompiler<'b> {
         self.code_block
     }
 
-    #[inline]
     fn compile_declaration_pattern(
         &mut self,
         pattern: &Pattern,
@@ -1501,7 +1463,6 @@ impl<'b> ByteCompiler<'b> {
         has_identifier_argument
     }
 
-    #[inline]
     pub(crate) fn create_decls_from_decl(
         &mut self,
         declaration: &Declaration,
@@ -1547,7 +1508,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     pub(crate) fn create_decls_from_stmt(
         &mut self,
         statement: &Statement,
@@ -1577,7 +1537,6 @@ impl<'b> ByteCompiler<'b> {
         }
     }
 
-    #[inline]
     pub(crate) fn create_decls_from_stmt_list_item(
         &mut self,
         item: &StatementListItem,

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -158,7 +158,6 @@ pub struct ClassBuilder<'context> {
 }
 
 impl<'context> ClassBuilder<'context> {
-    #[inline]
     pub(crate) fn new<T>(context: &'context mut Context) -> Self
     where
         T: ClassConstructor,
@@ -169,7 +168,6 @@ impl<'context> ClassBuilder<'context> {
         Self { builder }
     }
 
-    #[inline]
     pub(crate) fn build(mut self) -> JsFunction {
         JsFunction::from_object_unchecked(self.builder.build().into())
     }
@@ -177,7 +175,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a method to the class.
     ///
     /// It is added to `prototype`.
-    #[inline]
     pub fn method<N>(
         &mut self,
         name: N,
@@ -194,7 +191,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a static method to the class.
     ///
     /// It is added to class object itself.
-    #[inline]
     pub fn static_method<N>(
         &mut self,
         name: N,
@@ -211,7 +207,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a data property to the class, with the specified attribute.
     ///
     /// It is added to `prototype`.
-    #[inline]
     pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -224,7 +219,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a static data property to the class, with the specified attribute.
     ///
     /// It is added to class object itself.
-    #[inline]
     pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -237,7 +231,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add an accessor property to the class, with the specified attribute.
     ///
     /// It is added to `prototype`.
-    #[inline]
     pub fn accessor<K>(
         &mut self,
         key: K,
@@ -255,7 +248,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a static accessor property to the class, with the specified attribute.
     ///
     /// It is added to class object itself.
-    #[inline]
     pub fn static_accessor<K>(
         &mut self,
         key: K,
@@ -273,7 +265,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a property descriptor to the class, with the specified attribute.
     ///
     /// It is added to `prototype`.
-    #[inline]
     pub fn property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -286,7 +277,6 @@ impl<'context> ClassBuilder<'context> {
     /// Add a static property descriptor to the class, with the specified attribute.
     ///
     /// It is added to class object itself.
-    #[inline]
     pub fn static_property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -142,13 +142,11 @@ impl Context {
 
     /// A helper function for getting a mutable reference to the `console` object.
     #[cfg(feature = "console")]
-
     pub(crate) fn console_mut(&mut self) -> &mut Console {
         &mut self.console
     }
 
     /// Sets up the default global objects within Global
-
     fn create_intrinsics(&mut self) {
         let _timer = Profiler::global().start_event("create_intrinsics", "interpreter");
         // Create intrinsics, add global objects here
@@ -188,7 +186,6 @@ impl Context {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-call
-
     pub(crate) fn call(
         &mut self,
         f: &JsValue,
@@ -214,13 +211,11 @@ impl Context {
     }
 
     /// Return a mutable reference to the global object string bindings.
-
     pub(crate) fn global_bindings_mut(&mut self) -> &mut GlobalPropertyMap {
         self.realm.global_bindings_mut()
     }
 
     /// Constructs a `Error` with the specified message.
-
     pub fn construct_error<M>(&mut self, message: M) -> JsValue
     where
         M: Into<JsString>,
@@ -256,7 +251,6 @@ impl Context {
     /// [`FunctionBuilder`](crate::object::FunctionBuilder::native). And bind it to the global
     /// object with [`Context::register_global_property`](Context::register_global_property)
     /// method.
-
     pub fn register_global_function(
         &mut self,
         name: &str,
@@ -293,7 +287,6 @@ impl Context {
     /// The difference to [`Context::register_global_function`](Context::register_global_function) is,
     /// that the function will not be `constructable`.
     /// Usage of the function as a constructor will produce a `TypeError`.
-
     pub fn register_global_builtin_function(
         &mut self,
         name: &str,
@@ -340,7 +333,6 @@ impl Context {
     ///
     /// See <https://github.com/boa-dev/boa/issues/1515> for an explanation on
     /// why we need to restrict the set of accepted closures.
-
     pub fn register_global_closure<F>(&mut self, name: &str, length: usize, body: F) -> JsResult<()>
     where
         F: Fn(&JsValue, &[JsValue], &mut Self) -> JsResult<JsValue> + Copy + 'static,
@@ -364,7 +356,6 @@ impl Context {
     }
 
     /// <https://tc39.es/ecma262/#sec-hasproperty>
-
     pub(crate) fn has_property(&mut self, obj: &JsValue, key: &PropertyKey) -> JsResult<bool> {
         obj.as_object()
             .map_or(Ok(false), |obj| obj.__has_property__(key, self))
@@ -383,7 +374,6 @@ impl Context {
     ///
     /// context.register_global_class::<MyClass>();
     /// ```
-
     pub fn register_global_class<T>(&mut self) -> JsResult<()>
     where
         T: Class,
@@ -423,7 +413,6 @@ impl Context {
     ///     .build();
     /// context.register_global_property("myObjectProperty", object, Attribute::all());
     /// ```
-
     pub fn register_global_property<K, V>(&mut self, key: K, value: V, attribute: Attribute)
     where
         K: Into<PropertyKey>,
@@ -472,7 +461,6 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` ready to be executed by the VM.
-
     pub fn compile(&mut self, statement_list: &StatementList) -> JsResult<Gc<CodeBlock>> {
         let _timer = Profiler::global().start_event("Compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
@@ -482,7 +470,6 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
-
     pub fn compile_json_parse(
         &mut self,
         statement_list: &StatementList,
@@ -495,7 +482,6 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` with an additional declarative environment.
-
     pub(crate) fn compile_with_new_declarative(
         &mut self,
         statement_list: &StatementList,
@@ -513,7 +499,6 @@ impl Context {
     /// just a pointer copy. Therefore, if you'd like to execute the same `CodeBlock` multiple
     /// times, there is no need to re-compile it, and you can just call `clone()` on the
     /// `Gc<CodeBlock>` returned by the [`Self::compile()`] function.
-
     pub fn execute(&mut self, code_block: Gc<CodeBlock>) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Execution", "Main");
 
@@ -566,7 +551,6 @@ impl Context {
     }
 
     #[cfg(feature = "intl")]
-
     /// Get the ICU related utilities
     pub(crate) const fn icu(&self) -> &icu::Icu {
         &self.icu

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -142,13 +142,13 @@ impl Context {
 
     /// A helper function for getting a mutable reference to the `console` object.
     #[cfg(feature = "console")]
-    #[inline]
+
     pub(crate) fn console_mut(&mut self) -> &mut Console {
         &mut self.console
     }
 
     /// Sets up the default global objects within Global
-    #[inline]
+
     fn create_intrinsics(&mut self) {
         let _timer = Profiler::global().start_event("create_intrinsics", "interpreter");
         // Create intrinsics, add global objects here
@@ -188,7 +188,7 @@ impl Context {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-call
-    #[inline]
+
     pub(crate) fn call(
         &mut self,
         f: &JsValue,
@@ -214,13 +214,13 @@ impl Context {
     }
 
     /// Return a mutable reference to the global object string bindings.
-    #[inline]
+
     pub(crate) fn global_bindings_mut(&mut self) -> &mut GlobalPropertyMap {
         self.realm.global_bindings_mut()
     }
 
     /// Constructs a `Error` with the specified message.
-    #[inline]
+
     pub fn construct_error<M>(&mut self, message: M) -> JsValue
     where
         M: Into<JsString>,
@@ -256,7 +256,7 @@ impl Context {
     /// [`FunctionBuilder`](crate::object::FunctionBuilder::native). And bind it to the global
     /// object with [`Context::register_global_property`](Context::register_global_property)
     /// method.
-    #[inline]
+
     pub fn register_global_function(
         &mut self,
         name: &str,
@@ -293,7 +293,7 @@ impl Context {
     /// The difference to [`Context::register_global_function`](Context::register_global_function) is,
     /// that the function will not be `constructable`.
     /// Usage of the function as a constructor will produce a `TypeError`.
-    #[inline]
+
     pub fn register_global_builtin_function(
         &mut self,
         name: &str,
@@ -340,7 +340,7 @@ impl Context {
     ///
     /// See <https://github.com/boa-dev/boa/issues/1515> for an explanation on
     /// why we need to restrict the set of accepted closures.
-    #[inline]
+
     pub fn register_global_closure<F>(&mut self, name: &str, length: usize, body: F) -> JsResult<()>
     where
         F: Fn(&JsValue, &[JsValue], &mut Self) -> JsResult<JsValue> + Copy + 'static,
@@ -364,7 +364,7 @@ impl Context {
     }
 
     /// <https://tc39.es/ecma262/#sec-hasproperty>
-    #[inline]
+
     pub(crate) fn has_property(&mut self, obj: &JsValue, key: &PropertyKey) -> JsResult<bool> {
         obj.as_object()
             .map_or(Ok(false), |obj| obj.__has_property__(key, self))
@@ -383,7 +383,7 @@ impl Context {
     ///
     /// context.register_global_class::<MyClass>();
     /// ```
-    #[inline]
+
     pub fn register_global_class<T>(&mut self) -> JsResult<()>
     where
         T: Class,
@@ -423,7 +423,7 @@ impl Context {
     ///     .build();
     /// context.register_global_property("myObjectProperty", object, Attribute::all());
     /// ```
-    #[inline]
+
     pub fn register_global_property<K, V>(&mut self, key: K, value: V, attribute: Attribute)
     where
         K: Into<PropertyKey>,
@@ -472,7 +472,7 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` ready to be executed by the VM.
-    #[inline]
+
     pub fn compile(&mut self, statement_list: &StatementList) -> JsResult<Gc<CodeBlock>> {
         let _timer = Profiler::global().start_event("Compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
@@ -482,7 +482,7 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
-    #[inline]
+
     pub fn compile_json_parse(
         &mut self,
         statement_list: &StatementList,
@@ -495,7 +495,7 @@ impl Context {
     }
 
     /// Compile the AST into a `CodeBlock` with an additional declarative environment.
-    #[inline]
+
     pub(crate) fn compile_with_new_declarative(
         &mut self,
         statement_list: &StatementList,
@@ -513,7 +513,7 @@ impl Context {
     /// just a pointer copy. Therefore, if you'd like to execute the same `CodeBlock` multiple
     /// times, there is no need to re-compile it, and you can just call `clone()` on the
     /// `Gc<CodeBlock>` returned by the [`Self::compile()`] function.
-    #[inline]
+
     pub fn execute(&mut self, code_block: Gc<CodeBlock>) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Execution", "Main");
 
@@ -566,7 +566,7 @@ impl Context {
     }
 
     #[cfg(feature = "intl")]
-    #[inline]
+
     /// Get the ICU related utilities
     pub(crate) const fn icu(&self) -> &icu::Icu {
         &self.icu

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -31,7 +31,6 @@ pub(crate) struct CompileTimeEnvironment {
 
 impl CompileTimeEnvironment {
     /// Crate a new global compile time environment.
-
     pub(crate) fn new_global() -> Self {
         Self {
             outer: None,
@@ -42,7 +41,6 @@ impl CompileTimeEnvironment {
     }
 
     /// Check if environment has a lexical binding with the given name.
-
     pub(crate) fn has_lex_binding(&self, name: Identifier) -> bool {
         self.bindings
             .get(&name)
@@ -50,19 +48,16 @@ impl CompileTimeEnvironment {
     }
 
     /// Returns the number of bindings in this environment.
-
     pub(crate) fn num_bindings(&self) -> usize {
         self.bindings.len()
     }
 
     /// Check if the environment is a function environment.
-
     pub(crate) const fn is_function(&self) -> bool {
         self.function_scope
     }
 
     /// Get the locator for a binding name.
-
     pub(crate) fn get_binding(&self, name: Identifier) -> Option<BindingLocator> {
         self.bindings
             .get(&name)
@@ -70,7 +65,6 @@ impl CompileTimeEnvironment {
     }
 
     /// Get the locator for a binding name in this and all outer environments.
-
     pub(crate) fn get_binding_recursive(&self, name: Identifier) -> BindingLocator {
         if let Some(binding) = self.bindings.get(&name) {
             BindingLocator::declarative(name, self.environment_index, binding.index)
@@ -82,7 +76,6 @@ impl CompileTimeEnvironment {
     }
 
     /// Check if a binding name exists in this and all outer environments.
-
     pub(crate) fn has_binding_recursive(&self, name: Identifier) -> bool {
         if self.bindings.contains_key(&name) {
             true
@@ -96,7 +89,6 @@ impl CompileTimeEnvironment {
     /// Create a mutable binding.
     ///
     /// If the binding is a function scope binding and this is a declarative environment, try the outer environment.
-
     pub(crate) fn create_mutable_binding(
         &mut self,
         name: Identifier,
@@ -142,7 +134,6 @@ impl CompileTimeEnvironment {
     }
 
     /// Crate an immutable binding.
-
     pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
         let binding_index = self.bindings.len();
         self.bindings.insert(
@@ -157,7 +148,6 @@ impl CompileTimeEnvironment {
     }
 
     /// Return the binding locator for a mutable binding with the given binding name and scope.
-
     pub(crate) fn initialize_mutable_binding(
         &self,
         name: Identifier,
@@ -189,14 +179,12 @@ impl CompileTimeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding is not in the current environment.
-
     pub(crate) fn initialize_immutable_binding(&self, name: Identifier) -> BindingLocator {
         let binding = self.bindings.get(&name).expect("binding must exist");
         BindingLocator::declarative(name, self.environment_index, binding.index)
     }
 
     /// Return the binding locator for a mutable binding.
-
     pub(crate) fn set_mutable_binding_recursive(&self, name: Identifier) -> BindingLocator {
         match self.bindings.get(&name) {
             Some(binding) if binding.mutable => {
@@ -216,7 +204,6 @@ impl Context {
     /// Push either a new declarative or function environment on the compile time environment stack.
     ///
     /// Note: This function only works at bytecode compile time!
-
     pub(crate) fn push_compile_time_environment(&mut self, function_scope: bool) {
         let environment_index = self.realm.compile_env.borrow().environment_index + 1;
         let outer = self.realm.compile_env.clone();
@@ -236,7 +223,6 @@ impl Context {
     /// # Panics
     ///
     /// Panics if there are no more environments that can be pop'ed.
-
     pub(crate) fn pop_compile_time_environment(
         &mut self,
     ) -> (usize, Gc<GcCell<CompileTimeEnvironment>>) {
@@ -260,7 +246,6 @@ impl Context {
     /// # Panics
     ///
     /// Panics if there are no environments on the compile time environment stack.
-
     pub(crate) fn get_binding_number(&self) -> usize {
         self.realm.compile_env.borrow().num_bindings()
     }
@@ -268,7 +253,6 @@ impl Context {
     /// Get the binding locator of the binding at bytecode compile time.
     ///
     /// Note: This function only works at bytecode compile time!
-
     pub(crate) fn get_binding_value(&self, name: Identifier) -> BindingLocator {
         self.realm.compile_env.borrow().get_binding_recursive(name)
     }
@@ -277,7 +261,6 @@ impl Context {
     /// This does not include bindings on the global object.
     ///
     /// Note: This function only works at bytecode compile time!
-
     pub(crate) fn has_binding(&self, name: Identifier) -> bool {
         self.realm.compile_env.borrow().has_binding_recursive(name)
     }
@@ -290,7 +273,6 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment is not function scoped.
-
     pub(crate) fn create_mutable_binding(
         &mut self,
         name: Identifier,
@@ -329,7 +311,6 @@ impl Context {
     /// Initialize a mutable binding at bytecode compile time and return it's binding locator.
     ///
     /// Note: This function only works at bytecode compile time!
-
     pub(crate) fn initialize_mutable_binding(
         &self,
         name: Identifier,
@@ -349,7 +330,6 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment does not exist.
-
     pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
         self.realm
             .compile_env
@@ -364,7 +344,6 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment does not exist or a the binding was not created on the current environment.
-
     pub(crate) fn initialize_immutable_binding(&self, name: Identifier) -> BindingLocator {
         self.realm
             .compile_env
@@ -375,7 +354,6 @@ impl Context {
     /// Return the binding locator for a set operation on an existing binding.
     ///
     /// Note: This function only works at bytecode compile time!
-
     pub(crate) fn set_mutable_binding(&self, name: Identifier) -> BindingLocator {
         self.realm
             .compile_env

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -31,7 +31,7 @@ pub(crate) struct CompileTimeEnvironment {
 
 impl CompileTimeEnvironment {
     /// Crate a new global compile time environment.
-    #[inline]
+
     pub(crate) fn new_global() -> Self {
         Self {
             outer: None,
@@ -42,7 +42,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Check if environment has a lexical binding with the given name.
-    #[inline]
+
     pub(crate) fn has_lex_binding(&self, name: Identifier) -> bool {
         self.bindings
             .get(&name)
@@ -50,19 +50,19 @@ impl CompileTimeEnvironment {
     }
 
     /// Returns the number of bindings in this environment.
-    #[inline]
+
     pub(crate) fn num_bindings(&self) -> usize {
         self.bindings.len()
     }
 
     /// Check if the environment is a function environment.
-    #[inline]
+
     pub(crate) const fn is_function(&self) -> bool {
         self.function_scope
     }
 
     /// Get the locator for a binding name.
-    #[inline]
+
     pub(crate) fn get_binding(&self, name: Identifier) -> Option<BindingLocator> {
         self.bindings
             .get(&name)
@@ -70,7 +70,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Get the locator for a binding name in this and all outer environments.
-    #[inline]
+
     pub(crate) fn get_binding_recursive(&self, name: Identifier) -> BindingLocator {
         if let Some(binding) = self.bindings.get(&name) {
             BindingLocator::declarative(name, self.environment_index, binding.index)
@@ -82,7 +82,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Check if a binding name exists in this and all outer environments.
-    #[inline]
+
     pub(crate) fn has_binding_recursive(&self, name: Identifier) -> bool {
         if self.bindings.contains_key(&name) {
             true
@@ -96,7 +96,7 @@ impl CompileTimeEnvironment {
     /// Create a mutable binding.
     ///
     /// If the binding is a function scope binding and this is a declarative environment, try the outer environment.
-    #[inline]
+
     pub(crate) fn create_mutable_binding(
         &mut self,
         name: Identifier,
@@ -142,7 +142,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Crate an immutable binding.
-    #[inline]
+
     pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
         let binding_index = self.bindings.len();
         self.bindings.insert(
@@ -157,7 +157,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Return the binding locator for a mutable binding with the given binding name and scope.
-    #[inline]
+
     pub(crate) fn initialize_mutable_binding(
         &self,
         name: Identifier,
@@ -189,14 +189,14 @@ impl CompileTimeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding is not in the current environment.
-    #[inline]
+
     pub(crate) fn initialize_immutable_binding(&self, name: Identifier) -> BindingLocator {
         let binding = self.bindings.get(&name).expect("binding must exist");
         BindingLocator::declarative(name, self.environment_index, binding.index)
     }
 
     /// Return the binding locator for a mutable binding.
-    #[inline]
+
     pub(crate) fn set_mutable_binding_recursive(&self, name: Identifier) -> BindingLocator {
         match self.bindings.get(&name) {
             Some(binding) if binding.mutable => {
@@ -216,7 +216,7 @@ impl Context {
     /// Push either a new declarative or function environment on the compile time environment stack.
     ///
     /// Note: This function only works at bytecode compile time!
-    #[inline]
+
     pub(crate) fn push_compile_time_environment(&mut self, function_scope: bool) {
         let environment_index = self.realm.compile_env.borrow().environment_index + 1;
         let outer = self.realm.compile_env.clone();
@@ -236,7 +236,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if there are no more environments that can be pop'ed.
-    #[inline]
+
     pub(crate) fn pop_compile_time_environment(
         &mut self,
     ) -> (usize, Gc<GcCell<CompileTimeEnvironment>>) {
@@ -260,7 +260,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if there are no environments on the compile time environment stack.
-    #[inline]
+
     pub(crate) fn get_binding_number(&self) -> usize {
         self.realm.compile_env.borrow().num_bindings()
     }
@@ -268,7 +268,7 @@ impl Context {
     /// Get the binding locator of the binding at bytecode compile time.
     ///
     /// Note: This function only works at bytecode compile time!
-    #[inline]
+
     pub(crate) fn get_binding_value(&self, name: Identifier) -> BindingLocator {
         self.realm.compile_env.borrow().get_binding_recursive(name)
     }
@@ -277,7 +277,7 @@ impl Context {
     /// This does not include bindings on the global object.
     ///
     /// Note: This function only works at bytecode compile time!
-    #[inline]
+
     pub(crate) fn has_binding(&self, name: Identifier) -> bool {
         self.realm.compile_env.borrow().has_binding_recursive(name)
     }
@@ -290,7 +290,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment is not function scoped.
-    #[inline]
+
     pub(crate) fn create_mutable_binding(
         &mut self,
         name: Identifier,
@@ -329,7 +329,7 @@ impl Context {
     /// Initialize a mutable binding at bytecode compile time and return it's binding locator.
     ///
     /// Note: This function only works at bytecode compile time!
-    #[inline]
+
     pub(crate) fn initialize_mutable_binding(
         &self,
         name: Identifier,
@@ -349,7 +349,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment does not exist.
-    #[inline]
+
     pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
         self.realm
             .compile_env
@@ -364,7 +364,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the global environment does not exist or a the binding was not created on the current environment.
-    #[inline]
+
     pub(crate) fn initialize_immutable_binding(&self, name: Identifier) -> BindingLocator {
         self.realm
             .compile_env
@@ -375,7 +375,7 @@ impl Context {
     /// Return the binding locator for a set operation on an existing binding.
     ///
     /// Note: This function only works at bytecode compile time!
-    #[inline]
+
     pub(crate) fn set_mutable_binding(&self, name: Identifier) -> BindingLocator {
         self.realm
             .compile_env

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -190,7 +190,6 @@ impl DeclarativeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding value is out of range or not initialized.
-
     pub(crate) fn get(&self, index: usize) -> JsValue {
         self.bindings
             .borrow()
@@ -205,7 +204,6 @@ impl DeclarativeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding value is out of range or not initialized.
-
     pub(crate) fn set(&self, index: usize, value: JsValue) {
         let mut bindings = self.bindings.borrow_mut();
         let binding = bindings
@@ -227,7 +225,6 @@ pub struct DeclarativeEnvironmentStack {
 
 impl DeclarativeEnvironmentStack {
     /// Create a new environment stack with the most outer declarative environment.
-
     pub(crate) fn new(global_compile_environment: Gc<GcCell<CompileTimeEnvironment>>) -> Self {
         Self {
             stack: vec![Gc::new(DeclarativeEnvironment {
@@ -304,7 +301,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn set_global_binding_number(&mut self, binding_number: usize) {
         let environment = self
             .stack
@@ -328,7 +324,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn get_this_environment(&self) -> &EnvironmentSlots {
         for env in self.stack.iter().rev() {
             if let Some(slots) = &env.slots {
@@ -351,7 +346,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn push_declarative(
         &mut self,
         num_bindings: usize,
@@ -381,7 +375,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn push_function(
         &mut self,
         num_bindings: usize,
@@ -448,7 +441,6 @@ impl DeclarativeEnvironmentStack {
     }
 
     /// Pop environment from the environments stack.
-
     pub(crate) fn pop(&mut self) -> Gc<DeclarativeEnvironment> {
         debug_assert!(self.stack.len() > 1);
         self.stack
@@ -461,7 +453,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn current_function_slots(&self) -> &EnvironmentSlots {
         for env in self.stack.iter().rev() {
             if let Some(slots) = &env.slots {
@@ -477,7 +468,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn current(&mut self) -> Gc<DeclarativeEnvironment> {
         self.stack
             .last()
@@ -503,7 +493,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-
     pub(crate) fn poison_current(&mut self) {
         self.stack
             .last()
@@ -513,7 +502,6 @@ impl DeclarativeEnvironmentStack {
     }
 
     /// Mark that there may be added binding in all environments.
-
     pub(crate) fn poison_all(&mut self) {
         for env in &mut self.stack {
             if env.poisoned.get() {
@@ -528,7 +516,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn get_value_optional(
         &self,
         mut environment_index: usize,
@@ -569,7 +556,6 @@ impl DeclarativeEnvironmentStack {
     ///
     /// This only considers function environments that are poisoned.
     /// All other bindings are accessed via indices.
-
     pub(crate) fn get_value_if_global_poisoned(&self, name: Identifier) -> Option<JsValue> {
         for env in self.stack.iter().rev() {
             if !env.poisoned.get() {
@@ -598,7 +584,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn put_value(
         &mut self,
         environment_index: usize,
@@ -623,7 +608,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn put_value_if_initialized(
         &mut self,
         mut environment_index: usize,
@@ -673,7 +657,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn put_value_if_uninitialized(
         &mut self,
         environment_index: usize,
@@ -702,7 +685,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn put_value_if_global_poisoned(
         &mut self,
         name: Identifier,
@@ -742,7 +724,6 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-
     pub(crate) fn is_only_global_property(&mut self, name: Identifier) -> bool {
         for env in self
             .stack
@@ -779,7 +760,6 @@ pub(crate) struct BindingLocator {
 
 impl BindingLocator {
     /// Creates a new declarative binding locator that has knows indices.
-
     pub(in crate::environments) const fn declarative(
         name: Identifier,
         environment_index: usize,
@@ -796,7 +776,6 @@ impl BindingLocator {
     }
 
     /// Creates a binding locator that indicates that the binding is on the global object.
-
     pub(in crate::environments) const fn global(name: Identifier) -> Self {
         Self {
             name,
@@ -810,7 +789,6 @@ impl BindingLocator {
 
     /// Creates a binding locator that indicates that it was attempted to mutate an immutable binding.
     /// At runtime this should always produce a type error.
-
     pub(in crate::environments) const fn mutate_immutable(name: Identifier) -> Self {
         Self {
             name,
@@ -823,7 +801,6 @@ impl BindingLocator {
     }
 
     /// Creates a binding locator that indicates that any action is silently ignored.
-
     pub(in crate::environments) const fn silent(name: Identifier) -> Self {
         Self {
             name,
@@ -836,37 +813,31 @@ impl BindingLocator {
     }
 
     /// Returns the name of the binding.
-
     pub(crate) const fn name(&self) -> Identifier {
         self.name
     }
 
     /// Returns if the binding is located on the global object.
-
     pub(crate) const fn is_global(&self) -> bool {
         self.global
     }
 
     /// Returns the environment index of the binding.
-
     pub(crate) const fn environment_index(&self) -> usize {
         self.environment_index
     }
 
     /// Returns the binding index of the binding.
-
     pub(crate) const fn binding_index(&self) -> usize {
         self.binding_index
     }
 
     /// Returns if the binding is a silent operation.
-
     pub(crate) const fn is_silent(&self) -> bool {
         self.silent
     }
 
     /// Helper method to throws an error if the binding access is illegal.
-
     pub(crate) fn throw_mutate_immutable(
         &self,
         context: &mut Context,

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -190,7 +190,7 @@ impl DeclarativeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding value is out of range or not initialized.
-    #[inline]
+
     pub(crate) fn get(&self, index: usize) -> JsValue {
         self.bindings
             .borrow()
@@ -205,7 +205,7 @@ impl DeclarativeEnvironment {
     /// # Panics
     ///
     /// Panics if the binding value is out of range or not initialized.
-    #[inline]
+
     pub(crate) fn set(&self, index: usize, value: JsValue) {
         let mut bindings = self.bindings.borrow_mut();
         let binding = bindings
@@ -227,7 +227,7 @@ pub struct DeclarativeEnvironmentStack {
 
 impl DeclarativeEnvironmentStack {
     /// Create a new environment stack with the most outer declarative environment.
-    #[inline]
+
     pub(crate) fn new(global_compile_environment: Gc<GcCell<CompileTimeEnvironment>>) -> Self {
         Self {
             stack: vec![Gc::new(DeclarativeEnvironment {
@@ -304,7 +304,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn set_global_binding_number(&mut self, binding_number: usize) {
         let environment = self
             .stack
@@ -328,7 +328,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn get_this_environment(&self) -> &EnvironmentSlots {
         for env in self.stack.iter().rev() {
             if let Some(slots) = &env.slots {
@@ -351,7 +351,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn push_declarative(
         &mut self,
         num_bindings: usize,
@@ -381,7 +381,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn push_function(
         &mut self,
         num_bindings: usize,
@@ -448,7 +448,7 @@ impl DeclarativeEnvironmentStack {
     }
 
     /// Pop environment from the environments stack.
-    #[inline]
+
     pub(crate) fn pop(&mut self) -> Gc<DeclarativeEnvironment> {
         debug_assert!(self.stack.len() > 1);
         self.stack
@@ -461,7 +461,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn current_function_slots(&self) -> &EnvironmentSlots {
         for env in self.stack.iter().rev() {
             if let Some(slots) = &env.slots {
@@ -477,7 +477,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn current(&mut self) -> Gc<DeclarativeEnvironment> {
         self.stack
             .last()
@@ -503,7 +503,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if no environment exists on the stack.
-    #[inline]
+
     pub(crate) fn poison_current(&mut self) {
         self.stack
             .last()
@@ -513,7 +513,7 @@ impl DeclarativeEnvironmentStack {
     }
 
     /// Mark that there may be added binding in all environments.
-    #[inline]
+
     pub(crate) fn poison_all(&mut self) {
         for env in &mut self.stack {
             if env.poisoned.get() {
@@ -528,7 +528,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn get_value_optional(
         &self,
         mut environment_index: usize,
@@ -569,7 +569,7 @@ impl DeclarativeEnvironmentStack {
     ///
     /// This only considers function environments that are poisoned.
     /// All other bindings are accessed via indices.
-    #[inline]
+
     pub(crate) fn get_value_if_global_poisoned(&self, name: Identifier) -> Option<JsValue> {
         for env in self.stack.iter().rev() {
             if !env.poisoned.get() {
@@ -598,7 +598,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn put_value(
         &mut self,
         environment_index: usize,
@@ -623,7 +623,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn put_value_if_initialized(
         &mut self,
         mut environment_index: usize,
@@ -673,7 +673,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn put_value_if_uninitialized(
         &mut self,
         environment_index: usize,
@@ -702,7 +702,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn put_value_if_global_poisoned(
         &mut self,
         name: Identifier,
@@ -742,7 +742,7 @@ impl DeclarativeEnvironmentStack {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
-    #[inline]
+
     pub(crate) fn is_only_global_property(&mut self, name: Identifier) -> bool {
         for env in self
             .stack
@@ -779,7 +779,7 @@ pub(crate) struct BindingLocator {
 
 impl BindingLocator {
     /// Creates a new declarative binding locator that has knows indices.
-    #[inline]
+
     pub(in crate::environments) const fn declarative(
         name: Identifier,
         environment_index: usize,
@@ -796,7 +796,7 @@ impl BindingLocator {
     }
 
     /// Creates a binding locator that indicates that the binding is on the global object.
-    #[inline]
+
     pub(in crate::environments) const fn global(name: Identifier) -> Self {
         Self {
             name,
@@ -810,7 +810,7 @@ impl BindingLocator {
 
     /// Creates a binding locator that indicates that it was attempted to mutate an immutable binding.
     /// At runtime this should always produce a type error.
-    #[inline]
+
     pub(in crate::environments) const fn mutate_immutable(name: Identifier) -> Self {
         Self {
             name,
@@ -823,7 +823,7 @@ impl BindingLocator {
     }
 
     /// Creates a binding locator that indicates that any action is silently ignored.
-    #[inline]
+
     pub(in crate::environments) const fn silent(name: Identifier) -> Self {
         Self {
             name,
@@ -836,37 +836,37 @@ impl BindingLocator {
     }
 
     /// Returns the name of the binding.
-    #[inline]
+
     pub(crate) const fn name(&self) -> Identifier {
         self.name
     }
 
     /// Returns if the binding is located on the global object.
-    #[inline]
+
     pub(crate) const fn is_global(&self) -> bool {
         self.global
     }
 
     /// Returns the environment index of the binding.
-    #[inline]
+
     pub(crate) const fn environment_index(&self) -> usize {
         self.environment_index
     }
 
     /// Returns the binding index of the binding.
-    #[inline]
+
     pub(crate) const fn binding_index(&self) -> usize {
         self.binding_index
     }
 
     /// Returns if the binding is a silent operation.
-    #[inline]
+
     pub(crate) const fn is_silent(&self) -> bool {
         self.silent
     }
 
     /// Helper method to throws an error if the binding access is illegal.
-    #[inline]
+
     pub(crate) fn throw_mutate_immutable(
         &self,
         context: &mut Context,

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -26,7 +26,7 @@ impl JsArray {
     }
 
     /// Create an array from a `IntoIterator<Item = JsValue>` convertible object.
-    #[inline]
+
     pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
     where
         I: IntoIterator<Item = JsValue>,
@@ -65,7 +65,7 @@ impl JsArray {
     }
 
     /// Push an element to the array.
-    #[inline]
+
     pub fn push<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -86,7 +86,7 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.at()`.
-    #[inline]
+
     pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<i64>,
@@ -140,7 +140,7 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.fill()`.
-    #[inline]
+
     pub fn fill<T>(
         &self,
         value: T,
@@ -164,7 +164,7 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.indexOf()`.
-    #[inline]
+
     pub fn index_of<T>(
         &self,
         search_element: T,
@@ -191,7 +191,7 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.lastIndexOf()`.
-    #[inline]
+
     pub fn last_index_of<T>(
         &self,
         search_element: T,

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -26,7 +26,6 @@ impl JsArray {
     }
 
     /// Create an array from a `IntoIterator<Item = JsValue>` convertible object.
-
     pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
     where
         I: IntoIterator<Item = JsValue>,
@@ -65,7 +64,6 @@ impl JsArray {
     }
 
     /// Push an element to the array.
-
     pub fn push<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -86,7 +84,6 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.at()`.
-
     pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<i64>,
@@ -140,7 +137,6 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.fill()`.
-
     pub fn fill<T>(
         &self,
         value: T,
@@ -164,7 +160,6 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.indexOf()`.
-
     pub fn index_of<T>(
         &self,
         search_element: T,
@@ -191,7 +186,6 @@ impl JsArray {
     }
 
     /// Calls `Array.prototype.lastIndexOf()`.
-
     pub fn last_index_of<T>(
         &self,
         search_element: T,

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -75,7 +75,7 @@ impl JsArrayBuffer {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
         let byte_length = byte_block.len();
 

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -75,7 +75,6 @@ impl JsArrayBuffer {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
         let byte_length = byte_block.len();
 

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -38,7 +38,6 @@ pub struct JsDataView {
 
 impl JsDataView {
     /// Create a new `JsDataView` object from an existing `JsArrayBuffer`.
-
     pub fn from_js_array_buffer(
         array_buffer: &JsArrayBuffer,
         offset: Option<u64>,

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -38,7 +38,7 @@ pub struct JsDataView {
 
 impl JsDataView {
     /// Create a new `JsDataView` object from an existing `JsArrayBuffer`.
-    #[inline]
+
     pub fn from_js_array_buffer(
         array_buffer: &JsArrayBuffer,
         offset: Option<u64>,

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -241,7 +241,7 @@ impl JsDate {
     /// the UNIX epoch and the given date.
     ///
     /// Same as JavaScript's `Date.prototype.setDate()`.
-    #[inline]
+
     pub fn set_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -278,7 +278,7 @@ impl JsDate {
     /// the UNIX epoch and updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setMilliseconds()`.
-    #[inline]
+
     pub fn set_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -327,7 +327,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setTime()`.
-    #[inline]
+
     pub fn set_time<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -342,7 +342,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCDate()`.
-    #[inline]
+
     pub fn set_utc_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -383,7 +383,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMilliseconds()`.
-    #[inline]
+
     pub fn set_utc_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -528,7 +528,7 @@ impl JsDate {
     }
 
     /// Utility create a `Date` object from RFC3339 string
-    #[inline]
+
     pub fn new_from_parse(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let prototype = context.intrinsics().constructors().date().prototype();
         let string = value

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -241,7 +241,6 @@ impl JsDate {
     /// the UNIX epoch and the given date.
     ///
     /// Same as JavaScript's `Date.prototype.setDate()`.
-
     pub fn set_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -278,7 +277,6 @@ impl JsDate {
     /// the UNIX epoch and updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setMilliseconds()`.
-
     pub fn set_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -327,7 +325,6 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setTime()`.
-
     pub fn set_time<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -342,7 +339,6 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCDate()`.
-
     pub fn set_utc_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -383,7 +379,6 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMilliseconds()`.
-
     pub fn set_utc_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -528,7 +523,6 @@ impl JsDate {
     }
 
     /// Utility create a `Date` object from RFC3339 string
-
     pub fn new_from_parse(value: &JsValue, context: &mut Context) -> JsResult<Self> {
         let prototype = context.intrinsics().constructors().date().prototype();
         let string = value

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -13,7 +13,6 @@ pub struct JsFunction {
 }
 
 impl JsFunction {
-    #[inline]
     pub(crate) fn from_object_unchecked(object: JsObject) -> Self {
         Self { inner: object }
     }

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -46,7 +46,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.next()`
     ///
     /// This method returns an object with the properties `done` and `value`
-    #[inline]
+
     pub fn next<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -57,7 +57,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.return()`
     ///
     /// This method returns the given value and finishes the generator
-    #[inline]
+
     pub fn r#return<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -69,7 +69,7 @@ impl JsGenerator {
     ///
     /// This method resumes the execution of a generator by throwing an error and returning an
     /// an object with the properties `done` and `value`
-    #[inline]
+
     pub fn throw<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -46,7 +46,6 @@ impl JsGenerator {
     /// Calls `Generator.prototype.next()`
     ///
     /// This method returns an object with the properties `done` and `value`
-
     pub fn next<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -57,7 +56,6 @@ impl JsGenerator {
     /// Calls `Generator.prototype.return()`
     ///
     /// This method returns the given value and finishes the generator
-
     pub fn r#return<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -69,7 +67,6 @@ impl JsGenerator {
     ///
     /// This method resumes the execution of a generator by throwing an error and returning an
     /// an object with the properties `done` and `value`
-
     pub fn throw<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -115,7 +115,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn from_js_iterable(iterable: &JsValue, context: &mut Context) -> JsResult<Self> {
         // Create a new map object.
         let map = Self::create_map(context);
@@ -226,7 +226,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn set<K, V>(&self, key: K, value: V, context: &mut Context) -> JsResult<JsValue>
     where
         K: Into<JsValue>,
@@ -287,7 +287,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn delete<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -315,7 +315,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn get<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -369,7 +369,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn has<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -115,7 +115,6 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn from_js_iterable(iterable: &JsValue, context: &mut Context) -> JsResult<Self> {
         // Create a new map object.
         let map = Self::create_map(context);
@@ -226,7 +225,6 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn set<K, V>(&self, key: K, value: V, context: &mut Context) -> JsResult<JsValue>
     where
         K: Into<JsValue>,
@@ -287,7 +285,6 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn delete<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -315,7 +312,6 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn get<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -369,7 +365,6 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn has<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsproxy.rs
+++ b/boa_engine/src/object/builtins/jsproxy.rs
@@ -79,6 +79,7 @@ pub struct JsRevocableProxy {
 impl JsRevocableProxy {
     /// Disables the traps of the internal `proxy` object, essentially
     /// making it unusable and throwing `TypeError`s for all the traps.
+    #[inline]
     pub fn revoke(self, context: &mut Context) -> JsResult<()> {
         self.revoker.call(&JsValue::undefined(), &[], context)?;
         Ok(())
@@ -161,6 +162,7 @@ impl std::fmt::Debug for JsProxyBuilder {
 
 impl JsProxyBuilder {
     /// Create a new `ProxyBuilder` with every trap set to `undefined`.
+    #[inline]
     pub fn new(target: JsObject) -> Self {
         Self {
             target,
@@ -192,6 +194,7 @@ impl JsProxyBuilder {
     /// when trying to call the proxy, which will throw a type error.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/apply
+    #[inline]
     pub fn apply(mut self, apply: NativeFunctionSignature) -> Self {
         self.apply = Some(apply);
         self
@@ -209,6 +212,7 @@ impl JsProxyBuilder {
     /// when trying to construct an object using the proxy, which will throw a type error.
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/construct
+    #[inline]
     pub fn construct(mut self, construct: NativeFunctionSignature) -> Self {
         self.construct = Some(construct);
         self
@@ -221,6 +225,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/defineProperty
+    #[inline]
     pub fn define_property(mut self, define_property: NativeFunctionSignature) -> Self {
         self.define_property = Some(define_property);
         self
@@ -233,6 +238,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/deleteProperty
+    #[inline]
     pub fn delete_property(mut self, delete_property: NativeFunctionSignature) -> Self {
         self.delete_property = Some(delete_property);
         self
@@ -245,6 +251,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/get
+    #[inline]
     pub fn get(mut self, get: NativeFunctionSignature) -> Self {
         self.get = Some(get);
         self
@@ -257,6 +264,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getOwnPropertyDescriptor
+    #[inline]
     pub fn get_own_property_descriptor(
         mut self,
         get_own_property_descriptor: NativeFunctionSignature,
@@ -272,6 +280,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/getPrototypeOf
+    #[inline]
     pub fn get_prototype_of(mut self, get_prototype_of: NativeFunctionSignature) -> Self {
         self.get_prototype_of = Some(get_prototype_of);
         self
@@ -284,6 +293,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/has
+    #[inline]
     pub fn has(mut self, has: NativeFunctionSignature) -> Self {
         self.has = Some(has);
         self
@@ -296,6 +306,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/isExtensible
+    #[inline]
     pub fn is_extensible(mut self, is_extensible: NativeFunctionSignature) -> Self {
         self.is_extensible = Some(is_extensible);
         self
@@ -308,6 +319,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/ownKeys
+    #[inline]
     pub fn own_keys(mut self, own_keys: NativeFunctionSignature) -> Self {
         self.own_keys = Some(own_keys);
         self
@@ -320,6 +332,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/preventExtensions
+    #[inline]
     pub fn prevent_extensions(mut self, prevent_extensions: NativeFunctionSignature) -> Self {
         self.prevent_extensions = Some(prevent_extensions);
         self
@@ -332,6 +345,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set
+    #[inline]
     pub fn set(mut self, set: NativeFunctionSignature) -> Self {
         self.set = Some(set);
         self
@@ -344,6 +358,7 @@ impl JsProxyBuilder {
     /// - [MDN documentation][mdn]
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/setPrototypeOf
+    #[inline]
     pub fn set_prototype_of(mut self, set_prototype_of: NativeFunctionSignature) -> Self {
         self.set_prototype_of = Some(set_prototype_of);
         self

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -56,7 +56,6 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn new<S>(pattern: S, flags: S, context: &mut Context) -> JsResult<Self>
     where
         S: Into<JsValue>,
@@ -203,7 +202,6 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-
     pub fn test<S>(&self, search_string: S, context: &mut Context) -> JsResult<bool>
     where
         S: Into<JsValue>,
@@ -215,7 +213,6 @@ impl JsRegExp {
     /// Executes a search for a match in a specified string
     ///
     /// Returns a `JsArray` containing matched value and updates the `lastIndex` property, or `None`
-
     pub fn exec<S>(&self, search_string: S, context: &mut Context) -> JsResult<Option<JsArray>>
     where
         S: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -56,7 +56,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn new<S>(pattern: S, flags: S, context: &mut Context) -> JsResult<Self>
     where
         S: Into<JsValue>,
@@ -203,7 +203,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    #[inline]
+
     pub fn test<S>(&self, search_string: S, context: &mut Context) -> JsResult<bool>
     where
         S: Into<JsValue>,
@@ -215,7 +215,7 @@ impl JsRegExp {
     /// Executes a search for a match in a specified string
     ///
     /// Returns a `JsArray` containing matched value and updates the `lastIndex` property, or `None`
-    #[inline]
+
     pub fn exec<S>(&self, search_string: S, context: &mut Context) -> JsResult<Option<JsArray>>
     where
         S: Into<JsValue>,

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -40,7 +40,7 @@ impl JsSet {
     /// Returns the Set object with added value.
     ///
     /// Same as JavaScript's `set.add(value)`.
-    #[inline]
+
     pub fn add<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -71,7 +71,7 @@ impl JsSet {
     /// successfully removed or not.
     ///
     /// Same as JavaScript's `set.delete(value)`.
-    #[inline]
+
     pub fn delete<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
     where
         T: Into<JsValue>,
@@ -87,7 +87,7 @@ impl JsSet {
     /// with the given value in the Set object or not.
     ///
     /// Same as JavaScript's `set.has(value)`.
-    #[inline]
+
     pub fn has<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
     where
         T: Into<JsValue>,
@@ -156,7 +156,7 @@ impl JsSet {
     }
 
     /// Utility: Creates a `JsSet` from a `<IntoIterator<Item = JsValue>` convertible object.
-    #[inline]
+
     pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
     where
         I: IntoIterator<Item = JsValue>,

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -40,7 +40,6 @@ impl JsSet {
     /// Returns the Set object with added value.
     ///
     /// Same as JavaScript's `set.add(value)`.
-
     pub fn add<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
@@ -71,7 +70,6 @@ impl JsSet {
     /// successfully removed or not.
     ///
     /// Same as JavaScript's `set.delete(value)`.
-
     pub fn delete<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
     where
         T: Into<JsValue>,
@@ -87,7 +85,6 @@ impl JsSet {
     /// with the given value in the Set object or not.
     ///
     /// Same as JavaScript's `set.has(value)`.
-
     pub fn has<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
     where
         T: Into<JsValue>,
@@ -156,7 +153,6 @@ impl JsSet {
     }
 
     /// Utility: Creates a `JsSet` from a `<IntoIterator<Item = JsValue>` convertible object.
-
     pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
     where
         I: IntoIterator<Item = JsValue>,

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -50,7 +50,6 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.at()`.
-
     pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<i64>,
@@ -77,7 +76,6 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.fill()`.
-
     pub fn fill<T>(
         &self,
         value: T,
@@ -249,7 +247,6 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.indexOf()`.
-
     pub fn index_of<T>(
         &self,
         search_element: T,
@@ -276,7 +273,6 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.lastIndexOf()`.
-
     pub fn last_index_of<T>(
         &self,
         search_element: T,
@@ -351,7 +347,6 @@ macro_rules! JsTypedArrayType {
 
         impl $name {
             /// Create the typed array from a [`JsArrayBuffer`].
-
             pub fn from_array_buffer(
                 array_buffer: JsArrayBuffer,
                 context: &mut Context,
@@ -379,7 +374,6 @@ macro_rules! JsTypedArrayType {
             }
 
             /// Create the typed array from an iterator.
-
             pub fn from_iter<I>(elements: I, context: &mut Context) -> JsResult<Self>
             where
                 I: IntoIterator<Item = $element>,

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -50,7 +50,7 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.at()`.
-    #[inline]
+
     pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
     where
         T: Into<i64>,
@@ -77,7 +77,7 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.fill()`.
-    #[inline]
+
     pub fn fill<T>(
         &self,
         value: T,
@@ -249,7 +249,7 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.indexOf()`.
-    #[inline]
+
     pub fn index_of<T>(
         &self,
         search_element: T,
@@ -276,7 +276,7 @@ impl JsTypedArray {
     }
 
     /// Calls `TypedArray.prototype.lastIndexOf()`.
-    #[inline]
+
     pub fn last_index_of<T>(
         &self,
         search_element: T,
@@ -351,7 +351,7 @@ macro_rules! JsTypedArrayType {
 
         impl $name {
             /// Create the typed array from a [`JsArrayBuffer`].
-            #[inline]
+
             pub fn from_array_buffer(
                 array_buffer: JsArrayBuffer,
                 context: &mut Context,
@@ -379,7 +379,7 @@ macro_rules! JsTypedArrayType {
             }
 
             /// Create the typed array from an iterator.
-            #[inline]
+
             pub fn from_iter<I>(elements: I, context: &mut Context) -> JsResult<Self>
             where
                 I: IntoIterator<Item = $element>,

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -22,7 +22,6 @@ pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p
-
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -22,7 +22,7 @@ pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-arguments-exotic-objects-getownproperty-p
-#[inline]
+
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -98,7 +98,7 @@ pub(crate) fn arguments_exotic_define_own_property(
         {
             if let Some((_, value)) = &mapped {
                 PropertyDescriptor::builder()
-                    .value(value)
+                    .value(value.clone())
                     .writable(false)
                     .maybe_enumerable(desc.enumerable())
                     .maybe_configurable(desc.configurable())

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -28,7 +28,6 @@ pub(crate) static BOUND_CONSTRUCTOR_EXOTIC_INTERNAL_METHODS: InternalObjectMetho
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
 #[track_caller]
-
 fn bound_function_exotic_call(
     obj: &JsObject,
     _: &JsValue,
@@ -64,7 +63,6 @@ fn bound_function_exotic_call(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget
 #[track_caller]
-
 fn bound_function_exotic_construct(
     obj: &JsObject,
     arguments_list: &[JsValue],

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -28,7 +28,7 @@ pub(crate) static BOUND_CONSTRUCTOR_EXOTIC_INTERNAL_METHODS: InternalObjectMetho
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
 #[track_caller]
-#[inline]
+
 fn bound_function_exotic_call(
     obj: &JsObject,
     _: &JsValue,
@@ -64,7 +64,7 @@ fn bound_function_exotic_call(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-bound-function-exotic-objects-construct-argumentslist-newtarget
 #[track_caller]
-#[inline]
+
 fn bound_function_exotic_construct(
     obj: &JsObject,
     arguments_list: &[JsValue],

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -32,7 +32,6 @@ pub(crate) static CONSTRUCTOR_INTERNAL_METHODS: InternalObjectMethods = Internal
 // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
 // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
 #[track_caller]
-
 fn function_call(
     obj: &JsObject,
     this: &JsValue,
@@ -49,7 +48,6 @@ fn function_call(
 /// Panics if the object is currently mutably borrowed.
 // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
 #[track_caller]
-
 fn function_construct(
     obj: &JsObject,
     args: &[JsValue],

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -32,7 +32,7 @@ pub(crate) static CONSTRUCTOR_INTERNAL_METHODS: InternalObjectMethods = Internal
 // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
 // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
 #[track_caller]
-#[inline]
+
 fn function_call(
     obj: &JsObject,
     this: &JsValue,
@@ -49,7 +49,7 @@ fn function_call(
 /// Panics if the object is currently mutably borrowed.
 // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget>
 #[track_caller]
-#[inline]
+
 fn function_construct(
     obj: &JsObject,
     args: &[JsValue],

--- a/boa_engine/src/object/internal_methods/global.rs
+++ b/boa_engine/src/object/internal_methods/global.rs
@@ -36,7 +36,6 @@ pub(crate) static GLOBAL_INTERNAL_METHODS: InternalObjectMethods = InternalObjec
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_get_prototype_of(
     _: &JsObject,
@@ -52,7 +51,6 @@ pub(crate) fn global_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarysetprototypeof
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_set_prototype_of(
     _: &JsObject,
@@ -112,7 +110,6 @@ pub(crate) fn global_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetownproperty
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_get_own_property(
     _obj: &JsObject,
@@ -143,7 +140,6 @@ pub(crate) fn global_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
@@ -156,7 +152,6 @@ pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> Js
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_prevent_extensions(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Set O.[[Extensible]] to false.
@@ -172,7 +167,6 @@ pub(crate) fn global_prevent_extensions(_obj: &JsObject, context: &mut Context) 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydefineownproperty
-
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_define_own_property(
     obj: &JsObject,
@@ -199,7 +193,6 @@ pub(crate) fn global_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryhasproperty
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_has_property(
     _obj: &JsObject,
@@ -229,7 +222,6 @@ pub(crate) fn global_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryget
-
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_get(
     obj: &JsObject,
@@ -276,7 +268,6 @@ pub(crate) fn global_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryset
-
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_set(
     _obj: &JsObject,
@@ -385,7 +376,6 @@ pub(crate) fn global_set_no_receiver(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-
 #[allow(clippy::unnecessary_wraps, clippy::needless_pass_by_value)]
 pub(crate) fn global_delete(
     _obj: &JsObject,
@@ -401,7 +391,6 @@ pub(crate) fn global_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_delete_no_receiver(
     key: &PropertyKey,
@@ -431,7 +420,6 @@ pub(crate) fn global_delete_no_receiver(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_own_property_keys(
     _: &JsObject,
@@ -486,7 +474,6 @@ pub(crate) fn global_own_property_keys(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
-
 pub(crate) fn validate_and_apply_property_descriptor(
     key: &PropertyKey,
     extensible: bool,

--- a/boa_engine/src/object/internal_methods/global.rs
+++ b/boa_engine/src/object/internal_methods/global.rs
@@ -36,7 +36,7 @@ pub(crate) static GLOBAL_INTERNAL_METHODS: InternalObjectMethods = InternalObjec
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_get_prototype_of(
     _: &JsObject,
@@ -52,7 +52,7 @@ pub(crate) fn global_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarysetprototypeof
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_set_prototype_of(
     _: &JsObject,
@@ -112,7 +112,7 @@ pub(crate) fn global_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetownproperty
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_get_own_property(
     _obj: &JsObject,
@@ -143,7 +143,7 @@ pub(crate) fn global_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
@@ -156,7 +156,7 @@ pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> Js
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_prevent_extensions(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Set O.[[Extensible]] to false.
@@ -172,7 +172,7 @@ pub(crate) fn global_prevent_extensions(_obj: &JsObject, context: &mut Context) 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydefineownproperty
-#[inline]
+
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_define_own_property(
     obj: &JsObject,
@@ -199,7 +199,7 @@ pub(crate) fn global_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryhasproperty
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_has_property(
     _obj: &JsObject,
@@ -229,7 +229,7 @@ pub(crate) fn global_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryget
-#[inline]
+
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_get(
     obj: &JsObject,
@@ -276,7 +276,7 @@ pub(crate) fn global_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryset
-#[inline]
+
 #[allow(clippy::needless_pass_by_value)]
 pub(crate) fn global_set(
     _obj: &JsObject,
@@ -288,7 +288,6 @@ pub(crate) fn global_set(
     global_set_no_receiver(&key, value, context)
 }
 
-#[inline]
 pub(crate) fn global_set_no_receiver(
     key: &PropertyKey,
     value: JsValue,
@@ -386,7 +385,7 @@ pub(crate) fn global_set_no_receiver(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-#[inline]
+
 #[allow(clippy::unnecessary_wraps, clippy::needless_pass_by_value)]
 pub(crate) fn global_delete(
     _obj: &JsObject,
@@ -402,7 +401,7 @@ pub(crate) fn global_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_delete_no_receiver(
     key: &PropertyKey,
@@ -432,7 +431,7 @@ pub(crate) fn global_delete_no_receiver(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_own_property_keys(
     _: &JsObject,
@@ -487,7 +486,7 @@ pub(crate) fn global_own_property_keys(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
-#[inline]
+
 pub(crate) fn validate_and_apply_property_descriptor(
     key: &PropertyKey,
     extensible: bool,

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -31,7 +31,7 @@ pub(crate) static INTEGER_INDEXED_EXOTIC_INTERNAL_METHODS: InternalObjectMethods
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-getownproperty-p
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -66,7 +66,7 @@ pub(crate) fn integer_indexed_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-hasproperty-p
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -89,7 +89,7 @@ pub(crate) fn integer_indexed_exotic_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-defineownproperty-p-desc
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -135,7 +135,7 @@ pub(crate) fn integer_indexed_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-get-p-receiver
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -160,7 +160,7 @@ pub(crate) fn integer_indexed_exotic_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -189,7 +189,7 @@ pub(crate) fn integer_indexed_exotic_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-delete-p
-#[inline]
+
 pub(crate) fn integer_indexed_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -213,7 +213,7 @@ pub(crate) fn integer_indexed_exotic_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-ownpropertykeys
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn integer_indexed_exotic_own_property_keys(
     obj: &JsObject,

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -31,7 +31,6 @@ pub(crate) static INTEGER_INDEXED_EXOTIC_INTERNAL_METHODS: InternalObjectMethods
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-getownproperty-p
-
 pub(crate) fn integer_indexed_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -66,7 +65,6 @@ pub(crate) fn integer_indexed_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-hasproperty-p
-
 pub(crate) fn integer_indexed_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -89,7 +87,6 @@ pub(crate) fn integer_indexed_exotic_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-defineownproperty-p-desc
-
 pub(crate) fn integer_indexed_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -135,7 +132,6 @@ pub(crate) fn integer_indexed_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-get-p-receiver
-
 pub(crate) fn integer_indexed_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -160,7 +156,6 @@ pub(crate) fn integer_indexed_exotic_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-set-p-v-receiver
-
 pub(crate) fn integer_indexed_exotic_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -189,7 +184,6 @@ pub(crate) fn integer_indexed_exotic_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-delete-p
-
 pub(crate) fn integer_indexed_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -213,7 +207,6 @@ pub(crate) fn integer_indexed_exotic_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integer-indexed-exotic-objects-ownpropertykeys
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn integer_indexed_exotic_own_property_keys(
     obj: &JsObject,

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -33,7 +33,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
-
     #[track_caller]
     pub(crate) fn __get_prototype_of__(&self, context: &mut Context) -> JsResult<JsPrototype> {
         let _timer = Profiler::global().start_event("Object::__get_prototype_of__", "object");
@@ -49,7 +48,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v
-
     pub(crate) fn __set_prototype_of__(
         &self,
         val: JsPrototype,
@@ -68,7 +66,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-
     pub(crate) fn __is_extensible__(&self, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__is_extensible__", "object");
         let func = self.borrow().data.internal_methods.__is_extensible__;
@@ -83,7 +80,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-
     pub(crate) fn __prevent_extensions__(&self, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__prevent_extensions__", "object");
         let func = self.borrow().data.internal_methods.__prevent_extensions__;
@@ -98,7 +94,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
-
     pub(crate) fn __get_own_property__(
         &self,
         key: &PropertyKey,
@@ -117,7 +112,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-
     pub(crate) fn __define_own_property__(
         &self,
         key: PropertyKey,
@@ -137,7 +131,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
-
     pub(crate) fn __has_property__(
         &self,
         key: &PropertyKey,
@@ -156,7 +149,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-
     pub(crate) fn __get__(
         &self,
         key: &PropertyKey,
@@ -176,7 +168,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver
-
     pub(crate) fn __set__(
         &self,
         key: PropertyKey,
@@ -197,7 +188,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p
-
     pub(crate) fn __delete__(&self, key: &PropertyKey, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__delete__", "object");
         let func = self.borrow().data.internal_methods.__delete__;
@@ -212,7 +202,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
-
     #[track_caller]
     pub(crate) fn __own_property_keys__(
         &self,
@@ -231,7 +220,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
-
     #[track_caller]
     pub(crate) fn __call__(
         &self,
@@ -254,7 +242,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
-
     #[track_caller]
     pub(crate) fn __construct__(
         &self,
@@ -333,7 +320,6 @@ pub(crate) struct InternalObjectMethods {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_prototype_of(
     obj: &JsObject,
@@ -351,7 +337,6 @@ pub(crate) fn ordinary_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarysetprototypeof
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_set_prototype_of(
     obj: &JsObject,
@@ -411,7 +396,6 @@ pub(crate) fn ordinary_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
@@ -424,7 +408,6 @@ pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_prevent_extensions(
     obj: &JsObject,
@@ -443,7 +426,6 @@ pub(crate) fn ordinary_prevent_extensions(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetownproperty
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_own_property(
     obj: &JsObject,
@@ -474,7 +456,6 @@ pub(crate) fn ordinary_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydefineownproperty
-
 pub(crate) fn ordinary_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -503,7 +484,6 @@ pub(crate) fn ordinary_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryhasproperty
-
 pub(crate) fn ordinary_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -533,7 +513,6 @@ pub(crate) fn ordinary_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryget
-
 pub(crate) fn ordinary_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -579,7 +558,6 @@ pub(crate) fn ordinary_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryset
-
 pub(crate) fn ordinary_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -682,7 +660,6 @@ pub(crate) fn ordinary_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-
 pub(crate) fn ordinary_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -714,7 +691,6 @@ pub(crate) fn ordinary_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_own_property_keys(
     obj: &JsObject,
@@ -764,7 +740,6 @@ pub(crate) fn ordinary_own_property_keys(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor
-
 pub(crate) fn is_compatible_property_descriptor(
     extensible: bool,
     desc: PropertyDescriptor,
@@ -783,7 +758,6 @@ pub(crate) fn is_compatible_property_descriptor(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
-
 pub(crate) fn validate_and_apply_property_descriptor(
     obj_and_key: Option<(&JsObject, PropertyKey)>,
     extensible: bool,
@@ -935,7 +909,6 @@ pub(crate) fn validate_and_apply_property_descriptor(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-getprototypefromconstructor
-
 #[track_caller]
 pub(crate) fn get_prototype_from_constructor<F>(
     constructor: &JsValue,

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -33,7 +33,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
-    #[inline]
+
     #[track_caller]
     pub(crate) fn __get_prototype_of__(&self, context: &mut Context) -> JsResult<JsPrototype> {
         let _timer = Profiler::global().start_event("Object::__get_prototype_of__", "object");
@@ -49,7 +49,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-setprototypeof-v
-    #[inline]
+
     pub(crate) fn __set_prototype_of__(
         &self,
         val: JsPrototype,
@@ -68,7 +68,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-    #[inline]
+
     pub(crate) fn __is_extensible__(&self, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__is_extensible__", "object");
         let func = self.borrow().data.internal_methods.__is_extensible__;
@@ -83,7 +83,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-    #[inline]
+
     pub(crate) fn __prevent_extensions__(&self, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__prevent_extensions__", "object");
         let func = self.borrow().data.internal_methods.__prevent_extensions__;
@@ -98,7 +98,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getownproperty-p
-    #[inline]
+
     pub(crate) fn __get_own_property__(
         &self,
         key: &PropertyKey,
@@ -117,7 +117,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-    #[inline]
+
     pub(crate) fn __define_own_property__(
         &self,
         key: PropertyKey,
@@ -137,7 +137,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-hasproperty-p
-    #[inline]
+
     pub(crate) fn __has_property__(
         &self,
         key: &PropertyKey,
@@ -156,7 +156,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-get-p-receiver
-    #[inline]
+
     pub(crate) fn __get__(
         &self,
         key: &PropertyKey,
@@ -176,7 +176,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-set-p-v-receiver
-    #[inline]
+
     pub(crate) fn __set__(
         &self,
         key: PropertyKey,
@@ -197,7 +197,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p
-    #[inline]
+
     pub(crate) fn __delete__(&self, key: &PropertyKey, context: &mut Context) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__delete__", "object");
         let func = self.borrow().data.internal_methods.__delete__;
@@ -212,7 +212,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-ownpropertykeys
-    #[inline]
+
     #[track_caller]
     pub(crate) fn __own_property_keys__(
         &self,
@@ -231,7 +231,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
-    #[inline]
+
     #[track_caller]
     pub(crate) fn __call__(
         &self,
@@ -254,7 +254,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ecmascript-function-objects-construct-argumentslist-newtarget
-    #[inline]
+
     #[track_caller]
     pub(crate) fn __construct__(
         &self,
@@ -333,7 +333,7 @@ pub(crate) struct InternalObjectMethods {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetprototypeof
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_prototype_of(
     obj: &JsObject,
@@ -351,7 +351,7 @@ pub(crate) fn ordinary_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarysetprototypeof
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_set_prototype_of(
     obj: &JsObject,
@@ -411,7 +411,7 @@ pub(crate) fn ordinary_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
@@ -424,7 +424,7 @@ pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_prevent_extensions(
     obj: &JsObject,
@@ -443,7 +443,7 @@ pub(crate) fn ordinary_prevent_extensions(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarygetownproperty
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_own_property(
     obj: &JsObject,
@@ -474,7 +474,7 @@ pub(crate) fn ordinary_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydefineownproperty
-#[inline]
+
 pub(crate) fn ordinary_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -503,7 +503,7 @@ pub(crate) fn ordinary_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryhasproperty
-#[inline]
+
 pub(crate) fn ordinary_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -533,7 +533,7 @@ pub(crate) fn ordinary_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryget
-#[inline]
+
 pub(crate) fn ordinary_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -579,7 +579,7 @@ pub(crate) fn ordinary_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryset
-#[inline]
+
 pub(crate) fn ordinary_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -682,7 +682,7 @@ pub(crate) fn ordinary_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarydelete
-#[inline]
+
 pub(crate) fn ordinary_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -714,7 +714,7 @@ pub(crate) fn ordinary_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryownpropertykeys
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_own_property_keys(
     obj: &JsObject,
@@ -764,7 +764,7 @@ pub(crate) fn ordinary_own_property_keys(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-iscompatiblepropertydescriptor
-#[inline]
+
 pub(crate) fn is_compatible_property_descriptor(
     extensible: bool,
     desc: PropertyDescriptor,
@@ -783,7 +783,7 @@ pub(crate) fn is_compatible_property_descriptor(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-validateandapplypropertydescriptor
-#[inline]
+
 pub(crate) fn validate_and_apply_property_descriptor(
     obj_and_key: Option<(&JsObject, PropertyKey)>,
     extensible: bool,
@@ -935,7 +935,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-getprototypefromconstructor
-#[inline]
+
 #[track_caller]
 pub(crate) fn get_prototype_from_constructor<F>(
     constructor: &JsValue,

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -111,7 +111,7 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v
-#[inline]
+
 pub(crate) fn proxy_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
@@ -176,7 +176,7 @@ pub(crate) fn proxy_exotic_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible
-#[inline]
+
 pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -220,7 +220,7 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions
-#[inline]
+
 pub(crate) fn proxy_exotic_prevent_extensions(
     obj: &JsObject,
     context: &mut Context,
@@ -266,7 +266,7 @@ pub(crate) fn proxy_exotic_prevent_extensions(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
-#[inline]
+
 pub(crate) fn proxy_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -390,7 +390,7 @@ pub(crate) fn proxy_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-#[inline]
+
 pub(crate) fn proxy_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -503,7 +503,7 @@ pub(crate) fn proxy_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p
-#[inline]
+
 pub(crate) fn proxy_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -569,7 +569,7 @@ pub(crate) fn proxy_exotic_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-#[inline]
+
 pub(crate) fn proxy_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -638,7 +638,7 @@ pub(crate) fn proxy_exotic_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
-#[inline]
+
 pub(crate) fn proxy_exotic_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -722,7 +722,7 @@ pub(crate) fn proxy_exotic_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p
-#[inline]
+
 pub(crate) fn proxy_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -790,7 +790,7 @@ pub(crate) fn proxy_exotic_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
-#[inline]
+
 pub(crate) fn proxy_exotic_own_property_keys(
     obj: &JsObject,
     context: &mut Context,

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -111,7 +111,6 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-setprototypeof-v
-
 pub(crate) fn proxy_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
@@ -176,7 +175,6 @@ pub(crate) fn proxy_exotic_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible
-
 pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -220,7 +218,6 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions
-
 pub(crate) fn proxy_exotic_prevent_extensions(
     obj: &JsObject,
     context: &mut Context,
@@ -266,7 +263,6 @@ pub(crate) fn proxy_exotic_prevent_extensions(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getownproperty-p
-
 pub(crate) fn proxy_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -390,7 +386,6 @@ pub(crate) fn proxy_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-defineownproperty-p-desc
-
 pub(crate) fn proxy_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -503,7 +498,6 @@ pub(crate) fn proxy_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-hasproperty-p
-
 pub(crate) fn proxy_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -569,7 +563,6 @@ pub(crate) fn proxy_exotic_has_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-get-p-receiver
-
 pub(crate) fn proxy_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
@@ -638,7 +631,6 @@ pub(crate) fn proxy_exotic_get(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-set-p-v-receiver
-
 pub(crate) fn proxy_exotic_set(
     obj: &JsObject,
     key: PropertyKey,
@@ -722,7 +714,6 @@ pub(crate) fn proxy_exotic_set(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-delete-p
-
 pub(crate) fn proxy_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
@@ -790,7 +781,6 @@ pub(crate) fn proxy_exotic_delete(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
-
 pub(crate) fn proxy_exotic_own_property_keys(
     obj: &JsObject,
     context: &mut Context,

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -26,7 +26,6 @@ pub(crate) static STRING_EXOTIC_INTERNAL_METHODS: InternalObjectMethods = Intern
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p
-
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -51,7 +50,6 @@ pub(crate) fn string_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc
-
 pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -84,7 +82,6 @@ pub(crate) fn string_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys
-
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn string_exotic_own_property_keys(
     obj: &JsObject,
@@ -149,7 +146,6 @@ pub(crate) fn string_exotic_own_property_keys(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-stringgetownproperty
 #[allow(clippy::float_cmp)]
-
 fn string_get_own_property(obj: &JsObject, key: &PropertyKey) -> Option<PropertyDescriptor> {
     // 1. Assert: S is an Object that has a [[StringData]] internal slot.
     // 2. Assert: IsPropertyKey(P) is true.

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -26,7 +26,7 @@ pub(crate) static STRING_EXOTIC_INTERNAL_METHODS: InternalObjectMethods = Intern
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-getownproperty-p
-#[inline]
+
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
@@ -51,7 +51,7 @@ pub(crate) fn string_exotic_get_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-defineownproperty-p-desc
-#[inline]
+
 pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
@@ -84,7 +84,7 @@ pub(crate) fn string_exotic_define_own_property(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-string-exotic-objects-ownpropertykeys
-#[inline]
+
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn string_exotic_own_property_keys(
     obj: &JsObject,
@@ -149,7 +149,7 @@ pub(crate) fn string_exotic_own_property_keys(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-stringgetownproperty
 #[allow(clippy::float_cmp)]
-#[inline]
+
 fn string_get_own_property(obj: &JsObject, key: &PropertyKey) -> Option<PropertyDescriptor> {
     // 1. Assert: S is an Object that has a [[StringData]] internal slot.
     // 2. Assert: IsPropertyKey(P) is true.

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -34,7 +34,7 @@ pub struct JsObject {
 
 impl JsObject {
     /// Create a new `JsObject` from an internal `Object`.
-    #[inline]
+
     fn from_object(object: Object) -> Self {
         Self {
             inner: Gc::new(GcCell::new(object)),
@@ -52,7 +52,7 @@ impl JsObject {
     ///
     /// Create a `JsObject` and automatically set its internal methods and
     /// internal slots from the `data` provided.
-    #[inline]
+
     pub fn from_proto_and_data<O: Into<Option<Self>>>(prototype: O, data: ObjectData) -> Self {
         Self::from_object(Object {
             data,
@@ -198,7 +198,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-    #[inline]
+
     #[track_caller]
     pub fn is<T>(&self) -> bool
     where
@@ -213,7 +213,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-    #[inline]
+
     #[track_caller]
     pub fn downcast_ref<T>(&self) -> Option<Ref<'_, T>>
     where
@@ -235,7 +235,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently borrowed.
-    #[inline]
+
     #[track_caller]
     pub fn downcast_mut<T>(&mut self) -> Option<RefMut<'_, Object, T>>
     where
@@ -268,7 +268,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-    #[inline]
+
     pub(crate) fn extensible(&self) -> bool {
         self.borrow().extensible
     }
@@ -607,7 +607,7 @@ Cannot both specify accessors and a value or writable attribute",
     ///  - [ECMAScript][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-copydataproperties
-    #[inline]
+
     pub fn copy_data_properties<K>(
         &self,
         source: &JsValue,
@@ -672,7 +672,6 @@ Cannot both specify accessors and a value or writable attribute",
         Ok(())
     }
 
-    #[inline]
     pub(crate) fn get_property(&self, key: &PropertyKey) -> Option<PropertyDescriptor> {
         let mut obj = Some(self.clone());
 
@@ -686,7 +685,7 @@ Cannot both specify accessors and a value or writable attribute",
     }
 
     /// Helper function for property insertion.
-    #[inline]
+
     #[track_caller]
     pub(crate) fn insert<K, P>(&self, key: K, property: P) -> Option<PropertyDescriptor>
     where
@@ -700,7 +699,7 @@ Cannot both specify accessors and a value or writable attribute",
     ///
     /// If a field was already in the object with the same name that a `Some` is returned
     /// with that field, otherwise None is returned.
-    #[inline]
+
     pub fn insert_property<K, P>(&self, key: K, property: P) -> Option<PropertyDescriptor>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -34,7 +34,6 @@ pub struct JsObject {
 
 impl JsObject {
     /// Create a new `JsObject` from an internal `Object`.
-
     fn from_object(object: Object) -> Self {
         Self {
             inner: Gc::new(GcCell::new(object)),
@@ -52,7 +51,6 @@ impl JsObject {
     ///
     /// Create a `JsObject` and automatically set its internal methods and
     /// internal slots from the `data` provided.
-
     pub fn from_proto_and_data<O: Into<Option<Self>>>(prototype: O, data: ObjectData) -> Self {
         Self::from_object(Object {
             data,
@@ -198,7 +196,6 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-
     #[track_caller]
     pub fn is<T>(&self) -> bool
     where
@@ -213,7 +210,6 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-
     #[track_caller]
     pub fn downcast_ref<T>(&self) -> Option<Ref<'_, T>>
     where
@@ -235,7 +231,6 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently borrowed.
-
     #[track_caller]
     pub fn downcast_mut<T>(&mut self) -> Option<RefMut<'_, Object, T>>
     where
@@ -268,7 +263,6 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-
     pub(crate) fn extensible(&self) -> bool {
         self.borrow().extensible
     }
@@ -607,7 +601,6 @@ Cannot both specify accessors and a value or writable attribute",
     ///  - [ECMAScript][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-copydataproperties
-
     pub fn copy_data_properties<K>(
         &self,
         source: &JsValue,
@@ -685,7 +678,6 @@ Cannot both specify accessors and a value or writable attribute",
     }
 
     /// Helper function for property insertion.
-
     #[track_caller]
     pub(crate) fn insert<K, P>(&self, key: K, property: P) -> Option<PropertyDescriptor>
     where
@@ -699,7 +691,6 @@ Cannot both specify accessors and a value or writable attribute",
     ///
     /// If a field was already in the object with the same name that a `Some` is returned
     /// with that field, otherwise None is returned.
-
     pub fn insert_property<K, P>(&self, key: K, property: P) -> Option<PropertyDescriptor>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1499,7 +1499,6 @@ impl Object {
     /// [More information][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods
-
     #[track_caller]
     pub fn set_prototype<O: Into<JsPrototype>>(&mut self, prototype: O) -> bool {
         let prototype = prototype.into();
@@ -1586,7 +1585,6 @@ impl Object {
     }
 
     /// Return `true` if it is a native object and the native type is `T`.
-
     pub fn is<T>(&self) -> bool
     where
         T: NativeObject,
@@ -1602,7 +1600,6 @@ impl Object {
 
     /// Downcast a reference to the object,
     /// if the object is type native object type `T`.
-
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
         T: NativeObject,
@@ -1618,7 +1615,6 @@ impl Object {
 
     /// Downcast a mutable reference to the object,
     /// if the object is type native object type `T`.
-
     pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
     where
         T: NativeObject,
@@ -1647,7 +1643,6 @@ impl Object {
     ///
     /// If a field was already in the object with the same name, then a `Some` is returned
     /// with that field's value, otherwise, `None` is returned.
-
     pub(crate) fn insert<K, P>(&mut self, key: K, property: P) -> Option<PropertyDescriptor>
     where
         K: Into<PropertyKey>,
@@ -1675,7 +1670,6 @@ impl Object {
     }
 
     /// Set a private setter.
-
     pub(crate) fn set_private_element_setter(&mut self, name: Sym, setter: JsObject) {
         match self.private_elements.get_mut(&name) {
             Some(PrivateElement::Accessor {
@@ -1697,7 +1691,6 @@ impl Object {
     }
 
     /// Set a private getter.
-
     pub(crate) fn set_private_element_getter(&mut self, name: Sym, getter: JsObject) {
         match self.private_elements.get_mut(&name) {
             Some(PrivateElement::Accessor {
@@ -1810,7 +1803,6 @@ impl<'context> FunctionBuilder<'context> {
     }
 
     /// Create a new `FunctionBuilder` for creating a closure function.
-
     pub fn closure<F>(context: &'context mut Context, function: F) -> Self
     where
         F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
@@ -1833,7 +1825,6 @@ impl<'context> FunctionBuilder<'context> {
     ///
     /// You can only move variables that implement `Debug + Any + Trace + Clone`.
     /// In other words, only `NativeObject + Clone` objects are movable.
-
     pub fn closure_with_captures<F, C>(
         context: &'context mut Context,
         function: F,
@@ -1865,7 +1856,6 @@ impl<'context> FunctionBuilder<'context> {
     /// Specify the name property of object function object.
     ///
     /// The default is `""` (empty string).
-
     #[must_use]
     pub fn name<N>(mut self, name: N) -> Self
     where
@@ -1890,7 +1880,6 @@ impl<'context> FunctionBuilder<'context> {
     /// Specify whether the object function object can be called with `new` keyword.
     ///
     /// The default is `false`.
-
     #[must_use]
     pub fn constructor(mut self, yes: bool) -> Self {
         match self.function {
@@ -1915,7 +1904,6 @@ impl<'context> FunctionBuilder<'context> {
     }
 
     /// Build the function object.
-
     pub fn build(self) -> JsFunction {
         let function = JsObject::from_proto_and_data(
             self.context
@@ -1993,7 +1981,6 @@ impl<'context> ObjectInitializer<'context> {
     }
 
     /// Add a function to the object.
-
     pub fn function<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2022,7 +2009,6 @@ impl<'context> ObjectInitializer<'context> {
     }
 
     /// Add a property to the object.
-
     pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2114,7 +2100,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new method to the constructors prototype.
-
     pub fn method<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2143,7 +2128,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static method to the constructors object itself.
-
     pub fn static_method<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2172,7 +2156,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new data property to the constructor's prototype.
-
     pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2188,7 +2171,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static data property to the constructor object itself.
-
     pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2204,7 +2186,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new accessor property to the constructor's prototype.
-
     pub fn accessor<K>(
         &mut self,
         key: K,
@@ -2225,7 +2206,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static accessor property to the constructor object itself.
-
     pub fn static_accessor<K>(
         &mut self,
         key: K,
@@ -2246,7 +2226,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new property to the constructor's prototype.
-
     pub fn property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2258,7 +2237,6 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static property to the constructor object itself.
-
     pub fn static_property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2281,7 +2259,6 @@ impl<'context> ConstructorBuilder<'context> {
     /// Specify the name of the constructor function.
     ///
     /// Default is `"[object]"`
-
     pub fn name<N>(&mut self, name: N) -> &mut Self
     where
         N: AsRef<str>,
@@ -2312,7 +2289,6 @@ impl<'context> ConstructorBuilder<'context> {
     /// inherit from.
     ///
     /// Default is `Object.prototype`
-
     pub fn inherit<O: Into<JsPrototype>>(&mut self, prototype: O) -> &mut Self {
         self.inherit = Some(prototype.into());
         self
@@ -2321,7 +2297,6 @@ impl<'context> ConstructorBuilder<'context> {
     /// Specify the `[[Prototype]]` internal field of this constructor.
     ///
     /// Default is `Function.prototype`
-
     pub fn custom_prototype<O: Into<JsPrototype>>(&mut self, prototype: O) -> &mut Self {
         self.custom_prototype = Some(prototype.into());
         self

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -104,12 +104,10 @@ pub trait NativeObject: Debug + Any + Trace {
 }
 
 impl<T: Any + Debug + Trace> NativeObject for T {
-    #[inline]
     fn as_any(&self) -> &dyn Any {
         self
     }
 
-    #[inline]
     fn as_mut_any(&mut self) -> &mut dyn Any {
         self
     }
@@ -1501,7 +1499,7 @@ impl Object {
     /// [More information][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invariants-of-the-essential-internal-methods
-    #[inline]
+
     #[track_caller]
     pub fn set_prototype<O: Into<JsPrototype>>(&mut self, prototype: O) -> bool {
         let prototype = prototype.into();
@@ -1588,7 +1586,7 @@ impl Object {
     }
 
     /// Return `true` if it is a native object and the native type is `T`.
-    #[inline]
+
     pub fn is<T>(&self) -> bool
     where
         T: NativeObject,
@@ -1604,7 +1602,7 @@ impl Object {
 
     /// Downcast a reference to the object,
     /// if the object is type native object type `T`.
-    #[inline]
+
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
         T: NativeObject,
@@ -1620,7 +1618,7 @@ impl Object {
 
     /// Downcast a mutable reference to the object,
     /// if the object is type native object type `T`.
-    #[inline]
+
     pub fn downcast_mut<T>(&mut self) -> Option<&mut T>
     where
         T: NativeObject,
@@ -1649,7 +1647,7 @@ impl Object {
     ///
     /// If a field was already in the object with the same name, then a `Some` is returned
     /// with that field's value, otherwise, `None` is returned.
-    #[inline]
+
     pub(crate) fn insert<K, P>(&mut self, key: K, property: P) -> Option<PropertyDescriptor>
     where
         K: Into<PropertyKey>,
@@ -1677,7 +1675,7 @@ impl Object {
     }
 
     /// Set a private setter.
-    #[inline]
+
     pub(crate) fn set_private_element_setter(&mut self, name: Sym, setter: JsObject) {
         match self.private_elements.get_mut(&name) {
             Some(PrivateElement::Accessor {
@@ -1699,7 +1697,7 @@ impl Object {
     }
 
     /// Set a private getter.
-    #[inline]
+
     pub(crate) fn set_private_element_getter(&mut self, name: Sym, getter: JsObject) {
         match self.private_elements.get_mut(&name) {
             Some(PrivateElement::Accessor {
@@ -1779,7 +1777,6 @@ where
     B: Into<PropertyKey>,
     N: AsRef<str>,
 {
-    #[inline]
     fn from((binding, name): (B, N)) -> Self {
         Self {
             binding: binding.into(),
@@ -1813,7 +1810,7 @@ impl<'context> FunctionBuilder<'context> {
     }
 
     /// Create a new `FunctionBuilder` for creating a closure function.
-    #[inline]
+
     pub fn closure<F>(context: &'context mut Context, function: F) -> Self
     where
         F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
@@ -1836,7 +1833,7 @@ impl<'context> FunctionBuilder<'context> {
     ///
     /// You can only move variables that implement `Debug + Any + Trace + Clone`.
     /// In other words, only `NativeObject + Clone` objects are movable.
-    #[inline]
+
     pub fn closure_with_captures<F, C>(
         context: &'context mut Context,
         function: F,
@@ -1868,7 +1865,7 @@ impl<'context> FunctionBuilder<'context> {
     /// Specify the name property of object function object.
     ///
     /// The default is `""` (empty string).
-    #[inline]
+
     #[must_use]
     pub fn name<N>(mut self, name: N) -> Self
     where
@@ -1893,7 +1890,7 @@ impl<'context> FunctionBuilder<'context> {
     /// Specify whether the object function object can be called with `new` keyword.
     ///
     /// The default is `false`.
-    #[inline]
+
     #[must_use]
     pub fn constructor(mut self, yes: bool) -> Self {
         match self.function {
@@ -1918,7 +1915,7 @@ impl<'context> FunctionBuilder<'context> {
     }
 
     /// Build the function object.
-    #[inline]
+
     pub fn build(self) -> JsFunction {
         let function = JsObject::from_proto_and_data(
             self.context
@@ -1996,7 +1993,7 @@ impl<'context> ObjectInitializer<'context> {
     }
 
     /// Add a function to the object.
-    #[inline]
+
     pub fn function<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2025,7 +2022,7 @@ impl<'context> ObjectInitializer<'context> {
     }
 
     /// Add a property to the object.
-    #[inline]
+
     pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2096,7 +2093,6 @@ impl<'context> ConstructorBuilder<'context> {
         }
     }
 
-    #[inline]
     pub(crate) fn with_standard_constructor(
         context: &'context mut Context,
         function: NativeFunctionSignature,
@@ -2118,7 +2114,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new method to the constructors prototype.
-    #[inline]
+
     pub fn method<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2147,7 +2143,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static method to the constructors object itself.
-    #[inline]
+
     pub fn static_method<B>(
         &mut self,
         function: NativeFunctionSignature,
@@ -2176,7 +2172,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new data property to the constructor's prototype.
-    #[inline]
+
     pub fn property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2192,7 +2188,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static data property to the constructor object itself.
-    #[inline]
+
     pub fn static_property<K, V>(&mut self, key: K, value: V, attribute: Attribute) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2208,7 +2204,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new accessor property to the constructor's prototype.
-    #[inline]
+
     pub fn accessor<K>(
         &mut self,
         key: K,
@@ -2229,7 +2225,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static accessor property to the constructor object itself.
-    #[inline]
+
     pub fn static_accessor<K>(
         &mut self,
         key: K,
@@ -2250,7 +2246,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new property to the constructor's prototype.
-    #[inline]
+
     pub fn property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2262,7 +2258,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     /// Add new static property to the constructor object itself.
-    #[inline]
+
     pub fn static_property_descriptor<K, P>(&mut self, key: K, property: P) -> &mut Self
     where
         K: Into<PropertyKey>,
@@ -2285,7 +2281,7 @@ impl<'context> ConstructorBuilder<'context> {
     /// Specify the name of the constructor function.
     ///
     /// Default is `"[object]"`
-    #[inline]
+
     pub fn name<N>(&mut self, name: N) -> &mut Self
     where
         N: AsRef<str>,
@@ -2316,7 +2312,7 @@ impl<'context> ConstructorBuilder<'context> {
     /// inherit from.
     ///
     /// Default is `Object.prototype`
-    #[inline]
+
     pub fn inherit<O: Into<JsPrototype>>(&mut self, prototype: O) -> &mut Self {
         self.inherit = Some(prototype.into());
         self
@@ -2325,7 +2321,7 @@ impl<'context> ConstructorBuilder<'context> {
     /// Specify the `[[Prototype]]` internal field of this constructor.
     ///
     /// Default is `Function.prototype`
-    #[inline]
+
     pub fn custom_prototype<O: Into<JsPrototype>>(&mut self, prototype: O) -> &mut Self {
         self.custom_prototype = Some(prototype.into());
         self

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -63,7 +63,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-o-p
-    #[inline]
+
     pub fn get<K>(&self, key: K, context: &mut Context) -> JsResult<JsValue>
     where
         K: Into<PropertyKey>,
@@ -80,7 +80,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set-o-p-v-throw
-    #[inline]
+
     pub fn set<K, V>(&self, key: K, value: V, throw: bool, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -206,7 +206,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-definepropertyorthrow
-    #[inline]
+
     pub fn define_property_or_throw<K, P>(
         &self,
         key: K,
@@ -238,7 +238,7 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
-    #[inline]
+
     pub fn delete_property_or_throw<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -264,7 +264,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasproperty
-    #[inline]
+
     pub fn has_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -281,7 +281,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasownproperty
-    #[inline]
+
     pub fn has_own_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -353,7 +353,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-setintegritylevel
-    #[inline]
+
     pub fn set_integrity_level(
         &self,
         level: IntegrityLevel,
@@ -423,7 +423,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-testintegritylevel
-    #[inline]
+
     pub fn test_integrity_level(
         &self,
         level: IntegrityLevel,
@@ -467,7 +467,6 @@ impl JsObject {
         Ok(true)
     }
 
-    #[inline]
     pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<u64> {
         // 1. Assert: Type(obj) is Object.
         // 2. Return ℝ(? ToLength(? Get(obj, "length"))).
@@ -680,7 +679,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getv
-    #[inline]
+
     pub(crate) fn get_v<K>(&self, key: K, context: &mut Context) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
@@ -700,7 +699,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getmethod
-    #[inline]
+
     pub(crate) fn get_method<K>(&self, key: K, context: &mut Context) -> JsResult<Option<JsObject>>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -63,7 +63,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-o-p
-
     pub fn get<K>(&self, key: K, context: &mut Context) -> JsResult<JsValue>
     where
         K: Into<PropertyKey>,
@@ -80,7 +79,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set-o-p-v-throw
-
     pub fn set<K, V>(&self, key: K, value: V, throw: bool, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -206,7 +204,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-definepropertyorthrow
-
     pub fn define_property_or_throw<K, P>(
         &self,
         key: K,
@@ -238,7 +235,6 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
-
     pub fn delete_property_or_throw<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -264,7 +260,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasproperty
-
     pub fn has_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -281,7 +276,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasownproperty
-
     pub fn has_own_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -353,7 +347,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-setintegritylevel
-
     pub fn set_integrity_level(
         &self,
         level: IntegrityLevel,
@@ -423,7 +416,6 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-testintegritylevel
-
     pub fn test_integrity_level(
         &self,
         level: IntegrityLevel,
@@ -679,7 +671,6 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getv
-
     pub(crate) fn get_v<K>(&self, key: K, context: &mut Context) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
@@ -699,7 +690,6 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getmethod
-
     pub(crate) fn get_method<K>(&self, key: K, context: &mut Context) -> JsResult<Option<JsObject>>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/property_map.rs
+++ b/boa_engine/src/object/property_map.rs
@@ -63,7 +63,6 @@ impl Default for IndexedProperties {
 
 impl IndexedProperties {
     /// Get a property descriptor if it exists.
-
     fn get(&self, key: u32) -> Option<PropertyDescriptor> {
         match self {
             Self::Sparse(ref map) => map.get(&key).cloned(),
@@ -79,7 +78,6 @@ impl IndexedProperties {
     }
 
     /// Helper function for converting from a dense storage type to sparse storage type.
-
     fn convert_dense_to_sparse(vec: &mut Vec<JsValue>) -> FxHashMap<u32, PropertyDescriptor> {
         let data = std::mem::take(vec);
 
@@ -100,7 +98,6 @@ impl IndexedProperties {
     }
 
     /// Inserts a property descriptor with the specified key.
-
     fn insert(&mut self, key: u32, property: PropertyDescriptor) -> Option<PropertyDescriptor> {
         let vec = match self {
             Self::Sparse(map) => return map.insert(key, property),
@@ -152,7 +149,6 @@ impl IndexedProperties {
     }
 
     /// Inserts a property descriptor with the specified key.
-
     fn remove(&mut self, key: u32) -> Option<PropertyDescriptor> {
         let vec = match self {
             Self::Sparse(map) => return map.remove(&key),

--- a/boa_engine/src/object/property_map.rs
+++ b/boa_engine/src/object/property_map.rs
@@ -63,7 +63,7 @@ impl Default for IndexedProperties {
 
 impl IndexedProperties {
     /// Get a property descriptor if it exists.
-    #[inline]
+
     fn get(&self, key: u32) -> Option<PropertyDescriptor> {
         match self {
             Self::Sparse(ref map) => map.get(&key).cloned(),
@@ -79,7 +79,7 @@ impl IndexedProperties {
     }
 
     /// Helper function for converting from a dense storage type to sparse storage type.
-    #[inline]
+
     fn convert_dense_to_sparse(vec: &mut Vec<JsValue>) -> FxHashMap<u32, PropertyDescriptor> {
         let data = std::mem::take(vec);
 
@@ -100,7 +100,7 @@ impl IndexedProperties {
     }
 
     /// Inserts a property descriptor with the specified key.
-    #[inline]
+
     fn insert(&mut self, key: u32, property: PropertyDescriptor) -> Option<PropertyDescriptor> {
         let vec = match self {
             Self::Sparse(map) => return map.insert(key, property),
@@ -152,7 +152,7 @@ impl IndexedProperties {
     }
 
     /// Inserts a property descriptor with the specified key.
-    #[inline]
+
     fn remove(&mut self, key: u32) -> Option<PropertyDescriptor> {
         let vec = match self {
             Self::Sparse(map) => return map.remove(&key),
@@ -418,12 +418,10 @@ impl PropertyMap {
         }
     }
 
-    #[inline]
     pub(crate) const fn string_property_map(&self) -> &GlobalPropertyMap {
         &self.string_properties.0
     }
 
-    #[inline]
     pub(crate) fn string_property_map_mut(&mut self) -> &mut GlobalPropertyMap {
         &mut self.string_properties.0
     }
@@ -596,7 +594,6 @@ pub enum IndexProperties<'a> {
 impl Iterator for IndexProperties<'_> {
     type Item = (u32, PropertyDescriptor);
 
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Dense(vec) => vec.next().map(|(index, value)| {
@@ -690,7 +687,6 @@ pub enum IndexPropertyValues<'a> {
 impl Iterator for IndexPropertyValues<'_> {
     type Item = PropertyDescriptor;
 
-    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             Self::Dense(vec) => vec.next().map(|value| {

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -48,18 +48,15 @@ impl Realm {
         }
     }
 
-    #[inline]
     pub(crate) const fn global_object(&self) -> &JsObject {
         &self.global_object
     }
 
-    #[inline]
     pub(crate) fn global_bindings_mut(&mut self) -> &mut GlobalPropertyMap {
         self.global_property_map.string_property_map_mut()
     }
 
     /// Set the number of bindings on the global environment.
-    #[inline]
     pub(crate) fn set_global_binding_number(&mut self) {
         let binding_number = self.compile_env.borrow().num_bindings();
         self.environments.set_global_binding_number(binding_number);

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -215,7 +215,7 @@ impl TaggedJsString {
     ///
     /// `inner` must point to a valid instance of [`RawJsString`], which should be deallocated only
     /// by [`JsString`].
-    #[inline]
+
     const unsafe fn new_heap(inner: NonNull<RawJsString>) -> Self {
         Self(inner)
     }
@@ -226,7 +226,7 @@ impl TaggedJsString {
     /// # Safety
     ///
     /// `idx` must be a valid index on [`COMMON_STRINGS`].
-    #[inline]
+
     const unsafe fn new_static(idx: usize) -> Self {
         // SAFETY:
         // The operation `(idx << 1) | 1` sets the least significant bit to 1, meaning any pointer
@@ -235,7 +235,7 @@ impl TaggedJsString {
     }
 
     /// Checks if [`TaggedJsString`] contains an index for [`COMMON_STRINGS`].
-    #[inline]
+
     fn is_static(self) -> bool {
         (self.0.as_ptr() as usize) & 1 == 1
     }
@@ -246,7 +246,7 @@ impl TaggedJsString {
     /// # Safety
     ///
     /// `self` must be a heap allocated [`RawJsString`].
-    #[inline]
+
     const unsafe fn get_heap_unchecked(self) -> NonNull<RawJsString> {
         self.0
     }
@@ -258,7 +258,7 @@ impl TaggedJsString {
     ///
     /// `self` must not be a pointer to a heap allocated [`RawJsString`], and it must be a valid
     /// index inside [`COMMON_STRINGS`].
-    #[inline]
+
     unsafe fn get_static_unchecked(self) -> &'static [u16] {
         // SAFETY:
         // The caller must ensure `self` is a valid index inside `COMMON_STRINGS`.
@@ -546,7 +546,7 @@ impl JsString {
 
     /// Returns the inner pointer data, unwrapping its tagged data if the pointer contains a static
     /// index for [`COMMON_STRINGS`].
-    #[inline]
+
     fn ptr(&self) -> JsStringPtrKind {
         // Check the first bit to 1.
         if self.ptr.is_static() {
@@ -693,7 +693,6 @@ impl Default for JsString {
 }
 
 impl Drop for JsString {
-    #[inline]
     fn drop(&mut self) {
         if let JsStringPtrKind::Heap(raw) = self.ptr() {
             // SAFETY: The reference count of `JsString` guarantees that `raw` is always valid.
@@ -799,7 +798,6 @@ impl From<String> for JsString {
 }
 
 impl<const N: usize> From<&[u16; N]> for JsString {
-    #[inline]
     fn from(s: &[u16; N]) -> Self {
         Self::from(&s[..])
     }
@@ -953,7 +951,7 @@ mod tests {
 
     impl JsString {
         /// Gets the number of `JsString`s which point to this allocation.
-        #[inline]
+
         fn refcount(&self) -> Option<usize> {
             match self.ptr() {
                 JsStringPtrKind::Heap(inner) => {

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -215,7 +215,6 @@ impl TaggedJsString {
     ///
     /// `inner` must point to a valid instance of [`RawJsString`], which should be deallocated only
     /// by [`JsString`].
-
     const unsafe fn new_heap(inner: NonNull<RawJsString>) -> Self {
         Self(inner)
     }
@@ -226,7 +225,6 @@ impl TaggedJsString {
     /// # Safety
     ///
     /// `idx` must be a valid index on [`COMMON_STRINGS`].
-
     const unsafe fn new_static(idx: usize) -> Self {
         // SAFETY:
         // The operation `(idx << 1) | 1` sets the least significant bit to 1, meaning any pointer
@@ -235,7 +233,6 @@ impl TaggedJsString {
     }
 
     /// Checks if [`TaggedJsString`] contains an index for [`COMMON_STRINGS`].
-
     fn is_static(self) -> bool {
         (self.0.as_ptr() as usize) & 1 == 1
     }
@@ -246,7 +243,6 @@ impl TaggedJsString {
     /// # Safety
     ///
     /// `self` must be a heap allocated [`RawJsString`].
-
     const unsafe fn get_heap_unchecked(self) -> NonNull<RawJsString> {
         self.0
     }
@@ -258,7 +254,6 @@ impl TaggedJsString {
     ///
     /// `self` must not be a pointer to a heap allocated [`RawJsString`], and it must be a valid
     /// index inside [`COMMON_STRINGS`].
-
     unsafe fn get_static_unchecked(self) -> &'static [u16] {
         // SAFETY:
         // The caller must ensure `self` is a valid index inside `COMMON_STRINGS`.
@@ -546,7 +541,6 @@ impl JsString {
 
     /// Returns the inner pointer data, unwrapping its tagged data if the pointer contains a static
     /// index for [`COMMON_STRINGS`].
-
     fn ptr(&self) -> JsStringPtrKind {
         // Check the first bit to 1.
         if self.ptr.is_static() {
@@ -951,7 +945,6 @@ mod tests {
 
     impl JsString {
         /// Gets the number of `JsString`s which point to this allocation.
-
         fn refcount(&self) -> Option<usize> {
             match self.ptr() {
                 JsStringPtrKind::Heap(inner) => {

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -360,7 +360,6 @@ impl Ord for JsSymbol {
 }
 
 impl Hash for JsSymbol {
-    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.inner.hash.hash(state);
     }

--- a/boa_engine/src/value/conversions.rs
+++ b/boa_engine/src/value/conversions.rs
@@ -1,17 +1,9 @@
 use super::{JsBigInt, JsObject, JsString, JsSymbol, JsValue, Profiler};
 
-impl From<&Self> for JsValue {
-    #[inline]
-    fn from(value: &Self) -> Self {
-        value.clone()
-    }
-}
-
 impl<T> From<T> for JsValue
 where
     T: Into<JsString>,
 {
-    #[inline]
     fn from(value: T) -> Self {
         let _timer = Profiler::global().start_event("From<String>", "value");
 

--- a/boa_engine/src/value/hash.rs
+++ b/boa_engine/src/value/hash.rs
@@ -29,7 +29,6 @@ impl PartialEq for RationalHashable {
 impl Eq for RationalHashable {}
 
 impl Hash for RationalHashable {
-    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.0.to_bits().hash(state);
     }

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -91,7 +91,7 @@ unsafe impl Trace for JsValue {
 
 impl JsValue {
     /// Create a new [`JsValue`].
-    #[inline]
+
     pub fn new<T>(value: T) -> Self
     where
         T: Into<Self>,
@@ -197,6 +197,7 @@ impl JsValue {
     }
 
     /// Returns the symbol if the value is a symbol, otherwise `None`.
+    #[inline]
     pub fn as_symbol(&self) -> Option<JsSymbol> {
         match self {
             Self::Symbol(symbol) => Some(symbol.clone()),
@@ -229,7 +230,7 @@ impl JsValue {
     }
 
     /// Returns true if the value is integer.
-    #[inline]
+
     #[allow(clippy::float_cmp)]
     pub fn is_integer(&self) -> bool {
         // If it can fit in a i32 and the truncated version is

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -91,7 +91,6 @@ unsafe impl Trace for JsValue {
 
 impl JsValue {
     /// Create a new [`JsValue`].
-
     pub fn new<T>(value: T) -> Self
     where
         T: Into<Self>,
@@ -230,7 +229,6 @@ impl JsValue {
     }
 
     /// Returns true if the value is integer.
-
     #[allow(clippy::float_cmp)]
     pub fn is_integer(&self) -> bool {
         // If it can fit in a i32 and the truncated version is

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -11,7 +11,6 @@ use crate::{
 
 impl JsValue {
     /// Perform the binary `+` operator on the value and return the result.
-
     pub fn add(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -52,7 +51,6 @@ impl JsValue {
     }
 
     /// Perform the binary `-` operator on the value and return the result.
-
     pub fn sub(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -79,7 +77,6 @@ impl JsValue {
     }
 
     /// Perform the binary `*` operator on the value and return the result.
-
     pub fn mul(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -106,7 +103,6 @@ impl JsValue {
     }
 
     /// Perform the binary `/` operator on the value and return the result.
-
     pub fn div(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -148,7 +144,6 @@ impl JsValue {
     }
 
     /// Perform the binary `%` operator on the value and return the result.
-
     pub fn rem(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -200,7 +195,6 @@ impl JsValue {
     }
 
     /// Perform the binary `**` operator on the value and return the result.
-
     pub fn pow(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -228,7 +222,6 @@ impl JsValue {
     }
 
     /// Perform the binary `&` operator on the value and return the result.
-
     pub fn bitand(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -259,7 +252,6 @@ impl JsValue {
     }
 
     /// Perform the binary `|` operator on the value and return the result.
-
     pub fn bitor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -290,7 +282,6 @@ impl JsValue {
     }
 
     /// Perform the binary `^` operator on the value and return the result.
-
     pub fn bitxor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -321,7 +312,6 @@ impl JsValue {
     }
 
     /// Perform the binary `<<` operator on the value and return the result.
-
     pub fn shl(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -354,7 +344,6 @@ impl JsValue {
     }
 
     /// Perform the binary `>>` operator on the value and return the result.
-
     pub fn shr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -387,7 +376,6 @@ impl JsValue {
     }
 
     /// Perform the binary `>>>` operator on the value and return the result.
-
     pub fn ushr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -427,7 +415,6 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-instanceofoperator
-
     pub fn instance_of(&self, target: &Self, context: &mut Context) -> JsResult<bool> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         if !target.is_object() {
@@ -462,7 +449,6 @@ impl JsValue {
     }
 
     /// Returns the negated value.
-
     pub fn neg(&self, context: &mut Context) -> JsResult<Self> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::new(f64::NAN),

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -11,7 +11,7 @@ use crate::{
 
 impl JsValue {
     /// Perform the binary `+` operator on the value and return the result.
-    #[inline]
+
     pub fn add(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -52,7 +52,7 @@ impl JsValue {
     }
 
     /// Perform the binary `-` operator on the value and return the result.
-    #[inline]
+
     pub fn sub(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -79,7 +79,7 @@ impl JsValue {
     }
 
     /// Perform the binary `*` operator on the value and return the result.
-    #[inline]
+
     pub fn mul(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -106,7 +106,7 @@ impl JsValue {
     }
 
     /// Perform the binary `/` operator on the value and return the result.
-    #[inline]
+
     pub fn div(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -148,7 +148,7 @@ impl JsValue {
     }
 
     /// Perform the binary `%` operator on the value and return the result.
-    #[inline]
+
     pub fn rem(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -200,7 +200,7 @@ impl JsValue {
     }
 
     /// Perform the binary `**` operator on the value and return the result.
-    #[inline]
+
     pub fn pow(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -228,7 +228,7 @@ impl JsValue {
     }
 
     /// Perform the binary `&` operator on the value and return the result.
-    #[inline]
+
     pub fn bitand(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -259,7 +259,7 @@ impl JsValue {
     }
 
     /// Perform the binary `|` operator on the value and return the result.
-    #[inline]
+
     pub fn bitor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -290,7 +290,7 @@ impl JsValue {
     }
 
     /// Perform the binary `^` operator on the value and return the result.
-    #[inline]
+
     pub fn bitxor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -321,7 +321,7 @@ impl JsValue {
     }
 
     /// Perform the binary `<<` operator on the value and return the result.
-    #[inline]
+
     pub fn shl(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -354,7 +354,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>` operator on the value and return the result.
-    #[inline]
+
     pub fn shr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -387,7 +387,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>>` operator on the value and return the result.
-    #[inline]
+
     pub fn ushr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
@@ -427,7 +427,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-instanceofoperator
-    #[inline]
+
     pub fn instance_of(&self, target: &Self, context: &mut Context) -> JsResult<bool> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         if !target.is_object() {
@@ -462,7 +462,7 @@ impl JsValue {
     }
 
     /// Returns the negated value.
-    #[inline]
+
     pub fn neg(&self, context: &mut Context) -> JsResult<Self> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::new(f64::NAN),

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -814,7 +814,7 @@ impl JsObject {
                 };
 
                 for arg in args.iter().rev() {
-                    context.vm.push(arg);
+                    context.vm.push(arg.clone());
                 }
 
                 let param_count = code.params.as_ref().len();
@@ -934,7 +934,7 @@ impl JsObject {
                 };
 
                 for arg in args.iter().rev() {
-                    context.vm.push(arg);
+                    context.vm.push(arg.clone());
                 }
 
                 let param_count = code.params.as_ref().len();
@@ -1427,7 +1427,7 @@ impl JsObject {
                 };
 
                 for arg in args.iter().rev() {
-                    context.vm.push(arg);
+                    context.vm.push(arg.clone());
                 }
 
                 let param_count = code.params.as_ref().len();

--- a/boa_engine/src/vm/flowgraph/color.rs
+++ b/boa_engine/src/vm/flowgraph/color.rs
@@ -29,7 +29,6 @@ pub enum Color {
 impl Color {
     /// Function for converting HSV to RGB color format.
     #[allow(clippy::many_single_char_names)]
-    #[inline]
     #[must_use]
     pub fn hsv_to_rgb(h: f64, s: f64, v: f64) -> Self {
         let h_i = (h * 6.0) as i64;
@@ -76,7 +75,6 @@ impl Color {
 }
 
 impl Display for Color {
-    #[inline]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Color::None => f.write_str(""),

--- a/boa_engine/src/vm/flowgraph/edge.rs
+++ b/boa_engine/src/vm/flowgraph/edge.rs
@@ -39,7 +39,6 @@ pub struct Edge {
 
 impl Edge {
     /// Construct a new edge.
-
     pub(super) const fn new(
         from: usize,
         to: usize,

--- a/boa_engine/src/vm/flowgraph/edge.rs
+++ b/boa_engine/src/vm/flowgraph/edge.rs
@@ -39,7 +39,7 @@ pub struct Edge {
 
 impl Edge {
     /// Construct a new edge.
-    #[inline]
+
     pub(super) const fn new(
         from: usize,
         to: usize,

--- a/boa_engine/src/vm/flowgraph/graph.rs
+++ b/boa_engine/src/vm/flowgraph/graph.rs
@@ -94,7 +94,6 @@ impl SubGraph {
     }
 
     /// Format into the graphviz format.
-
     fn graphviz_format(&self, result: &mut String, prefix: &str) {
         result.push_str(&format!("\tsubgraph cluster_{prefix}_{} {{\n", self.label));
         result.push_str("\t\tstyle = filled;\n");
@@ -158,7 +157,6 @@ impl SubGraph {
     }
 
     /// Format into the mermaid format.
-
     fn mermaid_format(&self, result: &mut String, prefix: &str) {
         let rankdir = match self.direction {
             Direction::TopToBottom => "TB",
@@ -269,7 +267,6 @@ impl Graph {
     }
 
     /// Output the graph into the graphviz format.
-
     #[must_use]
     pub fn to_graphviz_format(&self) -> String {
         let mut result = String::new();
@@ -292,7 +289,6 @@ impl Graph {
     }
 
     /// Output the graph into the mermaid format.
-
     #[must_use]
     pub fn to_mermaid_format(&self) -> String {
         let mut result = String::new();

--- a/boa_engine/src/vm/flowgraph/graph.rs
+++ b/boa_engine/src/vm/flowgraph/graph.rs
@@ -94,7 +94,7 @@ impl SubGraph {
     }
 
     /// Format into the graphviz format.
-    #[inline]
+
     fn graphviz_format(&self, result: &mut String, prefix: &str) {
         result.push_str(&format!("\tsubgraph cluster_{prefix}_{} {{\n", self.label));
         result.push_str("\t\tstyle = filled;\n");
@@ -158,7 +158,7 @@ impl SubGraph {
     }
 
     /// Format into the mermaid format.
-    #[inline]
+
     fn mermaid_format(&self, result: &mut String, prefix: &str) {
         let rankdir = match self.direction {
             Direction::TopToBottom => "TB",
@@ -269,7 +269,7 @@ impl Graph {
     }
 
     /// Output the graph into the graphviz format.
-    #[inline]
+
     #[must_use]
     pub fn to_graphviz_format(&self) -> String {
         let mut result = String::new();
@@ -292,7 +292,7 @@ impl Graph {
     }
 
     /// Output the graph into the mermaid format.
-    #[inline]
+
     #[must_use]
     pub fn to_mermaid_format(&self) -> String {
         let mut result = String::new();

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -16,7 +16,6 @@ pub use node::*;
 
 impl CodeBlock {
     /// Output the [`CodeBlock`] VM instructions into a [`Graph`].
-
     pub fn to_graph(&self, interner: &Interner, graph: &mut SubGraph) {
         // Have to remove any invalid graph chars like `<` or `>`.
         let name = if self.name == Sym::MAIN {

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -16,7 +16,7 @@ pub use node::*;
 
 impl CodeBlock {
     /// Output the [`CodeBlock`] VM instructions into a [`Graph`].
-    #[inline]
+
     pub fn to_graph(&self, interner: &Interner, graph: &mut SubGraph) {
         // Have to remove any invalid graph chars like `<` or `>`.
         let name = if self.name == Sym::MAIN {

--- a/boa_engine/src/vm/flowgraph/node.rs
+++ b/boa_engine/src/vm/flowgraph/node.rs
@@ -26,7 +26,6 @@ pub struct Node {
 
 impl Node {
     /// Construct a new node.
-
     pub(super) fn new(location: usize, shape: NodeShape, label: Box<str>, color: Color) -> Self {
         Self {
             location,

--- a/boa_engine/src/vm/flowgraph/node.rs
+++ b/boa_engine/src/vm/flowgraph/node.rs
@@ -26,7 +26,7 @@ pub struct Node {
 
 impl Node {
     /// Construct a new node.
-    #[inline]
+
     pub(super) fn new(location: usize, shape: NodeShape, label: Box<str>, color: Color) -> Self {
         Self {
             location,

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -43,7 +43,7 @@ pub struct Vm {
 
 impl Vm {
     /// Push a value on the stack.
-    #[inline]
+
     pub(crate) fn push<T>(&mut self, value: T)
     where
         T: Into<JsValue>,
@@ -56,14 +56,14 @@ impl Vm {
     /// # Panics
     ///
     /// If there is nothing to pop, then this will panic.
-    #[inline]
+
     #[track_caller]
     pub(crate) fn pop(&mut self) -> JsValue {
         self.stack.pop().expect("stack was empty")
     }
 
     #[track_caller]
-    #[inline]
+
     pub(crate) fn read<T: Readable>(&mut self) -> T {
         let value = self.frame().code.read::<T>(self.frame().pc);
         self.frame_mut().pc += size_of::<T>();
@@ -75,7 +75,7 @@ impl Vm {
     /// # Panics
     ///
     /// If there is no frame, then this will panic.
-    #[inline]
+
     pub(crate) fn frame(&self) -> &CallFrame {
         self.frames.last().expect("no frame found")
     }
@@ -85,17 +85,15 @@ impl Vm {
     /// # Panics
     ///
     /// If there is no frame, then this will panic.
-    #[inline]
+
     pub(crate) fn frame_mut(&mut self) -> &mut CallFrame {
         self.frames.last_mut().expect("no frame found")
     }
 
-    #[inline]
     pub(crate) fn push_frame(&mut self, frame: CallFrame) {
         self.frames.push(frame);
     }
 
-    #[inline]
     pub(crate) fn pop_frame(&mut self) -> Option<CallFrame> {
         self.frames.pop()
     }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -43,7 +43,6 @@ pub struct Vm {
 
 impl Vm {
     /// Push a value on the stack.
-
     pub(crate) fn push<T>(&mut self, value: T)
     where
         T: Into<JsValue>,
@@ -56,14 +55,12 @@ impl Vm {
     /// # Panics
     ///
     /// If there is nothing to pop, then this will panic.
-
     #[track_caller]
     pub(crate) fn pop(&mut self) -> JsValue {
         self.stack.pop().expect("stack was empty")
     }
 
     #[track_caller]
-
     pub(crate) fn read<T: Readable>(&mut self) -> T {
         let value = self.frame().code.read::<T>(self.frame().pc);
         self.frame_mut().pc += size_of::<T>();
@@ -75,7 +72,6 @@ impl Vm {
     /// # Panics
     ///
     /// If there is no frame, then this will panic.
-
     pub(crate) fn frame(&self) -> &CallFrame {
         self.frames.last().expect("no frame found")
     }
@@ -85,7 +81,6 @@ impl Vm {
     /// # Panics
     ///
     /// If there is no frame, then this will panic.
-
     pub(crate) fn frame_mut(&mut self) -> &mut CallFrame {
         self.frames.last_mut().expect("no frame found")
     }

--- a/boa_engine/src/vm/opcode/await_stm/mod.rs
+++ b/boa_engine/src/vm/opcode/await_stm/mod.rs
@@ -43,7 +43,7 @@ impl Operation for Await {
                 context.vm.push_frame(frame.clone());
 
                 context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Normal;
-                context.vm.push(args.get_or_undefined(0));
+                context.vm.push(args.get_or_undefined(0).clone());
                 context.run()?;
 
                 *frame = context
@@ -82,7 +82,7 @@ impl Operation for Await {
                 context.vm.push_frame(frame.clone());
 
                 context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Throw;
-                context.vm.push(args.get_or_undefined(0));
+                context.vm.push(args.get_or_undefined(0).clone());
                 context.run()?;
 
                 *frame = context

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -19,7 +19,9 @@ impl Operation for This {
     fn execute(context: &mut Context) -> JsResult<ShouldExit> {
         let env = context.realm.environments.get_this_environment();
         match env {
-            EnvironmentSlots::Function(env) => context.vm.push(env.borrow().get_this_binding()?),
+            EnvironmentSlots::Function(env) => {
+                context.vm.push(env.borrow().get_this_binding()?.clone());
+            }
             EnvironmentSlots::Global => {
                 let this = context.realm.global_object();
                 context.vm.push(this.clone());

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -24,7 +24,7 @@ impl Operation for GetPrivateField {
             let object_borrow_mut = object.borrow();
             if let Some(element) = object_borrow_mut.get_private_element(name.sym()) {
                 match element {
-                    PrivateElement::Field(value) => context.vm.push(value),
+                    PrivateElement::Field(value) => context.vm.push(value.clone()),
                     PrivateElement::Method(method) => context.vm.push(method.clone()),
                     PrivateElement::Accessor {
                         getter: Some(getter),

--- a/boa_engine/src/vm/opcode/require/mod.rs
+++ b/boa_engine/src/vm/opcode/require/mod.rs
@@ -17,7 +17,7 @@ impl Operation for RequireObjectCoercible {
     fn execute(context: &mut Context) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let value = value.require_object_coercible()?;
-        context.vm.push(value);
+        context.vm.push(value.clone());
         Ok(ShouldExit::False)
     }
 }

--- a/boa_gc/src/cell.rs
+++ b/boa_gc/src/cell.rs
@@ -35,7 +35,6 @@ pub(crate) const BORROWFLAG_INIT: BorrowFlag = BorrowFlag(ROOT);
 
 impl BorrowFlag {
     /// Check the current `BorrowState` of `BorrowFlag`.
-
     pub(crate) const fn borrowed(self) -> BorrowState {
         match self.0 & !ROOT {
             UNUSED => BorrowState::Unused,
@@ -45,20 +44,17 @@ impl BorrowFlag {
     }
 
     /// Check whether the borrow bit is flagged.
-
     pub(crate) const fn rooted(self) -> bool {
         self.0 & ROOT > 0
     }
 
     /// Set the `BorrowFlag`'s state to writing.
-
     pub(crate) const fn set_writing(self) -> Self {
         // Set every bit other than the root bit, which is preserved
         Self(self.0 | WRITING)
     }
 
     /// Remove the root flag on `BorrowFlag`
-
     pub(crate) const fn set_unused(self) -> Self {
         // Clear every bit other than the root bit, which is preserved
         Self(self.0 & ROOT)
@@ -69,7 +65,6 @@ impl BorrowFlag {
     /// # Panic
     ///  - This method will panic if the current `BorrowState` is writing.
     ///  - This method will panic after incrementing if the borrow count overflows.
-
     pub(crate) fn add_reading(self) -> Self {
         assert!(self.borrowed() != BorrowState::Writing);
         // Add 1 to the integer starting at the second binary digit. As our
@@ -91,7 +86,6 @@ impl BorrowFlag {
     ///
     /// # Panic
     ///  - This method will panic if the current `BorrowState` is not reading.
-
     pub(crate) fn sub_reading(self) -> Self {
         assert!(self.borrowed() == BorrowState::Reading);
         // Subtract 1 from the integer starting at the second binary digit. As
@@ -104,7 +98,6 @@ impl BorrowFlag {
     }
 
     /// Set the root flag on the `BorrowFlag`.
-
     pub(crate) fn set_rooted(self, rooted: bool) -> Self {
         // Preserve the non-root bits
         Self((self.0 & !ROOT) | (usize::from(rooted)))
@@ -131,7 +124,6 @@ pub struct GcCell<T: ?Sized + 'static> {
 
 impl<T: Trace> GcCell<T> {
     /// Creates a new `GcCell` containing `value`.
-
     pub const fn new(value: T) -> Self {
         Self {
             flags: Cell::new(BORROWFLAG_INIT),
@@ -140,7 +132,6 @@ impl<T: Trace> GcCell<T> {
     }
 
     /// Consumes the `GcCell`, returning the wrapped value.
-
     pub fn into_inner(self) -> T {
         self.cell.into_inner()
     }
@@ -155,7 +146,6 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed.
-
     pub fn borrow(&self) -> GcCellRef<'_, T> {
         match self.try_borrow() {
             Ok(value) => value,
@@ -171,7 +161,6 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.
-
     pub fn borrow_mut(&self) -> GcCellRefMut<'_, T> {
         match self.try_borrow_mut() {
             Ok(value) => value,
@@ -328,7 +317,6 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     /// `GcCellRef::clone(...)`. A `Clone` implementation or a method
     /// would interfere with the use of `c.borrow().clone()` to clone
     /// the contents of a `GcCell`.
-
     #[allow(clippy::should_implement_trait)]
     #[must_use]
     pub fn clone(orig: &GcCellRef<'a, T>) -> GcCellRef<'a, T> {
@@ -346,7 +334,6 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     /// This is an associated function that needs to be used as `GcCellRef::map(...)`.
     /// A method would interfere with methods of the same name on the contents
     /// of a `GcCellRef` used through `Deref`.
-
     pub fn map<U, F>(orig: Self, f: F) -> GcCellRef<'a, U>
     where
         U: ?Sized,
@@ -370,7 +357,6 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     ///
     /// This is an associated function that needs to be used as `GcCellRef::map_split(...)`.
     /// A method would interfere with methods of the same name on the contents of a `GcCellRef` used through `Deref`.
-
     pub fn map_split<U, V, F>(orig: Self, f: F) -> (GcCellRef<'a, U>, GcCellRef<'a, V>)
     where
         U: ?Sized,
@@ -442,7 +428,6 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
     /// This is an associated function that needs to be used as
     /// `GcCellRefMut::map(...)`. A method would interfere with methods of the same
     /// name on the contents of a `GcCell` used through `Deref`.
-
     pub fn map<V, F>(orig: Self, f: F) -> GcCellRefMut<'a, T, V>
     where
         V: ?Sized,

--- a/boa_gc/src/internals/ephemeron_box.rs
+++ b/boa_gc/src/internals/ephemeron_box.rs
@@ -18,7 +18,6 @@ impl<K: Trace + ?Sized, V: Trace> EphemeronBox<K, V> {
 
 impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     /// Checks if the key pointer is marked by Trace
-
     pub(crate) fn is_marked(&self) -> bool {
         self.inner_key().map_or(false, GcBox::is_marked)
     }
@@ -26,14 +25,12 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     /// Returns some pointer to the `key`'s `GcBox` or None
     /// # Panics
     /// This method will panic if called while the garbage collector is dropping.
-
     pub(crate) fn inner_key_ptr(&self) -> Option<*mut GcBox<K>> {
         assert!(finalizer_safe());
         self.key.get().map(NonNull::as_ptr)
     }
 
     /// Returns some reference to `key`'s `GcBox` or None
-
     pub(crate) fn inner_key(&self) -> Option<&GcBox<K>> {
         // SAFETY: This is safe as `EphemeronBox::inner_key_ptr()` will
         // fetch either a live `GcBox` or None. The value of `key` is set
@@ -43,19 +40,16 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     }
 
     /// Returns a reference to the value of `key`'s `GcBox`
-
     pub(crate) fn key(&self) -> Option<&K> {
         self.inner_key().map(GcBox::value)
     }
 
     /// Returns a reference to `value`
-
     pub(crate) const fn value(&self) -> &V {
         &self.value
     }
 
     /// Calls [`Trace::weak_trace()`][crate::Trace] on key
-
     fn weak_trace_key(&self) {
         if let Some(key) = self.inner_key() {
             key.weak_trace_inner();
@@ -63,7 +57,6 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     }
 
     /// Calls [`Trace::weak_trace()`][crate::Trace] on value
-
     fn weak_trace_value(&self) {
         // SAFETY: Value is a sized element that must implement trace. The
         // operation is safe as EphemeronBox owns value and `Trace::weak_trace`
@@ -92,14 +85,12 @@ unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
     }
 
     /// Checks if the `key`'s `GcBox` has been marked by `Trace::trace()` or `Trace::weak_trace`.
-
     fn is_marked_ephemeron(&self) -> bool {
         self.is_marked()
     }
 
     /// Checks if this `EphemeronBox` has already been determined reachable. If so, continue to trace
     /// value in `key` and `value`.
-
     unsafe fn weak_trace(&self) {
         if self.is_marked() {
             self.weak_trace_key();
@@ -108,11 +99,9 @@ unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
     }
 
     // EphemeronBox does not implement root.
-
     unsafe fn root(&self) {}
 
     // EphemeronBox does not implement unroot
-
     unsafe fn unroot(&self) {}
 
     // An `EphemeronBox`'s key is set to None once it has been finalized.
@@ -120,7 +109,6 @@ unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
     // NOTE: while it is possible for the `key`'s pointer value to be
     // resurrected, we should still consider the finalize the ephemeron
     // box and set the `key` to None.
-
     fn run_finalizer(&self) {
         Finalize::finalize(self);
     }

--- a/boa_gc/src/internals/ephemeron_box.rs
+++ b/boa_gc/src/internals/ephemeron_box.rs
@@ -18,7 +18,7 @@ impl<K: Trace + ?Sized, V: Trace> EphemeronBox<K, V> {
 
 impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     /// Checks if the key pointer is marked by Trace
-    #[inline]
+
     pub(crate) fn is_marked(&self) -> bool {
         self.inner_key().map_or(false, GcBox::is_marked)
     }
@@ -26,14 +26,14 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     /// Returns some pointer to the `key`'s `GcBox` or None
     /// # Panics
     /// This method will panic if called while the garbage collector is dropping.
-    #[inline]
+
     pub(crate) fn inner_key_ptr(&self) -> Option<*mut GcBox<K>> {
         assert!(finalizer_safe());
         self.key.get().map(NonNull::as_ptr)
     }
 
     /// Returns some reference to `key`'s `GcBox` or None
-    #[inline]
+
     pub(crate) fn inner_key(&self) -> Option<&GcBox<K>> {
         // SAFETY: This is safe as `EphemeronBox::inner_key_ptr()` will
         // fetch either a live `GcBox` or None. The value of `key` is set
@@ -43,19 +43,19 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     }
 
     /// Returns a reference to the value of `key`'s `GcBox`
-    #[inline]
+
     pub(crate) fn key(&self) -> Option<&K> {
         self.inner_key().map(GcBox::value)
     }
 
     /// Returns a reference to `value`
-    #[inline]
+
     pub(crate) const fn value(&self) -> &V {
         &self.value
     }
 
     /// Calls [`Trace::weak_trace()`][crate::Trace] on key
-    #[inline]
+
     fn weak_trace_key(&self) {
         if let Some(key) = self.inner_key() {
             key.weak_trace_inner();
@@ -63,7 +63,7 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
     }
 
     /// Calls [`Trace::weak_trace()`][crate::Trace] on value
-    #[inline]
+
     fn weak_trace_value(&self) {
         // SAFETY: Value is a sized element that must implement trace. The
         // operation is safe as EphemeronBox owns value and `Trace::weak_trace`
@@ -78,7 +78,6 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> EphemeronBox<K, V> {
 // and therefore so has the `GcBox` that `key`stores the pointer to, then we set `key`
 // to None to guarantee that we do not access freed memory.
 impl<K: Trace + ?Sized, V: Trace + ?Sized> Finalize for EphemeronBox<K, V> {
-    #[inline]
     fn finalize(&self) {
         self.key.set(None);
     }
@@ -88,20 +87,19 @@ impl<K: Trace + ?Sized, V: Trace + ?Sized> Finalize for EphemeronBox<K, V> {
 // to determine whether the key field is stored and `Trace::weak_trace` which continues the `Trace::weak_trace()`
 // into `key` and `value`.
 unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
-    #[inline]
     unsafe fn trace(&self) {
         /* An ephemeron is never traced with Phase One Trace */
     }
 
     /// Checks if the `key`'s `GcBox` has been marked by `Trace::trace()` or `Trace::weak_trace`.
-    #[inline]
+
     fn is_marked_ephemeron(&self) -> bool {
         self.is_marked()
     }
 
     /// Checks if this `EphemeronBox` has already been determined reachable. If so, continue to trace
     /// value in `key` and `value`.
-    #[inline]
+
     unsafe fn weak_trace(&self) {
         if self.is_marked() {
             self.weak_trace_key();
@@ -110,11 +108,11 @@ unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
     }
 
     // EphemeronBox does not implement root.
-    #[inline]
+
     unsafe fn root(&self) {}
 
     // EphemeronBox does not implement unroot
-    #[inline]
+
     unsafe fn unroot(&self) {}
 
     // An `EphemeronBox`'s key is set to None once it has been finalized.
@@ -122,7 +120,7 @@ unsafe impl<K: Trace + ?Sized, V: Trace + ?Sized> Trace for EphemeronBox<K, V> {
     // NOTE: while it is possible for the `key`'s pointer value to be
     // resurrected, we should still consider the finalize the ephemeron
     // box and set the `key` to None.
-    #[inline]
+
     fn run_finalizer(&self) {
         Finalize::finalize(self);
     }

--- a/boa_gc/src/internals/gc_box.rs
+++ b/boa_gc/src/internals/gc_box.rs
@@ -28,7 +28,7 @@ pub(crate) struct GcBoxHeader {
 
 impl GcBoxHeader {
     /// Creates a new `GcBoxHeader` with a root of 1 and next set to None.
-    #[inline]
+
     pub(crate) fn new() -> Self {
         Self {
             roots: Cell::new(1),
@@ -37,7 +37,7 @@ impl GcBoxHeader {
     }
 
     /// Creates a new `GcBoxHeader` with the Weak bit at 1 and roots of 1.
-    #[inline]
+
     pub(crate) fn new_weak() -> Self {
         // Set weak_flag
         Self {
@@ -47,13 +47,13 @@ impl GcBoxHeader {
     }
 
     /// Returns the `GcBoxHeader`'s current root count
-    #[inline]
+
     pub(crate) fn roots(&self) -> usize {
         self.roots.get() & ROOTS_MASK
     }
 
     /// Increments `GcBoxHeader`'s root count.
-    #[inline]
+
     pub(crate) fn inc_roots(&self) {
         let roots = self.roots.get();
 
@@ -66,7 +66,7 @@ impl GcBoxHeader {
     }
 
     /// Decreases `GcBoxHeader`'s current root count.
-    #[inline]
+
     pub(crate) fn dec_roots(&self) {
         // Underflow check as a stop gap for current issue when dropping.
         if self.roots.get() > 0 {
@@ -75,25 +75,25 @@ impl GcBoxHeader {
     }
 
     /// Returns a bool for whether `GcBoxHeader`'s mark bit is 1.
-    #[inline]
+
     pub(crate) fn is_marked(&self) -> bool {
         self.roots.get() & MARK_MASK != 0
     }
 
     /// Sets `GcBoxHeader`'s mark bit to 1.
-    #[inline]
+
     pub(crate) fn mark(&self) {
         self.roots.set(self.roots.get() | MARK_MASK);
     }
 
     /// Sets `GcBoxHeader`'s mark bit to 0.
-    #[inline]
+
     pub(crate) fn unmark(&self) {
         self.roots.set(self.roots.get() & !MARK_MASK);
     }
 
     /// Returns a bool for whether the `GcBoxHeader`'s weak bit is 1.
-    #[inline]
+
     pub(crate) fn is_ephemeron(&self) -> bool {
         self.roots.get() & WEAK_MASK != 0
     }
@@ -143,7 +143,7 @@ impl<T: Trace + ?Sized> GcBox<T> {
     }
 
     /// Marks this `GcBox` and marks through its data.
-    #[inline]
+
     pub(crate) unsafe fn trace_inner(&self) {
         if !self.header.is_marked() && !self.header.is_ephemeron() {
             self.header.mark();
@@ -158,7 +158,7 @@ impl<T: Trace + ?Sized> GcBox<T> {
     }
 
     /// Trace inner data and search for ephemerons to add to the ephemeron queue.
-    #[inline]
+
     pub(crate) fn weak_trace_inner(&self) {
         if !self.header.is_marked() && !self.header.is_ephemeron() {
             self.header.mark();
@@ -173,7 +173,7 @@ impl<T: Trace + ?Sized> GcBox<T> {
     /// Increases the root count on this `GcBox`.
     ///
     /// Roots prevent the `GcBox` from being destroyed by the garbage collector.
-    #[inline]
+
     pub(crate) fn root_inner(&self) {
         self.header.inc_roots();
     }
@@ -181,19 +181,19 @@ impl<T: Trace + ?Sized> GcBox<T> {
     /// Decreases the root count on this `GcBox`.
     ///
     /// Roots prevent the `GcBox` from being destroyed by the garbage collector.
-    #[inline]
+
     pub(crate) fn unroot_inner(&self) {
         self.header.dec_roots();
     }
 
     /// Returns a reference to the `GcBox`'s value.
-    #[inline]
+
     pub(crate) const fn value(&self) -> &T {
         &self.value
     }
 
     /// Returns a bool for whether the header is marked.
-    #[inline]
+
     pub(crate) fn is_marked(&self) -> bool {
         self.header.is_marked()
     }

--- a/boa_gc/src/internals/gc_box.rs
+++ b/boa_gc/src/internals/gc_box.rs
@@ -28,7 +28,6 @@ pub(crate) struct GcBoxHeader {
 
 impl GcBoxHeader {
     /// Creates a new `GcBoxHeader` with a root of 1 and next set to None.
-
     pub(crate) fn new() -> Self {
         Self {
             roots: Cell::new(1),
@@ -37,7 +36,6 @@ impl GcBoxHeader {
     }
 
     /// Creates a new `GcBoxHeader` with the Weak bit at 1 and roots of 1.
-
     pub(crate) fn new_weak() -> Self {
         // Set weak_flag
         Self {
@@ -47,13 +45,11 @@ impl GcBoxHeader {
     }
 
     /// Returns the `GcBoxHeader`'s current root count
-
     pub(crate) fn roots(&self) -> usize {
         self.roots.get() & ROOTS_MASK
     }
 
     /// Increments `GcBoxHeader`'s root count.
-
     pub(crate) fn inc_roots(&self) {
         let roots = self.roots.get();
 
@@ -66,7 +62,6 @@ impl GcBoxHeader {
     }
 
     /// Decreases `GcBoxHeader`'s current root count.
-
     pub(crate) fn dec_roots(&self) {
         // Underflow check as a stop gap for current issue when dropping.
         if self.roots.get() > 0 {
@@ -75,25 +70,21 @@ impl GcBoxHeader {
     }
 
     /// Returns a bool for whether `GcBoxHeader`'s mark bit is 1.
-
     pub(crate) fn is_marked(&self) -> bool {
         self.roots.get() & MARK_MASK != 0
     }
 
     /// Sets `GcBoxHeader`'s mark bit to 1.
-
     pub(crate) fn mark(&self) {
         self.roots.set(self.roots.get() | MARK_MASK);
     }
 
     /// Sets `GcBoxHeader`'s mark bit to 0.
-
     pub(crate) fn unmark(&self) {
         self.roots.set(self.roots.get() & !MARK_MASK);
     }
 
     /// Returns a bool for whether the `GcBoxHeader`'s weak bit is 1.
-
     pub(crate) fn is_ephemeron(&self) -> bool {
         self.roots.get() & WEAK_MASK != 0
     }
@@ -143,7 +134,6 @@ impl<T: Trace + ?Sized> GcBox<T> {
     }
 
     /// Marks this `GcBox` and marks through its data.
-
     pub(crate) unsafe fn trace_inner(&self) {
         if !self.header.is_marked() && !self.header.is_ephemeron() {
             self.header.mark();
@@ -158,7 +148,6 @@ impl<T: Trace + ?Sized> GcBox<T> {
     }
 
     /// Trace inner data and search for ephemerons to add to the ephemeron queue.
-
     pub(crate) fn weak_trace_inner(&self) {
         if !self.header.is_marked() && !self.header.is_ephemeron() {
             self.header.mark();
@@ -173,7 +162,6 @@ impl<T: Trace + ?Sized> GcBox<T> {
     /// Increases the root count on this `GcBox`.
     ///
     /// Roots prevent the `GcBox` from being destroyed by the garbage collector.
-
     pub(crate) fn root_inner(&self) {
         self.header.inc_roots();
     }
@@ -181,19 +169,16 @@ impl<T: Trace + ?Sized> GcBox<T> {
     /// Decreases the root count on this `GcBox`.
     ///
     /// Roots prevent the `GcBox` from being destroyed by the garbage collector.
-
     pub(crate) fn unroot_inner(&self) {
         self.header.dec_roots();
     }
 
     /// Returns a reference to the `GcBox`'s value.
-
     pub(crate) const fn value(&self) -> &T {
         &self.value
     }
 
     /// Returns a bool for whether the header is marked.
-
     pub(crate) fn is_marked(&self) -> bool {
         self.header.is_marked()
     }

--- a/boa_gc/src/pointers/ephemeron.rs
+++ b/boa_gc/src/pointers/ephemeron.rs
@@ -69,7 +69,6 @@ unsafe impl<K: Trace, V: Trace> Trace for Ephemeron<K, V> {
     unsafe fn trace(&self) {}
 
     // Push this Ephemeron's pointer onto the EphemeronQueue
-
     unsafe fn weak_trace(&self) {
         EPHEMERON_QUEUE.with(|q| {
             let mut queue = q.take().expect("queue is initialized by weak_trace");

--- a/boa_gc/src/pointers/ephemeron.rs
+++ b/boa_gc/src/pointers/ephemeron.rs
@@ -31,31 +31,26 @@ impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
 }
 
 impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
-    #[inline]
     fn inner_ptr(&self) -> NonNull<GcBox<EphemeronBox<K, V>>> {
         self.inner_ptr.get()
     }
 
-    #[inline]
     fn inner(&self) -> &GcBox<EphemeronBox<K, V>> {
         // SAFETY: GcBox<EphemeronBox<K,V>> must live until it is unrooted by Drop
         unsafe { &*self.inner_ptr().as_ptr() }
     }
 
-    #[inline]
     /// Gets the weak key of this `Ephemeron`, or `None` if the key was already garbage
     /// collected.
     pub fn key(&self) -> Option<&K> {
         self.inner().value().key()
     }
 
-    #[inline]
     /// Gets the stored value of this `Ephemeron`.
     pub fn value(&self) -> &V {
         self.inner().value().value()
     }
 
-    #[inline]
     /// Gets a `Gc` for the stored key of this `Ephemeron`.
     pub fn upgrade_key(&self) -> Option<Gc<K>> {
         // SAFETY: ptr must be a valid pointer or None would have been returned.
@@ -71,11 +66,10 @@ impl<K: Trace, V: Trace> Finalize for Ephemeron<K, V> {}
 // SAFETY: Ephemerons trace implementation is standard for everything except `Trace::weak_trace()`,
 // which pushes the GcBox<EphemeronBox<_>> onto the EphemeronQueue
 unsafe impl<K: Trace, V: Trace> Trace for Ephemeron<K, V> {
-    #[inline]
     unsafe fn trace(&self) {}
 
     // Push this Ephemeron's pointer onto the EphemeronQueue
-    #[inline]
+
     unsafe fn weak_trace(&self) {
         EPHEMERON_QUEUE.with(|q| {
             let mut queue = q.take().expect("queue is initialized by weak_trace");
@@ -83,20 +77,16 @@ unsafe impl<K: Trace, V: Trace> Trace for Ephemeron<K, V> {
         });
     }
 
-    #[inline]
     unsafe fn root(&self) {}
 
-    #[inline]
     unsafe fn unroot(&self) {}
 
-    #[inline]
     fn run_finalizer(&self) {
         Finalize::finalize(self);
     }
 }
 
 impl<K: Trace + ?Sized, V: Trace> Clone for Ephemeron<K, V> {
-    #[inline]
     fn clone(&self) -> Self {
         // SAFETY: This is safe because the inner_ptr must live as long as it's roots.
         // Mismanagement of roots can cause inner_ptr to use after free or Undefined
@@ -113,7 +103,6 @@ impl<K: Trace + ?Sized, V: Trace> Clone for Ephemeron<K, V> {
 }
 
 impl<K: Trace + ?Sized, V: Trace> Drop for Ephemeron<K, V> {
-    #[inline]
     fn drop(&mut self) {
         // NOTE: We assert that this drop call is not a
         // drop from `Collector::dump` or `Collector::sweep`

--- a/boa_gc/src/pointers/gc.rs
+++ b/boa_gc/src/pointers/gc.rs
@@ -105,7 +105,6 @@ impl<T: Trace + ?Sized> Gc<T> {
         }
     }
 
-    #[inline]
     pub(crate) fn inner_ptr(&self) -> NonNull<GcBox<T>> {
         assert!(finalizer_safe());
         // SAFETY: inner_ptr must be a live GcBox. Calling this on a dropped GcBox
@@ -113,7 +112,6 @@ impl<T: Trace + ?Sized> Gc<T> {
         unsafe { clear_root_bit(self.inner_ptr.get()) }
     }
 
-    #[inline]
     fn inner(&self) -> &GcBox<T> {
         // SAFETY: Please see Gc::inner_ptr()
         unsafe { self.inner_ptr().as_ref() }
@@ -125,7 +123,6 @@ impl<T: Trace + ?Sized> Finalize for Gc<T> {}
 // SAFETY: `Gc` maintains it's own rootedness and implements all methods of
 // Trace. It is not possible to root an already rooted `Gc` and vice versa.
 unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
-    #[inline]
     unsafe fn trace(&self) {
         // SAFETY: Inner must be live and allocated GcBox.
         unsafe {
@@ -133,12 +130,10 @@ unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
         }
     }
 
-    #[inline]
     unsafe fn weak_trace(&self) {
         self.inner().weak_trace_inner();
     }
 
-    #[inline]
     unsafe fn root(&self) {
         assert!(!self.rooted(), "Can't double-root a Gc<T>");
         // Try to get inner before modifying our state. Inner may be
@@ -148,7 +143,6 @@ unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
         self.set_root();
     }
 
-    #[inline]
     unsafe fn unroot(&self) {
         assert!(self.rooted(), "Can't double-unroot a Gc<T>");
         // Try to get inner before modifying our state. Inner may be
@@ -158,14 +152,12 @@ unsafe impl<T: Trace + ?Sized> Trace for Gc<T> {
         self.clear_root();
     }
 
-    #[inline]
     fn run_finalizer(&self) {
         Finalize::finalize(self);
     }
 }
 
 impl<T: Trace + ?Sized> Clone for Gc<T> {
-    #[inline]
     fn clone(&self) -> Self {
         Self::from_ptr(self.inner_ptr())
     }
@@ -174,14 +166,12 @@ impl<T: Trace + ?Sized> Clone for Gc<T> {
 impl<T: Trace + ?Sized> Deref for Gc<T> {
     type Target = T;
 
-    #[inline]
     fn deref(&self) -> &T {
         self.inner().value()
     }
 }
 
 impl<T: Trace + ?Sized> Drop for Gc<T> {
-    #[inline]
     fn drop(&mut self) {
         // If this pointer was a root, we should unroot it.
         if self.rooted() {
@@ -191,7 +181,6 @@ impl<T: Trace + ?Sized> Drop for Gc<T> {
 }
 
 impl<T: Trace + Default> Default for Gc<T> {
-    #[inline]
     fn default() -> Self {
         Self::new(Default::default())
     }
@@ -236,7 +225,6 @@ impl<T: Trace + ?Sized + PartialOrd> PartialOrd for Gc<T> {
 }
 
 impl<T: Trace + ?Sized + Ord> Ord for Gc<T> {
-    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         (**self).cmp(&**other)
     }

--- a/boa_gc/src/pointers/weak.rs
+++ b/boa_gc/src/pointers/weak.rs
@@ -20,13 +20,11 @@ impl<T: Trace + ?Sized> WeakGc<T> {
 }
 
 impl<T: Trace + ?Sized> WeakGc<T> {
-    #[inline]
     /// Gets the value of this weak pointer, or `None` if the value was already garbage collected.
     pub fn value(&self) -> Option<&T> {
         self.inner.key()
     }
 
-    #[inline]
     /// Upgrade returns a `Gc` pointer for the internal value if valid, or None if the value was already garbage collected.
     pub fn upgrade(&self) -> Option<Gc<T>> {
         self.inner.upgrade_key()
@@ -34,7 +32,6 @@ impl<T: Trace + ?Sized> WeakGc<T> {
 }
 
 impl<T: Trace + ?Sized> Clone for WeakGc<T> {
-    #[inline]
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),

--- a/boa_gc/src/trace.rs
+++ b/boa_gc/src/trace.rs
@@ -105,7 +105,6 @@ macro_rules! custom_trace {
     ($this:ident, $body:expr) => {
         #[inline]
         unsafe fn trace(&self) {
-            #[inline]
             fn mark<T: $crate::Trace + ?Sized>(it: &T) {
                 // SAFETY: The implementor must ensure that `trace` is correctly implemented.
                 unsafe {
@@ -117,7 +116,6 @@ macro_rules! custom_trace {
         }
         #[inline]
         unsafe fn weak_trace(&self) {
-            #[inline]
             fn mark<T: $crate::Trace + ?Sized>(it: &T) {
                 // SAFETY: The implementor must ensure that `weak_trace` is correctly implemented.
                 unsafe {
@@ -129,7 +127,6 @@ macro_rules! custom_trace {
         }
         #[inline]
         unsafe fn root(&self) {
-            #[inline]
             fn mark<T: $crate::Trace + ?Sized>(it: &T) {
                 // SAFETY: The implementor must ensure that `root` is correctly implemented.
                 unsafe {
@@ -141,7 +138,6 @@ macro_rules! custom_trace {
         }
         #[inline]
         unsafe fn unroot(&self) {
-            #[inline]
             fn mark<T: $crate::Trace + ?Sized>(it: &T) {
                 // SAFETY: The implementor must ensure that `unroot` is correctly implemented.
                 unsafe {
@@ -153,7 +149,6 @@ macro_rules! custom_trace {
         }
         #[inline]
         fn run_finalizer(&self) {
-            #[inline]
             fn mark<T: $crate::Trace + ?Sized>(it: &T) {
                 $crate::Trace::run_finalizer(it);
             }

--- a/boa_interner/src/interned_str.rs
+++ b/boa_interner/src/interned_str.rs
@@ -26,7 +26,7 @@ impl<Char> InternedStr<Char> {
     ///
     /// Not maintaining the invariants specified on the struct definition
     /// could cause Undefined Behaviour.
-    #[inline]
+
     pub(super) const unsafe fn new(ptr: NonNull<[Char]>) -> Self {
         Self { ptr }
     }
@@ -37,7 +37,7 @@ impl<Char> InternedStr<Char> {
     ///
     /// Not maintaining the invariants specified on the struct definition
     /// could cause Undefined Behaviour.
-    #[inline]
+
     pub(super) unsafe fn as_ref(&self) -> &[Char] {
         // SAFETY:
         // The caller must ensure `ptr` is still valid throughout the

--- a/boa_interner/src/interned_str.rs
+++ b/boa_interner/src/interned_str.rs
@@ -26,7 +26,6 @@ impl<Char> InternedStr<Char> {
     ///
     /// Not maintaining the invariants specified on the struct definition
     /// could cause Undefined Behaviour.
-
     pub(super) const unsafe fn new(ptr: NonNull<[Char]>) -> Self {
         Self { ptr }
     }
@@ -37,7 +36,6 @@ impl<Char> InternedStr<Char> {
     ///
     /// Not maintaining the invariants specified on the struct definition
     /// could cause Undefined Behaviour.
-
     pub(super) unsafe fn as_ref(&self) -> &[Char] {
         // SAFETY:
         // The caller must ensure `ptr` is still valid throughout the

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -371,7 +371,7 @@ impl Interner {
     }
 
     /// Returns the string for the given symbol if any.
-    #[inline]
+
     #[must_use]
     pub fn resolve(&self, symbol: Sym) -> Option<JSInternedStrRef<'_, '_>> {
         let index = symbol.get() - 1;

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -371,7 +371,6 @@ impl Interner {
     }
 
     /// Returns the string for the given symbol if any.
-
     #[must_use]
     pub fn resolve(&self, symbol: Sym) -> Option<JSInternedStrRef<'_, '_>> {
         let index = symbol.get() - 1;

--- a/boa_interner/src/raw.rs
+++ b/boa_interner/src/raw.rs
@@ -36,7 +36,7 @@ impl<Char> Default for RawInterner<Char> {
 
 impl<Char> RawInterner<Char> {
     /// Creates a new `RawInterner` with the specified capacity.
-    #[inline]
+
     pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
             symbol_cache: FxHashMap::default(),
@@ -47,13 +47,13 @@ impl<Char> RawInterner<Char> {
     }
 
     /// Returns the number of strings interned by the interner.
-    #[inline]
+
     pub(super) fn len(&self) -> usize {
         self.spans.len()
     }
 
     /// Returns `true` if the interner contains no interned strings.
-    #[inline]
+
     pub(super) fn is_empty(&self) -> bool {
         self.spans.is_empty()
     }
@@ -105,7 +105,7 @@ where
     }
 
     /// Returns the string for the given index if any.
-    #[inline]
+
     pub(super) fn index(&self, index: usize) -> Option<&[Char]> {
         self.spans.get(index).map(|ptr|
             // SAFETY: We always ensure the stored `InternedStr`s always

--- a/boa_interner/src/raw.rs
+++ b/boa_interner/src/raw.rs
@@ -36,7 +36,6 @@ impl<Char> Default for RawInterner<Char> {
 
 impl<Char> RawInterner<Char> {
     /// Creates a new `RawInterner` with the specified capacity.
-
     pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
             symbol_cache: FxHashMap::default(),
@@ -47,13 +46,11 @@ impl<Char> RawInterner<Char> {
     }
 
     /// Returns the number of strings interned by the interner.
-
     pub(super) fn len(&self) -> usize {
         self.spans.len()
     }
 
     /// Returns `true` if the interner contains no interned strings.
-
     pub(super) fn is_empty(&self) -> bool {
         self.spans.is_empty()
     }
@@ -105,7 +102,6 @@ where
     }
 
     /// Returns the string for the given index if any.
-
     pub(super) fn index(&self, index: usize) -> Option<&[Char]> {
         self.spans.get(index).map(|ptr|
             // SAFETY: We always ensure the stored `InternedStr`s always

--- a/boa_interner/src/sym.rs
+++ b/boa_interner/src/sym.rs
@@ -111,7 +111,6 @@ impl Sym {
     pub const NAME: Self = unsafe { Self::new_unchecked(30) };
 
     /// Creates a new [`Sym`] from the provided `value`, or returns `None` if `index` is zero.
-
     pub(super) fn new(value: usize) -> Option<Self> {
         NonZeroUsize::new(value).map(|value| Self { value })
     }
@@ -121,7 +120,6 @@ impl Sym {
     /// # Safety
     ///
     /// `value` must not be zero.
-
     pub(super) const unsafe fn new_unchecked(value: usize) -> Self {
         Self {
             value:

--- a/boa_interner/src/sym.rs
+++ b/boa_interner/src/sym.rs
@@ -111,7 +111,7 @@ impl Sym {
     pub const NAME: Self = unsafe { Self::new_unchecked(30) };
 
     /// Creates a new [`Sym`] from the provided `value`, or returns `None` if `index` is zero.
-    #[inline]
+
     pub(super) fn new(value: usize) -> Option<Self> {
         NonZeroUsize::new(value).map(|value| Self { value })
     }
@@ -121,7 +121,7 @@ impl Sym {
     /// # Safety
     ///
     /// `value` must not be zero.
-    #[inline]
+
     pub(super) const unsafe fn new_unchecked(value: usize) -> Self {
         Self {
             value:

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -96,7 +96,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn trace(&self) {
                 #[allow(dead_code)]
-                #[inline]
+
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::trace(it);
@@ -107,7 +107,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn weak_trace(&self) {
                 #[allow(dead_code, unreachable_code)]
-                #[inline]
+
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::weak_trace(it)
@@ -118,7 +118,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn root(&self) {
                 #[allow(dead_code)]
-                #[inline]
+
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::root(it);
@@ -129,7 +129,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn unroot(&self) {
                 #[allow(dead_code)]
-                #[inline]
+
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::unroot(it);
@@ -141,7 +141,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             fn run_finalizer(&self) {
                 ::boa_gc::Finalize::finalize(self);
                 #[allow(dead_code)]
-                #[inline]
+
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::run_finalizer(it);

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -96,7 +96,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn trace(&self) {
                 #[allow(dead_code)]
-
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::trace(it);
@@ -107,7 +106,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn weak_trace(&self) {
                 #[allow(dead_code, unreachable_code)]
-
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::weak_trace(it)
@@ -118,7 +116,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn root(&self) {
                 #[allow(dead_code)]
-
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::root(it);
@@ -129,7 +126,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             #[inline]
             unsafe fn unroot(&self) {
                 #[allow(dead_code)]
-
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::unroot(it);
@@ -141,7 +137,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
             fn run_finalizer(&self) {
                 ::boa_gc::Finalize::finalize(self);
                 #[allow(dead_code)]
-
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
                     unsafe {
                         ::boa_gc::Trace::run_finalizer(it);

--- a/boa_parser/src/error.rs
+++ b/boa_parser/src/error.rs
@@ -88,7 +88,6 @@ impl Error {
     }
 
     /// Creates an `Expected` parsing error.
-
     pub(crate) fn expected<E, F>(expected: E, found: F, span: Span, context: &'static str) -> Self
     where
         E: Into<Box<[String]>>,
@@ -103,7 +102,6 @@ impl Error {
     }
 
     /// Creates an `Expected` parsing error.
-
     pub(crate) fn unexpected<F, C>(found: F, span: Span, message: C) -> Self
     where
         F: Into<Box<str>>,
@@ -117,13 +115,11 @@ impl Error {
     }
 
     /// Creates a "general" parsing error.
-
     pub(crate) const fn general(message: &'static str, position: Position) -> Self {
         Self::General { message, position }
     }
 
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration in non-strict mode.
-
     pub(crate) const fn wrong_function_declaration_non_strict(position: Position) -> Self {
         Self::General {
             message: "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.",
@@ -132,7 +128,6 @@ impl Error {
     }
 
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration with label.
-
     pub(crate) const fn wrong_labelled_function_declaration(position: Position) -> Self {
         Self::General {
             message: "Labelled functions can only be declared at top level or inside a block",
@@ -141,7 +136,6 @@ impl Error {
     }
 
     /// Creates a parsing error from a lexing error.
-
     pub(crate) const fn lex(e: LexError) -> Self {
         Self::Lex { err: e }
     }

--- a/boa_parser/src/error.rs
+++ b/boa_parser/src/error.rs
@@ -12,7 +12,6 @@ pub(crate) trait ErrorContext {
 }
 
 impl<T> ErrorContext for ParseResult<T> {
-    #[inline]
     fn context(self, context: &'static str) -> Self {
         self.map_err(|e| e.context(context))
     }
@@ -89,7 +88,7 @@ impl Error {
     }
 
     /// Creates an `Expected` parsing error.
-    #[inline]
+
     pub(crate) fn expected<E, F>(expected: E, found: F, span: Span, context: &'static str) -> Self
     where
         E: Into<Box<[String]>>,
@@ -104,7 +103,7 @@ impl Error {
     }
 
     /// Creates an `Expected` parsing error.
-    #[inline]
+
     pub(crate) fn unexpected<F, C>(found: F, span: Span, message: C) -> Self
     where
         F: Into<Box<str>>,
@@ -118,13 +117,13 @@ impl Error {
     }
 
     /// Creates a "general" parsing error.
-    #[inline]
+
     pub(crate) const fn general(message: &'static str, position: Position) -> Self {
         Self::General { message, position }
     }
 
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration in non-strict mode.
-    #[inline]
+
     pub(crate) const fn wrong_function_declaration_non_strict(position: Position) -> Self {
         Self::General {
             message: "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.",
@@ -133,7 +132,7 @@ impl Error {
     }
 
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration with label.
-    #[inline]
+
     pub(crate) const fn wrong_labelled_function_declaration(position: Position) -> Self {
         Self::General {
             message: "Labelled functions can only be declared at top level or inside a block",
@@ -142,7 +141,7 @@ impl Error {
     }
 
     /// Creates a parsing error from a lexing error.
-    #[inline]
+
     pub(crate) const fn lex(e: LexError) -> Self {
         Self::Lex { err: e }
     }

--- a/boa_parser/src/lexer/cursor.rs
+++ b/boa_parser/src/lexer/cursor.rs
@@ -13,13 +13,11 @@ pub(super) struct Cursor<R> {
 
 impl<R> Cursor<R> {
     /// Gets the current position of the cursor in the source code.
-
     pub(super) const fn pos(&self) -> Position {
         self.pos
     }
 
     /// Advances the position to the next column.
-
     pub(super) fn next_column(&mut self) {
         let current_line = self.pos.line_number();
         let next_column = self.pos.column_number() + 1;
@@ -27,7 +25,6 @@ impl<R> Cursor<R> {
     }
 
     /// Advances the position to the next line.
-
     fn next_line(&mut self) {
         let next_line = self.pos.line_number() + 1;
         self.pos = Position::new(next_line, 1);
@@ -49,7 +46,6 @@ where
     R: Read,
 {
     /// Creates a new Lexer cursor.
-
     pub(super) fn new(inner: R) -> Self {
         Self {
             iter: InnerIter::new(inner.bytes()),
@@ -59,7 +55,6 @@ where
     }
 
     /// Creates a new Lexer cursor with an initial position.
-
     pub(super) fn with_position(inner: R, pos: Position) -> Self {
         Self {
             iter: InnerIter::new(inner.bytes()),
@@ -69,7 +64,6 @@ where
     }
 
     /// Peeks the next byte.
-
     pub(super) fn peek(&mut self) -> Result<Option<u8>, Error> {
         let _timer = Profiler::global().start_event("cursor::peek()", "Lexing");
 
@@ -77,7 +71,6 @@ where
     }
 
     /// Peeks the next n bytes, the maximum number of peeked bytes is 4 (n <= 4).
-
     pub(super) fn peek_n(&mut self, n: u8) -> Result<&[u8], Error> {
         let _timer = Profiler::global().start_event("cursor::peek_n()", "Lexing");
 
@@ -85,15 +78,13 @@ where
     }
 
     /// Peeks the next UTF-8 character in u32 code point.
-
     pub(super) fn peek_char(&mut self) -> Result<Option<u32>, Error> {
         let _timer = Profiler::global().start_event("cursor::peek_char()", "Lexing");
 
         self.iter.peek_char()
     }
 
-    /// Compares the byte passed in to the next byte, if they match true is returned and the buffer is incremented
-
+    /// Compares the byte passed in to the next byte, if they match true is returned and the buffer is incremented.
     pub(super) fn next_is(&mut self, byte: u8) -> io::Result<bool> {
         let _timer = Profiler::global().start_event("cursor::next_is()", "Lexing");
 
@@ -111,7 +102,6 @@ where
     /// Otherwise returns the result from the predicate on the ascii in char
     ///
     /// The buffer is not incremented.
-
     pub(super) fn next_is_ascii_pred<F>(&mut self, pred: &F) -> io::Result<bool>
     where
         F: Fn(char) -> bool,
@@ -130,7 +120,6 @@ where
     ///
     /// The buffer is not incremented.
     #[allow(dead_code)]
-
     pub(super) fn next_is_char_pred<F>(&mut self, pred: &F) -> io::Result<bool>
     where
         F: Fn(u32) -> bool,
@@ -215,7 +204,6 @@ where
     ///
     /// This expects for the buffer to be fully filled. If it's not, it will fail with an
     /// `UnexpectedEof` I/O error.
-
     pub(super) fn fill_bytes(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let _timer = Profiler::global().start_event("cursor::fill_bytes()", "Lexing");
 
@@ -223,7 +211,6 @@ where
     }
 
     /// Retrieves the next byte.
-
     pub(crate) fn next_byte(&mut self) -> Result<Option<u8>, Error> {
         let _timer = Profiler::global().start_event("cursor::next_byte()", "Lexing");
 
@@ -257,7 +244,6 @@ where
     }
 
     /// Retrieves the next UTF-8 character.
-
     pub(crate) fn next_char(&mut self) -> Result<Option<u32>, Error> {
         let _timer = Profiler::global().start_event("cursor::next_char()", "Lexing");
 
@@ -294,7 +280,6 @@ struct InnerIter<R> {
 
 impl<R> InnerIter<R> {
     /// Creates a new inner iterator.
-
     const fn new(iter: Bytes<R>) -> Self {
         Self {
             iter,
@@ -313,7 +298,6 @@ where
     ///
     /// This expects for the buffer to be fully filled. If it's not, it will fail with an
     /// `UnexpectedEof` I/O error.
-
     fn fill_bytes(&mut self, buf: &mut [u8]) -> io::Result<()> {
         for byte in buf.iter_mut() {
             *byte = self.next_byte()?.ok_or_else(|| {
@@ -327,7 +311,6 @@ where
     }
 
     /// Increments the iter by n bytes.
-
     fn increment(&mut self, n: u32) -> Result<(), Error> {
         for _ in 0..n {
             if (self.next_byte()?).is_none() {
@@ -338,7 +321,6 @@ where
     }
 
     /// Peeks the next byte.
-
     pub(super) fn peek_byte(&mut self) -> Result<Option<u8>, Error> {
         if self.num_peeked_bytes > 0 {
             let byte = self.peeked_bytes[0];
@@ -356,7 +338,6 @@ where
     }
 
     /// Peeks the next n bytes, the maximum number of peeked bytes is 4 (n <= 4).
-
     pub(super) fn peek_n_bytes(&mut self, n: u8) -> Result<&[u8], Error> {
         while self.num_peeked_bytes < n && self.num_peeked_bytes < 4 {
             match self.iter.next().transpose()? {
@@ -371,7 +352,6 @@ where
     }
 
     /// Peeks the next unchecked character in u32 code point.
-
     pub(super) fn peek_char(&mut self) -> Result<Option<u32>, Error> {
         if let Some(ch) = self.peeked_char {
             Ok(ch)
@@ -421,7 +401,6 @@ where
     }
 
     /// Retrieves the next byte
-
     fn next_byte(&mut self) -> io::Result<Option<u8>> {
         self.peeked_char = None;
         if self.num_peeked_bytes > 0 {
@@ -435,7 +414,6 @@ where
     }
 
     /// Retrieves the next unchecked char in u32 code point.
-
     fn next_char(&mut self) -> io::Result<Option<u32>> {
         if let Some(ch) = self.peeked_char.take() {
             if let Some(c) = ch {
@@ -481,20 +459,17 @@ const CONT_MASK: u8 = 0b0011_1111;
 /// Returns the initial codepoint accumulator for the first byte.
 /// The first byte is special, only want bottom 5 bits for width 2, 4 bits
 /// for width 3, and 3 bits for width 4.
-
 fn utf8_first_byte(byte: u8, width: u32) -> u32 {
     u32::from(byte & (0x7F >> width))
 }
 
 /// Returns the value of `ch` updated with continuation byte `byte`.
-
 fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
     (ch << 6) | u32::from(byte & CONT_MASK)
 }
 
 /// Checks whether the byte is a UTF-8 first byte (i.e., ascii byte or starts with the
 /// bits `11`).
-
 const fn utf8_is_first_byte(byte: u8) -> bool {
     byte <= 0x7F || (byte >> 6) == 0x11
 }

--- a/boa_parser/src/lexer/cursor.rs
+++ b/boa_parser/src/lexer/cursor.rs
@@ -13,13 +13,13 @@ pub(super) struct Cursor<R> {
 
 impl<R> Cursor<R> {
     /// Gets the current position of the cursor in the source code.
-    #[inline]
+
     pub(super) const fn pos(&self) -> Position {
         self.pos
     }
 
     /// Advances the position to the next column.
-    #[inline]
+
     pub(super) fn next_column(&mut self) {
         let current_line = self.pos.line_number();
         let next_column = self.pos.column_number() + 1;
@@ -27,19 +27,17 @@ impl<R> Cursor<R> {
     }
 
     /// Advances the position to the next line.
-    #[inline]
+
     fn next_line(&mut self) {
         let next_line = self.pos.line_number() + 1;
         self.pos = Position::new(next_line, 1);
     }
 
-    #[inline]
     /// Returns if strict mode is currently active.
     pub(super) const fn strict_mode(&self) -> bool {
         self.strict_mode
     }
 
-    #[inline]
     /// Sets the current strict mode.
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
         self.strict_mode = strict_mode;
@@ -51,7 +49,7 @@ where
     R: Read,
 {
     /// Creates a new Lexer cursor.
-    #[inline]
+
     pub(super) fn new(inner: R) -> Self {
         Self {
             iter: InnerIter::new(inner.bytes()),
@@ -61,7 +59,7 @@ where
     }
 
     /// Creates a new Lexer cursor with an initial position.
-    #[inline]
+
     pub(super) fn with_position(inner: R, pos: Position) -> Self {
         Self {
             iter: InnerIter::new(inner.bytes()),
@@ -71,7 +69,7 @@ where
     }
 
     /// Peeks the next byte.
-    #[inline]
+
     pub(super) fn peek(&mut self) -> Result<Option<u8>, Error> {
         let _timer = Profiler::global().start_event("cursor::peek()", "Lexing");
 
@@ -79,7 +77,7 @@ where
     }
 
     /// Peeks the next n bytes, the maximum number of peeked bytes is 4 (n <= 4).
-    #[inline]
+
     pub(super) fn peek_n(&mut self, n: u8) -> Result<&[u8], Error> {
         let _timer = Profiler::global().start_event("cursor::peek_n()", "Lexing");
 
@@ -87,7 +85,7 @@ where
     }
 
     /// Peeks the next UTF-8 character in u32 code point.
-    #[inline]
+
     pub(super) fn peek_char(&mut self) -> Result<Option<u32>, Error> {
         let _timer = Profiler::global().start_event("cursor::peek_char()", "Lexing");
 
@@ -95,7 +93,7 @@ where
     }
 
     /// Compares the byte passed in to the next byte, if they match true is returned and the buffer is incremented
-    #[inline]
+
     pub(super) fn next_is(&mut self, byte: u8) -> io::Result<bool> {
         let _timer = Profiler::global().start_event("cursor::next_is()", "Lexing");
 
@@ -113,7 +111,7 @@ where
     /// Otherwise returns the result from the predicate on the ascii in char
     ///
     /// The buffer is not incremented.
-    #[inline]
+
     pub(super) fn next_is_ascii_pred<F>(&mut self, pred: &F) -> io::Result<bool>
     where
         F: Fn(char) -> bool,
@@ -132,7 +130,7 @@ where
     ///
     /// The buffer is not incremented.
     #[allow(dead_code)]
-    #[inline]
+
     pub(super) fn next_is_char_pred<F>(&mut self, pred: &F) -> io::Result<bool>
     where
         F: Fn(u32) -> bool,
@@ -217,7 +215,7 @@ where
     ///
     /// This expects for the buffer to be fully filled. If it's not, it will fail with an
     /// `UnexpectedEof` I/O error.
-    #[inline]
+
     pub(super) fn fill_bytes(&mut self, buf: &mut [u8]) -> io::Result<()> {
         let _timer = Profiler::global().start_event("cursor::fill_bytes()", "Lexing");
 
@@ -225,7 +223,7 @@ where
     }
 
     /// Retrieves the next byte.
-    #[inline]
+
     pub(crate) fn next_byte(&mut self) -> Result<Option<u8>, Error> {
         let _timer = Profiler::global().start_event("cursor::next_byte()", "Lexing");
 
@@ -259,7 +257,7 @@ where
     }
 
     /// Retrieves the next UTF-8 character.
-    #[inline]
+
     pub(crate) fn next_char(&mut self) -> Result<Option<u32>, Error> {
         let _timer = Profiler::global().start_event("cursor::next_char()", "Lexing");
 
@@ -296,7 +294,7 @@ struct InnerIter<R> {
 
 impl<R> InnerIter<R> {
     /// Creates a new inner iterator.
-    #[inline]
+
     const fn new(iter: Bytes<R>) -> Self {
         Self {
             iter,
@@ -315,7 +313,7 @@ where
     ///
     /// This expects for the buffer to be fully filled. If it's not, it will fail with an
     /// `UnexpectedEof` I/O error.
-    #[inline]
+
     fn fill_bytes(&mut self, buf: &mut [u8]) -> io::Result<()> {
         for byte in buf.iter_mut() {
             *byte = self.next_byte()?.ok_or_else(|| {
@@ -329,7 +327,7 @@ where
     }
 
     /// Increments the iter by n bytes.
-    #[inline]
+
     fn increment(&mut self, n: u32) -> Result<(), Error> {
         for _ in 0..n {
             if (self.next_byte()?).is_none() {
@@ -340,7 +338,7 @@ where
     }
 
     /// Peeks the next byte.
-    #[inline]
+
     pub(super) fn peek_byte(&mut self) -> Result<Option<u8>, Error> {
         if self.num_peeked_bytes > 0 {
             let byte = self.peeked_bytes[0];
@@ -358,7 +356,7 @@ where
     }
 
     /// Peeks the next n bytes, the maximum number of peeked bytes is 4 (n <= 4).
-    #[inline]
+
     pub(super) fn peek_n_bytes(&mut self, n: u8) -> Result<&[u8], Error> {
         while self.num_peeked_bytes < n && self.num_peeked_bytes < 4 {
             match self.iter.next().transpose()? {
@@ -373,7 +371,7 @@ where
     }
 
     /// Peeks the next unchecked character in u32 code point.
-    #[inline]
+
     pub(super) fn peek_char(&mut self) -> Result<Option<u32>, Error> {
         if let Some(ch) = self.peeked_char {
             Ok(ch)
@@ -423,7 +421,7 @@ where
     }
 
     /// Retrieves the next byte
-    #[inline]
+
     fn next_byte(&mut self) -> io::Result<Option<u8>> {
         self.peeked_char = None;
         if self.num_peeked_bytes > 0 {
@@ -437,7 +435,7 @@ where
     }
 
     /// Retrieves the next unchecked char in u32 code point.
-    #[inline]
+
     fn next_char(&mut self) -> io::Result<Option<u32>> {
         if let Some(ch) = self.peeked_char.take() {
             if let Some(c) = ch {
@@ -483,30 +481,28 @@ const CONT_MASK: u8 = 0b0011_1111;
 /// Returns the initial codepoint accumulator for the first byte.
 /// The first byte is special, only want bottom 5 bits for width 2, 4 bits
 /// for width 3, and 3 bits for width 4.
-#[inline]
+
 fn utf8_first_byte(byte: u8, width: u32) -> u32 {
     u32::from(byte & (0x7F >> width))
 }
 
 /// Returns the value of `ch` updated with continuation byte `byte`.
-#[inline]
+
 fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
     (ch << 6) | u32::from(byte & CONT_MASK)
 }
 
 /// Checks whether the byte is a UTF-8 first byte (i.e., ascii byte or starts with the
 /// bits `11`).
-#[inline]
+
 const fn utf8_is_first_byte(byte: u8) -> bool {
     byte <= 0x7F || (byte >> 6) == 0x11
 }
 
-#[inline]
 fn unwrap_or_0(opt: Option<u8>) -> u8 {
     opt.unwrap_or(0)
 }
 
-#[inline]
 const fn utf8_len(ch: u32) -> u32 {
     if ch <= 0x7F {
         1

--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -22,7 +22,7 @@ pub(super) struct Identifier {
 
 impl Identifier {
     /// Creates a new identifier/keyword lexer.
-    #[inline]
+
     pub(super) const fn new(init: char) -> Self {
         Self { init }
     }
@@ -33,7 +33,7 @@ impl Identifier {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-names-and-keywords
-    #[inline]
+
     pub(super) fn is_identifier_start(ch: u32) -> bool {
         matches!(ch, 0x0024 /* $ */ | 0x005F /* _ */)
             || char::try_from(ch).map_or(false, char::is_id_start)
@@ -45,7 +45,7 @@ impl Identifier {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-names-and-keywords
-    #[inline]
+
     fn is_identifier_part(ch: u32) -> bool {
         matches!(
             ch,
@@ -82,7 +82,6 @@ impl<R> Tokenizer<R> for Identifier {
 }
 
 impl Identifier {
-    #[inline]
     pub(super) fn take_identifier_name<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,

--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -22,7 +22,6 @@ pub(super) struct Identifier {
 
 impl Identifier {
     /// Creates a new identifier/keyword lexer.
-
     pub(super) const fn new(init: char) -> Self {
         Self { init }
     }
@@ -33,7 +32,6 @@ impl Identifier {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-names-and-keywords
-
     pub(super) fn is_identifier_start(ch: u32) -> bool {
         matches!(ch, 0x0024 /* $ */ | 0x005F /* _ */)
             || char::try_from(ch).map_or(false, char::is_id_start)
@@ -45,7 +43,6 @@ impl Identifier {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-names-and-keywords
-
     fn is_identifier_part(ch: u32) -> bool {
         matches!(
             ch,

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -89,31 +89,29 @@ impl<R> Lexer<R> {
     }
 
     /// Sets the goal symbol for the lexer.
-    #[inline]
+
     pub(crate) fn set_goal(&mut self, elm: InputElement) {
         self.goal_symbol = elm;
     }
 
     /// Gets the goal symbol the lexer is currently using.
-    #[inline]
+
     pub(crate) const fn get_goal(&self) -> InputElement {
         self.goal_symbol
     }
 
-    #[inline]
     /// Returns if strict mode is currently active.
     pub(super) const fn strict_mode(&self) -> bool {
         self.cursor.strict_mode()
     }
 
-    #[inline]
     /// Sets the current strict mode.
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
         self.cursor.set_strict_mode(strict_mode);
     }
 
     /// Creates a new lexer.
-    #[inline]
+
     pub fn new(reader: R) -> Self
     where
         R: Read,

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -89,13 +89,11 @@ impl<R> Lexer<R> {
     }
 
     /// Sets the goal symbol for the lexer.
-
     pub(crate) fn set_goal(&mut self, elm: InputElement) {
         self.goal_symbol = elm;
     }
 
     /// Gets the goal symbol the lexer is currently using.
-
     pub(crate) const fn get_goal(&self) -> InputElement {
         self.goal_symbol
     }
@@ -111,7 +109,6 @@ impl<R> Lexer<R> {
     }
 
     /// Creates a new lexer.
-
     pub fn new(reader: R) -> Self
     where
         R: Read,

--- a/boa_parser/src/lexer/number.rs
+++ b/boa_parser/src/lexer/number.rs
@@ -58,7 +58,6 @@ impl NumericKind {
     }
 }
 
-#[inline]
 fn take_signed_integer<R>(
     buf: &mut Vec<u8>,
     cursor: &mut Cursor<R>,
@@ -157,7 +156,7 @@ where
 ///  - [ECMAScript Specification][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-literals-numeric-literals
-#[inline]
+
 fn check_after_numeric_literal<R>(cursor: &mut Cursor<R>) -> Result<(), Error>
 where
     R: Read,

--- a/boa_parser/src/lexer/number.rs
+++ b/boa_parser/src/lexer/number.rs
@@ -156,7 +156,6 @@ where
 ///  - [ECMAScript Specification][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-literals-numeric-literals
-
 fn check_after_numeric_literal<R>(cursor: &mut Cursor<R>) -> Result<(), Error>
 where
     R: Read,

--- a/boa_parser/src/lexer/string.rs
+++ b/boa_parser/src/lexer/string.rs
@@ -105,7 +105,6 @@ impl StringLiteral {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-LineTerminator
-
     pub(super) const fn is_line_terminator(ch: u32) -> bool {
         matches!(
             ch,

--- a/boa_parser/src/lexer/string.rs
+++ b/boa_parser/src/lexer/string.rs
@@ -54,7 +54,6 @@ pub(crate) trait UTF16CodeUnitsBuffer {
 }
 
 impl UTF16CodeUnitsBuffer for Vec<u16> {
-    #[inline]
     fn push_code_point(&mut self, mut code_point: u32) {
         if let Ok(cp) = code_point.try_into() {
             self.push(cp);
@@ -72,7 +71,6 @@ impl UTF16CodeUnitsBuffer for Vec<u16> {
         self.push(cu2);
     }
 
-    #[inline]
     fn to_string_lossy(&self) -> String {
         String::from_utf16_lossy(self.as_slice())
     }
@@ -107,7 +105,7 @@ impl StringLiteral {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-LineTerminator
-    #[inline]
+
     pub(super) const fn is_line_terminator(ch: u32) -> bool {
         matches!(
             ch,
@@ -115,7 +113,6 @@ impl StringLiteral {
         )
     }
 
-    #[inline]
     fn take_string_characters<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
@@ -163,7 +160,6 @@ impl StringLiteral {
         Ok((buf, Span::new(start_pos, cursor.pos())))
     }
 
-    #[inline]
     pub(super) fn take_escape_sequence_or_line_continuation<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
@@ -250,7 +246,6 @@ impl StringLiteral {
         Ok(escape_value)
     }
 
-    #[inline]
     pub(super) fn take_unicode_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
@@ -299,7 +294,6 @@ impl StringLiteral {
         }
     }
 
-    #[inline]
     fn take_hex_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
@@ -317,7 +311,6 @@ impl StringLiteral {
         Ok(u32::from(code_point))
     }
 
-    #[inline]
     fn take_legacy_octal_escape_sequence<R>(
         cursor: &mut Cursor<R>,
         init_byte: u8,

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -70,14 +70,12 @@ where
     R: Read,
 {
     /// Sets the goal symbol for the lexer.
-
     pub(super) fn set_goal(&mut self, elm: InputElement) {
         let _timer = Profiler::global().start_event("cursor::set_goal()", "Parsing");
         self.lexer.set_goal(elm);
     }
 
     /// Lexes the next tokens as a regex assuming that the starting '/' has already been consumed.
-
     pub(super) fn lex_regex(
         &mut self,
         start: Position,

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -36,7 +36,6 @@ impl<R> From<Lexer<R>> for BufferedLexer<R>
 where
     R: Read,
 {
-    #[inline]
     fn from(lexer: Lexer<R>) -> Self {
         Self {
             lexer,
@@ -61,7 +60,6 @@ impl<R> From<R> for BufferedLexer<R>
 where
     R: Read,
 {
-    #[inline]
     fn from(reader: R) -> Self {
         Lexer::new(reader).into()
     }
@@ -72,14 +70,14 @@ where
     R: Read,
 {
     /// Sets the goal symbol for the lexer.
-    #[inline]
+
     pub(super) fn set_goal(&mut self, elm: InputElement) {
         let _timer = Profiler::global().start_event("cursor::set_goal()", "Parsing");
         self.lexer.set_goal(elm);
     }
 
     /// Lexes the next tokens as a regex assuming that the starting '/' has already been consumed.
-    #[inline]
+
     pub(super) fn lex_regex(
         &mut self,
         start: Position,
@@ -104,12 +102,10 @@ where
             .map_err(Error::from)
     }
 
-    #[inline]
     pub(super) const fn strict_mode(&self) -> bool {
         self.lexer.strict_mode()
     }
 
-    #[inline]
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
         self.lexer.set_strict_mode(strict_mode);
     }

--- a/boa_parser/src/parser/cursor/mod.rs
+++ b/boa_parser/src/parser/cursor/mod.rs
@@ -41,7 +41,7 @@ where
     R: Read,
 {
     /// Creates a new cursor with the given reader.
-    #[inline]
+
     pub(super) fn new(reader: R) -> Self {
         Self {
             buffered_lexer: Lexer::new(reader).into(),
@@ -51,12 +51,10 @@ where
         }
     }
 
-    #[inline]
     pub(super) fn set_goal(&mut self, elm: InputElement) {
         self.buffered_lexer.set_goal(elm);
     }
 
-    #[inline]
     pub(super) fn lex_regex(
         &mut self,
         start: Position,
@@ -65,7 +63,6 @@ where
         self.buffered_lexer.lex_regex(start, interner)
     }
 
-    #[inline]
     pub(super) fn lex_template(
         &mut self,
         start: Position,
@@ -75,7 +72,7 @@ where
     }
 
     /// Advances the cursor and returns the next token.
-    #[inline]
+
     pub(super) fn next(&mut self, interner: &mut Interner) -> ParseResult<Option<Token>> {
         self.buffered_lexer.next(true, interner)
     }
@@ -85,7 +82,7 @@ where
     /// # Panics
     ///
     /// This function will panic if there is no further token in the cursor.
-    #[inline]
+
     #[track_caller]
     pub(super) fn advance(&mut self, interner: &mut Interner) {
         self.next(interner)
@@ -95,7 +92,7 @@ where
     /// Peeks a future token, without consuming it or advancing the cursor.
     ///
     /// You can skip some tokens with the `skip_n` option.
-    #[inline]
+
     pub(super) fn peek(
         &mut self,
         skip_n: usize,
@@ -105,50 +102,50 @@ where
     }
 
     /// Gets the current strict mode for the cursor.
-    #[inline]
+
     pub(super) const fn strict_mode(&self) -> bool {
         self.buffered_lexer.strict_mode()
     }
 
     /// Sets the strict mode to strict or non-strict.
-    #[inline]
+
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
         self.buffered_lexer.set_strict_mode(strict_mode);
     }
 
     /// Returns if the cursor is currently in an arrow function declaration.
-    #[inline]
+
     pub(super) const fn arrow(&self) -> bool {
         self.arrow
     }
 
     /// Set if the cursor is currently in a arrow function declaration.
-    #[inline]
+
     pub(super) fn set_arrow(&mut self, arrow: bool) {
         self.arrow = arrow;
     }
 
     /// Returns if the cursor is currently used in `JSON.parse`.
-    #[inline]
+
     pub(super) const fn json_parse(&self) -> bool {
         self.json_parse
     }
 
     /// Set if the cursor is currently used in `JSON.parse`.
-    #[inline]
+
     pub(super) fn set_json_parse(&mut self, json_parse: bool) {
         self.json_parse = json_parse;
     }
 
     /// Push a new private environment.
-    #[inline]
+
     pub(super) fn push_private_environment(&mut self) {
         let new = FxHashMap::default();
         self.private_environments_stack.push(new);
     }
 
     /// Push a used private identifier.
-    #[inline]
+
     pub(super) fn push_used_private_identifier(
         &mut self,
         identifier: Sym,
@@ -172,7 +169,7 @@ where
     ///
     /// This function takes the private element names of the current class.
     /// If a used private identifier is not declared, this throws a syntax error.
-    #[inline]
+
     pub(super) fn pop_private_environment(
         &mut self,
         identifiers: &FxHashMap<Sym, PrivateElement>,
@@ -197,7 +194,7 @@ where
     }
 
     /// Returns an error if the next token is not of kind `kind`.
-    #[inline]
+
     pub(super) fn expect<K>(
         &mut self,
         kind: K,
@@ -227,7 +224,7 @@ where
     /// It will automatically insert a semicolon if needed, as specified in the [spec][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
-    #[inline]
+
     pub(super) fn peek_semicolon(
         &mut self,
         interner: &mut Interner,
@@ -247,7 +244,7 @@ where
     /// It will automatically insert a semicolon if needed, as specified in the [spec][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
-    #[inline]
+
     pub(super) fn expect_semicolon(
         &mut self,
         context: &'static str,
@@ -277,7 +274,7 @@ where
     ///
     /// This is just syntatic sugar for a `.peek(skip_n)` call followed by a check that the result
     /// is not a line terminator or `None`.
-    #[inline]
+
     pub(super) fn peek_expect_no_lineterminator(
         &mut self,
         skip_n: usize,
@@ -301,7 +298,7 @@ where
     }
 
     /// Check if the peeked token is a line terminator.
-    #[inline]
+
     pub(super) fn peek_is_line_terminator(
         &mut self,
         skip_n: usize,
@@ -319,7 +316,7 @@ where
     /// When the next token is a `kind` token, get the token, otherwise return `None`.
     ///
     /// No next token also returns None.
-    #[inline]
+
     pub(super) fn next_if<K>(
         &mut self,
         kind: K,

--- a/boa_parser/src/parser/cursor/mod.rs
+++ b/boa_parser/src/parser/cursor/mod.rs
@@ -41,7 +41,6 @@ where
     R: Read,
 {
     /// Creates a new cursor with the given reader.
-
     pub(super) fn new(reader: R) -> Self {
         Self {
             buffered_lexer: Lexer::new(reader).into(),
@@ -72,7 +71,6 @@ where
     }
 
     /// Advances the cursor and returns the next token.
-
     pub(super) fn next(&mut self, interner: &mut Interner) -> ParseResult<Option<Token>> {
         self.buffered_lexer.next(true, interner)
     }
@@ -82,7 +80,6 @@ where
     /// # Panics
     ///
     /// This function will panic if there is no further token in the cursor.
-
     #[track_caller]
     pub(super) fn advance(&mut self, interner: &mut Interner) {
         self.next(interner)
@@ -92,7 +89,6 @@ where
     /// Peeks a future token, without consuming it or advancing the cursor.
     ///
     /// You can skip some tokens with the `skip_n` option.
-
     pub(super) fn peek(
         &mut self,
         skip_n: usize,
@@ -102,50 +98,42 @@ where
     }
 
     /// Gets the current strict mode for the cursor.
-
     pub(super) const fn strict_mode(&self) -> bool {
         self.buffered_lexer.strict_mode()
     }
 
     /// Sets the strict mode to strict or non-strict.
-
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
         self.buffered_lexer.set_strict_mode(strict_mode);
     }
 
     /// Returns if the cursor is currently in an arrow function declaration.
-
     pub(super) const fn arrow(&self) -> bool {
         self.arrow
     }
 
     /// Set if the cursor is currently in a arrow function declaration.
-
     pub(super) fn set_arrow(&mut self, arrow: bool) {
         self.arrow = arrow;
     }
 
     /// Returns if the cursor is currently used in `JSON.parse`.
-
     pub(super) const fn json_parse(&self) -> bool {
         self.json_parse
     }
 
     /// Set if the cursor is currently used in `JSON.parse`.
-
     pub(super) fn set_json_parse(&mut self, json_parse: bool) {
         self.json_parse = json_parse;
     }
 
     /// Push a new private environment.
-
     pub(super) fn push_private_environment(&mut self) {
         let new = FxHashMap::default();
         self.private_environments_stack.push(new);
     }
 
     /// Push a used private identifier.
-
     pub(super) fn push_used_private_identifier(
         &mut self,
         identifier: Sym,
@@ -169,7 +157,6 @@ where
     ///
     /// This function takes the private element names of the current class.
     /// If a used private identifier is not declared, this throws a syntax error.
-
     pub(super) fn pop_private_environment(
         &mut self,
         identifiers: &FxHashMap<Sym, PrivateElement>,
@@ -194,7 +181,6 @@ where
     }
 
     /// Returns an error if the next token is not of kind `kind`.
-
     pub(super) fn expect<K>(
         &mut self,
         kind: K,
@@ -224,7 +210,6 @@ where
     /// It will automatically insert a semicolon if needed, as specified in the [spec][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
-
     pub(super) fn peek_semicolon(
         &mut self,
         interner: &mut Interner,
@@ -244,7 +229,6 @@ where
     /// It will automatically insert a semicolon if needed, as specified in the [spec][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-automatic-semicolon-insertion
-
     pub(super) fn expect_semicolon(
         &mut self,
         context: &'static str,
@@ -274,7 +258,6 @@ where
     ///
     /// This is just syntatic sugar for a `.peek(skip_n)` call followed by a check that the result
     /// is not a line terminator or `None`.
-
     pub(super) fn peek_expect_no_lineterminator(
         &mut self,
         skip_n: usize,
@@ -298,7 +281,6 @@ where
     }
 
     /// Check if the peeked token is a line terminator.
-
     pub(super) fn peek_is_line_terminator(
         &mut self,
         skip_n: usize,
@@ -316,7 +298,6 @@ where
     /// When the next token is a `kind` token, get the token, otherwise return `None`.
     ///
     /// No next token also returns None.
-
     pub(super) fn next_if<K>(
         &mut self,
         kind: K,

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -52,7 +52,6 @@ where
 struct AllowYield(bool);
 
 impl From<bool> for AllowYield {
-    #[inline]
     fn from(allow: bool) -> Self {
         Self(allow)
     }
@@ -63,7 +62,6 @@ impl From<bool> for AllowYield {
 struct AllowAwait(bool);
 
 impl From<bool> for AllowAwait {
-    #[inline]
     fn from(allow: bool) -> Self {
         Self(allow)
     }
@@ -74,7 +72,6 @@ impl From<bool> for AllowAwait {
 struct AllowIn(bool);
 
 impl From<bool> for AllowIn {
-    #[inline]
     fn from(allow: bool) -> Self {
         Self(allow)
     }
@@ -85,7 +82,6 @@ impl From<bool> for AllowIn {
 struct AllowReturn(bool);
 
 impl From<bool> for AllowReturn {
-    #[inline]
     fn from(allow: bool) -> Self {
         Self(allow)
     }
@@ -96,7 +92,6 @@ impl From<bool> for AllowReturn {
 struct AllowDefault(bool);
 
 impl From<bool> for AllowDefault {
-    #[inline]
     fn from(allow: bool) -> Self {
         Self(allow)
     }
@@ -119,7 +114,7 @@ pub struct Parser<R> {
 
 impl<R> Parser<R> {
     /// Create a new `Parser` with a reader as the input to parse.
-    #[inline]
+
     pub fn new(reader: R) -> Self
     where
         R: Read,
@@ -130,7 +125,7 @@ impl<R> Parser<R> {
     }
 
     /// Set the parser strict mode to true.
-    #[inline]
+
     pub fn set_strict(&mut self)
     where
         R: Read,
@@ -139,7 +134,7 @@ impl<R> Parser<R> {
     }
 
     /// Set the parser strict mode to true.
-    #[inline]
+
     pub fn set_json_parse(&mut self)
     where
         R: Read,
@@ -155,7 +150,7 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-Script
-    #[inline]
+
     pub fn parse_all(&mut self, interner: &mut Interner) -> ParseResult<StatementList>
     where
         R: Read,
@@ -172,7 +167,7 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-performeval
-    #[inline]
+
     pub fn parse_eval(
         &mut self,
         direct: bool,
@@ -191,7 +186,7 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-FunctionBody
-    #[inline]
+
     pub fn parse_function_body(
         &mut self,
         interner: &mut Interner,
@@ -211,7 +206,7 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-FormalParameterList
-    #[inline]
+
     pub fn parse_formal_parameters(
         &mut self,
         interner: &mut Interner,
@@ -352,7 +347,7 @@ where
 }
 
 /// Helper to check if any parameter names are declared in the given list.
-#[inline]
+
 fn name_in_lexically_declared_names(
     bound_names: &[Identifier],
     lexical_names: &[Identifier],
@@ -376,7 +371,6 @@ trait OrAbrupt<T> {
 }
 
 impl<T> OrAbrupt<T> for ParseResult<Option<T>> {
-    #[inline]
     fn or_abrupt(self) -> ParseResult<T> {
         self?.ok_or(Error::AbruptEnd)
     }

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -114,7 +114,6 @@ pub struct Parser<R> {
 
 impl<R> Parser<R> {
     /// Create a new `Parser` with a reader as the input to parse.
-
     pub fn new(reader: R) -> Self
     where
         R: Read,
@@ -125,7 +124,6 @@ impl<R> Parser<R> {
     }
 
     /// Set the parser strict mode to true.
-
     pub fn set_strict(&mut self)
     where
         R: Read,
@@ -150,7 +148,6 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-Script
-
     pub fn parse_all(&mut self, interner: &mut Interner) -> ParseResult<StatementList>
     where
         R: Read,
@@ -167,7 +164,6 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-performeval
-
     pub fn parse_eval(
         &mut self,
         direct: bool,
@@ -186,7 +182,6 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-FunctionBody
-
     pub fn parse_function_body(
         &mut self,
         interner: &mut Interner,
@@ -206,7 +201,6 @@ impl<R> Parser<R> {
     /// Will return `Err` on any parsing error, including invalid reads of the bytes being parsed.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-FormalParameterList
-
     pub fn parse_formal_parameters(
         &mut self,
         interner: &mut Interner,
@@ -347,7 +341,6 @@ where
 }
 
 /// Helper to check if any parameter names are declared in the given list.
-
 fn name_in_lexically_declared_names(
     bound_names: &[Identifier],
     lexical_names: &[Identifier],

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -132,7 +132,6 @@ impl<R> Parser<R> {
     }
 
     /// Set the parser strict mode to true.
-
     pub fn set_json_parse(&mut self)
     where
         R: Read,

--- a/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -44,42 +44,34 @@ impl AsyncGeneratorDeclaration {
 }
 
 impl CallableDeclaration for AsyncGeneratorDeclaration {
-    #[inline]
     fn error_context(&self) -> &'static str {
         "async generator declaration"
     }
 
-    #[inline]
     fn is_default(&self) -> bool {
         self.is_default.0
     }
 
-    #[inline]
     fn name_allow_yield(&self) -> bool {
         self.allow_yield.0
     }
 
-    #[inline]
     fn name_allow_await(&self) -> bool {
         self.allow_await.0
     }
 
-    #[inline]
     fn parameters_allow_yield(&self) -> bool {
         true
     }
 
-    #[inline]
     fn parameters_allow_await(&self) -> bool {
         true
     }
 
-    #[inline]
     fn body_allow_yield(&self) -> bool {
         true
     }
 
-    #[inline]
     fn body_allow_await(&self) -> bool {
         true
     }

--- a/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
@@ -138,7 +138,6 @@ trait CallableDeclaration {
 }
 
 // This is a helper function to not duplicate code in the individual callable declaration parsers.
-
 fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
     c: &C,
     cursor: &mut Cursor<R>,

--- a/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
@@ -138,7 +138,7 @@ trait CallableDeclaration {
 }
 
 // This is a helper function to not duplicate code in the individual callable declaration parsers.
-#[inline]
+
 fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
     c: &C,
     cursor: &mut Cursor<R>,

--- a/boa_parser/src/parser/statement/iteration/for_statement.rs
+++ b/boa_parser/src/parser/statement/iteration/for_statement.rs
@@ -284,7 +284,6 @@ where
     }
 }
 
-#[inline]
 fn initializer_to_iterable_loop_initializer(
     initializer: ForLoopInitializer,
     position: Position,

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -41,7 +41,6 @@ fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsRes
 ///
 /// Implements the `DetachArrayBuffer` abstract operation.
 fn detach_array_buffer(_this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-    #[inline]
     fn type_err() -> JsNativeError {
         JsNativeError::typ().with_message("The provided object was not an ArrayBuffer")
     }

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -381,7 +381,6 @@ struct Test {
 
 impl Test {
     /// Creates a new test.
-
     fn new<N, C>(name: N, content: C, metadata: MetaData) -> Self
     where
         N: Into<Box<str>>,

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -381,7 +381,7 @@ struct Test {
 
 impl Test {
     /// Creates a new test.
-    #[inline]
+
     fn new<N, C>(name: N, content: C, metadata: MetaData) -> Self
     where
         N: Into<Box<str>>,


### PR DESCRIPTION
Per the [Standard Library development guide](https://std-dev-guide.rust-lang.org/code-considerations/performance/inline.html):

> You can add `#[inline]`:
>
> - To public, small, non-generic functions.
>
> You shouldn't need `#[inline]`:
> - On methods that have any generics in scope.
> - On methods on traits that don't have a default implementation.
>
> `#[inline]` can always be introduced later, so if you're in doubt they can just be removed.

This PR follows this guideline to reduce the number of `#[inline]` annotations in our code, removing the annotation in:
- Non-public functions
- Generic functions
- Medium and big functions.

Hopefully this shouldn't impact our perf at all, but let's wait to see the benchmark results.