### PR TITLE
[Merged by Bors] - [profiler] Cache StringId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,6 +225,7 @@ version = "0.16.0"
 dependencies = [
  "measureme",
  "once_cell",
+ "rustc-hash",
 ]
 
 [[package]]

--- a/boa_profiler/Cargo.toml
+++ b/boa_profiler/Cargo.toml
@@ -11,8 +11,9 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-profiler = ["measureme", "once_cell"]
+profiler = ["measureme", "once_cell", "rustc-hash"]
 
 [dependencies]
 measureme = { version = "10.1.0", optional = true }
 once_cell = { version = "1.16.0", optional = true }
+rustc-hash = { version = "1.1.0", optional = true }

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -24,7 +24,7 @@
 //! [boa-web]: https://boa-dev.github.io/
 //! [boa-playground]: https://boa-dev.github.io/boa/playground/
 
-#![cfg_attr(not(test), forbid(clippy::unwrap_used))]
+#![cfg_attr(not(any(test, feature = "profiler")), forbid(clippy::unwrap_used))]
 #![warn(missing_docs, clippy::dbg_macro)]
 #![deny(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
@@ -128,7 +128,8 @@ impl Profiler {
             }
         }
         let mut cache = self.string_cache.write().unwrap();
-        match cache.entry(s.into()) {
+        let entry = cache.entry(s.into());
+        match entry {
             Entry::Occupied(entry) => *entry.get(),
             Entry::Vacant(entry) => {
                 let id = self.profiler.alloc_string(s);


### PR DESCRIPTION
boa_profiler was allocating new strings every time even when they are the same string, which leads to a crash when `start_event` is called too much. This change updates the profiler to use a hash map cache and avoid duplicate string allocations.