### PR TITLE
[Merged by Bors] - replace deprecated set-output command

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -57,7 +57,6 @@ jobs:
           cd boa
           comment="$(./target/release/boa_tester compare ../gh-pages/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
           comment="${comment//'%'/'%25'}"
-          comment="${comment//$'\n'/'%0A'}"
           comment="${comment//$'\r'/'%0D'}"
           echo "comment=$comment" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -59,7 +59,7 @@ jobs:
           comment="${comment//'%'/'%25'}"
           comment="${comment//$'\n'/'%0A'}"
           comment="${comment//$'\r'/'%0D'}"
-          echo "::set-output name=comment::$comment"
+          echo "comment=$comment" ?? $GITHUB_OUTPUT
 
       - name: Get the PR number
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -59,7 +59,7 @@ jobs:
           comment="${comment//'%'/'%25'}"
           comment="${comment//$'\n'/'%0A'}"
           comment="${comment//$'\r'/'%0D'}"
-          echo "comment=$comment" ?? $GITHUB_OUTPUT
+          echo "comment=$comment" >> $GITHUB_OUTPUT
 
       - name: Get the PR number
         if: github.event_name == 'pull_request'

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -56,9 +56,9 @@ jobs:
         run: |
           cd boa
           comment="$(./target/release/boa_tester compare ../gh-pages/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
-          comment="${comment//'%'/'%25'}"
-          comment="${comment//$'\r'/'%0D'}"
-          echo "comment=$comment" >> $GITHUB_OUTPUT
+          echo "comment<<EOF" >> $GITHUB_OUTPUT
+          echo "$comment" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get the PR number
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2415.

It changes the following:

- Replaced deprecated set-output command following [GitHub guide](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) 

