### PR TITLE
[Merged by Bors] - Use opcode table rather than match

### DIFF
--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -126,32 +126,32 @@ macro_rules! generate_impl {
                 unsafe { std::mem::transmute(value) }
             }
 
-            const STR_MAP: &[&'static str] = &[
+            const NAMES: &[&'static str] = &[
                 $($Variant::NAME),*
             ];
 
             /// Name of this opcode.
             #[must_use]
             pub const fn as_str(self) -> &'static str {
-                Self::STR_MAP[self as usize]
+                Self::NAMES[self as usize]
             }
 
-            const INSTRUCTION_STR_MAP: &[&'static str] = &[
+            const INSTRUCTIONS: &[&'static str] = &[
                 $($Variant::INSTRUCTION),*
             ];
 
             /// Name of the profiler event for this opcode.
             #[must_use]
             pub const fn as_instruction_str(self) -> &'static str {
-                Self::INSTRUCTION_STR_MAP[self as usize]
+                Self::INSTRUCTIONS[self as usize]
             }
 
-            const EXECUTE_FN_MAP: &[fn(&mut Context) -> JsResult<ShouldExit>] = &[
+            const EXECUTE_FNS: &[fn(&mut Context) -> JsResult<ShouldExit>] = &[
                 $($Variant::execute),*
             ];
 
             pub(super) fn execute(self, context: &mut Context) -> JsResult<ShouldExit> {
-                Self::EXECUTE_FN_MAP[self as usize](context)
+                Self::EXECUTE_FNS[self as usize](context)
             }
         }
     };

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -127,9 +127,7 @@ macro_rules! generate_impl {
             }
 
             const STR_MAP: &[&'static str] = &[
-                $(
-                    $Variant::NAME
-                ),*
+                $($Variant::NAME),*
             ];
 
             /// Name of this opcode.
@@ -139,9 +137,7 @@ macro_rules! generate_impl {
             }
 
             const INSTRUCTION_STR_MAP: &[&'static str] = &[
-                $(
-                    $Variant::INSTRUCTION
-                ),*
+                $($Variant::INSTRUCTION),*
             ];
 
             /// Name of the profiler event for this opcode.
@@ -151,9 +147,7 @@ macro_rules! generate_impl {
             }
 
             const EXECUTE_FN_MAP: &[fn(&mut Context) -> JsResult<ShouldExit>] = &[
-                $(
-                    $Variant::execute
-                ),*
+                $($Variant::execute),*
             ];
 
             pub(super) fn execute(self, context: &mut Context) -> JsResult<ShouldExit> {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -126,13 +126,11 @@ macro_rules! generate_impl {
                 unsafe { std::mem::transmute(value) }
             }
 
-            const STR_MAP: [&'static str; 256] = {
-                let mut map = [""; 256];
+            const STR_MAP: &[&'static str] = &[
                 $(
-                    map[Self::$Variant as usize] = $Variant::NAME;
-                )*
-                map
-            };
+                    $Variant::NAME
+                ),*
+            ];
 
             /// Name of this opcode.
             #[must_use]
@@ -140,13 +138,11 @@ macro_rules! generate_impl {
                 Self::STR_MAP[self as usize]
             }
 
-            const INSTRUCTION_STR_MAP: [&'static str; 256] = {
-                let mut map = [""; 256];
+            const INSTRUCTION_STR_MAP: &[&'static str] = &[
                 $(
-                    map[Self::$Variant as usize] = $Variant::INSTRUCTION;
-                )*
-                map
-            };
+                    $Variant::INSTRUCTION
+                ),*
+            ];
 
             /// Name of the profiler event for this opcode.
             #[must_use]
@@ -154,13 +150,11 @@ macro_rules! generate_impl {
                 Self::INSTRUCTION_STR_MAP[self as usize]
             }
 
-            const EXECUTE_FN_MAP: [&dyn Fn(&mut Context) -> JsResult<ShouldExit>; 256] = {
-                let mut map: [&dyn Fn(&mut Context) -> JsResult<ShouldExit>; 256]  = [&|_| { unreachable!(); }; 256];
+            const EXECUTE_FN_MAP: &[fn(&mut Context) -> JsResult<ShouldExit>] = &[
                 $(
-                    map[$Type::$Variant as usize] = &$Variant::execute;
-                )*
-                map
-            };
+                    $Variant::execute
+                ),*
+            ];
 
             pub(super) fn execute(self, context: &mut Context) -> JsResult<ShouldExit> {
                 Self::EXECUTE_FN_MAP[self as usize](context)


### PR DESCRIPTION
`execute_instruction` is heavily used. After decoding an opcode, `match` is used to find a proper `execute` function for the opcode. But, the `match` may not be able to be optimized into a table jump by rust compiler, so it may use multiple branches to find the function. When I tested with a toy program, only `enum -> &'static str` case was optimized to use a table while `enum -> function call` uses multiple branches. ([gotbolt](https://rust.godbolt.org/z/1rzK5vj6f))

This change makes the opcode to use a table explicitly. It improves the benchmark score of Richards by 1-2% (22.8 -> 23.2).