### PR TITLE
[Merged by Bors] - Fix unary operations on `this`

### DIFF
--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2836,3 +2836,15 @@ fn spread_with_call() {
     "#;
     assert_eq!(&exec(scenario), r#""message""#);
 }
+
+#[test]
+fn unary_operations_on_this() {
+    // https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
+    let mut context = Context::default();
+    let test_cases = [("++this", "1:1"), ("--this", "1:1"), ("this++", "1:5"), ("this--", "1:5")];
+    for (case, pos) in &test_cases {
+        let string = forward(&mut context, case);
+        assert!(string.starts_with("Uncaught SyntaxError: "));
+        assert!(string.contains(pos));
+    }
+}

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2841,7 +2841,12 @@ fn spread_with_call() {
 fn unary_operations_on_this() {
     // https://tc39.es/ecma262/#sec-assignment-operators-static-semantics-early-errors
     let mut context = Context::default();
-    let test_cases = [("++this", "1:1"), ("--this", "1:1"), ("this++", "1:5"), ("this--", "1:5")];
+    let test_cases = [
+        ("++this", "1:1"),
+        ("--this", "1:1"),
+        ("this++", "1:5"),
+        ("this--", "1:5"),
+    ];
     for (case, pos) in &test_cases {
         let string = forward(&mut context, case);
         assert!(string.starts_with("Uncaught SyntaxError: "));

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -56,7 +56,8 @@ impl UpdateExpression {
     }
 }
 
-// https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-static-semantics-assignmenttargettype
+/// <https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-static-semantics-assignmenttargettype>
+/// This function checks if the target type is simple
 fn is_simple(expr: &Expression, position: Position, strict: bool) -> ParseResult<bool> {
     match expr {
         Expression::Identifier(ident) => {

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -69,7 +69,6 @@ fn is_simple(expr: &Expression, position: Position, strict: bool) -> ParseResult
     }
 }
 
-// 74.54
 impl<R> TokenParser<R> for UpdateExpression
 where
     R: Read,

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -56,7 +56,6 @@ impl UpdateExpression {
     }
 }
 
-#[inline]
 fn is_simple(expr: &Expression, position: Position, strict: bool) -> ParseResult<bool> {
     match expr {
         Expression::Identifier(ident) => {

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -77,7 +77,7 @@ where
                     .parse(cursor, interner)?;
                 let strict = cursor.strict_mode();
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                let ok = match &target {
+                let simple = match &target {
                     Expression::Identifier(_) if !strict => true,
                     Expression::Identifier(ident)
                         if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
@@ -87,7 +87,7 @@ where
                     Expression::PropertyAccess(_) => true,
                     _ => false,
                 };
-                if !ok {
+                if !simple {
                     return Err(Error::lex(LexError::Syntax(
                         "Invalid left-hand side in assignment".into(),
                         position,
@@ -110,7 +110,7 @@ where
                     .parse(cursor, interner)?;
                 let strict = cursor.strict_mode();
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                let ok = match &target {
+                let simple = match &target {
                     Expression::Identifier(_) if !strict => true,
                     Expression::Identifier(ident)
                         if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
@@ -121,7 +121,7 @@ where
                     _ => false,
                 };
                 
-                if !ok {
+                if !simple {
                     return Err(Error::lex(LexError::Syntax(
                         "Invalid left-hand side in assignment".into(),
                         position,
@@ -150,7 +150,7 @@ where
                         .next(interner)?
                         .expect("Punctuator::Inc token disappeared");
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    let ok = match &lhs {
+                    let simple = match &lhs {
                         Expression::Identifier(_) if !strict => true,
                         Expression::Identifier(ident)
                             if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
@@ -160,7 +160,7 @@ where
                         Expression::PropertyAccess(_) => true,
                         _ => false,
                     };
-                    if !ok {
+                    if !simple {
                         return Err(Error::lex(LexError::Syntax(
                             "Invalid left-hand side in assignment".into(),
                             token_start,
@@ -174,7 +174,7 @@ where
                         .next(interner)?
                         .expect("Punctuator::Dec token disappeared");
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    let ok = match &lhs {
+                    let simple = match &lhs {
                         Expression::Identifier(_) if !strict => true,
                         Expression::Identifier(ident)
                             if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
@@ -184,7 +184,7 @@ where
                         Expression::PropertyAccess(_) => true,
                         _ => false,
                     };
-                    if !ok {
+                    if !simple {
                         return Err(Error::lex(LexError::Syntax(
                             "Invalid left-hand side in assignment".into(),
                             token_start,

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -56,6 +56,7 @@ impl UpdateExpression {
     }
 }
 
+// https://tc39.es/ecma262/multipage/syntax-directed-operations.html#sec-static-semantics-assignmenttargettype
 fn is_simple(expr: &Expression, position: Position, strict: bool) -> ParseResult<bool> {
     match expr {
         Expression::Identifier(ident) => {

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -23,7 +23,7 @@ use boa_ast::{
     },
     Expression, Punctuator,
 };
-use boa_interner::{Interner, Sym};
+use boa_interner::Interner;
 use boa_profiler::Profiler;
 use std::io::Read;
 
@@ -79,24 +79,19 @@ where
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
                 let simple = match &target {
                     Expression::Identifier(_) if !strict => true,
-                    Expression::Identifier(ident)
-                        if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
-                    {
+                    Expression::Identifier(ident) => {
+                        check_strict_arguments_or_eval(*ident, position)?;
                         true
                     }
                     Expression::PropertyAccess(_) => true,
                     _ => false,
                 };
+                
                 if !simple {
                     return Err(Error::lex(LexError::Syntax(
                         "Invalid left-hand side in assignment".into(),
                         position,
                     )));
-                }
-                if strict {
-                    if let Expression::Identifier(ident) = target {
-                        check_strict_arguments_or_eval(ident, position)?;
-                    }
                 }
 
                 return Ok(Unary::new(UnaryOp::IncrementPre, target).into());
@@ -112,9 +107,8 @@ where
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
                 let simple = match &target {
                     Expression::Identifier(_) if !strict => true,
-                    Expression::Identifier(ident)
-                        if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
-                    {
+                    Expression::Identifier(ident) => {
+                        check_strict_arguments_or_eval(*ident, position)?;
                         true
                     }
                     Expression::PropertyAccess(_) => true,
@@ -126,11 +120,6 @@ where
                         "Invalid left-hand side in assignment".into(),
                         position,
                     )));
-                }
-                if strict {
-                    if let Expression::Identifier(ident) = target {
-                        check_strict_arguments_or_eval(ident, position)?;
-                    }
                 }
 
                 return Ok(Unary::new(UnaryOp::DecrementPre, target).into());
@@ -152,9 +141,8 @@ where
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
                     let simple = match &lhs {
                         Expression::Identifier(_) if !strict => true,
-                        Expression::Identifier(ident)
-                            if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
-                        {
+                        Expression::Identifier(ident) => {
+                            check_strict_arguments_or_eval(*ident, token_start)?;
                             true
                         }
                         Expression::PropertyAccess(_) => true,
@@ -176,9 +164,8 @@ where
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
                     let simple = match &lhs {
                         Expression::Identifier(_) if !strict => true,
-                        Expression::Identifier(ident)
-                            if ![Sym::EVAL, Sym::ARGUMENTS].contains(&ident.sym()) =>
-                        {
+                        Expression::Identifier(ident) => {
+                            check_strict_arguments_or_eval(*ident, token_start)?;
                             true
                         }
                         Expression::PropertyAccess(_) => true,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2416.

Previously, prefix increment and decrement operations on `this` caused a panic. This PR makes the parser issue a syntax error when the operand UnaryExpression is not simple (as mentioned in https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors).
