### PR TITLE
[Merged by Bors] - Pass locale data provider by ref instead of boxing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,10 +71,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: misc
-      - name: Lint (rustfmt)
+      - name: Format (rustfmt)
         run: cargo fmt --all --check
-      - name: Lint (clippy)
+      - name: Lint (All features)
         run: cargo clippy --all-features --all-targets
+      - name: Lint (No features)
+        run: cargo clippy --no-default-features --all-targets
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
       - name: Build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,6 @@ dependencies = [
  "icu_locid_transform",
  "icu_plurals",
  "icu_provider",
- "icu_provider_adapters",
  "indexmap",
  "jemallocator",
  "num-bigint",
@@ -258,8 +257,10 @@ version = "0.16.0"
 dependencies = [
  "icu_datagen",
  "icu_provider",
+ "icu_provider_adapters",
  "icu_provider_blob",
  "log",
+ "once_cell",
  "simple_logger",
 ]
 
@@ -324,8 +325,6 @@ dependencies = [
  "color-eyre",
  "colored",
  "fxhash",
- "icu_provider_adapters",
- "icu_provider_blob",
  "once_cell",
  "rayon",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
- "gimli",
+ "gimli 0.27.0",
 ]
 
 [[package]]
@@ -42,9 +42,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.19"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -101,16 +101,16 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if 1.0.0",
  "libc",
- "miniz_oxide 0.5.4",
- "object 0.29.0",
+ "miniz_oxide",
+ "object 0.30.0",
  "rustc-demangle",
 ]
 
@@ -319,7 +319,6 @@ dependencies = [
  "bitflags",
  "boa_engine",
  "boa_gc",
- "boa_icu_provider",
  "boa_parser",
  "clap 4.0.32",
  "color-eyre",
@@ -441,9 +440,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 dependencies = [
  "jobserver",
 ]
@@ -470,7 +469,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -636,15 +635,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
+checksum = "5556015fe3aad8b968e5d4124980fbe2f6aaee7aeec6b749de1faaa2ca5d0a4c"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
- "terminal_size",
- "winapi",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -777,22 +775,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.7.1",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -809,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
+checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -821,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
+checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -836,15 +834,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
+checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.80"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
+checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -920,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4903dff04948f22033ca30232ab8eca2c3fc4c913a8b6a34ee5199699814817f"
+checksum = "f8a16495aeb28047bb1185fca837baf755e7d71ed3aeed7f8504654ffa927208"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1105,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "erased-serde"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54558e0ba96fbe24280072642eceb9d7d442e32c7ec0ea9e7ecd7b4ea2cf4e11"
+checksum = "e4ca605381c017ec7a5fef5e548f1cfaa419ed0f6df6367339300db74c92aa7d"
 dependencies = [
  "serde",
 ]
@@ -1176,12 +1174,12 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c93a581058d957dc4176875aad04f82f81613e6611d64aa1a9c755bdfb16711"
+checksum = "bb21c69b9fea5e15dbc1049e4b77145dd0ba1c84019c488102de0dc4ea4b0a27"
 dependencies = [
  "cfg-if 1.0.0",
- "rustix 0.35.13",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -1199,13 +1197,12 @@ dependencies = [
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceab5dbd7a3a08385160503f6b6636420dbd72d29babdf8c894d4534304191c3"
+checksum = "a7f6fa77730b2c921549ccecf3ad7b0ce0fb14481d47fad0c358addc4aeb456a"
 dependencies = [
  "displaydoc",
  "smallvec",
- "static_assertions",
  "writeable",
 ]
 
@@ -1216,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1373,6 +1370,12 @@ dependencies = [
  "indexmap",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "glob"
@@ -1975,15 +1978,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.5"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7d367024b3f3414d8e01f437f704f41a9f64ab36f9067fa73e526ad4c763c87"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
  "libc",
  "windows-sys 0.42.0",
@@ -1997,13 +1994,13 @@ checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927609f78c2913a6f6ac3c27a4fe87f43e2a35367c0c4b0f8265e8f49a104330"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
- "io-lifetimes 1.0.1",
- "rustix 0.36.4",
+ "io-lifetimes",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -2018,9 +2015,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jemalloc-sys"
@@ -2075,9 +2072,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -2091,24 +2088,18 @@ dependencies = [
 
 [[package]]
 name = "link-cplusplus"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.0.46"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "litemap"
@@ -2216,19 +2207,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -2296,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2339,11 +2330,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi 0.1.19",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -2376,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
@@ -2403,9 +2394,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.44"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29d971fd5722fec23977260f6e81aa67d2f22cadbdc2aa049f1022d9a3be1566"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2435,9 +2426,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.79"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5454462c0eced1e97f2ec09036abc8da362e66802f66fd20f86854d9d8cbcbc4"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -2448,15 +2439,15 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.1"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "69dc4ec9e7e12502579e09e8a53c6a305b3aceb62ad5c307a62f7c3eada78324"
 
 [[package]]
 name = "parking_lot"
@@ -2466,7 +2457,7 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core 0.8.5",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -2481,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -2675,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -2954,42 +2945,28 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.14",
+ "semver 1.0.16",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.35.13"
+version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 0.7.5",
+ "io-lifetimes",
  "libc",
- "linux-raw-sys 0.0.46",
- "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes 1.0.1",
- "libc",
- "linux-raw-sys 0.1.3",
+ "linux-raw-sys",
  "windows-sys 0.42.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
 
 [[package]]
 name = "rustyline"
@@ -3027,9 +3004,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "ryu-js"
@@ -3064,9 +3041,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "seahash"
@@ -3108,9 +3085,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "semver-parser"
@@ -3150,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "718dc5fff5b36f99093fc49b280cfc96ce6fc824317783bff5a1fed0c7a64819"
 dependencies = [
  "serde",
 ]
@@ -3493,16 +3470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3545,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
@@ -3795,9 +3762,9 @@ checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -3828,9 +3795,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e5fa573d8ac5f1a856f8d7be41d390ee973daf97c806b2c1a465e4e1406e68"
+checksum = "bc7ed8ba44ca06be78ea1ad2c3682a43349126c8818054231ee6f4748012aed2"
 
 [[package]]
 name = "url"
@@ -4044,7 +4011,7 @@ dependencies = [
  "byteorder",
  "dynasm",
  "dynasmrt",
- "gimli",
+ "gimli 0.26.2",
  "lazy_static",
  "loupe",
  "more-asserts",
@@ -4206,7 +4173,7 @@ dependencies = [
  "libc",
  "loupe",
  "mach",
- "memoffset",
+ "memoffset 0.6.5",
  "more-asserts",
  "region",
  "rkyv",
@@ -4493,9 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c2c5bb7c929b85c1b9ec69091b0d835f0878b4fd9eb67973b25936e06c4374"
+checksum = "1346e4cd025ae818b88566eac7eb65ab33a994ea55f355c86889af2e7e56b14e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4526,9 +4493,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d919a74c17749ccb17beaf6405562e413cd94e98ba52ca1e64bbe7eefbd8b8"
+checksum = "25931c326414781db3d859f6e341e5bba119a3eddb7c5ae9976fe0d703b2dd26"
 dependencies = [
  "databake",
  "serde",
@@ -4560,7 +4527,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "thiserror",
- "time 0.1.44",
+ "time 0.1.45",
 ]
 
 [[package]]

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["deser", "console", "flowgraph", "intl"] }
+boa_engine = { workspace = true, features = ["deser", "console", "flowgraph"] }
 boa_ast = { workspace = true, features = ["serde"]}
 boa_parser.workspace = true
 rustyline = "10.0.0"
@@ -22,6 +22,10 @@ serde_json = "1.0.91"
 colored = "2.0.0"
 regex = "1.7.0"
 phf = { version = "0.11.1", features = ["macros"] }
+
+[features]
+default = ["intl"]
+intl = ["boa_engine/intl"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5.0"

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -187,7 +187,7 @@ enum FlowgraphDirection {
 ///
 /// Returns a error of type String with a message,
 /// if the token stream has a parsing error.
-fn parse_tokens<S>(src: S, context: &mut Context) -> Result<StatementList, String>
+fn parse_tokens<S>(src: S, context: &mut Context<'_>) -> Result<StatementList, String>
 where
     S: AsRef<[u8]>,
 {
@@ -201,7 +201,7 @@ where
 ///
 /// Returns a error of type String with a error message,
 /// if the source has a syntax or parsing error.
-fn dump<S>(src: S, args: &Opt, context: &mut Context) -> Result<(), String>
+fn dump<S>(src: S, args: &Opt, context: &mut Context<'_>) -> Result<(), String>
 where
     S: AsRef<[u8]>,
 {
@@ -226,7 +226,7 @@ where
 }
 
 fn generate_flowgraph(
-    context: &mut Context,
+    context: &mut Context<'_>,
     src: &[u8],
     format: FlowgraphFormat,
     direction: Option<FlowgraphDirection>,

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -21,7 +21,6 @@ intl = [
     "dep:icu_datetime",
     "dep:icu_plurals",
     "dep:icu_provider",
-    "dep:icu_provider_adapters",
     "dep:icu_calendar",
     "dep:icu_collator",
     "dep:icu_list",
@@ -74,7 +73,6 @@ icu_calendar = { version = "1.0.0", optional = true }
 icu_collator = { version = "1.0.1", features = ["serde"], optional = true }
 icu_plurals = { version = "1.0.0", features = ["serde"], optional = true }
 icu_provider = { version = "1.0.1", optional = true }
-icu_provider_adapters = { version = "1.0.0", features = ["serde"], optional = true }
 icu_list = { version = "1.0.0", features = ["serde"], optional = true }
 writeable = { version = "0.5.0", optional = true }
 sys-locale = { version = "0.2.3", optional = true }

--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -54,7 +54,7 @@ impl ArrayIterator {
     pub(crate) fn create_array_iterator(
         array: JsObject,
         kind: PropertyNameKind,
-        context: &Context,
+        context: &Context<'_>,
     ) -> JsValue {
         let array_iterator = JsObject::from_proto_and_data(
             context
@@ -75,7 +75,11 @@ impl ArrayIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
-    pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn next(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let mut array_iterator = this.as_object().map(JsObject::borrow_mut);
         let array_iterator = array_iterator
             .as_mut()
@@ -135,7 +139,7 @@ impl ArrayIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -44,7 +44,7 @@ pub(crate) struct Array;
 impl BuiltIn for Array {
     const NAME: &'static str = "Array";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let symbol_iterator = WellKnownSymbols::iterator();
@@ -140,7 +140,7 @@ impl Array {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let proto be ? GetPrototypeFromConstructor(newTarget, "%Array.prototype%").
@@ -225,7 +225,7 @@ impl Array {
     pub(crate) fn array_create(
         length: u64,
         prototype: Option<JsObject>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. If length > 2^32 - 1, throw a RangeError exception.
         if length > 2u64.pow(32) - 1 {
@@ -264,7 +264,7 @@ impl Array {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createarrayfromlist
-    pub(crate) fn create_array_from_list<I>(elements: I, context: &mut Context) -> JsObject
+    pub(crate) fn create_array_from_list<I>(elements: I, context: &mut Context<'_>) -> JsObject
     where
         I: IntoIterator<Item = JsValue>,
     {
@@ -298,7 +298,7 @@ impl Array {
     /// Returns a Boolean valued property that if `true` indicates that
     /// an object should be flattened to its array elements
     /// by `Array.prototype.concat`.
-    fn is_concat_spreadable(o: &JsValue, context: &mut Context) -> JsResult<bool> {
+    fn is_concat_spreadable(o: &JsValue, context: &mut Context<'_>) -> JsResult<bool> {
         // 1. If Type(O) is not Object, return false.
         let Some(o) = o.as_object() else {
             return Ok(false);
@@ -327,7 +327,7 @@ impl Array {
     /// [spec]: https://tc39.es/ecma262/#sec-get-array-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -339,7 +339,7 @@ impl Array {
     pub(crate) fn array_species_create(
         original_array: &JsObject,
         length: u64,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let isArray be ? IsArray(originalArray).
         // 2. If isArray is false, return ? ArrayCreate(length).
@@ -405,7 +405,7 @@ impl Array {
     pub(crate) fn from(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let items = args.get_or_undefined(0);
         let mapfn = args.get_or_undefined(1);
@@ -557,7 +557,7 @@ impl Array {
     pub(crate) fn is_array(
         _: &JsValue,
         args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? IsArray(arg).
         args.get_or_undefined(0).is_array().map(Into::into)
@@ -574,7 +574,11 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.of
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of
-    pub(crate) fn of(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn of(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let len be the number of elements in items.
         // 2. Let lenNumber be 𝔽(len).
         let len = args.len();
@@ -618,7 +622,11 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.at
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at
-    pub(crate) fn at(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn at(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         //1. let O be ? ToObject(this value)
         let obj = this.to_object(context)?;
         //2. let len be ? LengthOfArrayLike(O)
@@ -658,7 +666,7 @@ impl Array {
     pub(crate) fn concat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let obj = this.to_object(context)?;
@@ -741,7 +749,7 @@ impl Array {
     pub(crate) fn push(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -780,7 +788,11 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.pop
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop
-    pub(crate) fn pop(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn pop(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
         // 2. Let len be ? LengthOfArrayLike(O).
@@ -822,7 +834,7 @@ impl Array {
     pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -868,7 +880,7 @@ impl Array {
     pub(crate) fn join(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -924,7 +936,7 @@ impl Array {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let array be ? ToObject(this value).
         let array = this.to_object(context)?;
@@ -954,7 +966,7 @@ impl Array {
     pub(crate) fn reverse(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1032,7 +1044,11 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.shift
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/shift
-    pub(crate) fn shift(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn shift(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
         // 2. Let len be ? LengthOfArrayLike(O).
@@ -1092,7 +1108,7 @@ impl Array {
     pub(crate) fn unshift(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1163,7 +1179,7 @@ impl Array {
     pub(crate) fn every(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1215,7 +1231,7 @@ impl Array {
     pub(crate) fn map(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1264,7 +1280,7 @@ impl Array {
     pub(crate) fn index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1351,7 +1367,7 @@ impl Array {
     pub(crate) fn last_index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1421,7 +1437,7 @@ impl Array {
     pub(crate) fn find(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1478,7 +1494,7 @@ impl Array {
     pub(crate) fn find_index(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1530,7 +1546,7 @@ impl Array {
     pub(crate) fn find_last(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1582,7 +1598,7 @@ impl Array {
     pub(crate) fn find_last_index(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1632,7 +1648,7 @@ impl Array {
     pub(crate) fn flat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ToObject(this value)
         let o = this.to_object(context)?;
@@ -1688,7 +1704,7 @@ impl Array {
     pub(crate) fn flat_map(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ToObject(this value)
         let o = this.to_object(context)?;
@@ -1735,7 +1751,7 @@ impl Array {
         depth: u64,
         mapper_function: Option<&JsObject>,
         this_arg: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<u64> {
         // 1. Assert target is Object
         // 2. Assert source is Object
@@ -1848,7 +1864,7 @@ impl Array {
     pub(crate) fn fill(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1896,7 +1912,7 @@ impl Array {
     pub(crate) fn includes_value(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1973,7 +1989,7 @@ impl Array {
     pub(crate) fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2041,7 +2057,7 @@ impl Array {
     pub(crate) fn to_locale_string(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let array be ? ToObject(this value).
         let array = this.to_object(context)?;
@@ -2101,7 +2117,7 @@ impl Array {
     pub(crate) fn splice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2286,7 +2302,7 @@ impl Array {
     pub(crate) fn filter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2352,7 +2368,7 @@ impl Array {
     pub(crate) fn some(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2404,7 +2420,7 @@ impl Array {
     pub(crate) fn sort(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
         let comparefn = match args.get_or_undefined(0) {
@@ -2424,7 +2440,7 @@ impl Array {
         //
         // [spec]: https://tc39.es/ecma262/#sec-sortcompare
         let sort_compare =
-            |x: &JsValue, y: &JsValue, context: &mut Context| -> JsResult<Ordering> {
+            |x: &JsValue, y: &JsValue, context: &mut Context<'_>| -> JsResult<Ordering> {
                 match (x.is_undefined(), y.is_undefined()) {
                     // 1. If x and y are both undefined, return +0𝔽.
                     (true, true) => return Ok(Ordering::Equal),
@@ -2535,7 +2551,7 @@ impl Array {
     pub(crate) fn reduce(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2632,7 +2648,7 @@ impl Array {
     pub(crate) fn reduce_right(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2726,7 +2742,7 @@ impl Array {
     pub(crate) fn copy_within(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2816,7 +2832,7 @@ impl Array {
     pub(crate) fn values(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2830,7 +2846,7 @@ impl Array {
     }
 
     /// Creates an `Array.prototype.values( )` function object.
-    pub(crate) fn create_array_prototype_values(context: &mut Context) -> JsFunction {
+    pub(crate) fn create_array_prototype_values(context: &mut Context<'_>) -> JsFunction {
         FunctionBuilder::native(context, Self::values)
             .name("values")
             .length(0)
@@ -2848,7 +2864,11 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/values
-    pub(crate) fn keys(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn keys(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
 
@@ -2873,7 +2893,7 @@ impl Array {
     pub(crate) fn entries(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -2888,7 +2908,7 @@ impl Array {
 
     /// Represents the algorithm to calculate `relativeStart` (or `k`) in array functions.
     pub(super) fn get_relative_start(
-        context: &mut Context,
+        context: &mut Context<'_>,
         arg: Option<&JsValue>,
         len: u64,
     ) -> JsResult<u64> {
@@ -2913,7 +2933,7 @@ impl Array {
 
     /// Represents the algorithm to calculate `relativeEnd` (or `final`) in array functions.
     pub(super) fn get_relative_end(
-        context: &mut Context,
+        context: &mut Context<'_>,
         arg: Option<&JsValue>,
         len: u64,
     ) -> JsResult<u64> {
@@ -2953,7 +2973,7 @@ impl Array {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype-@@unscopables
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/@@unscopables
-    pub(crate) fn unscopables_intrinsic(context: &mut Context) -> JsObject {
+    pub(crate) fn unscopables_intrinsic(context: &mut Context<'_>) -> JsObject {
         // 1. Let unscopableList be OrdinaryObjectCreate(null).
         let unscopable_list = JsObject::with_null_proto();
         // 2. Perform ! CreateDataPropertyOrThrow(unscopableList, "at", true).

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -50,7 +50,7 @@ impl ArrayBuffer {
 impl BuiltIn for ArrayBuffer {
     const NAME: &'static str = "ArrayBuffer";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
@@ -103,7 +103,7 @@ impl ArrayBuffer {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -126,7 +126,7 @@ impl ArrayBuffer {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-arraybuffer-@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -138,7 +138,7 @@ impl ArrayBuffer {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.isview
     #[allow(clippy::unnecessary_wraps)]
-    fn is_view(_: &JsValue, args: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
+    fn is_view(_: &JsValue, args: &[JsValue], _context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. If Type(arg) is not Object, return false.
         // 2. If arg has a [[ViewedArrayBuffer]] internal slot, return true.
         // 3. Return false.
@@ -159,7 +159,7 @@ impl ArrayBuffer {
     pub(crate) fn get_byte_length(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
@@ -190,7 +190,7 @@ impl ArrayBuffer {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
-    fn slice(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn slice(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         let obj = this.as_object().ok_or_else(|| {
@@ -332,7 +332,7 @@ impl ArrayBuffer {
     pub(crate) fn allocate(
         constructor: &JsValue,
         byte_length: u64,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] »).
         let prototype = get_prototype_from_constructor(
@@ -382,7 +382,7 @@ impl ArrayBuffer {
         src_byte_offset: u64,
         src_length: u64,
         clone_constructor: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
         let target_buffer = Self::allocate(clone_constructor, src_length, context)?;
@@ -627,7 +627,7 @@ impl ArrayBuffer {
         t: TypedArrayKind,
         value: &JsValue,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Vec<u8>> {
         Ok(match t {
             TypedArrayKind::Int8 if is_little_endian => {
@@ -722,7 +722,7 @@ impl ArrayBuffer {
         value: &JsValue,
         _order: SharedMemoryOrder,
         is_little_endian: Option<bool>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
         // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.

--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -26,7 +26,7 @@ pub struct AsyncFunction;
 impl BuiltIn for AsyncFunction {
     const NAME: &'static str = "AsyncFunction";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let prototype = &context
@@ -98,7 +98,7 @@ impl AsyncFunction {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         crate::builtins::function::BuiltInFunctionObject::create_dynamic_function(
             new_target, args, true, false, context,

--- a/boa_engine/src/builtins/async_generator/mod.rs
+++ b/boa_engine/src/builtins/async_generator/mod.rs
@@ -65,7 +65,7 @@ pub struct AsyncGenerator {
 impl BuiltIn for AsyncGenerator {
     const NAME: &'static str = "AsyncGenerator";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let iterator_prototype = context
@@ -125,7 +125,7 @@ impl AsyncGenerator {
     pub(crate) fn constructor(
         _: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let prototype = context
             .intrinsics()
@@ -154,7 +154,7 @@ impl AsyncGenerator {
     pub(crate) fn next(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -247,7 +247,7 @@ impl AsyncGenerator {
     pub(crate) fn r#return(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -335,7 +335,7 @@ impl AsyncGenerator {
     pub(crate) fn throw(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -460,7 +460,7 @@ impl AsyncGenerator {
         next: &AsyncGeneratorRequest,
         completion: JsResult<JsValue>,
         done: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) {
         // 1. Let queue be generator.[[AsyncGeneratorQueue]].
         // 2. Assert: queue is not empty.
@@ -513,7 +513,7 @@ impl AsyncGenerator {
         state: AsyncGeneratorState,
         generator_context: &Gc<GcCell<GeneratorContext>>,
         completion: (JsResult<JsValue>, bool),
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) {
         // 1. Assert: generator.[[AsyncGeneratorState]] is either suspendedStart or suspendedYield.
         assert!(
@@ -589,7 +589,7 @@ impl AsyncGenerator {
     pub(crate) fn await_return(
         generator: JsObject,
         completion: JsResult<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) {
         // 1. Let queue be generator.[[AsyncGeneratorQueue]].
         // 2. Assert: queue is not empty.
@@ -708,7 +708,7 @@ impl AsyncGenerator {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
-    pub(crate) fn drain_queue(generator: &JsObject, context: &mut Context) {
+    pub(crate) fn drain_queue(generator: &JsObject, context: &mut Context<'_>) {
         let mut generator_borrow_mut = generator.borrow_mut();
         let gen = generator_borrow_mut
             .as_async_generator_mut()

--- a/boa_engine/src/builtins/async_generator_function/mod.rs
+++ b/boa_engine/src/builtins/async_generator_function/mod.rs
@@ -25,7 +25,7 @@ pub struct AsyncGeneratorFunction;
 impl BuiltIn for AsyncGeneratorFunction {
     const NAME: &'static str = "AsyncGeneratorFunction";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let prototype = &context
@@ -121,7 +121,7 @@ impl AsyncGeneratorFunction {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         BuiltInFunctionObject::create_dynamic_function(new_target, args, true, true, context)
             .map(Into::into)

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -35,7 +35,7 @@ pub struct BigInt;
 impl BuiltIn for BigInt {
     const NAME: &'static str = "BigInt";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
@@ -81,7 +81,7 @@ impl BigInt {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is not undefined, throw a TypeError exception.
         if !new_target.is_undefined() {
@@ -167,7 +167,7 @@ impl BigInt {
     pub(crate) fn to_string(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisBigIntValue(this value).
         let x = Self::this_bigint_value(this)?;
@@ -216,7 +216,11 @@ impl BigInt {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/valueOf
-    pub(crate) fn value_of(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_bigint_value(this)?))
     }
 
@@ -230,7 +234,7 @@ impl BigInt {
     pub(crate) fn as_int_n(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let (modulo, bits) = Self::calculate_as_uint_n(args, context)?;
 
@@ -256,7 +260,7 @@ impl BigInt {
     pub(crate) fn as_uint_n(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let (modulo, _) = Self::calculate_as_uint_n(args, context)?;
 
@@ -268,7 +272,10 @@ impl BigInt {
     /// This function expects the same arguments as `as_uint_n` and wraps the value of a `BigInt`.
     /// Additionally to the wrapped unsigned value it returns the converted `bits` argument, so it
     /// can be reused from the `as_int_n` method.
-    fn calculate_as_uint_n(args: &[JsValue], context: &mut Context) -> JsResult<(JsBigInt, u32)> {
+    fn calculate_as_uint_n(
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<(JsBigInt, u32)> {
         let bits_arg = args.get_or_undefined(0);
         let bigint_arg = args.get_or_undefined(1);
 

--- a/boa_engine/src/builtins/bigint/tests.rs
+++ b/boa_engine/src/builtins/bigint/tests.rs
@@ -395,7 +395,7 @@ fn as_uint_n_errors() {
     assert_throws(&mut context, "BigInt.asUintN(0n, 0n)", "TypeError");
 }
 
-fn assert_throws(context: &mut Context, src: &str, error_type: &str) {
+fn assert_throws(context: &mut Context<'_>, src: &str, error_type: &str) {
     let result = forward(context, src);
     assert!(result.contains(error_type));
 }

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -32,7 +32,7 @@ impl BuiltIn for Boolean {
     /// The name of the object.
     const NAME: &'static str = "Boolean";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         ConstructorBuilder::with_standard_constructor(
@@ -60,7 +60,7 @@ impl Boolean {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // Get the argument, if any
         let data = args.get(0).map_or(false, JsValue::to_boolean);
@@ -100,7 +100,11 @@ impl Boolean {
     /// [spec]: https://tc39.es/ecma262/#sec-boolean-object
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let boolean = Self::this_boolean_value(this)?;
         Ok(JsValue::new(boolean.to_string()))
     }
@@ -113,7 +117,11 @@ impl Boolean {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-boolean.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean/valueOf
-    pub(crate) fn value_of(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_boolean_value(this)?))
     }
 }

--- a/boa_engine/src/builtins/console/mod.rs
+++ b/boa_engine/src/builtins/console/mod.rs
@@ -51,7 +51,7 @@ fn logger(msg: LogMessage, console_state: &Console) {
 }
 
 /// This represents the `console` formatter.
-pub fn formatter(data: &[JsValue], context: &mut Context) -> JsResult<String> {
+pub fn formatter(data: &[JsValue], context: &mut Context<'_>) -> JsResult<String> {
     match data {
         [] => Ok(String::new()),
         [val] => Ok(val.to_string(context)?.to_std_string_escaped()),
@@ -133,7 +133,7 @@ pub(crate) struct Console {
 impl BuiltIn for Console {
     const NAME: &'static str = "console";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
         ObjectInitializer::new(context)
             .function(Self::assert, "assert", 0)
@@ -179,7 +179,7 @@ impl Console {
     pub(crate) fn assert(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let assertion = args.get(0).map_or(false, JsValue::to_boolean);
 
@@ -215,7 +215,11 @@ impl Console {
     /// [spec]: https://console.spec.whatwg.org/#clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/clear
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn clear(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn clear(
+        _: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         context.console_mut().groups.clear();
         Ok(JsValue::undefined())
     }
@@ -230,7 +234,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#debug
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/debug
-    pub(crate) fn debug(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn debug(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Log(formatter(args, context)?),
             context.console(),
@@ -248,7 +256,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#error
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/error
-    pub(crate) fn error(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn error(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Error(formatter(args, context)?),
             context.console(),
@@ -266,7 +278,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#info
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/info
-    pub(crate) fn info(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn info(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Info(formatter(args, context)?),
             context.console(),
@@ -284,7 +300,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/log
-    pub(crate) fn log(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn log(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Log(formatter(args, context)?),
             context.console(),
@@ -292,7 +312,7 @@ impl Console {
         Ok(JsValue::undefined())
     }
 
-    fn get_stack_trace(context: &mut Context) -> Vec<String> {
+    fn get_stack_trace(context: &mut Context<'_>) -> Vec<String> {
         let mut stack_trace: Vec<String> = vec![];
 
         for frame in context.vm.frames.iter().rev() {
@@ -317,7 +337,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#trace
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/trace
-    pub(crate) fn trace(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn trace(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         if !args.is_empty() {
             logger(
                 LogMessage::Log(formatter(args, context)?),
@@ -341,7 +365,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#warn
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/warn
-    pub(crate) fn warn(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn warn(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Warn(formatter(args, context)?),
             context.console(),
@@ -359,7 +387,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#count
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/count
-    pub(crate) fn count(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn count(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
             None => "default".into(),
@@ -386,7 +418,7 @@ impl Console {
     pub(crate) fn count_reset(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -421,7 +453,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#time
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/time
-    pub(crate) fn time(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn time(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
             None => "default".into(),
@@ -456,7 +492,7 @@ impl Console {
     pub(crate) fn time_log(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -496,7 +532,7 @@ impl Console {
     pub(crate) fn time_end(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -536,7 +572,11 @@ impl Console {
     ///
     /// [spec]: https://console.spec.whatwg.org/#group
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/group
-    pub(crate) fn group(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn group(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let group_label = formatter(args, context)?;
 
         logger(
@@ -562,7 +602,7 @@ impl Console {
     pub(crate) fn group_end(
         _: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         context.console_mut().groups.pop();
 
@@ -580,7 +620,11 @@ impl Console {
     /// [spec]: https://console.spec.whatwg.org/#dir
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/dir
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn dir(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn dir(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         logger(
             LogMessage::Info(display_obj(args.get_or_undefined(0), true)),
             context.console(),

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -34,7 +34,7 @@ pub struct DataView {
 impl BuiltIn for DataView {
     const NAME: &'static str = "DataView";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
         let get_buffer = FunctionBuilder::native(context, Self::get_buffer)
@@ -107,7 +107,7 @@ impl DataView {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_length = args.get_or_undefined(2);
 
@@ -210,7 +210,7 @@ impl DataView {
     pub(crate) fn get_buffer(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -239,7 +239,7 @@ impl DataView {
     pub(crate) fn get_byte_length(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -280,7 +280,7 @@ impl DataView {
     pub(crate) fn get_byte_offset(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -322,7 +322,7 @@ impl DataView {
         request_index: &JsValue,
         is_little_endian: &JsValue,
         t: TypedArrayKind,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -393,7 +393,7 @@ impl DataView {
     pub(crate) fn get_big_int64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -422,7 +422,7 @@ impl DataView {
     pub(crate) fn get_big_uint64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -451,7 +451,7 @@ impl DataView {
     pub(crate) fn get_float32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -480,7 +480,7 @@ impl DataView {
     pub(crate) fn get_float64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -509,7 +509,7 @@ impl DataView {
     pub(crate) fn get_int8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -538,7 +538,7 @@ impl DataView {
     pub(crate) fn get_int16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -567,7 +567,7 @@ impl DataView {
     pub(crate) fn get_int32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -596,7 +596,7 @@ impl DataView {
     pub(crate) fn get_uint8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -625,7 +625,7 @@ impl DataView {
     pub(crate) fn get_uint16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -654,7 +654,7 @@ impl DataView {
     pub(crate) fn get_uint32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -685,7 +685,7 @@ impl DataView {
         is_little_endian: &JsValue,
         t: TypedArrayKind,
         value: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -765,7 +765,7 @@ impl DataView {
     pub(crate) fn set_big_int64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -796,7 +796,7 @@ impl DataView {
     pub(crate) fn set_big_uint64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -827,7 +827,7 @@ impl DataView {
     pub(crate) fn set_float32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -858,7 +858,7 @@ impl DataView {
     pub(crate) fn set_float64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -889,7 +889,7 @@ impl DataView {
     pub(crate) fn set_int8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -920,7 +920,7 @@ impl DataView {
     pub(crate) fn set_int16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -951,7 +951,7 @@ impl DataView {
     pub(crate) fn set_int32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -982,7 +982,7 @@ impl DataView {
     pub(crate) fn set_uint8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -1013,7 +1013,7 @@ impl DataView {
     pub(crate) fn set_uint16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -1044,7 +1044,7 @@ impl DataView {
     pub(crate) fn set_uint32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -104,7 +104,7 @@ impl Default for Date {
 impl BuiltIn for Date {
     const NAME: &'static str = "Date";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         ConstructorBuilder::with_standard_constructor(
@@ -190,7 +190,7 @@ impl Date {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, then
         if new_target.is_undefined() {
@@ -278,7 +278,7 @@ impl Date {
     /// Gets the timestamp from a list of component values.
     fn construct_date(
         values: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<NaiveDateTime>> {
         // 1. Let y be ? ToNumber(year).
         let Some(mut year) = values.get_or_undefined(0).to_integer_or_nan(context)?.as_integer() else {
@@ -371,7 +371,7 @@ impl Date {
     /// [spec]: https://tc39.es/ecma262/#sec-date.now
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn now(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn now(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         Ok(JsValue::new(Utc::now().timestamp_millis()))
     }
 
@@ -387,7 +387,11 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse
-    pub(crate) fn parse(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn parse(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // This method is implementation-defined and discouraged, so we just require the same format as the string
         // constructor.
 
@@ -413,7 +417,11 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.utc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/UTC
-    pub(crate) fn utc(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn utc(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let t = some_or_nan!(Self::construct_date(args, context)?);
 
         Ok(JsValue::from(t.timestamp_millis()))
@@ -429,7 +437,7 @@ impl Date {
     pub(crate) fn get_date<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -453,7 +461,7 @@ impl Date {
     pub(crate) fn get_day<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -480,7 +488,7 @@ impl Date {
     pub(crate) fn get_year(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -501,7 +509,7 @@ impl Date {
     pub(crate) fn get_full_year<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -524,7 +532,7 @@ impl Date {
     pub(crate) fn get_hours<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -547,7 +555,7 @@ impl Date {
     pub(crate) fn get_milliseconds<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -570,7 +578,7 @@ impl Date {
     pub(crate) fn get_minutes<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -594,7 +602,7 @@ impl Date {
     pub(crate) fn get_month<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -617,7 +625,7 @@ impl Date {
     pub(crate) fn get_seconds<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -643,7 +651,7 @@ impl Date {
     pub(crate) fn get_time(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisTimeValue(this value).
         let t = some_or_nan!(this_time_value(this)?);
@@ -664,7 +672,7 @@ impl Date {
     pub(crate) fn get_timezone_offset(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -685,7 +693,7 @@ impl Date {
     pub(crate) fn set_date<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be LocalTime(? thisTimeValue(this value)).
         get_mut_date!(let t = this);
@@ -726,7 +734,7 @@ impl Date {
     pub(crate) fn set_full_year<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -795,7 +803,7 @@ impl Date {
     pub(crate) fn set_hours<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -859,7 +867,7 @@ impl Date {
     pub(crate) fn set_milliseconds<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 1. Let t be LocalTime(? thisTimeValue(this value)).
@@ -900,7 +908,7 @@ impl Date {
     pub(crate) fn set_minutes<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -957,7 +965,7 @@ impl Date {
     pub(crate) fn set_month<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1005,7 +1013,7 @@ impl Date {
     pub(crate) fn set_seconds<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1060,7 +1068,7 @@ impl Date {
     pub(crate) fn set_year(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1127,7 +1135,7 @@ impl Date {
     pub(crate) fn set_time(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1160,7 +1168,7 @@ impl Date {
     pub(crate) fn to_date_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         // 2. Let tv be ? thisTimeValue(O).
@@ -1193,7 +1201,7 @@ impl Date {
     pub(crate) fn to_iso_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let t = this_time_value(this)?
             .ok_or_else(|| JsNativeError::range().with_message("Invalid time value"))?;
@@ -1217,7 +1225,7 @@ impl Date {
     pub(crate) fn to_json(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1250,7 +1258,7 @@ impl Date {
     pub(crate) fn to_locale_date_string(
         _this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new("Function Unimplemented")))
     }
@@ -1267,7 +1275,7 @@ impl Date {
     pub(crate) fn to_locale_string(
         _this: &JsValue,
         _: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new(
             "Function Unimplemented]",
@@ -1287,7 +1295,7 @@ impl Date {
     pub(crate) fn to_locale_time_string(
         _this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new(
             "Function Unimplemented]",
@@ -1303,7 +1311,11 @@ impl Date {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toString
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let tv be ? thisTimeValue(this value).
         // 2. Return ToDateString(tv).
         let Some(t) = this_time_value(this)? else {
@@ -1330,7 +1342,7 @@ impl Date {
     pub(crate) fn to_time_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         // 2. Let tv be ? thisTimeValue(O).
@@ -1361,7 +1373,7 @@ impl Date {
     pub(crate) fn to_utc_string(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         let Some(t) = this_time_value(this)? else {
@@ -1395,7 +1407,7 @@ impl Date {
     pub(crate) fn value_of(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisTimeValue(this value).
         Ok(Date(this_time_value(this)?).as_value())
@@ -1413,7 +1425,7 @@ impl Date {
     pub(crate) fn to_primitive(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, throw a TypeError exception.
@@ -1457,7 +1469,7 @@ impl Date {
     pub(crate) fn to_gmt_string(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // The initial value of the "toGMTString" property is %Date.prototype.toUTCString%
         Self::to_utc_string(this, &[], context)

--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -25,7 +25,7 @@ fn datetime_from_local(
         .naive_utc()
 }
 
-fn forward_dt(context: &mut Context, src: &str) -> Option<NaiveDateTime> {
+fn forward_dt(context: &mut Context<'_>, src: &str) -> Option<NaiveDateTime> {
     let date_time = forward_val(context, src).unwrap();
     let date_time = date_time.as_object().unwrap();
     let date_time = date_time.borrow();

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -27,7 +27,7 @@ pub(crate) struct AggregateError;
 impl BuiltIn for AggregateError {
     const NAME: &'static str = "AggregateError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -64,7 +64,7 @@ impl AggregateError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%AggregateError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -32,7 +32,7 @@ pub(crate) struct EvalError;
 impl BuiltIn for EvalError {
     const NAME: &'static str = "EvalError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -64,7 +64,7 @@ impl EvalError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -132,7 +132,7 @@ pub(crate) struct Error;
 impl BuiltIn for Error {
     const NAME: &'static str = "Error";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
@@ -159,7 +159,7 @@ impl Error {
     pub(crate) fn install_error_cause(
         o: &JsObject,
         options: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         // 1. If Type(options) is Object and ? HasProperty(options, "cause") is true, then
         if let Some(options) = options.as_object() {
@@ -182,7 +182,7 @@ impl Error {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
 
@@ -222,7 +222,7 @@ impl Error {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, throw a TypeError exception.

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -30,7 +30,7 @@ pub(crate) struct RangeError;
 impl BuiltIn for RangeError {
     const NAME: &'static str = "RangeError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -62,7 +62,7 @@ impl RangeError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -29,7 +29,7 @@ pub(crate) struct ReferenceError;
 impl BuiltIn for ReferenceError {
     const NAME: &'static str = "ReferenceError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -65,7 +65,7 @@ impl ReferenceError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -32,7 +32,7 @@ pub(crate) struct SyntaxError;
 impl BuiltIn for SyntaxError {
     const NAME: &'static str = "SyntaxError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -64,7 +64,7 @@ impl SyntaxError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -37,7 +37,7 @@ pub(crate) struct TypeError;
 impl BuiltIn for TypeError {
     const NAME: &'static str = "TypeError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -69,7 +69,7 @@ impl TypeError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
@@ -95,8 +95,8 @@ impl TypeError {
     }
 }
 
-pub(crate) fn create_throw_type_error(context: &mut Context) -> JsObject {
-    fn throw_type_error(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+pub(crate) fn create_throw_type_error(context: &mut Context<'_>) -> JsObject {
+    fn throw_type_error(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         Err(JsNativeError::typ().with_message("'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them").into())
     }
 

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -31,7 +31,7 @@ pub(crate) struct UriError;
 impl BuiltIn for UriError {
     const NAME: &'static str = "URIError";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let error_constructor = context.intrinsics().constructors().error().constructor();
@@ -63,7 +63,7 @@ impl UriError {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -34,7 +34,7 @@ impl BuiltIn for Eval {
         .union(Attribute::NON_ENUMERABLE)
         .union(Attribute::WRITABLE);
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let object = FunctionBuilder::native(context, Self::eval)
@@ -54,7 +54,7 @@ impl Eval {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-eval-x
-    fn eval(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn eval(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return ? PerformEval(x, false, false).
         Self::perform_eval(args.get_or_undefined(0), false, false, context)
     }
@@ -69,7 +69,7 @@ impl Eval {
         x: &JsValue,
         direct: bool,
         mut strict: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         bitflags::bitflags! {
             /// Flags used to throw early errors on invalid `eval` calls.
@@ -91,7 +91,7 @@ impl Eval {
         }
 
         /// Restores the environment after calling `eval` or after throwing an error.
-        fn restore_environment(context: &mut Context, action: EnvStackAction) {
+        fn restore_environment(context: &mut Context<'_>, action: EnvStackAction) {
             match action {
                 EnvStackAction::Truncate(size) => {
                     context.realm.environments.truncate(size);

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -71,7 +71,7 @@ impl Arguments {
     /// [spec]: https://tc39.es/ecma262/#sec-createunmappedargumentsobject
     pub(crate) fn create_unmapped_arguments_object(
         arguments_list: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         // 1. Let len be the number of elements in argumentsList.
         let len = arguments_list.len();
@@ -151,7 +151,7 @@ impl Arguments {
         formals: &FormalParameterList,
         arguments_list: &[JsValue],
         env: &Gc<DeclarativeEnvironment>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         // 1. Assert: formals does not contain a rest parameter, any binding patterns, or any initializers.
         // It may contain duplicate identifiers.

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -58,7 +58,7 @@ pub struct Generator {
 impl BuiltIn for Generator {
     const NAME: &'static str = "Generator";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let iterator_prototype = context
@@ -116,7 +116,7 @@ impl Generator {
     pub(crate) fn constructor(
         _: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let prototype = context.intrinsics().constructors().generator().prototype();
 
@@ -145,7 +145,7 @@ impl Generator {
     pub(crate) fn next(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? GeneratorResume(this value, value, empty).
         this.as_object().map_or_else(
@@ -171,7 +171,7 @@ impl Generator {
     pub(crate) fn r#return(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let g be the this value.
         // 2. Let C be Completion { [[Type]]: return, [[Value]]: value, [[Target]]: empty }.
@@ -193,7 +193,7 @@ impl Generator {
     pub(crate) fn throw(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let g be the this value.
         // 2. Let C be ThrowCompletion(exception).
@@ -214,7 +214,7 @@ impl Generator {
     pub(crate) fn generator_resume(
         generator_obj: &JsObject,
         value: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let mut generator_obj_mut = generator_obj.borrow_mut();
@@ -319,7 +319,7 @@ impl Generator {
     pub(crate) fn generator_resume_abrupt(
         this: &JsValue,
         abrupt_completion: JsResult<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let generator_obj = this.as_object().ok_or_else(|| {

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -30,7 +30,7 @@ pub struct GeneratorFunction;
 impl BuiltIn for GeneratorFunction {
     const NAME: &'static str = "GeneratorFunction";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let prototype = &context
@@ -120,7 +120,7 @@ impl GeneratorFunction {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         BuiltInFunctionObject::create_dynamic_function(new_target, args, false, true, context)
             .map(Into::into)

--- a/boa_engine/src/builtins/global_this/mod.rs
+++ b/boa_engine/src/builtins/global_this/mod.rs
@@ -22,7 +22,7 @@ pub(crate) struct GlobalThis;
 impl BuiltIn for GlobalThis {
     const NAME: &'static str = "globalThis";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         Some(context.global_object().clone().into())

--- a/boa_engine/src/builtins/infinity/mod.rs
+++ b/boa_engine/src/builtins/infinity/mod.rs
@@ -26,7 +26,7 @@ impl BuiltIn for Infinity {
         .union(Attribute::NON_ENUMERABLE)
         .union(Attribute::PERMANENT);
 
-    fn init(_: &mut Context) -> Option<JsValue> {
+    fn init(_: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         Some(f64::INFINITY.into())

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -25,7 +25,7 @@ use icu_datetime::options::preferences::HourCycle;
 use super::options::OptionType;
 
 impl OptionType for HourCycle {
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "h11" => Ok(HourCycle::H11),
             "h12" => Ok(HourCycle::H12),
@@ -65,7 +65,7 @@ pub struct DateTimeFormat {
 impl DateTimeFormat {
     const NAME: &'static str = "DateTimeFormat";
 
-    pub(super) fn init(context: &mut Context) -> JsFunction {
+    pub(super) fn init(context: &mut Context<'_>) -> JsFunction {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         ConstructorBuilder::new(context, Self::constructor)
@@ -87,7 +87,7 @@ impl DateTimeFormat {
     pub(crate) fn constructor(
         new_target: &JsValue,
         _args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
         let prototype = get_prototype_from_constructor(
@@ -159,7 +159,7 @@ pub(crate) fn to_date_time_options(
     options: &JsValue,
     required: &DateTimeReqs,
     defaults: &DateTimeReqs,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject> {
     // 1. If options is undefined, let options be null;
     // otherwise let options be ? ToObject(options).

--- a/boa_engine/src/builtins/intl/list_format/options.rs
+++ b/boa_engine/src/builtins/intl/list_format/options.rs
@@ -40,7 +40,7 @@ impl FromStr for ListFormatType {
 impl OptionTypeParsable for ListFormatType {}
 
 impl OptionType for ListLength {
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "long" => Ok(Self::Wide),
             "short" => Ok(Self::Short),

--- a/boa_engine/src/builtins/intl/locale/mod.rs
+++ b/boa_engine/src/builtins/intl/locale/mod.rs
@@ -37,7 +37,7 @@ pub(crate) struct Locale;
 impl BuiltIn for Locale {
     const NAME: &'static str = "Locale";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let base_name = FunctionBuilder::native(context, Self::base_name)
@@ -141,7 +141,7 @@ impl Locale {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -360,7 +360,7 @@ impl Locale {
     pub(crate) fn maximize(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -393,7 +393,7 @@ impl Locale {
     pub(crate) fn minimize(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -423,7 +423,11 @@ impl Locale {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/toString
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -444,7 +448,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/baseName
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.baseName
-    pub(crate) fn base_name(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn base_name(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -468,7 +476,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar
-    pub(crate) fn calendar(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn calendar(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -497,7 +509,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar
-    pub(crate) fn case_first(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn case_first(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -526,7 +542,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/collation
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation
-    pub(crate) fn collation(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn collation(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -555,7 +575,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/hourCycle
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
-    pub(crate) fn hour_cycle(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn hour_cycle(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -584,7 +608,7 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numeric
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
-    pub(crate) fn numeric(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn numeric(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -620,7 +644,7 @@ impl Locale {
     pub(crate) fn numbering_system(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -650,7 +674,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/language
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.language
-    pub(crate) fn language(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn language(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -675,7 +703,7 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/script
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script
-    pub(crate) fn script(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn script(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -705,7 +733,7 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/region
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region
-    pub(crate) fn region(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn region(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {

--- a/boa_engine/src/builtins/intl/locale/options.rs
+++ b/boa_engine/src/builtins/intl/locale/options.rs
@@ -1,9 +1,9 @@
 use icu_locid::extensions::unicode::Value;
 
-use crate::{builtins::intl::options::OptionType, JsNativeError};
+use crate::{builtins::intl::options::OptionType, Context, JsNativeError};
 
 impl OptionType for Value {
-    fn from_value(value: crate::JsValue, context: &mut crate::Context) -> crate::JsResult<Self> {
+    fn from_value(value: crate::JsValue, context: &mut Context<'_>) -> crate::JsResult<Self> {
         let val = value
             .to_string(context)?
             .to_std_string_escaped()

--- a/boa_engine/src/builtins/intl/locale/tests.rs
+++ b/boa_engine/src/builtins/intl/locale/tests.rs
@@ -73,7 +73,7 @@ impl Service for TestService {
 
 #[test]
 fn locale_resolution() {
-    let provider = boa_icu_provider::blob();
+    let provider = boa_icu_provider::buffer();
     let icu = Icu::new(BoaProvider::Buffer(provider)).unwrap();
     let mut default = default_locale(icu.locale_canonicalizer());
     default

--- a/boa_engine/src/builtins/intl/locale/tests.rs
+++ b/boa_engine/src/builtins/intl/locale/tests.rs
@@ -8,7 +8,6 @@ use icu_locid::{
 };
 use icu_plurals::provider::CardinalV1Marker;
 use icu_provider::{DataLocale, DataProvider, DataRequest, DataRequestMetadata};
-use icu_provider_adapters::fallback::LocaleFallbackProvider;
 
 use crate::{
     builtins::intl::{
@@ -26,15 +25,12 @@ struct TestOptions {
 
 struct TestService;
 
-impl<P> Service<P> for TestService
-where
-    P: DataProvider<TimeLengthsV1Marker>,
-{
+impl Service for TestService {
     type LangMarker = CardinalV1Marker;
 
     type LocaleOptions = TestOptions;
 
-    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: &P) {
+    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: BoaProvider<'_>) {
         let loc_hc = locale
             .extensions
             .unicode
@@ -53,7 +49,7 @@ where
                 locale: &DataLocale::from(&*locale),
                 metadata: DataRequestMetadata::default(),
             };
-            let preferred = DataProvider::<TimeLengthsV1Marker>::load(provider, req)
+            let preferred = DataProvider::<TimeLengthsV1Marker>::load(&provider, req)
                 .unwrap()
                 .take_payload()
                 .unwrap()
@@ -77,9 +73,8 @@ where
 
 #[test]
 fn locale_resolution() {
-    let provider =
-        LocaleFallbackProvider::try_new_with_buffer_provider(boa_icu_provider::blob()).unwrap();
-    let icu = Icu::new(BoaProvider::Buffer(Box::new(provider))).unwrap();
+    let provider = boa_icu_provider::blob();
+    let icu = Icu::new(BoaProvider::Buffer(provider)).unwrap();
     let mut default = default_locale(icu.locale_canonicalizer());
     default
         .extensions
@@ -94,7 +89,7 @@ fn locale_resolution() {
             hc: Some(HourCycle::H11),
         },
     };
-    let locale = resolve_locale::<TestService, _>(&[], &mut options, &icu);
+    let locale = resolve_locale::<TestService>(&[], &mut options, &icu);
     assert_eq!(locale, default);
 
     // test best fit
@@ -105,10 +100,10 @@ fn locale_resolution() {
         },
     };
 
-    let locale = resolve_locale::<TestService, _>(&[], &mut options, &icu);
-    let best = best_locale_for_provider::<<TestService as Service<BoaProvider>>::LangMarker>(
+    let locale = resolve_locale::<TestService>(&[], &mut options, &icu);
+    let best = best_locale_for_provider::<<TestService as Service>::LangMarker>(
         default.id.clone(),
-        icu.provider(),
+        &icu.provider(),
     )
     .unwrap();
     let mut best = Locale::from(best);
@@ -121,6 +116,6 @@ fn locale_resolution() {
         service_options: TestOptions { hc: None },
     };
 
-    let locale = resolve_locale::<TestService, _>(&[locale!("es-AR")], &mut options, &icu);
+    let locale = resolve_locale::<TestService>(&[locale!("es-AR")], &mut options, &icu);
     assert_eq!(locale, "es-u-hc-h23".parse().unwrap());
 }

--- a/boa_engine/src/builtins/intl/locale/utils.rs
+++ b/boa_engine/src/builtins/intl/locale/utils.rs
@@ -485,10 +485,10 @@ fn best_fit_supported_locales<M: KeyedDataMarker>(
 /// availableLocales has a matching locale
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-supportedlocales
-pub(in crate::builtins::intl) fn supported_locales<'context, 'icu: 'context, M: KeyedDataMarker>(
+pub(in crate::builtins::intl) fn supported_locales<'ctx, 'icu: 'ctx, M: KeyedDataMarker>(
     requested_locales: &[Locale],
     options: &JsValue,
-    context: &'context mut Context<'icu>,
+    context: &'ctx mut Context<'icu>,
 ) -> JsResult<JsObject>
 where
     BoaProvider<'icu>: DataProvider<M>,

--- a/boa_engine/src/builtins/intl/locale/utils.rs
+++ b/boa_engine/src/builtins/intl/locale/utils.rs
@@ -557,7 +557,7 @@ mod tests {
 
     #[test]
     fn best_avail_loc() {
-        let provider = boa_icu_provider::blob();
+        let provider = boa_icu_provider::buffer();
         let provider = provider.as_deserializing();
 
         assert_eq!(
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn lookup_match() {
-        let provider = boa_icu_provider::blob();
+        let provider = boa_icu_provider::buffer();
         let icu = Icu::new(BoaProvider::Buffer(provider)).unwrap();
 
         // requested: []

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -13,6 +13,7 @@ use super::JsArgs;
 use crate::{
     builtins::intl::date_time_format::DateTimeFormat,
     builtins::{Array, BuiltIn},
+    context::BoaProvider,
     object::ObjectInitializer,
     property::Attribute,
     symbol::WellKnownSymbols,
@@ -39,7 +40,7 @@ pub(crate) struct Intl;
 impl BuiltIn for Intl {
     const NAME: &'static str = "Intl";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let collator = Collator::init(context).expect("initialization should return a constructor");
@@ -106,7 +107,7 @@ impl Intl {
     pub(crate) fn get_canonical_locales(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let locales = args.get_or_undefined(0);
 
@@ -125,7 +126,7 @@ impl Intl {
 // to copy-paste the bounds of `impl<M> DataProvider<M> for BoaProvider` every time we need
 // to use `provider`. The type parameter solves this by delegating simpler bounds to every
 // implementor of `Service`.
-trait Service<P> {
+trait Service {
     /// The data marker used by [`resolve_locale`][locale::resolve_locale] to decide
     /// which locales are supported by this service.
     type LangMarker: KeyedDataMarker;
@@ -145,6 +146,10 @@ trait Service<P> {
     /// new final values.
     /// - If the implementor service doesn't contain any `[[RelevantExtensionKeys]]`, this can be
     /// skipped.
-    fn resolve(_locale: &mut icu_locid::Locale, _options: &mut Self::LocaleOptions, _provider: &P) {
+    fn resolve(
+        _locale: &mut icu_locid::Locale,
+        _options: &mut Self::LocaleOptions,
+        _provider: BoaProvider<'_>,
+    ) {
     }
 }

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -122,10 +122,10 @@ impl Intl {
     }
 }
 
-// Making `provider: &BoaProvider` instead of a type parameter `P` makes it so that we need
-// to copy-paste the bounds of `impl<M> DataProvider<M> for BoaProvider` every time we need
-// to use `provider`. The type parameter solves this by delegating simpler bounds to every
-// implementor of `Service`.
+/// A service component that is part of the `Intl` API.
+///
+/// This needs to be implemented for every `Intl` service in order to use the functions
+/// defined in `locale::utils`, such as locale resolution and selection.
 trait Service {
     /// The data marker used by [`resolve_locale`][locale::resolve_locale] to decide
     /// which locales are supported by this service.

--- a/boa_engine/src/builtins/intl/options.rs
+++ b/boa_engine/src/builtins/intl/options.rs
@@ -27,7 +27,7 @@ pub(super) trait OptionType: Sized {
     /// steps instead of returning a pure string, number or boolean.
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-getoption
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self>;
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self>;
 }
 
 pub(super) trait OptionTypeParsable: FromStr {}
@@ -36,7 +36,7 @@ impl<T: OptionTypeParsable> OptionType for T
 where
     T::Err: Display,
 {
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         value
             .to_string(context)?
             .to_std_string_escaped()
@@ -46,7 +46,7 @@ where
 }
 
 impl OptionType for bool {
-    fn from_value(value: JsValue, _: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, _: &mut Context<'_>) -> JsResult<Self> {
         // 5. If type is "boolean", then
         //      a. Set value to ! ToBoolean(value).
         Ok(value.to_boolean())
@@ -54,7 +54,7 @@ impl OptionType for bool {
 }
 
 impl OptionType for JsString {
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         // 6. If type is "string", then
         //      a. Set value to ? ToString(value).
         value.to_string(context)
@@ -92,7 +92,7 @@ impl FromStr for LocaleMatcher {
 impl OptionTypeParsable for LocaleMatcher {}
 
 impl OptionType for CaseFirst {
-    fn from_value(value: JsValue, context: &mut Context) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "upper" => Ok(CaseFirst::UpperFirst),
             "lower" => Ok(CaseFirst::LowerFirst),
@@ -122,7 +122,7 @@ pub(super) fn get_option<T: OptionType>(
     options: &JsObject,
     property: &str,
     required: bool,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<T>> {
     // 1. Let value be ? Get(options, property).
     let value = options.get(property, context)?;
@@ -161,7 +161,7 @@ pub(super) fn get_number_option(
     minimum: f64,
     maximum: f64,
     fallback: Option<f64>,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<f64>> {
     // 1. Assert: Type(options) is Object.
     // 2. Let value be ? Get(options, property).
@@ -183,7 +183,7 @@ pub(super) fn default_number_option(
     minimum: f64,
     maximum: f64,
     fallback: Option<f64>,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<f64>> {
     // 1. If value is undefined, return fallback.
     if value.is_undefined() {
@@ -239,7 +239,7 @@ pub(super) fn get_options_object(options: &JsValue) -> JsResult<JsObject> {
 /// [spec]: https://tc39.es/ecma402/#sec-coerceoptionstoobject
 pub(super) fn coerce_options_to_object(
     options: &JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject> {
     // If options is undefined, then
     if options.is_undefined() {

--- a/boa_engine/src/builtins/intl/segmenter/mod.rs
+++ b/boa_engine/src/builtins/intl/segmenter/mod.rs
@@ -15,7 +15,7 @@ pub(crate) struct Segmenter;
 impl BuiltIn for Segmenter {
     const NAME: &'static str = "Segmenter";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         ConstructorBuilder::with_standard_constructor(
@@ -35,7 +35,11 @@ impl Segmenter {
     pub(crate) const LENGTH: usize = 0;
 
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn constructor(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn constructor(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::Undefined)
     }
 }

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -17,7 +17,7 @@ use boa_profiler::Profiler;
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%-object
-pub(crate) fn create_async_from_sync_iterator_prototype(context: &mut Context) -> JsObject {
+pub(crate) fn create_async_from_sync_iterator_prototype(context: &mut Context<'_>) -> JsObject {
     let _timer = Profiler::global().start_event("AsyncFromSyncIteratorPrototype", "init");
 
     let prototype = JsObject::from_proto_and_data(
@@ -95,7 +95,7 @@ impl AsyncFromSyncIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-createasyncfromsynciterator
     pub(crate) fn create(
         sync_iterator_record: IteratorRecord,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> IteratorRecord {
         // 1. Let asyncIterator be OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, « [[SyncIteratorRecord]] »).
         // 2. Set asyncIterator.[[SyncIteratorRecord]] to syncIteratorRecord.
@@ -126,7 +126,7 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next
-    fn next(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn next(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
@@ -170,7 +170,7 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return
-    fn r#return(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn r#return(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -268,7 +268,7 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw
-    fn throw(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn throw(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -369,7 +369,7 @@ impl AsyncFromSyncIterator {
     fn continuation(
         result: &IteratorResult,
         promise_capability: &PromiseCapability,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. NOTE: Because promiseCapability is derived from the intrinsic %Promise%,
         // the calls to promiseCapability.[[Reject]] entailed by the

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -51,7 +51,7 @@ pub struct IteratorPrototypes {
 }
 
 impl IteratorPrototypes {
-    pub(crate) fn init(context: &mut Context) -> Self {
+    pub(crate) fn init(context: &mut Context<'_>) -> Self {
         let _timer = Profiler::global().start_event("IteratorPrototypes::init", "init");
 
         let iterator_prototype = create_iterator_prototype(context);
@@ -131,7 +131,7 @@ impl IteratorPrototypes {
 /// `CreateIterResultObject( value, done )`
 ///
 /// Generates an object supporting the `IteratorResult` interface.
-pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Context) -> JsValue {
+pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Context<'_>) -> JsValue {
     let _timer = Profiler::global().start_event("create_iter_result_object", "init");
 
     // 1. Assert: Type(done) is Boolean.
@@ -167,7 +167,7 @@ impl JsValue {
     /// [spec]: https://tc39.es/ecma262/#sec-getiterator
     pub fn get_iterator(
         &self,
-        context: &mut Context,
+        context: &mut Context<'_>,
         hint: Option<IteratorHint>,
         method: Option<JsObject>,
     ) -> JsResult<IteratorRecord> {
@@ -236,7 +236,7 @@ impl JsValue {
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-%iteratorprototype%-object
-fn create_iterator_prototype(context: &mut Context) -> JsObject {
+fn create_iterator_prototype(context: &mut Context<'_>) -> JsObject {
     let _timer = Profiler::global().start_event("Iterator Prototype", "init");
 
     let symbol_iterator = WellKnownSymbols::iterator();
@@ -272,7 +272,7 @@ impl IteratorResult {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorcomplete
     #[inline]
-    pub fn complete(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn complete(&self, context: &mut Context<'_>) -> JsResult<bool> {
         // 1. Return ToBoolean(? Get(iterResult, "done")).
         Ok(self.object.get("done", context)?.to_boolean())
     }
@@ -288,7 +288,7 @@ impl IteratorResult {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorvalue
     #[inline]
-    pub fn value(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn value(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return ? Get(iterResult, "value").
         self.object.get("value", context)
     }
@@ -365,7 +365,7 @@ impl IteratorRecord {
     pub(crate) fn next(
         &self,
         value: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<IteratorResult> {
         let _timer = Profiler::global().start_event("IteratorRecord::next", "iterator");
 
@@ -409,7 +409,7 @@ impl IteratorRecord {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorstep
-    pub(crate) fn step(&self, context: &mut Context) -> JsResult<Option<IteratorResult>> {
+    pub(crate) fn step(&self, context: &mut Context<'_>) -> JsResult<Option<IteratorResult>> {
         let _timer = Profiler::global().start_event("IteratorRecord::step", "iterator");
 
         // 1. Let result be ? IteratorNext(iteratorRecord).
@@ -441,7 +441,7 @@ impl IteratorRecord {
     pub(crate) fn close(
         &self,
         completion: JsResult<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("IteratorRecord::close", "iterator");
 
@@ -501,7 +501,7 @@ impl IteratorRecord {
 ///
 ///  [spec]: https://tc39.es/ecma262/#sec-iterabletolist
 pub(crate) fn iterable_to_list(
-    context: &mut Context,
+    context: &mut Context<'_>,
     items: &JsValue,
     method: Option<JsObject>,
 ) -> JsResult<Vec<JsValue>> {
@@ -560,7 +560,7 @@ pub(crate) use if_abrupt_close_iterator;
 ///  - [ECMA reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-asynciteratorprototype
-fn create_async_iterator_prototype(context: &mut Context) -> JsObject {
+fn create_async_iterator_prototype(context: &mut Context<'_>) -> JsObject {
     let _timer = Profiler::global().start_event("AsyncIteratorPrototype", "init");
 
     let symbol_iterator = WellKnownSymbols::async_iterator();

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -138,7 +138,7 @@ pub(crate) struct Json;
 impl BuiltIn for Json {
     const NAME: &'static str = "JSON";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
@@ -167,7 +167,11 @@ impl Json {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json.parse
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
-    pub(crate) fn parse(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn parse(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let jsonString be ? ToString(text).
         let json_string = args
             .get(0)
@@ -229,7 +233,7 @@ impl Json {
         holder: &JsObject,
         name: JsString,
         reviver: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let val be ? Get(holder, name).
         let val = holder.get(name.clone(), context)?;
@@ -319,7 +323,7 @@ impl Json {
     pub(crate) fn stringify(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let stack be a new empty List.
         let stack = Vec::new();
@@ -469,7 +473,7 @@ impl Json {
         state: &mut StateRecord,
         key: JsString,
         holder: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<JsString>> {
         // 1. Let value be ? Get(holder, key).
         let mut value = holder.get(key.clone(), context)?;
@@ -640,7 +644,7 @@ impl Json {
     fn serialize_json_object(
         state: &mut StateRecord,
         value: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsString> {
         // 1. If state.[[Stack]] contains value, throw a TypeError exception because the structure is cyclical.
         let limiter = RecursionLimiter::new(value);
@@ -768,7 +772,7 @@ impl Json {
     fn serialize_json_array(
         state: &mut StateRecord,
         value: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsString> {
         // 1. If state.[[Stack]] contains value, throw a TypeError exception because the structure is cyclical.
         let limiter = RecursionLimiter::new(value);

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -46,7 +46,7 @@ impl MapIterator {
     pub(crate) fn create_map_iterator(
         map: &JsValue,
         kind: PropertyNameKind,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(map_obj) = map.as_object() {
             if let Some(map) = map_obj.borrow_mut().as_map_mut() {
@@ -81,7 +81,11 @@ impl MapIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
-    pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn next(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let mut map_iterator = this.as_object().map(JsObject::borrow_mut);
         let map_iterator = map_iterator
             .as_mut()
@@ -134,7 +138,7 @@ impl MapIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%mapiteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -39,7 +39,7 @@ pub(crate) struct Map;
 impl BuiltIn for Map {
     const NAME: &'static str = "Map";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let get_species = FunctionBuilder::native(context, Self::get_species)
@@ -118,7 +118,7 @@ impl Map {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -157,7 +157,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-get-map-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -175,7 +175,7 @@ impl Map {
     pub(crate) fn entries(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, key+value).
@@ -192,7 +192,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/keys
-    pub(crate) fn keys(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn keys(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, key).
         MapIterator::create_map_iterator(this, PropertyNameKind::Key, context)
@@ -208,7 +212,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
-    pub(crate) fn set(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn set(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let key = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
 
@@ -255,7 +259,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-map.prototype.size
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/size
-    pub(crate) fn get_size(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn get_size(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         if let Some(object) = this.as_object() {
             // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
@@ -284,7 +292,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.delete
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/delete
-    pub(crate) fn delete(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn delete(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let key = args.get_or_undefined(0);
 
         // 1. Let M be the this value.
@@ -315,7 +327,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
-    pub(crate) fn get(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn get(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Rational(0f64);
 
         let key = args.get_or_undefined(0);
@@ -357,7 +369,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
-    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         if let Some(object) = this.as_object() {
@@ -387,7 +399,7 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Rational(0f64);
 
         let key = args.get_or_undefined(0);
@@ -432,7 +444,7 @@ impl Map {
     pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
@@ -503,7 +515,7 @@ impl Map {
     pub(crate) fn values(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, value).
@@ -523,7 +535,7 @@ pub(crate) fn add_entries_from_iterable(
     target: &JsObject,
     iterable: &JsValue,
     adder: &JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. If IsCallable(adder) is false, throw a TypeError exception.
     let adder = adder.as_callable().ok_or_else(|| {

--- a/boa_engine/src/builtins/math/mod.rs
+++ b/boa_engine/src/builtins/math/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct Math;
 impl BuiltIn for Math {
     const NAME: &'static str = "Math";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
@@ -98,7 +98,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.abs
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/abs
-    pub(crate) fn abs(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn abs(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -120,7 +124,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acos
-    pub(crate) fn acos(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn acos(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -140,7 +148,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.acosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/acosh
-    pub(crate) fn acosh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn acosh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -161,7 +173,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asin
-    pub(crate) fn asin(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn asin(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -181,7 +197,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.asinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/asinh
-    pub(crate) fn asinh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn asinh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -200,7 +220,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan
-    pub(crate) fn atan(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn atan(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -221,7 +245,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atanh
-    pub(crate) fn atanh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn atanh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -243,7 +271,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.atan2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/atan2
-    pub(crate) fn atan2(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn atan2(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let ny be ? ToNumber(y).
         let y = args.get_or_undefined(0).to_number(context)?;
 
@@ -286,7 +318,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cbrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cbrt
-    pub(crate) fn cbrt(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn cbrt(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -305,7 +341,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.ceil
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/ceil
-    pub(crate) fn ceil(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn ceil(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -326,7 +366,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.clz32
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
-    pub(crate) fn clz32(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn clz32(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToUint32(x).
@@ -345,7 +389,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cos
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cos
-    pub(crate) fn cos(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn cos(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -365,7 +413,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.cosh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/cosh
-    pub(crate) fn cosh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn cosh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -386,7 +438,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.exp
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/exp
-    pub(crate) fn exp(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn exp(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -409,7 +465,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.expm1
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/expm1
-    pub(crate) fn expm1(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn expm1(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -429,7 +489,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.floor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/floor
-    pub(crate) fn floor(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn floor(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -453,7 +517,7 @@ impl Math {
     pub(crate) fn fround(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let n be ? ToNumber(x).
         let x = args.get_or_undefined(0).to_number(context)?;
@@ -474,7 +538,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.hypot
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/hypot
-    pub(crate) fn hypot(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn hypot(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
         // a. Let n be ? ToNumber(arg).
@@ -504,7 +572,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.imul
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-    pub(crate) fn imul(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn imul(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let a be ℝ(? ToUint32(x)).
         let x = args.get_or_undefined(0).to_u32(context)?;
 
@@ -524,7 +596,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log
-    pub(crate) fn log(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn log(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -546,7 +622,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log1p
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p
-    pub(crate) fn log1p(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn log1p(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -567,7 +647,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log10
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log10
-    pub(crate) fn log10(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn log10(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -589,7 +673,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.log2
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log2
-    pub(crate) fn log2(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn log2(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -611,7 +699,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.max
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/max
-    pub(crate) fn max(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn max(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
         // b. Append n to coerced.
@@ -649,7 +741,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.min
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/min
-    pub(crate) fn min(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn min(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
         // b. Append n to coerced.
@@ -688,7 +784,11 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.pow
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/pow
     #[allow(clippy::float_cmp)]
-    pub(crate) fn pow(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn pow(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Set base to ? ToNumber(base).
         let x = args.get_or_undefined(0).to_number(context)?;
 
@@ -713,7 +813,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.random
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn random(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn random(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // NOTE: Each Math.random function created for distinct realms must produce a distinct sequence of values from successive calls.
         Ok(rand::random::<f64>().into())
     }
@@ -727,7 +827,11 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.round
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/round
     #[allow(clippy::float_cmp)]
-    pub(crate) fn round(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn round(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let num = args
             .get_or_undefined(0)
             //1. Let n be ? ToNumber(x).
@@ -753,7 +857,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sign
-    pub(crate) fn sign(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn sign(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let n be ? ToNumber(x).
         let n = args.get_or_undefined(0).to_number(context)?;
 
@@ -774,7 +882,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sin
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sin
-    pub(crate) fn sin(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn sin(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -794,7 +906,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sinh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sinh
-    pub(crate) fn sinh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn sinh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -813,7 +929,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.sqrt
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sqrt
-    pub(crate) fn sqrt(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn sqrt(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -833,7 +953,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tan
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tan
-    pub(crate) fn tan(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn tan(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -853,7 +977,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.tanh
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/tanh
-    pub(crate) fn tanh(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn tanh(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).
@@ -874,7 +1002,11 @@ impl Math {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math.trunc
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
-    pub(crate) fn trunc(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn trunc(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
             // 1. Let n be ? ToNumber(x).

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -116,12 +116,12 @@ pub(crate) trait BuiltIn {
     ///
     /// A return value of `None` indicates that the value must not be added as a global attribute
     /// for the global object.
-    fn init(context: &mut Context) -> Option<JsValue>;
+    fn init(context: &mut Context<'_>) -> Option<JsValue>;
 }
 
 /// Utility function that checks if a type implements `BuiltIn` before initializing it as a global
 /// built-in.
-fn init_builtin<B: BuiltIn>(context: &mut Context) {
+fn init_builtin<B: BuiltIn>(context: &mut Context<'_>) {
     if let Some(value) = B::init(context) {
         let property = PropertyDescriptor::builder()
             .value(value)
@@ -136,7 +136,7 @@ fn init_builtin<B: BuiltIn>(context: &mut Context) {
 }
 
 /// Initializes built-in objects and functions
-pub fn init(context: &mut Context) {
+pub fn init(context: &mut Context<'_>) {
     macro_rules! globals {
         ($( $builtin:ty ),*) => {
             $(init_builtin::<$builtin>(context)

--- a/boa_engine/src/builtins/nan/mod.rs
+++ b/boa_engine/src/builtins/nan/mod.rs
@@ -27,7 +27,7 @@ impl BuiltIn for NaN {
         .union(Attribute::NON_ENUMERABLE)
         .union(Attribute::PERMANENT);
 
-    fn init(_: &mut Context) -> Option<JsValue> {
+    fn init(_: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         Some(f64::NAN.into())

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -47,7 +47,7 @@ pub(crate) struct Number;
 impl BuiltIn for Number {
     const NAME: &'static str = "Number";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let parse_int = FunctionBuilder::native(context, Self::parse_int)
@@ -173,7 +173,7 @@ impl Number {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let data = match args.get(0) {
             Some(value) => value.to_numeric_number(context)?,
@@ -222,7 +222,7 @@ impl Number {
     pub(crate) fn to_exponential(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisNumberValue(this value).
         let this_num = Self::this_number_value(this)?;
@@ -267,7 +267,7 @@ impl Number {
     pub(crate) fn to_fixed(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let this_num be ? thisNumberValue(this value).
         let this_num = Self::this_number_value(this)?;
@@ -316,7 +316,7 @@ impl Number {
     pub(crate) fn to_locale_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let this_num = Self::this_number_value(this)?;
         let this_str_num = this_num.to_string();
@@ -424,7 +424,7 @@ impl Number {
     pub(crate) fn to_precision(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let precision = args.get_or_undefined(0);
 
@@ -675,7 +675,7 @@ impl Number {
     pub(crate) fn to_string(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisNumberValue(this value).
         let x = Self::this_number_value(this)?;
@@ -734,7 +734,11 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/valueOf
-    pub(crate) fn value_of(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_number_value(this)?))
     }
 
@@ -755,7 +759,7 @@ impl Number {
     pub(crate) fn parse_int(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let (Some(val), radix) = (args.get(0), args.get_or_undefined(1)) {
             // 1. Let inputString be ? ToString(string).
@@ -880,7 +884,7 @@ impl Number {
     pub(crate) fn parse_float(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(val) = args.get(0) {
             // TODO: parse float with optimal utf16 algorithm
@@ -934,7 +938,7 @@ impl Number {
     pub(crate) fn global_is_finite(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(context)?;
@@ -961,7 +965,7 @@ impl Number {
     pub(crate) fn global_is_nan(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(value) = args.get(0) {
             let number = value.to_number(context)?;
@@ -989,7 +993,7 @@ impl Number {
     pub(crate) fn number_is_finite(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context,
+        _ctx: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If number is not a Number, return false.
         // 2. If number is not finite, return false.
@@ -1015,7 +1019,7 @@ impl Number {
     pub(crate) fn number_is_integer(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context,
+        _ctx: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args.get(0).map_or(false, Self::is_integer).into())
     }
@@ -1038,7 +1042,7 @@ impl Number {
     pub(crate) fn number_is_nan(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context,
+        _ctx: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(
             if let Some(&JsValue::Rational(number)) = args.get(0) {
@@ -1067,7 +1071,7 @@ impl Number {
     pub(crate) fn is_safe_integer(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context,
+        _ctx: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(match args.get(0) {
             Some(JsValue::Integer(_)) => true,

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -54,7 +54,7 @@ impl ForInIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createforiniterator
-    pub(crate) fn create_for_in_iterator(object: JsValue, context: &Context) -> JsValue {
+    pub(crate) fn create_for_in_iterator(object: JsValue, context: &Context<'_>) -> JsValue {
         let for_in_iterator = JsObject::from_proto_and_data(
             context
                 .intrinsics()
@@ -74,7 +74,11 @@ impl ForInIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%.next
-    pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn next(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
@@ -135,7 +139,7 @@ impl ForInIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%foriniteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -45,7 +45,7 @@ pub struct Object;
 impl BuiltIn for Object {
     const NAME: &'static str = "Object";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let legacy_proto_getter = FunctionBuilder::native(context, Self::legacy_proto_getter)
@@ -122,7 +122,7 @@ impl Object {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is neither undefined nor the active function object, then
         if !new_target.is_undefined() {
@@ -158,7 +158,7 @@ impl Object {
     pub fn legacy_proto_getter(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let obj = this.to_object(context)?;
@@ -183,7 +183,7 @@ impl Object {
     pub fn legacy_proto_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -228,7 +228,7 @@ impl Object {
     pub fn legacy_define_getter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let getter = args.get_or_undefined(1);
 
@@ -271,7 +271,7 @@ impl Object {
     pub fn legacy_define_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let setter = args.get_or_undefined(1);
 
@@ -314,7 +314,7 @@ impl Object {
     pub fn legacy_lookup_getter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let mut obj = this.to_object(context)?;
@@ -358,7 +358,7 @@ impl Object {
     pub fn legacy_lookup_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let mut obj = this.to_object(context)?;
@@ -400,7 +400,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.create
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
-    pub fn create(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn create(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let prototype = args.get_or_undefined(0);
         let properties = args.get_or_undefined(1);
 
@@ -440,7 +440,7 @@ impl Object {
     pub fn get_own_property_descriptor(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
@@ -468,7 +468,7 @@ impl Object {
     pub fn get_own_property_descriptors(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
@@ -507,7 +507,7 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-frompropertydescriptor
     pub(crate) fn from_property_descriptor(
         desc: Option<PropertyDescriptor>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsValue {
         // 1. If Desc is undefined, return undefined.
         let desc = if let Some(desc) = desc {
@@ -567,7 +567,7 @@ impl Object {
     }
 
     /// Uses the `SameValue` algorithm to check equality of objects
-    pub fn is(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub fn is(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let x = args.get_or_undefined(0);
         let y = args.get_or_undefined(1);
 
@@ -582,7 +582,7 @@ impl Object {
     pub fn get_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if args.is_empty() {
             return Err(JsNativeError::typ()
@@ -609,7 +609,7 @@ impl Object {
     pub fn set_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if args.len() < 2 {
             return Err(JsNativeError::typ()
@@ -674,7 +674,7 @@ impl Object {
     pub fn is_prototype_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let v = args.get_or_undefined(0);
         if !v.is_object() {
@@ -697,7 +697,7 @@ impl Object {
     pub fn define_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let object = args.get_or_undefined(0);
         if let JsValue::Object(object) = object {
@@ -733,7 +733,7 @@ impl Object {
     pub fn define_properties(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let arg = args.get_or_undefined(0);
         if let JsValue::Object(obj) = arg {
@@ -755,7 +755,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
-    pub fn value_of(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn value_of(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return ? ToObject(this value).
         Ok(this.to_object(context)?.into())
     }
@@ -771,7 +771,11 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-object.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. If the this value is undefined, return "[object Undefined]".
         if this.is_undefined() {
             return Ok("[object Undefined]".into());
@@ -832,7 +836,7 @@ impl Object {
     pub fn to_locale_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Return ? Invoke(O, "toString").
@@ -853,7 +857,7 @@ impl Object {
     pub fn has_own_property(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let P be ? ToPropertyKey(V).
         let key = args.get_or_undefined(0).to_property_key(context)?;
@@ -879,7 +883,7 @@ impl Object {
     pub fn property_is_enumerable(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let key = match args.get(0) {
             None => return Ok(JsValue::new(false)),
@@ -910,7 +914,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.assign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-    pub fn assign(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn assign(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let to be ? ToObject(target).
         let to = args.get_or_undefined(0).to_object(context)?;
 
@@ -960,7 +964,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
-    pub fn keys(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn keys(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -985,7 +989,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.values
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values
-    pub fn values(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn values(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -1014,7 +1018,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.entries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
-    pub fn entries(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn entries(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -1040,7 +1044,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.seal
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal
-    pub fn seal(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn seal(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         if let Some(o) = o.as_object() {
@@ -1066,7 +1070,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.issealed
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isSealed
-    pub fn is_sealed(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn is_sealed(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         // 1. If Type(O) is not Object, return true.
@@ -1087,7 +1095,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.freeze
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
-    pub fn freeze(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn freeze(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         if let Some(o) = o.as_object() {
@@ -1113,7 +1121,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.isfrozen
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isFrozen
-    pub fn is_frozen(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn is_frozen(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         // 1. If Type(O) is not Object, return true.
@@ -1137,7 +1149,7 @@ impl Object {
     pub fn prevent_extensions(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
@@ -1167,7 +1179,7 @@ impl Object {
     pub fn is_extensible(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
         // 1. If Type(O) is not Object, return false.
@@ -1190,7 +1202,7 @@ impl Object {
     pub fn get_own_property_names(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? GetOwnPropertyKeys(O, string).
         let o = args.get_or_undefined(0);
@@ -1208,7 +1220,7 @@ impl Object {
     pub fn get_own_property_symbols(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? GetOwnPropertyKeys(O, symbol).
         let o = args.get_or_undefined(0);
@@ -1223,7 +1235,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.hasown
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn
-    pub fn has_own(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn has_own(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
 
@@ -1242,7 +1254,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.fromentries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries
-    pub fn from_entries(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn from_entries(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Perform ? RequireObjectCoercible(iterable).
         let iterable = args.get_or_undefined(0).require_object_coercible()?;
 
@@ -1287,7 +1303,7 @@ impl Object {
 fn object_define_properties(
     object: &JsObject,
     props: &JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<()> {
     // 1. Assert: Type(O) is Object.
     // 2. Let props be ? ToObject(Properties).
@@ -1345,7 +1361,7 @@ enum PropertyKeyType {
 fn get_own_property_keys(
     o: &JsValue,
     r#type: PropertyKeyType,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let obj be ? ToObject(o).
     let obj = o.to_object(context)?;

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -128,7 +128,7 @@ impl PromiseCapability {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-newpromisecapability
-    pub(crate) fn new(c: &JsValue, context: &mut Context) -> JsResult<Self> {
+    pub(crate) fn new(c: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         #[derive(Debug, Clone, Trace, Finalize)]
         struct RejectResolve {
             reject: JsValue,
@@ -251,7 +251,7 @@ impl BuiltIn for Promise {
         .union(Attribute::NON_ENUMERABLE)
         .union(Attribute::CONFIGURABLE);
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let get_species = FunctionBuilder::native(context, Self::get_species)
@@ -316,7 +316,7 @@ impl Promise {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -386,7 +386,7 @@ impl Promise {
     pub(crate) fn all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this;
@@ -448,7 +448,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct ResolveElementCaptures {
@@ -627,7 +627,7 @@ impl Promise {
     pub(crate) fn all_settled(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this;
@@ -689,7 +689,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct ResolveRejectElementCaptures {
@@ -966,7 +966,7 @@ impl Promise {
     pub(crate) fn any(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this;
@@ -1028,7 +1028,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct RejectElementCaptures {
@@ -1240,7 +1240,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-createresolvingfunctions
     fn create_resolving_functions(
         promise: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> ResolvingFunctionsRecord {
         #[derive(Debug, Trace, Finalize)]
         struct RejectResolveCaptures {
@@ -1442,7 +1442,7 @@ impl Promise {
     /// # Panics
     ///
     /// Panics if `Promise` is not pending.
-    fn fulfill_promise(&mut self, value: &JsValue, context: &mut Context) {
+    fn fulfill_promise(&mut self, value: &JsValue, context: &mut Context<'_>) {
         // 1. Assert: The value of promise.[[PromiseState]] is pending.
         assert!(
             matches!(self.promise_state, PromiseState::Pending),
@@ -1482,7 +1482,7 @@ impl Promise {
     /// # Panics
     ///
     /// Panics if `Promise` is not pending.
-    pub fn reject_promise(&mut self, reason: &JsValue, context: &mut Context) {
+    pub fn reject_promise(&mut self, reason: &JsValue, context: &mut Context<'_>) {
         // 1. Assert: The value of promise.[[PromiseState]] is pending.
         assert!(
             matches!(self.promise_state, PromiseState::Pending),
@@ -1530,7 +1530,7 @@ impl Promise {
     fn trigger_promise_reactions(
         reactions: &[ReactionRecord],
         argument: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) {
         // 1. For each element reaction of reactions, do
         for reaction in reactions {
@@ -1556,7 +1556,7 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.race
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/race
-    pub fn race(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn race(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let iterable = args.get_or_undefined(0);
 
         // 1. Let C be the this value.
@@ -1621,7 +1621,7 @@ impl Promise {
         constructor: &JsValue,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Repeat,
         loop {
@@ -1679,7 +1679,11 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.reject
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/reject
-    pub fn reject(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn reject(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let r = args.get_or_undefined(0);
 
         // 1. Let C be the this value.
@@ -1706,7 +1710,11 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.resolve
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/resolve
-    pub fn resolve(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn resolve(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let x = args.get_or_undefined(0);
 
         // 1. Let C be the this value.
@@ -1734,7 +1742,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-get-promise-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -1747,7 +1755,7 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.prototype.catch
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch
-    pub fn catch(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn catch(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let on_rejected = args.get_or_undefined(0);
 
         // 1. Let promise be the this value.
@@ -1768,7 +1776,11 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.prototype.finally
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally
-    pub fn finally(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn finally(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let promise be the this value.
         let promise = this;
 
@@ -1914,7 +1926,7 @@ impl Promise {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise.prototype.then
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/then
-    pub fn then(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn then(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let promise be the this value.
         let promise = this;
 
@@ -1957,7 +1969,7 @@ impl Promise {
         on_fulfilled: &JsValue,
         on_rejected: &JsValue,
         result_capability: Option<PromiseCapability>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsValue {
         // 1. Assert: IsPromise(promise) is true.
 
@@ -2067,7 +2079,7 @@ impl Promise {
     pub(crate) fn promise_resolve(
         c: JsObject,
         x: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If IsPromise(x) is true, then
         if let Some(x) = x.as_promise() {
@@ -2103,7 +2115,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-getpromiseresolve
     fn get_promise_resolve(
         promise_constructor: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let promiseResolve be ? Get(promiseConstructor, "resolve").
         let promise_resolve = promise_constructor.get("resolve", context)?;

--- a/boa_engine/src/builtins/promise/promise_job.rs
+++ b/boa_engine/src/builtins/promise/promise_job.rs
@@ -18,7 +18,7 @@ impl PromiseJob {
     pub(crate) fn new_promise_reaction_job(
         reaction: ReactionRecord,
         argument: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JobCallback {
         #[derive(Debug, Trace, Finalize)]
         struct ReactionJobCaptures {
@@ -118,12 +118,12 @@ impl PromiseJob {
         promise_to_resolve: JsObject,
         thenable: JsValue,
         then: JobCallback,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JobCallback {
         // 1. Let job be a new Job Abstract Closure with no parameters that captures promiseToResolve, thenable, and then and performs the following steps when called:
         let job = FunctionBuilder::closure_with_captures(
             context,
-            |_this: &JsValue, _args: &[JsValue], captures, context: &mut Context| {
+            |_this: &JsValue, _args: &[JsValue], captures, context: &mut Context<'_>| {
                 let JobCapture {
                     promise_to_resolve,
                     thenable,

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -29,7 +29,7 @@ pub struct Proxy {
 impl BuiltIn for Proxy {
     const NAME: &'static str = "Proxy";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         ConstructorBuilder::with_standard_constructor(
@@ -76,7 +76,7 @@ impl Proxy {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -98,7 +98,7 @@ impl Proxy {
     pub(crate) fn create(
         target: &JsValue,
         handler: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         let target = target.as_object().ok_or_else(|| {
@@ -131,7 +131,7 @@ impl Proxy {
         Ok(p)
     }
 
-    pub(crate) fn revoker(proxy: JsObject, context: &mut Context) -> JsFunction {
+    pub(crate) fn revoker(proxy: JsObject, context: &mut Context<'_>) -> JsFunction {
         // 3. Let revoker be ! CreateBuiltinFunction(revokerClosure, 0, "", « [[RevocableProxy]] »).
         // 4. Set revoker.[[RevocableProxy]] to p.
         FunctionBuilder::closure_with_captures(
@@ -165,7 +165,7 @@ impl Proxy {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-proxy.revocable
-    fn revocable(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn revocable(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let p be ? ProxyCreate(target, handler).
         let p = Self::create(args.get_or_undefined(0), args.get_or_undefined(1), context)?;
 

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -32,7 +32,7 @@ pub(crate) struct Reflect;
 impl BuiltIn for Reflect {
     const NAME: &'static str = "Reflect";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let to_string_tag = WellKnownSymbols::to_string_tag();
@@ -75,7 +75,11 @@ impl Reflect {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-reflect.apply
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/apply
-    pub(crate) fn apply(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn apply(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
@@ -103,7 +107,7 @@ impl Reflect {
     pub(crate) fn construct(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If IsConstructor(target) is false, throw a TypeError exception.
         let target = args
@@ -143,7 +147,7 @@ impl Reflect {
     pub(crate) fn define_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -174,7 +178,7 @@ impl Reflect {
     pub(crate) fn delete_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -193,7 +197,11 @@ impl Reflect {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-reflect.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/get
-    pub(crate) fn get(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn get(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         let target = args
             .get(0)
@@ -222,7 +230,7 @@ impl Reflect {
     pub(crate) fn get_own_property_descriptor(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if args.get_or_undefined(0).is_object() {
             // This function is the same as Object.prototype.getOwnPropertyDescriptor, that why
@@ -250,7 +258,7 @@ impl Reflect {
     pub(crate) fn get_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -269,7 +277,11 @@ impl Reflect {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-reflect.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/has
-    pub(crate) fn has(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn has(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
@@ -292,7 +304,7 @@ impl Reflect {
     pub(crate) fn is_extensible(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -312,7 +324,7 @@ impl Reflect {
     pub(crate) fn own_keys(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -339,7 +351,7 @@ impl Reflect {
     pub(crate) fn prevent_extensions(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -357,7 +369,11 @@ impl Reflect {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-reflect.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set
-    pub(crate) fn set(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn set(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let target = args
             .get(0)
             .and_then(JsValue::as_object)
@@ -384,7 +400,7 @@ impl Reflect {
     pub(crate) fn set_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -50,7 +50,7 @@ pub struct RegExp {
 impl BuiltIn for RegExp {
     const NAME: &'static str = "RegExp";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let get_species = FunctionBuilder::native(context, Self::get_species)
@@ -169,7 +169,7 @@ impl RegExp {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let pattern = args.get_or_undefined(0);
         let flags = args.get_or_undefined(1);
@@ -232,7 +232,7 @@ impl RegExp {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexpalloc
-    pub(crate) fn alloc(new_target: &JsValue, context: &mut Context) -> JsResult<JsObject> {
+    pub(crate) fn alloc(new_target: &JsValue, context: &mut Context<'_>) -> JsResult<JsObject> {
         // 1. Let obj be ? OrdinaryCreateFromConstructor(newTarget, "%RegExp.prototype%", « [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] »).
         let proto =
             get_prototype_from_constructor(new_target, StandardConstructors::regexp, context)?;
@@ -264,7 +264,7 @@ impl RegExp {
         obj: JsObject,
         pattern: &JsValue,
         flags: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If pattern is undefined, let P be the empty String.
         // 2. Else, let P be ? ToString(pattern).
@@ -331,7 +331,7 @@ impl RegExp {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexpcreate
-    pub(crate) fn create(p: &JsValue, f: &JsValue, context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn create(p: &JsValue, f: &JsValue, context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? RegExpAlloc(%RegExp%).
         let obj = Self::alloc(
             &context.global_object().clone().get(Self::NAME, context)?,
@@ -353,12 +353,12 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-get-regexp-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
 
-    fn regexp_has_flag(this: &JsValue, flag: u8, context: &mut Context) -> JsResult<JsValue> {
+    fn regexp_has_flag(this: &JsValue, flag: u8, context: &mut Context<'_>) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             if let Some(regexp) = object.borrow().as_regexp() {
                 return Ok(JsValue::new(match flag {
@@ -410,7 +410,7 @@ impl RegExp {
     pub(crate) fn get_has_indices(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'd', context)
     }
@@ -428,7 +428,7 @@ impl RegExp {
     pub(crate) fn get_global(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'g', context)
     }
@@ -446,7 +446,7 @@ impl RegExp {
     pub(crate) fn get_ignore_case(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'i', context)
     }
@@ -464,7 +464,7 @@ impl RegExp {
     pub(crate) fn get_multiline(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'm', context)
     }
@@ -482,7 +482,7 @@ impl RegExp {
     pub(crate) fn get_dot_all(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b's', context)
     }
@@ -501,7 +501,7 @@ impl RegExp {
     pub(crate) fn get_unicode(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'u', context)
     }
@@ -520,7 +520,7 @@ impl RegExp {
     pub(crate) fn get_sticky(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Self::regexp_has_flag(this, b'y', context)
     }
@@ -539,7 +539,7 @@ impl RegExp {
     pub(crate) fn get_flags(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let R be the this value.
         // 2. If Type(R) is not Object, throw a TypeError exception.
@@ -610,7 +610,7 @@ impl RegExp {
     pub(crate) fn get_source(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let R be the this value.
         // 2. If Type(R) is not Object, throw a TypeError exception.
@@ -694,7 +694,7 @@ impl RegExp {
     pub(crate) fn test(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let R be the this value.
         // 2. If Type(R) is not Object, throw a TypeError exception.
@@ -736,7 +736,7 @@ impl RegExp {
     pub(crate) fn exec(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let R be the this value.
         // 2. Perform ? RequireInternalSlot(R, [[RegExpMatcher]]).
@@ -764,7 +764,7 @@ impl RegExp {
     pub(crate) fn abstract_exec(
         this: &JsObject,
         input: JsString,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<JsObject>> {
         // 1. Assert: Type(R) is Object.
         // 2. Assert: Type(S) is String.
@@ -808,7 +808,7 @@ impl RegExp {
     pub(crate) fn abstract_builtin_exec(
         this: &JsObject,
         input: &JsString,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<JsObject>> {
         // 1. Assert: R is an initialized RegExp instance.
         let rx = {
@@ -1036,7 +1036,7 @@ impl RegExp {
     pub(crate) fn r#match(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
@@ -1126,7 +1126,11 @@ impl RegExp {
     /// [spec]: https://tc39.es/ecma262/#sec-regexp.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let (body, flags) = if let Some(object) = this.as_object() {
             let object = object.borrow();
             let regex = object.as_regexp().ok_or_else(|| {
@@ -1160,7 +1164,7 @@ impl RegExp {
     pub(crate) fn match_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let R be the this value.
         // 2. If Type(R) is not Object, throw a TypeError exception.
@@ -1220,7 +1224,7 @@ impl RegExp {
     pub(crate) fn replace(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
@@ -1436,7 +1440,7 @@ impl RegExp {
     pub(crate) fn search(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.
@@ -1490,7 +1494,7 @@ impl RegExp {
     pub(crate) fn split(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let rx be the this value.
         // 2. If Type(rx) is not Object, throw a TypeError exception.

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -60,7 +60,7 @@ impl RegExpStringIterator {
         string: JsString,
         global: bool,
         unicode: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsValue {
         // TODO: Implement this with closures and generators.
         //       For now all values of the closure are stored in RegExpStringIterator and the actual closure execution is in `.next()`.
@@ -92,7 +92,7 @@ impl RegExpStringIterator {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%.next
-    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()
@@ -164,7 +164,7 @@ impl RegExpStringIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event("RegExp String Iterator", "init");
 

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -38,7 +38,7 @@ pub(crate) struct Set;
 impl BuiltIn for Set {
     const NAME: &'static str = "Set";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let get_species = FunctionBuilder::native(context, Self::get_species)
@@ -114,7 +114,7 @@ impl Set {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -167,7 +167,7 @@ impl Set {
     }
 
     /// Utility for constructing `Set` objects.
-    pub(crate) fn set_create(prototype: Option<JsObject>, context: &mut Context) -> JsObject {
+    pub(crate) fn set_create(prototype: Option<JsObject>, context: &mut Context<'_>) -> JsObject {
         let prototype =
             prototype.unwrap_or_else(|| context.intrinsics().constructors().set().prototype());
 
@@ -175,7 +175,7 @@ impl Set {
     }
 
     /// Utility for constructing `Set` objects from an iterator of `JsValue`'s.
-    pub(crate) fn create_set_from_list<I>(elements: I, context: &mut Context) -> JsObject
+    pub(crate) fn create_set_from_list<I>(elements: I, context: &mut Context<'_>) -> JsObject
     where
         I: IntoIterator<Item = JsValue>,
     {
@@ -201,7 +201,7 @@ impl Set {
     /// [spec]: https://tc39.es/ecma262/#sec-get-set-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -216,7 +216,7 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.add
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add
-    pub(crate) fn add(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn add(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let value = args.get_or_undefined(0);
 
         if let Some(object) = this.as_object() {
@@ -250,7 +250,7 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
-    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let mut object = this
             .as_object()
             .map(JsObject::borrow_mut)
@@ -276,7 +276,11 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.delete
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/delete
-    pub(crate) fn delete(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn delete(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let value = args.get_or_undefined(0);
 
         let mut object = this
@@ -304,7 +308,7 @@ impl Set {
     pub(crate) fn entries(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             let object = object.borrow();
@@ -339,7 +343,7 @@ impl Set {
     pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if args.is_empty() {
             return Err(JsNativeError::typ()
@@ -390,7 +394,7 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let value = args.get_or_undefined(0);
 
         this.as_object()
@@ -415,7 +419,7 @@ impl Set {
     pub(crate) fn values(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(object) = this.as_object() {
             let object = object.borrow();
@@ -437,7 +441,7 @@ impl Set {
         ))
     }
 
-    fn size_getter(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn size_getter(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         Self::get_size(this).map(JsValue::from)
     }
 

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -53,7 +53,7 @@ impl SetIterator {
     pub(crate) fn create_set_iterator(
         set: JsValue,
         kind: PropertyNameKind,
-        context: &Context,
+        context: &Context<'_>,
     ) -> JsValue {
         let set_iterator = JsObject::from_proto_and_data(
             context
@@ -74,7 +74,11 @@ impl SetIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
-    pub(crate) fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn next(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let mut set_iterator = this.as_object().map(JsObject::borrow_mut);
 
         let set_iterator = set_iterator
@@ -141,7 +145,7 @@ impl SetIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%setiteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -1327,7 +1327,7 @@ impl String {
             // Default to common comparison if the user doesn't have `Intl` enabled.
             #[cfg(not(feature = "intl"))]
             {
-                s.cmp(&that_value) as i8;
+                s.cmp(&that_value) as i8
             }
         };
 

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -66,7 +66,7 @@ pub(crate) struct String;
 impl BuiltIn for String {
     const NAME: &'static str = "String";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let symbol_iterator = WellKnownSymbols::iterator();
@@ -138,7 +138,7 @@ impl String {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
@@ -173,7 +173,7 @@ impl String {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-stringcreate
-    fn string_create(value: JsString, prototype: JsObject, context: &mut Context) -> JsObject {
+    fn string_create(value: JsString, prototype: JsObject, context: &mut Context<'_>) -> JsObject {
         // 7. Let length be the number of code unit elements in value.
         let len = value.len();
 
@@ -238,7 +238,7 @@ impl String {
     pub(crate) fn from_code_point(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let result be the empty String.
         let mut result = Vec::with_capacity(args.len());
@@ -284,7 +284,11 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.raw
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/raw
-    pub(crate) fn raw(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn raw(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         let substitutions = args.get(1..).unwrap_or_default();
 
         // 1. Let numberOfSubstitutions be the number of elements in substitutions.
@@ -358,7 +362,7 @@ impl String {
     pub(crate) fn from_char_code(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let result be the empty String.
         let mut result = Vec::new();
@@ -383,7 +387,11 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.tostring
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Return ? thisStringValue(this value).
         Ok(Self::this_string_value(this)?.into())
     }
@@ -407,7 +415,7 @@ impl String {
     pub(crate) fn char_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -441,7 +449,11 @@ impl String {
     ///
     /// [spec]: https://tc39.es/proposal-relative-indexing-method/#sec-string.prototype.at
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/at
-    pub(crate) fn at(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn at(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
 
@@ -485,7 +497,7 @@ impl String {
     pub(crate) fn code_point_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -528,7 +540,7 @@ impl String {
     pub(crate) fn char_code_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -567,7 +579,7 @@ impl String {
     pub(crate) fn concat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -601,7 +613,7 @@ impl String {
     pub(crate) fn repeat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -654,7 +666,7 @@ impl String {
     pub(crate) fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -719,7 +731,7 @@ impl String {
     pub(crate) fn starts_with(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -788,7 +800,7 @@ impl String {
     pub(crate) fn ends_with(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -854,7 +866,7 @@ impl String {
     pub(crate) fn includes(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -906,7 +918,7 @@ impl String {
     pub(crate) fn replace(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         this.require_object_coercible()?;
@@ -1011,7 +1023,7 @@ impl String {
     pub(crate) fn replace_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1163,7 +1175,7 @@ impl String {
     pub(crate) fn index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1207,7 +1219,7 @@ impl String {
     pub(crate) fn last_index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1274,7 +1286,7 @@ impl String {
     pub(crate) fn locale_compare(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1337,7 +1349,7 @@ impl String {
     pub(crate) fn r#match(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1377,7 +1389,7 @@ impl String {
         max_length: &JsValue,
         fill_string: &JsValue,
         placement: Placement,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be ? ToString(O).
         let string = object.to_string(context)?;
@@ -1449,7 +1461,7 @@ impl String {
     pub(crate) fn pad_end(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1476,7 +1488,7 @@ impl String {
     pub(crate) fn pad_start(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1500,7 +1512,11 @@ impl String {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string.prototype.trim
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim
-    pub(crate) fn trim(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn trim(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, start+end).
         let object = this.require_object_coercible()?;
@@ -1523,7 +1539,7 @@ impl String {
     pub(crate) fn trim_start(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, start).
@@ -1547,7 +1563,7 @@ impl String {
     pub(crate) fn trim_end(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, end).
@@ -1570,7 +1586,7 @@ impl String {
     pub(crate) fn to_lowercase(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1628,7 +1644,7 @@ impl String {
     pub(crate) fn to_uppercase(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // This function behaves in exactly the same way as `String.prototype.toLowerCase`, except that the String is
         // mapped using the toUppercase algorithm of the Unicode Default Case Conversion.
@@ -1688,7 +1704,7 @@ impl String {
     pub(crate) fn substring(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1738,7 +1754,7 @@ impl String {
     pub(crate) fn substr(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1801,7 +1817,7 @@ impl String {
     pub(crate) fn split(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1920,7 +1936,7 @@ impl String {
     pub(crate) fn value_of(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context,
+        _context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisStringValue(this value).
         Self::this_string_value(this).map(JsValue::from)
@@ -1941,7 +1957,7 @@ impl String {
     pub(crate) fn match_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2000,7 +2016,7 @@ impl String {
     pub(crate) fn normalize(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         use unicode_normalization::UnicodeNormalization;
         /// Represents the type of normalization applied to a [`JsString`]
@@ -2102,7 +2118,7 @@ impl String {
     pub(crate) fn search(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2132,7 +2148,7 @@ impl String {
     pub(crate) fn iterator(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         StringIterator::create_string_iterator(this.clone(), context)
     }
@@ -2151,7 +2167,7 @@ pub(crate) fn get_substitution(
     captures: &[JsValue],
     named_captures: &JsValue,
     replacement: &JsString,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsString> {
     let mut buf = [0; 2];
     // 1. Assert: Type(matched) is String.
@@ -2337,7 +2353,7 @@ pub(crate) fn get_substitution(
 /// [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-isregexp
-fn is_reg_exp(argument: &JsValue, context: &mut Context) -> JsResult<bool> {
+fn is_reg_exp(argument: &JsValue, context: &mut Context<'_>) -> JsResult<bool> {
     // 1. If Type(argument) is not Object, return false.
     let argument = match argument {
         JsValue::Object(o) => o,
@@ -2346,7 +2362,7 @@ fn is_reg_exp(argument: &JsValue, context: &mut Context) -> JsResult<bool> {
 
     is_reg_exp_object(argument, context)
 }
-fn is_reg_exp_object(argument: &JsObject, context: &mut Context) -> JsResult<bool> {
+fn is_reg_exp_object(argument: &JsObject, context: &mut Context<'_>) -> JsResult<bool> {
     // 2. Let matcher be ? Get(argument, @@match).
     let matcher = argument.get(WellKnownSymbols::r#match(), context)?;
 

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -30,7 +30,7 @@ pub struct StringIterator {
 
 impl StringIterator {
     /// Create a new `StringIterator`.
-    pub fn create_string_iterator(string: JsValue, context: &mut Context) -> JsResult<JsValue> {
+    pub fn create_string_iterator(string: JsValue, context: &mut Context<'_>) -> JsResult<JsValue> {
         let string_iterator = JsObject::from_proto_and_data(
             context
                 .intrinsics()
@@ -46,7 +46,7 @@ impl StringIterator {
     }
 
     /// `StringIterator.prototype.next( )`
-    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         let mut string_iterator = this.as_object().map(JsObject::borrow_mut);
         let string_iterator = string_iterator
             .as_mut()
@@ -89,7 +89,7 @@ impl StringIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-%arrayiteratorprototype%-object
     pub(crate) fn create_prototype(
         iterator_prototype: JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsObject {
         let _timer = Profiler::global().start_event("String Iterator", "init");
 

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -77,7 +77,7 @@ pub struct Symbol;
 impl BuiltIn for Symbol {
     const NAME: &'static str = "Symbol";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let symbol_async_iterator = WellKnownSymbols::async_iterator();
@@ -173,7 +173,7 @@ impl Symbol {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is not undefined, throw a TypeError exception.
         if !new_target.is_undefined() {
@@ -215,7 +215,11 @@ impl Symbol {
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.tostring
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/toString
     #[allow(clippy::wrong_self_convention)]
-    pub(crate) fn to_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let sym be ? thisSymbolValue(this value).
         let symbol = Self::this_symbol_value(this)?;
 
@@ -233,7 +237,11 @@ impl Symbol {
     ///
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/valueOf
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.valueof
-    pub(crate) fn value_of(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Return ? thisSymbolValue(this value).
         let symbol = Self::this_symbol_value(this)?;
         Ok(JsValue::Symbol(symbol))
@@ -252,7 +260,7 @@ impl Symbol {
     pub(crate) fn get_description(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let s be the this value.
         // 2. Let sym be ? thisSymbolValue(s).
@@ -272,7 +280,11 @@ impl Symbol {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.for
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/for
-    pub(crate) fn for_(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn for_(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let stringKey be ? ToString(key).
         let string_key = args
             .get(0)
@@ -302,7 +314,7 @@ impl Symbol {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.keyfor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
-    pub(crate) fn key_for(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn key_for(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         let sym = args.get_or_undefined(0);
         // 1. If Type(sym) is not Symbol, throw a TypeError exception.
         if let Some(sym) = sym.as_symbol() {
@@ -337,7 +349,7 @@ impl Symbol {
     pub(crate) fn to_primitive(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context,
+        _: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let sym = Self::this_symbol_value(this)?;
         // 1. Return ? thisSymbolValue(this value).

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -52,7 +52,7 @@ macro_rules! typed_array {
                 .union(Attribute::NON_ENUMERABLE)
                 .union(Attribute::CONFIGURABLE);
 
-            fn init(context: &mut Context) -> Option<JsValue> {
+            fn init(context: &mut Context<'_>) -> Option<JsValue> {
                 let _timer = Profiler::global().start_event(Self::NAME, "init");
 
                 let typed_array_constructor = context
@@ -118,7 +118,7 @@ macro_rules! typed_array {
             pub(crate) fn constructor(
                 new_target: &JsValue,
                 args: &[JsValue],
-                context: &mut Context,
+                context: &mut Context<'_>,
             ) -> JsResult<JsValue> {
                 // 1. If NewTarget is undefined, throw a TypeError exception.
                 if new_target.is_undefined() {
@@ -249,7 +249,7 @@ pub(crate) struct TypedArray;
 
 impl BuiltIn for TypedArray {
     const NAME: &'static str = "TypedArray";
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let get_species = FunctionBuilder::native(context, Self::get_species)
             .name("get [Symbol.species]")
             .constructor(false)
@@ -383,7 +383,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%
-    fn constructor(_new_target: &JsValue, _args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn constructor(
+        _new_target: &JsValue,
+        _args: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
         Err(JsNativeError::typ()
             .with_message("the TypedArray constructor should never be called directly")
@@ -396,7 +400,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.from
-    fn from(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn from(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         // 2. If IsConstructor(C) is false, throw a TypeError exception.
         let constructor = match this.as_object() {
@@ -506,7 +510,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.of
-    fn of(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn of(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let len be the number of elements in items.
 
         // 2. Let C be the this value.
@@ -543,7 +547,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%-@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -554,7 +558,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.at
-    pub(crate) fn at(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn at(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let obj = this.as_object().ok_or_else(|| {
@@ -604,7 +612,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
-    fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -629,7 +637,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.bytelength
-    pub(crate) fn byte_length(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn byte_length(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -658,7 +670,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.byteoffset
-    pub(crate) fn byte_offset(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn byte_offset(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -687,7 +703,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
-    fn copy_within(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn copy_within(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         let obj = this.as_object().ok_or_else(|| {
             JsNativeError::typ().with_message("Value is not a typed array object")
@@ -860,7 +880,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries
-    fn entries(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn entries(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let o = this.as_object().ok_or_else(|| {
@@ -893,7 +913,7 @@ impl TypedArray {
     pub(crate) fn every(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -960,7 +980,7 @@ impl TypedArray {
     pub(crate) fn fill(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1048,7 +1068,7 @@ impl TypedArray {
     pub(crate) fn filter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1136,7 +1156,7 @@ impl TypedArray {
     pub(crate) fn find(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1202,7 +1222,7 @@ impl TypedArray {
     pub(crate) fn findindex(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1266,7 +1286,7 @@ impl TypedArray {
     pub(crate) fn foreach(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1325,7 +1345,7 @@ impl TypedArray {
     pub(crate) fn includes(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1404,7 +1424,7 @@ impl TypedArray {
     pub(crate) fn index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1492,7 +1512,7 @@ impl TypedArray {
     pub(crate) fn join(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1552,7 +1572,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.keys
-    pub(crate) fn keys(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn keys(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let o = this.as_object().ok_or_else(|| {
@@ -1585,7 +1609,7 @@ impl TypedArray {
     pub(crate) fn last_index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1662,7 +1686,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
-    pub(crate) fn length(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn length(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
@@ -1694,7 +1718,7 @@ impl TypedArray {
     pub(crate) fn map(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1760,7 +1784,7 @@ impl TypedArray {
     pub(crate) fn reduce(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1845,7 +1869,7 @@ impl TypedArray {
     pub(crate) fn reduceright(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1933,7 +1957,7 @@ impl TypedArray {
     pub(crate) fn reverse(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1994,7 +2018,7 @@ impl TypedArray {
     pub(crate) fn set(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let target be the this value.
         // 2. Perform ? RequireInternalSlot(target, [[TypedArrayName]]).
@@ -2054,7 +2078,7 @@ impl TypedArray {
         target: &JsObject,
         target_offset: IntegerOrInfinity,
         source: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         let target_borrow = target.borrow();
         let target_array = target_borrow
@@ -2277,7 +2301,7 @@ impl TypedArray {
         target: &JsObject,
         target_offset: IntegerOrInfinity,
         source: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         let target_borrow = target.borrow();
         let target_array = target_borrow
@@ -2396,7 +2420,7 @@ impl TypedArray {
     pub(crate) fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -2569,7 +2593,7 @@ impl TypedArray {
     pub(crate) fn some(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -2635,7 +2659,7 @@ impl TypedArray {
     pub(crate) fn sort(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
         let compare_fn = match args.get(0) {
@@ -2702,7 +2726,7 @@ impl TypedArray {
         let sort_compare = |x: &JsValue,
                             y: &JsValue,
                             compare_fn: Option<&JsObject>,
-                            context: &mut Context|
+                            context: &mut Context<'_>|
          -> JsResult<Ordering> {
             // 1. Assert: Both Type(x) and Type(y) are Number or both are BigInt.
             // 2. If comparefn is not undefined, then
@@ -2849,7 +2873,7 @@ impl TypedArray {
     pub(crate) fn subarray(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
@@ -2935,7 +2959,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.values
-    fn values(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn values(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let o = this.as_object().ok_or_else(|| {
@@ -2966,7 +2990,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
     #[allow(clippy::unnecessary_wraps)]
-    fn to_string_tag(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn to_string_tag(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, return undefined.
         // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
@@ -2993,7 +3017,7 @@ impl TypedArray {
         exemplar: &JsObject,
         typed_array_name: TypedArrayKind,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let defaultConstructor be the intrinsic object listed in column one of Table 73 for exemplar.[[TypedArrayName]].
         let default_constructor = match typed_array_name {
@@ -3044,7 +3068,7 @@ impl TypedArray {
     fn create(
         constructor: &JsObject,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let newTypedArray be ? Construct(constructor, argumentList).
         let new_typed_array = constructor.construct(args, Some(constructor), context)?;
@@ -3080,7 +3104,7 @@ impl TypedArray {
     fn allocate_buffer(
         indexed: &mut IntegerIndexed,
         length: u64,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         // 1. Assert: O.[[ViewedArrayBuffer]] is undefined.
         assert!(indexed.viewed_array_buffer().is_none());
@@ -3121,7 +3145,7 @@ impl TypedArray {
     pub(crate) fn initialize_from_list(
         o: &JsObject,
         values: Vec<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         // 1. Let len be the number of elements in values.
         let len = values.len() as u64;
@@ -3163,7 +3187,7 @@ impl TypedArray {
         new_target: &JsValue,
         default_proto: P,
         length: Option<u64>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsObject>
     where
         P: FnOnce(&StandardConstructors) -> &StandardConstructor,
@@ -3203,7 +3227,7 @@ impl TypedArray {
     fn initialize_from_typed_array(
         o: &JsObject,
         src_array: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         let o_obj = o.borrow();
         let src_array_obj = src_array.borrow();
@@ -3354,7 +3378,7 @@ impl TypedArray {
         buffer: JsObject,
         byte_offset: &JsValue,
         length: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         // 1. Let constructorName be the String value of O.[[TypedArrayName]].
         // 2. Let elementSize be the Element Size value specified in Table 73 for constructorName.
@@ -3455,7 +3479,7 @@ impl TypedArray {
     fn initialize_from_array_like(
         o: &JsObject,
         array_like: &JsObject,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()> {
         // 1. Let len be ? LengthOfArrayLike(arrayLike).
         let len = array_like.length_of_array_like(context)?;

--- a/boa_engine/src/builtins/undefined/mod.rs
+++ b/boa_engine/src/builtins/undefined/mod.rs
@@ -26,7 +26,7 @@ impl BuiltIn for Undefined {
         .union(Attribute::NON_ENUMERABLE)
         .union(Attribute::PERMANENT);
 
-    fn init(_: &mut Context) -> Option<JsValue> {
+    fn init(_: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         Some(JsValue::undefined())

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -30,7 +30,7 @@ pub(crate) struct Uri;
 impl BuiltIn for Uri {
     const NAME: &'static str = "Uri";
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let decode_uri = FunctionBuilder::native(context, Self::decode_uri)
             .name("decodeURI")
             .length(1)
@@ -100,7 +100,7 @@ impl Uri {
     pub(crate) fn decode_uri(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let encoded_uri = args.get_or_undefined(0);
 
@@ -129,7 +129,7 @@ impl Uri {
     pub(crate) fn decode_uri_component(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let encoded_uri_component = args.get_or_undefined(0);
 
@@ -161,7 +161,7 @@ impl Uri {
     pub(crate) fn encode_uri(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let uri = args.get_or_undefined(0);
 
@@ -190,7 +190,7 @@ impl Uri {
     pub(crate) fn encode_uri_component(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let uri_component = args.get_or_undefined(0);
 

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -31,7 +31,7 @@ impl BuiltIn for WeakRef {
 
     const ATTRIBUTE: Attribute = Attribute::WRITABLE.union(Attribute::CONFIGURABLE);
 
-    fn init(context: &mut Context) -> Option<JsValue> {
+    fn init(context: &mut Context<'_>) -> Option<JsValue> {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
         ConstructorBuilder::with_standard_constructor(
             context,
@@ -62,7 +62,7 @@ impl WeakRef {
     pub(crate) fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -99,7 +99,11 @@ impl WeakRef {
     /// proper [`JsObject`], or returns `undefined` otherwise.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-weak-ref.prototype.deref
-    pub(crate) fn deref(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn deref(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let weakRef be the this value.
         // 2. Perform ? RequireInternalSlot(weakRef, [[WeakRefTarget]]).
         let weak_ref = this.as_object().map(JsObject::borrow).ok_or_else(|| {

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -16,7 +16,7 @@ use crate::{
 
 use super::{ByteCompiler, Literal, NodeKind};
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     /// This function compiles a class declaration or expression.
     ///
     /// The compilation of a class declaration and expression is mostly equal.

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -9,7 +9,7 @@ use crate::{
     JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_declaration_pattern_impl(
         &mut self,
         pattern: &Pattern,

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -6,7 +6,7 @@ use crate::{
     JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_assign(&mut self, assign: &Assign, use_expr: bool) -> JsResult<()> {
         if assign.op() == AssignOp::Assign {
             match Access::from_assign_target(assign.lhs()) {
@@ -27,7 +27,7 @@ impl ByteCompiler<'_> {
                 .expect("patterns should throw early errors on complex assignment operators");
 
             let shortcircuit_operator_compilation =
-                |compiler: &mut ByteCompiler<'_>, opcode: Opcode| -> JsResult<()> {
+                |compiler: &mut ByteCompiler<'_, '_>, opcode: Opcode| -> JsResult<()> {
                     let (early_exit, pop_count) =
                         compiler.access_set(access, use_expr, |compiler, level| {
                             compiler.access_get(access, true)?;

--- a/boa_engine/src/bytecompiler/expression/binary.rs
+++ b/boa_engine/src/bytecompiler/expression/binary.rs
@@ -5,7 +5,7 @@ use boa_ast::expression::operator::{
 
 use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary(&mut self, binary: &Binary, use_expr: bool) -> JsResult<()> {
         self.compile_expr(binary.lhs(), true)?;
         match binary.op() {

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -21,7 +21,7 @@ mod unary;
 use boa_interner::Sym;
 
 use super::{Access, Callable, NodeKind};
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     fn compile_literal(&mut self, lit: &AstLiteral, use_expr: bool) {
         match lit {
             AstLiteral::String(v) => self.emit_push_literal(Literal::String(

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -9,7 +9,7 @@ use crate::{
     vm::Opcode,
     JsNativeError, JsResult,
 };
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_object_literal(
         &mut self,
         object: &ObjectLiteral,

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -9,7 +9,7 @@ use crate::{
     JsNativeError, JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_unary(&mut self, unary: &Unary, use_expr: bool) -> JsResult<()> {
         let opcode = match unary.op() {
             UnaryOp::IncrementPre => {

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -82,7 +82,7 @@ impl FunctionCompiler {
         mut self,
         parameters: &FormalParameterList,
         body: &StatementList,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Gc<CodeBlock>> {
         self.strict = self.strict || body.strict();
 

--- a/boa_engine/src/bytecompiler/statement/continue.rs
+++ b/boa_engine/src/bytecompiler/statement/continue.rs
@@ -6,7 +6,7 @@ use crate::{
     JsNativeError, JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_continue(&mut self, node: Continue) -> JsResult<()> {
         let next = self.next_opcode_location();
         if let Some(info) = self

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -14,7 +14,7 @@ use crate::{
     JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_for_loop(
         &mut self,
         for_loop: &ForLoop,

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -12,7 +12,7 @@ mod r#continue;
 mod r#loop;
 mod r#try;
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) -> JsResult<()> {
         self.compile_expr(node.cond(), true)?;
         let jelse = self.jump_if_false();

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -6,7 +6,7 @@ use crate::{
     JsResult,
 };
 
-impl ByteCompiler<'_> {
+impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_try(
         &mut self,
         t: &Try,

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -157,12 +157,12 @@ impl<T: Class> ClassConstructor for T {
 
 /// Class builder which allows adding methods and static methods to the class.
 #[derive(Debug)]
-pub struct ClassBuilder<'context, 'icu> {
-    builder: ConstructorBuilder<'context, 'icu>,
+pub struct ClassBuilder<'ctx, 'icu> {
+    builder: ConstructorBuilder<'ctx, 'icu>,
 }
 
-impl<'context, 'icu> ClassBuilder<'context, 'icu> {
-    pub(crate) fn new<T>(context: &'context mut Context<'icu>) -> Self
+impl<'ctx, 'icu> ClassBuilder<'ctx, 'icu> {
+    pub(crate) fn new<T>(context: &'ctx mut Context<'icu>) -> Self
     where
         T: ClassConstructor,
     {
@@ -288,5 +288,11 @@ impl<'context, 'icu> ClassBuilder<'context, 'icu> {
     {
         self.builder.static_property_descriptor(key, property);
         self
+    }
+
+    /// Return the current context.
+    #[inline]
+    pub fn context(&mut self) -> &mut Context<'icu> {
+        self.builder.context()
     }
 }

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -26,7 +26,7 @@
 //!     const LENGTH: usize = 1;
 //!
 //!     // This is what is called when we do `new Animal()`
-//!     fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<Self> {
+//!     fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<Self> {
 //!         // This is equivalent to `String(arg)`.
 //!         let kind = args.get_or_undefined(0).to_string(context)?;
 //!
@@ -79,10 +79,10 @@ pub trait Class: NativeObject + Sized {
     const ATTRIBUTES: Attribute = Attribute::all();
 
     /// The constructor of the class.
-    fn constructor(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<Self>;
+    fn constructor(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<Self>;
 
     /// Initializes the internals and the methods of the class.
-    fn init(class: &mut ClassBuilder<'_>) -> JsResult<()>;
+    fn init(class: &mut ClassBuilder<'_, '_>) -> JsResult<()>;
 }
 
 /// This is a wrapper around `Class::constructor` that sets the internal data of a class.
@@ -93,14 +93,18 @@ pub trait ClassConstructor: Class {
     fn raw_constructor(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue>
     where
         Self: Sized;
 }
 
 impl<T: Class> ClassConstructor for T {
-    fn raw_constructor(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue>
+    fn raw_constructor(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue>
     where
         Self: Sized,
     {
@@ -153,12 +157,12 @@ impl<T: Class> ClassConstructor for T {
 
 /// Class builder which allows adding methods and static methods to the class.
 #[derive(Debug)]
-pub struct ClassBuilder<'context> {
-    builder: ConstructorBuilder<'context>,
+pub struct ClassBuilder<'context, 'icu> {
+    builder: ConstructorBuilder<'context, 'icu>,
 }
 
-impl<'context> ClassBuilder<'context> {
-    pub(crate) fn new<T>(context: &'context mut Context) -> Self
+impl<'context, 'icu> ClassBuilder<'context, 'icu> {
+    pub(crate) fn new<T>(context: &'context mut Context<'icu>) -> Self
     where
         T: ClassConstructor,
     {
@@ -284,11 +288,5 @@ impl<'context> ClassBuilder<'context> {
     {
         self.builder.static_property_descriptor(key, property);
         self
-    }
-
-    /// Return the current context.
-    #[inline]
-    pub fn context(&mut self) -> &'_ mut Context {
-        self.builder.context()
     }
 }

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -29,8 +29,8 @@ pub enum BoaProvider<'a> {
 impl Debug for BoaProvider<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Buffer(_) => f.debug_tuple("Buffer").field(&"_").finish(),
-            Self::Any(_) => f.debug_tuple("Any").field(&"_").finish(),
+            Self::Buffer(_) => f.debug_tuple("Buffer").field(&"..").finish(),
+            Self::Any(_) => f.debug_tuple("Any").field(&"..").finish(),
         }
     }
 }

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -22,7 +22,7 @@ use crate::builtins::intl::list_format::ListFormatType;
 pub enum BoaProvider<'a> {
     /// A [`BufferProvider`] data provider.
     Buffer(&'a dyn BufferProvider),
-    /// An [`AnyProvider] data provider.
+    /// An [`AnyProvider`] data provider.
     Any(&'a dyn AnyProvider),
 }
 

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -751,7 +751,7 @@ pub struct IntrinsicObjects {
 
 impl IntrinsicObjects {
     /// Initialize the intrinsic objects
-    pub fn init(context: &mut Context) -> Self {
+    pub fn init(context: &mut Context<'_>) -> Self {
         Self {
             throw_type_error: create_throw_type_error(context),
             array_prototype_values: Array::create_array_prototype_values(context).into(),

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -626,7 +626,7 @@ impl<'a> ContextBuilder<'a> {
             },
             #[cfg(feature = "intl")]
             icu: self.icu.unwrap_or_else(|| {
-                let provider = BoaProvider::Buffer(boa_icu_provider::blob());
+                let provider = BoaProvider::Buffer(boa_icu_provider::buffer());
                 icu::Icu::new(provider).expect("Failed to initialize default icu data.")
             }),
             #[cfg(not(feature = "intl"))]

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -200,7 +200,7 @@ impl CompileTimeEnvironment {
     }
 }
 
-impl Context {
+impl Context<'_> {
     /// Push either a new declarative or function environment on the compile time environment stack.
     ///
     /// Note: This function only works at bytecode compile time!

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -840,7 +840,7 @@ impl BindingLocator {
     /// Helper method to throws an error if the binding access is illegal.
     pub(crate) fn throw_mutate_immutable(
         &self,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> Result<(), JsNativeError> {
         if self.mutate_immutable {
             Err(JsNativeError::typ().with_message(format!(

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -156,7 +156,7 @@ impl JsError {
     ///
     /// assert!(error_val.as_object().unwrap().borrow().is_error());
     /// ```
-    pub fn to_opaque(&self, context: &mut Context) -> JsValue {
+    pub fn to_opaque(&self, context: &mut Context<'_>) -> JsValue {
         match &self.inner {
             Repr::Native(e) => e.to_opaque(context).into(),
             Repr::Opaque(v) => v.clone(),
@@ -201,7 +201,7 @@ impl JsError {
     /// assert!(matches!(error.kind, JsNativeErrorKind::Type));
     /// assert_eq!(error.message(), "type error!");
     /// ```
-    pub fn try_native(&self, context: &mut Context) -> Result<JsNativeError, TryNativeError> {
+    pub fn try_native(&self, context: &mut Context<'_>) -> Result<JsNativeError, TryNativeError> {
         match &self.inner {
             Repr::Native(e) => Ok(e.clone()),
             Repr::Opaque(val) => {
@@ -213,7 +213,7 @@ impl JsError {
                     .as_error()
                     .ok_or_else(|| TryNativeError::NotAnErrorObject(val.clone()))?;
 
-                let try_get_property = |key, context: &mut Context| {
+                let try_get_property = |key, context: &mut Context<'_>| {
                     obj.has_property(key, context)
                         .map_err(|e| TryNativeError::InaccessibleProperty {
                             property: key,
@@ -636,7 +636,7 @@ impl JsNativeError {
     /// assert!(error_obj.borrow().is_error());
     /// assert_eq!(error_obj.get("message", context).unwrap(), "error!".into())
     /// ```
-    pub fn to_opaque(&self, context: &mut Context) -> JsObject {
+    pub fn to_opaque(&self, context: &mut Context<'_>) -> JsObject {
         let Self {
             kind,
             message,

--- a/boa_engine/src/job.rs
+++ b/boa_engine/src/job.rs
@@ -48,7 +48,7 @@ impl JobCallback {
         &self,
         v: &JsValue,
         arguments_list: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // It must perform and return the result of Call(jobCallback.[[Callback]], V, argumentsList).
 

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -155,7 +155,7 @@ pub type JsResult<T> = StdResult<T, JsError>;
 ///
 /// The state of the `Context` is changed, and a string representation of the result is returned.
 #[cfg(test)]
-pub(crate) fn forward<S>(context: &mut Context, src: S) -> String
+pub(crate) fn forward<S>(context: &mut Context<'_>, src: S) -> String
 where
     S: AsRef<[u8]>,
 {
@@ -170,7 +170,7 @@ where
 /// If the interpreter fails parsing an error value is returned instead (error object)
 #[allow(clippy::unit_arg, clippy::drop_copy)]
 #[cfg(test)]
-pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &mut Context, src: T) -> JsResult<JsValue> {
+pub(crate) fn forward_val<T: AsRef<[u8]>>(context: &mut Context<'_>, src: T) -> JsResult<JsValue> {
     use boa_profiler::Profiler;
 
     let main_timer = Profiler::global().start_event("Main", "Main");

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -18,7 +18,7 @@ pub struct JsArray {
 impl JsArray {
     /// Create a new empty array.
     #[inline]
-    pub fn new(context: &mut Context) -> Self {
+    pub fn new(context: &mut Context<'_>) -> Self {
         let inner = Array::array_create(0, None, context)
             .expect("creating an empty array with the default prototype must not fail");
 
@@ -26,7 +26,7 @@ impl JsArray {
     }
 
     /// Create an array from a `IntoIterator<Item = JsValue>` convertible object.
-    pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
+    pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> Self
     where
         I: IntoIterator<Item = JsValue>,
     {
@@ -53,18 +53,18 @@ impl JsArray {
     ///
     /// Same a `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn length(&self, context: &mut Context<'_>) -> JsResult<u64> {
         self.inner.length_of_array_like(context)
     }
 
     /// Check if the array is empty, i.e. the `length` is zero.
     #[inline]
-    pub fn is_empty(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn is_empty(&self, context: &mut Context<'_>) -> JsResult<bool> {
         self.inner.length_of_array_like(context).map(|len| len == 0)
     }
 
     /// Push an element to the array.
-    pub fn push<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn push<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -73,18 +73,18 @@ impl JsArray {
 
     /// Pushes a slice of elements to the array.
     #[inline]
-    pub fn push_items(&self, items: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn push_items(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Array::push(&self.inner.clone().into(), items, context)
     }
 
     /// Pops an element from the array.
     #[inline]
-    pub fn pop(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn pop(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Array::pop(&self.inner.clone().into(), &[], context)
     }
 
     /// Calls `Array.prototype.at()`.
-    pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn at<T>(&self, index: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<i64>,
     {
@@ -93,26 +93,26 @@ impl JsArray {
 
     /// Calls `Array.prototype.shift()`.
     #[inline]
-    pub fn shift(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn shift(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Array::shift(&self.inner.clone().into(), &[], context)
     }
 
     /// Calls `Array.prototype.unshift()`.
     #[inline]
-    pub fn unshift(&self, items: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn unshift(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Array::shift(&self.inner.clone().into(), items, context)
     }
 
     /// Calls `Array.prototype.reverse()`.
     #[inline]
-    pub fn reverse(&self, context: &mut Context) -> JsResult<Self> {
+    pub fn reverse(&self, context: &mut Context<'_>) -> JsResult<Self> {
         Array::reverse(&self.inner.clone().into(), &[], context)?;
         Ok(self.clone())
     }
 
     /// Calls `Array.prototype.concat()`.
     #[inline]
-    pub fn concat(&self, items: &[JsValue], context: &mut Context) -> JsResult<Self> {
+    pub fn concat(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<Self> {
         let object = Array::concat(&self.inner.clone().into(), items, context)?
             .as_object()
             .cloned()
@@ -123,7 +123,11 @@ impl JsArray {
 
     /// Calls `Array.prototype.join()`.
     #[inline]
-    pub fn join(&self, separator: Option<JsString>, context: &mut Context) -> JsResult<JsString> {
+    pub fn join(
+        &self,
+        separator: Option<JsString>,
+        context: &mut Context<'_>,
+    ) -> JsResult<JsString> {
         Array::join(
             &self.inner.clone().into(),
             &[separator.into_or_undefined()],
@@ -142,7 +146,7 @@ impl JsArray {
         value: T,
         start: Option<u32>,
         end: Option<u32>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self>
     where
         T: Into<JsValue>,
@@ -164,7 +168,7 @@ impl JsArray {
         &self,
         search_element: T,
         from_index: Option<u32>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<u32>>
     where
         T: Into<JsValue>,
@@ -190,7 +194,7 @@ impl JsArray {
         &self,
         search_element: T,
         from_index: Option<u32>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<u32>>
     where
         T: Into<JsValue>,
@@ -217,7 +221,7 @@ impl JsArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Array::find(
             &self.inner.clone().into(),
@@ -232,7 +236,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::filter(
             &self.inner.clone().into(),
@@ -252,7 +256,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::map(
             &self.inner.clone().into(),
@@ -272,7 +276,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let result = Array::every(
             &self.inner.clone().into(),
@@ -291,7 +295,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let result = Array::some(
             &self.inner.clone().into(),
@@ -306,7 +310,11 @@ impl JsArray {
 
     /// Calls `Array.prototype.sort()`.
     #[inline]
-    pub fn sort(&self, compare_fn: Option<JsFunction>, context: &mut Context) -> JsResult<Self> {
+    pub fn sort(
+        &self,
+        compare_fn: Option<JsFunction>,
+        context: &mut Context<'_>,
+    ) -> JsResult<Self> {
         Array::sort(
             &self.inner.clone().into(),
             &[compare_fn.into_or_undefined()],
@@ -322,7 +330,7 @@ impl JsArray {
         &self,
         start: Option<u32>,
         end: Option<u32>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::slice(
             &self.inner.clone().into(),
@@ -342,7 +350,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Array::reduce(
             &self.inner.clone().into(),
@@ -357,7 +365,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Array::reduce_right(
             &self.inner.clone().into(),

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -37,7 +37,7 @@ impl JsArrayBuffer {
     /// # }
     /// ```
     #[inline]
-    pub fn new(byte_length: usize, context: &mut Context) -> JsResult<Self> {
+    pub fn new(byte_length: usize, context: &mut Context<'_>) -> JsResult<Self> {
         let inner = ArrayBuffer::allocate(
             &context
                 .intrinsics()
@@ -75,7 +75,7 @@ impl JsArrayBuffer {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context) -> JsResult<Self> {
+    pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context<'_>) -> JsResult<Self> {
         let byte_length = byte_block.len();
 
         let constructor = context
@@ -148,7 +148,7 @@ impl JsArrayBuffer {
     /// # }
     ///  ```
     #[inline]
-    pub fn byte_length(&self, context: &mut Context) -> usize {
+    pub fn byte_length(&self, context: &mut Context<'_>) -> usize {
         ArrayBuffer::get_byte_length(&self.inner.clone().into(), &[], context)
             .expect("it should not throw")
             .as_number()

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -42,7 +42,7 @@ impl JsDataView {
         array_buffer: &JsArrayBuffer,
         offset: Option<u64>,
         byte_length: Option<u64>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let (byte_offset, byte_length) = {
             let borrowed_buffer = array_buffer.borrow();
@@ -122,20 +122,20 @@ impl JsDataView {
 
     /// Returns the `viewed_array_buffer` field for [`JsDataView`]
     #[inline]
-    pub fn buffer(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn buffer(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         DataView::get_buffer(&self.inner.clone().into(), &[], context)
     }
 
     /// Returns the `byte_length` property of [`JsDataView`] as a u64 integer
     #[inline]
-    pub fn byte_length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn byte_length(&self, context: &mut Context<'_>) -> JsResult<u64> {
         DataView::get_byte_length(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_number().expect("value should be a number") as u64)
     }
 
     /// Returns the `byte_offset` field property of [`JsDataView`] as a u64 integer
     #[inline]
-    pub fn byte_offset(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn byte_offset(&self, context: &mut Context<'_>) -> JsResult<u64> {
         DataView::get_byte_offset(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_number().expect("byte_offset value must be a number") as u64)
     }
@@ -146,7 +146,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<i64> {
         DataView::get_big_int64(
             &self.inner.clone().into(),
@@ -162,7 +162,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<u64> {
         DataView::get_big_uint64(
             &self.inner.clone().into(),
@@ -178,7 +178,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<f32> {
         DataView::get_float32(
             &self.inner.clone().into(),
@@ -194,7 +194,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<f64> {
         DataView::get_float64(
             &self.inner.clone().into(),
@@ -210,7 +210,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<i8> {
         DataView::get_int8(
             &self.inner.clone().into(),
@@ -226,7 +226,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<i16> {
         DataView::get_int16(
             &self.inner.clone().into(),
@@ -242,7 +242,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<i32> {
         DataView::get_int32(
             &self.inner.clone().into(),
@@ -258,7 +258,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<u8> {
         DataView::get_uint8(
             &self.inner.clone().into(),
@@ -274,7 +274,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<u16> {
         DataView::get_uint16(
             &self.inner.clone().into(),
@@ -290,7 +290,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<u32> {
         DataView::get_uint32(
             &self.inner.clone().into(),
@@ -307,7 +307,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i64,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_big_int64(
             &self.inner.clone().into(),
@@ -323,7 +323,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u64,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_big_uint64(
             &self.inner.clone().into(),
@@ -339,7 +339,7 @@ impl JsDataView {
         byte_offset: usize,
         value: f32,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_float32(
             &self.inner.clone().into(),
@@ -355,7 +355,7 @@ impl JsDataView {
         byte_offset: usize,
         value: f64,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_float64(
             &self.inner.clone().into(),
@@ -371,7 +371,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i8,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int8(
             &self.inner.clone().into(),
@@ -387,7 +387,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i16,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int16(
             &self.inner.clone().into(),
@@ -403,7 +403,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i32,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int32(
             &self.inner.clone().into(),
@@ -419,7 +419,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u8,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint8(
             &self.inner.clone().into(),
@@ -435,7 +435,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u16,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint16(
             &self.inner.clone().into(),
@@ -451,7 +451,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u32,
         is_little_endian: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint32(
             &self.inner.clone().into(),

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -40,7 +40,7 @@ pub struct JsDate {
 impl JsDate {
     /// Create a new `Date` object with universal time.
     #[inline]
-    pub fn new(context: &mut Context) -> Self {
+    pub fn new(context: &mut Context<'_>) -> Self {
         let prototype = context.intrinsics().constructors().date().prototype();
         let inner = JsObject::from_proto_and_data(prototype, ObjectData::date(Date::default()));
 
@@ -51,7 +51,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.now()`
     #[inline]
-    pub fn now(context: &mut Context) -> JsResult<JsValue> {
+    pub fn now(context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::now(&JsValue::Null, &[JsValue::Null], context)
     }
 
@@ -63,7 +63,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.parse(value)`.
     #[inline]
-    pub fn parse(value: JsValue, context: &mut Context) -> JsResult<JsValue> {
+    pub fn parse(value: JsValue, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::parse(&JsValue::Null, &[value], context)
     }
 
@@ -72,7 +72,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.UTC()`
     #[inline]
-    pub fn utc(values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn utc(values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::utc(&JsValue::Null, values, context)
     }
 
@@ -81,7 +81,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getDate()`.
     #[inline]
-    pub fn get_date(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_date(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_date::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -90,7 +90,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getDay()`.
     #[inline]
-    pub fn get_day(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_day(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_day::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -99,7 +99,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getFullYear()`.
     #[inline]
-    pub fn get_full_year(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_full_year(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_full_year::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -107,7 +107,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getHours()`.
     #[inline]
-    pub fn get_hours(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_hours(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_hours::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -116,7 +116,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMilliseconds()`.
     #[inline]
-    pub fn get_milliseconds(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_milliseconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_milliseconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -124,7 +124,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMinutes()`.
     #[inline]
-    pub fn get_minutes(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_minutes(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_minutes::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -132,7 +132,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMonth()`.
     #[inline]
-    pub fn get_month(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_month(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_month::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -140,7 +140,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getSeconds()`.
     #[inline]
-    pub fn get_seconds(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_seconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_seconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -150,7 +150,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getTime()`.
     #[inline]
-    pub fn get_time(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_time(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_time(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -158,7 +158,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getTimezoneOffset()`.
     #[inline]
-    pub fn get_timezone_offset(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_timezone_offset(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_timezone_offset(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -167,7 +167,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCDate()`.
     #[inline]
-    pub fn get_utc_date(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_date(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_date::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -176,7 +176,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCDay()`.
     #[inline]
-    pub fn get_utc_day(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_day(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_day::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -185,7 +185,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCFullYear()`.
     #[inline]
-    pub fn get_utc_full_year(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_full_year(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_full_year::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -194,7 +194,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCHours()`.
     #[inline]
-    pub fn get_utc_hours(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_hours(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_hours::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -203,7 +203,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMilliseconds()`.
     #[inline]
-    pub fn get_utc_milliseconds(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_milliseconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_milliseconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -212,7 +212,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMinutes()`.
     #[inline]
-    pub fn get_utc_minutes(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_minutes(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_minutes::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -221,7 +221,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMonth()`.
     #[inline]
-    pub fn get_utc_month(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_month(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_month::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -230,7 +230,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCSeconds()`.
     #[inline]
-    pub fn get_utc_seconds(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_utc_seconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::get_seconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -241,7 +241,7 @@ impl JsDate {
     /// the UNIX epoch and the given date.
     ///
     /// Same as JavaScript's `Date.prototype.setDate()`.
-    pub fn set_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn set_date<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -256,7 +256,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setFullYear()`.
     #[inline]
-    pub fn set_full_year(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_full_year(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_full_year::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -267,7 +271,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setHours()`.
     #[inline]
-    pub fn set_hours(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_hours(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::set_hours::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -277,7 +281,7 @@ impl JsDate {
     /// the UNIX epoch and updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setMilliseconds()`.
-    pub fn set_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn set_milliseconds<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -291,7 +295,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setMinutes()`.
     #[inline]
-    pub fn set_minutes(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_minutes(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::set_minutes::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -302,7 +306,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setMonth()`.
     #[inline]
-    pub fn set_month(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_month(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::set_month::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -313,7 +317,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setSeconds()`.
     #[inline]
-    pub fn set_seconds(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_seconds(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::set_seconds::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -325,7 +329,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setTime()`.
-    pub fn set_time<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn set_time<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -339,7 +343,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCDate()`.
-    pub fn set_utc_date<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn set_utc_date<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -357,7 +361,7 @@ impl JsDate {
     pub fn set_utc_full_year(
         &self,
         values: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_full_year::<false>(&self.inner.clone().into(), values, context)
     }
@@ -369,7 +373,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setUTCHours()`.
     #[inline]
-    pub fn set_utc_hours(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_utc_hours(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_hours::<false>(&self.inner.clone().into(), values, context)
     }
 
@@ -379,7 +387,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMilliseconds()`.
-    pub fn set_utc_milliseconds<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn set_utc_milliseconds<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -393,7 +401,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMinutes()`.
     #[inline]
-    pub fn set_utc_minutes(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_utc_minutes(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_minutes::<false>(&self.inner.clone().into(), values, context)
     }
 
@@ -404,7 +416,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMonth()`.
     #[inline]
-    pub fn set_utc_month(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_utc_month(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_month::<false>(&self.inner.clone().into(), values, context)
     }
 
@@ -415,7 +431,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setUTCSeconds()`.
     #[inline]
-    pub fn set_utc_seconds(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn set_utc_seconds(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_seconds::<false>(&self.inner.clone().into(), values, context)
     }
 
@@ -423,7 +443,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toDateString()`.
     #[inline]
-    pub fn to_date_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_date_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_date_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -434,7 +454,7 @@ impl JsDate {
     /// Same as JavaScript's legacy `Date.prototype.toGMTString()`
     #[deprecated]
     #[inline]
-    pub fn to_gmt_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_gmt_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_gmt_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -443,7 +463,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toISOString()`.
     #[inline]
-    pub fn to_iso_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_iso_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_iso_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -451,7 +471,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toJSON()`.
     #[inline]
-    pub fn to_json(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_json(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_json(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -464,7 +484,7 @@ impl JsDate {
     pub fn to_local_date_string(
         &self,
         values: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Date::to_locale_date_string(&self.inner.clone().into(), values, context)
     }
@@ -474,7 +494,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toLocaleDateString()`.
     #[inline]
-    pub fn to_locale_string(&self, values: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_locale_string(
+        &self,
+        values: &[JsValue],
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::to_locale_string(&self.inner.clone().into(), values, context)
     }
 
@@ -485,7 +509,7 @@ impl JsDate {
     pub fn to_locale_time_string(
         &self,
         values: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Date::to_locale_time_string(&self.inner.clone().into(), values, context)
     }
@@ -494,7 +518,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toString()`.
     #[inline]
-    pub fn to_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -502,7 +526,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toTimeString()`.
     #[inline]
-    pub fn to_time_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_time_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_time_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -510,7 +534,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toUTCString()`.
     #[inline]
-    pub fn to_utc_string(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn to_utc_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::to_utc_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -518,12 +542,12 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.valueOf()`.
     #[inline]
-    pub fn value_of(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn value_of(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Date::value_of(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
     /// Utility create a `Date` object from RFC3339 string
-    pub fn new_from_parse(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+    pub fn new_from_parse(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         let prototype = context.intrinsics().constructors().date().prototype();
         let string = value
             .to_string(context)?

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -17,7 +17,7 @@ pub struct JsGenerator {
 impl JsGenerator {
     /// Create a new `JsGenerator` object
     #[inline]
-    pub fn new(context: &mut Context) -> Self {
+    pub fn new(context: &mut Context<'_>) -> Self {
         let prototype = context.intrinsics().constructors().generator().prototype();
 
         let generator = JsObject::from_proto_and_data(
@@ -46,7 +46,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.next()`
     ///
     /// This method returns an object with the properties `done` and `value`
-    pub fn next<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn next<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -56,7 +56,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.return()`
     ///
     /// This method returns the given value and finishes the generator
-    pub fn r#return<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn r#return<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -67,7 +67,7 @@ impl JsGenerator {
     ///
     /// This method resumes the execution of a generator by throwing an error and returning an
     /// an object with the properties `done` and `value`
-    pub fn throw<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn throw<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -86,7 +86,7 @@ impl JsMap {
     /// let map = JsMap::new(context);
     /// ```
     #[inline]
-    pub fn new(context: &mut Context) -> Self {
+    pub fn new(context: &mut Context<'_>) -> Self {
         let map = Self::create_map(context);
         Self { inner: map }
     }
@@ -115,7 +115,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_js_iterable(iterable: &JsValue, context: &mut Context) -> JsResult<Self> {
+    pub fn from_js_iterable(iterable: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
         // Create a new map object.
         let map = Self::create_map(context);
 
@@ -178,7 +178,7 @@ impl JsMap {
     }
 
     // Utility function to generate the default `Map` object.
-    fn create_map(context: &mut Context) -> JsObject {
+    fn create_map(context: &mut Context<'_>) -> JsObject {
         // Get default Map prototype
         let prototype = context.intrinsics().constructors().map().prototype();
 
@@ -188,7 +188,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `[key, value]` pairs within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn entries(&self, context: &mut Context) -> JsResult<JsMapIterator> {
+    pub fn entries(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::entries(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
@@ -197,7 +197,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `key` for each element within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn keys(&self, context: &mut Context) -> JsResult<JsMapIterator> {
+    pub fn keys(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::keys(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
@@ -225,7 +225,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set<K, V>(&self, key: K, value: V, context: &mut Context) -> JsResult<JsValue>
+    pub fn set<K, V>(&self, key: K, value: V, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         K: Into<JsValue>,
         V: Into<JsValue>,
@@ -259,7 +259,7 @@ impl JsMap {
     /// # }
     /// ```
     #[inline]
-    pub fn get_size(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn get_size(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Map::get_size(&self.inner.clone().into(), &[], context)
     }
 
@@ -285,7 +285,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn delete<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn delete<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -312,7 +312,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn get<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -341,7 +341,7 @@ impl JsMap {
     /// # }
     /// ```
     #[inline]
-    pub fn clear(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn clear(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Map::clear(&self.inner.clone().into(), &[], context)
     }
 
@@ -365,7 +365,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn has<T>(&self, key: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn has<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -378,7 +378,7 @@ impl JsMap {
         &self,
         callback: JsFunction,
         this_arg: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Map::for_each(
             &self.inner.clone().into(),
@@ -389,7 +389,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `value` for each element within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn values(&self, context: &mut Context) -> JsResult<JsMapIterator> {
+    pub fn values(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::values(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();

--- a/boa_engine/src/object/builtins/jsmap_iterator.rs
+++ b/boa_engine/src/object/builtins/jsmap_iterator.rs
@@ -29,7 +29,7 @@ impl JsMapIterator {
     }
 
     /// Advances the `JsMapIterator` and gets the next result in the `JsMap`
-    pub fn next(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn next(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         MapIterator::next(&self.inner.clone().into(), &[], context)
     }
 }

--- a/boa_engine/src/object/builtins/jsproxy.rs
+++ b/boa_engine/src/object/builtins/jsproxy.rs
@@ -80,7 +80,7 @@ impl JsRevocableProxy {
     /// Disables the traps of the internal `proxy` object, essentially
     /// making it unusable and throwing `TypeError`s for all the traps.
     #[inline]
-    pub fn revoke(self, context: &mut Context) -> JsResult<()> {
+    pub fn revoke(self, context: &mut Context<'_>) -> JsResult<()> {
         self.revoker.call(&JsValue::undefined(), &[], context)?;
         Ok(())
     }
@@ -370,7 +370,7 @@ impl JsProxyBuilder {
     /// [`JsObject`] in case there's a need to manipulate the returned object
     /// inside Rust code.
     #[must_use]
-    pub fn build(self, context: &mut Context) -> JsProxy {
+    pub fn build(self, context: &mut Context<'_>) -> JsProxy {
         let handler = JsObject::with_object_proto(context);
 
         if let Some(apply) = self.apply {
@@ -487,7 +487,7 @@ impl JsProxyBuilder {
     /// revoker in case there's a need to manipulate the returned objects
     /// inside Rust code.
     #[must_use]
-    pub fn build_revocable(self, context: &mut Context) -> JsRevocableProxy {
+    pub fn build_revocable(self, context: &mut Context<'_>) -> JsRevocableProxy {
         let proxy = self.build(context);
         let revoker = Proxy::revoker(proxy.inner.clone(), context);
 

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -56,7 +56,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new<S>(pattern: S, flags: S, context: &mut Context) -> JsResult<Self>
+    pub fn new<S>(pattern: S, flags: S, context: &mut Context<'_>) -> JsResult<Self>
     where
         S: Into<JsValue>,
     {
@@ -90,49 +90,49 @@ impl JsRegExp {
 
     /// Returns a boolean value for whether the `d` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn has_indices(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn has_indices(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_has_indices(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `g` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn global(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn global(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_global(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `i` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn ignore_case(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn ignore_case(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_ignore_case(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `m` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn multiline(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn multiline(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_multiline(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `s` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn dot_all(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn dot_all(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_dot_all(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `u` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn unicode(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn unicode(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_unicode(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `y` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn sticky(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn sticky(&self, context: &mut Context<'_>) -> JsResult<bool> {
         RegExp::get_sticky(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
@@ -153,7 +153,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn flags(&self, context: &mut Context) -> JsResult<String> {
+    pub fn flags(&self, context: &mut Context<'_>) -> JsResult<String> {
         RegExp::get_flags(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be string")
@@ -178,7 +178,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn source(&self, context: &mut Context) -> JsResult<String> {
+    pub fn source(&self, context: &mut Context<'_>) -> JsResult<String> {
         RegExp::get_source(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be string")
@@ -202,7 +202,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn test<S>(&self, search_string: S, context: &mut Context) -> JsResult<bool>
+    pub fn test<S>(&self, search_string: S, context: &mut Context<'_>) -> JsResult<bool>
     where
         S: Into<JsValue>,
     {
@@ -213,7 +213,7 @@ impl JsRegExp {
     /// Executes a search for a match in a specified string
     ///
     /// Returns a `JsArray` containing matched value and updates the `lastIndex` property, or `None`
-    pub fn exec<S>(&self, search_string: S, context: &mut Context) -> JsResult<Option<JsArray>>
+    pub fn exec<S>(&self, search_string: S, context: &mut Context<'_>) -> JsResult<Option<JsArray>>
     where
         S: Into<JsValue>,
     {
@@ -245,7 +245,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn to_string(&self, context: &mut Context) -> JsResult<String> {
+    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<String> {
         RegExp::to_string(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be a string")

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -22,7 +22,7 @@ impl JsSet {
     /// Doesn't matches JavaScript `new Set()` as it doesn't takes an iterator
     /// similar to Rust initialization.
     #[inline]
-    pub fn new(context: &mut Context) -> Self {
+    pub fn new(context: &mut Context<'_>) -> Self {
         let inner = Set::set_create(None, context);
 
         Self { inner }
@@ -40,7 +40,7 @@ impl JsSet {
     /// Returns the Set object with added value.
     ///
     /// Same as JavaScript's `set.add(value)`.
-    pub fn add<T>(&self, value: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn add<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -52,7 +52,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.add(["one", "two", "three"])`
     #[inline]
-    pub fn add_items(&self, items: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub fn add_items(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
         Set::add(&self.inner.clone().into(), items, context)
     }
 
@@ -61,7 +61,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.clear()`.
     #[inline]
-    pub fn clear(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn clear(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         Set::clear(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -70,7 +70,7 @@ impl JsSet {
     /// successfully removed or not.
     ///
     /// Same as JavaScript's `set.delete(value)`.
-    pub fn delete<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
+    pub fn delete<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<bool>
     where
         T: Into<JsValue>,
     {
@@ -85,7 +85,7 @@ impl JsSet {
     /// with the given value in the Set object or not.
     ///
     /// Same as JavaScript's `set.has(value)`.
-    pub fn has<T>(&self, value: T, context: &mut Context) -> JsResult<bool>
+    pub fn has<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<bool>
     where
         T: Into<JsValue>,
     {
@@ -101,7 +101,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.values()`.
     #[inline]
-    pub fn values(&self, context: &mut Context) -> JsResult<JsSetIterator> {
+    pub fn values(&self, context: &mut Context<'_>) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
@@ -114,7 +114,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.keys()`.
     #[inline]
-    pub fn keys(&self, context: &mut Context) -> JsResult<JsSetIterator> {
+    pub fn keys(&self, context: &mut Context<'_>) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
@@ -131,7 +131,7 @@ impl JsSet {
         &self,
         callback: JsFunction,
         this_arg: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         Set::for_each(
             &self.inner.clone().into(),
@@ -153,7 +153,7 @@ impl JsSet {
     }
 
     /// Utility: Creates a `JsSet` from a `<IntoIterator<Item = JsValue>` convertible object.
-    pub fn from_iter<I>(elements: I, context: &mut Context) -> Self
+    pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> Self
     where
         I: IntoIterator<Item = JsValue>,
     {

--- a/boa_engine/src/object/builtins/jsset_iterator.rs
+++ b/boa_engine/src/object/builtins/jsset_iterator.rs
@@ -29,7 +29,7 @@ impl JsSetIterator {
         }
     }
     /// Advances the `JsSetIterator` and gets the next result in the `JsSet`.
-    pub fn next(&self, context: &mut Context) -> JsResult<JsValue> {
+    pub fn next(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
         SetIterator::next(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 }

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -36,7 +36,7 @@ impl JsTypedArray {
     ///
     /// Same a `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn length(&self, context: &mut Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::length(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -45,12 +45,12 @@ impl JsTypedArray {
 
     /// Check if the array is empty, i.e. the `length` is zero.
     #[inline]
-    pub fn is_empty(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn is_empty(&self, context: &mut Context<'_>) -> JsResult<bool> {
         Ok(self.length(context)? == 0)
     }
 
     /// Calls `TypedArray.prototype.at()`.
-    pub fn at<T>(&self, index: T, context: &mut Context) -> JsResult<JsValue>
+    pub fn at<T>(&self, index: T, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         T: Into<i64>,
     {
@@ -59,7 +59,7 @@ impl JsTypedArray {
 
     /// Returns `TypedArray.prototype.byteLength`.
     #[inline]
-    pub fn byte_length(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn byte_length(&self, context: &mut Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::byte_length(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -68,7 +68,7 @@ impl JsTypedArray {
 
     /// Returns `TypedArray.prototype.byteOffset`.
     #[inline]
-    pub fn byte_offset(&self, context: &mut Context) -> JsResult<usize> {
+    pub fn byte_offset(&self, context: &mut Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::byte_offset(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -81,7 +81,7 @@ impl JsTypedArray {
         value: T,
         start: Option<usize>,
         end: Option<usize>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self>
     where
         T: Into<JsValue>,
@@ -103,7 +103,7 @@ impl JsTypedArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let result = TypedArray::every(
             &self.inner,
@@ -122,7 +122,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let result = TypedArray::some(
             &self.inner,
@@ -137,7 +137,11 @@ impl JsTypedArray {
 
     /// Calls `TypedArray.prototype.sort()`.
     #[inline]
-    pub fn sort(&self, compare_fn: Option<JsFunction>, context: &mut Context) -> JsResult<Self> {
+    pub fn sort(
+        &self,
+        compare_fn: Option<JsFunction>,
+        context: &mut Context<'_>,
+    ) -> JsResult<Self> {
         TypedArray::sort(&self.inner, &[compare_fn.into_or_undefined()], context)?;
 
         Ok(self.clone())
@@ -149,7 +153,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::filter(
             &self.inner,
@@ -166,7 +170,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::map(
             &self.inner,
@@ -183,7 +187,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::reduce(
             &self.inner,
@@ -198,7 +202,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::reduceright(
             &self.inner,
@@ -209,7 +213,7 @@ impl JsTypedArray {
 
     /// Calls `TypedArray.prototype.reverse()`.
     #[inline]
-    pub fn reverse(&self, context: &mut Context) -> JsResult<Self> {
+    pub fn reverse(&self, context: &mut Context<'_>) -> JsResult<Self> {
         TypedArray::reverse(&self.inner, &[], context)?;
         Ok(self.clone())
     }
@@ -220,7 +224,7 @@ impl JsTypedArray {
         &self,
         start: Option<usize>,
         end: Option<usize>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::slice(
             &self.inner,
@@ -237,7 +241,7 @@ impl JsTypedArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::find(
             &self.inner,
@@ -251,7 +255,7 @@ impl JsTypedArray {
         &self,
         search_element: T,
         from_index: Option<usize>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<usize>>
     where
         T: Into<JsValue>,
@@ -277,7 +281,7 @@ impl JsTypedArray {
         &self,
         search_element: T,
         from_index: Option<usize>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<usize>>
     where
         T: Into<JsValue>,
@@ -300,7 +304,11 @@ impl JsTypedArray {
 
     /// Calls `TypedArray.prototype.join()`.
     #[inline]
-    pub fn join(&self, separator: Option<JsString>, context: &mut Context) -> JsResult<JsString> {
+    pub fn join(
+        &self,
+        separator: Option<JsString>,
+        context: &mut Context<'_>,
+    ) -> JsResult<JsString> {
         TypedArray::join(&self.inner, &[separator.into_or_undefined()], context).map(|x| {
             x.as_string()
                 .cloned()
@@ -349,7 +357,7 @@ macro_rules! JsTypedArrayType {
             /// Create the typed array from a [`JsArrayBuffer`].
             pub fn from_array_buffer(
                 array_buffer: JsArrayBuffer,
-                context: &mut Context,
+                context: &mut Context<'_>,
             ) -> JsResult<Self> {
                 let new_target = context
                     .intrinsics()
@@ -374,7 +382,7 @@ macro_rules! JsTypedArrayType {
             }
 
             /// Create the typed array from an iterator.
-            pub fn from_iter<I>(elements: I, context: &mut Context) -> JsResult<Self>
+            pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> JsResult<Self>
             where
                 I: IntoIterator<Item = $element>,
             {

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -25,7 +25,7 @@ pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let desc be OrdinaryGetOwnProperty(args, P).
     // 2. If desc is undefined, return desc.
@@ -70,7 +70,7 @@ pub(crate) fn arguments_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 2. Let isMapped be HasOwnProperty(map, P).
     let mapped = if let PropertyKey::Index(index) = key {
@@ -161,7 +161,7 @@ pub(crate) fn arguments_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     if let PropertyKey::Index(index) = key {
         // 1. Let map be args.[[ParameterMap]].
@@ -194,7 +194,7 @@ pub(crate) fn arguments_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If SameValue(args, Receiver) is false, then
     // a. Let isMapped be false.
@@ -226,7 +226,7 @@ pub(crate) fn arguments_exotic_set(
 pub(crate) fn arguments_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 3. Let result be ? OrdinaryDelete(args, P).
     let result = super::ordinary_delete(obj, key, context)?;

--- a/boa_engine/src/object/internal_methods/array.rs
+++ b/boa_engine/src/object/internal_methods/array.rs
@@ -29,7 +29,7 @@ pub(crate) fn array_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     match key {
@@ -108,7 +108,7 @@ pub(crate) fn array_exotic_define_own_property(
 fn array_set_length(
     obj: &JsObject,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Desc.[[Value]] is absent, then
     let new_len_val = match desc.value() {

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -32,7 +32,7 @@ fn bound_function_exotic_call(
     obj: &JsObject,
     _: &JsValue,
     arguments_list: &[JsValue],
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     let obj = obj.borrow();
     let bound_function = obj
@@ -67,7 +67,7 @@ fn bound_function_exotic_construct(
     obj: &JsObject,
     arguments_list: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject> {
     let object = obj.borrow();
     let bound_function = object

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -36,7 +36,7 @@ fn function_call(
     obj: &JsObject,
     this: &JsValue,
     args: &[JsValue],
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     obj.call_internal(this, args, context)
 }
@@ -52,7 +52,7 @@ fn function_construct(
     obj: &JsObject,
     args: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject> {
     obj.construct_internal(args, &new_target.clone().into(), context)
 }

--- a/boa_engine/src/object/internal_methods/global.rs
+++ b/boa_engine/src/object/internal_methods/global.rs
@@ -39,7 +39,7 @@ pub(crate) static GLOBAL_INTERNAL_METHODS: InternalObjectMethods = InternalObjec
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_get_prototype_of(
     _: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsPrototype> {
     // 1. Return O.[[Prototype]].
     Ok(context.realm.global_prototype.clone())
@@ -55,7 +55,7 @@ pub(crate) fn global_get_prototype_of(
 pub(crate) fn global_set_prototype_of(
     _: &JsObject,
     val: JsPrototype,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: Either Type(V) is Object or Type(V) is Null.
     {
@@ -114,7 +114,7 @@ pub(crate) fn global_set_prototype_of(
 pub(crate) fn global_get_own_property(
     _obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     let _timer = Profiler::global().start_event("Object::global_get_own_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -141,7 +141,7 @@ pub(crate) fn global_get_own_property(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
 #[allow(clippy::unnecessary_wraps)]
-pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context<'_>) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
     Ok(context.realm.global_extensible)
 }
@@ -153,7 +153,10 @@ pub(crate) fn global_is_extensible(_obj: &JsObject, context: &mut Context) -> Js
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinarypreventextensions
 #[allow(clippy::unnecessary_wraps)]
-pub(crate) fn global_prevent_extensions(_obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+pub(crate) fn global_prevent_extensions(
+    _obj: &JsObject,
+    context: &mut Context<'_>,
+) -> JsResult<bool> {
     // 1. Set O.[[Extensible]] to false.
     context.realm.global_extensible = false;
 
@@ -172,7 +175,7 @@ pub(crate) fn global_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::global_define_own_property", "object");
     // 1. Let current be ? O.[[GetOwnProperty]](P).
@@ -197,7 +200,7 @@ pub(crate) fn global_define_own_property(
 pub(crate) fn global_has_property(
     _obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::global_has_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -227,7 +230,7 @@ pub(crate) fn global_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     let _timer = Profiler::global().start_event("Object::global_get", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -274,7 +277,7 @@ pub(crate) fn global_set(
     key: PropertyKey,
     value: JsValue,
     _receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     global_set_no_receiver(&key, value, context)
 }
@@ -282,7 +285,7 @@ pub(crate) fn global_set(
 pub(crate) fn global_set_no_receiver(
     key: &PropertyKey,
     value: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::global_set", "object");
 
@@ -380,7 +383,7 @@ pub(crate) fn global_set_no_receiver(
 pub(crate) fn global_delete(
     _obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     global_delete_no_receiver(key, context)
 }
@@ -394,7 +397,7 @@ pub(crate) fn global_delete(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_delete_no_receiver(
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::global_delete", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -423,7 +426,7 @@ pub(crate) fn global_delete_no_receiver(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn global_own_property_keys(
     _: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     // 1. Let keys be a new empty List.
     let mut keys = Vec::new();
@@ -479,7 +482,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
     extensible: bool,
     desc: PropertyDescriptor,
     current: Option<PropertyDescriptor>,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> bool {
     let _timer = Profiler::global().start_event(
         "Object::global_validate_and_apply_property_descriptor",

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -34,7 +34,7 @@ pub(crate) static INTEGER_INDEXED_EXOTIC_INTERNAL_METHODS: InternalObjectMethods
 pub(crate) fn integer_indexed_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -68,7 +68,7 @@ pub(crate) fn integer_indexed_exotic_get_own_property(
 pub(crate) fn integer_indexed_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -91,7 +91,7 @@ pub(crate) fn integer_indexed_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -136,7 +136,7 @@ pub(crate) fn integer_indexed_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -161,7 +161,7 @@ pub(crate) fn integer_indexed_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -187,7 +187,7 @@ pub(crate) fn integer_indexed_exotic_set(
 pub(crate) fn integer_indexed_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -210,7 +210,7 @@ pub(crate) fn integer_indexed_exotic_delete(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn integer_indexed_exotic_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let obj = obj.borrow();
     let inner = obj.as_typed_array().expect(
@@ -328,7 +328,7 @@ fn integer_indexed_element_set(
     obj: &JsObject,
     index: usize,
     value: &JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<()> {
     let obj_borrow = obj.borrow();
     let inner = obj_borrow.as_typed_array().expect(

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -34,7 +34,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
     #[track_caller]
-    pub(crate) fn __get_prototype_of__(&self, context: &mut Context) -> JsResult<JsPrototype> {
+    pub(crate) fn __get_prototype_of__(&self, context: &mut Context<'_>) -> JsResult<JsPrototype> {
         let _timer = Profiler::global().start_event("Object::__get_prototype_of__", "object");
         let func = self.borrow().data.internal_methods.__get_prototype_of__;
         func(self, context)
@@ -51,7 +51,7 @@ impl JsObject {
     pub(crate) fn __set_prototype_of__(
         &self,
         val: JsPrototype,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set_prototype_of__", "object");
         let func = self.borrow().data.internal_methods.__set_prototype_of__;
@@ -66,7 +66,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-    pub(crate) fn __is_extensible__(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn __is_extensible__(&self, context: &mut Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__is_extensible__", "object");
         let func = self.borrow().data.internal_methods.__is_extensible__;
         func(self, context)
@@ -80,7 +80,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-    pub(crate) fn __prevent_extensions__(&self, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn __prevent_extensions__(&self, context: &mut Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__prevent_extensions__", "object");
         let func = self.borrow().data.internal_methods.__prevent_extensions__;
         func(self, context)
@@ -97,7 +97,7 @@ impl JsObject {
     pub(crate) fn __get_own_property__(
         &self,
         key: &PropertyKey,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Option<PropertyDescriptor>> {
         let _timer = Profiler::global().start_event("Object::__get_own_property__", "object");
         let func = self.borrow().data.internal_methods.__get_own_property__;
@@ -116,7 +116,7 @@ impl JsObject {
         &self,
         key: PropertyKey,
         desc: PropertyDescriptor,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__define_own_property__", "object");
         let func = self.borrow().data.internal_methods.__define_own_property__;
@@ -134,7 +134,7 @@ impl JsObject {
     pub(crate) fn __has_property__(
         &self,
         key: &PropertyKey,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__has_property__", "object");
         let func = self.borrow().data.internal_methods.__has_property__;
@@ -153,7 +153,7 @@ impl JsObject {
         &self,
         key: &PropertyKey,
         receiver: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__get__", "object");
         let func = self.borrow().data.internal_methods.__get__;
@@ -173,7 +173,7 @@ impl JsObject {
         key: PropertyKey,
         value: JsValue,
         receiver: JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set__", "object");
         let func = self.borrow().data.internal_methods.__set__;
@@ -188,7 +188,11 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-delete-p
-    pub(crate) fn __delete__(&self, key: &PropertyKey, context: &mut Context) -> JsResult<bool> {
+    pub(crate) fn __delete__(
+        &self,
+        key: &PropertyKey,
+        context: &mut Context<'_>,
+    ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__delete__", "object");
         let func = self.borrow().data.internal_methods.__delete__;
         func(self, key, context)
@@ -205,7 +209,7 @@ impl JsObject {
     #[track_caller]
     pub(crate) fn __own_property_keys__(
         &self,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Vec<PropertyKey>> {
         let _timer = Profiler::global().start_event("Object::__own_property_keys__", "object");
         let func = self.borrow().data.internal_methods.__own_property_keys__;
@@ -225,7 +229,7 @@ impl JsObject {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__call__", "object");
         let func = self.borrow().data.internal_methods.__call__;
@@ -247,7 +251,7 @@ impl JsObject {
         &self,
         args: &[JsValue],
         new_target: &Self,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let _timer = Profiler::global().start_event("Object::__construct__", "object");
         let func = self.borrow().data.internal_methods.__construct__;
@@ -294,24 +298,24 @@ pub(crate) static ORDINARY_INTERNAL_METHODS: InternalObjectMethods = InternalObj
 #[derive(Clone, Copy)]
 #[allow(clippy::type_complexity)]
 pub(crate) struct InternalObjectMethods {
-    pub(crate) __get_prototype_of__: fn(&JsObject, &mut Context) -> JsResult<JsPrototype>,
-    pub(crate) __set_prototype_of__: fn(&JsObject, JsPrototype, &mut Context) -> JsResult<bool>,
-    pub(crate) __is_extensible__: fn(&JsObject, &mut Context) -> JsResult<bool>,
-    pub(crate) __prevent_extensions__: fn(&JsObject, &mut Context) -> JsResult<bool>,
+    pub(crate) __get_prototype_of__: fn(&JsObject, &mut Context<'_>) -> JsResult<JsPrototype>,
+    pub(crate) __set_prototype_of__: fn(&JsObject, JsPrototype, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __is_extensible__: fn(&JsObject, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __prevent_extensions__: fn(&JsObject, &mut Context<'_>) -> JsResult<bool>,
     pub(crate) __get_own_property__:
-        fn(&JsObject, &PropertyKey, &mut Context) -> JsResult<Option<PropertyDescriptor>>,
+        fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<Option<PropertyDescriptor>>,
     pub(crate) __define_own_property__:
-        fn(&JsObject, PropertyKey, PropertyDescriptor, &mut Context) -> JsResult<bool>,
-    pub(crate) __has_property__: fn(&JsObject, &PropertyKey, &mut Context) -> JsResult<bool>,
-    pub(crate) __get__: fn(&JsObject, &PropertyKey, JsValue, &mut Context) -> JsResult<JsValue>,
+        fn(&JsObject, PropertyKey, PropertyDescriptor, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __has_property__: fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __get__: fn(&JsObject, &PropertyKey, JsValue, &mut Context<'_>) -> JsResult<JsValue>,
     pub(crate) __set__:
-        fn(&JsObject, PropertyKey, JsValue, JsValue, &mut Context) -> JsResult<bool>,
-    pub(crate) __delete__: fn(&JsObject, &PropertyKey, &mut Context) -> JsResult<bool>,
-    pub(crate) __own_property_keys__: fn(&JsObject, &mut Context) -> JsResult<Vec<PropertyKey>>,
+        fn(&JsObject, PropertyKey, JsValue, JsValue, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __delete__: fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __own_property_keys__: fn(&JsObject, &mut Context<'_>) -> JsResult<Vec<PropertyKey>>,
     pub(crate) __call__:
-        Option<fn(&JsObject, &JsValue, &[JsValue], &mut Context) -> JsResult<JsValue>>,
+        Option<fn(&JsObject, &JsValue, &[JsValue], &mut Context<'_>) -> JsResult<JsValue>>,
     pub(crate) __construct__:
-        Option<fn(&JsObject, &[JsValue], &JsObject, &mut Context) -> JsResult<JsObject>>,
+        Option<fn(&JsObject, &[JsValue], &JsObject, &mut Context<'_>) -> JsResult<JsObject>>,
 }
 
 /// Abstract operation `OrdinaryGetPrototypeOf`.
@@ -323,7 +327,7 @@ pub(crate) struct InternalObjectMethods {
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_prototype_of(
     obj: &JsObject,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<JsPrototype> {
     let _timer = Profiler::global().start_event("Object::ordinary_get_prototype_of", "object");
 
@@ -341,7 +345,7 @@ pub(crate) fn ordinary_get_prototype_of(
 pub(crate) fn ordinary_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    _: &mut Context,
+    _: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: Either Type(V) is Object or Type(V) is Null.
     {
@@ -397,7 +401,7 @@ pub(crate) fn ordinary_set_prototype_of(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
 #[allow(clippy::unnecessary_wraps)]
-pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> JsResult<bool> {
+pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context<'_>) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
     Ok(obj.borrow().extensible)
 }
@@ -411,7 +415,7 @@ pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context) -> 
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_prevent_extensions(
     obj: &JsObject,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Set O.[[Extensible]] to false.
     obj.borrow_mut().extensible = false;
@@ -430,7 +434,7 @@ pub(crate) fn ordinary_prevent_extensions(
 pub(crate) fn ordinary_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     let _timer = Profiler::global().start_event("Object::ordinary_get_own_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -460,7 +464,7 @@ pub(crate) fn ordinary_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_define_own_property", "object");
     // 1. Let current be ? O.[[GetOwnProperty]](P).
@@ -487,7 +491,7 @@ pub(crate) fn ordinary_define_own_property(
 pub(crate) fn ordinary_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_has_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -517,7 +521,7 @@ pub(crate) fn ordinary_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     let _timer = Profiler::global().start_event("Object::ordinary_get", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -563,7 +567,7 @@ pub(crate) fn ordinary_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_set", "object");
 
@@ -663,7 +667,7 @@ pub(crate) fn ordinary_set(
 pub(crate) fn ordinary_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_delete", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -694,7 +698,7 @@ pub(crate) fn ordinary_delete(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let _timer = Profiler::global().start_event("Object::ordinary_own_property_keys", "object");
     // 1. Let keys be a new empty List.
@@ -913,7 +917,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
 pub(crate) fn get_prototype_from_constructor<F>(
     constructor: &JsValue,
     default: F,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject>
 where
     F: FnOnce(&StandardConstructors) -> &StandardConstructor,

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -52,7 +52,7 @@ pub(crate) static PROXY_EXOTIC_INTERNAL_METHODS_ALL: InternalObjectMethods =
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
 pub(crate) fn proxy_exotic_get_prototype_of(
     obj: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsPrototype> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -114,7 +114,7 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 pub(crate) fn proxy_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -175,7 +175,10 @@ pub(crate) fn proxy_exotic_set_prototype_of(
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible
-pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+pub(crate) fn proxy_exotic_is_extensible(
+    obj: &JsObject,
+    context: &mut Context<'_>,
+) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
     // 3. Assert: Type(handler) is Object.
@@ -220,7 +223,7 @@ pub(crate) fn proxy_exotic_is_extensible(obj: &JsObject, context: &mut Context) 
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions
 pub(crate) fn proxy_exotic_prevent_extensions(
     obj: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -266,7 +269,7 @@ pub(crate) fn proxy_exotic_prevent_extensions(
 pub(crate) fn proxy_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -390,7 +393,7 @@ pub(crate) fn proxy_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -501,7 +504,7 @@ pub(crate) fn proxy_exotic_define_own_property(
 pub(crate) fn proxy_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -567,7 +570,7 @@ pub(crate) fn proxy_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -636,7 +639,7 @@ pub(crate) fn proxy_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -717,7 +720,7 @@ pub(crate) fn proxy_exotic_set(
 pub(crate) fn proxy_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -783,7 +786,7 @@ pub(crate) fn proxy_exotic_delete(
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
 pub(crate) fn proxy_exotic_own_property_keys(
     obj: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -919,7 +922,7 @@ fn proxy_exotic_call(
     obj: &JsObject,
     this: &JsValue,
     args: &[JsValue],
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -959,7 +962,7 @@ fn proxy_exotic_construct(
     obj: &JsObject,
     args: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsObject> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -29,7 +29,7 @@ pub(crate) static STRING_EXOTIC_INTERNAL_METHODS: InternalObjectMethods = Intern
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let desc be OrdinaryGetOwnProperty(S, P).
@@ -54,7 +54,7 @@ pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let stringDesc be ! StringGetOwnProperty(S, P).
@@ -85,7 +85,7 @@ pub(crate) fn string_exotic_define_own_property(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn string_exotic_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context,
+    _context: &mut Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let obj = obj.borrow();
 

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -41,7 +41,7 @@ impl JsObject {
     /// [call]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
     #[inline]
     #[must_use]
-    pub fn with_object_proto(context: &mut Context) -> Self {
+    pub fn with_object_proto(context: &mut Context<'_>) -> Self {
         Self::from_proto_and_data(
             context.intrinsics().constructors().object().prototype(),
             ObjectData::ordinary(),
@@ -154,7 +154,7 @@ impl JsObject {
     /// [spec]: https://tc39.es/ecma262/#sec-ordinarytoprimitive
     pub(crate) fn ordinary_to_primitive(
         &self,
-        context: &mut Context,
+        context: &mut Context<'_>,
         hint: PreferredType,
     ) -> JsResult<JsValue> {
         // 1. Assert: Type(O) is Object.
@@ -522,7 +522,10 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-topropertydescriptor
-    pub fn to_property_descriptor(&self, context: &mut Context) -> JsResult<PropertyDescriptor> {
+    pub fn to_property_descriptor(
+        &self,
+        context: &mut Context<'_>,
+    ) -> JsResult<PropertyDescriptor> {
         // 1 is implemented on the method `to_property_descriptor` of value
 
         // 2. Let desc be a new Property Descriptor that initially has no fields.
@@ -623,7 +626,7 @@ Cannot both specify accessors and a value or writable attribute",
         &self,
         source: &JsValue,
         excluded_keys: Vec<K>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<()>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1899,17 +1899,17 @@ where
 
 /// Builder for creating native function objects
 #[derive(Debug)]
-pub struct FunctionBuilder<'context> {
-    context: &'context mut Context,
+pub struct FunctionBuilder<'context, 'icu> {
+    context: &'context mut Context<'icu>,
     function: Function,
     name: JsString,
     length: usize,
 }
 
-impl<'context> FunctionBuilder<'context> {
+impl<'context, 'icu> FunctionBuilder<'context, 'icu> {
     /// Create a new `FunctionBuilder` for creating a native function.
     #[inline]
-    pub fn native(context: &'context mut Context, function: NativeFunctionSignature) -> Self {
+    pub fn native(context: &'context mut Context<'icu>, function: NativeFunctionSignature) -> Self {
         Self {
             context,
             function: Function::Native {
@@ -1922,9 +1922,9 @@ impl<'context> FunctionBuilder<'context> {
     }
 
     /// Create a new `FunctionBuilder` for creating a closure function.
-    pub fn closure<F>(context: &'context mut Context, function: F) -> Self
+    pub fn closure<F>(context: &'context mut Context<'icu>, function: F) -> Self
     where
-        F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<JsValue> + Copy + 'static,
+        F: Fn(&JsValue, &[JsValue], &mut Context<'_>) -> JsResult<JsValue> + Copy + 'static,
     {
         Self {
             context,
@@ -1945,12 +1945,12 @@ impl<'context> FunctionBuilder<'context> {
     /// You can only move variables that implement `Debug + Any + Trace + Clone`.
     /// In other words, only `NativeObject + Clone` objects are movable.
     pub fn closure_with_captures<F, C>(
-        context: &'context mut Context,
+        context: &'context mut Context<'icu>,
         function: F,
         captures: C,
     ) -> Self
     where
-        F: Fn(&JsValue, &[JsValue], &mut C, &mut Context) -> JsResult<JsValue> + Copy + 'static,
+        F: Fn(&JsValue, &[JsValue], &mut C, &mut Context<'_>) -> JsResult<JsValue> + Copy + 'static,
         C: NativeObject,
     {
         Self {
@@ -2086,15 +2086,15 @@ impl<'context> FunctionBuilder<'context> {
 /// }
 /// ```
 #[derive(Debug)]
-pub struct ObjectInitializer<'context> {
-    context: &'context mut Context,
+pub struct ObjectInitializer<'context, 'icu> {
+    context: &'context mut Context<'icu>,
     object: JsObject,
 }
 
-impl<'context> ObjectInitializer<'context> {
+impl<'context, 'icu> ObjectInitializer<'context, 'icu> {
     /// Create a new `ObjectBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context) -> Self {
+    pub fn new(context: &'context mut Context<'icu>) -> Self {
         let object = JsObject::with_object_proto(context);
         Self { context, object }
     }
@@ -2150,8 +2150,8 @@ impl<'context> ObjectInitializer<'context> {
 }
 
 /// Builder for creating constructors objects, like `Array`.
-pub struct ConstructorBuilder<'context> {
-    context: &'context mut Context,
+pub struct ConstructorBuilder<'context, 'icu> {
+    context: &'context mut Context<'icu>,
     function: NativeFunctionSignature,
     object: JsObject,
     has_prototype_property: bool,
@@ -2164,7 +2164,7 @@ pub struct ConstructorBuilder<'context> {
     custom_prototype: Option<JsPrototype>,
 }
 
-impl Debug for ConstructorBuilder<'_> {
+impl Debug for ConstructorBuilder<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ConstructorBuilder")
             .field("name", &self.name)
@@ -2179,10 +2179,10 @@ impl Debug for ConstructorBuilder<'_> {
     }
 }
 
-impl<'context> ConstructorBuilder<'context> {
+impl<'context, 'icu> ConstructorBuilder<'context, 'icu> {
     /// Create a new `ConstructorBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context, function: NativeFunctionSignature) -> Self {
+    pub fn new(context: &'context mut Context<'icu>, function: NativeFunctionSignature) -> Self {
         Self {
             context,
             function,
@@ -2199,7 +2199,7 @@ impl<'context> ConstructorBuilder<'context> {
     }
 
     pub(crate) fn with_standard_constructor(
-        context: &'context mut Context,
+        context: &'context mut Context<'icu>,
         function: NativeFunctionSignature,
         standard_constructor: StandardConstructor,
     ) -> Self {
@@ -2428,12 +2428,6 @@ impl<'context> ConstructorBuilder<'context> {
     pub fn has_prototype_property(&mut self, has_prototype_property: bool) -> &mut Self {
         self.has_prototype_property = has_prototype_property;
         self
-    }
-
-    /// Return the current context.
-    #[inline]
-    pub fn context(&mut self) -> &'_ mut Context {
-        self.context
     }
 
     /// Build the constructor function object.

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1899,17 +1899,17 @@ where
 
 /// Builder for creating native function objects
 #[derive(Debug)]
-pub struct FunctionBuilder<'context, 'icu> {
-    context: &'context mut Context<'icu>,
+pub struct FunctionBuilder<'ctx, 'icu> {
+    context: &'ctx mut Context<'icu>,
     function: Function,
     name: JsString,
     length: usize,
 }
 
-impl<'context, 'icu> FunctionBuilder<'context, 'icu> {
+impl<'ctx, 'icu> FunctionBuilder<'ctx, 'icu> {
     /// Create a new `FunctionBuilder` for creating a native function.
     #[inline]
-    pub fn native(context: &'context mut Context<'icu>, function: NativeFunctionSignature) -> Self {
+    pub fn native(context: &'ctx mut Context<'icu>, function: NativeFunctionSignature) -> Self {
         Self {
             context,
             function: Function::Native {
@@ -1922,7 +1922,7 @@ impl<'context, 'icu> FunctionBuilder<'context, 'icu> {
     }
 
     /// Create a new `FunctionBuilder` for creating a closure function.
-    pub fn closure<F>(context: &'context mut Context<'icu>, function: F) -> Self
+    pub fn closure<F>(context: &'ctx mut Context<'icu>, function: F) -> Self
     where
         F: Fn(&JsValue, &[JsValue], &mut Context<'_>) -> JsResult<JsValue> + Copy + 'static,
     {
@@ -1945,7 +1945,7 @@ impl<'context, 'icu> FunctionBuilder<'context, 'icu> {
     /// You can only move variables that implement `Debug + Any + Trace + Clone`.
     /// In other words, only `NativeObject + Clone` objects are movable.
     pub fn closure_with_captures<F, C>(
-        context: &'context mut Context<'icu>,
+        context: &'ctx mut Context<'icu>,
         function: F,
         captures: C,
     ) -> Self
@@ -2086,15 +2086,15 @@ impl<'context, 'icu> FunctionBuilder<'context, 'icu> {
 /// }
 /// ```
 #[derive(Debug)]
-pub struct ObjectInitializer<'context, 'icu> {
-    context: &'context mut Context<'icu>,
+pub struct ObjectInitializer<'ctx, 'icu> {
+    context: &'ctx mut Context<'icu>,
     object: JsObject,
 }
 
-impl<'context, 'icu> ObjectInitializer<'context, 'icu> {
+impl<'ctx, 'icu> ObjectInitializer<'ctx, 'icu> {
     /// Create a new `ObjectBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context<'icu>) -> Self {
+    pub fn new(context: &'ctx mut Context<'icu>) -> Self {
         let object = JsObject::with_object_proto(context);
         Self { context, object }
     }
@@ -2150,8 +2150,8 @@ impl<'context, 'icu> ObjectInitializer<'context, 'icu> {
 }
 
 /// Builder for creating constructors objects, like `Array`.
-pub struct ConstructorBuilder<'context, 'icu> {
-    context: &'context mut Context<'icu>,
+pub struct ConstructorBuilder<'ctx, 'icu> {
+    context: &'ctx mut Context<'icu>,
     function: NativeFunctionSignature,
     object: JsObject,
     has_prototype_property: bool,
@@ -2179,10 +2179,13 @@ impl Debug for ConstructorBuilder<'_, '_> {
     }
 }
 
-impl<'context, 'icu> ConstructorBuilder<'context, 'icu> {
+impl<'ctx, 'icu> ConstructorBuilder<'ctx, 'icu> {
     /// Create a new `ConstructorBuilder`.
     #[inline]
-    pub fn new(context: &'context mut Context<'icu>, function: NativeFunctionSignature) -> Self {
+    pub fn new(
+        context: &'ctx mut Context<'icu>,
+        function: NativeFunctionSignature,
+    ) -> ConstructorBuilder<'ctx, 'icu> {
         Self {
             context,
             function,
@@ -2199,10 +2202,10 @@ impl<'context, 'icu> ConstructorBuilder<'context, 'icu> {
     }
 
     pub(crate) fn with_standard_constructor(
-        context: &'context mut Context<'icu>,
+        context: &'ctx mut Context<'icu>,
         function: NativeFunctionSignature,
         standard_constructor: StandardConstructor,
-    ) -> Self {
+    ) -> ConstructorBuilder<'ctx, 'icu> {
         Self {
             context,
             function,
@@ -2428,6 +2431,12 @@ impl<'context, 'icu> ConstructorBuilder<'context, 'icu> {
     pub fn has_prototype_property(&mut self, has_prototype_property: bool) -> &mut Self {
         self.has_prototype_property = has_prototype_property;
         self
+    }
+
+    /// Return the current context.
+    #[inline]
+    pub fn context(&mut self) -> &mut Context<'icu> {
+        self.context
     }
 
     /// Build the constructor function object.

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -52,7 +52,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isextensible-o
     #[inline]
-    pub fn is_extensible(&self, context: &mut Context) -> JsResult<bool> {
+    pub fn is_extensible(&self, context: &mut Context<'_>) -> JsResult<bool> {
         // 1. Return ? O.[[IsExtensible]]().
         self.__is_extensible__(context)
     }
@@ -63,7 +63,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-o-p
-    pub fn get<K>(&self, key: K, context: &mut Context) -> JsResult<JsValue>
+    pub fn get<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<JsValue>
     where
         K: Into<PropertyKey>,
     {
@@ -79,7 +79,13 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set-o-p-v-throw
-    pub fn set<K, V>(&self, key: K, value: V, throw: bool, context: &mut Context) -> JsResult<bool>
+    pub fn set<K, V>(
+        &self,
+        key: K,
+        value: V,
+        throw: bool,
+        context: &mut Context<'_>,
+    ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
         V: Into<JsValue>,
@@ -110,7 +116,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -140,7 +146,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -171,7 +177,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) where
         K: Into<PropertyKey>,
         V: Into<JsValue>,
@@ -208,7 +214,7 @@ impl JsObject {
         &self,
         key: K,
         desc: P,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -235,7 +241,7 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
-    pub fn delete_property_or_throw<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
+    pub fn delete_property_or_throw<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -260,7 +266,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasproperty
-    pub fn has_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
+    pub fn has_property<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -276,7 +282,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasownproperty
-    pub fn has_own_property<K>(&self, key: K, context: &mut Context) -> JsResult<bool>
+    pub fn has_own_property<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -303,7 +309,7 @@ impl JsObject {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         // 2. If IsCallable(F) is false, throw a TypeError exception.
@@ -332,7 +338,7 @@ impl JsObject {
         &self,
         args: &[JsValue],
         new_target: Option<&Self>,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         // 1. If newTarget is not present, set newTarget to F.
         let new_target = new_target.unwrap_or(self);
@@ -350,7 +356,7 @@ impl JsObject {
     pub fn set_integrity_level(
         &self,
         level: IntegrityLevel,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: level is either sealed or frozen.
@@ -419,7 +425,7 @@ impl JsObject {
     pub fn test_integrity_level(
         &self,
         level: IntegrityLevel,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: level is either sealed or frozen.
@@ -464,7 +470,7 @@ impl JsObject {
     /// Returns the value of the "length" property of an array-like object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-lengthofarraylike
-    pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<u64> {
+    pub(crate) fn length_of_array_like(&self, context: &mut Context<'_>) -> JsResult<u64> {
         // 1. Assert: Type(obj) is Object.
         // 2. Return ℝ(? ToLength(? Get(obj, "length"))).
         self.get("length", context)?.to_length(context)
@@ -484,7 +490,7 @@ impl JsObject {
     pub(crate) fn species_constructor<F>(
         &self,
         default_constructor: F,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self>
     where
         F: FnOnce(&StandardConstructors) -> &StandardConstructor,
@@ -532,7 +538,7 @@ impl JsObject {
     pub(crate) fn enumerable_own_property_names(
         &self,
         kind: PropertyNameKind,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Vec<JsValue>> {
         // 1. Assert: Type(O) is Object.
         // 2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
@@ -593,7 +599,7 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getmethod
-    pub(crate) fn get_method<K>(&self, key: K, context: &mut Context) -> JsResult<Option<Self>>
+    pub(crate) fn get_method<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<Option<Self>>
     where
         K: Into<PropertyKey>,
     {
@@ -676,7 +682,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getv
-    pub(crate) fn get_v<K>(&self, key: K, context: &mut Context) -> JsResult<Self>
+    pub(crate) fn get_v<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
     {
@@ -695,7 +701,11 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getmethod
-    pub(crate) fn get_method<K>(&self, key: K, context: &mut Context) -> JsResult<Option<JsObject>>
+    pub(crate) fn get_method<K>(
+        &self,
+        key: K,
+        context: &mut Context<'_>,
+    ) -> JsResult<Option<JsObject>>
     where
         K: Into<PropertyKey>,
     {
@@ -714,7 +724,7 @@ impl JsValue {
     pub(crate) fn create_list_from_array_like(
         &self,
         element_types: &[Type],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Vec<Self>> {
         // 1. If elementTypes is not present, set elementTypes to « Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object ».
         let types = if element_types.is_empty() {
@@ -779,7 +789,7 @@ impl JsValue {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         self.as_callable()
             .ok_or_else(|| {
@@ -799,7 +809,12 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-invoke
-    pub(crate) fn invoke<K>(&self, key: K, args: &[Self], context: &mut Context) -> JsResult<Self>
+    pub(crate) fn invoke<K>(
+        &self,
+        key: K,
+        args: &[Self],
+        context: &mut Context<'_>,
+    ) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
     {
@@ -820,7 +835,7 @@ impl JsValue {
     pub fn ordinary_has_instance(
         function: &Self,
         object: &Self,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<bool> {
         // 1. If IsCallable(C) is false, return false.
         let Some(function) = function.as_callable() else {

--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -37,7 +37,7 @@ impl JsValue {
     /// This method is executed when doing abstract equality comparisons with the `==` operator.
     ///  For more information, check <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
     #[allow(clippy::float_cmp)]
-    pub fn equals(&self, other: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn equals(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         // 1. If Type(x) is the same as Type(y), then
         //     a. Return the result of performing Strict Equality Comparison x === y.
         if self.get_type() == other.get_type() {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -353,7 +353,7 @@ impl JsValue {
     /// <https://tc39.es/ecma262/#sec-toprimitive>
     pub fn to_primitive(
         &self,
-        context: &mut Context,
+        context: &mut Context<'_>,
         preferred_type: PreferredType,
     ) -> JsResult<Self> {
         // 1. Assert: input is an ECMAScript language value. (always a value not need to check)
@@ -409,7 +409,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobigint
-    pub fn to_bigint(&self, context: &mut Context) -> JsResult<JsBigInt> {
+    pub fn to_bigint(&self, context: &mut Context<'_>) -> JsResult<JsBigInt> {
         match self {
             Self::Null => Err(JsNativeError::typ()
                 .with_message("cannot convert null to a BigInt")
@@ -469,7 +469,7 @@ impl JsValue {
     /// Converts the value to a string.
     ///
     /// This function is equivalent to `String(value)` in JavaScript.
-    pub fn to_string(&self, context: &mut Context) -> JsResult<JsString> {
+    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<JsString> {
         match self {
             Self::Null => Ok("null".into()),
             Self::Undefined => Ok("undefined".into()),
@@ -493,7 +493,7 @@ impl JsValue {
     /// This function is equivalent to `Object(value)` in JavaScript.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toobject>
-    pub fn to_object(&self, context: &mut Context) -> JsResult<JsObject> {
+    pub fn to_object(&self, context: &mut Context<'_>) -> JsResult<JsObject> {
         match self {
             Self::Undefined | Self::Null => Err(JsNativeError::typ()
                 .with_message("cannot convert 'null' or 'undefined' to object")
@@ -560,7 +560,7 @@ impl JsValue {
     /// Converts the value to a `PropertyKey`, that can be used as a key for properties.
     ///
     /// See <https://tc39.es/ecma262/#sec-topropertykey>
-    pub fn to_property_key(&self, context: &mut Context) -> JsResult<PropertyKey> {
+    pub fn to_property_key(&self, context: &mut Context<'_>) -> JsResult<PropertyKey> {
         Ok(match self {
             // Fast path:
             Self::String(string) => string.clone().into(),
@@ -580,7 +580,7 @@ impl JsValue {
     /// It returns value converted to a numeric value of type `Number` or `BigInt`.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumeric>
-    pub fn to_numeric(&self, context: &mut Context) -> JsResult<Numeric> {
+    pub fn to_numeric(&self, context: &mut Context<'_>) -> JsResult<Numeric> {
         // 1. Let primValue be ? ToPrimitive(value, number).
         let primitive = self.to_primitive(context, PreferredType::Number)?;
 
@@ -598,7 +598,7 @@ impl JsValue {
     /// This function is equivalent to `value | 0` in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-touint32>
-    pub fn to_u32(&self, context: &mut Context) -> JsResult<u32> {
+    pub fn to_u32(&self, context: &mut Context<'_>) -> JsResult<u32> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Self::Integer(number) = *self {
             if let Ok(number) = u32::try_from(number) {
@@ -613,7 +613,7 @@ impl JsValue {
     /// Converts a value to an integral 32 bit signed integer.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toint32>
-    pub fn to_i32(&self, context: &mut Context) -> JsResult<i32> {
+    pub fn to_i32(&self, context: &mut Context<'_>) -> JsResult<i32> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Self::Integer(number) = *self {
             return Ok(number);
@@ -629,7 +629,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-toint8
-    pub fn to_int8(&self, context: &mut Context) -> JsResult<i8> {
+    pub fn to_int8(&self, context: &mut Context<'_>) -> JsResult<i8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -658,7 +658,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint8
-    pub fn to_uint8(&self, context: &mut Context) -> JsResult<u8> {
+    pub fn to_uint8(&self, context: &mut Context<'_>) -> JsResult<u8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -683,7 +683,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint8clamp
-    pub fn to_uint8_clamp(&self, context: &mut Context) -> JsResult<u8> {
+    pub fn to_uint8_clamp(&self, context: &mut Context<'_>) -> JsResult<u8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -730,7 +730,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-toint16
-    pub fn to_int16(&self, context: &mut Context) -> JsResult<i16> {
+    pub fn to_int16(&self, context: &mut Context<'_>) -> JsResult<i16> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -759,7 +759,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint16
-    pub fn to_uint16(&self, context: &mut Context) -> JsResult<u16> {
+    pub fn to_uint16(&self, context: &mut Context<'_>) -> JsResult<u16> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -784,7 +784,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobigint64
-    pub fn to_big_int64(&self, context: &mut Context) -> JsResult<BigInt> {
+    pub fn to_big_int64(&self, context: &mut Context<'_>) -> JsResult<BigInt> {
         // 1. Let n be ? ToBigInt(argument).
         let n = self.to_bigint(context)?;
 
@@ -805,7 +805,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobiguint64
-    pub fn to_big_uint64(&self, context: &mut Context) -> JsResult<BigInt> {
+    pub fn to_big_uint64(&self, context: &mut Context<'_>) -> JsResult<BigInt> {
         let two_e_64: u128 = 0x1_0000_0000_0000_0000;
         let two_e_64 = BigInt::from(two_e_64);
 
@@ -820,7 +820,7 @@ impl JsValue {
     /// Converts a value to a non-negative integer if it is a valid integer index value.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toindex>
-    pub fn to_index(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn to_index(&self, context: &mut Context<'_>) -> JsResult<u64> {
         // 1. If value is undefined, then
         if self.is_undefined() {
             // a. Return 0.
@@ -851,7 +851,7 @@ impl JsValue {
     /// Converts argument to an integer suitable for use as the length of an array-like object.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tolength>
-    pub fn to_length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn to_length(&self, context: &mut Context<'_>) -> JsResult<u64> {
         // 1. Let len be ? ToInteger(argument).
         // 2. If len ≤ +0, return +0.
         // 3. Return min(len, 2^53 - 1).
@@ -869,7 +869,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tointegerorinfinity
-    pub fn to_integer_or_infinity(&self, context: &mut Context) -> JsResult<IntegerOrInfinity> {
+    pub fn to_integer_or_infinity(&self, context: &mut Context<'_>) -> JsResult<IntegerOrInfinity> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -881,7 +881,7 @@ impl JsValue {
     ///
     /// This function is almost the same as [`Self::to_integer_or_infinity`], but with the exception
     /// that this will return `Nan` if [`Self::to_number`] returns a non-finite number.
-    pub(crate) fn to_integer_or_nan(&self, context: &mut Context) -> JsResult<IntegerOrNan> {
+    pub(crate) fn to_integer_or_nan(&self, context: &mut Context<'_>) -> JsResult<IntegerOrNan> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -898,7 +898,7 @@ impl JsValue {
     /// This function is equivalent to the unary `+` operator (`+value`) in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumber>
-    pub fn to_number(&self, context: &mut Context) -> JsResult<f64> {
+    pub fn to_number(&self, context: &mut Context<'_>) -> JsResult<f64> {
         match *self {
             Self::Null => Ok(0.0),
             Self::Undefined => Ok(f64::NAN),
@@ -924,7 +924,7 @@ impl JsValue {
     /// This function is equivalent to `Number(value)` in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumeric>
-    pub fn to_numeric_number(&self, context: &mut Context) -> JsResult<f64> {
+    pub fn to_numeric_number(&self, context: &mut Context<'_>) -> JsResult<f64> {
         let primitive = self.to_primitive(context, PreferredType::Number)?;
         if let Some(bigint) = primitive.as_bigint() {
             return Ok(bigint.to_f64());
@@ -961,7 +961,10 @@ impl JsValue {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-topropertydescriptor
     #[inline]
-    pub fn to_property_descriptor(&self, context: &mut Context) -> JsResult<PropertyDescriptor> {
+    pub fn to_property_descriptor(
+        &self,
+        context: &mut Context<'_>,
+    ) -> JsResult<PropertyDescriptor> {
         // 1. If Type(Obj) is not Object, throw a TypeError exception.
         self.as_object()
             .ok_or_else(|| {

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -11,7 +11,7 @@ use crate::{
 
 impl JsValue {
     /// Perform the binary `+` operator on the value and return the result.
-    pub fn add(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn add(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             // Numeric add
@@ -51,7 +51,7 @@ impl JsValue {
     }
 
     /// Perform the binary `-` operator on the value and return the result.
-    pub fn sub(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn sub(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -77,7 +77,7 @@ impl JsValue {
     }
 
     /// Perform the binary `*` operator on the value and return the result.
-    pub fn mul(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn mul(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -103,7 +103,7 @@ impl JsValue {
     }
 
     /// Perform the binary `/` operator on the value and return the result.
-    pub fn div(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn div(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -144,7 +144,7 @@ impl JsValue {
     }
 
     /// Perform the binary `%` operator on the value and return the result.
-    pub fn rem(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn rem(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => {
@@ -195,7 +195,7 @@ impl JsValue {
     }
 
     /// Perform the binary `**` operator on the value and return the result.
-    pub fn pow(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn pow(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => u32::try_from(*y)
@@ -222,7 +222,7 @@ impl JsValue {
     }
 
     /// Perform the binary `&` operator on the value and return the result.
-    pub fn bitand(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn bitand(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x & y),
@@ -252,7 +252,7 @@ impl JsValue {
     }
 
     /// Perform the binary `|` operator on the value and return the result.
-    pub fn bitor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn bitor(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x | y),
@@ -282,7 +282,7 @@ impl JsValue {
     }
 
     /// Perform the binary `^` operator on the value and return the result.
-    pub fn bitxor(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn bitxor(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x ^ y),
@@ -312,7 +312,7 @@ impl JsValue {
     }
 
     /// Perform the binary `<<` operator on the value and return the result.
-    pub fn shl(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn shl(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x.wrapping_shl(*y as u32)),
@@ -344,7 +344,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>` operator on the value and return the result.
-    pub fn shr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn shr(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x.wrapping_shr(*y as u32)),
@@ -376,7 +376,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>>` operator on the value and return the result.
-    pub fn ushr(&self, other: &Self, context: &mut Context) -> JsResult<Self> {
+    pub fn ushr(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new((*x as u32).wrapping_shr(*y as u32)),
@@ -415,7 +415,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-instanceofoperator
-    pub fn instance_of(&self, target: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn instance_of(&self, target: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         if !target.is_object() {
             return Err(JsNativeError::typ()
@@ -449,7 +449,7 @@ impl JsValue {
     }
 
     /// Returns the negated value.
-    pub fn neg(&self, context: &mut Context) -> JsResult<Self> {
+    pub fn neg(&self, context: &mut Context<'_>) -> JsResult<Self> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::new(f64::NAN),
             Self::Object(_) => Self::new(
@@ -493,7 +493,7 @@ impl JsValue {
         &self,
         other: &Self,
         left_first: bool,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<AbstractRelation> {
         Ok(match (self, other) {
             // Fast path (for some common operations):
@@ -571,7 +571,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn lt(&self, other: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn lt(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -588,7 +588,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn le(&self, other: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn le(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),
@@ -605,7 +605,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn gt(&self, other: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn gt(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -622,7 +622,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn ge(&self, other: &Self, context: &mut Context) -> JsResult<bool> {
+    pub fn ge(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -35,7 +35,7 @@ impl JsValue {
     /// #
     /// # assert_eq!(json, value.to_json(&mut context).unwrap());
     /// ```
-    pub fn from_json(json: &Value, context: &mut Context) -> JsResult<Self> {
+    pub fn from_json(json: &Value, context: &mut Context<'_>) -> JsResult<Self> {
         /// Biggest possible integer, as i64.
         const MAX_INT: i64 = i32::MAX as i64;
 
@@ -109,7 +109,7 @@ impl JsValue {
     /// # Panics
     ///
     /// Panics if the `JsValue` is `Undefined`.
-    pub fn to_json(&self, context: &mut Context) -> JsResult<Value> {
+    pub fn to_json(&self, context: &mut Context<'_>) -> JsResult<Value> {
         match self {
             Self::Null => Ok(Value::Null),
             Self::Undefined => todo!("undefined to JSON"),

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -490,7 +490,7 @@ pub(crate) fn create_function_object(
     r#async: bool,
     arrow: bool,
     prototype: Option<JsObject>,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsObject {
     let _timer = Profiler::global().start_event("JsVmFunction::new", "vm");
 
@@ -595,7 +595,7 @@ pub(crate) fn create_function_object(
 pub(crate) fn create_generator_function_object(
     code: Gc<CodeBlock>,
     r#async: bool,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsObject {
     let function_prototype = if r#async {
         context
@@ -687,7 +687,7 @@ impl JsObject {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let this_function_object = self.clone();
 
@@ -1264,7 +1264,7 @@ impl JsObject {
         &self,
         args: &[JsValue],
         this_target: &JsValue,
-        context: &mut Context,
+        context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let this_function_object = self.clone();
 
@@ -1511,7 +1511,7 @@ impl JsObject {
 pub(crate) fn initialize_instance_elements(
     target: &JsObject,
     constructor: &JsObject,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<()> {
     let constructor_borrow = constructor.borrow();
     let constructor_function = constructor_borrow

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -110,7 +110,7 @@ pub(crate) enum ReturnType {
     Yield,
 }
 
-impl Context {
+impl Context<'_> {
     fn execute_instruction(&mut self) -> JsResult<ShouldExit> {
         let opcode: Opcode = {
             let _timer = Profiler::global().start_event("Opcode retrieval", "vm");

--- a/boa_engine/src/vm/opcode/await_stm/mod.rs
+++ b/boa_engine/src/vm/opcode/await_stm/mod.rs
@@ -16,7 +16,7 @@ impl Operation for Await {
     const NAME: &'static str = "Await";
     const INSTRUCTION: &'static str = "INST - Await";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
 
         // 2. Let promise be ? PromiseResolve(%Promise%, value).

--- a/boa_engine/src/vm/opcode/binary_ops/logical.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/logical.rs
@@ -14,7 +14,7 @@ impl Operation for LogicalAnd {
     const NAME: &'static str = "LogicalAnd";
     const INSTRUCTION: &'static str = "INST - LogicalAnd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if !lhs.to_boolean() {
@@ -36,7 +36,7 @@ impl Operation for LogicalOr {
     const NAME: &'static str = "LogicalOr";
     const INSTRUCTION: &'static str = "INST - LogicalOr";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if lhs.to_boolean() {
@@ -58,7 +58,7 @@ impl Operation for Coalesce {
     const NAME: &'static str = "Coalesce";
     const INSTRUCTION: &'static str = "INST - Coalesce";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if !lhs.is_null_or_undefined() {

--- a/boa_engine/src/vm/opcode/binary_ops/macro_defined.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/macro_defined.rs
@@ -16,7 +16,7 @@ macro_rules! implement_bin_ops {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+            fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 let rhs = context.vm.pop();
                 let lhs = context.vm.pop();
                 let value = lhs.$op(&rhs, context)?;

--- a/boa_engine/src/vm/opcode/binary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/mod.rs
@@ -21,7 +21,7 @@ impl Operation for NotEq {
     const NAME: &'static str = "NotEq";
     const INSTRUCTION: &'static str = "INST - NotEq";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let rhs = context.vm.pop();
         let lhs = context.vm.pop();
         let value = !lhs.equals(&rhs, context)?;
@@ -41,7 +41,7 @@ impl Operation for StrictEq {
     const NAME: &'static str = "StrictEq";
     const INSTRUCTION: &'static str = "INST - StrictEq";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let rhs = context.vm.pop();
         let lhs = context.vm.pop();
         context.vm.push(lhs.strict_equals(&rhs));
@@ -60,7 +60,7 @@ impl Operation for StrictNotEq {
     const NAME: &'static str = "StrictNotEq";
     const INSTRUCTION: &'static str = "INST - StrictNotEq";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let rhs = context.vm.pop();
         let lhs = context.vm.pop();
         context.vm.push(!lhs.strict_equals(&rhs));
@@ -79,7 +79,7 @@ impl Operation for In {
     const NAME: &'static str = "In";
     const INSTRUCTION: &'static str = "INST - In";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let rhs = context.vm.pop();
         let lhs = context.vm.pop();
 
@@ -109,7 +109,7 @@ impl Operation for InstanceOf {
     const NAME: &'static str = "InstanceOf";
     const INSTRUCTION: &'static str = "INST - InstanceOf";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let target = context.vm.pop();
         let v = context.vm.pop();
         let value = v.instance_of(&target, context)?;

--- a/boa_engine/src/vm/opcode/call/mod.rs
+++ b/boa_engine/src/vm/opcode/call/mod.rs
@@ -16,7 +16,7 @@ impl Operation for CallEval {
     const NAME: &'static str = "CallEval";
     const INSTRUCTION: &'static str = "INST - CallEval";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")
@@ -72,7 +72,7 @@ impl Operation for CallEvalSpread {
     const NAME: &'static str = "CallEvalSpread";
     const INSTRUCTION: &'static str = "INST - CallEvalSpread";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")
@@ -134,7 +134,7 @@ impl Operation for Call {
     const NAME: &'static str = "Call";
     const INSTRUCTION: &'static str = "INST - Call";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")
@@ -173,7 +173,7 @@ impl Operation for CallSpread {
     const NAME: &'static str = "CallSpread";
     const INSTRUCTION: &'static str = "INST - CallSpread";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")

--- a/boa_engine/src/vm/opcode/concat/mod.rs
+++ b/boa_engine/src/vm/opcode/concat/mod.rs
@@ -14,7 +14,7 @@ impl Operation for ConcatToString {
     const NAME: &'static str = "ConcatToString";
     const INSTRUCTION: &'static str = "INST - ConcatToString";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value_count = context.vm.read::<u32>();
         let mut strings = Vec::with_capacity(value_count as usize);
         for _ in 0..value_count {

--- a/boa_engine/src/vm/opcode/copy/mod.rs
+++ b/boa_engine/src/vm/opcode/copy/mod.rs
@@ -14,7 +14,7 @@ impl Operation for CopyDataProperties {
     const NAME: &'static str = "CopyDataProperties";
     const INSTRUCTION: &'static str = "INST - CopyDataProperties";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let excluded_key_count = context.vm.read::<u32>();
         let excluded_key_count_computed = context.vm.read::<u32>();
         let mut excluded_keys = Vec::with_capacity(excluded_key_count as usize);

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -15,7 +15,7 @@ impl Operation for DefineClassGetterByName {
     const NAME: &'static str = "DefineClassGetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassGetterByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -63,7 +63,7 @@ impl Operation for DefineClassGetterByValue {
     const NAME: &'static str = "DefineClassGetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassGetterByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -15,7 +15,7 @@ impl Operation for DefineClassMethodByName {
     const NAME: &'static str = "DefineClassMethodByName";
     const INSTRUCTION: &'static str = "INST - DefineClassMethodByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -58,7 +58,7 @@ impl Operation for DefineClassMethodByValue {
     const NAME: &'static str = "DefineClassMethodByName";
     const INSTRUCTION: &'static str = "INST - DefineClassMethodByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -15,7 +15,7 @@ impl Operation for DefineClassSetterByName {
     const NAME: &'static str = "DefineClassSetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassSetterByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -63,7 +63,7 @@ impl Operation for DefineClassSetterByValue {
     const NAME: &'static str = "DefineClassSetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassSetterByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -21,7 +21,7 @@ impl Operation for DefVar {
     const NAME: &'static str = "DefVar";
     const INSTRUCTION: &'static str = "INST - DefVar";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
 
@@ -60,7 +60,7 @@ impl Operation for DefInitVar {
     const NAME: &'static str = "DefInitVar";
     const INSTRUCTION: &'static str = "INST - DefInitVar";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
@@ -98,7 +98,7 @@ impl Operation for DefLet {
     const NAME: &'static str = "DefLet";
     const INSTRUCTION: &'static str = "INST - DefLet";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         context.realm.environments.put_value(
@@ -123,7 +123,7 @@ macro_rules! implement_declaritives {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+            fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 let index = context.vm.read::<u32>();
                 let value = context.vm.pop();
                 let binding_locator = context.vm.frame().code.bindings[index as usize];

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -15,7 +15,7 @@ impl Operation for DefineOwnPropertyByName {
     const NAME: &'static str = "DefineOwnPropertyByName";
     const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -54,7 +54,7 @@ impl Operation for DefineOwnPropertyByValue {
     const NAME: &'static str = "DefineOwnPropertyByValue";
     const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -15,7 +15,7 @@ impl Operation for DeletePropertyByName {
     const NAME: &'static str = "DeletePropertyByName";
     const INSTRUCTION: &'static str = "INST - DeletePropertyByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let key = context.vm.frame().code.names[index as usize];
         let key = context
@@ -46,7 +46,7 @@ impl Operation for DeletePropertyByValue {
     const NAME: &'static str = "DeletePropertyByValue";
     const INSTRUCTION: &'static str = "INST - DeletePropertyByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let key = context.vm.pop();
         let object = context.vm.pop();
         let result = object
@@ -73,7 +73,7 @@ impl Operation for DeleteName {
     const NAME: &'static str = "DeleteName";
     const INSTRUCTION: &'static str = "INST - DeleteName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         binding_locator.throw_mutate_immutable(context)?;
@@ -130,7 +130,7 @@ impl Operation for DeleteSuperThrow {
     const NAME: &'static str = "DeleteSuperThrow";
     const INSTRUCTION: &'static str = "INST - DeleteSuperThrow";
 
-    fn execute(_: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(_: &mut Context<'_>) -> JsResult<ShouldExit> {
         Err(JsNativeError::reference()
             .with_message("cannot delete a property of `super`")
             .into())

--- a/boa_engine/src/vm/opcode/dup/mod.rs
+++ b/boa_engine/src/vm/opcode/dup/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Dup {
     const NAME: &'static str = "Dup";
     const INSTRUCTION: &'static str = "INST - Dup";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         context.vm.push(value.clone());
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -16,7 +16,7 @@ impl Operation for This {
     const NAME: &'static str = "This";
     const INSTRUCTION: &'static str = "INST - This";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let env = context.realm.environments.get_this_environment();
         match env {
             EnvironmentSlots::Function(env) => {
@@ -42,7 +42,7 @@ impl Operation for Super {
     const NAME: &'static str = "Super";
     const INSTRUCTION: &'static str = "INST - Super";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let home = {
             let env = context
                 .realm
@@ -84,7 +84,7 @@ impl Operation for SuperCall {
     const NAME: &'static str = "SuperCall";
     const INSTRUCTION: &'static str = "INST - SuperCall";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let argument_count = context.vm.read::<u32>();
         let mut arguments = Vec::with_capacity(argument_count as usize);
         for _ in 0..argument_count {
@@ -150,7 +150,7 @@ impl Operation for SuperCallSpread {
     const NAME: &'static str = "SuperCallWithRest";
     const INSTRUCTION: &'static str = "INST - SuperCallWithRest";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         // Get the arguments that are stored as an array object on the stack.
         let arguments_array = context.vm.pop();
         let arguments_array_object = arguments_array
@@ -221,7 +221,7 @@ impl Operation for SuperCallDerived {
     const NAME: &'static str = "SuperCallDerived";
     const INSTRUCTION: &'static str = "INST - SuperCallDerived";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let argument_count = context.vm.frame().arg_count;
         let mut arguments = Vec::with_capacity(argument_count);
         for _ in 0..argument_count {

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -27,7 +27,7 @@ impl Operation for GeneratorNext {
     const NAME: &'static str = "GeneratorNext";
     const INSTRUCTION: &'static str = "INST - GeneratorNext";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         match context.vm.frame().generator_resume_kind {
             GeneratorResumeKind::Normal => Ok(ShouldExit::False),
             GeneratorResumeKind::Throw => {
@@ -69,7 +69,7 @@ impl Operation for AsyncGeneratorNext {
     const NAME: &'static str = "AsyncGeneratorNext";
     const INSTRUCTION: &'static str = "INST - AsyncGeneratorNext";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
 
         if context.vm.frame().generator_resume_kind == GeneratorResumeKind::Throw {
@@ -133,7 +133,7 @@ impl Operation for GeneratorNextDelegate {
     const NAME: &'static str = "GeneratorNextDelegate";
     const INSTRUCTION: &'static str = "INST - GeneratorNextDelegate";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let done_address = context.vm.read::<u32>();
         let received = context.vm.pop();
         let done = context

--- a/boa_engine/src/vm/opcode/generator/yield_stm.rs
+++ b/boa_engine/src/vm/opcode/generator/yield_stm.rs
@@ -14,7 +14,7 @@ impl Operation for Yield {
     const NAME: &'static str = "Yield";
     const INSTRUCTION: &'static str = "INST - Yield";
 
-    fn execute(_context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(_context: &mut Context<'_>) -> JsResult<ShouldExit> {
         Ok(ShouldExit::Yield)
     }
 }

--- a/boa_engine/src/vm/opcode/get/function.rs
+++ b/boa_engine/src/vm/opcode/get/function.rs
@@ -14,7 +14,7 @@ impl Operation for GetArrowFunction {
     const NAME: &'static str = "GetArrowFunction";
     const INSTRUCTION: &'static str = "INST - GetArrowFunction";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_function_object(code, false, true, None, context);
@@ -34,7 +34,7 @@ impl Operation for GetAsyncArrowFunction {
     const NAME: &'static str = "GetAsyncArrowFunction";
     const INSTRUCTION: &'static str = "INST - GetAsyncArrowFunction";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_function_object(code, true, true, None, context);
@@ -54,7 +54,7 @@ impl Operation for GetFunction {
     const NAME: &'static str = "GetFunction";
     const INSTRUCTION: &'static str = "INST - GetFunction";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_function_object(code, false, false, None, context);
@@ -74,7 +74,7 @@ impl Operation for GetFunctionAsync {
     const NAME: &'static str = "GetFunctionAsync";
     const INSTRUCTION: &'static str = "INST - GetFunctionAsync";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_function_object(code, true, false, None, context);

--- a/boa_engine/src/vm/opcode/get/generator.rs
+++ b/boa_engine/src/vm/opcode/get/generator.rs
@@ -14,7 +14,7 @@ impl Operation for GetGenerator {
     const NAME: &'static str = "GetGenerator";
     const INSTRUCTION: &'static str = "INST - GetGenerator";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_generator_function_object(code, false, context);
@@ -34,7 +34,7 @@ impl Operation for GetGeneratorAsync {
     const NAME: &'static str = "GetGeneratorAsync";
     const INSTRUCTION: &'static str = "INST - GetGeneratorAsync";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let code = context.vm.frame().code.functions[index as usize].clone();
         let function = create_generator_function_object(code, true, context);

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -16,7 +16,7 @@ impl Operation for GetName {
     const NAME: &'static str = "GetName";
     const INSTRUCTION: &'static str = "INST - GetName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         binding_locator.throw_mutate_immutable(context)?;
@@ -90,7 +90,7 @@ impl Operation for GetNameOrUndefined {
     const NAME: &'static str = "GetNameOrUndefined";
     const INSTRUCTION: &'static str = "INST - GetNameOrUndefined";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         binding_locator.throw_mutate_immutable(context)?;

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -16,7 +16,7 @@ impl Operation for GetPrivateField {
     const NAME: &'static str = "GetPrivateField";
     const INSTRUCTION: &'static str = "INST - GetPrivateField";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -15,7 +15,7 @@ impl Operation for GetPropertyByName {
     const NAME: &'static str = "GetPropertyName";
     const INSTRUCTION: &'static str = "INST - GetPropertyName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
 
         let value = context.vm.pop();
@@ -49,7 +49,7 @@ impl Operation for GetPropertyByValue {
     const NAME: &'static str = "GetPropertyByValue";
     const INSTRUCTION: &'static str = "INST - GetPropertyByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let key = context.vm.pop();
         let object = context.vm.pop();
         let object = if let Some(object) = object.as_object() {
@@ -77,7 +77,7 @@ impl Operation for GetPropertyByValuePush {
     const NAME: &'static str = "GetPropertyByValuePush";
     const INSTRUCTION: &'static str = "INST - GetPropertyByValuePush";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let key = context.vm.pop();
         let object = context.vm.pop();
         let object = if let Some(object) = object.as_object() {

--- a/boa_engine/src/vm/opcode/iteration/for_await.rs
+++ b/boa_engine/src/vm/opcode/iteration/for_await.rs
@@ -16,7 +16,7 @@ impl Operation for ForAwaitOfLoopIterate {
     const NAME: &'static str = "ForAwaitOfLoopIterate";
     const INSTRUCTION: &'static str = "INST - ForAwaitOfLoopIterate";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let _done = context
             .vm
             .pop()
@@ -46,7 +46,7 @@ impl Operation for ForAwaitOfLoopNext {
     const NAME: &'static str = "ForAwaitOfLoopNext";
     const INSTRUCTION: &'static str = "INST - ForAwaitOfLoopNext";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
 
         let next_result = context.vm.pop();

--- a/boa_engine/src/vm/opcode/iteration/for_in.rs
+++ b/boa_engine/src/vm/opcode/iteration/for_in.rs
@@ -17,7 +17,7 @@ impl Operation for ForInLoopInitIterator {
     const NAME: &'static str = "ForInLoopInitIterator";
     const INSTRUCTION: &'static str = "INST - ForInLoopInitIterator";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
 
         let object = context.vm.pop();
@@ -53,7 +53,7 @@ impl Operation for ForInLoopNext {
     const NAME: &'static str = "ForInLoopInitIterator";
     const INSTRUCTION: &'static str = "INST - ForInLoopInitIterator";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
 
         let done = context

--- a/boa_engine/src/vm/opcode/iteration/init.rs
+++ b/boa_engine/src/vm/opcode/iteration/init.rs
@@ -15,7 +15,7 @@ impl Operation for InitIterator {
     const NAME: &'static str = "InitIterator";
     const INSTRUCTION: &'static str = "INST - InitIterator";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let object = context.vm.pop();
         let iterator = object.get_iterator(context, None, None)?;
         context.vm.push(iterator.iterator().clone());
@@ -36,7 +36,7 @@ impl Operation for InitIteratorAsync {
     const NAME: &'static str = "InitIteratorAsync";
     const INSTRUCTION: &'static str = "INST - InitIteratorAsync";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let object = context.vm.pop();
         let iterator = object.get_iterator(context, Some(IteratorHint::Async), None)?;
         context.vm.push(iterator.iterator().clone());

--- a/boa_engine/src/vm/opcode/iteration/iterator.rs
+++ b/boa_engine/src/vm/opcode/iteration/iterator.rs
@@ -15,7 +15,7 @@ impl Operation for IteratorNext {
     const NAME: &'static str = "IteratorNext";
     const INSTRUCTION: &'static str = "INST - IteratorNext";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let done = context
             .vm
             .pop()
@@ -53,7 +53,7 @@ impl Operation for IteratorClose {
     const NAME: &'static str = "IteratorClose";
     const INSTRUCTION: &'static str = "INST - IteratorClose";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let done = context
             .vm
             .pop()
@@ -81,7 +81,7 @@ impl Operation for IteratorToArray {
     const NAME: &'static str = "IteratorToArray";
     const INSTRUCTION: &'static str = "INST - IteratorToArray";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let done = context
             .vm
             .pop()

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -14,7 +14,7 @@ impl Operation for LoopStart {
     const NAME: &'static str = "LoopStart";
     const INSTRUCTION: &'static str = "INST - LoopStart";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.vm.frame_mut().loop_env_stack.push(0);
         context.vm.frame_mut().try_env_stack_loop_inc();
         Ok(ShouldExit::False)
@@ -32,7 +32,7 @@ impl Operation for LoopContinue {
     const NAME: &'static str = "LoopContinue";
     const INSTRUCTION: &'static str = "INST - LoopContinue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let env_num = context
             .vm
             .frame_mut()
@@ -59,7 +59,7 @@ impl Operation for LoopEnd {
     const NAME: &'static str = "LoopEnd";
     const INSTRUCTION: &'static str = "INST - LoopEnd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let env_num = context
             .vm
             .frame_mut()

--- a/boa_engine/src/vm/opcode/jump/mod.rs
+++ b/boa_engine/src/vm/opcode/jump/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Jump {
     const NAME: &'static str = "Jump";
     const INSTRUCTION: &'static str = "INST - Jump";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         context.vm.frame_mut().pc = address as usize;
         Ok(ShouldExit::False)
@@ -32,7 +32,7 @@ impl Operation for JumpIfFalse {
     const NAME: &'static str = "JumpIfFalse";
     const INSTRUCTION: &'static str = "INST - JumpIfFalse";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         if !context.vm.pop().to_boolean() {
             context.vm.frame_mut().pc = address as usize;
@@ -52,7 +52,7 @@ impl Operation for JumpIfNotUndefined {
     const NAME: &'static str = "JumpIfNotUndefined";
     const INSTRUCTION: &'static str = "INST - JumpIfNotUndefined";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         let value = context.vm.pop();
         if !value.is_undefined() {
@@ -74,7 +74,7 @@ impl Operation for JumpIfNullOrUndefined {
     const NAME: &'static str = "JumpIfNullOrUndefined";
     const INSTRUCTION: &'static str = "INST - JumpIfNullOrUndefined";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         let value = context.vm.pop();
         if value.is_null_or_undefined() {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -146,11 +146,11 @@ macro_rules! generate_impl {
                 Self::INSTRUCTIONS[self as usize]
             }
 
-            const EXECUTE_FNS: &[fn(&mut Context) -> JsResult<ShouldExit>] = &[
+            const EXECUTE_FNS: &[fn(&mut Context<'_>) -> JsResult<ShouldExit>] = &[
                 $($Variant::execute),*
             ];
 
-            pub(super) fn execute(self, context: &mut Context) -> JsResult<ShouldExit> {
+            pub(super) fn execute(self, context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 Self::EXECUTE_FNS[self as usize](context)
             }
         }
@@ -167,7 +167,7 @@ pub(crate) trait Operation {
     const NAME: &'static str;
     const INSTRUCTION: &'static str;
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit>;
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit>;
 }
 
 generate_impl! {

--- a/boa_engine/src/vm/opcode/new/mod.rs
+++ b/boa_engine/src/vm/opcode/new/mod.rs
@@ -15,7 +15,7 @@ impl Operation for New {
     const NAME: &'static str = "New";
     const INSTRUCTION: &'static str = "INST - New";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")
@@ -54,7 +54,7 @@ impl Operation for NewSpread {
     const NAME: &'static str = "NewSpread";
     const INSTRUCTION: &'static str = "INST - NewSpread";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if context.vm.stack_size_limit <= context.vm.stack.len() {
             return Err(JsNativeError::range()
                 .with_message("Maximum call stack size exceeded")

--- a/boa_engine/src/vm/opcode/nop/mod.rs
+++ b/boa_engine/src/vm/opcode/nop/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Nop {
     const NAME: &'static str = "Nop";
     const INSTRUCTION: &'static str = "INST - Nop";
 
-    fn execute(_context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(_context: &mut Context<'_>) -> JsResult<ShouldExit> {
         Ok(ShouldExit::False)
     }
 }

--- a/boa_engine/src/vm/opcode/pop/mod.rs
+++ b/boa_engine/src/vm/opcode/pop/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Pop {
     const NAME: &'static str = "Pop";
     const INSTRUCTION: &'static str = "INST - Pop";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let _val = context.vm.pop();
         Ok(ShouldExit::False)
     }
@@ -31,7 +31,7 @@ impl Operation for PopIfThrown {
     const NAME: &'static str = "PopIfThrown";
     const INSTRUCTION: &'static str = "INST - PopIfThrown";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let frame = context.vm.frame_mut();
         if frame.thrown {
             frame.thrown = false;
@@ -52,7 +52,7 @@ impl Operation for PopEnvironment {
     const NAME: &'static str = "PopEnvironment";
     const INSTRUCTION: &'static str = "INST - PopEnvironment";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.realm.environments.pop();
         context.vm.frame_mut().loop_env_stack_dec();
         context.vm.frame_mut().try_env_stack_dec();
@@ -71,7 +71,7 @@ impl Operation for PopOnReturnAdd {
     const NAME: &'static str = "PopOnReturnAdd";
     const INSTRUCTION: &'static str = "INST - PopOnReturnAdd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.vm.frame_mut().pop_on_return += 1;
         Ok(ShouldExit::False)
     }
@@ -88,7 +88,7 @@ impl Operation for PopOnReturnSub {
     const NAME: &'static str = "PopOnReturnSub";
     const INSTRUCTION: &'static str = "INST - PopOnReturnSub";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.vm.frame_mut().pop_on_return -= 1;
         Ok(ShouldExit::False)
     }

--- a/boa_engine/src/vm/opcode/promise/mod.rs
+++ b/boa_engine/src/vm/opcode/promise/mod.rs
@@ -14,7 +14,7 @@ impl Operation for FinallyStart {
     const NAME: &'static str = "FinallyStart";
     const INSTRUCTION: &'static str = "INST - FinallyStart";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         *context
             .vm
             .frame_mut()
@@ -36,7 +36,7 @@ impl Operation for FinallyEnd {
     const NAME: &'static str = "FinallyEnd";
     const INSTRUCTION: &'static str = "INST - FinallyEnd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context
             .vm
             .frame_mut()
@@ -67,7 +67,7 @@ impl Operation for FinallySetJump {
     const NAME: &'static str = "FinallySetJump";
     const INSTRUCTION: &'static str = "INST - FinallySetJump";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         *context
             .vm

--- a/boa_engine/src/vm/opcode/push/array.rs
+++ b/boa_engine/src/vm/opcode/push/array.rs
@@ -15,7 +15,7 @@ impl Operation for PushNewArray {
     const NAME: &'static str = "PushNewArray";
     const INSTRUCTION: &'static str = "INST - PushNewArray";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let array = Array::array_create(0, None, context)
             .expect("Array creation with 0 length should never fail");
         context.vm.push(array);
@@ -34,7 +34,7 @@ impl Operation for PushValueToArray {
     const NAME: &'static str = "PushValueToArray";
     const INSTRUCTION: &'static str = "INST - PushValueToArray";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let array = context.vm.pop();
         let o = array.as_object().expect("should be an object");
@@ -59,7 +59,7 @@ impl Operation for PushElisionToArray {
     const NAME: &'static str = "PushElisionToArray";
     const INSTRUCTION: &'static str = "INST - PushElisionToArray";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let array = context.vm.pop();
         let o = array.as_object().expect("should always be an object");
 
@@ -84,7 +84,7 @@ impl Operation for PushIteratorToArray {
     const NAME: &'static str = "PushIteratorToArray";
     const INSTRUCTION: &'static str = "INST - PushIteratorToArray";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let done = context
             .vm
             .pop()

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -15,7 +15,7 @@ impl Operation for PushClassField {
     const NAME: &'static str = "PushClassField";
     const INSTRUCTION: &'static str = "INST - PushClassField";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let field_function_value = context.vm.pop();
         let field_name_value = context.vm.pop();
         let class_value = context.vm.pop();
@@ -55,7 +55,7 @@ impl Operation for PushClassFieldPrivate {
     const NAME: &'static str = "PushClassFieldPrivate";
     const INSTRUCTION: &'static str = "INST - PushClassFieldPrivate";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let field_function_value = context.vm.pop();

--- a/boa_engine/src/vm/opcode/push/class/mod.rs
+++ b/boa_engine/src/vm/opcode/push/class/mod.rs
@@ -22,7 +22,7 @@ impl Operation for PushClassPrototype {
     const NAME: &'static str = "PushClassPrototype";
     const INSTRUCTION: &'static str = "INST - PushClassPrototype";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let superclass = context.vm.pop();
 
         if let Some(superclass) = superclass.as_constructor() {

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -15,7 +15,7 @@ impl Operation for PushClassPrivateMethod {
     const NAME: &'static str = "PushClassPrivateMethod";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateMethod";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let method = context.vm.pop();
@@ -43,7 +43,7 @@ impl Operation for PushClassPrivateGetter {
     const NAME: &'static str = "PushClassPrivateGetter";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateGetter";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let getter = context.vm.pop();
@@ -77,7 +77,7 @@ impl Operation for PushClassPrivateSetter {
     const NAME: &'static str = "PushClassPrivateSetter";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateSetter";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let setter = context.vm.pop();

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -14,7 +14,7 @@ impl Operation for PushDeclarativeEnvironment {
     const NAME: &'static str = "PushDeclarativeEnvironment";
     const INSTRUCTION: &'static str = "INST - PushDeclarativeEnvironment";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code.compile_environments
@@ -41,7 +41,7 @@ impl Operation for PushFunctionEnvironment {
     const NAME: &'static str = "PushFunctionEnvironment";
     const INSTRUCTION: &'static str = "INST - PushFunctionEnvironment";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code.compile_environments

--- a/boa_engine/src/vm/opcode/push/literal.rs
+++ b/boa_engine/src/vm/opcode/push/literal.rs
@@ -14,7 +14,7 @@ impl Operation for PushLiteral {
     const NAME: &'static str = "PushLiteral";
     const INSTRUCTION: &'static str = "INST - PushLiteral";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>() as usize;
         let value = context.vm.frame().code.literals[index].clone();
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/push/mod.rs
+++ b/boa_engine/src/vm/opcode/push/mod.rs
@@ -32,7 +32,7 @@ macro_rules! implement_push_generics {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+            fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 context.vm.push($push_value);
                 Ok(ShouldExit::False)
             }

--- a/boa_engine/src/vm/opcode/push/new_target.rs
+++ b/boa_engine/src/vm/opcode/push/new_target.rs
@@ -14,7 +14,7 @@ impl Operation for PushNewTarget {
     const NAME: &'static str = "PushNewTarget";
     const INSTRUCTION: &'static str = "INST - PushNewTarget";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if let Some(env) = context
             .realm
             .environments

--- a/boa_engine/src/vm/opcode/push/numbers.rs
+++ b/boa_engine/src/vm/opcode/push/numbers.rs
@@ -16,7 +16,7 @@ macro_rules! implement_push_numbers_with_conversion {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+            fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 let value = context.vm.read::<$num_type>();
                 context.vm.push(i32::from(value));
                 Ok(ShouldExit::False)
@@ -38,7 +38,7 @@ macro_rules! implement_push_numbers_no_conversion {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+            fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
                 let value = context.vm.read::<$num_type>();
                 context.vm.push(value);
                 Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/push/object.rs
+++ b/boa_engine/src/vm/opcode/push/object.rs
@@ -15,7 +15,7 @@ impl Operation for PushEmptyObject {
     const NAME: &'static str = "PushEmptyObject";
     const INSTRUCTION: &'static str = "INST - PushEmptyObject";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let o = JsObject::with_object_proto(context);
         context.vm.push(o);
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/require/mod.rs
+++ b/boa_engine/src/vm/opcode/require/mod.rs
@@ -14,7 +14,7 @@ impl Operation for RequireObjectCoercible {
     const NAME: &'static str = "RequireObjectCoercible";
     const INSTRUCTION: &'static str = "INST - RequireObjectCoercible";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let value = value.require_object_coercible()?;
         context.vm.push(value.clone());

--- a/boa_engine/src/vm/opcode/rest_parameter/mod.rs
+++ b/boa_engine/src/vm/opcode/rest_parameter/mod.rs
@@ -15,7 +15,7 @@ impl Operation for RestParameterInit {
     const NAME: &'static str = "FunctionRestParameter";
     const INSTRUCTION: &'static str = "INST - FunctionRestParameter";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let arg_count = context.vm.frame().arg_count;
         let param_count = context.vm.frame().param_count;
         if arg_count >= param_count {
@@ -49,7 +49,7 @@ impl Operation for RestParameterPop {
     const NAME: &'static str = "RestParameterPop";
     const INSTRUCTION: &'static str = "INST - RestParameterPop";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let arg_count = context.vm.frame().arg_count;
         let param_count = context.vm.frame().param_count;
         if arg_count > param_count {

--- a/boa_engine/src/vm/opcode/return_stm/mod.rs
+++ b/boa_engine/src/vm/opcode/return_stm/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Return {
     const NAME: &'static str = "Return";
     const INSTRUCTION: &'static str = "INST - Return";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         if let Some(finally_address) = context.vm.frame().catch.last().and_then(|c| c.finally) {
             let frame = context.vm.frame_mut();
             frame.pc = finally_address as usize;

--- a/boa_engine/src/vm/opcode/set/class_prototype.rs
+++ b/boa_engine/src/vm/opcode/set/class_prototype.rs
@@ -16,7 +16,7 @@ impl Operation for SetClassPrototype {
     const NAME: &'static str = "SetClassPrototype";
     const INSTRUCTION: &'static str = "INST - SetClassPrototype";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let prototype_value = context.vm.pop();
         let prototype = match &prototype_value {
             JsValue::Object(proto) => Some(proto.clone()),

--- a/boa_engine/src/vm/opcode/set/home_object.rs
+++ b/boa_engine/src/vm/opcode/set/home_object.rs
@@ -14,7 +14,7 @@ impl Operation for SetHomeObject {
     const NAME: &'static str = "SetHomeObject";
     const INSTRUCTION: &'static str = "INST - SetHomeObject";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let function = context.vm.pop();
         let function_object = function.as_object().expect("must be object");
         let home = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -15,7 +15,7 @@ impl Operation for SetName {
     const NAME: &'static str = "SetName";
     const INSTRUCTION: &'static str = "INST - SetName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code.bindings[index as usize];
         let value = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -16,7 +16,7 @@ impl Operation for AssignPrivateField {
     const NAME: &'static str = "AssignPrivateField";
     const INSTRUCTION: &'static str = "INST - AssignPrivateField";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();
@@ -73,7 +73,7 @@ impl Operation for SetPrivateField {
     const NAME: &'static str = "SetPrivateValue";
     const INSTRUCTION: &'static str = "INST - SetPrivateValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();
@@ -111,7 +111,7 @@ impl Operation for SetPrivateMethod {
     const NAME: &'static str = "SetPrivateMethod";
     const INSTRUCTION: &'static str = "INST - SetPrivateMethod";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();
@@ -141,7 +141,7 @@ impl Operation for SetPrivateSetter {
     const NAME: &'static str = "SetPrivateSetter";
     const INSTRUCTION: &'static str = "INST - SetPrivateSetter";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();
@@ -170,7 +170,7 @@ impl Operation for SetPrivateGetter {
     const NAME: &'static str = "SetPrivateGetter";
     const INSTRUCTION: &'static str = "INST - SetPrivateGetter";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.names[index as usize];
         let value = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -16,7 +16,7 @@ impl Operation for SetPropertyByName {
     const NAME: &'static str = "SetPropertyByName";
     const INSTRUCTION: &'static str = "INST - SetPropertyByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
 
         let value = context.vm.pop();
@@ -51,7 +51,7 @@ impl Operation for SetPropertyByValue {
     const NAME: &'static str = "SetPropertyByValue";
     const INSTRUCTION: &'static str = "INST - SetPropertyByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();
@@ -79,7 +79,7 @@ impl Operation for SetPropertyGetterByName {
     const NAME: &'static str = "SetPropertyGetterByName";
     const INSTRUCTION: &'static str = "INST - SetPropertyGetterByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -120,7 +120,7 @@ impl Operation for SetPropertyGetterByValue {
     const NAME: &'static str = "SetPropertyGetterByValue";
     const INSTRUCTION: &'static str = "INST - SetPropertyGetterByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();
@@ -156,7 +156,7 @@ impl Operation for SetPropertySetterByName {
     const NAME: &'static str = "SetPropertySetterByName";
     const INSTRUCTION: &'static str = "INST - SetPropertySetterByName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let object = context.vm.pop();
@@ -197,7 +197,7 @@ impl Operation for SetPropertySetterByValue {
     const NAME: &'static str = "SetPropertySetterByValue";
     const INSTRUCTION: &'static str = "INST - SetPropertySetterByValue";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = context.vm.pop();
         let object = context.vm.pop();
@@ -233,7 +233,7 @@ impl Operation for SetFunctionName {
     const NAME: &'static str = "SetFunctionName";
     const INSTRUCTION: &'static str = "INST - SetFunctionName";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let prefix = context.vm.read::<u8>();
 
         let function = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/prototype.rs
+++ b/boa_engine/src/vm/opcode/set/prototype.rs
@@ -14,7 +14,7 @@ impl Operation for SetPrototype {
     const NAME: &'static str = "SetPrototype";
     const INSTRUCTION: &'static str = "INST - SetPrototype";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let object = context.vm.pop();
 

--- a/boa_engine/src/vm/opcode/swap/mod.rs
+++ b/boa_engine/src/vm/opcode/swap/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Swap {
     const NAME: &'static str = "Swap";
     const INSTRUCTION: &'static str = "INST - Swap";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let first = context.vm.pop();
         let second = context.vm.pop();
 
@@ -35,7 +35,7 @@ impl Operation for RotateLeft {
     const NAME: &'static str = "RotateLeft";
     const INSTRUCTION: &'static str = "INST - RotateLeft";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let n = context.vm.read::<u8>() as usize;
         let len = context.vm.stack.len();
         context.vm.stack[(len - n)..].rotate_left(1);
@@ -54,7 +54,7 @@ impl Operation for RotateRight {
     const NAME: &'static str = "RotateRight";
     const INSTRUCTION: &'static str = "INST - RotateRight";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let n = context.vm.read::<u8>() as usize;
         let len = context.vm.stack.len();
         context.vm.stack[(len - n)..].rotate_right(1);

--- a/boa_engine/src/vm/opcode/switch/mod.rs
+++ b/boa_engine/src/vm/opcode/switch/mod.rs
@@ -15,7 +15,7 @@ impl Operation for Case {
     const NAME: &'static str = "Case";
     const INSTRUCTION: &'static str = "INST - Case";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
         let cond = context.vm.pop();
         let value = context.vm.pop();
@@ -40,7 +40,7 @@ impl Operation for Default {
     const NAME: &'static str = "Default";
     const INSTRUCTION: &'static str = "INST - Default";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let exit = context.vm.read::<u32>();
         let _val = context.vm.pop();
         context.vm.frame_mut().pc = exit as usize;

--- a/boa_engine/src/vm/opcode/throw/mod.rs
+++ b/boa_engine/src/vm/opcode/throw/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Throw {
     const NAME: &'static str = "Throw";
     const INSTRUCTION: &'static str = "INST - Throw";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         Err(JsError::from_opaque(value))
     }

--- a/boa_engine/src/vm/opcode/to/mod.rs
+++ b/boa_engine/src/vm/opcode/to/mod.rs
@@ -14,7 +14,7 @@ impl Operation for ToBoolean {
     const NAME: &'static str = "ToBoolean";
     const INSTRUCTION: &'static str = "INST - ToBoolean";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         context.vm.push(value.to_boolean());
         Ok(ShouldExit::False)
@@ -32,7 +32,7 @@ impl Operation for ToPropertyKey {
     const NAME: &'static str = "ToPropertyKey";
     const INSTRUCTION: &'static str = "INST - ToPropertyKey";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let key = value.to_property_key(context)?;
         context.vm.push(key);

--- a/boa_engine/src/vm/opcode/try_catch/mod.rs
+++ b/boa_engine/src/vm/opcode/try_catch/mod.rs
@@ -14,7 +14,7 @@ impl Operation for TryStart {
     const NAME: &'static str = "TryStart";
     const INSTRUCTION: &'static str = "INST - TryStart";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let next = context.vm.read::<u32>();
         let finally = context.vm.read::<u32>();
         let finally = if finally == 0 { None } else { Some(finally) };
@@ -44,7 +44,7 @@ impl Operation for TryEnd {
     const NAME: &'static str = "TryEnd";
     const INSTRUCTION: &'static str = "INST - TryEnd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.vm.frame_mut().catch.pop();
         let try_stack_entry = context
             .vm
@@ -86,7 +86,7 @@ impl Operation for CatchStart {
     const NAME: &'static str = "CatchStart";
     const INSTRUCTION: &'static str = "INST - CatchStart";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let finally = context.vm.read::<u32>();
         context.vm.frame_mut().catch.push(CatchAddresses {
             next: finally,
@@ -112,7 +112,7 @@ impl Operation for CatchEnd {
     const NAME: &'static str = "CatchEnd";
     const INSTRUCTION: &'static str = "INST - CatchEnd";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         context.vm.frame_mut().catch.pop();
         let try_stack_entry = context
             .vm
@@ -154,7 +154,7 @@ impl Operation for CatchEnd2 {
     const NAME: &'static str = "CatchEnd2";
     const INSTRUCTION: &'static str = "INST - CatchEnd2";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let frame = context.vm.frame_mut();
         if frame.finally_return == FinallyReturn::Err {
             frame.finally_return = FinallyReturn::None;

--- a/boa_engine/src/vm/opcode/unary_ops/decrement.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/decrement.rs
@@ -15,7 +15,7 @@ impl Operation for Dec {
     const NAME: &'static str = "Dec";
     const INSTRUCTION: &'static str = "INST - Dec";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         match value.to_numeric(context)? {
             Numeric::Number(number) => context.vm.push(number - 1f64),
@@ -38,7 +38,7 @@ impl Operation for DecPost {
     const NAME: &'static str = "DecPost";
     const INSTRUCTION: &'static str = "INST - DecPost";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let value = value.to_numeric(context)?;
         match value {

--- a/boa_engine/src/vm/opcode/unary_ops/increment.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/increment.rs
@@ -15,7 +15,7 @@ impl Operation for Inc {
     const NAME: &'static str = "Inc";
     const INSTRUCTION: &'static str = "INST - Inc";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         match value.to_numeric(context)? {
             Numeric::Number(number) => context.vm.push(number + 1f64),
@@ -38,7 +38,7 @@ impl Operation for IncPost {
     const NAME: &'static str = "IncPost";
     const INSTRUCTION: &'static str = "INST - IncPost";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let value = value.to_numeric(context)?;
         match value {

--- a/boa_engine/src/vm/opcode/unary_ops/logical.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/logical.rs
@@ -14,7 +14,7 @@ impl Operation for LogicalNot {
     const NAME: &'static str = "LogicalNot";
     const INSTRUCTION: &'static str = "INST - LogicalNot";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         context.vm.push(!value.to_boolean());
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/unary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/mod.rs
@@ -27,7 +27,7 @@ impl Operation for TypeOf {
     const NAME: &'static str = "TypeOf";
     const INSTRUCTION: &'static str = "INST - TypeOf";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         context.vm.push(value.type_of());
         Ok(ShouldExit::False)
@@ -45,7 +45,7 @@ impl Operation for Pos {
     const NAME: &'static str = "Pos";
     const INSTRUCTION: &'static str = "INST - Pos";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         let value = value.to_number(context)?;
         context.vm.push(value);
@@ -64,7 +64,7 @@ impl Operation for Neg {
     const NAME: &'static str = "Neg";
     const INSTRUCTION: &'static str = "INST - Neg";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         match value.to_numeric(context)? {
             Numeric::Number(number) => context.vm.push(number.neg()),
@@ -85,7 +85,7 @@ impl Operation for BitNot {
     const NAME: &'static str = "BitNot";
     const INSTRUCTION: &'static str = "INST - BitNot";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         match value.to_numeric(context)? {
             Numeric::Number(number) => context.vm.push(Number::not(number)),

--- a/boa_engine/src/vm/opcode/unary_ops/void.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/void.rs
@@ -14,7 +14,7 @@ impl Operation for Void {
     const NAME: &'static str = "Void";
     const INSTRUCTION: &'static str = "INST - Void";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let _old = context.vm.pop();
         context.vm.push(JsValue::undefined());
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/value/mod.rs
+++ b/boa_engine/src/vm/opcode/value/mod.rs
@@ -15,7 +15,7 @@ impl Operation for ValueNotNullOrUndefined {
     const NAME: &'static str = "ValueNotNullOrUndefined";
     const INSTRUCTION: &'static str = "INST - ValueNotNullOrUndefined";
 
-    fn execute(context: &mut Context) -> JsResult<ShouldExit> {
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let value = context.vm.pop();
         if value.is_null() {
             return Err(JsNativeError::typ()

--- a/boa_examples/src/bin/classes.rs
+++ b/boa_examples/src/bin/classes.rs
@@ -30,7 +30,7 @@ struct Person {
 // or any function that matches the required signature.
 impl Person {
     /// Says hello if `this` is a `Person`
-    fn say_hello(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn say_hello(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
         // We check if this is an object.
         if let Some(object) = this.as_object() {
             // If it is we downcast the type to type `Person`.
@@ -63,7 +63,7 @@ impl Class for Person {
     const LENGTH: usize = 2;
 
     // This is what is called when we construct a `Person` with the expression `new Person()`.
-    fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<Self> {
+    fn constructor(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<Self> {
         // We get the first argument. If it is unavailable we default to `undefined`,
         // and then we call `to_string()`.
         //

--- a/boa_examples/src/bin/modulehandler.rs
+++ b/boa_examples/src/bin/modulehandler.rs
@@ -32,7 +32,7 @@ fn main() {
 }
 
 // Custom implementation that mimics the 'require' module loader
-fn require(_: &JsValue, args: &[JsValue], ctx: &mut Context) -> JsResult<JsValue> {
+fn require(_: &JsValue, args: &[JsValue], ctx: &mut Context<'_>) -> JsResult<JsValue> {
     let arg = args.get(0).unwrap();
 
     // BUG: Dev branch seems to be passing string arguments along with quotes

--- a/boa_icu_provider/Cargo.toml
+++ b/boa_icu_provider/Cargo.toml
@@ -15,9 +15,11 @@ rust-version.workspace = true
 [dependencies]
 icu_provider = { version = "1.0.1", features = ["serde", "sync"] }
 icu_provider_blob = "1.0.0"
+icu_provider_adapters = { version = "1.0.0", features = ["serde"]}
 icu_datagen = { version = "1.0.2", optional = true }
 log = { version = "0.4.17", optional = true }
 simple_logger = { version = "4.0.0", optional = true }
+once_cell = "1.16.0"
 
 [features]
 bin = ["dep:icu_datagen", "dep:simple_logger", "dep:log"]

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -1,7 +1,7 @@
 //! Boa's **`boa_icu_provider`** exports the default data provider used by its `Intl` implementation.
 //!
 //! # Crate Overview
-//! This crate exports the function [`blob`], which contains an extensive dataset of locale data to
+//! This crate exports the function [`buffer`], which contains an extensive dataset of locale data to
 //! enable `Intl` functionality in the engine. The set of locales included is precisely the ["modern"]
 //! subset of locales in the [Unicode Common Locale Data Repository][cldr].
 //!

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -72,13 +72,14 @@ pub fn data_root() -> std::path::PathBuf {
     std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR")).join("data")
 }
 
+use icu_provider::BufferProvider;
 use icu_provider_adapters::fallback::LocaleFallbackProvider;
 use icu_provider_blob::BlobDataProvider;
 use once_cell::sync::Lazy;
 
-/// Gets a data provider that is stored as a static Postcard blob.
+/// Gets a data provider that is stored as a [`BufferProvider`]
 #[must_use]
-pub fn blob() -> &'static LocaleFallbackProvider<BlobDataProvider> {
+pub fn buffer() -> &'static impl BufferProvider {
     static PROVIDER: Lazy<LocaleFallbackProvider<BlobDataProvider>> = Lazy::new(|| {
         let blob = BlobDataProvider::try_new_from_static_blob(include_bytes!(concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -89,5 +90,5 @@ pub fn blob() -> &'static LocaleFallbackProvider<BlobDataProvider> {
             .expect("The statically compiled data file should be valid.")
     });
 
-    &PROVIDER
+    &*PROVIDER
 }

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 boa_engine.workspace = true 
 boa_gc.workspace = true
 boa_parser.workspace = true
-boa_icu_provider = { workspace = true, optional = true }
 clap = { version = "4.0.32", features = ["derive"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.16"
@@ -31,4 +30,4 @@ color-eyre = "0.6.2"
 
 [features]
 default = ["intl"]
-intl = ["boa_engine/intl", "dep:boa_icu_provider"]
+intl = ["boa_engine/intl"]

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -12,12 +12,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["intl"] }
+boa_engine.workspace = true 
 boa_gc.workspace = true
 boa_parser.workspace = true
-boa_icu_provider.workspace = true
-icu_provider_adapters = { version = "1.0.0", features = ["serde"]}
-icu_provider_blob = "1.0.0"
+boa_icu_provider = { workspace = true, optional = true }
 clap = { version = "4.0.32", features = ["derive"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.16"
@@ -30,3 +28,7 @@ fxhash = "0.2.1"
 rayon = "1.6.1"
 toml = "0.5.10"
 color-eyre = "0.6.2"
+
+[features]
+default = ["intl"]
+intl = ["boa_engine/intl", "dep:boa_icu_provider"]

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -6,7 +6,7 @@ use boa_engine::{
 };
 
 /// Initializes the object in the context.
-pub(super) fn init(context: &mut Context) -> JsObject {
+pub(super) fn init(context: &mut Context<'_>) -> JsObject {
     let global_obj = context.global_object().clone();
 
     let obj = ObjectInitializer::new(context)
@@ -28,7 +28,7 @@ pub(super) fn init(context: &mut Context) -> JsObject {
 /// Creates a new ECMAScript Realm, defines this API on the new realm's global object, and
 /// returns the `$262` property of the new realm's global object.
 #[allow(clippy::unnecessary_wraps)]
-fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
+fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context<'_>) -> JsResult<JsValue> {
     let mut context = Context::default();
 
     // add the $262 object.
@@ -40,7 +40,11 @@ fn create_realm(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsRes
 /// The `$262.detachArrayBuffer()` function.
 ///
 /// Implements the `DetachArrayBuffer` abstract operation.
-fn detach_array_buffer(_this: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+fn detach_array_buffer(
+    _this: &JsValue,
+    args: &[JsValue],
+    _: &mut Context<'_>,
+) -> JsResult<JsValue> {
     fn type_err() -> JsNativeError {
         JsNativeError::typ().with_message("The provided object was not an ArrayBuffer")
     }
@@ -76,7 +80,7 @@ fn detach_array_buffer(_this: &JsValue, args: &[JsValue], _: &mut Context) -> Js
 /// The `$262.evalScript()` function.
 ///
 /// Accepts a string value as its first argument and executes it as an ECMAScript script.
-fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
     args.get(0).and_then(JsValue::as_string).map_or_else(
         || Ok(JsValue::undefined()),
         |source_text| match context.parse(source_text.to_std_string_escaped()) {
@@ -97,7 +101,7 @@ fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context) -> JsRe
 /// Must throw an exception if no capability exists. This is necessary for testing the
 /// semantics of any feature that relies on garbage collection, e.g. the `WeakRef` API.
 #[allow(clippy::unnecessary_wraps)]
-fn gc(_this: &JsValue, _: &[JsValue], _context: &mut Context) -> JsResult<JsValue> {
+fn gc(_this: &JsValue, _: &[JsValue], _context: &mut Context<'_>) -> JsResult<JsValue> {
     boa_gc::force_collect();
     Ok(JsValue::undefined())
 }

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -170,7 +170,7 @@ impl Test {
                     #[cfg(feature = "intl")]
                     {
                         ContextBuilder::default()
-                            .icu_provider(BoaProvider::Buffer(boa_icu_provider::blob()))
+                            .icu_provider(BoaProvider::Buffer(boa_icu_provider::buffer()))
                             .expect("default locale data should be valid")
                             .build()
                     }

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -16,9 +16,6 @@ use colored::Colorize;
 use rayon::prelude::*;
 use std::borrow::Cow;
 
-#[cfg(feature = "intl")]
-use boa_engine::context::{BoaProvider, ContextBuilder};
-
 impl TestSuite {
     /// Runs the test suite.
     pub(crate) fn run(&self, harness: &Harness, verbose: u8, parallel: bool) -> SuiteResult {
@@ -166,19 +163,7 @@ impl Test {
 
         let result = std::panic::catch_unwind(|| match self.expected_outcome {
             Outcome::Positive => {
-                let mut context = {
-                    #[cfg(feature = "intl")]
-                    {
-                        ContextBuilder::default()
-                            .icu_provider(BoaProvider::Buffer(boa_icu_provider::buffer()))
-                            .expect("default locale data should be valid")
-                            .build()
-                    }
-                    #[cfg(not(feature = "intl"))]
-                    {
-                        Context::default()
-                    }
-                };
+                let mut context = Context::default();
                 let async_result = AsyncResult::default();
 
                 if let Err(e) = self.set_up_env(harness, &mut context, async_result.clone()) {

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -7,20 +7,17 @@ use super::{
 };
 use crate::read::ErrorType;
 use boa_engine::{
-    builtins::JsArgs,
-    context::{BoaProvider, ContextBuilder},
-    object::FunctionBuilder,
-    property::Attribute,
-    Context, JsNativeErrorKind, JsResult, JsValue,
+    builtins::JsArgs, object::FunctionBuilder, property::Attribute, Context, JsNativeErrorKind,
+    JsResult, JsValue,
 };
 use boa_gc::{Finalize, Gc, GcCell, Trace};
 use boa_parser::Parser;
 use colored::Colorize;
-use icu_provider_adapters::fallback::LocaleFallbackProvider;
-use icu_provider_blob::BlobDataProvider;
-use once_cell::sync::Lazy;
 use rayon::prelude::*;
 use std::borrow::Cow;
+
+#[cfg(feature = "intl")]
+use boa_engine::context::{BoaProvider, ContextBuilder};
 
 impl TestSuite {
     /// Runs the test suite.
@@ -135,7 +132,6 @@ impl Test {
 
     /// Runs the test once, in strict or non-strict mode
     fn run_once(&self, harness: &Harness, strict: bool, verbose: u8) -> TestResult {
-        static LOCALE_DATA: Lazy<BlobDataProvider> = Lazy::new(boa_icu_provider::blob);
         if self.ignored {
             if verbose > 1 {
                 println!(
@@ -170,13 +166,19 @@ impl Test {
 
         let result = std::panic::catch_unwind(|| match self.expected_outcome {
             Outcome::Positive => {
-                let mut context = ContextBuilder::default()
-                    .icu_provider(BoaProvider::Buffer(Box::new(
-                        LocaleFallbackProvider::try_new_with_buffer_provider(LOCALE_DATA.clone())
-                            .expect("default locale data should be valid"),
-                    )))
-                    .expect("default locale data should be valid")
-                    .build();
+                let mut context = {
+                    #[cfg(feature = "intl")]
+                    {
+                        ContextBuilder::default()
+                            .icu_provider(BoaProvider::Buffer(boa_icu_provider::blob()))
+                            .expect("default locale data should be valid")
+                            .build()
+                    }
+                    #[cfg(not(feature = "intl"))]
+                    {
+                        Context::default()
+                    }
+                };
                 let async_result = AsyncResult::default();
 
                 if let Err(e) = self.set_up_env(harness, &mut context, async_result.clone()) {
@@ -329,7 +331,7 @@ impl Test {
     fn set_up_env(
         &self,
         harness: &Harness,
-        context: &mut Context,
+        context: &mut Context<'_>,
         async_result: AsyncResult,
     ) -> Result<(), String> {
         // Register the print() function.
@@ -371,7 +373,7 @@ impl Test {
     }
 
     /// Registers the print function in the context.
-    fn register_print_fn(context: &mut Context, async_result: AsyncResult) {
+    fn register_print_fn(context: &mut Context<'_>, async_result: AsyncResult) {
         // We use `FunctionBuilder` to define a closure with additional captures.
         let js_function =
             FunctionBuilder::closure_with_captures(context, test262_print, async_result)
@@ -407,7 +409,7 @@ fn test262_print(
     _this: &JsValue,
     args: &[JsValue],
     async_result: &mut AsyncResult,
-    context: &mut Context,
+    context: &mut Context<'_>,
 ) -> JsResult<JsValue> {
     let message = args
         .get_or_undefined(0)


### PR DESCRIPTION
This change is actually pretty simple, but since now we have to pass a lifetime parameter to all references of `Context`, it touches a lot of files.

Relevant changes:

- https://github.com/boa-dev/boa/pull/2508/files#diff-73e17259d77e5fbef83b2bdbbe4dc40a912f807472287f7f45b77e0cbf78792d

- https://github.com/boa-dev/boa/pull/2508/files#diff-e7ebcd61f7a01c432b62e1742a6cfd8e28326a1f2b6afb37ba66d4964b3db521

- https://github.com/boa-dev/boa/pull/2508/files#diff-7b2a85f5aa9b5a8070e04e87a67b4f7cc700a43a520e0d6cc6e0b701711ccb7c

- https://github.com/boa-dev/boa/pull/2508/files#diff-872037c107c01bf644ede412e4802b3eefeb5a70ce595c441f75651d45111b2a

- https://github.com/boa-dev/boa/pull/2508/files#diff-a665b3b6f564521875fd0d725bffbc4f0cc84e5feefdc5fd875fd943e56311cd

- https://github.com/boa-dev/boa/pull/2508/files#diff-3e1f19581f227120ddc3334fd0450152b767811c9b6cb4048581347fcd9fc91d

- https://github.com/boa-dev/boa/pull/2508/files#diff-5fe65193a910618375d9575d918cd584430437ee2738a987c92068dea3117297

- https://github.com/boa-dev/boa/pull/2508/files#diff-4ce8770f8aaf50785ece12a9a15b781a544bfc47f080e2ff62ddfb18264a44ef

All the other changes are just replacing `Context` with `Context<'_>`.