### PR TITLE
[Merged by Bors] - Refactor some class features

### DIFF
--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -216,6 +216,27 @@ impl Expression {
                 | Self::Class(_)
         )
     }
+
+    /// Returns if the expression is a function definition without a name.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-isanonymousfunctiondefinition
+    #[must_use]
+    #[inline]
+    pub const fn is_anonymous_function_definition(&self) -> bool {
+        match self {
+            Self::ArrowFunction(f) => f.name().is_none(),
+            Self::AsyncArrowFunction(f) => f.name().is_none(),
+            Self::Function(f) => f.name().is_none(),
+            Self::Generator(f) => f.name().is_none(),
+            Self::AsyncGenerator(f) => f.name().is_none(),
+            Self::AsyncFunction(f) => f.name().is_none(),
+            Self::Class(f) => f.name().is_none(),
+            _ => false,
+        }
+    }
 }
 
 impl From<Expression> for Statement {

--- a/boa_ast/src/function/mod.rs
+++ b/boa_ast/src/function/mod.rs
@@ -33,7 +33,7 @@ pub use arrow_function::ArrowFunction;
 pub use async_arrow_function::AsyncArrowFunction;
 pub use async_function::AsyncFunction;
 pub use async_generator::AsyncGenerator;
-pub use class::{Class, ClassElement};
+pub use class::{Class, ClassElement, PrivateName};
 use core::ops::ControlFlow;
 pub use generator::Generator;
 pub use parameters::{FormalParameter, FormalParameterList, FormalParameterListFlags};

--- a/boa_ast/src/position.rs
+++ b/boa_ast/src/position.rs
@@ -7,7 +7,7 @@ use std::{cmp::Ordering, fmt, num::NonZeroU32};
 /// ## Similar Implementations
 /// [V8: Location](https://cs.chromium.org/chromium/src/v8/src/parsing/scanner.h?type=cs&q=isValid+Location&g=0&l=216)
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Position {
     /// Line number.
     line_number: NonZeroU32,
@@ -55,7 +55,7 @@ impl fmt::Display for Position {
 /// Note that spans are of the form [start, end) i.e. that the start position is inclusive
 /// and the end position is exclusive.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Span {
     start: Position,
     end: Position,

--- a/boa_ast/src/property.rs
+++ b/boa_ast/src/property.rs
@@ -1,5 +1,6 @@
 //! Property definition related types, used in object literals and class definitions.
 
+use crate::function::PrivateName;
 use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use boa_interner::{Interner, Sym, ToInternedString};
@@ -354,7 +355,7 @@ pub enum ClassElementName {
     /// A public property.
     PropertyName(PropertyName),
     /// A private property.
-    PrivateIdentifier(Sym),
+    PrivateIdentifier(PrivateName),
 }
 
 impl ClassElementName {

--- a/boa_ast/src/visitor.rs
+++ b/boa_ast/src/visitor.rs
@@ -24,7 +24,7 @@ use crate::{
     },
     function::{
         ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class, ClassElement,
-        FormalParameter, FormalParameterList, Function, Generator,
+        FormalParameter, FormalParameterList, Function, Generator, PrivateName,
     },
     pattern::{ArrayPattern, ArrayPatternElement, ObjectPattern, ObjectPatternElement, Pattern},
     property::{MethodDefinition, PropertyDefinition, PropertyName},
@@ -145,6 +145,7 @@ node_ref! {
     Identifier,
     FormalParameterList,
     ClassElement,
+    PrivateName,
     VariableList,
     Variable,
     Binding,
@@ -230,6 +231,7 @@ pub trait Visitor<'ast>: Sized {
     define_visit!(visit_identifier, Identifier);
     define_visit!(visit_formal_parameter_list, FormalParameterList);
     define_visit!(visit_class_element, ClassElement);
+    define_visit!(visit_private_name, PrivateName);
     define_visit!(visit_variable_list, VariableList);
     define_visit!(visit_variable, Variable);
     define_visit!(visit_binding, Binding);
@@ -312,6 +314,7 @@ pub trait Visitor<'ast>: Sized {
             NodeRef::Identifier(n) => self.visit_identifier(n),
             NodeRef::FormalParameterList(n) => self.visit_formal_parameter_list(n),
             NodeRef::ClassElement(n) => self.visit_class_element(n),
+            NodeRef::PrivateName(n) => self.visit_private_name(n),
             NodeRef::VariableList(n) => self.visit_variable_list(n),
             NodeRef::Variable(n) => self.visit_variable(n),
             NodeRef::Binding(n) => self.visit_binding(n),
@@ -399,6 +402,7 @@ pub trait VisitorMut<'ast>: Sized {
     define_visit_mut!(visit_identifier_mut, Identifier);
     define_visit_mut!(visit_formal_parameter_list_mut, FormalParameterList);
     define_visit_mut!(visit_class_element_mut, ClassElement);
+    define_visit_mut!(visit_private_name_mut, PrivateName);
     define_visit_mut!(visit_variable_list_mut, VariableList);
     define_visit_mut!(visit_variable_mut, Variable);
     define_visit_mut!(visit_binding_mut, Binding);
@@ -481,6 +485,7 @@ pub trait VisitorMut<'ast>: Sized {
             NodeRefMut::Identifier(n) => self.visit_identifier_mut(n),
             NodeRefMut::FormalParameterList(n) => self.visit_formal_parameter_list_mut(n),
             NodeRefMut::ClassElement(n) => self.visit_class_element_mut(n),
+            NodeRefMut::PrivateName(n) => self.visit_private_name_mut(n),
             NodeRefMut::VariableList(n) => self.visit_variable_list_mut(n),
             NodeRefMut::Variable(n) => self.visit_variable_mut(n),
             NodeRefMut::Binding(n) => self.visit_binding_mut(n),

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -154,18 +154,20 @@ impl Eval {
                     flags |= Flags::IN_METHOD;
                 }
 
-                // iv. If F.[[ConstructorKind]] is derived, set inDerivedConstructor to true.
-                if function_object
+                let function_object = function_object
                     .as_function()
-                    .expect("must be function object")
-                    .is_derived_constructor()
-                {
+                    .expect("must be function object");
+
+                // iv. If F.[[ConstructorKind]] is derived, set inDerivedConstructor to true.
+                if function_object.is_derived_constructor() {
                     flags |= Flags::IN_DERIVED_CONSTRUCTOR;
                 }
 
-                // TODO:
                 // v. Let classFieldInitializerName be F.[[ClassFieldInitializerName]].
                 // vi. If classFieldInitializerName is not empty, set inClassFieldInitializer to true.
+                if function_object.class_field_initializer_name().is_some() {
+                    flags |= Flags::IN_CLASS_FIELD_INITIALIZER;
+                }
 
                 flags
             }

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -23,21 +23,29 @@ impl ByteCompiler<'_, '_> {
     /// A class declaration binds the resulting class object to it's identifier.
     /// A class expression leaves the resulting class object on the stack for following operations.
     pub(crate) fn compile_class(&mut self, class: &Class, expression: bool) -> JsResult<()> {
-        let code = CodeBlock::new(
-            class.name().map_or(Sym::EMPTY_STRING, Identifier::sym),
-            0,
-            true,
-        );
+        let class_name = class.name().map_or(Sym::EMPTY_STRING, Identifier::sym);
+
+        let code = CodeBlock::new(class_name, 0, true);
         let mut compiler = ByteCompiler {
             code_block: code,
             literals_map: FxHashMap::default(),
             names_map: FxHashMap::default(),
+            private_names_map: FxHashMap::default(),
             bindings_map: FxHashMap::default(),
             jump_info: Vec::new(),
             in_async_generator: false,
             json_parse: self.json_parse,
             context: self.context,
         };
+
+        if let Some(class_name) = class.name() {
+            if class.has_binding_identifier() {
+                compiler.code_block.has_binding_identifier = true;
+                compiler.context.push_compile_time_environment(false);
+                compiler.context.create_immutable_binding(class_name, true);
+            }
+        }
+
         compiler.context.push_compile_time_environment(true);
 
         if let Some(expr) = class.constructor() {
@@ -118,6 +126,11 @@ impl ByteCompiler<'_, '_> {
             compiler.code_block.is_class_constructor = true;
         }
 
+        if class.name().is_some() && class.has_binding_identifier() {
+            let (_, compile_environment) = compiler.context.pop_compile_time_environment();
+            compiler.push_compile_environment(compile_environment);
+        }
+
         compiler.emit_opcode(Opcode::PushUndefined);
         compiler.emit_opcode(Opcode::Return);
 
@@ -141,83 +154,83 @@ impl ByteCompiler<'_, '_> {
             match element {
                 ClassElement::StaticMethodDefinition(name, method_definition) => {
                     self.emit_opcode(Opcode::Dup);
-                    match &method_definition {
+                    match method_definition {
                         MethodDefinition::Get(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassGetterByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticGetterByName, &[index]);
                             }
-                            PropertyName::Computed(ref name_node) => {
+                            PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassGetterByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticGetterByValue);
                             }
                         },
                         MethodDefinition::Set(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassSetterByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticSetterByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassSetterByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticSetterByValue);
                             }
                         },
                         MethodDefinition::Ordinary(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassMethodByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticMethodByValue);
                             }
                         },
                         MethodDefinition::Async(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassMethodByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticMethodByValue);
                             }
                         },
                         MethodDefinition::Generator(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassMethodByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticMethodByValue);
                             }
                         },
                         MethodDefinition::AsyncGenerator(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
-                                self.emit_opcode(Opcode::DefineClassMethodByValue);
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                                self.emit_opcode(Opcode::DefineClassStaticMethodByValue);
                             }
                         },
                     }
@@ -225,35 +238,35 @@ impl ByteCompiler<'_, '_> {
                 // TODO: set names for private methods
                 ClassElement::PrivateStaticMethodDefinition(name, method_definition) => {
                     self.emit_opcode(Opcode::Dup);
-                    match &method_definition {
+                    match method_definition {
                         MethodDefinition::Get(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateGetter, &[index]);
                         }
                         MethodDefinition::Set(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateSetter, &[index]);
                         }
                         MethodDefinition::Ordinary(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateMethod, &[index]);
                         }
                         MethodDefinition::Async(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateMethod, &[index]);
                         }
                         MethodDefinition::Generator(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateMethod, &[index]);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::SetPrivateMethod, &[index]);
                         }
                     }
@@ -275,12 +288,17 @@ impl ByteCompiler<'_, '_> {
                         code_block: field_code,
                         literals_map: FxHashMap::default(),
                         names_map: FxHashMap::default(),
+                        private_names_map: FxHashMap::default(),
                         bindings_map: FxHashMap::default(),
                         jump_info: Vec::new(),
                         in_async_generator: false,
                         json_parse: self.json_parse,
                         context: self.context,
                     };
+                    field_compiler.context.push_compile_time_environment(false);
+                    field_compiler
+                        .context
+                        .create_immutable_binding(class_name.into(), true);
                     field_compiler.context.push_compile_time_environment(true);
                     if let Some(node) = field {
                         field_compiler.compile_expr(node, true)?;
@@ -290,10 +308,15 @@ impl ByteCompiler<'_, '_> {
                     let (num_bindings, compile_environment) =
                         field_compiler.context.pop_compile_time_environment();
                     field_compiler.push_compile_environment(compile_environment);
+                    let (_, compile_environment) =
+                        field_compiler.context.pop_compile_time_environment();
+                    field_compiler.push_compile_environment(compile_environment);
                     field_compiler.code_block.num_bindings = num_bindings;
                     field_compiler.emit_opcode(Opcode::Return);
 
-                    let code = Gc::new(field_compiler.finish());
+                    let mut code = field_compiler.finish();
+                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    let code = Gc::new(code);
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
@@ -301,18 +324,23 @@ impl ByteCompiler<'_, '_> {
                 }
                 ClassElement::PrivateFieldDefinition(name, field) => {
                     self.emit_opcode(Opcode::Dup);
-                    let name_index = self.get_or_insert_name((*name).into());
+                    let name_index = self.get_or_insert_private_name(*name);
                     let field_code = CodeBlock::new(Sym::EMPTY_STRING, 0, true);
                     let mut field_compiler = ByteCompiler {
                         code_block: field_code,
                         literals_map: FxHashMap::default(),
                         names_map: FxHashMap::default(),
+                        private_names_map: FxHashMap::default(),
                         bindings_map: FxHashMap::default(),
                         jump_info: Vec::new(),
                         in_async_generator: false,
                         json_parse: self.json_parse,
                         context: self.context,
                     };
+                    field_compiler.context.push_compile_time_environment(false);
+                    field_compiler
+                        .context
+                        .create_immutable_binding(class_name.into(), true);
                     field_compiler.context.push_compile_time_environment(true);
                     if let Some(node) = field {
                         field_compiler.compile_expr(node, true)?;
@@ -322,10 +350,15 @@ impl ByteCompiler<'_, '_> {
                     let (num_bindings, compile_environment) =
                         field_compiler.context.pop_compile_time_environment();
                     field_compiler.push_compile_environment(compile_environment);
+                    let (_, compile_environment) =
+                        field_compiler.context.pop_compile_time_environment();
+                    field_compiler.push_compile_environment(compile_environment);
                     field_compiler.code_block.num_bindings = num_bindings;
                     field_compiler.emit_opcode(Opcode::Return);
 
-                    let code = Gc::new(field_compiler.finish());
+                    let mut code = field_compiler.finish();
+                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    let code = Gc::new(code);
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
@@ -333,26 +366,60 @@ impl ByteCompiler<'_, '_> {
                 }
                 ClassElement::StaticFieldDefinition(name, field) => {
                     self.emit_opcode(Opcode::Dup);
-                    match name {
+                    self.emit_opcode(Opcode::Dup);
+                    let name_index = match name {
                         PropertyName::Literal(name) => {
-                            if let Some(node) = field {
-                                self.compile_expr(node, true)?;
-                            } else {
-                                self.emit_opcode(Opcode::PushUndefined);
-                            }
-                            let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::DefineOwnPropertyByName, &[index]);
+                            Some(self.get_or_insert_name((*name).into()))
                         }
-                        PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
-                            self.emit_opcode(Opcode::ToPropertyKey);
-                            if let Some(node) = field {
-                                self.compile_expr(node, true)?;
-                            } else {
-                                self.emit_opcode(Opcode::PushUndefined);
-                            }
-                            self.emit_opcode(Opcode::DefineOwnPropertyByValue);
+                        PropertyName::Computed(name) => {
+                            self.compile_expr(name, true)?;
+                            self.emit_opcode(Opcode::Swap);
+                            None
                         }
+                    };
+                    let field_code = CodeBlock::new(Sym::EMPTY_STRING, 0, true);
+                    let mut field_compiler = ByteCompiler {
+                        code_block: field_code,
+                        literals_map: FxHashMap::default(),
+                        names_map: FxHashMap::default(),
+                        private_names_map: FxHashMap::default(),
+                        bindings_map: FxHashMap::default(),
+                        jump_info: Vec::new(),
+                        in_async_generator: false,
+                        json_parse: self.json_parse,
+                        context: self.context,
+                    };
+                    field_compiler.context.push_compile_time_environment(false);
+                    field_compiler
+                        .context
+                        .create_immutable_binding(class_name.into(), true);
+                    field_compiler.context.push_compile_time_environment(true);
+                    if let Some(node) = field {
+                        field_compiler.compile_expr(node, true)?;
+                    } else {
+                        field_compiler.emit_opcode(Opcode::PushUndefined);
+                    }
+                    let (num_bindings, compile_environment) =
+                        field_compiler.context.pop_compile_time_environment();
+                    field_compiler.push_compile_environment(compile_environment);
+                    let (_, compile_environment) =
+                        field_compiler.context.pop_compile_time_environment();
+                    field_compiler.push_compile_environment(compile_environment);
+                    field_compiler.code_block.num_bindings = num_bindings;
+                    field_compiler.emit_opcode(Opcode::Return);
+
+                    let mut code = field_compiler.finish();
+                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    let code = Gc::new(code);
+                    let index = self.code_block.functions.len() as u32;
+                    self.code_block.functions.push(code);
+                    self.emit(Opcode::GetFunction, &[index]);
+                    self.emit_opcode(Opcode::SetHomeObject);
+                    self.emit(Opcode::Call, &[0]);
+                    if let Some(name_index) = name_index {
+                        self.emit(Opcode::DefineOwnPropertyByName, &[name_index]);
+                    } else {
+                        self.emit_opcode(Opcode::DefineOwnPropertyByValue);
                     }
                 }
                 ClassElement::PrivateStaticFieldDefinition(name, field) => {
@@ -362,18 +429,24 @@ impl ByteCompiler<'_, '_> {
                     } else {
                         self.emit_opcode(Opcode::PushUndefined);
                     }
-                    let index = self.get_or_insert_name((*name).into());
+                    let index = self.get_or_insert_private_name(*name);
                     self.emit(Opcode::SetPrivateField, &[index]);
                 }
                 ClassElement::StaticBlock(statement_list) => {
                     self.emit_opcode(Opcode::Dup);
                     let mut compiler =
                         ByteCompiler::new(Sym::EMPTY_STRING, true, false, self.context);
+                    compiler.context.push_compile_time_environment(false);
+                    compiler
+                        .context
+                        .create_immutable_binding(class_name.into(), true);
                     compiler.context.push_compile_time_environment(true);
                     compiler.create_decls(statement_list, false);
                     compiler.compile_statement_list(statement_list, false, false)?;
                     let (num_bindings, compile_environment) =
                         compiler.context.pop_compile_time_environment();
+                    compiler.push_compile_environment(compile_environment);
+                    let (_, compile_environment) = compiler.context.pop_compile_time_environment();
                     compiler.push_compile_environment(compile_environment);
                     compiler.code_block.num_bindings = num_bindings;
 
@@ -390,33 +463,33 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::Dup);
                     match method_definition {
                         MethodDefinition::Get(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateGetter, &[index]);
                         }
                         MethodDefinition::Set(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateSetter, &[index]);
                         }
                         MethodDefinition::Ordinary(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateMethod, &[index]);
                         }
                         MethodDefinition::Async(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateMethod, &[index]);
                         }
                         MethodDefinition::Generator(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateMethod, &[index]);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
-                            let index = self.get_or_insert_name((*name).into());
+                            self.method(expr.into(), NodeKind::Expression, class_name, true)?;
+                            let index = self.get_or_insert_private_name(*name);
                             self.emit(Opcode::PushClassPrivateMethod, &[index]);
                         }
                     }
@@ -435,79 +508,79 @@ impl ByteCompiler<'_, '_> {
                     match method_definition {
                         MethodDefinition::Get(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassGetterByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassGetterByValue);
                             }
                         },
                         MethodDefinition::Set(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassSetterByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassSetterByValue);
                             }
                         },
                         MethodDefinition::Ordinary(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassMethodByValue);
                             }
                         },
                         MethodDefinition::Async(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassMethodByValue);
                             }
                         },
                         MethodDefinition::Generator(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassMethodByValue);
                             }
                         },
                         MethodDefinition::AsyncGenerator(expr) => match name {
                             PropertyName::Literal(name) => {
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 let index = self.get_or_insert_name((*name).into());
                                 self.emit(Opcode::DefineClassMethodByName, &[index]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true)?;
                                 self.emit_opcode(Opcode::ToPropertyKey);
-                                self.function(expr.into(), NodeKind::Expression, true)?;
+                                self.method(expr.into(), NodeKind::Expression, class_name, true)?;
                                 self.emit_opcode(Opcode::DefineClassMethodByValue);
                             }
                         },

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -430,7 +430,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::PushUndefined);
                     }
                     let index = self.get_or_insert_private_name(*name);
-                    self.emit(Opcode::SetPrivateField, &[index]);
+                    self.emit(Opcode::DefinePrivateField, &[index]);
                 }
                 ClassElement::StaticBlock(statement_list) => {
                     self.emit_opcode(Opcode::Dup);

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -217,7 +217,7 @@ impl ByteCompiler<'_, '_> {
                     Expression::PropertyAccess(PropertyAccess::Private(access)) => {
                         self.compile_expr(access.target(), true)?;
                         self.emit(Opcode::Dup, &[]);
-                        let index = self.get_or_insert_name(access.field().into());
+                        let index = self.get_or_insert_private_name(access.field());
                         self.emit(Opcode::GetPrivateField, &[index]);
                     }
                     expr => {
@@ -238,6 +238,7 @@ impl ByteCompiler<'_, '_> {
                     }
                     self.emit_opcode(Opcode::PushValueToArray);
                 }
+                self.emit_opcode(Opcode::Dup);
                 self.emit_opcode(Opcode::Dup);
 
                 self.emit_opcode(Opcode::PushNewArray);
@@ -310,7 +311,6 @@ impl ByteCompiler<'_, '_> {
             // TODO: try to remove this variant somehow
             Expression::FormalParameterList(_) => unreachable!(),
         }
-
         Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -37,7 +37,7 @@ impl ByteCompiler<'_, '_> {
                     PropertyName::Computed(name_node) => {
                         self.compile_expr(name_node, true)?;
                         self.emit_opcode(Opcode::ToPropertyKey);
-                        if expr.is_function_definition() {
+                        if expr.is_anonymous_function_definition() {
                             self.emit_opcode(Opcode::Dup);
                             self.compile_expr(expr, true)?;
                             self.emit_opcode(Opcode::SetFunctionName);

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -586,7 +586,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
                     self.compile_expr(access.target(), true)?;
                     let result = expr_fn(self, 1);
                     let index = self.get_or_insert_private_name(access.field());
-                    self.emit(Opcode::AssignPrivateField, &[index]);
+                    self.emit(Opcode::SetPrivateField, &[index]);
                     if !use_expr {
                         self.emit(Opcode::Pop, &[]);
                     }

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -21,7 +21,7 @@ use boa_ast::{
     },
     function::{
         ArrowFunction, AsyncArrowFunction, AsyncFunction, AsyncGenerator, Class,
-        FormalParameterList, Function, Generator,
+        FormalParameterList, Function, Generator, PrivateName,
     },
     operations::bound_names,
     pattern::Pattern,
@@ -206,6 +206,7 @@ pub struct ByteCompiler<'b, 'icu> {
     code_block: CodeBlock,
     literals_map: FxHashMap<Literal, u32>,
     names_map: FxHashMap<Identifier, u32>,
+    private_names_map: FxHashMap<PrivateName, u32>,
     bindings_map: FxHashMap<BindingLocator, u32>,
     jump_info: Vec<JumpControlInfo>,
     in_async_generator: bool,
@@ -229,6 +230,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
             code_block: CodeBlock::new(name, 0, strict),
             literals_map: FxHashMap::default(),
             names_map: FxHashMap::default(),
+            private_names_map: FxHashMap::default(),
             bindings_map: FxHashMap::default(),
             jump_info: Vec::new(),
             in_async_generator: false,
@@ -278,6 +280,19 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
         index
     }
 
+    #[inline]
+    fn get_or_insert_private_name(&mut self, name: PrivateName) -> u32 {
+        if let Some(index) = self.private_names_map.get(&name) {
+            return *index;
+        }
+
+        let index = self.code_block.private_names.len() as u32;
+        self.code_block.private_names.push(name);
+        self.private_names_map.insert(name, index);
+        index
+    }
+
+    #[inline]
     fn get_or_insert_binding(&mut self, binding: BindingLocator) -> u32 {
         if let Some(index) = self.bindings_map.get(&binding) {
             return *index;
@@ -482,7 +497,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
                     }
                 },
                 PropertyAccess::Private(access) => {
-                    let index = self.get_or_insert_name(access.field().into());
+                    let index = self.get_or_insert_private_name(access.field());
                     self.compile_expr(access.target(), true)?;
                     self.emit(Opcode::GetPrivateField, &[index]);
                 }
@@ -546,7 +561,8 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
                 PropertyAccess::Simple(access) => match access.field() {
                     PropertyAccessField::Const(name) => {
                         self.compile_expr(access.target(), true)?;
-                        let result = expr_fn(self, 1);
+                        self.emit_opcode(Opcode::Dup);
+                        let result = expr_fn(self, 2);
                         let index = self.get_or_insert_name((*name).into());
 
                         self.emit(Opcode::SetPropertyByName, &[index]);
@@ -569,7 +585,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
                 PropertyAccess::Private(access) => {
                     self.compile_expr(access.target(), true)?;
                     let result = expr_fn(self, 1);
-                    let index = self.get_or_insert_name(access.field().into());
+                    let index = self.get_or_insert_private_name(access.field());
                     self.emit(Opcode::AssignPrivateField, &[index]);
                     if !use_expr {
                         self.emit(Opcode::Pop, &[]);
@@ -578,7 +594,8 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
                 }
                 PropertyAccess::Super(access) => match access.field() {
                     PropertyAccessField::Const(name) => {
-                        self.emit(Opcode::Super, &[]);
+                        self.emit_opcode(Opcode::Super);
+                        self.emit_opcode(Opcode::This);
                         let result = expr_fn(self, 1);
                         let index = self.get_or_insert_name((*name).into());
                         self.emit(Opcode::SetPropertyByName, &[index]);
@@ -715,7 +732,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
             PropertyAccess::Private(access) => {
                 self.compile_expr(access.target(), true)?;
                 self.emit_opcode(Opcode::Dup);
-                let index = self.get_or_insert_name(access.field().into());
+                let index = self.get_or_insert_private_name(access.field());
                 self.emit(Opcode::GetPrivateField, &[index]);
             }
             PropertyAccess::Super(access) => {
@@ -826,7 +843,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
             }
             OptionalOperationKind::PrivatePropertyAccess { field } => {
                 self.emit_opcode(Opcode::Dup);
-                let index = self.get_or_insert_name((*field).into());
+                let index = self.get_or_insert_private_name(*field);
                 self.emit(Opcode::GetPrivateField, &[index]);
                 self.emit_opcode(Opcode::RotateLeft);
                 self.emit_u8(3);
@@ -998,13 +1015,98 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
             ..
         } = function;
 
+        let binding_identifier = if has_binding_identifier {
+            if let Some(name) = name {
+                Some(name.sym())
+            } else {
+                Some(Sym::EMPTY_STRING)
+            }
+        } else {
+            None
+        };
+
         let code = FunctionCompiler::new()
             .name(name.map(Identifier::sym))
             .generator(generator)
             .r#async(r#async)
             .strict(self.code_block.strict)
             .arrow(arrow)
-            .has_binding_identifier(has_binding_identifier)
+            .binding_identifier(binding_identifier)
+            .compile(parameters, body, self.context)?;
+
+        let index = self.code_block.functions.len() as u32;
+        self.code_block.functions.push(code);
+
+        if r#async && generator {
+            self.emit(Opcode::GetGeneratorAsync, &[index]);
+        } else if generator {
+            self.emit(Opcode::GetGenerator, &[index]);
+        } else if r#async && arrow {
+            self.emit(Opcode::GetAsyncArrowFunction, &[index]);
+        } else if r#async {
+            self.emit(Opcode::GetFunctionAsync, &[index]);
+        } else if arrow {
+            self.emit(Opcode::GetArrowFunction, &[index]);
+        } else {
+            self.emit(Opcode::GetFunction, &[index]);
+        }
+
+        match node_kind {
+            NodeKind::Declaration => {
+                self.emit_binding(
+                    BindingOpcode::InitVar,
+                    name.expect("function declaration must have a name"),
+                );
+            }
+            NodeKind::Expression => {
+                if !use_expr {
+                    self.emit(Opcode::Pop, &[]);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Compile a class method AST Node into bytecode.
+    fn method(
+        &mut self,
+        function: FunctionSpec<'_>,
+        node_kind: NodeKind,
+        class_name: Sym,
+        use_expr: bool,
+    ) -> JsResult<()> {
+        let (generator, r#async, arrow) = (
+            function.is_generator(),
+            function.is_async(),
+            function.is_arrow(),
+        );
+        let FunctionSpec {
+            name,
+            parameters,
+            body,
+            has_binding_identifier,
+            ..
+        } = function;
+
+        let binding_identifier = if has_binding_identifier {
+            if let Some(name) = name {
+                Some(name.sym())
+            } else {
+                Some(Sym::EMPTY_STRING)
+            }
+        } else {
+            None
+        };
+
+        let code = FunctionCompiler::new()
+            .name(name.map(Identifier::sym))
+            .generator(generator)
+            .r#async(r#async)
+            .strict(true)
+            .arrow(arrow)
+            .binding_identifier(binding_identifier)
+            .class_name(class_name)
             .compile(parameters, body, self.context)?;
 
         let index = self.code_block.functions.len() as u32;

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -11,7 +11,6 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_gc::{self, Finalize, Gc, GcCell, Trace};
-use rustc_hash::FxHashMap;
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -74,7 +73,7 @@ impl JsObject {
                 prototype: prototype.into(),
                 extensible: true,
                 properties: PropertyMap::default(),
-                private_elements: FxHashMap::default(),
+                private_elements: Vec::new(),
             })),
         }
     }

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -1,13 +1,14 @@
 use crate::{
-    builtins::Array,
+    builtins::{function::ClassFieldDefinition, Array},
     context::intrinsics::{StandardConstructor, StandardConstructors},
     error::JsNativeError,
-    object::JsObject,
+    object::{JsObject, PrivateElement},
     property::{PropertyDescriptor, PropertyDescriptorBuilder, PropertyKey, PropertyNameKind},
     symbol::WellKnownSymbols,
     value::Type,
     Context, JsResult, JsValue,
 };
+use boa_ast::function::PrivateName;
 
 /// Object integrity level.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -656,19 +657,331 @@ impl JsObject {
 
     // todo: CopyDataProperties
 
-    // todo: PrivateElementFind
+    /// Abstract operation `PrivateElementFind ( O, P )`
+    ///
+    /// Get the private element from an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-privateelementfind
+    #[allow(clippy::similar_names)]
+    pub(crate) fn private_element_find(
+        &self,
+        name: &PrivateName,
+        is_getter: bool,
+        is_setter: bool,
+    ) -> Option<PrivateElement> {
+        // 1. If O.[[PrivateElements]] contains a PrivateElement whose [[Key]] is P, then
+        for (key, value) in &self.borrow().private_elements {
+            if key == name {
+                // a. Let entry be that PrivateElement.
+                // b. Return entry.
+                if let PrivateElement::Accessor { getter, setter } = value {
+                    if getter.is_some() && is_getter || setter.is_some() && is_setter {
+                        return Some(value.clone());
+                    }
+                } else {
+                    return Some(value.clone());
+                }
+            }
+        }
 
-    // todo: PrivateFieldAdd
+        // 2. Return empty.
+        None
+    }
 
-    // todo: PrivateMethodOrAccessorAdd
+    /// Abstract operation `PrivateFieldAdd ( O, P, value )`
+    ///
+    /// Add private field to an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-privatefieldadd
+    pub(crate) fn private_field_add(
+        &self,
+        name: &PrivateName,
+        value: JsValue,
+        context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        // 1. If the host is a web browser, then
+        // a. Perform ? HostEnsureCanAddPrivateElement(O).
+        self.host_ensure_can_add_private_element(context)?;
 
-    // todo: PrivateGet
+        // 2. Let entry be PrivateElementFind(O, P).
+        let entry = self.private_element_find(name, false, false);
 
-    // todo: PrivateSet
+        // 3. If entry is not empty, throw a TypeError exception.
+        if entry.is_some() {
+            return Err(JsNativeError::typ()
+                .with_message("Private field already exists on prototype")
+                .into());
+        }
 
-    // todo: DefineField
+        // 4. Append PrivateElement { [[Key]]: P, [[Kind]]: field, [[Value]]: value } to O.[[PrivateElements]].
+        self.borrow_mut()
+            .private_elements
+            .push((*name, PrivateElement::Field(value)));
 
-    // todo: InitializeInstanceElements
+        // 5. Return unused.
+        Ok(())
+    }
+
+    /// Abstract operation `PrivateMethodOrAccessorAdd ( O, method )`
+    ///
+    /// Add private method or accessor to an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-privatemethodoraccessoradd
+    pub(crate) fn private_method_or_accessor_add(
+        &self,
+        name: &PrivateName,
+        method: &PrivateElement,
+        context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        // 1. Assert: method.[[Kind]] is either method or accessor.
+        assert!(matches!(
+            method,
+            PrivateElement::Method(_) | PrivateElement::Accessor { .. }
+        ));
+        let (getter, setter) = if let PrivateElement::Accessor { getter, setter } = method {
+            (getter.is_some(), setter.is_some())
+        } else {
+            (false, false)
+        };
+
+        // 2. If the host is a web browser, then
+        // a. Perform ? HostEnsureCanAddPrivateElement(O).
+        self.host_ensure_can_add_private_element(context)?;
+
+        // 3. Let entry be PrivateElementFind(O, method.[[Key]]).
+        let entry = self.private_element_find(name, getter, setter);
+
+        // 4. If entry is not empty, throw a TypeError exception.
+        if entry.is_some() {
+            return Err(JsNativeError::typ()
+                .with_message("Private method already exists on prototype")
+                .into());
+        }
+
+        // 5. Append method to O.[[PrivateElements]].
+        self.borrow_mut()
+            .append_private_element(*name, method.clone());
+
+        // 6. Return unused.
+        Ok(())
+    }
+
+    /// Abstract operation `HostEnsureCanAddPrivateElement ( O )`
+    ///
+    /// Ensure private elements can be added to an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-hostensurecanaddprivateelement
+    #[allow(clippy::unnecessary_wraps, clippy::unused_self)]
+    fn host_ensure_can_add_private_element(&self, _context: &mut Context<'_>) -> JsResult<()> {
+        // TODO: Make this operation host-defined.
+        Ok(())
+    }
+
+    /// Abstract operation `PrivateGet ( O, P )`
+    ///
+    /// Get the value of a private element.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-privateget
+    pub(crate) fn private_get(
+        &self,
+        name: &PrivateName,
+        context: &mut Context<'_>,
+    ) -> JsResult<JsValue> {
+        // 1. Let entry be PrivateElementFind(O, P).
+        let entry = self.private_element_find(name, true, true);
+
+        match &entry {
+            // 2. If entry is empty, throw a TypeError exception.
+            None => Err(JsNativeError::typ()
+                .with_message("Private element does not exist on object")
+                .into()),
+
+            // 3. If entry.[[Kind]] is field or method, then
+            // a. Return entry.[[Value]].
+            Some(PrivateElement::Field(value)) => Ok(value.clone()),
+            Some(PrivateElement::Method(value)) => Ok(value.clone().into()),
+
+            // 4. Assert: entry.[[Kind]] is accessor.
+            Some(PrivateElement::Accessor { getter, .. }) => {
+                // 5. If entry.[[Get]] is undefined, throw a TypeError exception.
+                // 6. Let getter be entry.[[Get]].
+                let getter = if let Some(getter) = getter {
+                    getter
+                } else {
+                    return Err(JsNativeError::typ()
+                        .with_message("private property was defined without a getter")
+                        .into());
+                };
+
+                // 7. Return ? Call(getter, O).
+                getter.call(&self.clone().into(), &[], context)
+            }
+        }
+    }
+
+    /// Abstract operation `PrivateSet ( O, P, value )`
+    ///
+    /// Set the value of a private element.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-privateset
+    pub(crate) fn private_set(
+        &self,
+        name: &PrivateName,
+        value: JsValue,
+        context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        // 1. Let entry be PrivateElementFind(O, P).
+        // Note: This function is inlined here for mutable access.
+        let mut object_mut = self.borrow_mut();
+        let mut entry = None;
+        for (key, value) in &mut object_mut.private_elements {
+            if key == name {
+                entry = Some(value);
+            }
+        }
+
+        match entry {
+            // 2. If entry is empty, throw a TypeError exception.
+            None => {
+                return Err(JsNativeError::typ()
+                    .with_message("Private element does not exist on object")
+                    .into())
+            }
+
+            // 3. If entry.[[Kind]] is field, then
+            // a. Set entry.[[Value]] to value.
+            Some(PrivateElement::Field(field)) => {
+                *field = value;
+            }
+
+            // 4. Else if entry.[[Kind]] is method, then
+            // a. Throw a TypeError exception.
+            Some(PrivateElement::Method(_)) => {
+                return Err(JsNativeError::typ()
+                    .with_message("private method is not writable")
+                    .into())
+            }
+
+            // 5. Else,
+            Some(PrivateElement::Accessor { setter, .. }) => {
+                // a. Assert: entry.[[Kind]] is accessor.
+                // b. If entry.[[Set]] is undefined, throw a TypeError exception.
+                // c. Let setter be entry.[[Set]].
+                let setter = if let Some(setter) = setter {
+                    setter.clone()
+                } else {
+                    return Err(JsNativeError::typ()
+                        .with_message("private property was defined without a setter")
+                        .into());
+                };
+
+                // d. Perform ? Call(setter, O, « value »).
+                drop(object_mut);
+                setter.call(&self.clone().into(), &[value], context)?;
+            }
+        }
+
+        // 6. Return unused.
+        Ok(())
+    }
+
+    /// Abstract operation `DefineField ( receiver, fieldRecord )`
+    ///
+    /// Define a field on an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-definefield
+    pub(crate) fn define_field(
+        &self,
+        field_record: &ClassFieldDefinition,
+        context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        // 2. Let initializer be fieldRecord.[[Initializer]].
+        let initializer = match field_record {
+            ClassFieldDefinition::Public(_, function)
+            | ClassFieldDefinition::Private(_, function) => function,
+        };
+
+        // 3. If initializer is not empty, then
+        // a. Let initValue be ? Call(initializer, receiver).
+        // 4. Else, let initValue be undefined.
+        let init_value = initializer.call(&self.clone().into(), &[], context)?;
+
+        match field_record {
+            // 1. Let fieldName be fieldRecord.[[Name]].
+            // 5. If fieldName is a Private Name, then
+            ClassFieldDefinition::Private(field_name, _) => {
+                // a. Perform ? PrivateFieldAdd(receiver, fieldName, initValue).
+                self.private_field_add(field_name, init_value, context)?;
+            }
+            // 1. Let fieldName be fieldRecord.[[Name]].
+            // 6. Else,
+            ClassFieldDefinition::Public(field_name, _) => {
+                // a. Assert: IsPropertyKey(fieldName) is true.
+                // b. Perform ? CreateDataPropertyOrThrow(receiver, fieldName, initValue).
+                self.create_data_property_or_throw(field_name.clone(), init_value, context)?;
+            }
+        }
+
+        // 7. Return unused.
+        Ok(())
+    }
+
+    /// Abstract operation `InitializeInstanceElements ( O, constructor )`
+    ///
+    /// Add private methods and fields from a class constructor to an object.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-initializeinstanceelements
+    pub(crate) fn initialize_instance_elements(
+        &self,
+        constructor: &JsObject,
+        context: &mut Context<'_>,
+    ) -> JsResult<()> {
+        let constructor_borrow = constructor.borrow();
+        let constructor_function = constructor_borrow
+            .as_function()
+            .expect("class constructor must be function object");
+
+        // 1. Let methods be the value of constructor.[[PrivateMethods]].
+        // 2. For each PrivateElement method of methods, do
+        for (name, method) in constructor_function.get_private_methods() {
+            // a. Perform ? PrivateMethodOrAccessorAdd(O, method).
+            self.private_method_or_accessor_add(name, method, context)?;
+        }
+
+        // 3. Let fields be the value of constructor.[[Fields]].
+        // 4. For each element fieldRecord of fields, do
+        for field_record in constructor_function.get_fields() {
+            // a. Perform ? DefineField(O, fieldRecord).
+            self.define_field(field_record, context)?;
+        }
+
+        // 5. Return unused.
+        Ok(())
+    }
 
     /// Abstract operation `Invoke ( V, P [ , argumentsList ] )`
     ///

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -23,7 +23,10 @@ use crate::{
     vm::{call_frame::FinallyReturn, CallFrame, Opcode},
     Context, JsResult, JsString, JsValue,
 };
-use boa_ast::{expression::Identifier, function::FormalParameterList};
+use boa_ast::{
+    expression::Identifier,
+    function::{FormalParameterList, PrivateName},
+};
 use boa_gc::{Finalize, Gc, GcCell, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 use boa_profiler::Profiler;
@@ -88,6 +91,10 @@ pub struct CodeBlock {
     #[unsafe_ignore_trace]
     pub(crate) names: Vec<Identifier>,
 
+    /// Private names.
+    #[unsafe_ignore_trace]
+    pub(crate) private_names: Vec<PrivateName>,
+
     /// Locators for all bindings in the codeblock.
     #[unsafe_ignore_trace]
     pub(crate) bindings: Vec<BindingLocator>,
@@ -108,6 +115,10 @@ pub struct CodeBlock {
     /// The `[[IsClassConstructor]]` internal slot.
     pub(crate) is_class_constructor: bool,
 
+    /// The `[[ClassFieldInitializerName]]` internal slot.
+    #[unsafe_ignore_trace]
+    pub(crate) class_field_initializer_name: Option<Sym>,
+
     /// Marks the location in the code where the function environment in pushed.
     /// This is only relevant for functions with expressions in the parameters.
     /// We execute the parameter expressions in the function code and push the function environment afterward.
@@ -123,6 +134,7 @@ impl CodeBlock {
             code: Vec::new(),
             literals: Vec::new(),
             names: Vec::new(),
+            private_names: Vec::new(),
             bindings: Vec::new(),
             num_bindings: 0,
             functions: Vec::new(),
@@ -135,6 +147,7 @@ impl CodeBlock {
             arguments_binding: None,
             compile_environments: Vec::new(),
             is_class_constructor: false,
+            class_field_initializer_name: None,
             function_environment_push_location: 0,
         }
     }
@@ -284,18 +297,28 @@ impl CodeBlock {
             Opcode::GetPropertyByName
             | Opcode::SetPropertyByName
             | Opcode::DefineOwnPropertyByName
+            | Opcode::DefineClassStaticMethodByName
             | Opcode::DefineClassMethodByName
             | Opcode::SetPropertyGetterByName
+            | Opcode::DefineClassStaticGetterByName
             | Opcode::DefineClassGetterByName
             | Opcode::SetPropertySetterByName
+            | Opcode::DefineClassStaticSetterByName
             | Opcode::DefineClassSetterByName
-            | Opcode::AssignPrivateField
+            | Opcode::DeletePropertyByName => {
+                let operand = self.read::<u32>(*pc);
+                *pc += size_of::<u32>();
+                format!(
+                    "{operand:04}: '{}'",
+                    interner.resolve_expect(self.names[operand as usize].sym()),
+                )
+            }
+            Opcode::AssignPrivateField
             | Opcode::SetPrivateField
             | Opcode::SetPrivateMethod
             | Opcode::SetPrivateSetter
             | Opcode::SetPrivateGetter
             | Opcode::GetPrivateField
-            | Opcode::DeletePropertyByName
             | Opcode::PushClassFieldPrivate
             | Opcode::PushClassPrivateGetter
             | Opcode::PushClassPrivateSetter
@@ -304,7 +327,7 @@ impl CodeBlock {
                 *pc += size_of::<u32>();
                 format!(
                     "{operand:04}: '{}'",
-                    interner.resolve_expect(self.names[operand as usize].sym()),
+                    interner.resolve_expect(self.private_names[operand as usize].description()),
                 )
             }
             Opcode::Pop
@@ -360,10 +383,13 @@ impl CodeBlock {
             | Opcode::GetPropertyByValuePush
             | Opcode::SetPropertyByValue
             | Opcode::DefineOwnPropertyByValue
+            | Opcode::DefineClassStaticMethodByValue
             | Opcode::DefineClassMethodByValue
             | Opcode::SetPropertyGetterByValue
+            | Opcode::DefineClassStaticGetterByValue
             | Opcode::DefineClassGetterByValue
             | Opcode::SetPropertySetterByValue
+            | Opcode::DefineClassStaticSetterByValue
             | Opcode::DefineClassSetterByValue
             | Opcode::DeletePropertyByValue
             | Opcode::DeleteSuperThrow
@@ -543,6 +569,7 @@ pub(crate) fn create_function_object(
             environments: context.realm.environments.clone(),
             home_object: None,
             promise_capability,
+            class_object: None,
         }
     } else {
         Function::Ordinary {
@@ -552,6 +579,7 @@ pub(crate) fn create_function_object(
             home_object: None,
             fields: Vec::new(),
             private_methods: Vec::new(),
+            class_object: None,
         }
     };
 
@@ -649,6 +677,7 @@ pub(crate) fn create_generator_function_object(
             code,
             environments: context.realm.environments.clone(),
             home_object: None,
+            class_object: None,
         };
         JsObject::from_proto_and_data(
             function_prototype,
@@ -659,6 +688,7 @@ pub(crate) fn create_generator_function_object(
             code,
             environments: context.realm.environments.clone(),
             home_object: None,
+            class_object: None,
         };
         JsObject::from_proto_and_data(function_prototype, ObjectData::generator_function(function))
     };
@@ -717,10 +747,14 @@ impl JsObject {
                 }
             }
             Function::Ordinary {
-                code, environments, ..
+                code,
+                environments,
+                class_object,
+                ..
             } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
+                let class_object = class_object.clone();
                 drop(object);
 
                 if code.is_class_constructor {
@@ -749,6 +783,20 @@ impl JsObject {
                 };
 
                 let compile_time_environment_index = usize::from(code.params.has_expressions());
+
+                if let Some(class_object) = class_object {
+                    let index = context.realm.environments.push_declarative(
+                        1,
+                        code.compile_environments[compile_time_environment_index
+                            + usize::from(code.has_binding_identifier)
+                            + 1]
+                        .clone(),
+                    );
+                    context
+                        .realm
+                        .environments
+                        .put_value(index, 0, class_object.into());
+                }
 
                 if code.has_binding_identifier {
                     let index = context.realm.environments.push_declarative(
@@ -842,11 +890,13 @@ impl JsObject {
                 code,
                 environments,
                 promise_capability,
+                class_object,
                 ..
             } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
                 let promise = promise_capability.promise().clone();
+                let class_object = class_object.clone();
                 drop(object);
 
                 let environments_len = environments.len();
@@ -869,6 +919,20 @@ impl JsObject {
                 };
 
                 let compile_time_environment_index = usize::from(code.params.has_expressions());
+
+                if let Some(class_object) = class_object {
+                    let index = context.realm.environments.push_declarative(
+                        1,
+                        code.compile_environments[compile_time_environment_index
+                            + usize::from(code.has_binding_identifier)
+                            + 1]
+                        .clone(),
+                    );
+                    context
+                        .realm
+                        .environments
+                        .put_value(index, 0, class_object.into());
+                }
 
                 if code.has_binding_identifier {
                     let index = context.realm.environments.push_declarative(
@@ -958,10 +1022,14 @@ impl JsObject {
                 Ok(promise.into())
             }
             Function::Generator {
-                code, environments, ..
+                code,
+                environments,
+                class_object,
+                ..
             } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
+                let class_object = class_object.clone();
                 drop(object);
 
                 std::mem::swap(&mut environments, &mut context.realm.environments);
@@ -983,6 +1051,20 @@ impl JsObject {
                 };
 
                 let compile_time_environment_index = usize::from(code.params.has_expressions());
+
+                if let Some(class_object) = class_object {
+                    let index = context.realm.environments.push_declarative(
+                        1,
+                        code.compile_environments[compile_time_environment_index
+                            + usize::from(code.has_binding_identifier)
+                            + 1]
+                        .clone(),
+                    );
+                    context
+                        .realm
+                        .environments
+                        .put_value(index, 0, class_object.into());
+                }
 
                 if code.has_binding_identifier {
                     let index = context.realm.environments.push_declarative(
@@ -1096,10 +1178,14 @@ impl JsObject {
                 Ok(generator.into())
             }
             Function::AsyncGenerator {
-                code, environments, ..
+                code,
+                environments,
+                class_object,
+                ..
             } => {
                 let code = code.clone();
                 let mut environments = environments.clone();
+                let class_object = class_object.clone();
                 drop(object);
 
                 std::mem::swap(&mut environments, &mut context.realm.environments);
@@ -1121,6 +1207,20 @@ impl JsObject {
                 };
 
                 let compile_time_environment_index = usize::from(code.params.has_expressions());
+
+                if let Some(class_object) = class_object {
+                    let index = context.realm.environments.push_declarative(
+                        1,
+                        code.compile_environments[compile_time_environment_index
+                            + usize::from(code.has_binding_identifier)
+                            + 1]
+                        .clone(),
+                    );
+                    context
+                        .realm
+                        .environments
+                        .put_value(index, 0, class_object.into());
+                }
 
                 if code.has_binding_identifier {
                     let index = context.realm.environments.push_declarative(
@@ -1311,9 +1411,6 @@ impl JsObject {
                 let constructor_kind = *constructor_kind;
                 drop(object);
 
-                let environments_len = environments.len();
-                std::mem::swap(&mut environments, &mut context.realm.environments);
-
                 let this = if constructor_kind.is_base() {
                     // If the prototype of the constructor is not an object, then use the default object
                     // prototype as prototype for the new object
@@ -1332,6 +1429,9 @@ impl JsObject {
                 } else {
                     None
                 };
+
+                let environments_len = environments.len();
+                std::mem::swap(&mut environments, &mut context.realm.environments);
 
                 let new_target = this_target.as_object().expect("must be object");
 
@@ -1485,6 +1585,12 @@ pub(crate) fn initialize_instance_elements(
         .expect("class constructor must be function object");
 
     for (name, private_method) in constructor_function.get_private_methods() {
+        if target.borrow().has_private_name(name, private_method) {
+            return Err(JsNativeError::typ()
+                .with_message("Private method already exists on the prototype")
+                .into());
+        }
+
         match private_method {
             PrivateElement::Method(_) => {
                 target

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -340,10 +340,13 @@ impl CodeBlock {
                 Opcode::GetPropertyByName
                 | Opcode::SetPropertyByName
                 | Opcode::DefineOwnPropertyByName
+                | Opcode::DefineClassStaticMethodByName
                 | Opcode::DefineClassMethodByName
                 | Opcode::SetPropertyGetterByName
+                | Opcode::DefineClassStaticGetterByName
                 | Opcode::DefineClassGetterByName
                 | Opcode::SetPropertySetterByName
+                | Opcode::DefineClassStaticSetterByName
                 | Opcode::DefineClassSetterByName
                 | Opcode::AssignPrivateField
                 | Opcode::SetPrivateField
@@ -430,10 +433,13 @@ impl CodeBlock {
                 | Opcode::GetPropertyByValuePush
                 | Opcode::SetPropertyByValue
                 | Opcode::DefineOwnPropertyByValue
+                | Opcode::DefineClassStaticMethodByValue
                 | Opcode::DefineClassMethodByValue
                 | Opcode::SetPropertyGetterByValue
+                | Opcode::DefineClassStaticGetterByValue
                 | Opcode::DefineClassGetterByValue
                 | Opcode::SetPropertySetterByValue
+                | Opcode::DefineClassStaticSetterByValue
                 | Opcode::DefineClassSetterByValue
                 | Opcode::DeletePropertyByValue
                 | Opcode::DeleteSuperThrow

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -348,8 +348,8 @@ impl CodeBlock {
                 | Opcode::SetPropertySetterByName
                 | Opcode::DefineClassStaticSetterByName
                 | Opcode::DefineClassSetterByName
-                | Opcode::AssignPrivateField
                 | Opcode::SetPrivateField
+                | Opcode::DefinePrivateField
                 | Opcode::SetPrivateMethod
                 | Opcode::SetPrivateSetter
                 | Opcode::SetPrivateGetter

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -1,8 +1,61 @@
 use crate::{
+    builtins::function::set_function_name,
     property::PropertyDescriptor,
     vm::{opcode::Operation, ShouldExit},
     Context, JsResult, JsString,
 };
+
+/// `DefineClassStaticGetterByName` implements the Opcode Operation for `Opcode::DefineClassStaticGetterByName`
+///
+/// Operation:
+///  - Defines a class getter by name.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefineClassStaticGetterByName;
+
+impl Operation for DefineClassStaticGetterByName {
+    const NAME: &'static str = "DefineClassStaticGetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
+        let index = context.vm.read::<u32>();
+        let function = context.vm.pop();
+        let class = context.vm.pop();
+        let class = class.as_object().expect("class must be object");
+        let key = context
+            .interner()
+            .resolve_expect(context.vm.frame().code.names[index as usize].sym())
+            .into_common::<JsString>(false)
+            .into();
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("get")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class.clone());
+            function_mut.set_class_object(class.clone());
+        }
+        let set = class
+            .__get_own_property__(&key, context)?
+            .as_ref()
+            .and_then(PropertyDescriptor::set)
+            .cloned();
+        class.__define_own_property__(
+            key,
+            PropertyDescriptor::builder()
+                .maybe_get(Some(function))
+                .maybe_set(set)
+                .enumerable(false)
+                .configurable(true)
+                .build(),
+            context,
+        )?;
+        Ok(ShouldExit::False)
+    }
+}
 
 /// `DefineClassGetterByName` implements the Opcode Operation for `Opcode::DefineClassGetterByName`
 ///
@@ -17,31 +70,91 @@ impl Operation for DefineClassGetterByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let value = context.vm.pop();
-        let object = context.vm.pop();
-        let object = object.to_object(context)?;
-        value
-            .as_object()
-            .expect("method must be function object")
-            .borrow_mut()
-            .as_function_mut()
-            .expect("method must be function object")
-            .set_home_object(object.clone());
-        let name = context.vm.frame().code.names[index as usize];
-        let name = context
+        let function = context.vm.pop();
+        let class_proto = context.vm.pop();
+        let class_proto = class_proto.as_object().expect("class must be object");
+        let key = context
             .interner()
-            .resolve_expect(name.sym())
+            .resolve_expect(context.vm.frame().code.names[index as usize].sym())
             .into_common::<JsString>(false)
             .into();
-        let set = object
-            .__get_own_property__(&name, context)?
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("get")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class_proto.clone());
+            let class = class_proto
+                .get("constructor", context)
+                .expect("class prototype must have constructor")
+                .as_object()
+                .expect("class must be object")
+                .clone();
+            function_mut.set_class_object(class);
+        }
+        let set = class_proto
+            .__get_own_property__(&key, context)?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
-        object.__define_own_property__(
-            name,
+        class_proto.__define_own_property__(
+            key,
             PropertyDescriptor::builder()
-                .maybe_get(Some(value))
+                .maybe_get(Some(function))
+                .maybe_set(set)
+                .enumerable(false)
+                .configurable(true)
+                .build(),
+            context,
+        )?;
+        Ok(ShouldExit::False)
+    }
+}
+
+/// `DefineClassStaticGetterByValue` implements the Opcode Operation for `Opcode::DefineClassStaticGetterByValue`
+///
+/// Operation:
+///  - Defines a class getter by value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefineClassStaticGetterByValue;
+
+impl Operation for DefineClassStaticGetterByValue {
+    const NAME: &'static str = "DefineClassStaticGetterByValue";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByValue";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
+        let function = context.vm.pop();
+        let key = context.vm.pop();
+        let class = context.vm.pop();
+        let class = class.as_object().expect("class must be object");
+        let key = key
+            .to_property_key(context)
+            .expect("property key must already be valid");
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("get")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class.clone());
+            function_mut.set_class_object(class.clone());
+        }
+        let set = class
+            .__get_own_property__(&key, context)?
+            .as_ref()
+            .and_then(PropertyDescriptor::set)
+            .cloned();
+        class.__define_own_property__(
+            key,
+            PropertyDescriptor::builder()
+                .maybe_get(Some(function))
                 .maybe_set(set)
                 .enumerable(false)
                 .configurable(true)
@@ -64,27 +177,40 @@ impl Operation for DefineClassGetterByValue {
     const INSTRUCTION: &'static str = "INST - DefineClassGetterByValue";
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
-        let value = context.vm.pop();
+        let function = context.vm.pop();
         let key = context.vm.pop();
-        let object = context.vm.pop();
-        let object = object.to_object(context)?;
-        value
-            .as_object()
-            .expect("method must be function object")
-            .borrow_mut()
-            .as_function_mut()
-            .expect("method must be function object")
-            .set_home_object(object.clone());
-        let name = key.to_property_key(context)?;
-        let set = object
-            .__get_own_property__(&name, context)?
+        let class_proto = context.vm.pop();
+        let class_proto = class_proto.as_object().expect("class must be object");
+        let key = key
+            .to_property_key(context)
+            .expect("property key must already be valid");
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("get")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class_proto.clone());
+            let class = class_proto
+                .get("constructor", context)
+                .expect("class prototype must have constructor")
+                .as_object()
+                .expect("class must be object")
+                .clone();
+            function_mut.set_class_object(class);
+        }
+        let set = class_proto
+            .__get_own_property__(&key, context)?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
-        object.__define_own_property__(
-            name,
+        class_proto.__define_own_property__(
+            key,
             PropertyDescriptor::builder()
-                .maybe_get(Some(value))
+                .maybe_get(Some(function))
                 .maybe_set(set)
                 .enumerable(false)
                 .configurable(true)

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -1,8 +1,61 @@
 use crate::{
+    builtins::function::set_function_name,
     property::PropertyDescriptor,
     vm::{opcode::Operation, ShouldExit},
     Context, JsResult, JsString,
 };
+
+/// `DefineClassStaticSetterByName` implements the Opcode Operation for `Opcode::DefineClassStaticSetterByName`
+///
+/// Operation:
+///  - Defines a class setter by name.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefineClassStaticSetterByName;
+
+impl Operation for DefineClassStaticSetterByName {
+    const NAME: &'static str = "DefineClassStaticSetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
+        let index = context.vm.read::<u32>();
+        let function = context.vm.pop();
+        let class = context.vm.pop();
+        let class = class.as_object().expect("class must be object");
+        let key = context
+            .interner()
+            .resolve_expect(context.vm.frame().code.names[index as usize].sym())
+            .into_common::<JsString>(false)
+            .into();
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("set")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class.clone());
+            function_mut.set_class_object(class.clone());
+        }
+        let get = class
+            .__get_own_property__(&key, context)?
+            .as_ref()
+            .and_then(PropertyDescriptor::get)
+            .cloned();
+        class.__define_own_property__(
+            key,
+            PropertyDescriptor::builder()
+                .maybe_set(Some(function))
+                .maybe_get(get)
+                .enumerable(false)
+                .configurable(true)
+                .build(),
+            context,
+        )?;
+        Ok(ShouldExit::False)
+    }
+}
 
 /// `DefineClassSetterByName` implements the Opcode Operation for `Opcode::DefineClassSetterByName`
 ///
@@ -17,31 +70,91 @@ impl Operation for DefineClassSetterByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let value = context.vm.pop();
-        let object = context.vm.pop();
-        let object = object.to_object(context)?;
-        value
-            .as_object()
-            .expect("method must be function object")
-            .borrow_mut()
-            .as_function_mut()
-            .expect("method must be function object")
-            .set_home_object(object.clone());
-        let name = context.vm.frame().code.names[index as usize];
-        let name = context
+        let function = context.vm.pop();
+        let class_proto = context.vm.pop();
+        let class_proto = class_proto.as_object().expect("class must be object");
+        let key = context
             .interner()
-            .resolve_expect(name.sym())
+            .resolve_expect(context.vm.frame().code.names[index as usize].sym())
             .into_common::<JsString>(false)
             .into();
-        let get = object
-            .__get_own_property__(&name, context)?
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("set")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class_proto.clone());
+            let class = class_proto
+                .get("constructor", context)
+                .expect("class prototype must have constructor")
+                .as_object()
+                .expect("class must be object")
+                .clone();
+            function_mut.set_class_object(class);
+        }
+        let get = class_proto
+            .__get_own_property__(&key, context)?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
-        object.__define_own_property__(
-            name,
+        class_proto.__define_own_property__(
+            key,
             PropertyDescriptor::builder()
-                .maybe_set(Some(value))
+                .maybe_set(Some(function))
+                .maybe_get(get)
+                .enumerable(false)
+                .configurable(true)
+                .build(),
+            context,
+        )?;
+        Ok(ShouldExit::False)
+    }
+}
+
+/// `DefineClassStaticSetterByValue` implements the Opcode Operation for `Opcode::DefineClassStaticSetterByValue`
+///
+/// Operation:
+///  - Defines a class setter by value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DefineClassStaticSetterByValue;
+
+impl Operation for DefineClassStaticSetterByValue {
+    const NAME: &'static str = "DefineClassStaticSetterByValue";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByValue";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
+        let function = context.vm.pop();
+        let key = context.vm.pop();
+        let class = context.vm.pop();
+        let class = class.as_object().expect("class must be object");
+        let key = key
+            .to_property_key(context)
+            .expect("property key must already be valid");
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("set")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class.clone());
+            function_mut.set_class_object(class.clone());
+        }
+        let get = class
+            .__get_own_property__(&key, context)?
+            .as_ref()
+            .and_then(PropertyDescriptor::get)
+            .cloned();
+        class.__define_own_property__(
+            key,
+            PropertyDescriptor::builder()
+                .maybe_set(Some(function))
                 .maybe_get(get)
                 .enumerable(false)
                 .configurable(true)
@@ -64,27 +177,40 @@ impl Operation for DefineClassSetterByValue {
     const INSTRUCTION: &'static str = "INST - DefineClassSetterByValue";
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
-        let value = context.vm.pop();
+        let function = context.vm.pop();
         let key = context.vm.pop();
-        let object = context.vm.pop();
-        let object = object.to_object(context)?;
-        value
-            .as_object()
-            .expect("method must be function object")
-            .borrow_mut()
-            .as_function_mut()
-            .expect("method must be function object")
-            .set_home_object(object.clone());
-        let name = key.to_property_key(context)?;
-        let get = object
-            .__get_own_property__(&name, context)?
+        let class_proto = context.vm.pop();
+        let class_proto = class_proto.as_object().expect("class must be object");
+        let key = key
+            .to_property_key(context)
+            .expect("property key must already be valid");
+        {
+            let function_object = function
+                .as_object()
+                .expect("method must be function object");
+            set_function_name(function_object, &key, Some(JsString::from("set")), context);
+            let mut function_object = function_object.borrow_mut();
+            let function_mut = function_object
+                .as_function_mut()
+                .expect("method must be function object");
+            function_mut.set_home_object(class_proto.clone());
+            let class = class_proto
+                .get("constructor", context)
+                .expect("class prototype must have constructor")
+                .as_object()
+                .expect("class must be object")
+                .clone();
+            function_mut.set_class_object(class);
+        }
+        let get = class_proto
+            .__get_own_property__(&key, context)?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
-        object.__define_own_property__(
-            name,
+        class_proto.__define_own_property__(
+            key,
             PropertyDescriptor::builder()
-                .maybe_set(Some(value))
+                .maybe_set(Some(function))
                 .maybe_get(get)
                 .enumerable(false)
                 .configurable(true)

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -1,7 +1,7 @@
 use crate::{
     property::PropertyDescriptor,
     vm::{opcode::Operation, ShouldExit},
-    Context, JsResult, JsString,
+    Context, JsNativeError, JsResult, JsString,
 };
 
 /// `DefineOwnPropertyByName` implements the Opcode Operation for `Opcode::DefineOwnPropertyByName`
@@ -64,7 +64,7 @@ impl Operation for DefineOwnPropertyByValue {
             object.to_object(context)?
         };
         let key = key.to_property_key(context)?;
-        object.__define_own_property__(
+        let success = object.__define_own_property__(
             key,
             PropertyDescriptor::builder()
                 .value(value)
@@ -74,6 +74,11 @@ impl Operation for DefineOwnPropertyByValue {
                 .build(),
             context,
         )?;
+        if !success {
+            return Err(JsNativeError::typ()
+                .with_message("failed to defined own property")
+                .into());
+        }
         Ok(ShouldExit::False)
     }
 }

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -120,8 +120,6 @@ impl Operation for SuperCall {
 
         let result = super_constructor.__construct__(&arguments, &new_target, context)?;
 
-        initialize_instance_elements(&result, &active_function, context)?;
-
         let this_env = context
             .realm
             .environments
@@ -134,6 +132,9 @@ impl Operation for SuperCall {
                 .with_message("this already initialized")
                 .into());
         }
+
+        initialize_instance_elements(&result, &active_function, context)?;
+
         context.vm.push(result);
         Ok(ShouldExit::False)
     }
@@ -191,8 +192,6 @@ impl Operation for SuperCallSpread {
 
         let result = super_constructor.__construct__(&arguments, &new_target, context)?;
 
-        initialize_instance_elements(&result, &active_function, context)?;
-
         let this_env = context
             .realm
             .environments
@@ -205,6 +204,9 @@ impl Operation for SuperCallSpread {
                 .with_message("this already initialized")
                 .into());
         }
+
+        initialize_instance_elements(&result, &active_function, context)?;
+
         context.vm.push(result);
         Ok(ShouldExit::False)
     }
@@ -257,19 +259,20 @@ impl Operation for SuperCallDerived {
 
         let result = super_constructor.__construct__(&arguments, &new_target, context)?;
 
-        initialize_instance_elements(&result, &active_function, context)?;
-
         let this_env = context
             .realm
             .environments
             .get_this_environment()
             .as_function_slots()
             .expect("super call must be in function environment");
+
         if !this_env.borrow_mut().bind_this_value(&result) {
             return Err(JsNativeError::reference()
                 .with_message("this already initialized")
                 .into());
         }
+
+        initialize_instance_elements(&result, &active_function, context)?;
 
         context.vm.push(result);
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     environments::EnvironmentSlots,
     error::JsNativeError,
-    vm::{code_block::initialize_instance_elements, opcode::Operation, ShouldExit},
+    vm::{opcode::Operation, ShouldExit},
     Context, JsResult, JsValue,
 };
 
@@ -133,7 +133,7 @@ impl Operation for SuperCall {
                 .into());
         }
 
-        initialize_instance_elements(&result, &active_function, context)?;
+        result.initialize_instance_elements(&active_function, context)?;
 
         context.vm.push(result);
         Ok(ShouldExit::False)
@@ -205,7 +205,7 @@ impl Operation for SuperCallSpread {
                 .into());
         }
 
-        initialize_instance_elements(&result, &active_function, context)?;
+        result.initialize_instance_elements(&active_function, context)?;
 
         context.vm.push(result);
         Ok(ShouldExit::False)
@@ -272,7 +272,7 @@ impl Operation for SuperCallDerived {
                 .into());
         }
 
-        initialize_instance_elements(&result, &active_function, context)?;
+        result.initialize_instance_elements(&active_function, context)?;
 
         context.vm.push(result);
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -1,6 +1,4 @@
 use crate::{
-    error::JsNativeError,
-    object::PrivateElement,
     vm::{opcode::Operation, ShouldExit},
     Context, JsResult,
 };
@@ -20,35 +18,9 @@ impl Operation for GetPrivateField {
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
-        if let Some(object) = value.as_object() {
-            let object_borrow_mut = object.borrow();
-            if let Some(element) = object_borrow_mut.get_private_element(name) {
-                match element {
-                    PrivateElement::Field(value) => context.vm.push(value.clone()),
-                    PrivateElement::Method(method) => context.vm.push(method.clone()),
-                    PrivateElement::Accessor {
-                        getter: Some(getter),
-                        setter: _,
-                    } => {
-                        let value = getter.call(&value, &[], context)?;
-                        context.vm.push(value);
-                    }
-                    PrivateElement::Accessor { .. } => {
-                        return Err(JsNativeError::typ()
-                            .with_message("private property was defined without a getter")
-                            .into());
-                    }
-                }
-            } else {
-                return Err(JsNativeError::typ()
-                    .with_message("private property does not exist")
-                    .into());
-            }
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message("cannot read private property from non-object")
-                .into());
-        }
+        let base_obj = value.to_object(context)?;
+        let result = base_obj.private_get(&name, context)?;
+        context.vm.push(result);
         Ok(ShouldExit::False)
     }
 }

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -18,11 +18,11 @@ impl Operation for GetPrivateField {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         if let Some(object) = value.as_object() {
             let object_borrow_mut = object.borrow();
-            if let Some(element) = object_borrow_mut.get_private_element(name.sym()) {
+            if let Some(element) = object_borrow_mut.get_private_element(name) {
                 match element {
                     PrivateElement::Field(value) => context.vm.push(value.clone()),
                     PrivateElement::Method(method) => context.vm.push(method.clone()),

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -741,7 +741,7 @@ generate_impl! {
         ///
         /// Operands: name_index: `u32`
         ///
-        /// Stack: object, value **=>** value
+        /// Stack: object, receiver, value **=>** value
         SetPropertyByName,
 
         /// Sets the name of a function object.
@@ -767,11 +767,18 @@ generate_impl! {
         /// Stack: object, value **=>**
         DefineOwnPropertyByName,
 
+        /// Defines a static class method by name.
+        ///
+        /// Operands: name_index: `u32`
+        ///
+        /// Stack: class, function **=>**
+        DefineClassStaticMethodByName,
+
         /// Defines a class method by name.
         ///
         /// Operands: name_index: `u32`
         ///
-        /// Stack: object, value **=>**
+        /// Stack: class_proto, function **=>**
         DefineClassMethodByName,
 
         /// Sets a property by value of an object.
@@ -790,11 +797,18 @@ generate_impl! {
         /// Stack: object, key, value **=>**
         DefineOwnPropertyByValue,
 
+        /// Defines a static class method by value.
+        ///
+        /// Operands:
+        ///
+        /// Stack: class, key, function **=>**
+        DefineClassStaticMethodByValue,
+
         /// Defines a class method by value.
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: class_proto, key, function **=>**
         DefineClassMethodByValue,
 
         /// Sets a getter property by name of an object.
@@ -806,13 +820,22 @@ generate_impl! {
         /// Stack: object, value **=>**
         SetPropertyGetterByName,
 
+        /// Defines a static getter class method by name.
+        ///
+        /// Like `static get name() value`
+        ///
+        /// Operands: name_index: `u32`
+        ///
+        /// Stack: class, function **=>**
+        DefineClassStaticGetterByName,
+
         /// Defines a getter class method by name.
         ///
         /// Like `get name() value`
         ///
         /// Operands: name_index: `u32`
         ///
-        /// Stack: object, value **=>**
+        /// Stack: class_proto, function **=>** class
         DefineClassGetterByName,
 
         /// Sets a getter property by value of an object.
@@ -824,13 +847,22 @@ generate_impl! {
         /// Stack: object, key, value **=>**
         SetPropertyGetterByValue,
 
+        /// Defines a static getter class method by value.
+        ///
+        /// Like `static get [key]() value`
+        ///
+        /// Operands:
+        ///
+        /// Stack: class, key, function **=>**
+        DefineClassStaticGetterByValue,
+
         /// Defines a getter class method by value.
         ///
         /// Like `get [key]() value`
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: class_proto, key, function **=>**
         DefineClassGetterByValue,
 
         /// Sets a setter property by name of an object.
@@ -842,13 +874,22 @@ generate_impl! {
         /// Stack: object, value **=>**
         SetPropertySetterByName,
 
+        /// Defines a static setter class method by name.
+        ///
+        /// Like `static set name() value`
+        ///
+        /// Operands: name_index: `u32`
+        ///
+        /// Stack: class, function **=>**
+        DefineClassStaticSetterByName,
+
         /// Defines a setter class method by name.
         ///
         /// Like `set name() value`
         ///
         /// Operands: name_index: `u32`
         ///
-        /// Stack: object, value **=>**
+        /// Stack: class_proto, function **=>**
         DefineClassSetterByName,
 
         /// Sets a setter property by value of an object.
@@ -860,20 +901,29 @@ generate_impl! {
         /// Stack: object, key, value **=>**
         SetPropertySetterByValue,
 
+        /// Defines a static setter class method by value.
+        ///
+        /// Like `static set [key]() value`
+        ///
+        /// Operands:
+        ///
+        /// Stack: class, key, function **=>**
+        DefineClassStaticSetterByValue,
+
         /// Defines a setter class method by value.
         ///
         /// Like `set [key]() value`
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: class_proto, key, function **=>**
         DefineClassSetterByValue,
 
         /// Assign the value of a private property of an object by it's name.
         ///
         /// Like `obj.#name = value`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>** value
         AssignPrivateField,
@@ -882,7 +932,7 @@ generate_impl! {
         ///
         /// Like `#name = value`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>**
         SetPrivateField,
@@ -891,7 +941,7 @@ generate_impl! {
         ///
         /// Like `#name() {}`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>**
         SetPrivateMethod,
@@ -900,7 +950,7 @@ generate_impl! {
         ///
         /// Like `set #name() {}`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>**
         SetPrivateSetter,
@@ -909,7 +959,7 @@ generate_impl! {
         ///
         /// Like `get #name() {}`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>**
         SetPrivateGetter,
@@ -918,7 +968,7 @@ generate_impl! {
         ///
         /// Like `object.#name`
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: object **=>** value
         GetPrivateField,
@@ -932,28 +982,28 @@ generate_impl! {
 
         /// Push a private field to the class.
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: class, field_function **=>**
         PushClassFieldPrivate,
 
         /// Push a private getter to the class.
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: class, getter **=>**
         PushClassPrivateGetter,
 
         /// Push a private setter to the class.
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: class, setter **=>**
         PushClassPrivateSetter,
 
         /// Push a private method to the class.
         ///
-        /// Operands: name_index: `u32`
+        /// Operands: private_name_index: `u32`
         ///
         /// Stack: class, method **=>**
         PushClassPrivateMethod,

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -919,23 +919,23 @@ generate_impl! {
         /// Stack: class_proto, key, function **=>**
         DefineClassSetterByValue,
 
-        /// Assign the value of a private property of an object by it's name.
+        /// Set the value of a private property of an object by it's name.
         ///
         /// Like `obj.#name = value`
         ///
         /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>** value
-        AssignPrivateField,
+        SetPrivateField,
 
-        /// Set a private property of a class constructor by it's name.
+        /// Define a private property of a class constructor by it's name.
         ///
         /// Like `#name = value`
         ///
         /// Operands: private_name_index: `u32`
         ///
         /// Stack: object, value **=>**
-        SetPrivateField,
+        DefinePrivateField,
 
         /// Set a private method of a class constructor by it's name.
         ///

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -32,6 +32,7 @@ impl Operation for PushClassField {
             .as_object()
             .expect("class must be function object");
         field_function.set_home_object(class_object.clone());
+        field_function.set_class_object(class_object.clone());
         class_object
             .borrow_mut()
             .as_function_mut()
@@ -57,7 +58,7 @@ impl Operation for PushClassFieldPrivate {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let field_function_value = context.vm.pop();
         let class_value = context.vm.pop();
 
@@ -72,12 +73,13 @@ impl Operation for PushClassFieldPrivate {
             .as_object()
             .expect("class must be function object");
         field_function.set_home_object(class_object.clone());
+        field_function.set_class_object(class_object.clone());
         class_object
             .borrow_mut()
             .as_function_mut()
             .expect("class must be function object")
             .push_field_private(
-                name.sym(),
+                name,
                 JsFunction::from_object_unchecked(field_function_object.clone()),
             );
         Ok(ShouldExit::False)

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -1,5 +1,6 @@
 use crate::{
     object::PrivateElement,
+    property::PropertyDescriptor,
     vm::{opcode::Operation, ShouldExit},
     Context, JsResult,
 };
@@ -17,17 +18,34 @@ impl Operation for PushClassPrivateMethod {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let method = context.vm.pop();
         let method_object = method.as_callable().expect("method must be callable");
+
+        let name_string = format!("#{}", context.interner().resolve_expect(name.description()));
+        let desc = PropertyDescriptor::builder()
+            .value(name_string)
+            .writable(false)
+            .enumerable(false)
+            .configurable(true)
+            .build();
+        method_object
+            .__define_own_property__("name".into(), desc, context)
+            .expect("failed to set name property on private method");
+
         let class = context.vm.pop();
-        class
-            .as_object()
-            .expect("class must be function object")
+        let class_object = class.as_object().expect("class must be function object");
+        class_object
             .borrow_mut()
             .as_function_mut()
             .expect("class must be function object")
-            .push_private_method(name.sym(), PrivateElement::Method(method_object.clone()));
+            .push_private_method(name, PrivateElement::Method(method_object.clone()));
+
+        let mut method_object_mut = method_object.borrow_mut();
+        let function = method_object_mut
+            .as_function_mut()
+            .expect("method must be function object");
+        function.set_class_object(class_object.clone());
         Ok(ShouldExit::False)
     }
 }
@@ -45,23 +63,27 @@ impl Operation for PushClassPrivateGetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let getter = context.vm.pop();
         let getter_object = getter.as_callable().expect("getter must be callable");
         let class = context.vm.pop();
-        class
-            .as_object()
-            .expect("class must be function object")
+        let class_object = class.as_object().expect("class must be function object");
+        class_object
             .borrow_mut()
             .as_function_mut()
             .expect("class must be function object")
             .push_private_method(
-                name.sym(),
+                name,
                 PrivateElement::Accessor {
                     getter: Some(getter_object.clone()),
                     setter: None,
                 },
             );
+        let mut getter_object_mut = getter_object.borrow_mut();
+        let function = getter_object_mut
+            .as_function_mut()
+            .expect("getter must be function object");
+        function.set_class_object(class_object.clone());
         Ok(ShouldExit::False)
     }
 }
@@ -79,23 +101,27 @@ impl Operation for PushClassPrivateSetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let setter = context.vm.pop();
         let setter_object = setter.as_callable().expect("getter must be callable");
         let class = context.vm.pop();
-        class
-            .as_object()
-            .expect("class must be function object")
+        let class_object = class.as_object().expect("class must be function object");
+        class_object
             .borrow_mut()
             .as_function_mut()
             .expect("class must be function object")
             .push_private_method(
-                name.sym(),
+                name,
                 PrivateElement::Accessor {
                     getter: None,
                     setter: Some(setter_object.clone()),
                 },
             );
+        let mut setter_object_mut = setter_object.borrow_mut();
+        let function = setter_object_mut
+            .as_function_mut()
+            .expect("setter must be function object");
+        function.set_class_object(class_object.clone());
         Ok(ShouldExit::False)
     }
 }

--- a/boa_engine/src/vm/opcode/set/home_object.rs
+++ b/boa_engine/src/vm/opcode/set/home_object.rs
@@ -16,15 +16,18 @@ impl Operation for SetHomeObject {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let function = context.vm.pop();
-        let function_object = function.as_object().expect("must be object");
         let home = context.vm.pop();
-        let home_object = home.as_object().expect("must be object");
 
-        function_object
-            .borrow_mut()
-            .as_function_mut()
-            .expect("must be function object")
-            .set_home_object(home_object.clone());
+        {
+            let function_object = function.as_object().expect("must be object");
+            let home_object = home.as_object().expect("must be object");
+            let mut function_object_mut = function_object.borrow_mut();
+            let function_mut = function_object_mut
+                .as_function_mut()
+                .expect("must be function object");
+            function_mut.set_home_object(home_object.clone());
+            function_mut.set_class_object(home_object.clone());
+        }
 
         context.vm.push(home);
         context.vm.push(function);

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -1,6 +1,7 @@
 use crate::{
     error::JsNativeError,
     object::PrivateElement,
+    property::PropertyDescriptor,
     vm::{opcode::Operation, ShouldExit},
     Context, JsResult,
 };
@@ -18,15 +19,20 @@ impl Operation for AssignPrivateField {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         let object = context.vm.pop();
         if let Some(object) = object.as_object() {
             let mut object_borrow_mut = object.borrow_mut();
-            match object_borrow_mut.get_private_element(name.sym()) {
+            match object_borrow_mut.get_private_element(name) {
                 Some(PrivateElement::Field(_)) => {
-                    object_borrow_mut
-                        .set_private_element(name.sym(), PrivateElement::Field(value.clone()));
+                    if !object_borrow_mut
+                        .assign_private_element(name, PrivateElement::Field(value.clone()))
+                    {
+                        return Err(JsNativeError::typ()
+                            .with_message("cannot assign to private field")
+                            .into());
+                    }
                 }
                 Some(PrivateElement::Method(_)) => {
                     return Err(JsNativeError::typ()
@@ -75,7 +81,7 @@ impl Operation for SetPrivateField {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         let object = context.vm.pop();
         if let Some(object) = object.as_object() {
@@ -83,13 +89,13 @@ impl Operation for SetPrivateField {
             if let Some(PrivateElement::Accessor {
                 getter: _,
                 setter: Some(setter),
-            }) = object_borrow_mut.get_private_element(name.sym())
+            }) = object_borrow_mut.get_private_element(name)
             {
                 let setter = setter.clone();
                 drop(object_borrow_mut);
                 setter.call(&object.clone().into(), &[value], context)?;
             } else {
-                object_borrow_mut.set_private_element(name.sym(), PrivateElement::Field(value));
+                object_borrow_mut.set_private_element(name, PrivateElement::Field(value));
             }
         } else {
             return Err(JsNativeError::typ()
@@ -113,14 +119,31 @@ impl Operation for SetPrivateMethod {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         let value = value.as_callable().expect("method must be callable");
+
+        let name_string = format!("#{}", context.interner().resolve_expect(name.description()));
+        let desc = PropertyDescriptor::builder()
+            .value(name_string)
+            .writable(false)
+            .enumerable(false)
+            .configurable(true)
+            .build();
+        value
+            .__define_own_property__("name".into(), desc, context)
+            .expect("failed to set name property on private method");
+
         let object = context.vm.pop();
         if let Some(object) = object.as_object() {
-            let mut object_borrow_mut = object.borrow_mut();
-            object_borrow_mut
-                .set_private_element(name.sym(), PrivateElement::Method(value.clone()));
+            object
+                .borrow_mut()
+                .set_private_element(name, PrivateElement::Method(value.clone()));
+            let mut value_mut = value.borrow_mut();
+            let function = value_mut
+                .as_function_mut()
+                .expect("method must be a function");
+            function.set_class_object(object.clone());
         } else {
             return Err(JsNativeError::typ()
                 .with_message("cannot set private setter on non-object")
@@ -143,13 +166,19 @@ impl Operation for SetPrivateSetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         let value = value.as_callable().expect("setter must be callable");
         let object = context.vm.pop();
         if let Some(object) = object.as_object() {
-            let mut object_borrow_mut = object.borrow_mut();
-            object_borrow_mut.set_private_element_setter(name.sym(), value.clone());
+            object
+                .borrow_mut()
+                .set_private_element_setter(name, value.clone());
+            let mut value_mut = value.borrow_mut();
+            let function = value_mut
+                .as_function_mut()
+                .expect("method must be a function");
+            function.set_class_object(object.clone());
         } else {
             return Err(JsNativeError::typ()
                 .with_message("cannot set private setter on non-object")
@@ -172,13 +201,19 @@ impl Operation for SetPrivateGetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code.names[index as usize];
+        let name = context.vm.frame().code.private_names[index as usize];
         let value = context.vm.pop();
         let value = value.as_callable().expect("getter must be callable");
         let object = context.vm.pop();
         if let Some(object) = object.as_object() {
-            let mut object_borrow_mut = object.borrow_mut();
-            object_borrow_mut.set_private_element_getter(name.sym(), value.clone());
+            object
+                .borrow_mut()
+                .set_private_element_getter(name, value.clone());
+            let mut value_mut = value.borrow_mut();
+            let function = value_mut
+                .as_function_mut()
+                .expect("method must be a function");
+            function.set_class_object(object.clone());
         } else {
             return Err(JsNativeError::typ()
                 .with_message("cannot set private getter on non-object")

--- a/boa_parser/src/parser/expression/left_hand_side/call.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/call.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     Error,
 };
+use ast::function::PrivateName;
 use boa_ast::{
     self as ast,
     expression::{
@@ -109,8 +110,13 @@ where
                         }
                         TokenKind::NullLiteral => SimplePropertyAccess::new(lhs, Sym::NULL).into(),
                         TokenKind::PrivateIdentifier(name) => {
-                            cursor.push_used_private_identifier(*name, token.span().start())?;
-                            PrivatePropertyAccess::new(lhs, *name).into()
+                            if !cursor.in_class() {
+                                return Err(Error::general(
+                                    "Private identifier outside of class",
+                                    token.span().start(),
+                                ));
+                            }
+                            PrivatePropertyAccess::new(lhs, PrivateName::new(*name)).into()
                         }
                         _ => {
                             return Err(Error::expected(

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -31,6 +31,7 @@ fn check_async_ordinary_method() {
             None,
             None,
             elements.into(),
+            true,
         ))
         .into()],
         interner,
@@ -57,6 +58,7 @@ fn check_async_field_initialization() {
             None,
             None,
             elements.into(),
+            true,
         ))
         .into()],
         interner,
@@ -82,6 +84,7 @@ fn check_async_field() {
             None,
             None,
             elements.into(),
+            true,
         ))
         .into()],
         interner,

--- a/boa_parser/src/parser/statement/declaration/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/mod.rs
@@ -13,7 +13,6 @@ mod lexical;
 mod tests;
 
 pub(in crate::parser) use hoistable::class_decl::ClassTail;
-pub(crate) use hoistable::class_decl::PrivateElement;
 pub(in crate::parser) use hoistable::FunctionDeclaration;
 use hoistable::HoistableDeclaration;
 pub(in crate::parser) use lexical::LexicalDeclaration;

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -54,7 +54,6 @@ use boa_profiler::Profiler;
 use std::io::Read;
 
 pub(in crate::parser) use declaration::ClassTail;
-pub(crate) use declaration::PrivateElement;
 
 /// Statement parsing.
 ///


### PR DESCRIPTION
This Pull Request fixes various bugs related to classes.

The biggest changes are:

- Changed private names to be unique across multiple classes.
- Changed private name resolution to work via a visitor after a class is parsed. The way class early errors are defined makes it impossible to perform private name resolution while parsing.
- Added function names to class methods.
- Added class name binding to method function environments.
- Separated opcodes for `static` and non-`static` class method definitions to make the above operations possible.

There are still some bugs and further issues with classes but this is already a lot.