### PR TITLE
[Merged by Bors] - Add early errors for 'eval' or 'arguments' in parameters

### DIFF
--- a/boa_ast/src/operations.rs
+++ b/boa_ast/src/operations.rs
@@ -47,6 +47,8 @@ pub enum ContainsSymbol {
     This,
     /// A method definition.
     MethodDefinition,
+    /// The BindingIdentifier "eval" or "arguments".
+    EvalOrArguments,
 }
 
 /// Returns `true` if the node contains the given symbol.
@@ -65,6 +67,15 @@ where
 
     impl<'ast> Visitor<'ast> for ContainsVisitor {
         type BreakTy = ();
+
+        fn visit_identifier(&mut self, node: &'ast Identifier) -> ControlFlow<Self::BreakTy> {
+            if self.0 == ContainsSymbol::EvalOrArguments
+                && (node.sym() == Sym::EVAL || node.sym() == Sym::ARGUMENTS)
+            {
+                return ControlFlow::Break(());
+            }
+            ControlFlow::Continue(())
+        }
 
         fn visit_function(&mut self, _: &'ast Function) -> ControlFlow<Self::BreakTy> {
             ControlFlow::Continue(())

--- a/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
@@ -115,13 +115,15 @@ where
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if (cursor.strict_mode() || body.strict())
-            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
-        {
-            return Err(Error::lex(LexError::Syntax(
-                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
-                name_span.start(),
-            )));
+        if let Some(name) = name {
+            if (cursor.strict_mode() || body.strict())
+                && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
+            {
+                return Err(Error::lex(LexError::Syntax(
+                    "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                    name_span.start(),
+                )));
+            }
         }
 
         // Catch early error for BindingIdentifier, because strictness of the functions body is also
@@ -142,12 +144,7 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncFunction::new(
-            if name.is_some() { name } else { self.name },
-            params,
-            body,
-            name.is_some(),
-        );
+        let function = AsyncFunction::new(name.or(self.name), params, body, name.is_some());
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     parser::{
         expression::BindingIdentifier,
         function::{FormalParameters, FunctionBody},
-        name_in_lexically_declared_names, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
+        name_in_lexically_declared_names, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
     Error,
 };
@@ -14,7 +14,7 @@ use boa_ast::{
     expression::Identifier,
     function::AsyncFunction,
     operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
-    Keyword, Position, Punctuator,
+    Keyword, Punctuator,
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
@@ -31,20 +31,15 @@ use std::io::Read;
 #[derive(Debug, Clone, Copy)]
 pub(super) struct AsyncFunctionExpression {
     name: Option<Identifier>,
-    allow_yield: AllowYield,
 }
 
 impl AsyncFunctionExpression {
     /// Creates a new `AsyncFunctionExpression` parser.
-    pub(super) fn new<N, Y>(name: N, allow_yield: Y) -> Self
+    pub(super) fn new<N>(name: N) -> Self
     where
         N: Into<Option<Identifier>>,
-        Y: Into<AllowYield>,
     {
-        Self {
-            name: name.into(),
-            allow_yield: allow_yield.into(),
-        }
+        Self { name: name.into() }
     }
 }
 
@@ -63,26 +58,20 @@ where
             interner,
         )?;
 
-        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
-            TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
-            _ => (
-                Some(BindingIdentifier::new(self.allow_yield, true).parse(cursor, interner)?),
-                true,
-            ),
-        };
+        let token = cursor.peek(0, interner).or_abrupt()?;
+        let (name, name_span) = match token.kind() {
+            TokenKind::Identifier(_)
+            | TokenKind::Keyword((
+                Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
+                _,
+            )) => {
+                let span = token.span();
+                let name = BindingIdentifier::new(false, true).parse(cursor, interner)?;
 
-        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
-        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if let Some(name) = name {
-            if cursor.strict_mode() && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym()) {
-                return Err(Error::lex(LexError::Syntax(
-                    "Unexpected eval or arguments in strict mode".into(),
-                    cursor
-                        .peek(0, interner)?
-                        .map_or_else(|| Position::new(1, 1), |token| token.span().end()),
-                )));
+                (Some(name), span)
             }
-        }
+            _ => (None, token.span()),
+        };
 
         let params_start_position = cursor
             .expect(Punctuator::OpenParen, "async function expression", interner)?
@@ -124,6 +113,26 @@ where
             )));
         }
 
+        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+        if (cursor.strict_mode() || body.strict())
+            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
+        {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                name_span.start(),
+            )));
+        }
+
+        // Catch early error for BindingIdentifier, because strictness of the functions body is also
+        // relevant for the function parameters.
+        if body.strict() && contains(&params, ContainsSymbol::EvalOrArguments) {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
@@ -133,7 +142,12 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncFunction::new(name, params, body, has_binding_identifier);
+        let function = AsyncFunction::new(
+            if name.is_some() { name } else { self.name },
+            params,
+            body,
+            name.is_some(),
+        );
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -153,13 +153,15 @@ where
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if (cursor.strict_mode() || body.strict())
-            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
-        {
-            return Err(Error::lex(LexError::Syntax(
-                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
-                name_span.start(),
-            )));
+        if let Some(name) = name {
+            if (cursor.strict_mode() || body.strict())
+                && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
+            {
+                return Err(Error::lex(LexError::Syntax(
+                    "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                    name_span.start(),
+                )));
+            }
         }
 
         // Catch early error for BindingIdentifier, because strictness of the functions body is also
@@ -179,12 +181,7 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncGenerator::new(
-            if name.is_some() { name } else { self.name },
-            params,
-            body,
-            name.is_some(),
-        );
+        let function = AsyncGenerator::new(name.or(self.name), params, body, name.is_some());
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -23,7 +23,7 @@ use boa_ast::{
     expression::Identifier,
     function::AsyncGenerator,
     operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
-    Keyword, Position, Punctuator,
+    Keyword, Punctuator,
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
@@ -72,26 +72,20 @@ where
             interner,
         )?;
 
-        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
-            TokenKind::Punctuator(Punctuator::OpenParen) => (self.name, false),
-            _ => (
-                Some(BindingIdentifier::new(true, true).parse(cursor, interner)?),
-                true,
-            ),
-        };
+        let token = cursor.peek(0, interner).or_abrupt()?;
+        let (name, name_span) = match token.kind() {
+            TokenKind::Identifier(_)
+            | TokenKind::Keyword((
+                Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
+                _,
+            )) => {
+                let span = token.span();
+                let name = BindingIdentifier::new(true, true).parse(cursor, interner)?;
 
-        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict
-        // mode code, it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if let Some(name) = name {
-            if cursor.strict_mode() && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym()) {
-                return Err(Error::lex(LexError::Syntax(
-                    "Unexpected eval or arguments in strict mode".into(),
-                    cursor
-                        .peek(0, interner)?
-                        .map_or_else(|| Position::new(1, 1), |token| token.span().end()),
-                )));
+                (Some(name), span)
             }
-        }
+            _ => (None, token.span()),
+        };
 
         let params_start_position = cursor
             .expect(
@@ -157,6 +151,26 @@ where
             )));
         }
 
+        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+        if (cursor.strict_mode() || body.strict())
+            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
+        {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                name_span.start(),
+            )));
+        }
+
+        // Catch early error for BindingIdentifier, because strictness of the functions body is also
+        // relevant for the function parameters.
+        if body.strict() && contains(&params, ContainsSymbol::EvalOrArguments) {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         name_in_lexically_declared_names(
@@ -165,7 +179,12 @@ where
             params_start_position,
         )?;
 
-        let function = AsyncGenerator::new(name, params, body, has_binding_identifier);
+        let function = AsyncGenerator::new(
+            if name.is_some() { name } else { self.name },
+            params,
+            body,
+            name.is_some(),
+        );
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/function_expression/mod.rs
@@ -23,7 +23,7 @@ use boa_ast::{
     expression::Identifier,
     function::Function,
     operations::{bound_names, contains, top_level_lexically_declared_names, ContainsSymbol},
-    Keyword, Position, Punctuator,
+    Keyword, Punctuator,
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
@@ -61,28 +61,19 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("FunctionExpression", "Parsing");
 
-        let (name, has_binding_identifier) = match cursor.peek(0, interner).or_abrupt()?.kind() {
+        let token = cursor.peek(0, interner).or_abrupt()?;
+        let (name, name_span) = match token.kind() {
             TokenKind::Identifier(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
                 _,
             )) => {
+                let span = token.span();
                 let name = BindingIdentifier::new(false, false).parse(cursor, interner)?;
 
-                // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
-                // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-                if cursor.strict_mode() && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym()) {
-                    return Err(Error::lex(LexError::Syntax(
-                        "Unexpected eval or arguments in strict mode".into(),
-                        cursor
-                            .peek(0, interner)?
-                            .map_or_else(|| Position::new(1, 1), |token| token.span().end()),
-                    )));
-                }
-
-                (Some(name), true)
+                (Some(name), span)
             }
-            _ => (self.name, false),
+            _ => (None, token.span()),
         };
 
         let params_start_position = cursor
@@ -117,6 +108,26 @@ where
             )));
         }
 
+        // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
+        // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
+        if (cursor.strict_mode() || body.strict())
+            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
+        {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                name_span.start(),
+            )));
+        }
+
+        // Catch early error for BindingIdentifier, because strictness of the functions body is also
+        // relevant for the function parameters.
+        if body.strict() && contains(&params, ContainsSymbol::EvalOrArguments) {
+            return Err(Error::lex(LexError::Syntax(
+                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                params_start_position,
+            )));
+        }
+
         // It is a Syntax Error if any element of the BoundNames of FormalParameters
         // also occurs in the LexicallyDeclaredNames of FunctionBody.
         // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors
@@ -126,8 +137,12 @@ where
             params_start_position,
         )?;
 
-        let function =
-            Function::new_with_binding_identifier(name, params, body, has_binding_identifier);
+        let function = Function::new_with_binding_identifier(
+            if name.is_some() { name } else { self.name },
+            params,
+            body,
+            name.is_some(),
+        );
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
@@ -118,13 +118,15 @@ where
 
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-        if (cursor.strict_mode() || body.strict())
-            && [Some(Sym::EVAL), Some(Sym::ARGUMENTS)].contains(&name.map(Identifier::sym))
-        {
-            return Err(Error::lex(LexError::Syntax(
-                "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
-                name_span.start(),
-            )));
+        if let Some(name) = name {
+            if (cursor.strict_mode() || body.strict())
+                && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
+            {
+                return Err(Error::lex(LexError::Syntax(
+                    "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
+                    name_span.start(),
+                )));
+            }
         }
 
         // Catch early error for BindingIdentifier, because strictness of the functions body is also
@@ -154,12 +156,7 @@ where
             )));
         }
 
-        let function = Generator::new(
-            if name.is_some() { name } else { self.name },
-            params,
-            body,
-            name.is_some(),
-        );
+        let function = Generator::new(name.or(self.name), params, body, name.is_some());
 
         if contains(&function, ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -147,7 +147,7 @@ where
                                     .parse(cursor, interner)
                                     .map(Into::into)
                             }
-                            _ => AsyncFunctionExpression::new(self.name, self.allow_yield)
+                            _ => AsyncFunctionExpression::new(self.name)
                                 .parse(cursor, interner)
                                 .map(Into::into),
                         }


### PR DESCRIPTION
This Pull Request changes the following:

- Add early errors for functions to make sure that 'eval' or 'arguments' cannot be used as binding identifiers in function parameters. When the function body contains a strict directive, this also has to be accounted for.
- Fix early errors for function identifiers to make sure they cannot be 'eval' or 'arguments' when a function body contains a strict directive.
