### PR TITLE
[Merged by Bors] - Remove `Literal::Undefined`

### DIFF
--- a/boa_ast/src/expression/literal/mod.rs
+++ b/boa_ast/src/expression/literal/mod.rs
@@ -110,16 +110,6 @@ pub enum Literal {
     /// [spec]: https://tc39.es/ecma262/#sec-null-value
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/null
     Null,
-
-    /// The `undefined` is a primitive value automatically assigned to variables that have just been declared, or to formal arguments for which there are no actual arguments.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-undefined
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/undefined
-    Undefined,
 }
 
 impl From<Sym> for Literal {
@@ -183,7 +173,6 @@ impl ToInternedString for Literal {
             Self::BigInt(ref num) => num.to_string(),
             Self::Bool(v) => v.to_string(),
             Self::Null => "null".to_owned(),
-            Self::Undefined => "undefined".to_owned(),
         }
     }
 }

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -35,7 +35,6 @@ impl ByteCompiler<'_, '_> {
             AstLiteral::Bool(true) => self.emit(Opcode::PushTrue, &[]),
             AstLiteral::Bool(false) => self.emit(Opcode::PushFalse, &[]),
             AstLiteral::Null => self.emit(Opcode::PushNull, &[]),
-            AstLiteral::Undefined => self.emit(Opcode::PushUndefined, &[]),
         }
 
         if !use_expr {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2512 .

Removes `Literal::Undefined` so that `undefined` is treated as an identifier name. Ran the parser's idempotency fuzzer and ensured the bug doesn't reproduce.
