### PR TITLE
[Merged by Bors] - Recognize Directive Prologues correctly

### DIFF
--- a/boa_ast/src/statement_list.rs
+++ b/boa_ast/src/statement_list.rs
@@ -121,6 +121,18 @@ pub struct StatementList {
 }
 
 impl StatementList {
+    /// Creates a new `StatementList` AST node.
+    #[must_use]
+    pub fn new<S>(statements: S, strict: bool) -> Self
+    where
+        S: Into<Box<[StatementListItem]>>,
+    {
+        Self {
+            statements: statements.into(),
+            strict,
+        }
+    }
+
     /// Gets the list of statements.
     #[inline]
     #[must_use]
@@ -133,12 +145,6 @@ impl StatementList {
     #[must_use]
     pub const fn strict(&self) -> bool {
         self.strict
-    }
-
-    /// Set the strict mode.
-    #[inline]
-    pub fn set_strict(&mut self, strict: bool) {
-        self.strict = strict;
     }
 }
 

--- a/boa_parser/src/parser/statement/block/mod.rs
+++ b/boa_parser/src/parser/statement/block/mod.rs
@@ -90,6 +90,8 @@ where
             self.allow_await,
             self.allow_return,
             &BLOCK_BREAK_TOKENS,
+            false,
+            false,
         )
         .parse(cursor, interner)
         .map(statement::Block::from)?;

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -609,9 +609,15 @@ where
                     let strict = cursor.strict_mode();
                     cursor.set_strict_mode(true);
                     let position = cursor.peek(0, interner).or_abrupt()?.span().start();
-                    let statement_list =
-                        StatementList::new(false, true, false, &FUNCTION_BREAK_TOKENS)
-                            .parse(cursor, interner)?;
+                    let statement_list = StatementList::new(
+                        false,
+                        true,
+                        false,
+                        &FUNCTION_BREAK_TOKENS,
+                        false,
+                        false,
+                    )
+                    .parse(cursor, interner)?;
 
                     let mut lexical_names = FxHashSet::default();
                     for name in &lexically_declared_names(&statement_list) {

--- a/boa_parser/src/parser/statement/switch/mod.rs
+++ b/boa_parser/src/parser/statement/switch/mod.rs
@@ -173,6 +173,8 @@ where
                         self.allow_await,
                         self.allow_return,
                         &CASE_BREAK_TOKENS,
+                        false,
+                        false,
                     )
                     .parse(cursor, interner)?;
 
@@ -195,6 +197,8 @@ where
                         self.allow_await,
                         self.allow_return,
                         &CASE_BREAK_TOKENS,
+                        false,
+                        false,
                     )
                     .parse(cursor, interner)?;
 


### PR DESCRIPTION
This Pull Request changes the following:

- Recognize the `"use strict"` directive prologue correctly.
- Refactor parsers to remove a setter function.