### PR TITLE
chore: add .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+	// See https://aka.ms/vscode-remote/devcontainer.json for format details.
+	"name": "boa",
+	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"rust-lang.rust-analyzer"
+			]
+		}
+	},
+
+	// Port 8080 is used for the demo server
+	"forwardPorts": [8080]
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,15 +1,16 @@
 {
-	// See https://aka.ms/vscode-remote/devcontainer.json for format details.
-	"name": "boa",
-	"image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
-	"customizations": {
-		"vscode": {
-			"extensions": [
-				"rust-lang.rust-analyzer"
-			]
-		}
-	},
+  // See https://aka.ms/vscode-remote/devcontainer.json for format details.
+  "name": "boa",
+  "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  },
 
-	// Port 8080 is used for the demo server
-	"forwardPorts": [8080]
+  // Port 8080 is used for the demo server
+  "forwardPorts": [8080],
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {}
+  }
 }


### PR DESCRIPTION
This adds a rust [dev container](https://containers.dev/) for spinning up a dev environment locally. 