### PR TITLE
[Merged by Bors] - `Break` Opcode and `ByteCompiler` changes

### DIFF
--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -1,0 +1,344 @@
+use crate::{
+    bytecompiler::{ByteCompiler, Label},
+    vm::Opcode,
+};
+use boa_interner::Sym;
+use std::mem::size_of;
+
+#[derive(Debug, Clone)]
+pub(crate) struct JumpControlInfo {
+    label: Option<Sym>,
+    start_address: u32,
+    kind: JumpControlInfoKind,
+    breaks: Vec<Label>,
+    try_continues: Vec<Label>,
+    in_catch: bool,
+    has_finally: bool,
+    finally_start: Option<Label>,
+    for_of_in_loop: bool,
+    decl_envs: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum JumpControlInfoKind {
+    Loop,
+    Switch,
+    Try,
+    LabelledBlock,
+}
+
+// ---- Creation Methods ---- //
+
+impl JumpControlInfo {
+    pub(crate) const fn new() -> Self {
+        Self {
+            label: None,
+            start_address: u32::MAX,
+            kind: JumpControlInfoKind::Loop,
+            breaks: Vec::new(),
+            try_continues: Vec::new(),
+            in_catch: false,
+            has_finally: false,
+            finally_start: None,
+            for_of_in_loop: false,
+            decl_envs: 0,
+        }
+    }
+
+    pub(crate) const fn with_label(mut self, label: Option<Sym>) -> Self {
+        self.label = label;
+        self
+    }
+
+    pub(crate) const fn with_start_address(mut self, address: u32) -> Self {
+        self.start_address = address;
+        self
+    }
+
+    pub(crate) const fn with_kind(mut self, kind: JumpControlInfoKind) -> Self {
+        self.kind = kind;
+        self
+    }
+
+    pub(crate) const fn with_has_finally(mut self, value: bool) -> Self {
+        self.has_finally = value;
+        self
+    }
+
+    pub(crate) const fn with_for_of_in_loop(mut self, value: bool) -> Self {
+        self.for_of_in_loop = value;
+        self
+    }
+}
+
+impl JumpControlInfo {
+    pub(crate) const fn label(&self) -> Option<Sym> {
+        self.label
+    }
+
+    pub(crate) fn set_label(&mut self, label: Option<Sym>) {
+        assert!(self.label.is_none());
+        self.label = label;
+    }
+
+    pub(crate) const fn start_address(&self) -> u32 {
+        self.start_address
+    }
+
+    pub(crate) fn set_start_address(&mut self, start_address: u32) {
+        self.start_address = start_address;
+    }
+
+    pub(crate) const fn kind(&self) -> JumpControlInfoKind {
+        self.kind
+    }
+
+    pub(crate) fn set_in_catch(&mut self, value: bool) {
+        self.in_catch = value;
+    }
+
+    pub(crate) const fn in_catch(&self) -> bool {
+        self.in_catch
+    }
+
+    pub(crate) const fn has_finally(&self) -> bool {
+        self.has_finally
+    }
+
+    pub(crate) fn set_finally_start(&mut self, label: Label) {
+        self.finally_start = Some(label);
+    }
+
+    pub(crate) const fn finally_start(&self) -> Option<Label> {
+        self.finally_start
+    }
+
+    pub(crate) const fn for_of_in_loop(&self) -> bool {
+        self.for_of_in_loop
+    }
+
+    pub(crate) const fn decl_envs(&self) -> u32 {
+        self.decl_envs
+    }
+
+    pub(crate) fn inc_decl_envs(&mut self) {
+        self.decl_envs += 1;
+    }
+
+    pub(crate) fn dec_decl_envs(&mut self) {
+        self.decl_envs -= 1;
+    }
+
+    pub(crate) fn push_break_label(&mut self, break_label: Label) {
+        self.breaks.push(break_label);
+    }
+
+    pub(crate) fn push_try_continue_label(&mut self, try_continue_label: Label) {
+        self.try_continues.push(try_continue_label);
+    }
+}
+
+impl ByteCompiler<'_, '_> {
+    pub(crate) fn push_new_jump_control(&mut self) {
+        self.jump_info.push(JumpControlInfo::new());
+    }
+
+    /*
+    pub(crate) fn inc_jump_control_decl_envs(&mut self) {
+        assert!(!self.jump_info.is_empty());
+        self.jump_info
+            .last_mut()
+            .expect("JumpInfo must exist")
+            .inc_decl_envs();
+    }
+    */
+
+    pub(crate) fn set_jump_control_label(&mut self, label: Option<Sym>) {
+        assert!(!self.jump_info.is_empty());
+        self.jump_info
+            .last_mut()
+            .expect("JumpInfo must exist")
+            .set_label(label);
+    }
+
+    pub(crate) fn set_jump_control_start_address(&mut self, start_address: u32) {
+        assert!(!self.jump_info.is_empty());
+        self.jump_info
+            .last_mut()
+            .expect("JumpInfo must exist")
+            .set_start_address(start_address);
+    }
+
+    pub(crate) fn set_jump_control_finally_start(&mut self, start: Label) {
+        if !self.jump_info.is_empty() {
+            let info = self
+                .jump_info
+                .last_mut()
+                .expect("must have try control label");
+            assert!(info.kind == JumpControlInfoKind::Try);
+            info.set_finally_start(start);
+        }
+    }
+
+    pub(crate) fn set_jump_control_catch_start(&mut self, value: bool) {
+        if !self.jump_info.is_empty() {
+            let info = self
+                .jump_info
+                .last_mut()
+                .expect("must have try control label");
+            assert!(info.kind == JumpControlInfoKind::Try);
+            info.set_in_catch(value);
+        }
+    }
+
+    /// Emits the `PushDeclarativeEnvironment` and updates the current jump info to track environments
+    pub(crate) fn emit_and_track_decl_env(&mut self) -> (Label, Label) {
+        let pushed_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        if !self.jump_info.is_empty() {
+            let current_jump_info = self
+                .jump_info
+                .last_mut()
+                .expect("Jump info must exist as the vector is not empty");
+            current_jump_info.inc_decl_envs();
+        }
+        pushed_env
+    }
+
+    pub(crate) fn emit_and_track_pop_env(&mut self) {
+        self.emit_opcode(Opcode::PopEnvironment);
+        if !self.jump_info.is_empty() {
+            let current_info = self.jump_info.last_mut().expect("JumpInfo must exist");
+            current_info.dec_decl_envs();
+        }
+    }
+
+    pub(crate) fn push_loop_control_info(&mut self, label: Option<Sym>, start_address: u32) {
+        let new_info = JumpControlInfo::new()
+            .with_label(label)
+            .with_start_address(start_address);
+        self.jump_info.push(new_info);
+    }
+
+    pub(crate) fn push_loop_control_info_for_of_in_loop(
+        &mut self,
+        label: Option<Sym>,
+        start_address: u32,
+    ) {
+        let new_info = JumpControlInfo::new()
+            .with_label(label)
+            .with_start_address(start_address)
+            .with_for_of_in_loop(true);
+        self.jump_info.push(new_info);
+    }
+
+    pub(crate) fn pop_loop_control_info(&mut self) {
+        let loop_info = self.jump_info.pop().expect("no jump information found");
+
+        assert!(loop_info.kind == JumpControlInfoKind::Loop);
+
+        for label in loop_info.breaks {
+            self.patch_jump(label);
+        }
+
+        for label in loop_info.try_continues {
+            self.patch_jump_with_target(label, loop_info.start_address);
+        }
+    }
+
+    pub(crate) fn push_switch_control_info(&mut self, label: Option<Sym>, start_address: u32) {
+        let new_info = JumpControlInfo::new()
+            .with_kind(JumpControlInfoKind::Switch)
+            .with_label(label)
+            .with_start_address(start_address);
+        self.jump_info.push(new_info);
+    }
+
+    pub(crate) fn pop_switch_control_info(&mut self) {
+        let info = self.jump_info.pop().expect("no jump information found");
+
+        assert!(info.kind == JumpControlInfoKind::Switch);
+
+        for label in info.breaks {
+            self.patch_jump(label);
+        }
+    }
+
+    pub(crate) fn push_try_control_info(&mut self, has_finally: bool) {
+        if !self.jump_info.is_empty() {
+            let start_address = self
+                .jump_info
+                .last()
+                .expect("no jump information found")
+                .start_address();
+
+            let new_info = JumpControlInfo::new()
+                .with_kind(JumpControlInfoKind::Try)
+                .with_start_address(start_address)
+                .with_has_finally(has_finally);
+
+            self.jump_info.push(new_info);
+        }
+    }
+
+    pub(crate) fn pop_try_control_info(&mut self, finally_start_address: Option<u32>) {
+        if !self.jump_info.is_empty() {
+            let mut info = self.jump_info.pop().expect("no jump information found");
+
+            assert!(info.kind == JumpControlInfoKind::Try);
+
+            let mut breaks = Vec::with_capacity(info.breaks.len());
+
+            if let Some(finally_start_address) = finally_start_address {
+                for label in info.try_continues {
+                    if label.index < finally_start_address {
+                        self.patch_jump_with_target(label, finally_start_address);
+                    } else {
+                        self.patch_jump_with_target(label, info.start_address);
+                    }
+                }
+
+                for label in info.breaks {
+                    if label.index < finally_start_address {
+                        self.patch_jump_with_target(label, finally_start_address);
+                        let Label { mut index } = label;
+                        index -= size_of::<Opcode>() as u32;
+                        index -= size_of::<u32>() as u32;
+                        breaks.push(Label { index });
+                    } else {
+                        breaks.push(label);
+                    }
+                }
+                if let Some(jump_info) = self.jump_info.last_mut() {
+                    jump_info.breaks.append(&mut breaks);
+                }
+            } else if let Some(jump_info) = self.jump_info.last_mut() {
+                jump_info.breaks.append(&mut info.breaks);
+                jump_info.try_continues.append(&mut info.try_continues);
+            }
+        }
+    }
+
+    pub(crate) fn push_labelled_block_control_info(&mut self, label: Sym, start_address: u32) {
+        let new_info = JumpControlInfo::new()
+            .with_kind(JumpControlInfoKind::LabelledBlock)
+            .with_label(Some(label))
+            .with_start_address(start_address);
+        self.jump_info.push(new_info);
+    }
+
+    pub(crate) fn pop_labelled_block_control_info(&mut self) {
+        let info = self.jump_info.pop().expect("no jump information found");
+
+        assert!(info.kind == JumpControlInfoKind::LabelledBlock);
+
+        self.emit_opcode(Opcode::PopEnvironment);
+
+        for label in info.breaks {
+            self.patch_jump(label);
+        }
+
+        for label in info.try_continues {
+            self.patch_jump_with_target(label, info.start_address);
+        }
+    }
+}

--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -174,20 +174,8 @@ impl ByteCompiler<'_, '_> {
         self.jump_info.push(JumpControlInfo::default());
     }
 
-    pub(crate) fn set_jump_control_label(&mut self, label: Option<Sym>) {
-        assert!(!self.jump_info.is_empty());
-        self.jump_info
-            .last_mut()
-            .expect("JumpInfo must exist")
-            .set_label(label);
-    }
-
-    pub(crate) fn set_jump_control_start_address(&mut self, start_address: u32) {
-        assert!(!self.jump_info.is_empty());
-        self.jump_info
-            .last_mut()
-            .expect("JumpInfo must exist")
-            .set_start_address(start_address);
+    pub(crate) fn current_jump_control_mut(&mut self) -> Option<&mut JumpControlInfo> {
+        self.jump_info.last_mut()
     }
 
     pub(crate) fn set_jump_control_finally_start(&mut self, start: Label) {

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -237,7 +237,7 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
     /// Represents a placeholder address that will be patched later.
     const DUMMY_ADDRESS: u32 = u32::MAX;
 
-    /// Creates a new [`ByteCompiler`].
+    /// Creates a new `ByteCompiler`.
     #[inline]
     pub fn new(
         name: Sym,
@@ -1172,61 +1172,6 @@ impl<'b, 'icu> ByteCompiler<'b, 'icu> {
             Declaration::Class(class) => self.class(class, false),
             Declaration::Lexical(lexical) => self.compile_lexical_decl(lexical),
         }
-    }
-
-    /// Compiles a [`Statement`]
-    pub fn compile_stmt(
-        &mut self,
-        node: &Statement,
-        use_expr: bool,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
-        match node {
-            Statement::Var(var) => self.compile_var_decl(var)?,
-            Statement::If(node) => self.compile_if(node, configurable_globals)?,
-            Statement::ForLoop(for_loop) => {
-                self.compile_for_loop(for_loop, None, configurable_globals)?;
-            }
-            Statement::ForInLoop(for_in_loop) => {
-                self.compile_for_in_loop(for_in_loop, None, configurable_globals)?;
-            }
-            Statement::ForOfLoop(for_of_loop) => {
-                self.compile_for_of_loop(for_of_loop, None, configurable_globals)?;
-            }
-            Statement::WhileLoop(while_loop) => {
-                self.compile_while_loop(while_loop, None, configurable_globals)?;
-            }
-            Statement::DoWhileLoop(do_while_loop) => {
-                self.compile_do_while_loop(do_while_loop, None, configurable_globals)?;
-            }
-            Statement::Block(block) => {
-                self.compile_block(block, None, use_expr, configurable_globals)?;
-            }
-            Statement::Labelled(labelled) => {
-                self.compile_labelled(labelled, use_expr, configurable_globals)?;
-            }
-            Statement::Continue(node) => self.compile_continue(*node)?,
-            Statement::Break(node) => self.compile_break(*node)?,
-            Statement::Throw(throw) => {
-                self.compile_expr(throw.target(), true)?;
-                self.emit(Opcode::Throw, &[]);
-            }
-            Statement::Switch(switch) => {
-                self.compile_switch(switch, configurable_globals)?;
-            }
-            Statement::Return(ret) => {
-                if let Some(expr) = ret.target() {
-                    self.compile_expr(expr, true)?;
-                } else {
-                    self.emit(Opcode::PushUndefined, &[]);
-                }
-                self.emit(Opcode::Return, &[]);
-            }
-            Statement::Try(t) => self.compile_try(t, use_expr, configurable_globals)?,
-            Statement::Empty => {}
-            Statement::Expression(expr) => self.compile_expr(expr, use_expr)?,
-        }
-        Ok(())
     }
 
     /// Compile a function AST Node into bytecode.

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -32,7 +32,7 @@ use boa_interner::{Interner, Sym};
 use rustc_hash::FxHashMap;
 
 pub(crate) use function::FunctionCompiler;
-pub(crate) use jump_control::{JumpControlInfo, JumpControlInfoKind};
+pub(crate) use jump_control::JumpControlInfo;
 
 /// Describes how a node has been defined in the source code.
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -1,9 +1,4 @@
-
-use crate::{
-    bytecompiler::ByteCompiler,
-    vm::Opcode,
-    JsResult,
-};
+use crate::{bytecompiler::ByteCompiler, JsResult};
 
 use boa_ast::statement::Block;
 use boa_interner::Sym;
@@ -23,9 +18,11 @@ impl ByteCompiler<'_, '_> {
         }
 
         self.context.push_compile_time_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        let push_env = self.emit_declarative_env();
+
         self.create_decls(block.statement_list(), configurable_globals);
         self.compile_statement_list(block.statement_list(), use_expr, configurable_globals)?;
+
         let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
         let index_compile_environment = self.push_compile_environment(compile_environment);
         self.patch_jump_with_target(push_env.0, num_bindings as u32);
@@ -35,7 +32,7 @@ impl ByteCompiler<'_, '_> {
             self.pop_labelled_block_control_info();
         }
 
-        self.emit_opcode(Opcode::PopEnvironment);
+        self.emit_pop_env();
         Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -1,0 +1,41 @@
+
+use crate::{
+    bytecompiler::ByteCompiler,
+    vm::Opcode,
+    JsResult,
+};
+
+use boa_ast::statement::Block;
+use boa_interner::Sym;
+
+impl ByteCompiler<'_, '_> {
+    /// Compile a [`Block`] *boa_ast* node
+    pub(crate) fn compile_block(
+        &mut self,
+        block: &Block,
+        label: Option<Sym>,
+        use_expr: bool,
+        configurable_globals: bool,
+    ) -> JsResult<()> {
+        if let Some(label) = label {
+            let next = self.next_opcode_location();
+            self.push_labelled_block_control_info(label, next);
+        }
+
+        self.context.push_compile_time_environment(false);
+        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        self.create_decls(block.statement_list(), configurable_globals);
+        self.compile_statement_list(block.statement_list(), use_expr, configurable_globals)?;
+        let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
+        let index_compile_environment = self.push_compile_environment(compile_environment);
+        self.patch_jump_with_target(push_env.0, num_bindings as u32);
+        self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
+
+        if label.is_some() {
+            self.pop_labelled_block_control_info();
+        }
+
+        self.emit_opcode(Opcode::PopEnvironment);
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -4,7 +4,7 @@ use boa_ast::statement::Block;
 use boa_interner::Sym;
 
 impl ByteCompiler<'_, '_> {
-    /// Compile a [`Block`] *boa_ast* node
+    /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(
         &mut self,
         block: &Block,
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
         }
 
         self.context.push_compile_time_environment(false);
-        let push_env = self.emit_declarative_env();
+        let push_env = self.emit_and_track_decl_env();
 
         self.create_decls(block.statement_list(), configurable_globals);
         self.compile_statement_list(block.statement_list(), use_expr, configurable_globals)?;
@@ -30,9 +30,10 @@ impl ByteCompiler<'_, '_> {
 
         if label.is_some() {
             self.pop_labelled_block_control_info();
+        } else {
+            self.emit_and_track_pop_env();
         }
 
-        self.emit_pop_env();
         Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/break.rs
+++ b/boa_engine/src/bytecompiler/statement/break.rs
@@ -1,20 +1,12 @@
 use boa_ast::statement::Break;
 
-use crate::{
-    bytecompiler::{ByteCompiler, JumpControlInfoKind},
-    vm::Opcode,
-    JsNativeError, JsResult,
-};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsNativeError, JsResult};
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`Break`] `boa_ast` node
     pub(crate) fn compile_break(&mut self, node: Break) -> JsResult<()> {
         let next = self.next_opcode_location();
-        if let Some(info) = self
-            .jump_info
-            .last()
-            .filter(|info| info.kind() == JumpControlInfoKind::Try)
-        {
+        if let Some(info) = self.jump_info.last().filter(|info| info.is_try_block()) {
             let in_finally = if let Some(finally_start) = info.finally_start() {
                 next >= finally_start.index
             } else {

--- a/boa_engine/src/bytecompiler/statement/break.rs
+++ b/boa_engine/src/bytecompiler/statement/break.rs
@@ -1,0 +1,68 @@
+use boa_ast::statement::Break;
+
+use crate::{
+    bytecompiler::{ByteCompiler, JumpControlInfoKind},
+    vm::Opcode,
+    JsResult, JsNativeError,
+};
+
+impl ByteCompiler<'_,'_> {
+    /// Compile a [`Break`] boa_ast node
+    pub(crate) fn compile_break(&mut self, node: Break) -> JsResult<()> {
+        let next = self.next_opcode_location();
+        if let Some(info) = self
+            .jump_info
+            .last()
+            .filter(|info| info.kind == JumpControlInfoKind::Try)
+        {
+            let in_finally = if let Some(finally_start) = info.finally_start {
+                next >= finally_start.index
+            } else {
+                false
+            };
+            let in_catch_no_finally = !info.has_finally && info.in_catch;
+
+            if in_finally {
+                self.emit_opcode(Opcode::PopIfThrown);
+            }
+            if in_finally || in_catch_no_finally {
+                self.emit_opcode(Opcode::CatchEnd2);
+            } else {
+                self.emit_opcode(Opcode::TryEnd);
+            }
+            self.emit(Opcode::FinallySetJump, &[u32::MAX]);
+        }
+        let label = self.jump();
+        if let Some(label_name) = node.label() {
+            let mut found = false;
+            for info in self.jump_info.iter_mut().rev() {
+                if info.label == Some(label_name) {
+                    info.breaks.push(label);
+                    found = true;
+                    break;
+                }
+            }
+            // TODO: promote to an early error.
+            if !found {
+                return Err(JsNativeError::syntax()
+                    .with_message(format!(
+                        "Cannot use the undeclared label '{}'",
+                        self.interner().resolve_expect(label_name)
+                    ))
+                    .into());
+            }
+        } else {
+            self.jump_info
+                .last_mut()
+                // TODO: promote to an early error.
+                .ok_or_else(|| {
+                    JsNativeError::syntax()
+                        .with_message("unlabeled break must be inside loop or switch")
+                })?
+                .breaks
+                .push(label);
+        }
+
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/statement/if.rs
+++ b/boa_engine/src/bytecompiler/statement/if.rs
@@ -1,9 +1,5 @@
-
+use crate::{bytecompiler::ByteCompiler, JsResult};
 use boa_ast::statement::If;
-use crate::{
-    bytecompiler::ByteCompiler,
-    JsResult,
-};
 
 impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) -> JsResult<()> {

--- a/boa_engine/src/bytecompiler/statement/if.rs
+++ b/boa_engine/src/bytecompiler/statement/if.rs
@@ -1,0 +1,29 @@
+
+use boa_ast::statement::If;
+use crate::{
+    bytecompiler::ByteCompiler,
+    JsResult,
+};
+
+impl ByteCompiler<'_, '_> {
+    pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) -> JsResult<()> {
+        self.compile_expr(node.cond(), true)?;
+        let jelse = self.jump_if_false();
+
+        self.compile_stmt(node.body(), false, configurable_globals)?;
+
+        match node.else_node() {
+            None => {
+                self.patch_jump(jelse);
+            }
+            Some(else_body) => {
+                let exit = self.jump();
+                self.patch_jump(jelse);
+                self.compile_stmt(else_body, false, configurable_globals)?;
+                self.patch_jump(exit);
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 impl ByteCompiler<'_, '_> {
-    /// Compile a [`Labelled`] boa_ast node
+    /// Compile a [`Labelled`] `boa_ast` node
     pub(crate) fn compile_labelled(
         &mut self,
         labelled: &Labelled,

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -1,4 +1,3 @@
-
 use boa_ast::{
     statement::{Labelled, LabelledItem},
     Statement,

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -1,0 +1,70 @@
+
+use boa_ast::{
+    statement::{Labelled, LabelledItem},
+    Statement,
+};
+
+use crate::{
+    bytecompiler::{ByteCompiler, NodeKind},
+    JsResult,
+};
+
+impl ByteCompiler<'_, '_> {
+    /// Compile a [`Labelled`] boa_ast node
+    pub(crate) fn compile_labelled(
+        &mut self,
+        labelled: &Labelled,
+        use_expr: bool,
+        configurable_globals: bool,
+    ) -> JsResult<()> {
+        match labelled.item() {
+            LabelledItem::Statement(stmt) => match stmt {
+                Statement::ForLoop(for_loop) => {
+                    self.compile_for_loop(for_loop, Some(labelled.label()), configurable_globals)?;
+                }
+                Statement::ForInLoop(for_in_loop) => {
+                    self.compile_for_in_loop(
+                        for_in_loop,
+                        Some(labelled.label()),
+                        configurable_globals,
+                    )?;
+                }
+                Statement::ForOfLoop(for_of_loop) => {
+                    self.compile_for_of_loop(
+                        for_of_loop,
+                        Some(labelled.label()),
+                        configurable_globals,
+                    )?;
+                }
+                Statement::WhileLoop(while_loop) => {
+                    self.compile_while_loop(
+                        while_loop,
+                        Some(labelled.label()),
+                        configurable_globals,
+                    )?;
+                }
+                Statement::DoWhileLoop(do_while_loop) => {
+                    self.compile_do_while_loop(
+                        do_while_loop,
+                        Some(labelled.label()),
+                        configurable_globals,
+                    )?;
+                }
+                Statement::Block(block) => {
+                    self.compile_block(
+                        block,
+                        Some(labelled.label()),
+                        use_expr,
+                        configurable_globals,
+                    )?;
+                }
+                stmt => self.compile_stmt(stmt, use_expr, configurable_globals)?,
+            },
+            LabelledItem::Function(f) => {
+                self.function(f.into(), NodeKind::Declaration, false)?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -22,6 +22,7 @@ impl ByteCompiler<'_, '_> {
         configurable_globals: bool,
     ) -> JsResult<()> {
         self.context.push_compile_time_environment(false);
+        self.push_new_jump_control();
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
         if let Some(init) = for_loop.init() {
@@ -42,7 +43,8 @@ impl ByteCompiler<'_, '_> {
         let initial_jump = self.jump();
 
         let start_address = self.next_opcode_location();
-        self.push_loop_control_info(label, start_address);
+        self.set_jump_control_label(label);
+        self.set_jump_control_start_address(start_address);
 
         self.emit_opcode(Opcode::LoopContinue);
         if let Some(final_expr) = for_loop.final_expr() {

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -23,7 +23,7 @@ impl ByteCompiler<'_, '_> {
     ) -> JsResult<()> {
         self.context.push_compile_time_environment(false);
         let push_env = self.emit_and_track_decl_env();
-        self.push_new_jump_control();
+        self.push_empty_loop_jump_control();
 
         if let Some(init) = for_loop.init() {
             match init {

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -43,8 +43,12 @@ impl ByteCompiler<'_, '_> {
         let initial_jump = self.jump();
 
         let start_address = self.next_opcode_location();
-        self.set_jump_control_label(label);
-        self.set_jump_control_start_address(start_address);
+        self.current_jump_control_mut()
+            .expect("jump_control must exist as it was just pushed")
+            .set_label(label);
+        self.current_jump_control_mut()
+            .expect("jump_control must exist as it was just pushed")
+            .set_start_address(start_address);
 
         self.emit_opcode(Opcode::LoopContinue);
         if let Some(final_expr) = for_loop.final_expr() {

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -1,228 +1,74 @@
-use boa_ast::{
-    statement::{Block, Break, If, Labelled, LabelledItem, Switch},
-    Statement,
+
+use crate::{
+    bytecompiler::ByteCompiler,
+    vm::Opcode, 
+    JsResult
 };
-use boa_interner::Sym;
 
-use crate::{vm::Opcode, JsNativeError, JsResult};
-
-use super::{ByteCompiler, JumpControlInfoKind, NodeKind};
+use boa_ast::Statement;
 
 mod r#continue;
 mod r#loop;
 mod r#try;
+mod r#if;
+mod labelled;
+mod r#break;
+mod switch;
+mod block;
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) -> JsResult<()> {
-        self.compile_expr(node.cond(), true)?;
-        let jelse = self.jump_if_false();
-
-        self.compile_stmt(node.body(), false, configurable_globals)?;
-
-        match node.else_node() {
-            None => {
-                self.patch_jump(jelse);
-            }
-            Some(else_body) => {
-                let exit = self.jump();
-                self.patch_jump(jelse);
-                self.compile_stmt(else_body, false, configurable_globals)?;
-                self.patch_jump(exit);
-            }
-        }
-
-        Ok(())
-    }
-
-    pub(crate) fn compile_labelled(
+    /// Compiles a [`Statement`] *boa_ast* node.
+    pub fn compile_stmt(
         &mut self,
-        labelled: &Labelled,
+        node: &Statement,
         use_expr: bool,
         configurable_globals: bool,
     ) -> JsResult<()> {
-        match labelled.item() {
-            LabelledItem::Statement(stmt) => match stmt {
-                Statement::ForLoop(for_loop) => {
-                    self.compile_for_loop(for_loop, Some(labelled.label()), configurable_globals)?;
-                }
-                Statement::ForInLoop(for_in_loop) => {
-                    self.compile_for_in_loop(
-                        for_in_loop,
-                        Some(labelled.label()),
-                        configurable_globals,
-                    )?;
-                }
-                Statement::ForOfLoop(for_of_loop) => {
-                    self.compile_for_of_loop(
-                        for_of_loop,
-                        Some(labelled.label()),
-                        configurable_globals,
-                    )?;
-                }
-                Statement::WhileLoop(while_loop) => {
-                    self.compile_while_loop(
-                        while_loop,
-                        Some(labelled.label()),
-                        configurable_globals,
-                    )?;
-                }
-                Statement::DoWhileLoop(do_while_loop) => {
-                    self.compile_do_while_loop(
-                        do_while_loop,
-                        Some(labelled.label()),
-                        configurable_globals,
-                    )?;
-                }
-                Statement::Block(block) => {
-                    self.compile_block(
-                        block,
-                        Some(labelled.label()),
-                        use_expr,
-                        configurable_globals,
-                    )?;
-                }
-                stmt => self.compile_stmt(stmt, use_expr, configurable_globals)?,
-            },
-            LabelledItem::Function(f) => {
-                self.function(f.into(), NodeKind::Declaration, false)?;
+        match node {
+            Statement::Var(var) => self.compile_var_decl(var)?,
+            Statement::If(node) => self.compile_if(node, configurable_globals)?,
+            Statement::ForLoop(for_loop) => {
+                self.compile_for_loop(for_loop, None, configurable_globals)?;
             }
-        }
-
-        Ok(())
-    }
-
-    pub(crate) fn compile_break(&mut self, node: Break) -> JsResult<()> {
-        let next = self.next_opcode_location();
-        if let Some(info) = self
-            .jump_info
-            .last()
-            .filter(|info| info.kind == JumpControlInfoKind::Try)
-        {
-            let in_finally = if let Some(finally_start) = info.finally_start {
-                next >= finally_start.index
-            } else {
-                false
-            };
-            let in_catch_no_finally = !info.has_finally && info.in_catch;
-
-            if in_finally {
-                self.emit_opcode(Opcode::PopIfThrown);
+            Statement::ForInLoop(for_in_loop) => {
+                self.compile_for_in_loop(for_in_loop, None, configurable_globals)?;
             }
-            if in_finally || in_catch_no_finally {
-                self.emit_opcode(Opcode::CatchEnd2);
-            } else {
-                self.emit_opcode(Opcode::TryEnd);
+            Statement::ForOfLoop(for_of_loop) => {
+                self.compile_for_of_loop(for_of_loop, None, configurable_globals)?;
             }
-            self.emit(Opcode::FinallySetJump, &[u32::MAX]);
-        }
-        let label = self.jump();
-        if let Some(label_name) = node.label() {
-            let mut found = false;
-            for info in self.jump_info.iter_mut().rev() {
-                if info.label == Some(label_name) {
-                    info.breaks.push(label);
-                    found = true;
-                    break;
+            Statement::WhileLoop(while_loop) => {
+                self.compile_while_loop(while_loop, None, configurable_globals)?;
+            }
+            Statement::DoWhileLoop(do_while_loop) => {
+                self.compile_do_while_loop(do_while_loop, None, configurable_globals)?;
+            }
+            Statement::Block(block) => {
+                self.compile_block(block, None, use_expr, configurable_globals)?;
+            }
+            Statement::Labelled(labelled) => {
+                self.compile_labelled(labelled, use_expr, configurable_globals)?;
+            }
+            Statement::Continue(node) => self.compile_continue(*node)?,
+            Statement::Break(node) => self.compile_break(*node)?,
+            Statement::Throw(throw) => {
+                self.compile_expr(throw.target(), true)?;
+                self.emit(Opcode::Throw, &[]);
+            }
+            Statement::Switch(switch) => {
+                self.compile_switch(switch, configurable_globals)?;
+            }
+            Statement::Return(ret) => {
+                if let Some(expr) = ret.target() {
+                    self.compile_expr(expr, true)?;
+                } else {
+                    self.emit(Opcode::PushUndefined, &[]);
                 }
+                self.emit(Opcode::Return, &[]);
             }
-            // TODO: promote to an early error.
-            if !found {
-                return Err(JsNativeError::syntax()
-                    .with_message(format!(
-                        "Cannot use the undeclared label '{}'",
-                        self.interner().resolve_expect(label_name)
-                    ))
-                    .into());
-            }
-        } else {
-            self.jump_info
-                .last_mut()
-                // TODO: promote to an early error.
-                .ok_or_else(|| {
-                    JsNativeError::syntax()
-                        .with_message("unlabeled break must be inside loop or switch")
-                })?
-                .breaks
-                .push(label);
+            Statement::Try(t) => self.compile_try(t, use_expr, configurable_globals)?,
+            Statement::Empty => {}
+            Statement::Expression(expr) => self.compile_expr(expr, use_expr)?,
         }
-
-        Ok(())
-    }
-
-    pub(crate) fn compile_switch(
-        &mut self,
-        switch: &Switch,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
-        self.context.push_compile_time_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
-        for case in switch.cases() {
-            self.create_decls(case.body(), configurable_globals);
-        }
-        self.emit_opcode(Opcode::LoopStart);
-
-        let start_address = self.next_opcode_location();
-        self.push_switch_control_info(None, start_address);
-
-        self.compile_expr(switch.val(), true)?;
-        let mut labels = Vec::with_capacity(switch.cases().len());
-        for case in switch.cases() {
-            self.compile_expr(case.condition(), true)?;
-            labels.push(self.emit_opcode_with_operand(Opcode::Case));
-        }
-
-        let exit = self.emit_opcode_with_operand(Opcode::Default);
-
-        for (label, case) in labels.into_iter().zip(switch.cases()) {
-            self.patch_jump(label);
-            self.compile_statement_list(case.body(), false, configurable_globals)?;
-        }
-
-        self.patch_jump(exit);
-        if let Some(body) = switch.default() {
-            self.create_decls(body, configurable_globals);
-            self.compile_statement_list(body, false, configurable_globals)?;
-        }
-
-        self.pop_switch_control_info();
-
-        self.emit_opcode(Opcode::LoopEnd);
-
-        let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
-        let index_compile_environment = self.push_compile_environment(compile_environment);
-        self.patch_jump_with_target(push_env.0, num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
-        self.emit_opcode(Opcode::PopEnvironment);
-
-        Ok(())
-    }
-
-    pub(crate) fn compile_block(
-        &mut self,
-        block: &Block,
-        label: Option<Sym>,
-        use_expr: bool,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
-        if let Some(label) = label {
-            let next = self.next_opcode_location();
-            self.push_labelled_block_control_info(label, next);
-        }
-
-        self.context.push_compile_time_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
-        self.create_decls(block.statement_list(), configurable_globals);
-        self.compile_statement_list(block.statement_list(), use_expr, configurable_globals)?;
-        let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
-        let index_compile_environment = self.push_compile_environment(compile_environment);
-        self.patch_jump_with_target(push_env.0, num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
-
-        if label.is_some() {
-            self.pop_labelled_block_control_info();
-        }
-
-        self.emit_opcode(Opcode::PopEnvironment);
         Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -12,7 +12,7 @@ mod switch;
 mod r#try;
 
 impl ByteCompiler<'_, '_> {
-    /// Compiles a [`Statement`] *boa_ast* node.
+    /// Compiles a [`Statement`] `boa_ast` node.
     pub fn compile_stmt(
         &mut self,
         node: &Statement,

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -1,20 +1,15 @@
-
-use crate::{
-    bytecompiler::ByteCompiler,
-    vm::Opcode, 
-    JsResult
-};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
 
 use boa_ast::Statement;
 
+mod block;
+mod r#break;
 mod r#continue;
-mod r#loop;
-mod r#try;
 mod r#if;
 mod labelled;
-mod r#break;
+mod r#loop;
 mod switch;
-mod block;
+mod r#try;
 
 impl ByteCompiler<'_, '_> {
     /// Compiles a [`Statement`] *boa_ast* node.

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -3,7 +3,7 @@ use boa_ast::statement::Switch;
 use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
 
 impl ByteCompiler<'_, '_> {
-    /// Compile a [`Swtich`] boa_ast node
+    /// Compile a [`Switch`] `boa_ast` node
     pub(crate) fn compile_switch(
         &mut self,
         switch: &Switch,

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -1,11 +1,6 @@
-
 use boa_ast::statement::Switch;
 
-use crate::{
-    bytecompiler::ByteCompiler,
-    vm::Opcode,
-    JsResult,
-};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`Swtich`] boa_ast node

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -1,0 +1,59 @@
+
+use boa_ast::statement::Switch;
+
+use crate::{
+    bytecompiler::ByteCompiler,
+    vm::Opcode,
+    JsResult,
+};
+
+impl ByteCompiler<'_, '_> {
+    /// Compile a [`Swtich`] boa_ast node
+    pub(crate) fn compile_switch(
+        &mut self,
+        switch: &Switch,
+        configurable_globals: bool,
+    ) -> JsResult<()> {
+        self.context.push_compile_time_environment(false);
+        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        for case in switch.cases() {
+            self.create_decls(case.body(), configurable_globals);
+        }
+        self.emit_opcode(Opcode::LoopStart);
+
+        let start_address = self.next_opcode_location();
+        self.push_switch_control_info(None, start_address);
+
+        self.compile_expr(switch.val(), true)?;
+        let mut labels = Vec::with_capacity(switch.cases().len());
+        for case in switch.cases() {
+            self.compile_expr(case.condition(), true)?;
+            labels.push(self.emit_opcode_with_operand(Opcode::Case));
+        }
+
+        let exit = self.emit_opcode_with_operand(Opcode::Default);
+
+        for (label, case) in labels.into_iter().zip(switch.cases()) {
+            self.patch_jump(label);
+            self.compile_statement_list(case.body(), false, configurable_globals)?;
+        }
+
+        self.patch_jump(exit);
+        if let Some(body) = switch.default() {
+            self.create_decls(body, configurable_globals);
+            self.compile_statement_list(body, false, configurable_globals)?;
+        }
+
+        self.pop_switch_control_info();
+
+        self.emit_opcode(Opcode::LoopEnd);
+
+        let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
+        let index_compile_environment = self.push_compile_environment(compile_environment);
+        self.patch_jump_with_target(push_env.0, num_bindings as u32);
+        self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
+        self.emit_opcode(Opcode::PopEnvironment);
+
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -33,7 +33,7 @@ impl ByteCompiler<'_, '_> {
         self.patch_jump(Label { index: try_start });
 
         if let Some(catch) = t.catch() {
-            self.push_try_control_info_catch_start();
+            self.set_jump_control_catch_start(true);
             let catch_start = if t.finally().is_some() {
                 Some(self.emit_opcode_with_operand(Opcode::CatchStart))
             } else {
@@ -83,7 +83,7 @@ impl ByteCompiler<'_, '_> {
         if let Some(finally) = t.finally() {
             self.emit_opcode(Opcode::FinallyStart);
             let finally_start_address = self.next_opcode_location();
-            self.push_try_control_info_finally_start(Label {
+            self.set_jump_control_finally_start(Label {
                 index: finally_start_address,
             });
             self.patch_jump_with_target(

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2096,6 +2096,100 @@ fn bigger_switch_example() {
 }
 
 #[test]
+fn break_environment_gauntlet() {
+    // test that break handles popping environments correctly.
+    let scenario = r#"
+        let a = 0;
+
+        while(true) {
+            break;
+        }
+
+        while(true) break
+
+        do {break} while(true);
+
+        while (a < 3) {
+            let a = 1;
+            if (a == 1) {
+                break;
+            }
+
+            let b = 2;
+        }
+
+        {
+            b = 0;
+            do {
+                b = 2
+                if (b == 2) {
+                    break;
+                }
+                b++
+            } while( i < 3);
+
+            let c = 1;
+        }
+
+        {
+            for (let r = 0; r< 3; r++) {
+                if (r == 2) {
+                    break;
+                }
+            }
+        }
+
+        basic: for (let a = 0; a < 2; a++) {
+            break;
+        }
+
+        {
+            let result = true;
+            {
+                let x = 2;
+                L: {
+                    let x = 3;
+                    result &&= (x === 3);
+                    break L;
+                    result &&= (false);
+                }
+                result &&= (x === 2);
+            }
+            result;
+        }
+
+        {
+            var str = "";
+
+            outer: for (let i = 0; i < 5; i++) {
+                inner: for (let b = 0; b < 5; b++) {
+                    if (b === 2) {
+                        break outer;
+                    }
+                    str = str + b;
+                }
+                str = str + i;
+            }
+            str
+        }
+
+        {
+            result = "";
+            lab_block: {
+                try {
+                    result = "try_block";
+                    break lab_block;
+                    result = "did not break"
+                } catch (err) {}
+            }
+            str
+        }
+    "#;
+
+    assert_eq!(&exec(scenario), "\"01\"");
+}
+
+#[test]
 fn while_loop_late_break() {
     // Ordering with statement before the break.
     let scenario = r#"

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2160,17 +2160,25 @@ fn break_environment_gauntlet() {
 
         {
             var str = "";
-
-            outer: for (let i = 0; i < 5; i++) {
-                inner: for (let b = 0; b < 5; b++) {
-                    if (b === 2) {
-                        break outer;
+            
+            far_outer: {
+                outer: for (let i = 0; i < 5; i++) {
+                    inner: for (let b = 5; b < 10; b++) {
+                        if (b === 7) {
+                            break far_outer;
+                        }
+                        str = str + b;
                     }
-                    str = str + b;
+                    str = str + i;
                 }
-                str = str + i;
             }
             str
+        }
+
+        {
+            for (let r = 0; r < 2; r++) {
+                str = str + r
+            }
         }
 
         {
@@ -2187,7 +2195,7 @@ fn break_environment_gauntlet() {
         }
     "#;
 
-    assert_eq!(&exec(scenario), "\"01try_block\"");
+    assert_eq!(&exec(scenario), "\"5601try_block\"");
 }
 
 #[test]

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2181,12 +2181,13 @@ fn break_environment_gauntlet() {
                     break lab_block;
                     result = "did not break"
                 } catch (err) {}
-            }
+            } 
+            str = str + result
             str
         }
     "#;
 
-    assert_eq!(&exec(scenario), "\"01\"");
+    assert_eq!(&exec(scenario), "\"01try_block\"");
 }
 
 #[test]

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -241,7 +241,8 @@ impl CodeBlock {
             Opcode::TryStart
             | Opcode::PushDeclarativeEnvironment
             | Opcode::PushFunctionEnvironment
-            | Opcode::CopyDataProperties => {
+            | Opcode::CopyDataProperties
+            | Opcode::Break => {
                 let operand1 = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
                 let operand2 = self.read::<u32>(*pc);

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -241,7 +241,7 @@ impl CodeBlock {
                         );
                     }
                 }
-                Opcode::CopyDataProperties => {
+                Opcode::CopyDataProperties | Opcode::Break => {
                     let operand1 = self.read::<u32>(pc);
                     pc += size_of::<u32>();
                     let operand2 = self.read::<u32>(pc);

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -129,6 +129,22 @@ impl CodeBlock {
                         EdgeStyle::Line,
                     );
                 }
+                Opcode::Break => {
+                    let jump_operand = self.read::<u32>(pc);
+                    pc += size_of::<u32>();
+                    let envs_operand = self.read::<u32>(pc);
+                    pc += size_of::<u32>();
+
+                    let label = format!("{opcode_str} {jump_operand}, pop {envs_operand}");
+                    graph.add_node(previous_pc, NodeShape::None, label.into(), Color::Red);
+                    graph.add_edge(
+                        previous_pc,
+                        jump_operand as usize,
+                        Some("BREAK".into()),
+                        Color::Red,
+                        EdgeStyle::Line,
+                    );
+                }
                 Opcode::LogicalAnd | Opcode::LogicalOr | Opcode::Coalesce => {
                     let exit = self.read::<u32>(pc);
                     pc += size_of::<u32>();
@@ -241,7 +257,7 @@ impl CodeBlock {
                         );
                     }
                 }
-                Opcode::CopyDataProperties | Opcode::Break => {
+                Opcode::CopyDataProperties => {
                     let operand1 = self.read::<u32>(pc);
                     pc += size_of::<u32>();
                     let operand2 = self.read::<u32>(pc);

--- a/boa_engine/src/vm/opcode/jump/break.rs
+++ b/boa_engine/src/vm/opcode/jump/break.rs
@@ -15,10 +15,26 @@ impl Operation for Break {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let address = context.vm.read::<u32>();
-        let envs = context.vm.read::<u32>();
+        let pop_envs = context.vm.read::<u32>();
 
-        for _i in 0..envs {
+        for _ in 0..pop_envs {
             context.realm.environments.pop();
+
+            let loop_envs = *context
+                .vm
+                .frame()
+                .loop_env_stack
+                .last()
+                .expect("loop env stack must exist");
+            if loop_envs == 0 {
+                context
+                    .vm
+                    .frame_mut()
+                    .loop_env_stack
+                    .pop()
+                    .expect("loop env stack must exist");
+            }
+
             context.vm.frame_mut().loop_env_stack_dec();
             context.vm.frame_mut().try_env_stack_dec();
         }

--- a/boa_engine/src/vm/opcode/jump/break.rs
+++ b/boa_engine/src/vm/opcode/jump/break.rs
@@ -1,0 +1,28 @@
+use crate::{
+    vm::{opcode::Operation, ShouldExit},
+    Context, JsResult,
+};
+
+/// `Break` implements the Opcode Operation for `Opcode::Break`
+///
+/// Operation:
+///   - Pop required environments and jump to address.
+pub(crate) struct Break;
+
+impl Operation for Break {
+    const NAME: &'static str = "Break";
+    const INSTRUCTION: &'static str = "INST - Break";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
+        let address = context.vm.read::<u32>();
+        let envs = context.vm.read::<u32>();
+
+        for _i in 0..envs {
+            context.realm.environments.pop();
+            context.vm.frame_mut().loop_env_stack_dec();
+            context.vm.frame_mut().try_env_stack_dec();
+        }
+        context.vm.frame_mut().pc = address as usize;
+        Ok(ShouldExit::False)
+    }
+}

--- a/boa_engine/src/vm/opcode/jump/mod.rs
+++ b/boa_engine/src/vm/opcode/jump/mod.rs
@@ -3,6 +3,9 @@ use crate::{
     Context, JsResult,
 };
 
+pub(crate) mod r#break;
+
+pub(crate) use r#break::*;
 /// `Jump` implements the Opcode Operation for `Opcode::Jump`
 ///
 /// Operation:

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1435,6 +1435,9 @@ generate_impl! {
         /// Stack: promise **=>**
         Await,
 
+        /// Jumps to a target location and pops the environments involved.
+        Break,
+
         /// Push the current new target to the stack.
         ///
         /// Operands:


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Hi all! 😄

This Pull Request addresses #2424. There are also a few changes made to the `ByteCompiler`, the majority of which are involving `JumpControlInfo`.

It changes the following:

- Adds `Break` Opcode
- Shifts `compile_stmt` into the `statement` module. 
- Moves `JumpControlInfo` to it's own module.
