### PR TITLE
[Merged by Bors] - Improve the design of ephemerons in our GC

### DIFF
--- a/boa_engine/src/builtins/async_generator/mod.rs
+++ b/boa_engine/src/builtins/async_generator/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     vm::GeneratorResumeKind,
     Context, JsError, JsResult,
 };
-use boa_gc::{Finalize, Gc, GcCell, Trace};
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_profiler::Profiler;
 use std::collections::VecDeque;
 
@@ -57,7 +57,7 @@ pub struct AsyncGenerator {
     pub(crate) state: AsyncGeneratorState,
 
     /// The `[[AsyncGeneratorContext]]` internal slot.
-    pub(crate) context: Option<Gc<GcCell<GeneratorContext>>>,
+    pub(crate) context: Option<Gc<GcRefCell<GeneratorContext>>>,
 
     /// The `[[AsyncGeneratorQueue]]` internal slot.
     pub(crate) queue: VecDeque<AsyncGeneratorRequest>,
@@ -512,7 +512,7 @@ impl AsyncGenerator {
     pub(crate) fn resume(
         generator: &JsObject,
         state: AsyncGeneratorState,
-        generator_context: &Gc<GcCell<GeneratorContext>>,
+        generator_context: &Gc<GcRefCell<GeneratorContext>>,
         completion: (JsResult<JsValue>, bool),
         context: &mut Context<'_>,
     ) {

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     vm::{CallFrame, GeneratorResumeKind, ReturnType},
     Context, JsError, JsResult,
 };
-use boa_gc::{Finalize, Gc, GcCell, Trace};
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_profiler::Profiler;
 
 /// Indicates the state of a generator.
@@ -52,7 +52,7 @@ pub struct Generator {
     pub(crate) state: GeneratorState,
 
     /// The `[[GeneratorContext]]` internal slot.
-    pub(crate) context: Option<Gc<GcCell<GeneratorContext>>>,
+    pub(crate) context: Option<Gc<GcRefCell<GeneratorContext>>>,
 }
 
 impl BuiltIn for Generator {

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -19,7 +19,7 @@ use crate::{
     value::JsValue,
     Context, JsError, JsResult,
 };
-use boa_gc::{Finalize, Gc, GcCell, Trace};
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_profiler::Profiler;
 use std::{cell::Cell, rc::Rc};
 use tap::{Conv, Pipe};
@@ -161,7 +161,7 @@ impl PromiseCapability {
 
         // 2. NOTE: C is assumed to be a constructor function that supports the parameter conventions of the Promise constructor (see 27.2.3.1).
         // 3. Let promiseCapability be the PromiseCapability Record { [[Promise]]: undefined, [[Resolve]]: undefined, [[Reject]]: undefined }.
-        let promise_capability = Gc::new(GcCell::new(RejectResolve {
+        let promise_capability = Gc::new(GcRefCell::new(RejectResolve {
             reject: JsValue::undefined(),
             resolve: JsValue::undefined(),
         }));
@@ -208,7 +208,7 @@ impl PromiseCapability {
         .into();
 
         // 6. Let promise be ? Construct(C, « executor »).
-        let promise = c.construct(&[executor], Some(&c), context)?;
+        let promise = c.construct(&[executor], None, context)?;
 
         let promise_capability = promise_capability.borrow();
 
@@ -470,14 +470,14 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            values: Gc<GcCell<Vec<JsValue>>>,
+            values: Gc<GcRefCell<Vec<JsValue>>>,
             capability_resolve: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements_count: Rc<Cell<i32>>,
         }
 
         // 1. Let values be a new empty List.
-        let values = Gc::new(GcCell::new(Vec::new()));
+        let values = Gc::new(GcRefCell::new(Vec::new()));
 
         // 2. Let remainingElementsCount be the Record { [[Value]]: 1 }.
         let remaining_elements_count = Rc::new(Cell::new(1));
@@ -714,14 +714,14 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            values: Gc<GcCell<Vec<JsValue>>>,
+            values: Gc<GcRefCell<Vec<JsValue>>>,
             capability: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements: Rc<Cell<i32>>,
         }
 
         // 1. Let values be a new empty List.
-        let values = Gc::new(GcCell::new(Vec::new()));
+        let values = Gc::new(GcRefCell::new(Vec::new()));
 
         // 2. Let remainingElementsCount be the Record { [[Value]]: 1 }.
         let remaining_elements_count = Rc::new(Cell::new(1));
@@ -1057,14 +1057,14 @@ impl Promise {
             #[unsafe_ignore_trace]
             already_called: Rc<Cell<bool>>,
             index: usize,
-            errors: Gc<GcCell<Vec<JsValue>>>,
+            errors: Gc<GcRefCell<Vec<JsValue>>>,
             capability_reject: JsFunction,
             #[unsafe_ignore_trace]
             remaining_elements_count: Rc<Cell<i32>>,
         }
 
         // 1. Let errors be a new empty List.
-        let errors = Gc::new(GcCell::new(Vec::new()));
+        let errors = Gc::new(GcRefCell::new(Vec::new()));
 
         // 2. Let remainingElementsCount be the Record { [[Value]]: 1 }.
         let remaining_elements_count = Rc::new(Cell::new(1));

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -27,7 +27,7 @@ use boa_ast::{
     pattern::Pattern,
     Declaration, Expression, Statement, StatementList, StatementListItem,
 };
-use boa_gc::{Gc, GcCell};
+use boa_gc::{Gc, GcRefCell};
 use boa_interner::{Interner, Sym};
 use rustc_hash::FxHashMap;
 
@@ -246,7 +246,7 @@ impl<'b, 'host> ByteCompiler<'b, 'host> {
     /// Push a compile time environment to the current `CodeBlock` and return it's index.
     fn push_compile_environment(
         &mut self,
-        environment: Gc<GcCell<CompileTimeEnvironment>>,
+        environment: Gc<GcRefCell<CompileTimeEnvironment>>,
     ) -> usize {
         let index = self.code_block.compile_environments.len();
         self.code_block.compile_environments.push(environment);

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -2,7 +2,7 @@ use crate::{
     environments::runtime::BindingLocator, property::PropertyDescriptor, Context, JsString, JsValue,
 };
 use boa_ast::expression::Identifier;
-use boa_gc::{Finalize, Gc, GcCell, Trace};
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 
 use rustc_hash::FxHashMap;
 
@@ -22,7 +22,7 @@ struct CompileTimeBinding {
 /// A compile time environment also indicates, if it is a function environment.
 #[derive(Debug, Finalize, Trace)]
 pub(crate) struct CompileTimeEnvironment {
-    outer: Option<Gc<GcCell<Self>>>,
+    outer: Option<Gc<GcRefCell<Self>>>,
     environment_index: usize,
     #[unsafe_ignore_trace]
     bindings: FxHashMap<Identifier, CompileTimeBinding>,
@@ -208,7 +208,7 @@ impl Context<'_> {
         let environment_index = self.realm.compile_env.borrow().environment_index + 1;
         let outer = self.realm.compile_env.clone();
 
-        self.realm.compile_env = Gc::new(GcCell::new(CompileTimeEnvironment {
+        self.realm.compile_env = Gc::new(GcRefCell::new(CompileTimeEnvironment {
             outer: Some(outer),
             environment_index,
             bindings: FxHashMap::default(),
@@ -225,7 +225,7 @@ impl Context<'_> {
     /// Panics if there are no more environments that can be pop'ed.
     pub(crate) fn pop_compile_time_environment(
         &mut self,
-    ) -> (usize, Gc<GcCell<CompileTimeEnvironment>>) {
+    ) -> (usize, Gc<GcRefCell<CompileTimeEnvironment>>) {
         let current_env_borrow = self.realm.compile_env.borrow();
         if let Some(outer) = &current_env_borrow.outer {
             let outer_clone = outer.clone();

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -10,7 +10,7 @@ use crate::{
     value::PreferredType,
     Context, JsResult, JsValue,
 };
-use boa_gc::{self, Finalize, Gc, GcCell, Trace};
+use boa_gc::{self, Finalize, Gc, GcRefCell, Trace};
 use std::{
     cell::RefCell,
     collections::HashMap,
@@ -20,15 +20,15 @@ use std::{
 };
 
 /// A wrapper type for an immutably borrowed type T.
-pub type Ref<'a, T> = boa_gc::GcCellRef<'a, T>;
+pub type Ref<'a, T> = boa_gc::GcRef<'a, T>;
 
 /// A wrapper type for a mutably borrowed type T.
-pub type RefMut<'a, T, U> = boa_gc::GcCellRefMut<'a, T, U>;
+pub type RefMut<'a, T, U> = boa_gc::GcRefMut<'a, T, U>;
 
 /// Garbage collected `Object`.
 #[derive(Trace, Finalize, Clone, Default)]
 pub struct JsObject {
-    inner: Gc<GcCell<Object>>,
+    inner: Gc<GcRefCell<Object>>,
 }
 
 impl JsObject {
@@ -68,7 +68,7 @@ impl JsObject {
     /// [`OrdinaryObjectCreate`]: https://tc39.es/ecma262/#sec-ordinaryobjectcreate
     pub fn from_proto_and_data<O: Into<Option<Self>>>(prototype: O, data: ObjectData) -> Self {
         Self {
-            inner: Gc::new(GcCell::new(Object {
+            inner: Gc::new(GcRefCell::new(Object {
                 data,
                 prototype: prototype.into(),
                 extensible: true,
@@ -754,21 +754,21 @@ Cannot both specify accessors and a value or writable attribute",
         )
     }
 
-    pub(crate) const fn inner(&self) -> &Gc<GcCell<Object>> {
+    pub(crate) const fn inner(&self) -> &Gc<GcRefCell<Object>> {
         &self.inner
     }
 }
 
-impl AsRef<GcCell<Object>> for JsObject {
+impl AsRef<GcRefCell<Object>> for JsObject {
     #[inline]
-    fn as_ref(&self) -> &GcCell<Object> {
+    fn as_ref(&self) -> &GcRefCell<Object> {
         &self.inner
     }
 }
 
-impl From<Gc<GcCell<Object>>> for JsObject {
+impl From<Gc<GcRefCell<Object>>> for JsObject {
     #[inline]
-    fn from(inner: Gc<GcCell<Object>>) -> Self {
+    fn from(inner: Gc<GcRefCell<Object>>) -> Self {
         Self { inner }
     }
 }

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -55,7 +55,7 @@ use crate::{
     Context, JsBigInt, JsString, JsSymbol, JsValue,
 };
 
-use boa_gc::{custom_trace, Finalize, GcCell, Trace, WeakGc};
+use boa_gc::{custom_trace, Finalize, GcRefCell, Trace, WeakGc};
 use std::{
     any::Any,
     fmt::{self, Debug},
@@ -266,7 +266,7 @@ pub enum ObjectKind {
     Promise(Promise),
 
     /// The `WeakRef` object kind.
-    WeakRef(WeakGc<GcCell<Object>>),
+    WeakRef(WeakGc<GcRefCell<Object>>),
 
     /// The `Intl.Collator` object kind.
     #[cfg(feature = "intl")]
@@ -618,7 +618,7 @@ impl ObjectData {
     }
 
     /// Creates the `WeakRef` object data
-    pub fn weak_ref(weak_ref: WeakGc<GcCell<Object>>) -> Self {
+    pub fn weak_ref(weak_ref: WeakGc<GcRefCell<Object>>) -> Self {
         Self {
             kind: ObjectKind::WeakRef(weak_ref),
             internal_methods: &ORDINARY_INTERNAL_METHODS,
@@ -1623,7 +1623,7 @@ impl Object {
 
     /// Gets the `WeakRef` data if the object is a `WeakRef`.
     #[inline]
-    pub const fn as_weak_ref(&self) -> Option<&WeakGc<GcCell<Self>>> {
+    pub const fn as_weak_ref(&self) -> Option<&WeakGc<GcRefCell<Self>>> {
         match self.data {
             ObjectData {
                 kind: ObjectKind::WeakRef(ref weak_ref),

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -10,7 +10,7 @@ use crate::{
     environments::{CompileTimeEnvironment, DeclarativeEnvironmentStack},
     object::{GlobalPropertyMap, JsObject, JsPrototype, ObjectData, PropertyMap},
 };
-use boa_gc::{Gc, GcCell};
+use boa_gc::{Gc, GcRefCell};
 use boa_profiler::Profiler;
 
 /// Representation of a Realm.
@@ -23,7 +23,7 @@ pub struct Realm {
     pub(crate) global_property_map: PropertyMap,
     pub(crate) global_prototype: JsPrototype,
     pub(crate) environments: DeclarativeEnvironmentStack,
-    pub(crate) compile_env: Gc<GcCell<CompileTimeEnvironment>>,
+    pub(crate) compile_env: Gc<GcRefCell<CompileTimeEnvironment>>,
 }
 
 impl Realm {
@@ -36,7 +36,8 @@ impl Realm {
         // Allow identification of the global object easily
         let global_object = JsObject::from_proto_and_data(None, ObjectData::global());
 
-        let global_compile_environment = Gc::new(GcCell::new(CompileTimeEnvironment::new_global()));
+        let global_compile_environment =
+            Gc::new(GcRefCell::new(CompileTimeEnvironment::new_global()));
 
         Self {
             global_object,

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -22,7 +22,7 @@ use boa_ast::{
     expression::Identifier,
     function::{FormalParameterList, PrivateName},
 };
-use boa_gc::{Finalize, Gc, GcCell, Trace};
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_interner::{Interner, Sym, ToInternedString};
 use boa_profiler::Profiler;
 use std::{collections::VecDeque, convert::TryInto, mem::size_of};
@@ -105,7 +105,7 @@ pub struct CodeBlock {
     pub(crate) arguments_binding: Option<BindingLocator>,
 
     /// Compile time environments in this function.
-    pub(crate) compile_environments: Vec<Gc<GcCell<CompileTimeEnvironment>>>,
+    pub(crate) compile_environments: Vec<Gc<GcRefCell<CompileTimeEnvironment>>>,
 
     /// The `[[IsClassConstructor]]` internal slot.
     pub(crate) is_class_constructor: bool,
@@ -1125,7 +1125,7 @@ impl JsObject {
                     prototype,
                     ObjectData::generator(Generator {
                         state: GeneratorState::SuspendedStart,
-                        context: Some(Gc::new(GcCell::new(GeneratorContext {
+                        context: Some(Gc::new(GcRefCell::new(GeneratorContext {
                             environments,
                             call_frame,
                             stack,
@@ -1272,7 +1272,7 @@ impl JsObject {
                     prototype,
                     ObjectData::async_generator(AsyncGenerator {
                         state: AsyncGeneratorState::SuspendedStart,
-                        context: Some(Gc::new(GcCell::new(GeneratorContext {
+                        context: Some(Gc::new(GcRefCell::new(GeneratorContext {
                             environments,
                             call_frame,
                             stack,

--- a/boa_engine/src/vm/opcode/await_stm/mod.rs
+++ b/boa_engine/src/vm/opcode/await_stm/mod.rs
@@ -1,4 +1,4 @@
-use boa_gc::{Gc, GcCell};
+use boa_gc::{Gc, GcRefCell};
 
 use crate::{
     builtins::{JsArgs, Promise},
@@ -61,7 +61,7 @@ impl Operation for Await {
 
                     Ok(JsValue::undefined())
                 },
-                Gc::new(GcCell::new((
+                Gc::new(GcRefCell::new((
                     context.realm.environments.clone(),
                     context.vm.stack.clone(),
                     context.vm.frame().clone(),
@@ -104,7 +104,7 @@ impl Operation for Await {
 
                     Ok(JsValue::undefined())
                 },
-                Gc::new(GcCell::new((
+                Gc::new(GcRefCell::new((
                     context.realm.environments.clone(),
                     context.vm.stack.clone(),
                     context.vm.frame().clone(),

--- a/boa_examples/src/bin/closures.rs
+++ b/boa_examples/src/bin/closures.rs
@@ -11,7 +11,7 @@ use boa_engine::{
     string::utf16,
     Context, JsError, JsNativeError, JsString, JsValue,
 };
-use boa_gc::{Finalize, GcCell, Trace};
+use boa_gc::{Finalize, GcRefCell, Trace};
 
 fn main() -> Result<(), JsError> {
     // We create a new `Context` to create a new Javascript executor.
@@ -96,7 +96,7 @@ fn main() -> Result<(), JsError> {
                 Ok(message.into())
             },
             // Here is where we move `clone_variable` into the closure.
-            GcCell::new(clone_variable),
+            GcRefCell::new(clone_variable),
         ),
     )
     // And here we assign `createMessage` to the `name` property of the closure.

--- a/boa_gc/src/cell.rs
+++ b/boa_gc/src/cell.rs
@@ -117,12 +117,12 @@ impl Debug for BorrowFlag {
 /// that can be used inside of a garbage-collected pointer.
 ///
 /// This object is a `RefCell` that can be used inside of a `Gc<T>`.
-pub struct GcCell<T: ?Sized + 'static> {
+pub struct GcRefCell<T: ?Sized + 'static> {
     pub(crate) flags: Cell<BorrowFlag>,
     pub(crate) cell: UnsafeCell<T>,
 }
 
-impl<T: Trace> GcCell<T> {
+impl<T: Trace> GcRefCell<T> {
     /// Creates a new `GcCell` containing `value`.
     pub const fn new(value: T) -> Self {
         Self {
@@ -137,7 +137,7 @@ impl<T: Trace> GcCell<T> {
     }
 }
 
-impl<T: Trace + ?Sized> GcCell<T> {
+impl<T: Trace + ?Sized> GcRefCell<T> {
     /// Immutably borrows the wrapped value.
     ///
     /// The borrow lasts until the returned `GcCellRef` exits scope.
@@ -146,7 +146,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently mutably borrowed.
-    pub fn borrow(&self) -> GcCellRef<'_, T> {
+    pub fn borrow(&self) -> GcRef<'_, T> {
         match self.try_borrow() {
             Ok(value) => value,
             Err(e) => panic!("{}", e),
@@ -161,7 +161,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Panics
     ///
     /// Panics if the value is currently borrowed.
-    pub fn borrow_mut(&self) -> GcCellRefMut<'_, T> {
+    pub fn borrow_mut(&self) -> GcRefMut<'_, T> {
         match self.try_borrow_mut() {
             Ok(value) => value,
             Err(e) => panic!("{}", e),
@@ -179,7 +179,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Errors
     ///
     /// Returns an `Err` if the value is currently mutably borrowed.
-    pub fn try_borrow(&self) -> Result<GcCellRef<'_, T>, BorrowError> {
+    pub fn try_borrow(&self) -> Result<GcRef<'_, T>, BorrowError> {
         if self.flags.get().borrowed() == BorrowState::Writing {
             return Err(BorrowError);
         }
@@ -187,7 +187,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
 
         // SAFETY: calling value on a rooted value may cause Undefined Behavior
         unsafe {
-            Ok(GcCellRef {
+            Ok(GcRef {
                 flags: &self.flags,
                 value: &*self.cell.get(),
             })
@@ -204,7 +204,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
     /// # Errors
     ///
     /// Returns an `Err` if the value is currently borrowed.
-    pub fn try_borrow_mut(&self) -> Result<GcCellRefMut<'_, T>, BorrowMutError> {
+    pub fn try_borrow_mut(&self) -> Result<GcRefMut<'_, T>, BorrowMutError> {
         if self.flags.get().borrowed() != BorrowState::Unused {
             return Err(BorrowMutError);
         }
@@ -219,7 +219,7 @@ impl<T: Trace + ?Sized> GcCell<T> {
                 (*self.cell.get()).root();
             }
 
-            Ok(GcCellRefMut {
+            Ok(GcRefMut {
                 gc_cell: self,
                 value: &mut *self.cell.get(),
             })
@@ -247,13 +247,13 @@ impl Display for BorrowMutError {
     }
 }
 
-impl<T: Trace + ?Sized> Finalize for GcCell<T> {}
+impl<T: Trace + ?Sized> Finalize for GcRefCell<T> {}
 
 // SAFETY: GcCell maintains it's own BorrowState and rootedness. GcCell's implementation
 // focuses on only continuing Trace based methods while the cell state is not written.
 // Implementing a Trace while the cell is being written to or incorrectly implementing Trace
 // on GcCell's value may cause Undefined Behavior
-unsafe impl<T: Trace + ?Sized> Trace for GcCell<T> {
+unsafe impl<T: Trace + ?Sized> Trace for GcRefCell<T> {
     unsafe fn trace(&self) {
         match self.flags.get().borrowed() {
             BorrowState::Writing => (),
@@ -295,12 +295,12 @@ unsafe impl<T: Trace + ?Sized> Trace for GcCell<T> {
 }
 
 /// A wrapper type for an immutably borrowed value from a `GcCell<T>`.
-pub struct GcCellRef<'a, T: ?Sized + 'static> {
+pub struct GcRef<'a, T: ?Sized + 'static> {
     pub(crate) flags: &'a Cell<BorrowFlag>,
     pub(crate) value: &'a T,
 }
 
-impl<'a, T: ?Sized> GcCellRef<'a, T> {
+impl<'a, T: ?Sized> GcRef<'a, T> {
     /// Copies a `GcCellRef`.
     ///
     /// The `GcCell` is already immutably borrowed, so this cannot fail.
@@ -311,9 +311,9 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     /// the contents of a `GcCell`.
     #[allow(clippy::should_implement_trait)]
     #[must_use]
-    pub fn clone(orig: &GcCellRef<'a, T>) -> GcCellRef<'a, T> {
+    pub fn clone(orig: &GcRef<'a, T>) -> GcRef<'a, T> {
         orig.flags.set(orig.flags.get().add_reading());
-        GcCellRef {
+        GcRef {
             flags: orig.flags,
             value: orig.value,
         }
@@ -326,12 +326,12 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     /// This is an associated function that needs to be used as `GcCellRef::map(...)`.
     /// A method would interfere with methods of the same name on the contents
     /// of a `GcCellRef` used through `Deref`.
-    pub fn map<U, F>(orig: Self, f: F) -> GcCellRef<'a, U>
+    pub fn map<U, F>(orig: Self, f: F) -> GcRef<'a, U>
     where
         U: ?Sized,
         F: FnOnce(&T) -> &U,
     {
-        let ret = GcCellRef {
+        let ret = GcRef {
             flags: orig.flags,
             value: f(orig.value),
         };
@@ -349,7 +349,7 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     ///
     /// This is an associated function that needs to be used as `GcCellRef::map_split(...)`.
     /// A method would interfere with methods of the same name on the contents of a `GcCellRef` used through `Deref`.
-    pub fn map_split<U, V, F>(orig: Self, f: F) -> (GcCellRef<'a, U>, GcCellRef<'a, V>)
+    pub fn map_split<U, V, F>(orig: Self, f: F) -> (GcRef<'a, U>, GcRef<'a, V>)
     where
         U: ?Sized,
         V: ?Sized,
@@ -360,11 +360,11 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
         orig.flags.set(orig.flags.get().add_reading());
 
         let ret = (
-            GcCellRef {
+            GcRef {
                 flags: orig.flags,
                 value: a,
             },
-            GcCellRef {
+            GcRef {
                 flags: orig.flags,
                 value: b,
             },
@@ -378,7 +378,7 @@ impl<'a, T: ?Sized> GcCellRef<'a, T> {
     }
 }
 
-impl<T: ?Sized> Deref for GcCellRef<'_, T> {
+impl<T: ?Sized> Deref for GcRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -386,32 +386,32 @@ impl<T: ?Sized> Deref for GcCellRef<'_, T> {
     }
 }
 
-impl<T: ?Sized> Drop for GcCellRef<'_, T> {
+impl<T: ?Sized> Drop for GcRef<'_, T> {
     fn drop(&mut self) {
         debug_assert!(self.flags.get().borrowed() == BorrowState::Reading);
         self.flags.set(self.flags.get().sub_reading());
     }
 }
 
-impl<T: ?Sized + Debug> Debug for GcCellRef<'_, T> {
+impl<T: ?Sized + Debug> Debug for GcRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl<T: ?Sized + Display> Display for GcCellRef<'_, T> {
+impl<T: ?Sized + Display> Display for GcRef<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&**self, f)
     }
 }
 
 /// A wrapper type for a mutably borrowed value from a `GcCell<T>`.
-pub struct GcCellRefMut<'a, T: Trace + ?Sized + 'static, U: ?Sized = T> {
-    pub(crate) gc_cell: &'a GcCell<T>,
+pub struct GcRefMut<'a, T: Trace + ?Sized + 'static, U: ?Sized = T> {
+    pub(crate) gc_cell: &'a GcRefCell<T>,
     pub(crate) value: &'a mut U,
 }
 
-impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
+impl<'a, T: Trace + ?Sized, U: ?Sized> GcRefMut<'a, T, U> {
     /// Makes a new `GcCellRefMut` for a component of the borrowed data, e.g., an enum
     /// variant.
     ///
@@ -420,7 +420,7 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
     /// This is an associated function that needs to be used as
     /// `GcCellRefMut::map(...)`. A method would interfere with methods of the same
     /// name on the contents of a `GcCell` used through `Deref`.
-    pub fn map<V, F>(orig: Self, f: F) -> GcCellRefMut<'a, T, V>
+    pub fn map<V, F>(orig: Self, f: F) -> GcRefMut<'a, T, V>
     where
         V: ?Sized,
         F: FnOnce(&mut U) -> &mut V,
@@ -429,7 +429,7 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
         // SAFETY: This is safe as `GcCellRefMut` is already borrowed, so the value is rooted.
         let value = unsafe { &mut *(orig.value as *mut U) };
 
-        let ret = GcCellRefMut {
+        let ret = GcRefMut {
             gc_cell: orig.gc_cell,
             value: f(value),
         };
@@ -442,7 +442,7 @@ impl<'a, T: Trace + ?Sized, U: ?Sized> GcCellRefMut<'a, T, U> {
     }
 }
 
-impl<T: Trace + ?Sized, U: ?Sized> Deref for GcCellRefMut<'_, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> Deref for GcRefMut<'_, T, U> {
     type Target = U;
 
     fn deref(&self) -> &U {
@@ -450,13 +450,13 @@ impl<T: Trace + ?Sized, U: ?Sized> Deref for GcCellRefMut<'_, T, U> {
     }
 }
 
-impl<T: Trace + ?Sized, U: ?Sized> DerefMut for GcCellRefMut<'_, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> DerefMut for GcRefMut<'_, T, U> {
     fn deref_mut(&mut self) -> &mut U {
         self.value
     }
 }
 
-impl<T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'_, T, U> {
+impl<T: Trace + ?Sized, U: ?Sized> Drop for GcRefMut<'_, T, U> {
     fn drop(&mut self) {
         debug_assert!(self.gc_cell.flags.get().borrowed() == BorrowState::Writing);
         // Restore the rooted state of the GcCell's contents to the state of the GcCell.
@@ -474,45 +474,45 @@ impl<T: Trace + ?Sized, U: ?Sized> Drop for GcCellRefMut<'_, T, U> {
     }
 }
 
-impl<T: Trace + ?Sized, U: Debug + ?Sized> Debug for GcCellRefMut<'_, T, U> {
+impl<T: Trace + ?Sized, U: Debug + ?Sized> Debug for GcRefMut<'_, T, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl<T: Trace + ?Sized, U: Display + ?Sized> Display for GcCellRefMut<'_, T, U> {
+impl<T: Trace + ?Sized, U: Display + ?Sized> Display for GcRefMut<'_, T, U> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&**self, f)
     }
 }
 
 // SAFETY: GcCell<T> tracks it's `BorrowState` is `Writing`
-unsafe impl<T: ?Sized + Send> Send for GcCell<T> {}
+unsafe impl<T: ?Sized + Send> Send for GcRefCell<T> {}
 
-impl<T: Trace + Clone> Clone for GcCell<T> {
+impl<T: Trace + Clone> Clone for GcRefCell<T> {
     fn clone(&self) -> Self {
         Self::new(self.borrow().clone())
     }
 }
 
-impl<T: Trace + Default> Default for GcCell<T> {
+impl<T: Trace + Default> Default for GcRefCell<T> {
     fn default() -> Self {
         Self::new(Default::default())
     }
 }
 
 #[allow(clippy::inline_always)]
-impl<T: Trace + ?Sized + PartialEq> PartialEq for GcCell<T> {
+impl<T: Trace + ?Sized + PartialEq> PartialEq for GcRefCell<T> {
     #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         *self.borrow() == *other.borrow()
     }
 }
 
-impl<T: Trace + ?Sized + Eq> Eq for GcCell<T> {}
+impl<T: Trace + ?Sized + Eq> Eq for GcRefCell<T> {}
 
 #[allow(clippy::inline_always)]
-impl<T: Trace + ?Sized + PartialOrd> PartialOrd for GcCell<T> {
+impl<T: Trace + ?Sized + PartialOrd> PartialOrd for GcRefCell<T> {
     #[inline(always)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         (*self.borrow()).partial_cmp(&*other.borrow())
@@ -539,13 +539,13 @@ impl<T: Trace + ?Sized + PartialOrd> PartialOrd for GcCell<T> {
     }
 }
 
-impl<T: Trace + ?Sized + Ord> Ord for GcCell<T> {
+impl<T: Trace + ?Sized + Ord> Ord for GcRefCell<T> {
     fn cmp(&self, other: &Self) -> Ordering {
         (*self.borrow()).cmp(&*other.borrow())
     }
 }
 
-impl<T: Trace + ?Sized + Debug> Debug for GcCell<T> {
+impl<T: Trace + ?Sized + Debug> Debug for GcRefCell<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.flags.get().borrowed() {
             BorrowState::Unused | BorrowState::Reading => f

--- a/boa_gc/src/internals/ephemeron_box.rs
+++ b/boa_gc/src/internals/ephemeron_box.rs
@@ -88,6 +88,16 @@ pub(crate) struct EphemeronBox<K: Trace + ?Sized + 'static, V: Trace + 'static> 
     data: Cell<Option<NonNull<Data<K, V>>>>,
 }
 
+impl<K: Trace + ?Sized + 'static, V: Trace + 'static> Drop for EphemeronBox<K, V> {
+    fn drop(&mut self) {
+        if let Some(data) = self.data.take() {
+            // SAFETY: `data` comes from an `into_raw` call, so this pointer is safe to pass to
+            // `from_raw`.
+            drop(unsafe { Box::from_raw(data.as_ptr()) });
+        }
+    }
+}
+
 struct Data<K: Trace + ?Sized + 'static, V: Trace + 'static> {
     key: NonNull<GcBox<K>>,
     value: V,

--- a/boa_gc/src/internals/mod.rs
+++ b/boa_gc/src/internals/mod.rs
@@ -1,5 +1,5 @@
 mod ephemeron_box;
 mod gc_box;
 
-pub(crate) use self::ephemeron_box::EphemeronBox;
+pub(crate) use self::ephemeron_box::{EphemeronBox, ErasedEphemeronBox};
 pub use self::gc_box::GcBox;

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -105,7 +105,7 @@ use std::{
 
 pub use crate::trace::{Finalize, Trace};
 pub use boa_macros::{Finalize, Trace};
-pub use cell::{GcCell, GcCellRef, GcCellRefMut};
+pub use cell::{GcRef, GcRefCell, GcRefMut};
 pub use internals::GcBox;
 pub use pointers::{Ephemeron, Gc, WeakGc};
 

--- a/boa_gc/src/pointers/ephemeron.rs
+++ b/boa_gc/src/pointers/ephemeron.rs
@@ -2,11 +2,12 @@ use crate::{
     finalizer_safe,
     internals::EphemeronBox,
     trace::{Finalize, Trace},
-    Allocator, Gc, GcBox, EPHEMERON_QUEUE,
+    Allocator, Gc,
 };
 use std::{cell::Cell, ptr::NonNull};
 
-#[derive(Debug)]
+use super::rootable::Rootable;
+
 /// A key-value pair where the value becomes unaccesible when the key is garbage collected.
 ///
 /// See Racket's explanation on [**ephemerons**][eph] for a brief overview or read Barry Hayes'
@@ -15,70 +16,119 @@ use std::{cell::Cell, ptr::NonNull};
 ///
 /// [eph]: https://docs.racket-lang.org/reference/ephemerons.html
 /// [acm]: https://dl.acm.org/doi/10.1145/263700.263733
+#[derive(Debug)]
 pub struct Ephemeron<K: Trace + ?Sized + 'static, V: Trace + 'static> {
-    inner_ptr: Cell<NonNull<GcBox<EphemeronBox<K, V>>>>,
+    inner_ptr: Cell<Rootable<EphemeronBox<K, V>>>,
+}
+
+impl<K: Trace + ?Sized, V: Trace + Clone> Ephemeron<K, V> {
+    /// Gets the stored value of this `Ephemeron`, or `None` if the key was already garbage collected.
+    ///
+    /// This needs to return a clone of the value because holding a reference to it between
+    /// garbage collection passes could drop the underlying allocation, causing an Use After Free.
+    pub fn value(&self) -> Option<V> {
+        // SAFETY: this is safe because `Ephemeron` is tracked to always point to a valid pointer
+        // `inner_ptr`.
+        unsafe { self.inner_ptr.get().as_ref().value().cloned() }
+    }
 }
 
 impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
     /// Creates a new `Ephemeron`.
     pub fn new(key: &Gc<K>, value: V) -> Self {
-        Self {
-            inner_ptr: Cell::new(Allocator::allocate(GcBox::new_weak(EphemeronBox::new(
-                key, value,
-            )))),
+        // SAFETY: `value` comes from the stack and should be rooted, meaning unrooting
+        // it to pass it to the underlying `EphemeronBox` is safe.
+        unsafe {
+            value.unroot();
+        }
+        // SAFETY: EphemeronBox is at least 2 bytes in size, and so its alignment is always a
+        // multiple of 2.
+        unsafe {
+            Self {
+                inner_ptr: Cell::new(
+                    Rootable::new_unchecked(Allocator::alloc_ephemeron(EphemeronBox::new(
+                        key, value,
+                    )))
+                    .rooted(),
+                ),
+            }
+        }
+    }
+
+    /// Returns `true` if the two `Ephemeron`s point to the same allocation.
+    pub fn ptr_eq(this: &Self, other: &Self) -> bool {
+        EphemeronBox::ptr_eq(this.inner(), other.inner())
+    }
+
+    fn is_rooted(&self) -> bool {
+        self.inner_ptr.get().is_rooted()
+    }
+
+    fn root_ptr(&self) {
+        self.inner_ptr.set(self.inner_ptr.get().rooted());
+    }
+
+    fn unroot_ptr(&self) {
+        self.inner_ptr.set(self.inner_ptr.get().unrooted());
+    }
+
+    pub(crate) fn inner_ptr(&self) -> NonNull<EphemeronBox<K, V>> {
+        assert!(finalizer_safe());
+        self.inner_ptr.get().as_ptr()
+    }
+
+    fn inner(&self) -> &EphemeronBox<K, V> {
+        // SAFETY: Please see Gc::inner_ptr()
+        unsafe { self.inner_ptr().as_ref() }
+    }
+
+    /// Constructs an `Ephemeron<K, V>` from a raw pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function is unsafe because improper use may lead to memory corruption, double-free,
+    /// or misbehaviour of the garbage collector.
+    #[must_use]
+    unsafe fn from_raw(ptr: NonNull<EphemeronBox<K, V>>) -> Self {
+        // SAFETY: it is the caller's job to ensure the safety of this operation.
+        unsafe {
+            Self {
+                inner_ptr: Cell::new(Rootable::new_unchecked(ptr).rooted()),
+            }
         }
     }
 }
 
-impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
-    fn inner_ptr(&self) -> NonNull<GcBox<EphemeronBox<K, V>>> {
-        self.inner_ptr.get()
+impl<K: Trace + ?Sized, V: Trace> Finalize for Ephemeron<K, V> {}
+
+// SAFETY: `Ephemeron`s trace implementation only marks its inner box because we want to stop
+// tracing through weakly held pointers.
+unsafe impl<K: Trace + ?Sized, V: Trace> Trace for Ephemeron<K, V> {
+    unsafe fn trace(&self) {
+        // SAFETY: We need to mark the inner box of the `Ephemeron` since it is reachable
+        // from a root and this means it cannot be dropped.
+        unsafe {
+            self.inner().mark();
+        }
     }
 
-    fn inner(&self) -> &GcBox<EphemeronBox<K, V>> {
-        // SAFETY: GcBox<EphemeronBox<K,V>> must live until it is unrooted by Drop
-        unsafe { &*self.inner_ptr().as_ptr() }
+    unsafe fn root(&self) {
+        assert!(!self.is_rooted(), "Can't double-root a Gc<T>");
+        // Try to get inner before modifying our state. Inner may be
+        // inaccessible due to this method being invoked during the sweeping
+        // phase, and we don't want to modify our state before panicking.
+        self.inner().root();
+        self.root_ptr();
     }
 
-    /// Gets the weak key of this `Ephemeron`, or `None` if the key was already garbage
-    /// collected.
-    pub fn key(&self) -> Option<&K> {
-        self.inner().value().key()
+    unsafe fn unroot(&self) {
+        assert!(self.is_rooted(), "Can't double-unroot a Gc<T>");
+        // Try to get inner before modifying our state. Inner may be
+        // inaccessible due to this method being invoked during the sweeping
+        // phase, and we don't want to modify our state before panicking.
+        self.inner().unroot();
+        self.unroot_ptr();
     }
-
-    /// Gets the stored value of this `Ephemeron`.
-    pub fn value(&self) -> &V {
-        self.inner().value().value()
-    }
-
-    /// Gets a `Gc` for the stored key of this `Ephemeron`.
-    pub fn upgrade_key(&self) -> Option<Gc<K>> {
-        // SAFETY: ptr must be a valid pointer or None would have been returned.
-        self.inner().value().inner_key_ptr().map(|ptr| unsafe {
-            let inner_ptr = NonNull::new_unchecked(ptr);
-            Gc::from_ptr(inner_ptr)
-        })
-    }
-}
-
-impl<K: Trace, V: Trace> Finalize for Ephemeron<K, V> {}
-
-// SAFETY: Ephemerons trace implementation is standard for everything except `Trace::weak_trace()`,
-// which pushes the GcBox<EphemeronBox<_>> onto the EphemeronQueue
-unsafe impl<K: Trace, V: Trace> Trace for Ephemeron<K, V> {
-    unsafe fn trace(&self) {}
-
-    // Push this Ephemeron's pointer onto the EphemeronQueue
-    unsafe fn weak_trace(&self) {
-        EPHEMERON_QUEUE.with(|q| {
-            let mut queue = q.take().expect("queue is initialized by weak_trace");
-            queue.push(self.inner_ptr());
-        });
-    }
-
-    unsafe fn root(&self) {}
-
-    unsafe fn unroot(&self) {}
 
     fn run_finalizer(&self) {
         Finalize::finalize(self);
@@ -87,26 +137,22 @@ unsafe impl<K: Trace, V: Trace> Trace for Ephemeron<K, V> {
 
 impl<K: Trace + ?Sized, V: Trace> Clone for Ephemeron<K, V> {
     fn clone(&self) -> Self {
-        // SAFETY: This is safe because the inner_ptr must live as long as it's roots.
-        // Mismanagement of roots can cause inner_ptr to use after free or Undefined
-        // Behavior.
+        let ptr = self.inner_ptr();
+        // SAFETY: since an `Ephemeron` is always valid, its `inner_ptr` must also be always a valid
+        // pointer.
         unsafe {
-            let eph = Self {
-                inner_ptr: Cell::new(NonNull::new_unchecked(self.inner_ptr().as_ptr())),
-            };
-            // Increment the Ephemeron's GcBox roots by 1
-            self.inner().root_inner();
-            eph
+            ptr.as_ref().root();
         }
+        // SAFETY: `&self` is a valid Ephemeron pointer.
+        unsafe { Self::from_raw(ptr) }
     }
 }
 
 impl<K: Trace + ?Sized, V: Trace> Drop for Ephemeron<K, V> {
     fn drop(&mut self) {
-        // NOTE: We assert that this drop call is not a
-        // drop from `Collector::dump` or `Collector::sweep`
-        if finalizer_safe() {
-            self.inner().unroot_inner();
+        // If this pointer was a root, we should unroot it.
+        if self.is_rooted() {
+            self.inner().unroot();
         }
     }
 }

--- a/boa_gc/src/pointers/mod.rs
+++ b/boa_gc/src/pointers/mod.rs
@@ -2,8 +2,21 @@
 
 mod ephemeron;
 mod gc;
+mod rootable;
 mod weak;
+
+use std::ptr::{self, addr_of_mut};
 
 pub use ephemeron::Ephemeron;
 pub use gc::Gc;
 pub use weak::WeakGc;
+
+// Technically, this function is safe, since we're just modifying the address of a pointer without
+// dereferencing it.
+pub(crate) fn set_data_ptr<T: ?Sized, U>(mut ptr: *mut T, data: *mut U) -> *mut T {
+    // SAFETY: this should be safe as ptr must be a valid nonnull
+    unsafe {
+        ptr::write(addr_of_mut!(ptr).cast::<*mut u8>(), data.cast::<u8>());
+    }
+    ptr
+}

--- a/boa_gc/src/pointers/mod.rs
+++ b/boa_gc/src/pointers/mod.rs
@@ -5,18 +5,6 @@ mod gc;
 mod rootable;
 mod weak;
 
-use std::ptr::{self, addr_of_mut};
-
 pub use ephemeron::Ephemeron;
 pub use gc::Gc;
 pub use weak::WeakGc;
-
-// Technically, this function is safe, since we're just modifying the address of a pointer without
-// dereferencing it.
-pub(crate) fn set_data_ptr<T: ?Sized, U>(mut ptr: *mut T, data: *mut U) -> *mut T {
-    // SAFETY: this should be safe as ptr must be a valid nonnull
-    unsafe {
-        ptr::write(addr_of_mut!(ptr).cast::<*mut u8>(), data.cast::<u8>());
-    }
-    ptr
-}

--- a/boa_gc/src/pointers/rootable.rs
+++ b/boa_gc/src/pointers/rootable.rs
@@ -1,0 +1,79 @@
+use std::ptr::NonNull;
+
+use super::set_data_ptr;
+
+/// A [`NonNull`] pointer with a `rooted` tag.
+///
+/// This pointer can be created only from pointers that are 2-byte aligned. In other words,
+/// the pointer must point to an address that is a multiple of 2.
+pub(crate) struct Rootable<T: ?Sized> {
+    ptr: NonNull<T>,
+}
+
+impl<T: ?Sized> Copy for Rootable<T> {}
+
+impl<T: ?Sized> Clone for Rootable<T> {
+    fn clone(&self) -> Self {
+        Self { ptr: self.ptr }
+    }
+}
+
+impl<T: ?Sized> std::fmt::Debug for Rootable<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Rootable")
+            .field("ptr", &self.as_ptr())
+            .field("is_rooted", &self.is_rooted())
+            .finish()
+    }
+}
+
+impl<T: ?Sized> Rootable<T> {
+    /// Creates a new `Rootable` without checking if the [`NonNull`] is properly aligned.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be 2-byte aligned.
+    pub(crate) const unsafe fn new_unchecked(ptr: NonNull<T>) -> Self {
+        Self { ptr }
+    }
+
+    /// Returns `true` if the pointer is rooted.
+    pub(crate) fn is_rooted(self) -> bool {
+        self.ptr.as_ptr().cast::<u8>() as usize & 1 != 0
+    }
+
+    /// Returns a pointer with the same address as `self` but rooted.
+    pub(crate) fn rooted(self) -> Self {
+        let ptr = self.ptr.as_ptr();
+        let data = ptr.cast::<u8>();
+        let addr = data as isize;
+        let ptr = set_data_ptr(ptr, data.wrapping_offset((addr | 1) - addr));
+        // SAFETY: ptr must be a non null value.
+        unsafe { Self::new_unchecked(NonNull::new_unchecked(ptr)) }
+    }
+
+    /// Returns a pointer with the same address as `self` but unrooted.
+    pub(crate) fn unrooted(self) -> Self {
+        let ptr = self.ptr.as_ptr();
+        let data = ptr.cast::<u8>();
+        let addr = data as isize;
+        let ptr = set_data_ptr(ptr, data.wrapping_offset((addr & !1) - addr));
+        // SAFETY: ptr must be a non null value
+        unsafe { Self::new_unchecked(NonNull::new_unchecked(ptr)) }
+    }
+
+    /// Acquires the underlying `NonNull` pointer.
+    pub(crate) fn as_ptr(self) -> NonNull<T> {
+        self.unrooted().ptr
+    }
+
+    /// Returns a shared reference to the pointee.
+    ///
+    /// # Safety
+    ///
+    /// See [`NonNull::as_ref`].
+    pub(crate) unsafe fn as_ref(&self) -> &T {
+        // SAFETY: it is the caller's job to ensure the safety of this operation.
+        unsafe { self.as_ptr().as_ref() }
+    }
+}

--- a/boa_gc/src/pointers/rootable.rs
+++ b/boa_gc/src/pointers/rootable.rs
@@ -1,6 +1,4 @@
-use std::ptr::NonNull;
-
-use super::set_data_ptr;
+use std::ptr::{self, addr_of_mut, NonNull};
 
 /// A [`NonNull`] pointer with a `rooted` tag.
 ///
@@ -76,4 +74,14 @@ impl<T: ?Sized> Rootable<T> {
         // SAFETY: it is the caller's job to ensure the safety of this operation.
         unsafe { self.as_ptr().as_ref() }
     }
+}
+
+// Technically, this function is safe, since we're just modifying the address of a pointer without
+// dereferencing it.
+fn set_data_ptr<T: ?Sized, U>(mut ptr: *mut T, data: *mut U) -> *mut T {
+    // SAFETY: this should be safe as ptr must be a valid nonnull
+    unsafe {
+        ptr::write(addr_of_mut!(ptr).cast::<*mut u8>(), data.cast::<u8>());
+    }
+    ptr
 }

--- a/boa_gc/src/pointers/weak.rs
+++ b/boa_gc/src/pointers/weak.rs
@@ -3,35 +3,28 @@ use crate::{Ephemeron, Finalize, Gc, Trace};
 /// A weak reference to a [`Gc`].
 ///
 /// This type allows keeping references to [`Gc`] managed values without keeping them alive for
-/// garbage collections. However, this also means [`WeakGc::value`] can return `None` at any moment.
+/// garbage collections. However, this also means [`WeakGc::upgrade`] could return `None` at any moment.
 #[derive(Debug, Trace, Finalize)]
 #[repr(transparent)]
 pub struct WeakGc<T: Trace + ?Sized + 'static> {
-    inner: Ephemeron<T, ()>,
+    inner: Ephemeron<T, Gc<T>>,
 }
 
-impl<T: Trace + ?Sized> WeakGc<T> {
+impl<T: Trace> WeakGc<T> {
     /// Creates a new weak pointer for a garbage collected value.
     pub fn new(value: &Gc<T>) -> Self {
         Self {
-            inner: Ephemeron::new(value, ()),
+            inner: Ephemeron::new(value, value.clone()),
         }
-    }
-}
-
-impl<T: Trace + ?Sized> WeakGc<T> {
-    /// Gets the value of this weak pointer, or `None` if the value was already garbage collected.
-    pub fn value(&self) -> Option<&T> {
-        self.inner.key()
     }
 
     /// Upgrade returns a `Gc` pointer for the internal value if valid, or None if the value was already garbage collected.
     pub fn upgrade(&self) -> Option<Gc<T>> {
-        self.inner.upgrade_key()
+        self.inner.value()
     }
 }
 
-impl<T: Trace + ?Sized> Clone for WeakGc<T> {
+impl<T: Trace> Clone for WeakGc<T> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -39,8 +32,8 @@ impl<T: Trace + ?Sized> Clone for WeakGc<T> {
     }
 }
 
-impl<T: Trace + ?Sized> From<Ephemeron<T, ()>> for WeakGc<T> {
-    fn from(inner: Ephemeron<T, ()>) -> Self {
+impl<T: Trace> From<Ephemeron<T, Gc<T>>> for WeakGc<T> {
+    fn from(inner: Ephemeron<T, Gc<T>>) -> Self {
         Self { inner }
     }
 }

--- a/boa_gc/src/test/allocation.rs
+++ b/boa_gc/src/test/allocation.rs
@@ -1,10 +1,10 @@
 use super::{run_test, Harness};
-use crate::{force_collect, Gc, GcCell};
+use crate::{force_collect, Gc, GcRefCell};
 
 #[test]
 fn gc_basic_cell_allocation() {
     run_test(|| {
-        let gc_cell = Gc::new(GcCell::new(16_u16));
+        let gc_cell = Gc::new(GcRefCell::new(16_u16));
 
         force_collect();
         Harness::assert_collections(1);

--- a/boa_gc/src/test/cell.rs
+++ b/boa_gc/src/test/cell.rs
@@ -1,13 +1,13 @@
 use super::run_test;
-use crate::{Gc, GcCell};
+use crate::{Gc, GcRefCell};
 
 #[test]
 fn boa_borrow_mut_test() {
     run_test(|| {
-        let v = Gc::new(GcCell::new(Vec::new()));
+        let v = Gc::new(GcRefCell::new(Vec::new()));
 
         for _ in 1..=259 {
-            let cell = Gc::new(GcCell::new([0u8; 10]));
+            let cell = Gc::new(GcRefCell::new([0u8; 10]));
             v.borrow_mut().push(cell);
         }
     });

--- a/boa_gc/src/test/mod.rs
+++ b/boa_gc/src/test/mod.rs
@@ -34,7 +34,7 @@ impl Harness {
         BOA_GC.with(|current| {
             let gc = current.borrow();
             assert_eq!(gc.runtime.bytes_allocated, bytes);
-        })
+        });
     }
 }
 

--- a/boa_gc/src/test/mod.rs
+++ b/boa_gc/src/test/mod.rs
@@ -18,7 +18,7 @@ impl Harness {
         BOA_GC.with(|current| {
             let gc = current.borrow();
 
-            assert!(gc.adult_start.get().is_none());
+            assert!(gc.strong_start.get().is_none());
             assert!(gc.runtime.bytes_allocated == 0);
         });
     }

--- a/boa_gc/src/test/mod.rs
+++ b/boa_gc/src/test/mod.rs
@@ -29,6 +29,13 @@ impl Harness {
             assert!(gc.runtime.bytes_allocated > 0);
         });
     }
+
+    fn assert_exact_bytes_allocated(bytes: usize) {
+        BOA_GC.with(|current| {
+            let gc = current.borrow();
+            assert_eq!(gc.runtime.bytes_allocated, bytes);
+        })
+    }
 }
 
 fn run_test(test: impl FnOnce() + Send + 'static) {

--- a/boa_gc/src/test/weak.rs
+++ b/boa_gc/src/test/weak.rs
@@ -166,7 +166,7 @@ fn eph_self_referential() {
         force_collect();
 
         Harness::assert_exact_bytes_allocated(root_size);
-    })
+    });
 }
 
 #[test]
@@ -216,5 +216,5 @@ fn eph_self_referential_chain() {
         force_collect();
 
         Harness::assert_exact_bytes_allocated(root_size);
-    })
+    });
 }

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -104,16 +104,6 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
                 match *self { #trace_body }
             }
             #[inline]
-            unsafe fn weak_trace(&self) {
-                #[allow(dead_code, unreachable_code)]
-                fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {
-                    unsafe {
-                        ::boa_gc::Trace::weak_trace(it)
-                    }
-                }
-                match *self { #trace_body }
-            }
-            #[inline]
             unsafe fn root(&self) {
                 #[allow(dead_code)]
                 fn mark<T: ::boa_gc::Trace + ?Sized>(it: &T) {


### PR DESCRIPTION
This PR changes the following:
- Modifies `EphemeronBox` to be more akin to `GcBox`, with its own header, roots and markers. This also makes it more similar to [Racket's](https://docs.racket-lang.org/reference/ephemerons.html) implementation.
- Removes `EPHEMERON_QUEUE`.
- Ephemerons are now tracked on a special `weak_start` linked list, instead of `strong_start` which is where all other GC boxes live.
- Documents all unsafe blocks.
- Documents our current garbage collection algorithm. I hope this'll clarify a bit what exactly are we doing on every garbage collection.
- Renames/removes some functions.
