### PR TITLE
[Merged by Bors] - Fix some HoistableDeclaration parsing errors

### DIFF
--- a/boa_ast/src/statement_list.rs
+++ b/boa_ast/src/statement_list.rs
@@ -33,12 +33,23 @@ impl StatementListItem {
     pub const fn hoistable_order(a: &Self, b: &Self) -> Ordering {
         match (a, b) {
             (
-                Self::Declaration(Declaration::Function(_)),
-                Self::Declaration(Declaration::Function(_)),
-            ) => Ordering::Equal,
-            (_, Self::Declaration(Declaration::Function(_))) => Ordering::Greater,
-            (Self::Declaration(Declaration::Function(_)), _) => Ordering::Less,
-
+                _,
+                Self::Declaration(
+                    Declaration::Function(_)
+                    | Declaration::Generator(_)
+                    | Declaration::AsyncFunction(_)
+                    | Declaration::AsyncGenerator(_),
+                ),
+            ) => Ordering::Greater,
+            (
+                Self::Declaration(
+                    Declaration::Function(_)
+                    | Declaration::Generator(_)
+                    | Declaration::AsyncFunction(_)
+                    | Declaration::AsyncGenerator(_),
+                ),
+                _,
+            ) => Ordering::Less,
             (_, _) => Ordering::Equal,
         }
     }

--- a/boa_parser/src/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -65,6 +65,9 @@ impl CallableDeclaration for AsyncFunctionDeclaration {
     fn body_allow_await(&self) -> bool {
         true
     }
+    fn parameters_await_is_early_error(&self) -> bool {
+        true
+    }
 }
 
 impl<R> TokenParser<R> for AsyncFunctionDeclaration

--- a/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -75,6 +75,12 @@ impl CallableDeclaration for AsyncGeneratorDeclaration {
     fn body_allow_await(&self) -> bool {
         true
     }
+    fn parameters_await_is_early_error(&self) -> bool {
+        true
+    }
+    fn parameters_yield_is_early_error(&self) -> bool {
+        true
+    }
 }
 
 impl<R> TokenParser<R> for AsyncGeneratorDeclaration

--- a/boa_parser/src/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -65,6 +65,9 @@ impl CallableDeclaration for GeneratorDeclaration {
     fn body_allow_await(&self) -> bool {
         false
     }
+    fn parameters_yield_is_early_error(&self) -> bool {
+        true
+    }
 }
 
 impl<R> TokenParser<R> for GeneratorDeclaration

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -377,8 +377,17 @@ where
                 .parse(cursor, interner)
                 .map(ast::StatementListItem::from),
             TokenKind::Keyword((Keyword::Async, _)) => {
+                let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {
+                    2
+                } else {
+                    1
+                };
+                let is_line_terminator = cursor
+                    .peek_is_line_terminator(skip_n, interner)?
+                    .unwrap_or(true);
+
                 match cursor.peek(1, interner)?.map(Token::kind) {
-                    Some(TokenKind::Keyword((Keyword::Function, _))) => {
+                    Some(TokenKind::Keyword((Keyword::Function, _))) if !is_line_terminator => {
                         Declaration::new(self.allow_yield, self.allow_await)
                             .parse(cursor, interner)
                             .map(ast::StatementListItem::from)


### PR DESCRIPTION
This Pull Request hanges the following:

- Add early errors for invalid `yield` and `await` usage in function parameters.
- Add missing function types to hoistable ordering.
- Do not attempt to parse `async` with a following line terminator as an async function.