### PR TITLE
[Merged by Bors] - Labelled ByteCompiler Fix

### DIFF
--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -376,9 +376,6 @@ impl ByteCompiler<'_, '_> {
 
         assert!(info.is_labelled());
 
-        // We should no longer have to PopEnvironment here
-        // self.emit_opcode(Opcode::PopEnvironment);
-
         for label in info.breaks {
             self.patch_jump(label);
         }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -1,22 +1,15 @@
 use crate::{bytecompiler::ByteCompiler, JsResult};
 
 use boa_ast::statement::Block;
-use boa_interner::Sym;
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(
         &mut self,
         block: &Block,
-        label: Option<Sym>,
         use_expr: bool,
         configurable_globals: bool,
     ) -> JsResult<()> {
-        if let Some(label) = label {
-            let next = self.next_opcode_location();
-            self.push_labelled_block_control_info(label, next);
-        }
-
         self.context.push_compile_time_environment(false);
         let push_env = self.emit_and_track_decl_env();
 
@@ -28,11 +21,7 @@ impl ByteCompiler<'_, '_> {
         self.patch_jump_with_target(push_env.0, num_bindings as u32);
         self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
 
-        if label.is_some() {
-            self.pop_labelled_block_control_info();
-        } else {
-            self.emit_and_track_pop_env();
-        }
+        self.emit_and_track_pop_env();
 
         Ok(())
     }

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -16,7 +16,6 @@ impl ByteCompiler<'_, '_> {
         use_expr: bool,
         configurable_globals: bool,
     ) -> JsResult<()> {
-        // Push a label jump control info
         let labelled_loc = self.next_opcode_location();
         self.push_labelled_control_info(labelled.label(), labelled_loc);
 

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
     ) -> JsResult<()> {
         // Push a label jump control info
         let labelled_loc = self.next_opcode_location();
-        self.push_labelled_control_info(labelled.label(), labelled_loc); 
+        self.push_labelled_control_info(labelled.label(), labelled_loc);
 
         match labelled.item() {
             LabelledItem::Statement(stmt) => match stmt {
@@ -59,7 +59,7 @@ impl ByteCompiler<'_, '_> {
                 self.function(f.into(), NodeKind::Declaration, false)?;
             }
         }
-        
+
         self.pop_labelled_control_info();
 
         Ok(())

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -16,6 +16,10 @@ impl ByteCompiler<'_, '_> {
         use_expr: bool,
         configurable_globals: bool,
     ) -> JsResult<()> {
+        // Push a label jump control info
+        let labelled_loc = self.next_opcode_location();
+        self.push_labelled_control_info(labelled.label(), labelled_loc); 
+
         match labelled.item() {
             LabelledItem::Statement(stmt) => match stmt {
                 Statement::ForLoop(for_loop) => {
@@ -49,20 +53,14 @@ impl ByteCompiler<'_, '_> {
                         configurable_globals,
                     )?;
                 }
-                Statement::Block(block) => {
-                    self.compile_block(
-                        block,
-                        Some(labelled.label()),
-                        use_expr,
-                        configurable_globals,
-                    )?;
-                }
                 stmt => self.compile_stmt(stmt, use_expr, configurable_globals)?,
             },
             LabelledItem::Function(f) => {
                 self.function(f.into(), NodeKind::Declaration, false)?;
             }
         }
+        
+        self.pop_labelled_control_info();
 
         Ok(())
     }

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -38,7 +38,7 @@ impl ByteCompiler<'_, '_> {
                 self.compile_do_while_loop(do_while_loop, None, configurable_globals)?;
             }
             Statement::Block(block) => {
-                self.compile_block(block, None, use_expr, configurable_globals)?;
+                self.compile_block(block, use_expr, configurable_globals)?;
             }
             Statement::Labelled(labelled) => {
                 self.compile_labelled(labelled, use_expr, configurable_globals)?;

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2198,9 +2198,8 @@ fn break_environment_gauntlet() {
     assert_eq!(&exec(scenario), "\"5601try_block\"");
 }
 
-#[test]               
+#[test]
 fn break_labelled_if_statement() {
-
     let scenario = r#"
         let result = "";
         bar: if(true) {
@@ -2213,10 +2212,9 @@ fn break_labelled_if_statement() {
 
     assert_eq!(&exec(scenario), "\"foo\"")
 }
-              
+
 #[test]
 fn break_labelled_try_statement() {
-
     let scenario = r#"
         let result = ""
         one: try {

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2198,6 +2198,40 @@ fn break_environment_gauntlet() {
     assert_eq!(&exec(scenario), "\"5601try_block\"");
 }
 
+#[test]               
+fn break_labelled_if_statement() {
+
+    let scenario = r#"
+        let result = "";
+        bar: if(true) {
+            result = "foo";
+            break bar;
+            result = 'this will not be executed';
+        }
+        result
+    "#;
+
+    assert_eq!(&exec(scenario), "\"foo\"")
+}
+              
+#[test]
+fn break_labelled_try_statement() {
+
+    let scenario = r#"
+        let result = ""
+        one: try {
+            result = "foo";
+            break one;
+            result = "did not break"
+        } catch (err) {
+            console.log(err)
+        }
+        result
+    "#;
+
+    assert_eq!(&exec(scenario), "\"foo\"")
+}
+
 #[test]
 fn while_loop_late_break() {
     // Ordering with statement before the break.

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -2210,7 +2210,7 @@ fn break_labelled_if_statement() {
         result
     "#;
 
-    assert_eq!(&exec(scenario), "\"foo\"")
+    assert_eq!(&exec(scenario), "\"foo\"");
 }
 
 #[test]
@@ -2227,7 +2227,7 @@ fn break_labelled_try_statement() {
         result
     "#;
 
-    assert_eq!(&exec(scenario), "\"foo\"")
+    assert_eq!(&exec(scenario), "\"foo\"");
 }
 
 #[test]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request addresses #2295, and another case that I came across when I was adding `Break` to the `ByteCompiler`

I did have a question that came up during this regarding the spec. We currently don't implement the [BreakableStatement](https://tc39.es/ecma262/#prod-BreakableStatement). Any thoughts on whether we should be? Especially since `BreakableStatement` seems to be a bit of a inaccurate since `LabelledStatement` is breakable too.

It changes the following:

- Moves handling of label jump out of `compile_block` and into `compile_labelled`.
- Adds a couple more tests to keep track of `LabelledStatement` breaks.
