### PR TITLE
[Merged by Bors] - First batch of `no_std` support for some sub-crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d299f547288d6db8d5c3a2916f7b2f66134b15b8c1ac1c4357dd3b8752af7bb2"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,6 +280,7 @@ version = "0.16.0"
 dependencies = [
  "arbitrary",
  "boa_macros",
+ "hashbrown 0.13.2",
  "indexmap",
  "once_cell",
  "phf",
@@ -1446,12 +1456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
- "atomic-polyfill",
+ "atomic-polyfill 0.1.11",
  "hash32",
  "rustc_version 0.4.0",
  "serde",
@@ -2411,6 +2427,10 @@ name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+dependencies = [
+ "atomic-polyfill 1.0.1",
+ "critical-section",
+]
 
 [[package]]
 name = "oorandom"

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 
 [features]
 serde = ["dep:serde", "boa_interner/serde"]
-
 arbitrary = ["dep:arbitrary", "boa_interner/arbitrary", "num-bigint/arbitrary"]
 
 [dependencies]

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -11,15 +11,15 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-serde = ["boa_interner/serde", "dep:serde"]
+serde = ["dep:serde", "boa_interner/serde"]
 
-fuzz = ["arbitrary", "boa_interner/fuzz", "num-bigint/arbitrary"]
+arbitrary = ["dep:arbitrary", "boa_interner/arbitrary", "num-bigint/arbitrary"]
 
 [dependencies]
 boa_interner.workspace = true
 boa_macros.workspace = true
 rustc-hash = "1.1.0"
-serde = { version = "1.0.152", features = ["derive"], optional = true }
 bitflags = "1.3.2"
 num-bigint = "0.4.3"
-arbitrary = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"], optional = true }
+arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/boa_ast/src/declaration/mod.rs
+++ b/boa_ast/src/declaration/mod.rs
@@ -27,7 +27,7 @@ pub use variable::*;
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Declaration {
     /// See [`Function`]

--- a/boa_ast/src/declaration/variable.rs
+++ b/boa_ast/src/declaration/variable.rs
@@ -45,7 +45,7 @@ use super::Declaration;
 /// [varstmt]: https://tc39.es/ecma262/#prod-VariableStatement
 /// [hoisting]: https://developer.mozilla.org/en-US/docs/Glossary/Hoisting
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VarDeclaration(pub VariableList);
 
@@ -82,7 +82,7 @@ impl VisitWith for VarDeclaration {
 ///
 /// [lexical declaration]: https://tc39.es/ecma262/#sec-let-and-const-declarations
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum LexicalDeclaration {
     /// A <code>[const]</code> variable creates a constant whose scope can be either global or local
@@ -158,7 +158,7 @@ impl VisitWith for LexicalDeclaration {
 
 /// List of variables in a variable declaration.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct VariableList {
     list: Box<[Variable]>,
@@ -249,7 +249,7 @@ impl TryFrom<Vec<Variable>> for VariableList {
 /// [spec2]: https://tc39.es/ecma262/#prod-VariableDeclaration
 /// [spec3]:  https://tc39.es/ecma262/#sec-declarations-and-the-variable-statement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Variable {
     binding: Binding,
@@ -332,7 +332,7 @@ impl VisitWith for Variable {
 ///
 /// [spec]:  https://tc39.es/ecma262/#sec-declarations-and-the-variable-statement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Binding {
     /// A single identifier binding.

--- a/boa_ast/src/expression/access.rs
+++ b/boa_ast/src/expression/access.rs
@@ -25,7 +25,7 @@ use core::ops::ControlFlow;
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyAccessField {
     /// A constant property field, such as `x.prop`.
@@ -74,7 +74,7 @@ impl VisitWith for PropertyAccessField {
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyAccess {
     /// A simple property access (`x.prop`).
@@ -129,7 +129,7 @@ impl VisitWith for PropertyAccess {
 
 /// A simple property access, where the target object is an [`Expression`].
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SimplePropertyAccess {
     target: Box<Expression>,
@@ -212,7 +212,7 @@ impl VisitWith for SimplePropertyAccess {
 /// [spec]: https://tc39.es/ecma262/#prod-MemberExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct PrivatePropertyAccess {
     target: Box<Expression>,
@@ -289,7 +289,7 @@ impl VisitWith for PrivatePropertyAccess {
 /// [spec]: https://tc39.es/ecma262/#prod-SuperProperty
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SuperPropertyAccess {
     field: PropertyAccessField,

--- a/boa_ast/src/expression/await.rs
+++ b/boa_ast/src/expression/await.rs
@@ -16,7 +16,7 @@ use boa_interner::{Interner, ToIndentedString, ToInternedString};
 /// [spec]: https://tc39.es/ecma262/#prod-AwaitExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Await {
     target: Box<Expression>,

--- a/boa_ast/src/expression/call.rs
+++ b/boa_ast/src/expression/call.rs
@@ -21,7 +21,7 @@ use super::Expression;
 /// [spec]: https://tc39.es/ecma262/#prod-CallExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Functions#Calling_functions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Call {
     function: Box<Expression>,
@@ -105,7 +105,7 @@ impl VisitWith for Call {
 /// [spec]: https://tc39.es/ecma262/#prod-SuperCall
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/super
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct SuperCall {
     args: Box<[Expression]>,

--- a/boa_ast/src/expression/identifier.rs
+++ b/boa_ast/src/expression/identifier.rs
@@ -43,7 +43,7 @@ pub const RESERVED_IDENTIFIERS_STRICT: [Sym; 9] = [
     derive(serde::Serialize, serde::Deserialize),
     serde(transparent)
 )]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct Identifier {

--- a/boa_ast/src/expression/literal/array.rs
+++ b/boa_ast/src/expression/literal/array.rs
@@ -25,7 +25,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ArrayLiteral
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ArrayLiteral {
     arr: Box<[Option<Expression>]>,

--- a/boa_ast/src/expression/literal/mod.rs
+++ b/boa_ast/src/expression/literal/mod.rs
@@ -33,7 +33,7 @@ use super::Expression;
 /// [spec]: https://tc39.es/ecma262/#sec-primary-expression-literals
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Literal {
     /// A string literal is zero or more characters enclosed in double (`"`) or single (`'`) quotation marks.

--- a/boa_ast/src/expression/literal/object.rs
+++ b/boa_ast/src/expression/literal/object.rs
@@ -34,7 +34,7 @@ use core::ops::ControlFlow;
 /// [primitive]: https://developer.mozilla.org/en-US/docs/Glossary/primitive
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ObjectLiteral {
     properties: Box<[PropertyDefinition]>,

--- a/boa_ast/src/expression/literal/template.rs
+++ b/boa_ast/src/expression/literal/template.rs
@@ -21,7 +21,7 @@ use crate::{
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals
 /// [spec]: https://tc39.es/ecma262/#sec-template-literals
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct TemplateLiteral {
     elements: Box<[TemplateElement]>,
@@ -41,7 +41,7 @@ impl From<TemplateLiteral> for Expression {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-template-literals
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum TemplateElement {
     /// A simple string.

--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -51,7 +51,7 @@ pub mod operator;
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expression {
     /// The ECMAScript `this` keyword refers to the object it belongs to.

--- a/boa_ast/src/expression/new.rs
+++ b/boa_ast/src/expression/new.rs
@@ -21,7 +21,7 @@ use super::Expression;
 /// [spec]: https://tc39.es/ecma262/#prod-NewExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/new
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct New {
     call: Call,

--- a/boa_ast/src/expression/operator/assign/mod.rs
+++ b/boa_ast/src/expression/operator/assign/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Assign {
     op: AssignOp,
@@ -112,7 +112,7 @@ impl VisitWith for Assign {
 ///
 /// [spec]: hhttps://tc39.es/ecma262/#prod-LeftHandSideExpression
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum AssignTarget {
     /// A simple identifier, such as `a`.

--- a/boa_ast/src/expression/operator/assign/op.rs
+++ b/boa_ast/src/expression/operator/assign/op.rs
@@ -12,7 +12,7 @@
 /// [spec]: https://tc39.es/ecma262/#prod-AssignmentOperator
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Assignment
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AssignOp {
     /// The assignment operator assigns the value of the right operand to the left operand.

--- a/boa_ast/src/expression/operator/binary/mod.rs
+++ b/boa_ast/src/expression/operator/binary/mod.rs
@@ -31,7 +31,7 @@ use crate::{
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Binary {
     op: BinaryOp,

--- a/boa_ast/src/expression/operator/binary/op.rs
+++ b/boa_ast/src/expression/operator/binary/op.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter, Result};
 
 /// This represents a binary operation between two values.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BinaryOp {
     /// Numeric operation.
@@ -87,7 +87,7 @@ impl Display for BinaryOp {
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Arithmetic
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ArithmeticOp {
     /// The addition operator produces the sum of numeric operands or string concatenation.
@@ -198,7 +198,7 @@ impl Display for ArithmeticOp {
 ///
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Bitwise
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BitwiseOp {
     /// Performs the AND operation on each pair of bits. a AND b yields 1 only if both a and b are 1.
@@ -322,7 +322,7 @@ impl Display for BitwiseOp {
 /// [spec]: tc39.es/ecma262/#sec-testing-and-comparison-operations
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Comparison
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RelationalOp {
     /// The equality operator converts the operands if they are not of the same type, then applies
@@ -516,7 +516,7 @@ impl Display for RelationalOp {
 /// [spec]: https://tc39.es/ecma262/#sec-binary-logical-operators
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Logical
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LogicalOp {
     /// The logical AND operator returns the value of the first operand if it can be coerced into `false`;

--- a/boa_ast/src/expression/operator/conditional.rs
+++ b/boa_ast/src/expression/operator/conditional.rs
@@ -21,7 +21,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ConditionalExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#Literals
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Conditional {
     condition: Box<Expression>,

--- a/boa_ast/src/expression/operator/unary/mod.rs
+++ b/boa_ast/src/expression/operator/unary/mod.rs
@@ -30,7 +30,7 @@ use crate::visitor::{VisitWith, Visitor, VisitorMut};
 /// [spec]: https://tc39.es/ecma262/#prod-UnaryExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Unary_operators
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Unary {
     op: UnaryOp,

--- a/boa_ast/src/expression/operator/unary/op.rs
+++ b/boa_ast/src/expression/operator/unary/op.rs
@@ -11,7 +11,7 @@
 /// [spec]: https://tc39.es/ecma262/#prod-UnaryExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Unary
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnaryOp {
     /// The increment operator increments (adds one to) its operand and returns a value.

--- a/boa_ast/src/expression/optional.rs
+++ b/boa_ast/src/expression/optional.rs
@@ -9,7 +9,7 @@ use core::ops::ControlFlow;
 
 /// List of valid operations in an [`Optional`] chain.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum OptionalOperationKind {
     /// A property access (`a?.prop`).
@@ -70,7 +70,7 @@ impl VisitWith for OptionalOperationKind {
 /// In contrast, a non-shorted operation (`.prop`) will try to access the property, even if the target
 /// is `undefined` or `null`.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct OptionalOperation {
     kind: OptionalOperationKind,
@@ -173,7 +173,7 @@ impl VisitWith for OptionalOperation {
 /// [spec]: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#prod-OptionalExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Optional {
     target: Box<Expression>,

--- a/boa_ast/src/expression/spread.rs
+++ b/boa_ast/src/expression/spread.rs
@@ -23,7 +23,7 @@ use super::Expression;
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(transparent))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Spread {
     target: Box<Expression>,

--- a/boa_ast/src/expression/tagged_template.rs
+++ b/boa_ast/src/expression/tagged_template.rs
@@ -14,7 +14,7 @@ use super::Expression;
 /// [moz]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals#tagged_templates
 /// [spec]: https://tc39.es/ecma262/#sec-tagged-templates
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct TaggedTemplate {
     tag: Box<Expression>,

--- a/boa_ast/src/expression/yield.rs
+++ b/boa_ast/src/expression/yield.rs
@@ -14,7 +14,7 @@ use super::Expression;
 /// [spec]: https://tc39.es/ecma262/#prod-YieldExpression
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/yield
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Yield {
     target: Option<Box<Expression>>,

--- a/boa_ast/src/function/arrow_function.rs
+++ b/boa_ast/src/function/arrow_function.rs
@@ -19,7 +19,7 @@ use super::FormalParameterList;
 /// [spec]: https://tc39.es/ecma262/#prod-ArrowFunction
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ArrowFunction {
     name: Option<Identifier>,

--- a/boa_ast/src/function/async_arrow_function.rs
+++ b/boa_ast/src/function/async_arrow_function.rs
@@ -19,7 +19,7 @@ use boa_interner::{Interner, ToIndentedString};
 /// [spec]: https://tc39.es/ecma262/#prod-AsyncArrowFunction
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AsyncArrowFunction {
     name: Option<Identifier>,

--- a/boa_ast/src/function/async_function.rs
+++ b/boa_ast/src/function/async_function.rs
@@ -20,7 +20,7 @@ use super::FormalParameterList;
 /// [spec]: https://tc39.es/ecma262/#sec-async-function-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AsyncFunction {
     name: Option<Identifier>,

--- a/boa_ast/src/function/async_generator.rs
+++ b/boa_ast/src/function/async_generator.rs
@@ -19,7 +19,7 @@ use super::FormalParameterList;
 /// [spec]: https://tc39.es/ecma262/#sec-async-generator-function-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function*
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct AsyncGenerator {
     name: Option<Identifier>,

--- a/boa_ast/src/function/class.rs
+++ b/boa_ast/src/function/class.rs
@@ -21,7 +21,7 @@ use std::hash::Hash;
 /// [spec]: https://tc39.es/ecma262/#sec-class-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Class {
     name: Option<Identifier>,
@@ -424,7 +424,7 @@ impl VisitWith for Class {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-ClassElement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ClassElement {
     /// A method definition, including `get` and `set` accessors.
@@ -533,7 +533,7 @@ impl VisitWith for ClassElement {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-private-names
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct PrivateName {
     /// The `[[Description]]` internal slot of the private name.

--- a/boa_ast/src/function/generator.rs
+++ b/boa_ast/src/function/generator.rs
@@ -21,7 +21,7 @@ use super::FormalParameterList;
 /// [spec]: https://tc39.es/ecma262/#sec-generator-function-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Generator {
     name: Option<Identifier>,

--- a/boa_ast/src/function/mod.rs
+++ b/boa_ast/src/function/mod.rs
@@ -57,7 +57,7 @@ use super::Declaration;
 /// [spec]: https://tc39.es/ecma262/#sec-function-definitions
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Function {
     name: Option<Identifier>,

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -166,7 +166,7 @@ impl VisitWith for FormalParameterList {
     }
 }
 
-#[cfg(feature = "fuzz")]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for FormalParameterList {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let params: Vec<FormalParameter> = u.arbitrary()?;
@@ -214,7 +214,7 @@ impl Default for FormalParameterListFlags {
 /// [spec]: https://tc39.es/ecma262/#prod-FormalParameter
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Missing_formal_parameter
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct FormalParameter {
     variable: Variable,

--- a/boa_ast/src/pattern.rs
+++ b/boa_ast/src/pattern.rs
@@ -36,7 +36,7 @@ use core::ops::ControlFlow;
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Pattern {
     /// An object pattern (`let {a, b, c} = object`).
@@ -109,7 +109,7 @@ impl VisitWith for Pattern {
 /// [spec1]: https://tc39.es/ecma262/#prod-ObjectBindingPattern
 /// [spec2]: https://tc39.es/ecma262/#prod-ObjectAssignmentPattern
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ObjectPattern(Box<[ObjectPatternElement]>);
 
@@ -198,7 +198,7 @@ impl VisitWith for ObjectPattern {
 /// [spec1]: https://tc39.es/ecma262/#prod-ArrayBindingPattern
 /// [spec2]: https://tc39.es/ecma262/#prod-ArrayAssignmentPattern
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ArrayPattern(Box<[ArrayPatternElement]>);
 
@@ -273,7 +273,7 @@ impl VisitWith for ArrayPattern {
 /// [spec1]: https://tc39.es/ecma262/#prod-BindingProperty
 /// [spec2]: https://tc39.es/ecma262/#prod-AssignmentProperty
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ObjectPatternElement {
     /// SingleName represents one of the following properties:
@@ -573,7 +573,7 @@ impl VisitWith for ObjectPatternElement {
 /// [spec1]: https://tc39.es/ecma262/#prod-BindingElement
 /// [spec2]: https://tc39.es/ecma262/#prod-AssignmentElement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ArrayPatternElement {
     /// Elision represents the elision of an item in the array binding pattern.

--- a/boa_ast/src/property.rs
+++ b/boa_ast/src/property.rs
@@ -26,7 +26,7 @@ use super::{
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Glossary/property/JavaScript
 // TODO: Support all features: https://tc39.es/ecma262/#prod-PropertyDefinition
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyDefinition {
     /// Puts a variable into an object.
@@ -139,7 +139,7 @@ impl VisitWith for PropertyDefinition {
 /// [spec]: https://tc39.es/ecma262/#prod-MethodDefinition
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum MethodDefinition {
     /// The `get` syntax binds an object property to a function that will be called when that property is looked up.
@@ -247,7 +247,7 @@ impl VisitWith for MethodDefinition {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-PropertyName
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum PropertyName {
     /// A `Literal` property name can be either an identifier, a string or a numeric literal.

--- a/boa_ast/src/statement/block.rs
+++ b/boa_ast/src/statement/block.rs
@@ -23,7 +23,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-BlockStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/block
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct Block {
     #[cfg_attr(feature = "serde", serde(flatten))]

--- a/boa_ast/src/statement/if.rs
+++ b/boa_ast/src/statement/if.rs
@@ -26,7 +26,7 @@ use core::ops::ControlFlow;
 /// [falsy]: https://developer.mozilla.org/en-US/docs/Glossary/falsy
 /// [expression]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Expressions_and_Operators#Expressions
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct If {
     condition: Expression,

--- a/boa_ast/src/statement/iteration/break.rs
+++ b/boa_ast/src/statement/iteration/break.rs
@@ -19,7 +19,7 @@ use crate::Statement;
 /// [spec]: https://tc39.es/ecma262/#prod-BreakStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/break
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Break {
     label: Option<Sym>,

--- a/boa_ast/src/statement/iteration/continue.rs
+++ b/boa_ast/src/statement/iteration/continue.rs
@@ -17,7 +17,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ContinueStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/continue
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Continue {
     label: Option<Sym>,

--- a/boa_ast/src/statement/iteration/do_while_loop.rs
+++ b/boa_ast/src/statement/iteration/do_while_loop.rs
@@ -20,7 +20,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#sec-do-while-statement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/do...while
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct DoWhileLoop {
     body: Box<Statement>,

--- a/boa_ast/src/statement/iteration/for_in_loop.rs
+++ b/boa_ast/src/statement/iteration/for_in_loop.rs
@@ -15,7 +15,7 @@ use core::ops::ControlFlow;
 /// [forin]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...in
 /// [spec]: https://tc39.es/ecma262/#prod-ForInOfStatement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForInLoop {
     initializer: IterableLoopInitializer,

--- a/boa_ast/src/statement/iteration/for_loop.rs
+++ b/boa_ast/src/statement/iteration/for_loop.rs
@@ -19,7 +19,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ForDeclaration
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForLoop {
     #[cfg_attr(feature = "serde", serde(flatten))]
@@ -136,7 +136,7 @@ impl VisitWith for ForLoop {
 
 /// Inner structure to avoid multiple indirections in the heap.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 struct InnerForLoop {
     init: Option<ForLoopInitializer>,
@@ -196,7 +196,7 @@ impl InnerForLoop {
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-ForStatement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ForLoopInitializer {
     /// An expression initializer.

--- a/boa_ast/src/statement/iteration/for_of_loop.rs
+++ b/boa_ast/src/statement/iteration/for_of_loop.rs
@@ -20,7 +20,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ForInOfStatement
 /// [forawait]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForOfLoop {
     init: IterableLoopInitializer,

--- a/boa_ast/src/statement/iteration/mod.rs
+++ b/boa_ast/src/statement/iteration/mod.rs
@@ -35,7 +35,7 @@ use boa_interner::{Interner, ToInternedString};
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-ForInOfStatement
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum IterableLoopInitializer {
     /// An already declared variable.

--- a/boa_ast/src/statement/iteration/while_loop.rs
+++ b/boa_ast/src/statement/iteration/while_loop.rs
@@ -19,7 +19,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-grammar-notation-WhileStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/while
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct WhileLoop {
     condition: Expression,

--- a/boa_ast/src/statement/labelled.rs
+++ b/boa_ast/src/statement/labelled.rs
@@ -17,7 +17,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-LabelledItem
 /// [label-fn]: https://tc39.es/ecma262/#sec-labelled-function-declarations
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum LabelledItem {
     /// A labelled [`Function`].
@@ -82,7 +82,7 @@ impl VisitWith for LabelledItem {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-labelled-statements
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Labelled {
     item: Box<LabelledItem>,

--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -38,7 +38,7 @@ use super::{declaration::VarDeclaration, expression::Expression};
 ///
 /// See the [module level documentation][self] for more information.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum Statement {
     /// See [`Block`].

--- a/boa_ast/src/statement/return.rs
+++ b/boa_ast/src/statement/return.rs
@@ -24,7 +24,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ReturnStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/return
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Return {
     target: Option<Expression>,

--- a/boa_ast/src/statement/switch.rs
+++ b/boa_ast/src/statement/switch.rs
@@ -19,7 +19,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-CaseClause
 /// [truthy]: https://developer.mozilla.org/en-US/docs/Glossary/Truthy
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Case {
     condition: Expression,
@@ -84,7 +84,7 @@ impl VisitWith for Case {
 /// [spec]: https://tc39.es/ecma262/#prod-SwitchStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/switch
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Switch {
     val: Expression,

--- a/boa_ast/src/statement/throw.rs
+++ b/boa_ast/src/statement/throw.rs
@@ -21,7 +21,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-ThrowStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Throw {
     target: Expression,

--- a/boa_ast/src/statement/try.rs
+++ b/boa_ast/src/statement/try.rs
@@ -23,7 +23,7 @@ use core::ops::ControlFlow;
 /// [spec]: https://tc39.es/ecma262/#prod-TryStatement
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/try...catch
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Try {
     block: Block,
@@ -32,7 +32,7 @@ pub struct Try {
 
 /// The type of error handler in a [`Try`] statement.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum ErrorHandler {
     /// A [`Catch`] error handler.
@@ -139,7 +139,7 @@ impl VisitWith for Try {
 
 /// Catch block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Catch {
     parameter: Option<Binding>,
@@ -208,7 +208,7 @@ impl VisitWith for Catch {
 
 /// Finally block.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub struct Finally {
     block: Block,

--- a/boa_ast/src/statement_list.rs
+++ b/boa_ast/src/statement_list.rs
@@ -18,7 +18,7 @@ use std::cmp::Ordering;
 ///
 /// [spec]: https://tc39.es/ecma262/#prod-StatementListItem
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "fuzz", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Debug, PartialEq)]
 pub enum StatementListItem {
     /// See [`Statement`].
@@ -204,7 +204,7 @@ impl VisitWith for StatementList {
     }
 }
 
-#[cfg(feature = "fuzz")]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for StatementList {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -28,7 +28,7 @@ intl = [
     "dep:sys-locale",
 ]
 
-fuzz = ["boa_ast/fuzz", "boa_interner/fuzz"]
+fuzz = ["boa_ast/arbitrary", "boa_interner/arbitrary"]
 
 # Enable Boa's VM instruction flowgraph generator.
 flowgraph = []

--- a/boa_icu_provider/Cargo.toml
+++ b/boa_icu_provider/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_icu_provider"
 description = "ICU4X data provider for the Boa JavaScript engine."
 keywords = ["javascript", "cldr", "unicode"]
-categories = ["internationalization"]
+categories = ["internationalization", "no-std"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -15,13 +15,15 @@ rust-version.workspace = true
 [dependencies]
 icu_provider = { version = "1.0.1", features = ["serde", "sync"] }
 icu_provider_blob = "1.0.0"
-icu_provider_adapters = { version = "1.0.0", features = ["serde"]}
+icu_provider_adapters = { version = "1.0.0", features = ["serde"] }
+once_cell = {version = "1.17.0", default-features = false, features = ["critical-section"]}
 icu_datagen = { version = "1.0.2", optional = true }
 log = { version = "0.4.17", optional = true }
 simple_logger = { version = "4.0.0", optional = true }
-once_cell = "1.17.0"
 
 [features]
+default = ["std"]
+std = ["once_cell/std"]
 bin = ["dep:icu_datagen", "dep:simple_logger", "dep:log"]
 
 [[bin]]

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -64,8 +64,10 @@
     clippy::pedantic,
     clippy::nursery,
 )]
+#![cfg_attr(not(feature = "bin"), no_std)]
 
 /// Gets the path to the directory where the generated data is stored.
+#[cfg(feature = "bin")]
 #[must_use]
 #[doc(hidden)]
 pub fn data_root() -> std::path::PathBuf {

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_interner"
 description = "String interner for the Boa JavaScript engine."
 keywords = ["javascript", "js", "string", "interner"]
-categories = ["data-structures"]
+categories = ["data-structures", "no-std"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -11,14 +11,16 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-fuzz = ["arbitrary"]
+default = ["std"]
+std = ["once_cell/std"]
 
 [dependencies]
 boa_macros.workspace = true
-serde = { version = "1.0.152", features = ["derive"], optional = true }
-phf = { version = "0.11.1", features = ["macros"] }
-rustc-hash = "1.1.0"
+phf = { version = "0.11.1", default-features = false, features = ["macros"] }
+rustc-hash = { version = "1.1.0", default-features = false }
 static_assertions = "1.1.0"
-once_cell = "1.17.0"
+once_cell = {version = "1.17.0", default-features = false, features = ["critical-section"]}
 indexmap = "1.9.2"
-arbitrary = { version = "1", optional = true, features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"], optional = true }
+arbitrary = { version = "1", features = ["derive"], optional = true }
+hashbrown = { version = "0.13.2", default-features = false, features = ["inline-more"] }

--- a/boa_interner/src/fixed_string.rs
+++ b/boa_interner/src/fixed_string.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::interned_str::InternedStr;
 
 #[derive(Debug)]

--- a/boa_interner/src/interned_str.rs
+++ b/boa_interner/src/interned_str.rs
@@ -1,4 +1,4 @@
-use std::{hash::Hash, ptr::NonNull};
+use core::{hash::Hash, ptr::NonNull};
 
 /// Wrapper for an interned str pointer, required to
 /// quickly check using a hash if a string is inside an [`Interner`][`super::Interner`].
@@ -69,7 +69,7 @@ impl<Char> Hash for InternedStr<Char>
 where
     Char: Hash,
 {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         // SAFETY:
         // The caller must ensure `ptr` is still valid throughout the
         // lifetime of `self`.

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -89,6 +89,9 @@
     // TODO deny once false positive is fixed (https://github.com/rust-lang/rust-clippy/issues/9626).
     clippy::trait_duplication_in_bounds
 )]
+#![cfg_attr(not(feature = "arbitrary"), no_std)]
+
+extern crate alloc;
 
 extern crate static_assertions as sa;
 
@@ -100,8 +103,8 @@ mod sym;
 #[cfg(test)]
 mod tests;
 
+use alloc::{borrow::Cow, format, string::String};
 use raw::RawInterner;
-use std::borrow::Cow;
 
 pub use sym::*;
 
@@ -213,10 +216,10 @@ impl<'a, 'b> JSInternedStrRef<'a, 'b> {
     }
 }
 
-impl std::fmt::Display for JSInternedStrRef<'_, '_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for JSInternedStrRef<'_, '_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.join_with_context(
-            std::fmt::Display::fmt,
+            core::fmt::Display::fmt,
             |js, f| {
                 char::decode_utf16(js.iter().copied())
                     .map(|r| match r {
@@ -395,7 +398,7 @@ impl Interner {
             // We only manipulate valid UTF-8 `str`s and convert them to `[u8]` for convenience,
             // so converting back to a `str` is safe.
             let utf8 = unsafe {
-                std::str::from_utf8_unchecked(
+                core::str::from_utf8_unchecked(
                     self.utf8_interner
                         .index(index)
                         .expect("both interners must have the same size"),

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -151,7 +151,7 @@ fn derive_trace(mut s: Structure<'_>) -> proc_macro2::TokenStream {
     // type and encourage people to use Finalize. This implementation will
     // call `Finalize::finalize` if it is safe to do so.
     let drop_impl = s.unbound_impl(
-        quote!(::std::ops::Drop),
+        quote!(::core::ops::Drop),
         quote! {
             fn drop(&mut self) {
                 if ::boa_gc::finalizer_safe() {

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -77,8 +77,9 @@
     clippy::pedantic,
     clippy::nursery,
 )]
+#![cfg_attr(not(feature = "profiler"), no_std)]
 
-use std::fmt::{self, Debug};
+use core::fmt::{self, Debug};
 
 #[cfg(feature = "profiler")]
 use measureme::{EventId, Profiler as MeasuremeProfiler, StringId, TimingGuard};

--- a/boa_unicode/Cargo.toml
+++ b/boa_unicode/Cargo.toml
@@ -2,7 +2,7 @@
 name = "boa_unicode"
 description = "Unicode support for the Boa JavaScript engine."
 keywords = ["javascript", "compiler", "lexer", "parser", "unicode"]
-categories = ["parsing"]
+categories = ["parsing", "no-std"]
 version.workspace = true
 edition.workspace = true
 authors.workspace = true

--- a/boa_unicode/src/lib.rs
+++ b/boa_unicode/src/lib.rs
@@ -87,6 +87,7 @@
     clippy::nursery,
 )]
 #![allow(clippy::redundant_pub_crate)]
+#![no_std]
 
 mod tables;
 #[cfg(test)]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request enables support for `no_std` targets on some of our sub-crates. I intentionally left out `boa_ast` and `boa_cli` because they're the largest crates we have after `boa_engine`.
`boa_gc` is a monster on its own, because we'll need to design a `no_std` multithreaded GC.

Anyways, this changes the following:

- Adds support for `no_std` on `boa_unicode`.
- Adds support for `no_std` on `boa_profiler`.
- Adds support for `no_std` on `boa_interner`.
- Adds support for `no_std` on `boa_icu_provider`.
