### PR TITLE
Fix conformance page accordion with `.` in suite name

### DIFF
--- a/test262/results.js
+++ b/test262/results.js
@@ -264,7 +264,7 @@ function showData(data) {
 }
 
 function addSuite(suite, parentID, namespace, upstream) {
-  const newID = parentID + suite.n;
+  const newID = (parentID + suite.n).replaceAll(".", "-");
   const newInnerID = newID + "-inner";
   const headerID = newID + "header";
 


### PR DESCRIPTION
The accordions for suite tests on our conformance page currently breaks when the suite name has a `.`. This change makes the accordion show and hide work as expected by replacing the `.` in the relevant identifiers.