### PR TITLE
[Merged by Bors] - Fix error for static class methods named `prototype`

### DIFF
--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -151,7 +151,7 @@ impl Operation for DefineClassStaticGetterByValue {
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
-        class.__define_own_property__(
+        class.define_property_or_throw(
             key,
             PropertyDescriptor::builder()
                 .maybe_get(Some(function))

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -136,7 +136,7 @@ impl Operation for DefineClassStaticMethodByValue {
             function_mut.set_home_object(class.clone());
             function_mut.set_class_object(class.clone());
         }
-        class.__define_own_property__(
+        class.define_property_or_throw(
             key,
             PropertyDescriptor::builder()
                 .value(function)

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -151,7 +151,7 @@ impl Operation for DefineClassStaticSetterByValue {
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
-        class.__define_own_property__(
+        class.define_property_or_throw(
             key,
             PropertyDescriptor::builder()
                 .maybe_set(Some(function))

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -723,7 +723,7 @@ where
 
                 match class_element_name {
                     ClassElementName::PropertyName(property_name) if r#static => {
-                        if property_name.prop_name() == Some(Sym::PROTOTYPE) {
+                        if property_name.literal() == Some(Sym::PROTOTYPE) {
                             return Err(Error::general(
                                 "class may not have static method definitions named 'prototype'",
                                 name_position,
@@ -780,7 +780,7 @@ where
                         cursor.set_strict_mode(strict);
                         match class_element_name {
                             ClassElementName::PropertyName(property_name) if r#static => {
-                                if property_name.prop_name() == Some(Sym::PROTOTYPE) {
+                                if property_name.literal() == Some(Sym::PROTOTYPE) {
                                     return Err(Error::general(
                                         "class may not have static method definitions named 'prototype'",
                                         name_position,
@@ -825,11 +825,11 @@ where
 
                         match class_element_name {
                             ClassElementName::PropertyName(property_name) if r#static => {
-                                if property_name.prop_name() == Some(Sym::PROTOTYPE) {
+                                if property_name.literal() == Some(Sym::PROTOTYPE) {
                                     return Err(Error::general(
-                                            "class may not have static method definitions named 'prototype'",
-                                            name_position,
-                                        ));
+                                        "class may not have static method definitions named 'prototype'",
+                                        name_position,
+                                    ));
                                 }
                                 function::ClassElement::StaticMethodDefinition(
                                     property_name,
@@ -957,13 +957,11 @@ where
                             body,
                         ));
                         if r#static {
-                            if let Some(name) = name.prop_name() {
-                                if name == Sym::PROTOTYPE {
-                                    return Err(Error::general(
-                                            "class may not have static method definitions named 'prototype'",
-                                            name_position,
-                                        ));
-                                }
+                            if name.literal() == Some(Sym::PROTOTYPE) {
+                                return Err(Error::general(
+                                    "class may not have static method definitions named 'prototype'",
+                                    name_position,
+                                ));
                             }
                             function::ClassElement::StaticMethodDefinition(name, method)
                         } else {
@@ -1081,13 +1079,11 @@ where
                         cursor.set_strict_mode(strict);
                         let method = MethodDefinition::Set(Function::new(None, params, body));
                         if r#static {
-                            if let Some(name) = name.prop_name() {
-                                if name == Sym::PROTOTYPE {
-                                    return Err(Error::general(
-                                            "class may not have static method definitions named 'prototype'",
-                                            name_position,
-                                        ));
-                                }
+                            if name.literal() == Some(Sym::PROTOTYPE) {
+                                return Err(Error::general(
+                                    "class may not have static method definitions named 'prototype'",
+                                    name_position,
+                                ));
                             }
                             function::ClassElement::StaticMethodDefinition(name, method)
                         } else {
@@ -1253,13 +1249,11 @@ where
                         }
                     }
                     TokenKind::Punctuator(Punctuator::OpenParen) => {
-                        if let Some(name) = name.prop_name() {
-                            if r#static && name == Sym::PROTOTYPE {
-                                return Err(Error::general(
-                                        "class may not have static method definitions named 'prototype'",
-                                        name_position,
-                                    ));
-                            }
+                        if r#static && name.literal() == Some(Sym::PROTOTYPE) {
+                            return Err(Error::general(
+                                "class may not have static method definitions named 'prototype'",
+                                name_position,
+                            ));
                         }
                         let strict = cursor.strict_mode();
                         cursor.set_strict_mode(true);


### PR DESCRIPTION
This Pull Request changes the following:

- Remove wrong early errors for static class methods with the computed property name `prototype`.
- Switch static class method definition opcodes from `__define_own_property__` to `define_property_or_throw` to correctly throw runtime errors on property redefinitions.
