### PR TITLE
[Merged by Bors] - Avoid creating `prototype` property on methods

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -616,9 +616,16 @@ impl BuiltInFunctionObject {
             let environments = context.realm.environments.pop_to_global();
 
             let function_object = if generator {
-                crate::vm::create_generator_function_object(code, r#async, context)
+                crate::vm::create_generator_function_object(code, r#async, false, context)
             } else {
-                crate::vm::create_function_object(code, r#async, false, Some(prototype), context)
+                crate::vm::create_function_object(
+                    code,
+                    r#async,
+                    false,
+                    Some(prototype),
+                    false,
+                    context,
+                )
             };
 
             context.realm.environments.extend(environments);
@@ -636,7 +643,7 @@ impl BuiltInFunctionObject {
 
             let environments = context.realm.environments.pop_to_global();
             let function_object =
-                crate::vm::create_generator_function_object(code, r#async, context);
+                crate::vm::create_generator_function_object(code, r#async, false, context);
             context.realm.environments.extend(environments);
 
             Ok(function_object)
@@ -648,8 +655,14 @@ impl BuiltInFunctionObject {
             )?;
 
             let environments = context.realm.environments.pop_to_global();
-            let function_object =
-                crate::vm::create_function_object(code, r#async, false, Some(prototype), context);
+            let function_object = crate::vm::create_function_object(
+                code,
+                r#async,
+                false,
+                Some(prototype),
+                false,
+                context,
+            );
             context.realm.environments.extend(environments);
 
             Ok(function_object)

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -138,6 +138,7 @@ impl ByteCompiler<'_, '_> {
         let index = self.code_block.functions.len() as u32;
         self.code_block.functions.push(code);
         self.emit(Opcode::GetFunction, &[index]);
+        self.emit_u8(0);
 
         self.emit_opcode(Opcode::Dup);
         if let Some(node) = class.super_ref() {
@@ -320,6 +321,7 @@ impl ByteCompiler<'_, '_> {
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
+                    self.emit_u8(0);
                     self.emit_opcode(Opcode::PushClassField);
                 }
                 ClassElement::PrivateFieldDefinition(name, field) => {
@@ -362,6 +364,7 @@ impl ByteCompiler<'_, '_> {
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
+                    self.emit_u8(0);
                     self.emit(Opcode::PushClassFieldPrivate, &[name_index]);
                 }
                 ClassElement::StaticFieldDefinition(name, field) => {
@@ -414,6 +417,7 @@ impl ByteCompiler<'_, '_> {
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
+                    self.emit_u8(0);
                     self.emit_opcode(Opcode::SetHomeObject);
                     self.emit(Opcode::Call, &[0]);
                     if let Some(name_index) = name_index {
@@ -454,6 +458,7 @@ impl ByteCompiler<'_, '_> {
                     let index = self.code_block.functions.len() as u32;
                     self.code_block.functions.push(code);
                     self.emit(Opcode::GetFunction, &[index]);
+                    self.emit_u8(0);
                     self.emit_opcode(Opcode::SetHomeObject);
                     self.emit(Opcode::Call, &[0]);
                     self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -1065,6 +1065,7 @@ impl<'b, 'host> ByteCompiler<'b, 'host> {
         } else {
             self.emit(Opcode::GetFunction, &[index]);
         }
+        self.emit_u8(0);
 
         match node_kind {
             NodeKind::Declaration => {
@@ -1140,6 +1141,7 @@ impl<'b, 'host> ByteCompiler<'b, 'host> {
         } else {
             self.emit(Opcode::GetFunction, &[index]);
         }
+        self.emit_u8(1);
 
         match node_kind {
             NodeKind::Declaration => {

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -310,7 +310,7 @@ impl CodeBlock {
                     let fn_name = interner
                         .resolve_expect(self.functions[operand as usize].name)
                         .to_string();
-                    pc += size_of::<u32>();
+                    pc += size_of::<u32>() + size_of::<u8>();
                     let label = format!(
                         "{opcode_str} '{fn_name}' (length: {})",
                         self.functions[operand as usize].length

--- a/boa_engine/src/vm/opcode/get/function.rs
+++ b/boa_engine/src/vm/opcode/get/function.rs
@@ -16,8 +16,9 @@ impl Operation for GetArrowFunction {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        context.vm.read::<u8>();
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, false, true, None, context);
+        let function = create_function_object(code, false, true, None, false, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }
@@ -36,8 +37,9 @@ impl Operation for GetAsyncArrowFunction {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        context.vm.read::<u8>();
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, true, true, None, context);
+        let function = create_function_object(code, true, true, None, false, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }
@@ -56,8 +58,9 @@ impl Operation for GetFunction {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, false, false, None, context);
+        let function = create_function_object(code, false, false, None, method, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }
@@ -76,8 +79,9 @@ impl Operation for GetFunctionAsync {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, true, false, None, context);
+        let function = create_function_object(code, true, false, None, method, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }

--- a/boa_engine/src/vm/opcode/get/generator.rs
+++ b/boa_engine/src/vm/opcode/get/generator.rs
@@ -16,8 +16,9 @@ impl Operation for GetGenerator {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_generator_function_object(code, false, context);
+        let function = create_generator_function_object(code, false, method, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }
@@ -36,8 +37,9 @@ impl Operation for GetGeneratorAsync {
 
     fn execute(context: &mut Context<'_>) -> JsResult<ShouldExit> {
         let index = context.vm.read::<u32>();
+        let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_generator_function_object(code, true, context);
+        let function = create_generator_function_object(code, true, method, context);
         context.vm.push(function);
         Ok(ShouldExit::False)
     }

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1207,42 +1207,42 @@ generate_impl! {
 
         /// Get arrow function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetArrowFunction,
 
         /// Get async arrow function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetAsyncArrowFunction,
 
         /// Get function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetFunction,
 
         /// Get async function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetFunctionAsync,
 
         /// Get generator function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetGenerator,
 
         /// Get async generator function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`
+        /// Operands: address: `u32`, method: `u8`
         ///
         /// Stack: **=>** func
         GetGeneratorAsync,


### PR DESCRIPTION
This Pull Request changes the following:

- Stop creating a `prototype` property on class methods by passing a flag to the relevant opcodes.
