### PR TITLE
[Merged by Bors] - Pin tarpaulin version to 0.22

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.22.0'
           args: --features intl --ignore-tests --engine llvm
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.22.0'
+          version: 0.22.0
           args: --features intl --ignore-tests --engine llvm
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Our CI broke because the new version of `tarpaulin` released more assets than the default 'travis.tar.gz'. We'll have to pin our version of `tarpaulin` until the issue gets fixed.