### PR TITLE
[Merged by Bors] - Move increment and decrement operations to `Update` expression

### DIFF
--- a/boa_ast/src/expression/mod.rs
+++ b/boa_ast/src/expression/mod.rs
@@ -15,7 +15,7 @@ use core::ops::ControlFlow;
 use self::{
     access::PropertyAccess,
     literal::{ArrayLiteral, Literal, ObjectLiteral, TemplateLiteral},
-    operator::{Assign, Binary, Conditional, Unary},
+    operator::{Assign, Binary, Conditional, Unary, Update},
 };
 
 use super::{
@@ -138,6 +138,9 @@ pub enum Expression {
     /// See [`Unary`].
     Unary(Unary),
 
+    /// See [`Unary`].
+    Update(Update),
+
     /// See [`Binary`].
     Binary(Binary),
 
@@ -188,6 +191,7 @@ impl Expression {
             Self::TaggedTemplate(tag) => tag.to_interned_string(interner),
             Self::Assign(assign) => assign.to_interned_string(interner),
             Self::Unary(unary) => unary.to_interned_string(interner),
+            Self::Update(update) => update.to_interned_string(interner),
             Self::Binary(bin) => bin.to_interned_string(interner),
             Self::Conditional(cond) => cond.to_interned_string(interner),
             Self::Await(aw) => aw.to_interned_string(interner),
@@ -280,6 +284,7 @@ impl VisitWith for Expression {
             Self::TaggedTemplate(tt) => visitor.visit_tagged_template(tt),
             Self::Assign(a) => visitor.visit_assign(a),
             Self::Unary(u) => visitor.visit_unary(u),
+            Self::Update(u) => visitor.visit_update(u),
             Self::Binary(b) => visitor.visit_binary(b),
             Self::Conditional(c) => visitor.visit_conditional(c),
             Self::Await(a) => visitor.visit_await(a),
@@ -318,6 +323,7 @@ impl VisitWith for Expression {
             Self::TaggedTemplate(tt) => visitor.visit_tagged_template_mut(tt),
             Self::Assign(a) => visitor.visit_assign_mut(a),
             Self::Unary(u) => visitor.visit_unary_mut(u),
+            Self::Update(u) => visitor.visit_update_mut(u),
             Self::Binary(b) => visitor.visit_binary_mut(b),
             Self::Conditional(c) => visitor.visit_conditional_mut(c),
             Self::Await(a) => visitor.visit_await_mut(a),

--- a/boa_ast/src/expression/operator/mod.rs
+++ b/boa_ast/src/expression/operator/mod.rs
@@ -5,7 +5,8 @@
 //! An operator expression can be any of the following:
 //!
 //! - A [`Unary`] expression.
-//! - An [`Assign`] expression.
+//! - A [`Update`] expression.
+//! - A [`Assign`] expression.
 //! - A [`Binary`] expression.
 //! - A [`Conditional`] expression.
 //!
@@ -16,5 +17,8 @@ mod conditional;
 pub mod assign;
 pub mod binary;
 pub mod unary;
+pub mod update;
 
-pub use self::{assign::Assign, binary::Binary, conditional::Conditional, unary::Unary};
+pub use self::{
+    assign::Assign, binary::Binary, conditional::Conditional, unary::Unary, update::Update,
+};

--- a/boa_ast/src/expression/operator/unary/mod.rs
+++ b/boa_ast/src/expression/operator/unary/mod.rs
@@ -1,25 +1,24 @@
 //! Unary expression nodes.
 //!
-//! A Binary expression comprises any operation applied to a single expression. Some examples include:
+//! A unary expression comprises any operation applied to a single expression. Some examples include:
 //!
-//! - [Increment and decrement operations][inc] (`++`, `--`).
 //! - The [`delete`][del] operator.
 //! - The [bitwise NOT][not] operator (`~`).
 //!
 //! The full list of valid unary operators is defined in [`UnaryOp`].
 //!
-//! [inc]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement
 //! [del]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/delete
 //! [not]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT
 mod op;
 
-use core::ops::ControlFlow;
-pub use op::*;
-
+use crate::{
+    expression::Expression,
+    visitor::{VisitWith, Visitor, VisitorMut},
+};
 use boa_interner::{Interner, ToInternedString};
+use core::ops::ControlFlow;
 
-use crate::expression::Expression;
-use crate::visitor::{VisitWith, Visitor, VisitorMut};
+pub use op::*;
 
 /// A unary expression is an operation with only one operand.
 ///

--- a/boa_ast/src/expression/operator/unary/op.rs
+++ b/boa_ast/src/expression/operator/unary/op.rs
@@ -14,62 +14,6 @@
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum UnaryOp {
-    /// The increment operator increments (adds one to) its operand and returns a value.
-    ///
-    /// Syntax: `++x`
-    ///
-    /// This operator increments and returns the value after incrementing.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-postfix-increment-operator
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment
-    IncrementPost,
-
-    /// The increment operator increments (adds one to) its operand and returns a value.
-    ///
-    /// Syntax: `x++`
-    ///
-    /// This operator increments and returns the value before incrementing.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-prefix-increment-operator
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment
-    IncrementPre,
-
-    /// The decrement operator decrements (subtracts one from) its operand and returns a value.
-    ///
-    /// Syntax: `--x`
-    ///
-    /// This operator decrements and returns the value before decrementing.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-postfix-decrement-operator
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement
-    DecrementPost,
-
-    /// The decrement operator decrements (subtracts one from) its operand and returns a value.
-    ///
-    /// Syntax: `x--`
-    ///
-    /// This operator decrements the operand and returns the value after decrementing.
-    ///
-    /// More information:
-    ///  - [ECMAScript reference][spec]
-    ///  - [MDN documentation][mdn]
-    ///
-    /// [spec]: https://tc39.es/ecma262/#sec-prefix-decrement-operator
-    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement
-    DecrementPre,
-
     /// The unary negation operator precedes its operand and negates it.
     ///
     /// Syntax: `-x`
@@ -195,8 +139,6 @@ impl UnaryOp {
     /// Retrieves the operation as a static string.
     const fn as_str(self) -> &'static str {
         match self {
-            Self::IncrementPost | Self::IncrementPre => "++",
-            Self::DecrementPost | Self::DecrementPre => "--",
             Self::Plus => "+",
             Self::Minus => "-",
             Self::Not => "!",

--- a/boa_ast/src/expression/operator/update/mod.rs
+++ b/boa_ast/src/expression/operator/update/mod.rs
@@ -127,8 +127,8 @@ impl ToInternedString for UpdateTarget {
     #[inline]
     fn to_interned_string(&self, interner: &Interner) -> String {
         match self {
-            UpdateTarget::Identifier(identifier) => identifier.to_interned_string(interner),
-            UpdateTarget::PropertyAccess(access) => access.to_interned_string(interner),
+            Self::Identifier(identifier) => identifier.to_interned_string(interner),
+            Self::PropertyAccess(access) => access.to_interned_string(interner),
         }
     }
 }

--- a/boa_ast/src/expression/operator/update/mod.rs
+++ b/boa_ast/src/expression/operator/update/mod.rs
@@ -1,0 +1,134 @@
+//! Update expression nodes.
+//!
+//! A update expression increments or decrements it's operand and returns a value
+//!
+//! - [Increment and decrement operations][mdn] (`++`, `--`).
+//!
+//! The full list of valid update operators is defined in [`UpdateOp`].
+//!
+//! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement
+mod op;
+
+use crate::{
+    expression::{access::PropertyAccess, Identifier},
+    visitor::{VisitWith, Visitor, VisitorMut},
+    Expression,
+};
+use boa_interner::{Interner, ToInternedString};
+use core::ops::ControlFlow;
+
+pub use op::*;
+
+/// A update expression is an operation with only one operand.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-UpdateExpression
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Clone, Debug, PartialEq)]
+pub struct Update {
+    op: UpdateOp,
+    target: Box<UpdateTarget>,
+}
+
+impl Update {
+    /// Creates a new `Update` AST expression.
+    #[inline]
+    #[must_use]
+    pub fn new(op: UpdateOp, target: UpdateTarget) -> Self {
+        Self {
+            op,
+            target: Box::new(target),
+        }
+    }
+
+    /// Gets the update operation of the expression.
+    #[inline]
+    #[must_use]
+    pub const fn op(&self) -> UpdateOp {
+        self.op
+    }
+
+    /// Gets the target of this update operator.
+    #[inline]
+    #[must_use]
+    pub fn target(&self) -> &UpdateTarget {
+        self.target.as_ref()
+    }
+}
+
+impl ToInternedString for Update {
+    #[inline]
+    fn to_interned_string(&self, interner: &Interner) -> String {
+        match self.op {
+            UpdateOp::IncrementPost | UpdateOp::DecrementPost => {
+                format!("{}{}", self.target.to_interned_string(interner), self.op)
+            }
+            UpdateOp::IncrementPre | UpdateOp::DecrementPre => {
+                format!("{}{}", self.op, self.target.to_interned_string(interner))
+            }
+        }
+    }
+}
+
+impl From<Update> for Expression {
+    #[inline]
+    fn from(op: Update) -> Self {
+        Self::Update(op)
+    }
+}
+
+impl VisitWith for Update {
+    fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
+    where
+        V: Visitor<'a>,
+    {
+        match self.target.as_ref() {
+            UpdateTarget::Identifier(ident) => visitor.visit_identifier(ident),
+            UpdateTarget::PropertyAccess(access) => visitor.visit_property_access(access),
+        }
+    }
+
+    fn visit_with_mut<'a, V>(&'a mut self, visitor: &mut V) -> ControlFlow<V::BreakTy>
+    where
+        V: VisitorMut<'a>,
+    {
+        match &mut *self.target {
+            UpdateTarget::Identifier(ident) => visitor.visit_identifier_mut(ident),
+            UpdateTarget::PropertyAccess(access) => visitor.visit_property_access_mut(access),
+        }
+    }
+}
+
+/// A update expression can only be performed on identifier expressions or property access expressions.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-UpdateExpression
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Clone, Debug, PartialEq)]
+pub enum UpdateTarget {
+    /// An [`Identifier`] expression.
+    Identifier(Identifier),
+
+    /// An [`PropertyAccess`] expression.
+    PropertyAccess(PropertyAccess),
+}
+
+impl ToInternedString for UpdateTarget {
+    #[inline]
+    fn to_interned_string(&self, interner: &Interner) -> String {
+        match self {
+            UpdateTarget::Identifier(identifier) => identifier.to_interned_string(interner),
+            UpdateTarget::PropertyAccess(access) => access.to_interned_string(interner),
+        }
+    }
+}

--- a/boa_ast/src/expression/operator/update/op.rs
+++ b/boa_ast/src/expression/operator/update/op.rs
@@ -1,0 +1,85 @@
+/// A update operator is one that takes a single operand/argument and performs an operation.
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///  - [MDN documentation][mdn]
+///
+/// [spec]: https://tc39.es/ecma262/#prod-UpdateExpression
+/// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators#increment_and_decrement
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpdateOp {
+    /// The increment operator increments (adds one to) its operand and returns a value.
+    ///
+    /// Syntax: `x++`
+    ///
+    /// This operator increments and returns the value after incrementing.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-postfix-increment-operator
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment
+    IncrementPost,
+
+    /// The increment operator increments (adds one to) its operand and returns a value.
+    ///
+    /// Syntax: `++x`
+    ///
+    /// This operator increments and returns the value before incrementing.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-prefix-increment-operator
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Increment
+    IncrementPre,
+
+    /// The decrement operator decrements (subtracts one from) its operand and returns a value.
+    ///
+    /// Syntax: `x--`
+    ///
+    /// This operator decrements and returns the value before decrementing.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-postfix-decrement-operator
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement
+    DecrementPost,
+
+    /// The decrement operator decrements (subtracts one from) its operand and returns a value.
+    ///
+    /// Syntax: `--x`
+    ///
+    /// This operator decrements the operand and returns the value after decrementing.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///  - [MDN documentation][mdn]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-prefix-decrement-operator
+    /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Arithmetic_Operators#Decrement
+    DecrementPre,
+}
+
+impl UpdateOp {
+    /// Retrieves the operation as a static string.
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::IncrementPost | Self::IncrementPre => "++",
+            Self::DecrementPost | Self::DecrementPre => "--",
+        }
+    }
+}
+
+impl std::fmt::Display for UpdateOp {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/boa_ast/src/visitor.rs
+++ b/boa_ast/src/visitor.rs
@@ -17,7 +17,7 @@ use crate::{
         literal::{ArrayLiteral, Literal, ObjectLiteral, TemplateElement, TemplateLiteral},
         operator::{
             assign::{Assign, AssignTarget},
-            Binary, Conditional, Unary,
+            Binary, Conditional, Unary, Update,
         },
         Await, Call, Expression, Identifier, New, Optional, OptionalOperation,
         OptionalOperationKind, Spread, SuperCall, TaggedTemplate, Yield,
@@ -165,6 +165,7 @@ node_ref! {
     TaggedTemplate,
     Assign,
     Unary,
+    Update,
     Binary,
     Conditional,
     Await,
@@ -251,6 +252,7 @@ pub trait Visitor<'ast>: Sized {
     define_visit!(visit_tagged_template, TaggedTemplate);
     define_visit!(visit_assign, Assign);
     define_visit!(visit_unary, Unary);
+    define_visit!(visit_update, Update);
     define_visit!(visit_binary, Binary);
     define_visit!(visit_conditional, Conditional);
     define_visit!(visit_await, Await);
@@ -334,6 +336,7 @@ pub trait Visitor<'ast>: Sized {
             NodeRef::TaggedTemplate(n) => self.visit_tagged_template(n),
             NodeRef::Assign(n) => self.visit_assign(n),
             NodeRef::Unary(n) => self.visit_unary(n),
+            NodeRef::Update(n) => self.visit_update(n),
             NodeRef::Binary(n) => self.visit_binary(n),
             NodeRef::Conditional(n) => self.visit_conditional(n),
             NodeRef::Await(n) => self.visit_await(n),
@@ -422,6 +425,7 @@ pub trait VisitorMut<'ast>: Sized {
     define_visit_mut!(visit_tagged_template_mut, TaggedTemplate);
     define_visit_mut!(visit_assign_mut, Assign);
     define_visit_mut!(visit_unary_mut, Unary);
+    define_visit_mut!(visit_update_mut, Update);
     define_visit_mut!(visit_binary_mut, Binary);
     define_visit_mut!(visit_conditional_mut, Conditional);
     define_visit_mut!(visit_await_mut, Await);
@@ -505,6 +509,7 @@ pub trait VisitorMut<'ast>: Sized {
             NodeRefMut::TaggedTemplate(n) => self.visit_tagged_template_mut(n),
             NodeRefMut::Assign(n) => self.visit_assign_mut(n),
             NodeRefMut::Unary(n) => self.visit_unary_mut(n),
+            NodeRefMut::Update(n) => self.visit_update_mut(n),
             NodeRefMut::Binary(n) => self.visit_binary_mut(n),
             NodeRefMut::Conditional(n) => self.visit_conditional_mut(n),
             NodeRefMut::Await(n) => self.visit_await_mut(n),

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -1,9 +1,15 @@
+mod assign;
+mod binary;
+mod object_literal;
+mod unary;
+mod update;
+
+use super::{Access, Callable, NodeKind};
 use crate::{
     bytecompiler::{ByteCompiler, Literal},
     vm::Opcode,
     JsResult,
 };
-
 use boa_ast::{
     expression::{
         access::{PropertyAccess, PropertyAccessField},
@@ -12,15 +18,8 @@ use boa_ast::{
     },
     Expression,
 };
-
-mod assign;
-mod binary;
-mod object_literal;
-mod unary;
-
 use boa_interner::Sym;
 
-use super::{Access, Callable, NodeKind};
 impl ByteCompiler<'_, '_> {
     fn compile_literal(&mut self, lit: &AstLiteral, use_expr: bool) {
         match lit {
@@ -90,6 +89,7 @@ impl ByteCompiler<'_, '_> {
         match expr {
             Expression::Literal(lit) => self.compile_literal(lit, use_expr),
             Expression::Unary(unary) => self.compile_unary(unary, use_expr)?,
+            Expression::Update(update) => self.compile_update(update, use_expr)?,
             Expression::Binary(binary) => self.compile_binary(binary, use_expr)?,
             Expression::Assign(assign) => self.compile_assign(assign, use_expr)?,
             Expression::ObjectLiteral(object) => {

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -6,71 +6,12 @@ use boa_ast::{
 use crate::{
     bytecompiler::{Access, ByteCompiler},
     vm::Opcode,
-    JsNativeError, JsResult,
+    JsResult,
 };
 
 impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_unary(&mut self, unary: &Unary, use_expr: bool) -> JsResult<()> {
         let opcode = match unary.op() {
-            UnaryOp::IncrementPre => {
-                // TODO: promote to an early error.
-                let access = Access::from_expression(unary.target()).ok_or_else(|| {
-                    JsNativeError::syntax().with_message("Invalid increment operand")
-                })?;
-
-                self.access_set(access, true, |compiler, _| {
-                    compiler.compile_expr(unary.target(), true)?;
-                    compiler.emit(Opcode::Inc, &[]);
-                    Ok(())
-                })?;
-
-                None
-            }
-            UnaryOp::DecrementPre => {
-                // TODO: promote to an early error.
-                let access = Access::from_expression(unary.target()).ok_or_else(|| {
-                    JsNativeError::syntax().with_message("Invalid decrement operand")
-                })?;
-
-                self.access_set(access, true, |compiler, _| {
-                    compiler.compile_expr(unary.target(), true)?;
-                    compiler.emit(Opcode::Dec, &[]);
-                    Ok(())
-                })?;
-                None
-            }
-            UnaryOp::IncrementPost => {
-                // TODO: promote to an early error.
-                let access = Access::from_expression(unary.target()).ok_or_else(|| {
-                    JsNativeError::syntax().with_message("Invalid increment operand")
-                })?;
-
-                self.access_set(access, false, |compiler, level| {
-                    compiler.compile_expr(unary.target(), true)?;
-                    compiler.emit(Opcode::IncPost, &[]);
-                    compiler.emit_opcode(Opcode::RotateRight);
-                    compiler.emit_u8(level + 2);
-                    Ok(())
-                })?;
-
-                None
-            }
-            UnaryOp::DecrementPost => {
-                // TODO: promote to an early error.
-                let access = Access::from_expression(unary.target()).ok_or_else(|| {
-                    JsNativeError::syntax().with_message("Invalid decrement operand")
-                })?;
-
-                self.access_set(access, false, |compiler, level| {
-                    compiler.compile_expr(unary.target(), true)?;
-                    compiler.emit(Opcode::DecPost, &[]);
-                    compiler.emit_opcode(Opcode::RotateRight);
-                    compiler.emit_u8(level + 2);
-                    Ok(())
-                })?;
-
-                None
-            }
             UnaryOp::Delete => {
                 if let Some(access) = Access::from_expression(unary.target()) {
                     self.access_delete(access)?;

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -1,0 +1,53 @@
+use crate::{
+    bytecompiler::{Access, ByteCompiler},
+    vm::Opcode,
+    JsResult,
+};
+use boa_ast::expression::operator::{update::UpdateOp, Update};
+
+impl ByteCompiler<'_, '_> {
+    pub(crate) fn compile_update(&mut self, update: &Update, use_expr: bool) -> JsResult<()> {
+        let access = Access::from_update_target(update.target());
+
+        match update.op() {
+            UpdateOp::IncrementPre => {
+                self.access_set(access, true, |compiler, _| {
+                    compiler.access_get(access, true)?;
+                    compiler.emit_opcode(Opcode::Inc);
+                    Ok(())
+                })?;
+            }
+            UpdateOp::DecrementPre => {
+                self.access_set(access, true, |compiler, _| {
+                    compiler.access_get(access, true)?;
+                    compiler.emit_opcode(Opcode::Dec);
+                    Ok(())
+                })?;
+            }
+            UpdateOp::IncrementPost => {
+                self.access_set(access, false, |compiler, level| {
+                    compiler.access_get(access, true)?;
+                    compiler.emit_opcode(Opcode::IncPost);
+                    compiler.emit_opcode(Opcode::RotateRight);
+                    compiler.emit_u8(level + 2);
+                    Ok(())
+                })?;
+            }
+            UpdateOp::DecrementPost => {
+                self.access_set(access, false, |compiler, level| {
+                    compiler.access_get(access, true)?;
+                    compiler.emit_opcode(Opcode::DecPost);
+                    compiler.emit_opcode(Opcode::RotateRight);
+                    compiler.emit_u8(level + 2);
+                    Ok(())
+                })?;
+            }
+        }
+
+        if !use_expr {
+            self.emit_opcode(Opcode::Pop);
+        }
+
+        Ok(())
+    }
+}

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -16,7 +16,7 @@ use boa_ast::{
     declaration::{Binding, LexicalDeclaration, VarDeclaration},
     expression::{
         access::{PropertyAccess, PropertyAccessField},
-        operator::assign::AssignTarget,
+        operator::{assign::AssignTarget, update::UpdateTarget},
         Call, Identifier, New, Optional, OptionalOperationKind,
     },
     function::{
@@ -196,6 +196,13 @@ impl Access<'_> {
             Expression::PropertyAccess(access) => Some(Access::Property { access }),
             Expression::This => Some(Access::This),
             _ => None,
+        }
+    }
+
+    const fn from_update_target(target: &UpdateTarget) -> Access<'_> {
+        match target {
+            UpdateTarget::Identifier(name) => Access::Variable { name: *name },
+            UpdateTarget::PropertyAccess(access) => Access::Property { access },
         }
     }
 }

--- a/boa_parser/src/parser/statement/block/tests.rs
+++ b/boa_parser/src/parser/statement/block/tests.rs
@@ -7,7 +7,11 @@ use boa_ast::{
     declaration::{VarDeclaration, Variable},
     expression::{
         literal::Literal,
-        operator::{assign::AssignOp, unary::UnaryOp, Assign, Unary},
+        operator::{
+            assign::AssignOp,
+            update::{UpdateOp, UpdateTarget},
+            Assign, Update,
+        },
         Call, Identifier,
     },
     function::{FormalParameterList, Function},
@@ -54,9 +58,9 @@ fn non_empty() {
                 .unwrap(),
             ))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
         ],
@@ -94,9 +98,9 @@ fn non_empty() {
                 .unwrap(),
             ))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
         ],
@@ -135,9 +139,9 @@ fn hoisting() {
                 .unwrap(),
             ))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
         ],
@@ -160,9 +164,9 @@ fn hoisting() {
                 Literal::from(10).into(),
             )))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
             Statement::Var(VarDeclaration(

--- a/boa_parser/src/parser/statement/iteration/tests.rs
+++ b/boa_parser/src/parser/statement/iteration/tests.rs
@@ -4,7 +4,12 @@ use boa_ast::{
     expression::{
         access::SimplePropertyAccess,
         literal::Literal,
-        operator::{assign::AssignOp, binary::RelationalOp, unary::UnaryOp, Assign, Binary, Unary},
+        operator::{
+            assign::AssignOp,
+            binary::RelationalOp,
+            update::{UpdateOp, UpdateTarget},
+            Assign, Binary, Update,
+        },
         Call, Identifier,
     },
     statement::{Block, Break, DoWhileLoop, WhileLoop},
@@ -81,9 +86,11 @@ fn check_do_while_semicolon_insertion() {
                 ),
                 Binary::new(
                     RelationalOp::LessThan.into(),
-                    Unary::new(
-                        UnaryOp::IncrementPost,
-                        Identifier::new(interner.get_or_intern_static("i", utf16!("i"))).into(),
+                    Update::new(
+                        UpdateOp::IncrementPost,
+                        UpdateTarget::Identifier(Identifier::new(
+                            interner.get_or_intern_static("i", utf16!("i")),
+                        )),
                     )
                     .into(),
                     Literal::from(10).into(),
@@ -154,9 +161,11 @@ fn check_do_while_semicolon_insertion_no_space() {
                 ),
                 Binary::new(
                     RelationalOp::LessThan.into(),
-                    Unary::new(
-                        UnaryOp::IncrementPost,
-                        Identifier::new(interner.get_or_intern_static("i", utf16!("i"))).into(),
+                    Update::new(
+                        UpdateOp::IncrementPost,
+                        UpdateTarget::Identifier(Identifier::new(
+                            interner.get_or_intern_static("i", utf16!("i")),
+                        )),
                     )
                     .into(),
                     Literal::from(10).into(),

--- a/boa_parser/src/parser/tests/mod.rs
+++ b/boa_parser/src/parser/tests/mod.rs
@@ -13,8 +13,8 @@ use boa_ast::{
         operator::{
             assign::AssignOp,
             binary::{ArithmeticOp, BinaryOp, LogicalOp, RelationalOp},
-            unary::UnaryOp,
-            Assign, Binary, Unary,
+            update::{UpdateOp, UpdateTarget},
+            Assign, Binary, Update,
         },
         Call, Identifier, New,
     },
@@ -126,9 +126,9 @@ fn hoisting() {
                 .unwrap(),
             ))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
         ],
@@ -150,9 +150,9 @@ fn hoisting() {
                 Literal::from(10).into(),
             )))
             .into(),
-            Statement::Expression(Expression::from(Unary::new(
-                UnaryOp::IncrementPost,
-                Identifier::new(a).into(),
+            Statement::Expression(Expression::from(Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(a)),
             )))
             .into(),
             Statement::Var(VarDeclaration(
@@ -429,7 +429,11 @@ fn increment_in_comma_op() {
         s,
         vec![Statement::Expression(Expression::from(Binary::new(
             BinaryOp::Comma,
-            Unary::new(UnaryOp::IncrementPost, Identifier::new(b).into()).into(),
+            Update::new(
+                UpdateOp::IncrementPost,
+                UpdateTarget::Identifier(Identifier::new(b)),
+            )
+            .into(),
             Identifier::new(b).into(),
         )))
         .into()],


### PR DESCRIPTION
This Pull Request changes the following:

- Move postfix/prefix increment and decrement operations from the `Unary` expression to a new `Update` expression.
- Add a special type for the `Update` expression target as it is very limited in comparision to an `Unary` target.
- This makes bytecode compilation more typesafe for these operations and removes syntax errors from the bytecompiler without introducing panics (see #1907).
