### PR TITLE
[Merged by Bors] - fuzzer: bubble up NoInstructionsRemain error instead of trying to handle as exception

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,9 +10,9 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 
-boa_ast = { path = "../boa_ast", features = ["fuzz"] }
+boa_ast = { path = "../boa_ast", features = ["arbitrary"] }
 boa_engine = { path = "../boa_engine", features = ["fuzz"] }
-boa_interner = { path = "../boa_interner", features = ["fuzz"] }
+boa_interner = { path = "../boa_interner", features = ["arbitrary"] }
 boa_parser = { path = "../boa_parser" }
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION
Hi,

the `vm-implied` fuzzer panics when executing this testcase:

```javascript
try {
    new function() {
        while (this) {}
    }();
} catch {
}
```

`internal error: entered unreachable code: The NoInstructionsRemain native error cannot be converted to an opaque type`

Handling the `NoInstructionsRemain` error upfront instead of going through the VM exception handling logic seems to work.