### PR TITLE
[Merged by Bors] - Rename `check_parser` and `Identifier`

### DIFF
--- a/boa_parser/src/lexer/error.rs
+++ b/boa_parser/src/lexer/error.rs
@@ -6,7 +6,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard
 
 use boa_ast::Position;
-use std::{error::Error as StdError, fmt, io};
+use std::{error, fmt, io};
 
 /// An error that occurred during the lexing.
 #[derive(Debug)]
@@ -25,6 +25,7 @@ pub enum Error {
 }
 
 impl From<io::Error> for Error {
+    #[inline]
     fn from(err: io::Error) -> Self {
         Self::IO(err)
     }
@@ -42,6 +43,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::IO(e) => write!(f, "I/O error: {e}"),
@@ -50,8 +52,9 @@ impl fmt::Display for Error {
     }
 }
 
-impl StdError for Error {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+impl error::Error for Error {
+    #[inline]
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         match self {
             Self::IO(err) => Some(err),
             Self::Syntax(_, _) => None,

--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -73,7 +73,7 @@ impl<R> Tokenizer<R> for Identifier {
             Ok(Keyword::False) => TokenKind::BooleanLiteral(false),
             Ok(Keyword::Null) => TokenKind::NullLiteral,
             Ok(keyword) => TokenKind::Keyword((keyword, contains_escaped_chars)),
-            _ => TokenKind::Identifier((
+            _ => TokenKind::IdentifierName((
                 interner.get_or_intern(identifier_name.as_str()),
                 ContainsEscapeSequence(contains_escaped_chars),
             )),

--- a/boa_parser/src/lexer/tests.rs
+++ b/boa_parser/src/lexer/tests.rs
@@ -95,15 +95,15 @@ fn check_identifier() {
         TokenKind::identifier(
             interner.get_or_intern_static("x\u{200C}\u{200D}", utf16!("x\u{200C}\u{200D}")),
         ),
-        TokenKind::Identifier((
+        TokenKind::IdentifierName((
             interner.get_or_intern_static("x", utf16!("x")),
             ContainsEscapeSequence(true),
         )),
-        TokenKind::Identifier((
+        TokenKind::IdentifierName((
             interner.get_or_intern_static("xx", utf16!("xx")),
             ContainsEscapeSequence(true),
         )),
-        TokenKind::Identifier((
+        TokenKind::IdentifierName((
             interner.get_or_intern_static("xxx", utf16!("xxx")),
             ContainsEscapeSequence(true),
         )),

--- a/boa_parser/src/lexer/token.rs
+++ b/boa_parser/src/lexer/token.rs
@@ -98,16 +98,24 @@ pub enum TokenKind {
     /// The end of the file.
     EOF,
 
-    /// An identifier.
-    Identifier((Sym, ContainsEscapeSequence)),
+    /// An [**identifier name**][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-IdentifierName
+    IdentifierName((Sym, ContainsEscapeSequence)),
 
-    /// A private identifier.
+    /// A [**private identifier**][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-PrivateIdentifier
     PrivateIdentifier(Sym),
 
     /// A keyword and a flag if the keyword contains unicode escaped chars.
+    ///
+    /// For more information, see [`Keyword`].
     Keyword((Keyword, bool)),
 
-    /// A `null` literal.
+    /// The [`null` literal][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-NullLiteral
     NullLiteral,
 
     /// A numeric literal.
@@ -116,7 +124,9 @@ pub enum TokenKind {
     /// A piece of punctuation
     Punctuator(Punctuator),
 
-    /// A string literal.
+    /// A [**string literal**][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-StringLiteral
     StringLiteral((Sym, Option<EscapeSequence>)),
 
     /// A part of a template literal without substitution.
@@ -128,7 +138,9 @@ pub enum TokenKind {
     /// A regular expression, consisting of body and flags.
     RegularExpressionLiteral(Sym, Sym),
 
-    /// Indicates the end of a line (`\n`).
+    /// Indicates a [**line terminator (`\n`)**][spec].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#prod-LineTerminator
     LineTerminator,
 
     /// Indicates a comment, the content isn't stored.
@@ -136,24 +148,28 @@ pub enum TokenKind {
 }
 
 impl From<bool> for TokenKind {
+    #[inline]
     fn from(oth: bool) -> Self {
         Self::BooleanLiteral(oth)
     }
 }
 
 impl From<(Keyword, bool)> for TokenKind {
+    #[inline]
     fn from(kw: (Keyword, bool)) -> Self {
         Self::Keyword(kw)
     }
 }
 
 impl From<Punctuator> for TokenKind {
+    #[inline]
     fn from(punc: Punctuator) -> Self {
         Self::Punctuator(punc)
     }
 }
 
 impl From<Numeric> for TokenKind {
+    #[inline]
     fn from(num: Numeric) -> Self {
         Self::NumericLiteral(num)
     }
@@ -161,21 +177,24 @@ impl From<Numeric> for TokenKind {
 
 impl TokenKind {
     /// Creates a `BooleanLiteral` token kind.
+    #[inline]
     #[must_use]
     pub const fn boolean_literal(lit: bool) -> Self {
         Self::BooleanLiteral(lit)
     }
 
     /// Creates an `EOF` token kind.
+    #[inline]
     #[must_use]
     pub const fn eof() -> Self {
         Self::EOF
     }
 
     /// Creates an `Identifier` token type.
+    #[inline]
     #[must_use]
     pub const fn identifier(ident: Sym) -> Self {
-        Self::Identifier((ident, ContainsEscapeSequence(false)))
+        Self::IdentifierName((ident, ContainsEscapeSequence(false)))
     }
 
     /// Creates a `NumericLiteral` token kind.
@@ -187,42 +206,49 @@ impl TokenKind {
     }
 
     /// Creates a `Punctuator` token type.
+    #[inline]
     #[must_use]
     pub const fn punctuator(punc: Punctuator) -> Self {
         Self::Punctuator(punc)
     }
 
     /// Creates a `StringLiteral` token type.
+    #[inline]
     #[must_use]
     pub const fn string_literal(lit: Sym, escape_sequence: Option<EscapeSequence>) -> Self {
         Self::StringLiteral((lit, escape_sequence))
     }
 
     /// Creates a `TemplateMiddle` token type.
+    #[inline]
     #[must_use]
     pub const fn template_middle(template_string: TemplateString) -> Self {
         Self::TemplateMiddle(template_string)
     }
 
     /// Creates a `TemplateNoSubstitution` token type.
+    #[inline]
     #[must_use]
     pub const fn template_no_substitution(template_string: TemplateString) -> Self {
         Self::TemplateNoSubstitution(template_string)
     }
 
     /// Creates a `RegularExpressionLiteral` token kind.
+    #[inline]
     #[must_use]
     pub const fn regular_expression_literal(body: Sym, flags: Sym) -> Self {
         Self::RegularExpressionLiteral(body, flags)
     }
 
     /// Creates a `LineTerminator` token kind.
+    #[inline]
     #[must_use]
     pub const fn line_terminator() -> Self {
         Self::LineTerminator
     }
 
     /// Creates a 'Comment' token kind.
+    #[inline]
     #[must_use]
     pub const fn comment() -> Self {
         Self::Comment
@@ -234,7 +260,7 @@ impl TokenKind {
         match *self {
             Self::BooleanLiteral(val) => val.to_string(),
             Self::EOF => "end of file".to_owned(),
-            Self::Identifier((ident, _)) => interner.resolve_expect(ident).to_string(),
+            Self::IdentifierName((ident, _)) => interner.resolve_expect(ident).to_string(),
             Self::PrivateIdentifier(ident) => format!("#{}", interner.resolve_expect(ident)),
             Self::Keyword((word, _)) => word.to_string(),
             Self::NullLiteral => "null".to_owned(),

--- a/boa_parser/src/parser/expression/assignment/mod.rs
+++ b/boa_parser/src/parser/expression/assignment/mod.rs
@@ -108,7 +108,8 @@ where
                     .parse(cursor, interner)
             }
             // ArrowFunction[?In, ?Yield, ?Await] -> ArrowParameters[?Yield, ?Await] -> BindingIdentifier[?Yield, ?Await]
-            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
+            TokenKind::IdentifierName(_)
+            | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 cursor.set_goal(InputElement::Div);
 
                 // Because we already peeked the identifier token, there may be a line terminator before the identifier token.
@@ -146,7 +147,7 @@ where
                     .or_abrupt()?
                     && matches!(
                         cursor.peek(1, interner).or_abrupt()?.kind(),
-                        TokenKind::Identifier(_)
+                        TokenKind::IdentifierName(_)
                             | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _))
                             | TokenKind::Punctuator(Punctuator::OpenParen)
                     )

--- a/boa_parser/src/parser/expression/assignment/yield.rs
+++ b/boa_parser/src/parser/expression/assignment/yield.rs
@@ -75,7 +75,7 @@ where
                     .parse(cursor, interner)?;
                 Ok(Yield::new(Some(expr), true).into())
             }
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Punctuator(
                 Punctuator::OpenParen
                 | Punctuator::Add

--- a/boa_parser/src/parser/expression/identifiers.rs
+++ b/boa_parser/src/parser/expression/identifiers.rs
@@ -65,7 +65,7 @@ where
         let token = cursor.next(interner).or_abrupt()?;
 
         match token.kind() {
-            TokenKind::Identifier((ident, _))
+            TokenKind::IdentifierName((ident, _))
                 if cursor.strict_mode() && RESERVED_IDENTIFIERS_STRICT.contains(ident) =>
             {
                 Err(Error::general(
@@ -73,7 +73,7 @@ where
                     token.span().start(),
                 ))
             }
-            TokenKind::Identifier((ident, _)) => Ok(Identifier::new(*ident)),
+            TokenKind::IdentifierName((ident, _)) => Ok(Identifier::new(*ident)),
             TokenKind::Keyword((Keyword::Let, _)) if cursor.strict_mode() => Err(Error::general(
                 "using future reserved keyword not allowed in strict mode IdentifierReference",
                 token.span().start(),
@@ -155,19 +155,17 @@ where
         let next_token = cursor.next(interner).or_abrupt()?;
 
         match next_token.kind() {
-            TokenKind::Identifier((Sym::ARGUMENTS, _)) if cursor.strict_mode() => {
+            TokenKind::IdentifierName((Sym::ARGUMENTS | Sym::EVAL, _)) if cursor.strict_mode() => {
                 Err(Error::lex(LexError::Syntax(
-                    "unexpected identifier 'arguments' in strict mode".into(),
+                    format!(
+                        "unexpected identifier '{}' in strict mode",
+                        next_token.to_string(interner)
+                    )
+                    .into(),
                     next_token.span().start(),
                 )))
             }
-            TokenKind::Identifier((Sym::EVAL, _)) if cursor.strict_mode() => {
-                Err(Error::lex(LexError::Syntax(
-                    "unexpected identifier 'eval' in strict mode".into(),
-                    next_token.span().start(),
-                )))
-            }
-            TokenKind::Identifier((ident, _)) => {
+            TokenKind::IdentifierName((ident, _)) => {
                 if cursor.strict_mode() && RESERVED_IDENTIFIERS_STRICT.contains(ident) {
                     return Err(Error::general(
                         "using future reserved keyword not allowed in strict mode",

--- a/boa_parser/src/parser/expression/left_hand_side/call.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/call.rs
@@ -98,7 +98,7 @@ where
                     cursor.advance(interner);
 
                     let access = match cursor.next(interner).or_abrupt()?.kind() {
-                        TokenKind::Identifier((name, _)) => {
+                        TokenKind::IdentifierName((name, _)) => {
                             SimplePropertyAccess::new(lhs, *name).into()
                         }
                         TokenKind::Keyword((kw, _)) => {

--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -85,13 +85,13 @@ where
                 if cursor.next_if(Punctuator::Dot, interner)?.is_some() {
                     let token = cursor.next(interner).or_abrupt()?;
                     match token.kind() {
-                        TokenKind::Identifier((Sym::TARGET, ContainsEscapeSequence(true))) => {
+                        TokenKind::IdentifierName((Sym::TARGET, ContainsEscapeSequence(true))) => {
                             return Err(Error::general(
                                 "'new.target' must not contain escaped characters",
                                 token.span().start(),
                             ));
                         }
-                        TokenKind::Identifier((Sym::TARGET, ContainsEscapeSequence(false))) => {
+                        TokenKind::IdentifierName((Sym::TARGET, ContainsEscapeSequence(false))) => {
                             return Ok(ast::Expression::NewTarget)
                         }
                         _ => {
@@ -122,7 +122,7 @@ where
                     TokenKind::Punctuator(Punctuator::Dot) => {
                         let token = cursor.next(interner).or_abrupt()?;
                         let field = match token.kind() {
-                            TokenKind::Identifier((name, _)) => {
+                            TokenKind::IdentifierName((name, _)) => {
                                 SuperPropertyAccess::new(PropertyAccessField::from(*name))
                             }
                             TokenKind::Keyword((kw, _)) => {
@@ -184,7 +184,7 @@ where
                     let token = cursor.next(interner).or_abrupt()?;
 
                     let access = match token.kind() {
-                        TokenKind::Identifier((name, _)) => {
+                        TokenKind::IdentifierName((name, _)) => {
                             SimplePropertyAccess::new(lhs, *name).into()
                         }
                         TokenKind::Keyword((kw, _)) => {

--- a/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -66,9 +66,11 @@ where
             interner: &mut Interner,
         ) -> ParseResult<OptionalOperationKind> {
             let item = match token.kind() {
-                TokenKind::Identifier((name, _)) => OptionalOperationKind::SimplePropertyAccess {
-                    field: PropertyAccessField::Const(*name),
-                },
+                TokenKind::IdentifierName((name, _)) => {
+                    OptionalOperationKind::SimplePropertyAccess {
+                        field: PropertyAccessField::Const(*name),
+                    }
+                }
                 TokenKind::Keyword((kw, _)) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(kw.to_sym(interner)),
                 },

--- a/boa_parser/src/parser/expression/left_hand_side/optional/tests.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/tests.rs
@@ -1,7 +1,7 @@
 use boa_interner::Interner;
 use boa_macros::utf16;
 
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     expression::{
         access::PropertyAccessField, literal::Literal, Identifier, Optional, OptionalOperation,
@@ -14,7 +14,7 @@ use boa_ast::{
 fn simple() {
     let interner = &mut Interner::default();
 
-    check_parser(
+    check_script_parser(
         r#"5?.name"#,
         vec![Statement::Expression(
             Optional::new(
@@ -40,7 +40,7 @@ fn simple() {
 fn complex_chain() {
     let interner = &mut Interner::default();
 
-    check_parser(
+    check_script_parser(
         r#"a?.b(true)?.["c"]"#,
         vec![Statement::Expression(
             Optional::new(

--- a/boa_parser/src/parser/expression/left_hand_side/tests.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::{access::SimplePropertyAccess, Call, Identifier},
     Expression, Statement,
@@ -9,7 +9,7 @@ use boa_macros::utf16;
 macro_rules! check_call_property_identifier {
     ($property:literal) => {{
         let interner = &mut Interner::default();
-        check_parser(
+        check_script_parser(
             format!("a().{}", $property).as_str(),
             vec![Statement::Expression(Expression::PropertyAccess(
                 SimplePropertyAccess::new(
@@ -40,7 +40,7 @@ fn check_call_properties() {
 macro_rules! check_member_property_identifier {
     ($property:literal) => {{
         let interner = &mut Interner::default();
-        check_parser(
+        check_script_parser(
             format!("a.{}", $property).as_str(),
             vec![Statement::Expression(Expression::PropertyAccess(
                 SimplePropertyAccess::new(

--- a/boa_parser/src/parser/expression/primary/array_initializer/tests.rs
+++ b/boa_parser/src/parser/expression/primary/array_initializer/tests.rs
@@ -1,6 +1,6 @@
 // ! Tests for array initializer parsing.
 
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::{ArrayLiteral, Literal},
     Expression, Statement,
@@ -11,7 +11,7 @@ use boa_macros::utf16;
 /// Checks an empty array.
 #[test]
 fn check_empty() {
-    check_parser(
+    check_script_parser(
         "[]",
         vec![Statement::Expression(Expression::from(ArrayLiteral::from(vec![]))).into()],
         &mut Interner::default(),
@@ -21,7 +21,7 @@ fn check_empty() {
 /// Checks an array with empty slot.
 #[test]
 fn check_empty_slot() {
-    check_parser(
+    check_script_parser(
         "[,]",
         vec![Statement::Expression(Expression::from(ArrayLiteral::from(vec![None]))).into()],
         &mut Interner::default(),
@@ -31,7 +31,7 @@ fn check_empty_slot() {
 /// Checks a numeric array.
 #[test]
 fn check_numeric_array() {
-    check_parser(
+    check_script_parser(
         "[1, 2, 3]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![
@@ -48,7 +48,7 @@ fn check_numeric_array() {
 // Checks a numeric array with trailing comma
 #[test]
 fn check_numeric_array_trailing() {
-    check_parser(
+    check_script_parser(
         "[1, 2, 3,]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![
@@ -65,7 +65,7 @@ fn check_numeric_array_trailing() {
 /// Checks a numeric array with an elision.
 #[test]
 fn check_numeric_array_elision() {
-    check_parser(
+    check_script_parser(
         "[1, 2, , 3]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![
@@ -83,7 +83,7 @@ fn check_numeric_array_elision() {
 /// Checks a numeric array with repeated elisions.
 #[test]
 fn check_numeric_array_repeated_elision() {
-    check_parser(
+    check_script_parser(
         "[1, 2, ,, 3]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![
@@ -103,7 +103,7 @@ fn check_numeric_array_repeated_elision() {
 #[test]
 fn check_combined() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "[1, \"a\", 2]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![
@@ -120,7 +120,7 @@ fn check_combined() {
 /// Checks a combined array with an empty string
 #[test]
 fn check_combined_empty_str() {
-    check_parser(
+    check_script_parser(
         "[1, \"\", 2]",
         vec![
             Statement::Expression(Expression::from(ArrayLiteral::from(vec![

--- a/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
@@ -60,7 +60,7 @@ where
 
         let token = cursor.peek(0, interner).or_abrupt()?;
         let (name, name_span) = match token.kind() {
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
                 _,

--- a/boa_parser/src/parser/expression/primary/async_function_expression/tests.rs
+++ b/boa_parser/src/parser/expression/primary/async_function_expression/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     declaration::{Declaration, LexicalDeclaration, Variable},
     expression::literal::Literal,
@@ -14,7 +14,7 @@ use boa_macros::utf16;
 fn check_async_expression() {
     let interner = &mut Interner::default();
     let add = interner.get_or_intern_static("add", utf16!("add"));
-    check_parser(
+    check_script_parser(
         "const add = async function() {
             return 1;
         };
@@ -48,7 +48,7 @@ fn check_nested_async_expression() {
     let interner = &mut Interner::default();
     let a = interner.get_or_intern_static("a", utf16!("a"));
     let b = interner.get_or_intern_static("b", utf16!("b"));
-    check_parser(
+    check_script_parser(
         "const a = async function() {
             const b = async function() {
                 return 1;

--- a/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -74,7 +74,7 @@ where
 
         let token = cursor.peek(0, interner).or_abrupt()?;
         let (name, name_span) = match token.kind() {
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
                 _,

--- a/boa_parser/src/parser/expression/primary/async_generator_expression/tests.rs
+++ b/boa_parser/src/parser/expression/primary/async_generator_expression/tests.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::literal::Literal,
@@ -17,7 +17,7 @@ use boa_macros::utf16;
 fn check_async_generator_expr() {
     let interner = &mut Interner::default();
     let add = interner.get_or_intern_static("add", utf16!("add"));
-    check_parser(
+    check_script_parser(
         "const add = async function*(){
             return 1;
         };
@@ -51,7 +51,7 @@ fn check_nested_async_generator_expr() {
     let interner = &mut Interner::default();
     let a = interner.get_or_intern_static("a", utf16!("a"));
     let b = interner.get_or_intern_static("b", utf16!("b"));
-    check_parser(
+    check_script_parser(
         "const a = async function*() {
             const b = async function*() {
                 return 1;

--- a/boa_parser/src/parser/expression/primary/class_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/class_expression/mod.rs
@@ -53,7 +53,8 @@ where
         let mut has_binding_identifier = false;
         let token = cursor.peek(0, interner).or_abrupt()?;
         let name = match token.kind() {
-            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
+            TokenKind::IdentifierName(_)
+            | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 has_binding_identifier = true;
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?

--- a/boa_parser/src/parser/expression/primary/function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/function_expression/mod.rs
@@ -63,7 +63,7 @@ where
 
         let token = cursor.peek(0, interner).or_abrupt()?;
         let (name, name_span) = match token.kind() {
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
                 _,

--- a/boa_parser/src/parser/expression/primary/function_expression/tests.rs
+++ b/boa_parser/src/parser/expression/primary/function_expression/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::literal::Literal,
@@ -14,7 +14,7 @@ use boa_macros::utf16;
 fn check_function_expression() {
     let interner = &mut Interner::default();
     let add = interner.get_or_intern_static("add", utf16!("add"));
-    check_parser(
+    check_script_parser(
         "const add = function() {
             return 1;
         };
@@ -47,7 +47,7 @@ fn check_nested_function_expression() {
     let interner = &mut Interner::default();
     let a = interner.get_or_intern_static("a", utf16!("a"));
     let b = interner.get_or_intern_static("b", utf16!("b"));
-    check_parser(
+    check_script_parser(
         "const a = function() {
             const b = function() {
                 return 1;
@@ -118,35 +118,35 @@ fn check_function_non_reserved_keyword() {
 
     let interner = &mut Interner::default();
     let ast = genast!("as", interner);
-    check_parser("const add = function as() { return 1; };", ast, interner);
+    check_script_parser("const add = function as() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("async", interner);
-    check_parser("const add = function async() { return 1; };", ast, interner);
+    check_script_parser("const add = function async() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("from", interner);
-    check_parser("const add = function from() { return 1; };", ast, interner);
+    check_script_parser("const add = function from() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("get", interner);
-    check_parser("const add = function get() { return 1; };", ast, interner);
+    check_script_parser("const add = function get() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("meta", interner);
-    check_parser("const add = function meta() { return 1; };", ast, interner);
+    check_script_parser("const add = function meta() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("of", interner);
-    check_parser("const add = function of() { return 1; };", ast, interner);
+    check_script_parser("const add = function of() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("set", interner);
-    check_parser("const add = function set() { return 1; };", ast, interner);
+    check_script_parser("const add = function set() { return 1; };", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("target", interner);
-    check_parser(
+    check_script_parser(
         "const add = function target() { return 1; };",
         ast,
         interner,

--- a/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
@@ -69,7 +69,7 @@ where
 
         let token = cursor.peek(0, interner).or_abrupt()?;
         let (name, name_span) = match token.kind() {
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Keyword((
                 Keyword::Yield | Keyword::Await | Keyword::Async | Keyword::Of,
                 _,

--- a/boa_parser/src/parser/expression/primary/generator_expression/tests.rs
+++ b/boa_parser/src/parser/expression/primary/generator_expression/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::{literal::Literal, Yield},
@@ -12,7 +12,7 @@ use boa_macros::utf16;
 fn check_generator_function_expression() {
     let interner = &mut Interner::default();
     let gen = interner.get_or_intern_static("gen", utf16!("gen"));
-    check_parser(
+    check_script_parser(
         "const gen = function*() {
             yield 1;
         };
@@ -45,7 +45,7 @@ fn check_generator_function_expression() {
 fn check_generator_function_delegate_yield_expression() {
     let interner = &mut Interner::default();
     let gen = interner.get_or_intern_static("gen", utf16!("gen"));
-    check_parser(
+    check_script_parser(
         "const gen = function*() {
             yield* 1;
         };

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -202,7 +202,7 @@ where
                 cursor.advance(interner);
                 Ok(Literal::Null.into())
             }
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::Keyword((
                 Keyword::Let | Keyword::Yield | Keyword::Await | Keyword::Of,
                 _,

--- a/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
@@ -291,7 +291,7 @@ where
         }
 
         let set_or_get_escaped_position = match token.kind() {
-            TokenKind::Identifier((Sym::GET | Sym::SET, ContainsEscapeSequence(true))) => {
+            TokenKind::IdentifierName((Sym::GET | Sym::SET, ContainsEscapeSequence(true))) => {
                 Some(token.span().start())
             }
             _ => None,
@@ -578,7 +578,7 @@ where
                 cursor.expect(Punctuator::CloseBracket, "expected token ']'", interner)?;
                 return Ok(node.into());
             }
-            TokenKind::Identifier((name, _)) | TokenKind::StringLiteral((name, _)) => {
+            TokenKind::IdentifierName((name, _)) | TokenKind::StringLiteral((name, _)) => {
                 (*name).into()
             }
             TokenKind::NumericLiteral(num) => match num {

--- a/boa_parser/src/parser/expression/primary/object_initializer/tests.rs
+++ b/boa_parser/src/parser/expression/primary/object_initializer/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::{
@@ -31,7 +31,7 @@ fn check_object_literal() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             a: true,
             b: false,
@@ -70,7 +70,7 @@ fn check_object_short_function() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             a: true,
             b() {},
@@ -120,7 +120,7 @@ fn check_object_short_function_arguments() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             a: true,
             b(test) {}
@@ -162,7 +162,7 @@ fn check_object_getter() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             a: true,
             get b() {}
@@ -215,7 +215,7 @@ fn check_object_setter() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             a: true,
             set b(test) {}
@@ -247,7 +247,7 @@ fn check_object_short_function_get() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             get() {}
          };
@@ -278,7 +278,7 @@ fn check_object_short_function_set() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             set() {}
          };
@@ -304,7 +304,7 @@ fn check_object_shorthand_property_names() {
         interner.get_or_intern_static("a", utf16!("a")).into(),
     )];
 
-    check_parser(
+    check_script_parser(
         "const a = true;
             const x = { a };
         ",
@@ -345,7 +345,7 @@ fn check_object_shorthand_multiple_properties() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const a = true;
             const b = false;
             const x = { a, b, };
@@ -397,7 +397,7 @@ fn check_object_spread() {
         ),
     ];
 
-    check_parser(
+    check_script_parser(
         "const x = { a: 1, ...b };
         ",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
@@ -427,7 +427,7 @@ fn check_async_method() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             async dive() {}
         };
@@ -465,7 +465,7 @@ fn check_async_generator_method() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             async* vroom() {}
         };
@@ -522,7 +522,7 @@ fn check_async_ordinary_method() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             async() {}
          };
@@ -549,7 +549,7 @@ fn check_async_property() {
         Literal::from(true).into(),
     )];
 
-    check_parser(
+    check_script_parser(
         "const x = {
             async: true
          };

--- a/boa_parser/src/parser/expression/primary/tests.rs
+++ b/boa_parser/src/parser/expression/primary/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{expression::literal::Literal, Expression, Statement};
 use boa_interner::{Interner, Sym};
 use boa_macros::utf16;
@@ -6,7 +6,7 @@ use boa_macros::utf16;
 #[test]
 fn check_string() {
     // Check empty string
-    check_parser(
+    check_script_parser(
         "\"\"",
         vec![Statement::Expression(Expression::from(Literal::from(Sym::EMPTY_STRING))).into()],
         &mut Interner::default(),
@@ -14,7 +14,7 @@ fn check_string() {
 
     // Check non-empty string
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "\"hello\"",
         vec![Statement::Expression(Expression::from(Literal::from(
             interner.get_or_intern_static("hello", utf16!("hello")),

--- a/boa_parser/src/parser/expression/tests.rs
+++ b/boa_parser/src/parser/expression/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::{
@@ -19,7 +19,7 @@ use boa_macros::utf16;
 #[test]
 fn check_numeric_operations() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a + b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Add.into(),
@@ -31,7 +31,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a+1",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Add.into(),
@@ -43,7 +43,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a - b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Sub.into(),
@@ -55,7 +55,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a-1",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Sub.into(),
@@ -67,7 +67,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a / b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Div.into(),
@@ -79,7 +79,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a/2",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Div.into(),
@@ -91,7 +91,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let myRegex = /=/;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -118,7 +118,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "fn(/=/);",
         vec![Statement::Expression(Expression::from(Call::new(
             Identifier::new(interner.get_or_intern_static("fn", utf16!("fn"))).into(),
@@ -138,7 +138,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "fn(a / b);",
         vec![Statement::Expression(Expression::from(Call::new(
             Identifier::new(interner.get_or_intern_static("fn", utf16!("fn"))).into(),
@@ -154,7 +154,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "fn(a) / b;",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Div.into(),
@@ -171,7 +171,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a * b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Mul.into(),
@@ -183,7 +183,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a*2",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Mul.into(),
@@ -195,7 +195,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a ** b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Exp.into(),
@@ -207,7 +207,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a**2",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Exp.into(),
@@ -219,7 +219,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a % b",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Mod.into(),
@@ -231,7 +231,7 @@ fn check_numeric_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a%2",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Mod.into(),
@@ -247,7 +247,7 @@ fn check_numeric_operations() {
 #[test]
 fn check_complex_numeric_operations() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a + d*(b-3)+1",
         vec![Statement::Expression(Expression::from(Binary::new(
             ArithmeticOp::Add.into(),
@@ -278,7 +278,7 @@ fn check_complex_numeric_operations() {
 #[test]
 fn check_bitwise_operations() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a & b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::And.into(),
@@ -290,7 +290,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a&b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::And.into(),
@@ -302,7 +302,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a | b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Or.into(),
@@ -314,7 +314,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a|b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Or.into(),
@@ -326,7 +326,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a ^ b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Xor.into(),
@@ -338,7 +338,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a^b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Xor.into(),
@@ -350,7 +350,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a << b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Shl.into(),
@@ -362,7 +362,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a<<b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Shl.into(),
@@ -374,7 +374,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a >> b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Shr.into(),
@@ -386,7 +386,7 @@ fn check_bitwise_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a>>b",
         vec![Statement::Expression(Expression::from(Binary::new(
             BitwiseOp::Shr.into(),
@@ -402,7 +402,7 @@ fn check_bitwise_operations() {
 #[test]
 fn check_assign_operations() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a += b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Add,
@@ -414,7 +414,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a -= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Sub,
@@ -426,7 +426,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a *= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Mul,
@@ -438,7 +438,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a **= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Exp,
@@ -450,7 +450,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a /= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Div,
@@ -462,7 +462,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a %= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Mod,
@@ -474,7 +474,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a &= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::And,
@@ -486,7 +486,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a |= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Or,
@@ -498,7 +498,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a ^= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Xor,
@@ -510,7 +510,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a <<= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Shl,
@@ -522,7 +522,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a >>= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Shr,
@@ -534,7 +534,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a >>>= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Ushr,
@@ -546,7 +546,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a %= 10 / 2",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Mod,
@@ -563,7 +563,7 @@ fn check_assign_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a ??= b",
         vec![Statement::Expression(Expression::from(Assign::new(
             AssignOp::Coalesce,
@@ -578,7 +578,7 @@ fn check_assign_operations() {
 #[test]
 fn check_relational_operations() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a < b",
         vec![Statement::Expression(Expression::from(Binary::new(
             RelationalOp::LessThan.into(),
@@ -590,7 +590,7 @@ fn check_relational_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a > b",
         vec![Statement::Expression(Expression::from(Binary::new(
             RelationalOp::GreaterThan.into(),
@@ -602,7 +602,7 @@ fn check_relational_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a <= b",
         vec![Statement::Expression(Expression::from(Binary::new(
             RelationalOp::LessThanOrEqual.into(),
@@ -614,7 +614,7 @@ fn check_relational_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a >= b",
         vec![Statement::Expression(Expression::from(Binary::new(
             RelationalOp::GreaterThanOrEqual.into(),
@@ -626,7 +626,7 @@ fn check_relational_operations() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "p in o",
         vec![Statement::Expression(Expression::from(Binary::new(
             RelationalOp::In.into(),
@@ -641,7 +641,7 @@ fn check_relational_operations() {
 #[test]
 fn check_logical_expressions() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a && b || c && d || e",
         vec![Statement::Expression(Expression::from(Binary::new(
             LogicalOp::Or.into(),
@@ -668,7 +668,7 @@ fn check_logical_expressions() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "a ?? b ?? c",
         vec![Statement::Expression(Expression::from(Binary::new(
             LogicalOp::Coalesce.into(),
@@ -693,7 +693,7 @@ fn check_logical_expressions() {
 macro_rules! check_non_reserved_identifier {
     ($keyword:literal) => {{
         let interner = &mut Interner::default();
-        check_parser(
+        check_script_parser(
             format!("({})", $keyword).as_str(),
             vec![Statement::Expression(Expression::from(Identifier::new(
                 interner.get_or_intern_static($keyword, utf16!($keyword)),

--- a/boa_parser/src/parser/function/tests.rs
+++ b/boa_parser/src/parser/function/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::{
@@ -25,7 +25,7 @@ fn check_basic() {
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
 
-    check_parser(
+    check_script_parser(
         "function foo(a) { return a; }",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -61,7 +61,7 @@ fn check_duplicates_strict_off() {
         FormalParameterListFlags::default().union(FormalParameterListFlags::HAS_DUPLICATES)
     );
     assert_eq!(params.length(), 2);
-    check_parser(
+    check_script_parser(
         "function foo(a, a) { return a; }",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -95,7 +95,7 @@ fn check_basic_semicolon_insertion() {
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
 
-    check_parser(
+    check_script_parser(
         "function foo(a) { return a }",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -122,7 +122,7 @@ fn check_empty_return() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "function foo(a) { return; }",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -147,7 +147,7 @@ fn check_empty_return_semicolon_insertion() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "function foo(a) { return }",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -181,7 +181,7 @@ fn check_rest_operator() {
         FormalParameterListFlags::empty().union(FormalParameterListFlags::HAS_REST_PARAMETER)
     );
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "function foo(a, ...b) {}",
         vec![Declaration::Function(Function::new(
             Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
@@ -206,7 +206,7 @@ fn check_arrow_only_rest() {
         FormalParameterListFlags::empty().union(FormalParameterListFlags::HAS_REST_PARAMETER)
     );
     assert_eq!(params.length(), 0);
-    check_parser(
+    check_script_parser(
         "(...a) => {}",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -241,7 +241,7 @@ fn check_arrow_rest() {
         FormalParameterListFlags::empty().union(FormalParameterListFlags::HAS_REST_PARAMETER)
     );
     assert_eq!(params.length(), 2);
-    check_parser(
+    check_script_parser(
         "(a, b, ...c) => {}",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -269,7 +269,7 @@ fn check_arrow() {
     ]);
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 2);
-    check_parser(
+    check_script_parser(
         "(a, b) => { return a + b; }",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -305,7 +305,7 @@ fn check_arrow_semicolon_insertion() {
             false,
         ),
     ]);
-    check_parser(
+    check_script_parser(
         "(a, b) => { return a + b }",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -341,7 +341,7 @@ fn check_arrow_epty_return() {
             false,
         ),
     ]);
-    check_parser(
+    check_script_parser(
         "(a, b) => { return; }",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -370,7 +370,7 @@ fn check_arrow_empty_return_semicolon_insertion() {
             false,
         ),
     ]);
-    check_parser(
+    check_script_parser(
         "(a, b) => { return }",
         vec![Statement::Expression(Expression::from(ArrowFunction::new(
             None,
@@ -394,7 +394,7 @@ fn check_arrow_assignment() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "let foo = (a) => { return a };",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -431,7 +431,7 @@ fn check_arrow_assignment_nobrackets() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "let foo = (a) => a;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -468,7 +468,7 @@ fn check_arrow_assignment_noparenthesis() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "let foo = a => { return a };",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -505,7 +505,7 @@ fn check_arrow_assignment_noparenthesis_nobrackets() {
     ));
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 1);
-    check_parser(
+    check_script_parser(
         "let foo = a => a;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -548,7 +548,7 @@ fn check_arrow_assignment_2arg() {
     ]);
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 2);
-    check_parser(
+    check_script_parser(
         "let foo = (a, b) => { return a };",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -591,7 +591,7 @@ fn check_arrow_assignment_2arg_nobrackets() {
     ]);
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 2);
-    check_parser(
+    check_script_parser(
         "let foo = (a, b) => a;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -638,7 +638,7 @@ fn check_arrow_assignment_3arg() {
     ]);
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 3);
-    check_parser(
+    check_script_parser(
         "let foo = (a, b, c) => { return a };",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -685,7 +685,7 @@ fn check_arrow_assignment_3arg_nobrackets() {
     ]);
     assert_eq!(params.flags(), FormalParameterListFlags::default());
     assert_eq!(params.length(), 3);
-    check_parser(
+    check_script_parser(
         "let foo = (a, b, c) => a;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(

--- a/boa_parser/src/parser/statement/block/tests.rs
+++ b/boa_parser/src/parser/statement/block/tests.rs
@@ -2,7 +2,7 @@
 
 use std::convert::TryInto;
 
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     declaration::{VarDeclaration, Variable},
     expression::{
@@ -23,7 +23,7 @@ fn check_block<B>(js: &str, block: B, interner: &mut Interner)
 where
     B: Into<Box<[StatementListItem]>>,
 {
-    check_parser(
+    check_script_parser(
         js,
         vec![Statement::Block(Block::from(block.into())).into()],
         interner,

--- a/boa_parser/src/parser/statement/break_stm/tests.rs
+++ b/boa_parser/src/parser/statement/break_stm/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
     statement::{Block, Break, WhileLoop},
@@ -9,7 +9,7 @@ use boa_macros::utf16;
 
 #[test]
 fn inline() {
-    check_parser(
+    check_script_parser(
         "while (true) break;",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -22,7 +22,7 @@ fn inline() {
 
 #[test]
 fn new_line() {
-    check_parser(
+    check_script_parser(
         "while (true)
             break;",
         vec![Statement::WhileLoop(WhileLoop::new(
@@ -36,7 +36,7 @@ fn new_line() {
 
 #[test]
 fn inline_block_semicolon_insertion() {
-    check_parser(
+    check_script_parser(
         "while (true) {break}",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -53,7 +53,7 @@ fn inline_block_semicolon_insertion() {
 #[test]
 fn new_line_semicolon_insertion() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             break test
         }",
@@ -71,7 +71,7 @@ fn new_line_semicolon_insertion() {
 
 #[test]
 fn inline_block() {
-    check_parser(
+    check_script_parser(
         "while (true) {break;}",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -88,7 +88,7 @@ fn inline_block() {
 #[test]
 fn new_line_block() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             break test;
         }",
@@ -107,7 +107,7 @@ fn new_line_block() {
 #[test]
 fn reserved_label() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             break await;
         }",
@@ -125,7 +125,7 @@ fn reserved_label() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             break yield;
         }",
@@ -145,7 +145,7 @@ fn reserved_label() {
 
 #[test]
 fn new_line_block_empty() {
-    check_parser(
+    check_script_parser(
         "while (true) {
             break;
         }",
@@ -163,7 +163,7 @@ fn new_line_block_empty() {
 
 #[test]
 fn new_line_block_empty_semicolon_insertion() {
-    check_parser(
+    check_script_parser(
         "while (true) {
             break
         }",

--- a/boa_parser/src/parser/statement/continue_stm/tests.rs
+++ b/boa_parser/src/parser/statement/continue_stm/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
     statement::{Block, Continue, WhileLoop},
@@ -9,7 +9,7 @@ use boa_macros::utf16;
 
 #[test]
 fn inline() {
-    check_parser(
+    check_script_parser(
         "while (true) continue;",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -22,7 +22,7 @@ fn inline() {
 
 #[test]
 fn new_line() {
-    check_parser(
+    check_script_parser(
         "while (true)
             continue;",
         vec![Statement::WhileLoop(WhileLoop::new(
@@ -36,7 +36,7 @@ fn new_line() {
 
 #[test]
 fn inline_block_semicolon_insertion() {
-    check_parser(
+    check_script_parser(
         "while (true) {continue}",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -53,7 +53,7 @@ fn inline_block_semicolon_insertion() {
 #[test]
 fn new_line_semicolon_insertion() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue test
         }",
@@ -71,7 +71,7 @@ fn new_line_semicolon_insertion() {
 
 #[test]
 fn inline_block() {
-    check_parser(
+    check_script_parser(
         "while (true) {continue;}",
         vec![Statement::WhileLoop(WhileLoop::new(
             Literal::from(true).into(),
@@ -88,7 +88,7 @@ fn inline_block() {
 #[test]
 fn new_line_block() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue test;
         }",
@@ -107,7 +107,7 @@ fn new_line_block() {
 #[test]
 fn reserved_label() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue await;
         }",
@@ -125,7 +125,7 @@ fn reserved_label() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue yield;
         }",
@@ -145,7 +145,7 @@ fn reserved_label() {
 
 #[test]
 fn new_line_block_empty() {
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue;
         }",
@@ -163,7 +163,7 @@ fn new_line_block_empty() {
 
 #[test]
 fn new_line_block_empty_semicolon_insertion() {
-    check_parser(
+    check_script_parser(
         "while (true) {
             continue
         }",

--- a/boa_parser/src/parser/statement/declaration/hoistable/async_function_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/async_function_decl/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     function::{AsyncFunction, FormalParameterList},
     Declaration, StatementList,
@@ -10,7 +10,7 @@ use boa_macros::utf16;
 #[test]
 fn async_function_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "async function hello() {}",
         vec![Declaration::AsyncFunction(AsyncFunction::new(
             Some(
@@ -31,7 +31,7 @@ fn async_function_declaration() {
 #[test]
 fn async_function_declaration_keywords() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "async function yield() {}",
         vec![Declaration::AsyncFunction(AsyncFunction::new(
             Some(
@@ -48,7 +48,7 @@ fn async_function_declaration_keywords() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "async function await() {}",
         vec![Declaration::AsyncFunction(AsyncFunction::new(
             Some(

--- a/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/async_generator_decl/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     function::{AsyncGenerator, FormalParameterList},
     Declaration, StatementList,
@@ -9,7 +9,7 @@ use boa_macros::utf16;
 #[test]
 fn async_generator_function_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "async function* gen() {}",
         vec![Declaration::AsyncGenerator(AsyncGenerator::new(
             Some(interner.get_or_intern_static("gen", utf16!("gen")).into()),

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -76,7 +76,8 @@ where
         let mut has_binding_identifier = false;
         let token = cursor.peek(0, interner).or_abrupt()?;
         let name = match token.kind() {
-            TokenKind::Identifier(_) | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
+            TokenKind::IdentifierName(_)
+            | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _)) => {
                 has_binding_identifier = true;
                 BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?
@@ -595,11 +596,11 @@ where
                 cursor.advance(interner);
                 return Ok((None, None));
             }
-            TokenKind::Identifier((Sym::STATIC, ContainsEscapeSequence(contains_escape))) => {
+            TokenKind::IdentifierName((Sym::STATIC, ContainsEscapeSequence(contains_escape))) => {
                 let contains_escape = *contains_escape;
                 let token = cursor.peek(1, interner).or_abrupt()?;
                 match token.kind() {
-                    TokenKind::Identifier(_)
+                    TokenKind::IdentifierName(_)
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
@@ -637,7 +638,7 @@ where
         let token = cursor.peek(0, interner).or_abrupt()?;
         let position = token.span().start();
         let element = match token.kind() {
-            TokenKind::Identifier((Sym::CONSTRUCTOR, _)) if !r#static => {
+            TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) if !r#static => {
                 cursor.advance(interner);
                 let strict = cursor.strict_mode();
                 cursor.set_strict_mode(true);
@@ -716,7 +717,7 @@ where
                 let token = cursor.peek(1, interner).or_abrupt()?;
                 let name_position = token.span().start();
                 if !r#static {
-                    if let TokenKind::Identifier((Sym::CONSTRUCTOR, _)) = token.kind() {
+                    if let TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) = token.kind() {
                         return Err(Error::general(
                             "class constructor may not be a generator method",
                             token.span().start(),
@@ -780,7 +781,7 @@ where
                                     token.span().start(),
                                 ));
                             }
-                            TokenKind::Identifier((Sym::CONSTRUCTOR, _)) if !r#static => {
+                            TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) if !r#static => {
                                 return Err(Error::general(
                                     "class constructor may not be a generator method",
                                     token.span().start(),
@@ -824,7 +825,7 @@ where
                             }
                         }
                     }
-                    TokenKind::Identifier((Sym::CONSTRUCTOR, _)) if !r#static => {
+                    TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) if !r#static => {
                         return Err(Error::general(
                             "class constructor may not be an async method",
                             token.span().start(),
@@ -875,13 +876,13 @@ where
                     }
                 }
             }
-            TokenKind::Identifier((Sym::GET, ContainsEscapeSequence(true))) if is_keyword => {
+            TokenKind::IdentifierName((Sym::GET, ContainsEscapeSequence(true))) if is_keyword => {
                 return Err(Error::general(
                     "keyword must not contain escaped characters",
                     token.span().start(),
                 ))
             }
-            TokenKind::Identifier((Sym::GET, ContainsEscapeSequence(false))) if is_keyword => {
+            TokenKind::IdentifierName((Sym::GET, ContainsEscapeSequence(false))) if is_keyword => {
                 cursor.advance(interner);
                 let token = cursor.peek(0, interner).or_abrupt()?;
                 match token.kind() {
@@ -933,13 +934,13 @@ where
                             )
                         }
                     }
-                    TokenKind::Identifier((Sym::CONSTRUCTOR, _)) if !r#static => {
+                    TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) if !r#static => {
                         return Err(Error::general(
                             "class constructor may not be a getter method",
                             token.span().start(),
                         ))
                     }
-                    TokenKind::Identifier(_)
+                    TokenKind::IdentifierName(_)
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
@@ -1006,13 +1007,13 @@ where
                     }
                 }
             }
-            TokenKind::Identifier((Sym::SET, ContainsEscapeSequence(true))) if is_keyword => {
+            TokenKind::IdentifierName((Sym::SET, ContainsEscapeSequence(true))) if is_keyword => {
                 return Err(Error::general(
                     "keyword must not contain escaped characters",
                     token.span().start(),
                 ))
             }
-            TokenKind::Identifier((Sym::SET, ContainsEscapeSequence(false))) if is_keyword => {
+            TokenKind::IdentifierName((Sym::SET, ContainsEscapeSequence(false))) if is_keyword => {
                 cursor.advance(interner);
                 let token = cursor.peek(0, interner).or_abrupt()?;
                 match token.kind() {
@@ -1064,13 +1065,13 @@ where
                             )
                         }
                     }
-                    TokenKind::Identifier((Sym::CONSTRUCTOR, _)) if !r#static => {
+                    TokenKind::IdentifierName((Sym::CONSTRUCTOR, _)) if !r#static => {
                         return Err(Error::general(
                             "class constructor may not be a setter method",
                             token.span().start(),
                         ))
                     }
-                    TokenKind::Identifier(_)
+                    TokenKind::IdentifierName(_)
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
@@ -1231,7 +1232,7 @@ where
                     }
                 }
             }
-            TokenKind::Identifier(_)
+            TokenKind::IdentifierName(_)
             | TokenKind::StringLiteral(_)
             | TokenKind::NumericLiteral(_)
             | TokenKind::Keyword(_)

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
     function::{Class, ClassElement, FormalParameterList, Function},
@@ -21,7 +21,7 @@ fn check_async_ordinary_method() {
         )),
     )];
 
-    check_parser(
+    check_script_parser(
         "class A {
             async() { }
          }
@@ -47,7 +47,7 @@ fn check_async_field_initialization() {
         Some(Literal::from(1).into()),
     )];
 
-    check_parser(
+    check_script_parser(
         "class A {
             async
               = 1
@@ -74,7 +74,7 @@ fn check_async_field() {
         None,
     )];
 
-    check_parser(
+    check_script_parser(
         "class A {
             async
          }

--- a/boa_parser/src/parser/statement/declaration/hoistable/function_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/function_decl/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     function::{FormalParameterList, Function},
     Declaration, StatementList,
@@ -10,7 +10,7 @@ use boa_macros::utf16;
 #[test]
 fn function_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "function hello() {}",
         vec![Declaration::Function(Function::new(
             Some(
@@ -46,41 +46,41 @@ fn function_declaration_keywords() {
 
     let interner = &mut Interner::default();
     let ast = genast!("yield", interner);
-    check_parser("function yield() {}", ast, interner);
+    check_script_parser("function yield() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("await", interner);
-    check_parser("function await() {}", ast, interner);
+    check_script_parser("function await() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("as", interner);
-    check_parser("function as() {}", ast, interner);
+    check_script_parser("function as() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("async", interner);
-    check_parser("function async() {}", ast, interner);
+    check_script_parser("function async() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("from", interner);
-    check_parser("function from() {}", ast, interner);
+    check_script_parser("function from() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("get", interner);
-    check_parser("function get() {}", ast, interner);
+    check_script_parser("function get() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("meta", interner);
-    check_parser("function meta() {}", ast, interner);
+    check_script_parser("function meta() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("of", interner);
-    check_parser("function of() {}", ast, interner);
+    check_script_parser("function of() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("set", interner);
-    check_parser("function set() {}", ast, interner);
+    check_script_parser("function set() {}", ast, interner);
 
     let interner = &mut Interner::default();
     let ast = genast!("target", interner);
-    check_parser("function target() {}", ast, interner);
+    check_script_parser("function target() {}", ast, interner);
 }

--- a/boa_parser/src/parser/statement/declaration/hoistable/generator_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/generator_decl/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     function::{FormalParameterList, Generator},
     Declaration, StatementList,
@@ -9,7 +9,7 @@ use boa_macros::utf16;
 #[test]
 fn generator_function_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "function* gen() {}",
         vec![Declaration::Generator(Generator::new(
             Some(interner.get_or_intern_static("gen", utf16!("gen")).into()),

--- a/boa_parser/src/parser/statement/declaration/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/tests.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{LexicalDeclaration, VarDeclaration, Variable},
     expression::literal::Literal,
@@ -13,7 +13,7 @@ use boa_macros::utf16;
 #[test]
 fn var_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var a = 5;",
         vec![Statement::Var(VarDeclaration(
             vec![Variable::from_identifier(
@@ -32,7 +32,7 @@ fn var_declaration() {
 #[test]
 fn var_declaration_keywords() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var yield = 5;",
         vec![Statement::Var(VarDeclaration(
             vec![Variable::from_identifier(
@@ -49,7 +49,7 @@ fn var_declaration_keywords() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var await = 5;",
         vec![Statement::Var(VarDeclaration(
             vec![Variable::from_identifier(
@@ -70,7 +70,7 @@ fn var_declaration_keywords() {
 #[test]
 fn var_declaration_no_spaces() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var a=5;",
         vec![Statement::Var(VarDeclaration(
             vec![Variable::from_identifier(
@@ -89,7 +89,7 @@ fn var_declaration_no_spaces() {
 #[test]
 fn empty_var_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var a;",
         vec![Statement::Var(VarDeclaration(
             vec![Variable::from_identifier(
@@ -108,7 +108,7 @@ fn empty_var_declaration() {
 #[test]
 fn multiple_var_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "var a = 5, b, c = 6;",
         vec![Statement::Var(VarDeclaration(
             vec![
@@ -137,7 +137,7 @@ fn multiple_var_declaration() {
 #[test]
 fn let_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let a = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -156,7 +156,7 @@ fn let_declaration() {
 #[test]
 fn let_declaration_keywords() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let yield = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -173,7 +173,7 @@ fn let_declaration_keywords() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let await = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -194,7 +194,7 @@ fn let_declaration_keywords() {
 #[test]
 fn let_declaration_no_spaces() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let a=5;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -213,7 +213,7 @@ fn let_declaration_no_spaces() {
 #[test]
 fn empty_let_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let a;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![Variable::from_identifier(
@@ -232,7 +232,7 @@ fn empty_let_declaration() {
 #[test]
 fn multiple_let_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "let a = 5, b, c = 6;",
         vec![Declaration::Lexical(LexicalDeclaration::Let(
             vec![
@@ -261,7 +261,7 @@ fn multiple_let_declaration() {
 #[test]
 fn const_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "const a = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
             vec![Variable::from_identifier(
@@ -280,7 +280,7 @@ fn const_declaration() {
 #[test]
 fn const_declaration_keywords() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "const yield = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
             vec![Variable::from_identifier(
@@ -297,7 +297,7 @@ fn const_declaration_keywords() {
     );
 
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "const await = 5;",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
             vec![Variable::from_identifier(
@@ -318,7 +318,7 @@ fn const_declaration_keywords() {
 #[test]
 fn const_declaration_no_spaces() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "const a=5;",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
             vec![Variable::from_identifier(
@@ -343,7 +343,7 @@ fn empty_const_declaration() {
 #[test]
 fn multiple_const_declaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "const a = 5, c = 6;",
         vec![Declaration::Lexical(LexicalDeclaration::Const(
             vec![

--- a/boa_parser/src/parser/statement/if_stm/tests.rs
+++ b/boa_parser/src/parser/statement/if_stm/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
     statement::{Block, If},
@@ -8,7 +8,7 @@ use boa_interner::Interner;
 
 #[test]
 fn if_without_else_block() {
-    check_parser(
+    check_script_parser(
         "if (true) {}",
         vec![Statement::If(If::new(
             Literal::from(true).into(),
@@ -22,7 +22,7 @@ fn if_without_else_block() {
 
 #[test]
 fn if_without_else_block_with_trailing_newline() {
-    check_parser(
+    check_script_parser(
         "if (true) {}\n",
         vec![Statement::If(If::new(
             Literal::from(true).into(),

--- a/boa_parser/src/parser/statement/iteration/tests.rs
+++ b/boa_parser/src/parser/statement/iteration/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{VarDeclaration, Variable},
     expression::{
@@ -17,7 +17,7 @@ use boa_macros::utf16;
 #[test]
 fn check_do_while() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         r#"do {
             a += 1;
         } while (true)"#,
@@ -43,7 +43,7 @@ fn check_do_while() {
 #[test]
 fn check_do_while_semicolon_insertion() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         r#"var i = 0;
         do {console.log("hello");} while(i++ < 10) console.log("end");"#,
         vec![
@@ -116,7 +116,7 @@ fn check_do_while_semicolon_insertion() {
 #[test]
 fn check_do_while_semicolon_insertion_no_space() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         r#"var i = 0;
         do {console.log("hello");} while(i++ < 10)console.log("end");"#,
         vec![
@@ -187,7 +187,7 @@ fn check_do_while_semicolon_insertion_no_space() {
 /// Checks parsing of a while statement which is seperated out with line terminators.
 #[test]
 fn while_spaces() {
-    check_parser(
+    check_script_parser(
         r#"
 
         while
@@ -213,7 +213,7 @@ fn while_spaces() {
 /// Checks parsing of a while statement which is seperated out with line terminators.
 #[test]
 fn do_while_spaces() {
-    check_parser(
+    check_script_parser(
         r#"
 
         do

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -190,7 +190,7 @@ where
                 cursor.advance(interner);
                 Ok(ast::Statement::Empty)
             }
-            TokenKind::Identifier(_) => {
+            TokenKind::IdentifierName(_) => {
                 // Labelled Statement check
                 cursor.set_goal(InputElement::Div);
                 let tok = cursor.peek(1, interner)?;
@@ -504,7 +504,7 @@ where
                         TokenKind::Punctuator(Punctuator::OpenBracket)
                         | TokenKind::StringLiteral(_)
                         | TokenKind::NumericLiteral(_) => true,
-                        TokenKind::Identifier(_) if next_token_is_colon => true,
+                        TokenKind::IdentifierName(_) if next_token_is_colon => true,
                         TokenKind::Keyword(_) if next_token_is_colon => true,
                         _ => false,
                     };

--- a/boa_parser/src/parser/statement/switch/tests.rs
+++ b/boa_parser/src/parser/statement/switch/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{LexicalDeclaration, Variable},
     expression::{access::SimplePropertyAccess, literal::Literal, Call, Identifier},
@@ -152,7 +152,7 @@ fn check_separated_switch() {
     let console = interner.get_or_intern_static("console", utf16!("console"));
     let a = interner.get_or_intern_static("a", utf16!("a"));
 
-    check_parser(
+    check_script_parser(
         s,
         vec![
             Declaration::Lexical(LexicalDeclaration::Let(

--- a/boa_parser/src/parser/statement/throw/tests.rs
+++ b/boa_parser/src/parser/statement/throw/tests.rs
@@ -1,4 +1,4 @@
-use crate::parser::tests::check_parser;
+use crate::parser::tests::check_script_parser;
 use boa_ast::{expression::literal::Literal, statement::Throw, Statement};
 use boa_interner::Interner;
 use boa_macros::utf16;
@@ -6,7 +6,7 @@ use boa_macros::utf16;
 #[test]
 fn check_throw_parsing() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "throw 'error';",
         vec![Statement::Throw(Throw::new(
             Literal::from(interner.get_or_intern_static("error", utf16!("error"))).into(),

--- a/boa_parser/src/parser/statement/try_stm/catch.rs
+++ b/boa_parser/src/parser/statement/try_stm/catch.rs
@@ -168,7 +168,7 @@ where
                     .parse(cursor, interner)?;
                 Ok(Binding::Pattern(pat.into()))
             }
-            TokenKind::Identifier(_) => {
+            TokenKind::IdentifierName(_) => {
                 let ident = BindingIdentifier::new(self.allow_yield, self.allow_await)
                     .parse(cursor, interner)?;
                 Ok(Binding::Identifier(ident))

--- a/boa_parser/src/parser/statement/try_stm/tests.rs
+++ b/boa_parser/src/parser/statement/try_stm/tests.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-use crate::parser::tests::{check_invalid, check_parser};
+use crate::parser::tests::{check_invalid, check_script_parser};
 use boa_ast::{
     declaration::{VarDeclaration, Variable},
     expression::{literal::Literal, Identifier},
@@ -15,7 +15,7 @@ use boa_macros::utf16;
 #[test]
 fn check_inline_with_empty_try_catch() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try { } catch(e) {}",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -32,7 +32,7 @@ fn check_inline_with_empty_try_catch() {
 #[test]
 fn check_inline_with_var_decl_inside_try() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try { var x = 1; } catch(e) {}",
         vec![Statement::Try(Try::new(
             vec![Statement::Var(VarDeclaration(
@@ -58,7 +58,7 @@ fn check_inline_with_var_decl_inside_try() {
 #[test]
 fn check_inline_with_var_decl_inside_catch() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try { var x = 1; } catch(e) { var x = 1; }",
         vec![Statement::Try(Try::new(
             vec![Statement::Var(VarDeclaration(
@@ -93,7 +93,7 @@ fn check_inline_with_var_decl_inside_catch() {
 #[test]
 fn check_inline_with_empty_try_catch_finally() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try {} catch(e) {} finally {}",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -112,7 +112,7 @@ fn check_inline_with_empty_try_catch_finally() {
 
 #[test]
 fn check_inline_with_empty_try_finally() {
-    check_parser(
+    check_script_parser(
         "try {} finally {}",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -126,7 +126,7 @@ fn check_inline_with_empty_try_finally() {
 #[test]
 fn check_inline_with_empty_try_var_decl_in_finally() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try {} finally { var x = 1; }",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -149,7 +149,7 @@ fn check_inline_with_empty_try_var_decl_in_finally() {
 #[test]
 fn check_inline_empty_try_paramless_catch() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try {} catch { var x = 1; }",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -176,7 +176,7 @@ fn check_inline_empty_try_paramless_catch() {
 fn check_inline_with_binding_pattern_object() {
     let interner = &mut Interner::default();
     let a = interner.get_or_intern_static("a", utf16!("a"));
-    check_parser(
+    check_script_parser(
         "try {} catch ({ a, b: c }) {}",
         vec![Statement::Try(Try::new(
             Block::default(),
@@ -209,7 +209,7 @@ fn check_inline_with_binding_pattern_object() {
 #[test]
 fn check_inline_with_binding_pattern_array() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try {} catch ([a, b]) {}",
         vec![Statement::Try(Try::new(
             Block::from(vec![]),
@@ -238,7 +238,7 @@ fn check_inline_with_binding_pattern_array() {
 #[test]
 fn check_catch_with_var_redeclaration() {
     let interner = &mut Interner::default();
-    check_parser(
+    check_script_parser(
         "try {} catch(e) { var e = 'oh' }",
         vec![Statement::Try(Try::new(
             Block::from(vec![]),


### PR DESCRIPTION
Extracted from #2411 to reduce its size a bit.

This PR:
- Renames `Identifier` to `IdentifierName`, which is the name stated in the spec.
- Renames the utility function `check_parser` to `check_script_parser` to prepare for modules.
- Adds some missing `#[inline]` and rewrites some patterns.