### PR TITLE
[Merged by Bors] - Create `Source` to abstract JS code sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,6 @@ dependencies = [
  "bitflags",
  "boa_engine",
  "boa_gc",
- "boa_parser",
  "clap 4.1.4",
  "color-eyre",
  "colored",

--- a/boa_engine/benches/full.rs
+++ b/boa_engine/benches/full.rs
@@ -1,6 +1,6 @@
 //! Benchmarks of the whole execution engine in Boa.
 
-use boa_engine::{realm::Realm, Context};
+use boa_engine::{realm::Realm, Context, Source};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 
@@ -23,7 +23,7 @@ macro_rules! full_benchmarks {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
                     let mut context = Context::default();
                     c.bench_function(concat!($id, " (Parser)"), move |b| {
-                        b.iter(|| context.parse(black_box(CODE)))
+                        b.iter(|| context.parse(black_box(Source::from_bytes(CODE))))
                     });
                 }
             )*
@@ -33,7 +33,7 @@ macro_rules! full_benchmarks {
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
                     let mut context = Context::default();
-                    let statement_list = context.parse(CODE).expect("parsing failed");
+                    let statement_list = context.parse(Source::from_bytes(CODE)).expect("parsing failed");
                     c.bench_function(concat!($id, " (Compiler)"), move |b| {
                         b.iter(|| {
                             context.compile(black_box(&statement_list))
@@ -47,7 +47,7 @@ macro_rules! full_benchmarks {
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
                     let mut context = Context::default();
-                    let statement_list = context.parse(CODE).expect("parsing failed");
+                    let statement_list = context.parse(Source::from_bytes(CODE)).expect("parsing failed");
                     let code_block = context.compile(&statement_list).unwrap();
                     c.bench_function(concat!($id, " (Execution)"), move |b| {
                         b.iter(|| {

--- a/boa_engine/src/builtins/array/tests.rs
+++ b/boa_engine/src/builtins/array/tests.rs
@@ -1,3 +1,5 @@
+use boa_parser::Source;
+
 use super::Array;
 use crate::builtins::Number;
 use crate::{forward, Context, JsValue};
@@ -10,60 +12,85 @@ fn is_array() {
         var new_arr = new Array();
         var many = ["a", "b", "c"];
         "#;
-    context.eval(init).unwrap();
+    context.eval(Source::from_bytes(init)).unwrap();
     assert_eq!(
-        context.eval("Array.isArray(empty)").unwrap(),
+        context
+            .eval(Source::from_bytes("Array.isArray(empty)"))
+            .unwrap(),
         JsValue::new(true)
-    );
-    assert_eq!(
-        context.eval("Array.isArray(new_arr)").unwrap(),
-        JsValue::new(true)
-    );
-    assert_eq!(
-        context.eval("Array.isArray(many)").unwrap(),
-        JsValue::new(true)
-    );
-    assert_eq!(
-        context.eval("Array.isArray([1, 2, 3])").unwrap(),
-        JsValue::new(true)
-    );
-    assert_eq!(
-        context.eval("Array.isArray([])").unwrap(),
-        JsValue::new(true)
-    );
-    assert_eq!(
-        context.eval("Array.isArray({})").unwrap(),
-        JsValue::new(false)
-    );
-    // assert_eq!(context.eval("Array.isArray(new Array)"), "true");
-    assert_eq!(
-        context.eval("Array.isArray()").unwrap(),
-        JsValue::new(false)
     );
     assert_eq!(
         context
-            .eval("Array.isArray({ constructor: Array })")
+            .eval(Source::from_bytes("Array.isArray(new_arr)"))
+            .unwrap(),
+        JsValue::new(true)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray(many)"))
+            .unwrap(),
+        JsValue::new(true)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray([1, 2, 3])"))
+            .unwrap(),
+        JsValue::new(true)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray([])"))
+            .unwrap(),
+        JsValue::new(true)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray({})"))
             .unwrap(),
         JsValue::new(false)
     );
     assert_eq!(
         context
-            .eval("Array.isArray({ push: Array.prototype.push, concat: Array.prototype.concat })")
+            .eval(Source::from_bytes("Array.isArray(new Array)"))
             .unwrap(),
-        JsValue::new(false)
+        JsValue::new(true)
     );
     assert_eq!(
-        context.eval("Array.isArray(17)").unwrap(),
+        context.eval(Source::from_bytes("Array.isArray()")).unwrap(),
         JsValue::new(false)
     );
     assert_eq!(
         context
-            .eval("Array.isArray({ __proto__: Array.prototype })")
+            .eval(Source::from_bytes("Array.isArray({ constructor: Array })"))
             .unwrap(),
         JsValue::new(false)
     );
     assert_eq!(
-        context.eval("Array.isArray({ length: 0 })").unwrap(),
+        context
+            .eval(Source::from_bytes(
+                "Array.isArray({ push: Array.prototype.push, concat: Array.prototype.concat })"
+            ))
+            .unwrap(),
+        JsValue::new(false)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray(17)"))
+            .unwrap(),
+        JsValue::new(false)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes(
+                "Array.isArray({ __proto__: Array.prototype })"
+            ))
+            .unwrap(),
+        JsValue::new(false)
+    );
+    assert_eq!(
+        context
+            .eval(Source::from_bytes("Array.isArray({ length: 0 })"))
+            .unwrap(),
         JsValue::new(false)
     );
 }
@@ -73,48 +100,68 @@ fn of() {
     let mut context = Context::default();
     assert_eq!(
         context
-            .eval("Array.of(1, 2, 3)")
+            .eval(Source::from_bytes("Array.of(1, 2, 3)"))
             .unwrap()
             .to_string(&mut context)
             .unwrap(),
         context
-            .eval("[1, 2, 3]")
+            .eval(Source::from_bytes("[1, 2, 3]"))
             .unwrap()
             .to_string(&mut context)
             .unwrap()
     );
     assert_eq!(
         context
-            .eval("Array.of(1, 'a', [], undefined, null)")
+            .eval(Source::from_bytes("Array.of(1, 'a', [], undefined, null)"))
             .unwrap()
             .to_string(&mut context)
             .unwrap(),
         context
-            .eval("[1, 'a', [], undefined, null]")
+            .eval(Source::from_bytes("[1, 'a', [], undefined, null]"))
             .unwrap()
             .to_string(&mut context)
             .unwrap()
     );
     assert_eq!(
         context
-            .eval("Array.of()")
+            .eval(Source::from_bytes("Array.of()"))
             .unwrap()
             .to_string(&mut context)
             .unwrap(),
-        context.eval("[]").unwrap().to_string(&mut context).unwrap()
+        context
+            .eval(Source::from_bytes("[]"))
+            .unwrap()
+            .to_string(&mut context)
+            .unwrap()
     );
 
     context
-        .eval(r#"let a = Array.of.call(Date, "a", undefined, 3);"#)
+        .eval(Source::from_bytes(
+            r#"let a = Array.of.call(Date, "a", undefined, 3);"#,
+        ))
         .unwrap();
     assert_eq!(
-        context.eval("a instanceof Date").unwrap(),
+        context
+            .eval(Source::from_bytes("a instanceof Date"))
+            .unwrap(),
         JsValue::new(true)
     );
-    assert_eq!(context.eval("a[0]").unwrap(), JsValue::new("a"));
-    assert_eq!(context.eval("a[1]").unwrap(), JsValue::undefined());
-    assert_eq!(context.eval("a[2]").unwrap(), JsValue::new(3));
-    assert_eq!(context.eval("a.length").unwrap(), JsValue::new(3));
+    assert_eq!(
+        context.eval(Source::from_bytes("a[0]")).unwrap(),
+        JsValue::new("a")
+    );
+    assert_eq!(
+        context.eval(Source::from_bytes("a[1]")).unwrap(),
+        JsValue::undefined()
+    );
+    assert_eq!(
+        context.eval(Source::from_bytes("a[2]")).unwrap(),
+        JsValue::new(3)
+    );
+    assert_eq!(
+        context.eval(Source::from_bytes("a.length")).unwrap(),
+        JsValue::new(3)
+    );
 }
 
 #[test]
@@ -124,31 +171,31 @@ fn concat() {
     var empty = [];
     var one = [1];
     "#;
-    context.eval(init).unwrap();
+    context.eval(Source::from_bytes(init)).unwrap();
     // Empty ++ Empty
     let ee = context
-        .eval("empty.concat(empty)")
+        .eval(Source::from_bytes("empty.concat(empty)"))
         .unwrap()
         .display()
         .to_string();
     assert_eq!(ee, "[]");
     // Empty ++ NonEmpty
     let en = context
-        .eval("empty.concat(one)")
+        .eval(Source::from_bytes("empty.concat(one)"))
         .unwrap()
         .display()
         .to_string();
     assert_eq!(en, "[ 1 ]");
     // NonEmpty ++ Empty
     let ne = context
-        .eval("one.concat(empty)")
+        .eval(Source::from_bytes("one.concat(empty)"))
         .unwrap()
         .display()
         .to_string();
     assert_eq!(ne, "[ 1 ]");
     // NonEmpty ++ NonEmpty
     let nn = context
-        .eval("one.concat(one)")
+        .eval(Source::from_bytes("one.concat(one)"))
         .unwrap()
         .display()
         .to_string();

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -22,7 +22,7 @@ use boa_ast::operations::{
     contains, contains_arguments, top_level_var_declared_names, ContainsSymbol,
 };
 use boa_gc::Gc;
-use boa_parser::Parser;
+use boa_parser::{Parser, Source};
 use boa_profiler::Profiler;
 
 #[derive(Debug, Clone, Copy)]
@@ -124,7 +124,7 @@ impl Eval {
         //     b. If script is a List of errors, throw a SyntaxError exception.
         //     c. If script Contains ScriptBody is false, return undefined.
         //     d. Let body be the ScriptBody of script.
-        let mut parser = Parser::new(x.as_bytes());
+        let mut parser = Parser::new(Source::from_bytes(&x));
         if strict {
             parser.set_strict();
         }

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     value::IntegerOrInfinity,
     Context, JsResult, JsString, JsValue,
 };
-use boa_parser::Parser;
+use boa_parser::{Parser, Source};
 use boa_profiler::Profiler;
 use tap::{Conv, Pipe};
 
@@ -198,7 +198,7 @@ impl Json {
         // 8. NOTE: The PropertyDefinitionEvaluation semantics defined in 13.2.5.5 have special handling for the above evaluation.
         // 9. Let unfiltered be completion.[[Value]].
         // 10. Assert: unfiltered is either a String, Number, Boolean, Null, or an Object that is defined by either an ArrayLiteral or an ObjectLiteral.
-        let mut parser = Parser::new(script_string.as_bytes());
+        let mut parser = Parser::new(Source::from_bytes(&script_string));
         parser.set_json_parse();
         let statement_list = parser.parse_all(context.interner_mut())?;
         let code_block = context.compile_json_parse(&statement_list)?;

--- a/boa_engine/src/builtins/object/tests.rs
+++ b/boa_engine/src/builtins/object/tests.rs
@@ -1,3 +1,5 @@
+use boa_parser::Source;
+
 use crate::{check_output, forward, Context, JsValue, TestAction};
 
 #[test]
@@ -249,7 +251,10 @@ fn get_own_property_descriptor_1_arg_returns_undefined() {
         let obj = {a: 2};
         Object.getOwnPropertyDescriptor(obj)
     "#;
-    assert_eq!(context.eval(code).unwrap(), JsValue::undefined());
+    assert_eq!(
+        context.eval(Source::from_bytes(code)).unwrap(),
+        JsValue::undefined()
+    );
 }
 
 #[test]
@@ -318,7 +323,10 @@ fn object_is_prototype_of() {
         Object.prototype.isPrototypeOf(String.prototype)
     "#;
 
-    assert_eq!(context.eval(init).unwrap(), JsValue::new(true));
+    assert_eq!(
+        context.eval(Source::from_bytes(init)).unwrap(),
+        JsValue::new(true)
+    );
 }
 
 #[test]

--- a/boa_engine/src/builtins/promise/tests.rs
+++ b/boa_engine/src/builtins/promise/tests.rs
@@ -1,3 +1,5 @@
+use boa_parser::Source;
+
 use crate::{context::ContextBuilder, forward, job::SimpleJobQueue};
 
 #[test]
@@ -13,7 +15,7 @@ fn promise() {
         count += 1;
         count;
     "#;
-    let result = context.eval(init).unwrap();
+    let result = context.eval(Source::from_bytes(init)).unwrap();
     assert_eq!(result.as_number(), Some(2_f64));
     context.run_jobs();
     let after_completion = forward(&mut context, "count");

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -141,6 +141,8 @@ impl WeakRef {
 
 #[cfg(test)]
 mod tests {
+    use boa_parser::Source;
+
     use crate::{Context, JsValue};
 
     #[test]
@@ -148,7 +150,7 @@ mod tests {
         let context = &mut Context::default();
 
         assert!(context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
             var ptr;
             {
@@ -157,7 +159,7 @@ mod tests {
             }
             ptr.deref()
         "#
-            )
+            ))
             .unwrap()
             .is_object());
 
@@ -165,11 +167,11 @@ mod tests {
 
         assert_eq!(
             context
-                .eval(
+                .eval(Source::from_bytes(
                     r#"
             ptr.deref()
         "#
-                )
+                ))
                 .unwrap(),
             JsValue::undefined()
         );

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -16,7 +16,7 @@ use crate::{
 /// need to be redefined:
 ///
 /// ```
-/// use boa_engine::{JsNativeError, JsResult, context::{Context, ContextBuilder, HostHooks}};
+/// use boa_engine::{JsNativeError, JsResult, context::{Context, ContextBuilder, HostHooks}, Source};
 ///
 /// struct Hooks;
 ///
@@ -30,7 +30,7 @@ use crate::{
 /// }
 /// let hooks = Hooks; // Can have additional state.
 /// let context = &mut ContextBuilder::new().host_hooks(&hooks).build();
-/// let result = context.eval(r#"eval("let a = 5")"#);
+/// let result = context.eval(Source::from_bytes(r#"eval("let a = 5")"#));
 /// assert_eq!(result.unwrap_err().to_string(), "TypeError: eval calls not available");
 /// ```
 ///

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -1,3 +1,5 @@
+use boa_parser::Source;
+
 use crate::{
     builtins::Number, check_output, exec, forward, forward_val, string::utf16,
     value::IntegerOrInfinity, Context, JsValue, TestAction,
@@ -454,7 +456,7 @@ fn test_invalid_break_target() {
         }
         "#;
 
-    assert!(Context::default().eval(src).is_err());
+    assert!(Context::default().eval(Source::from_bytes(src)).is_err());
 }
 
 #[test]
@@ -2091,7 +2093,7 @@ fn bigger_switch_example() {
             "#,
         );
 
-        assert_eq!(&exec(scenario), val);
+        assert_eq!(&exec(&scenario), val);
     }
 }
 

--- a/boa_engine/src/value/serde_json.rs
+++ b/boa_engine/src/value/serde_json.rs
@@ -168,6 +168,8 @@ impl JsValue {
 
 #[cfg(test)]
 mod tests {
+    use boa_parser::Source;
+
     use crate::object::JsArray;
     use crate::{Context, JsValue};
 
@@ -225,61 +227,61 @@ mod tests {
         let mut context = Context::default();
 
         let add = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 1000000 + 500
             "#,
-            )
+            ))
             .unwrap();
         let add: u32 = serde_json::from_value(add.to_json(&mut context).unwrap()).unwrap();
         assert_eq!(add, 1_000_500);
 
         let sub = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 1000000 - 500
             "#,
-            )
+            ))
             .unwrap();
         let sub: u32 = serde_json::from_value(sub.to_json(&mut context).unwrap()).unwrap();
         assert_eq!(sub, 999_500);
 
         let mult = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 1000000 * 500
             "#,
-            )
+            ))
             .unwrap();
         let mult: u32 = serde_json::from_value(mult.to_json(&mut context).unwrap()).unwrap();
         assert_eq!(mult, 500_000_000);
 
         let div = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 1000000 / 500
             "#,
-            )
+            ))
             .unwrap();
         let div: u32 = serde_json::from_value(div.to_json(&mut context).unwrap()).unwrap();
         assert_eq!(div, 2000);
 
         let rem = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 233894 % 500
             "#,
-            )
+            ))
             .unwrap();
         let rem: u32 = serde_json::from_value(rem.to_json(&mut context).unwrap()).unwrap();
         assert_eq!(rem, 394);
 
         let pow = context
-            .eval(
+            .eval(Source::from_bytes(
                 r#"
                 36 ** 5
             "#,
-            )
+            ))
             .unwrap();
 
         let pow: u32 = serde_json::from_value(pow.to_json(&mut context).unwrap()).unwrap();

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -1,3 +1,5 @@
+use boa_parser::Source;
+
 use crate::{check_output, exec, Context, JsValue, TestAction};
 
 #[test]
@@ -45,7 +47,7 @@ fn try_catch_finally_from_init() {
 
     assert_eq!(
         Context::default()
-            .eval(source.as_bytes())
+            .eval(Source::from_bytes(source))
             .unwrap_err()
             .as_opaque()
             .unwrap(),
@@ -68,7 +70,7 @@ fn multiple_catches() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::Undefined
     );
 }
@@ -87,7 +89,7 @@ fn use_last_expr_try_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::from("Hello!")
     );
 }
@@ -105,7 +107,7 @@ fn use_last_expr_catch_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::from("Hello!")
     );
 }
@@ -121,7 +123,7 @@ fn no_use_last_expr_finally_block() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::undefined()
     );
 }
@@ -140,7 +142,7 @@ fn finally_block_binding_env() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::from("Hey hey people")
     );
 }
@@ -159,7 +161,7 @@ fn run_super_method_in_object() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::from("super")
     );
 }
@@ -185,7 +187,7 @@ fn get_reference_by_super() {
     "#;
 
     assert_eq!(
-        Context::default().eval(source.as_bytes()).unwrap(),
+        Context::default().eval(Source::from_bytes(source)).unwrap(),
         JsValue::from("ab")
     );
 }

--- a/boa_examples/src/bin/classes.rs
+++ b/boa_examples/src/bin/classes.rs
@@ -4,7 +4,7 @@ use boa_engine::{
     class::{Class, ClassBuilder},
     error::JsNativeError,
     property::Attribute,
-    Context, JsResult, JsString, JsValue,
+    Context, JsResult, JsString, JsValue, Source,
 };
 
 use boa_gc::{Finalize, Trace};
@@ -130,7 +130,7 @@ fn main() {
     // Having done all of that, we can execute Javascript code with `eval`,
     // and access the `Person` class defined in Rust!
     context
-        .eval(
+        .eval(Source::from_bytes(
             r"
 		let person = new Person('John', 19);
 		person.sayHello();
@@ -146,6 +146,6 @@ fn main() {
         console.log(person.inheritedProperty);
 	    console.log(Person.prototype.inheritedProperty === person.inheritedProperty);
     ",
-        )
+        ))
         .unwrap();
 }

--- a/boa_examples/src/bin/closures.rs
+++ b/boa_examples/src/bin/closures.rs
@@ -9,7 +9,7 @@ use boa_engine::{
     object::{builtins::JsArray, FunctionObjectBuilder, JsObject},
     property::{Attribute, PropertyDescriptor},
     string::utf16,
-    Context, JsError, JsNativeError, JsString, JsValue,
+    Context, JsError, JsNativeError, JsString, JsValue, Source,
 };
 use boa_gc::{Finalize, GcRefCell, Trace};
 
@@ -36,7 +36,7 @@ fn main() -> Result<(), JsError> {
         }),
     );
 
-    assert_eq!(context.eval("closure()")?, 255.into());
+    assert_eq!(context.eval(Source::from_bytes("closure()"))?, 255.into());
 
     // We have created a closure with moved variables and executed that closure
     // inside Javascript!
@@ -117,13 +117,13 @@ fn main() -> Result<(), JsError> {
     );
 
     assert_eq!(
-        context.eval("createMessage()")?,
+        context.eval(Source::from_bytes("createMessage()"))?,
         "message from `Boa dev`: Hello!".into()
     );
 
     // The data mutates between calls
     assert_eq!(
-        context.eval("createMessage(); createMessage();")?,
+        context.eval(Source::from_bytes("createMessage(); createMessage();"))?,
         "message from `Boa dev`: Hello! Hello! Hello!".into()
     );
 
@@ -167,7 +167,7 @@ fn main() -> Result<(), JsError> {
     );
 
     // First call should return the array `[0]`.
-    let result = context.eval("enumerate()")?;
+    let result = context.eval(Source::from_bytes("enumerate()"))?;
     let object = result
         .as_object()
         .cloned()
@@ -178,7 +178,7 @@ fn main() -> Result<(), JsError> {
     assert_eq!(array.get(1, &mut context)?, JsValue::undefined());
 
     // First call should return the array `[0, 1]`.
-    let result = context.eval("enumerate()")?;
+    let result = context.eval(Source::from_bytes("enumerate()"))?;
     let object = result
         .as_object()
         .cloned()

--- a/boa_examples/src/bin/commuter_visitor.rs
+++ b/boa_examples/src/bin/commuter_visitor.rs
@@ -10,11 +10,11 @@ use boa_ast::{
     visitor::{VisitWith, VisitorMut},
     Expression,
 };
-use boa_engine::Context;
+use boa_engine::{Context, Source};
 use boa_interner::ToInternedString;
 use boa_parser::Parser;
 use core::ops::ControlFlow;
-use std::{convert::Infallible, fs::File, io::BufReader};
+use std::{convert::Infallible, path::Path};
 
 /// Visitor which, when applied to a binary expression, will swap the operands. Use in other
 /// circumstances is undefined.
@@ -65,9 +65,8 @@ impl<'ast> VisitorMut<'ast> for CommutorVisitor {
 }
 
 fn main() {
-    let mut parser = Parser::new(BufReader::new(
-        File::open("boa_examples/scripts/calc.js").unwrap(),
-    ));
+    let mut parser =
+        Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
     let mut ctx = Context::default();
 
     let mut statements = parser.parse_all(ctx.interner_mut()).unwrap();

--- a/boa_examples/src/bin/loadfile.rs
+++ b/boa_examples/src/bin/loadfile.rs
@@ -1,14 +1,14 @@
 // This example shows how to load, parse and execute JS code from a source file
 // (./scripts/helloworld.js)
 
-use std::fs;
+use std::path::Path;
 
-use boa_engine::Context;
+use boa_engine::{Context, Source};
 
 fn main() {
     let js_file_path = "./scripts/helloworld.js";
 
-    match fs::read(js_file_path) {
+    match Source::from_filepath(Path::new(js_file_path)) {
         Ok(src) => {
             // Instantiate the execution context
             let mut context = Context::default();

--- a/boa_examples/src/bin/loadstring.rs
+++ b/boa_examples/src/bin/loadstring.rs
@@ -1,6 +1,6 @@
 // This example loads, parses and executes a JS code string
 
-use boa_engine::Context;
+use boa_engine::{Context, Source};
 
 fn main() {
     let js_code = "console.log('Hello World from a JS code string!')";
@@ -9,7 +9,7 @@ fn main() {
     let mut context = Context::default();
 
     // Parse the source code
-    match context.eval(js_code) {
+    match context.eval(Source::from_bytes(js_code)) {
         Ok(res) => {
             println!(
                 "{}",

--- a/boa_examples/src/bin/modulehandler.rs
+++ b/boa_examples/src/bin/modulehandler.rs
@@ -3,7 +3,7 @@
 
 use boa_engine::{
     native_function::NativeFunction, prelude::JsObject, property::Attribute, Context, JsResult,
-    JsValue,
+    JsValue, Source,
 };
 use std::fs::read_to_string;
 
@@ -31,7 +31,7 @@ fn main() {
 
     // Instantiating the engine with the execution context
     // Loading, parsing and executing the JS code from the source file
-    ctx.eval(&buffer.unwrap()).unwrap();
+    ctx.eval(Source::from_bytes(&buffer.unwrap())).unwrap();
 }
 
 // Custom implementation that mimics the 'require' module loader
@@ -52,7 +52,7 @@ fn require(_: &JsValue, args: &[JsValue], ctx: &mut Context<'_>) -> JsResult<JsV
         Ok(JsValue::Rational(-1.0))
     } else {
         // Load and parse the module source
-        ctx.eval(&buffer.unwrap()).unwrap();
+        ctx.eval(Source::from_bytes(&buffer.unwrap())).unwrap();
 
         // Access module.exports and return as ResultValue
         let global_obj = ctx.global_object().to_owned();

--- a/boa_examples/src/bin/symbol_visitor.rs
+++ b/boa_examples/src/bin/symbol_visitor.rs
@@ -24,9 +24,8 @@ impl<'ast> Visitor<'ast> for SymbolVisitor {
 }
 
 fn main() {
-    let mut parser = Parser::new(
-        Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap(),
-    );
+    let mut parser =
+        Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
     let mut ctx = Context::default();
 
     let statements = parser.parse_all(ctx.interner_mut()).unwrap();

--- a/boa_examples/src/bin/symbol_visitor.rs
+++ b/boa_examples/src/bin/symbol_visitor.rs
@@ -25,7 +25,7 @@ impl<'ast> Visitor<'ast> for SymbolVisitor {
 
 fn main() {
     let mut parser = Parser::new(
-        Source::from_filepath(Path::new(Path::new("boa_examples/scripts/calc.js"))).unwrap(),
+        Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap(),
     );
     let mut ctx = Context::default();
 

--- a/boa_examples/src/bin/symbol_visitor.rs
+++ b/boa_examples/src/bin/symbol_visitor.rs
@@ -3,11 +3,11 @@
 // which mutates the AST.
 
 use boa_ast::visitor::Visitor;
-use boa_engine::Context;
+use boa_engine::{Context, Source};
 use boa_interner::Sym;
 use boa_parser::Parser;
 use core::ops::ControlFlow;
-use std::{collections::HashSet, convert::Infallible, fs::File, io::BufReader};
+use std::{collections::HashSet, convert::Infallible, path::Path};
 
 #[derive(Debug, Clone, Default)]
 struct SymbolVisitor {
@@ -24,9 +24,9 @@ impl<'ast> Visitor<'ast> for SymbolVisitor {
 }
 
 fn main() {
-    let mut parser = Parser::new(BufReader::new(
-        File::open("boa_examples/scripts/calc.js").unwrap(),
-    ));
+    let mut parser = Parser::new(
+        Source::from_filepath(Path::new(Path::new("boa_examples/scripts/calc.js"))).unwrap(),
+    );
     let mut ctx = Context::default();
 
     let statements = parser.parse_all(ctx.interner_mut()).unwrap();

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -95,7 +95,9 @@
 pub mod error;
 pub mod lexer;
 pub mod parser;
+mod source;
 
 pub use error::Error;
 pub use lexer::Lexer;
 pub use parser::Parser;
+pub use source::Source;

--- a/boa_parser/src/parser/tests/format/mod.rs
+++ b/boa_parser/src/parser/tests/format/mod.rs
@@ -16,7 +16,7 @@ mod statement;
 fn test_formatting(source: &'static str) {
     // Remove preceding newline.
 
-    use crate::Parser;
+    use crate::{Parser, Source};
     use boa_interner::{Interner, ToInternedString};
     let source = &source[1..];
 
@@ -30,8 +30,9 @@ fn test_formatting(source: &'static str) {
         .map(|l| &l[characters_to_remove..]) // Remove preceding whitespace from each line
         .collect::<Vec<&'static str>>()
         .join("\n");
+    let source = Source::from_bytes(source);
     let interner = &mut Interner::default();
-    let result = Parser::new(scenario.as_bytes())
+    let result = Parser::new(source)
         .parse_all(interner)
         .expect("parsing failed")
         .to_interned_string(interner);

--- a/boa_parser/src/parser/tests/mod.rs
+++ b/boa_parser/src/parser/tests/mod.rs
@@ -4,7 +4,7 @@ mod format;
 
 use std::convert::TryInto;
 
-use crate::Parser;
+use crate::{Parser, Source};
 use boa_ast::{
     declaration::{Declaration, LexicalDeclaration, VarDeclaration, Variable},
     expression::{
@@ -36,7 +36,7 @@ where
     L: Into<Box<[StatementListItem]>>,
 {
     assert_eq!(
-        Parser::new(js.as_bytes())
+        Parser::new(Source::from_bytes(js))
             .parse_all(interner)
             .expect("failed to parse"),
         StatementList::from(expr.into())
@@ -46,7 +46,7 @@ where
 /// Checks that the given javascript string creates a parse error.
 #[track_caller]
 pub(super) fn check_invalid(js: &str) {
-    assert!(Parser::new(js.as_bytes())
+    assert!(Parser::new(Source::from_bytes(js))
         .parse_all(&mut Interner::default())
         .is_err());
 }

--- a/boa_parser/src/source.rs
+++ b/boa_parser/src/source.rs
@@ -15,8 +15,9 @@ pub struct Source<'path, R> {
 }
 
 impl<'bytes> Source<'static, &'bytes [u8]> {
-    /// Creates a new `Source` from any type equivalent to a slice of bytes e.g. [`&str`], [`Vec<u8>`]
-    /// <code>[Box]<[\[u8\]][slice]></code> or a plain slice <code>[&\[u8\]][slice]</code>.
+    /// Creates a new `Source` from any type equivalent to a slice of bytes e.g. [`&str`][str],
+    /// <code>[Vec]<[u8]></code>, <code>[Box]<[\[u8\]][slice]></code> or a plain slice
+    /// <code>[&\[u8\]][slice]</code>.
     ///
     /// # Examples
     ///
@@ -26,7 +27,6 @@ impl<'bytes> Source<'static, &'bytes [u8]> {
     /// let source = Source::from_bytes(code);
     /// ```
     ///
-    /// [`&str`]: str
     /// [slice]: std::slice
     pub fn from_bytes<T: AsRef<[u8]> + ?Sized>(source: &'bytes T) -> Self {
         Self {

--- a/boa_parser/src/source.rs
+++ b/boa_parser/src/source.rs
@@ -1,0 +1,88 @@
+use std::{
+    fs::File,
+    io::{self, BufReader, Read},
+    path::Path,
+};
+
+/// A source of ECMAScript code.
+///
+/// [`Source`]s can be created from plain [`str`]s, file [`Path`]s or more generally, any [`Read`]
+/// instance.
+#[derive(Debug)]
+pub struct Source<'path, R> {
+    pub(crate) reader: R,
+    pub(crate) path: Option<&'path Path>,
+}
+
+impl<'bytes> Source<'static, &'bytes [u8]> {
+    /// Creates a new `Source` from any type equivalent to a slice of bytes e.g. [`&str`], [`Vec<u8>`]
+    /// <code>[Box]<[\[u8\]][slice]></code> or a plain slice <code>[&\[u8\]][slice]</code>.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_parser::Source;
+    /// let code = r#"var array = [5, 4, 3, 2, 1];"#;
+    /// let source = Source::from_bytes(code);
+    /// ```
+    ///
+    /// [`&str`]: str
+    /// [slice]: std::slice
+    pub fn from_bytes<T: AsRef<[u8]> + ?Sized>(source: &'bytes T) -> Self {
+        Self {
+            reader: source.as_ref(),
+            path: None,
+        }
+    }
+}
+
+impl<'path> Source<'path, BufReader<File>> {
+    /// Creates a new `Source` from a `Path` to a file.
+    ///
+    /// # Errors
+    ///
+    /// See [`File::open`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use boa_parser::Source;
+    /// # use std::{fs::File, path::Path};
+    /// # fn main() -> std::io::Result<()> {
+    /// let path = Path::new("script.js");
+    /// let source = Source::from_filepath(path)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_filepath(source: &'path Path) -> io::Result<Self> {
+        let reader = File::open(source)?;
+        Ok(Self {
+            reader: BufReader::new(reader),
+            path: Some(source),
+        })
+    }
+}
+
+impl<'path, R: Read> Source<'path, R> {
+    /// Creates a new `Source` from a [`Read`] instance and an optional [`Path`].
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use boa_parser::Source;
+    /// # use std::{fs::File, io::Read, path::Path};
+    /// # fn main() -> std::io::Result<()> {
+    /// let strictler = r#""use strict""#;
+    ///
+    /// let path = Path::new("no_strict.js");
+    /// let file = File::open(path)?;
+    /// let strict = strictler.as_bytes().chain(file);
+    ///
+    /// let source = Source::from_reader(strict, Some(path));
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub const fn from_reader(reader: R, path: Option<&'path Path>) -> Self {
+        Self { reader, path }
+    }
+}

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -14,7 +14,6 @@ rust-version.workspace = true
 [dependencies]
 boa_engine.workspace = true 
 boa_gc.workspace = true
-boa_parser.workspace = true
 clap = { version = "4.1.4", features = ["derive"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_yaml = "0.9.17"

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -2,7 +2,7 @@ use boa_engine::{
     builtins::JsArgs,
     object::{JsObject, ObjectInitializer},
     property::Attribute,
-    Context, JsNativeError, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue, Source,
 };
 
 /// Initializes the object in the context.
@@ -83,14 +83,15 @@ fn detach_array_buffer(
 fn eval_script(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
     args.get(0).and_then(JsValue::as_string).map_or_else(
         || Ok(JsValue::undefined()),
-        |source_text| match context.parse(source_text.to_std_string_escaped()) {
+        |source_text| match context.parse(Source::from_bytes(&source_text.to_std_string_escaped()))
+        {
             // TODO: check strict
             Err(e) => Err(JsNativeError::typ()
                 .with_message(format!("Uncaught Syntax Error: {e}"))
                 .into()),
             // Calling eval here parses the code a second time.
             // TODO: We can fix this after we have have defined the public api for the vm executer.
-            Ok(_) => context.eval(source_text.to_std_string_escaped()),
+            Ok(_) => context.eval(Source::from_bytes(&source_text.to_std_string_escaped())),
         },
     )
 }

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -297,16 +297,23 @@ fn run_test_suite(
 /// All the harness include files.
 #[derive(Debug, Clone)]
 struct Harness {
-    assert: Box<str>,
-    sta: Box<str>,
-    doneprint_handle: Box<str>,
-    includes: FxHashMap<Box<str>, Box<str>>,
+    assert: HarnessFile,
+    sta: HarnessFile,
+    doneprint_handle: HarnessFile,
+    includes: FxHashMap<Box<str>, HarnessFile>,
+}
+
+#[derive(Debug, Clone)]
+struct HarnessFile {
+    content: Box<str>,
+    path: Box<Path>,
 }
 
 /// Represents a test suite.
 #[derive(Debug, Clone)]
 struct TestSuite {
     name: Box<str>,
+    path: Box<Path>,
     suites: Box<[TestSuite]>,
     tests: Box<[Test]>,
 }
@@ -362,7 +369,7 @@ enum TestOutcomeResult {
 }
 
 /// Represents a test.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 struct Test {
     name: Box<str>,
@@ -374,16 +381,16 @@ struct Test {
     expected_outcome: Outcome,
     includes: Box<[Box<str>]>,
     locale: Locale,
-    content: Box<str>,
+    path: Box<Path>,
     ignored: bool,
 }
 
 impl Test {
     /// Creates a new test.
-    fn new<N, C>(name: N, content: C, metadata: MetaData) -> Self
+    fn new<N, C>(name: N, path: C, metadata: MetaData) -> Self
     where
         N: Into<Box<str>>,
-        C: Into<Box<str>>,
+        C: Into<Box<Path>>,
     {
         Self {
             name: name.into(),
@@ -395,7 +402,7 @@ impl Test {
             expected_outcome: Outcome::from(metadata.negative),
             includes: metadata.includes,
             locale: metadata.locale,
-            content: content.into(),
+            path: path.into(),
             ignored: false,
         }
     }

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -57,7 +57,7 @@
     clippy::nursery,
 )]
 
-use boa_engine::Context;
+use boa_engine::{Context, Source};
 use getrandom as _;
 use wasm_bindgen::prelude::*;
 
@@ -66,7 +66,7 @@ use wasm_bindgen::prelude::*;
 pub fn evaluate(src: &str) -> Result<String, JsValue> {
     // Setup executor
     Context::default()
-        .eval(src)
+        .eval(Source::from_bytes(src))
         .map_err(|e| JsValue::from(format!("Uncaught {e}")))
         .map(|v| v.display().to_string())
 }


### PR DESCRIPTION
Slightly related to #2411 since we need an API to pass module files, but more useful for #1760, #1313 and other error reporting issues.

It changes the following:

- Introduces a new `Source` API to store the path of a provided file or `None` if the source is a plain string.
- Improves the display of `boa_tester` to show the path of the tests being run. This also enables hyperlinks to directly jump to the tested file from the VS terminal.
- Adjusts the repo to this change.

Hopefully, this will improve our error display in the future.
