### PR TITLE
[Merged by Bors] - Improve identifier parsing

### DIFF
--- a/boa_ast/src/keyword.rs
+++ b/boa_ast/src/keyword.rs
@@ -10,7 +10,7 @@
 //! [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#Keywords
 
 use crate::expression::operator::binary::{BinaryOp, RelationalOp};
-use boa_interner::{Interner, Sym};
+use boa_interner::Sym;
 use boa_macros::utf16;
 use std::{convert::TryFrom, error, fmt, str::FromStr};
 
@@ -534,11 +534,52 @@ impl Keyword {
         }
     }
 
-    // TODO: promote all keywords to statics inside Interner
     /// Converts the keyword to a symbol in the given interner.
-    pub fn to_sym(self, interner: &mut Interner) -> Sym {
-        let (utf8, utf16) = self.as_str();
-        interner.get_or_intern_static(utf8, utf16)
+    #[must_use]
+    pub const fn to_sym(self) -> Sym {
+        match self {
+            Self::Await => Sym::AWAIT,
+            Self::Async => Sym::ASYNC,
+            Self::Break => Sym::BREAK,
+            Self::Case => Sym::CASE,
+            Self::Catch => Sym::CATCH,
+            Self::Class => Sym::CLASS,
+            Self::Continue => Sym::CONTINUE,
+            Self::Const => Sym::CONST,
+            Self::Debugger => Sym::DEBUGGER,
+            Self::Default => Sym::DEFAULT,
+            Self::Delete => Sym::DELETE,
+            Self::Do => Sym::DO,
+            Self::Else => Sym::ELSE,
+            Self::Enum => Sym::ENUM,
+            Self::Export => Sym::EXPORT,
+            Self::Extends => Sym::EXTENDS,
+            Self::False => Sym::FALSE,
+            Self::Finally => Sym::FINALLY,
+            Self::For => Sym::FOR,
+            Self::Function => Sym::FUNCTION,
+            Self::If => Sym::IF,
+            Self::In => Sym::IN,
+            Self::InstanceOf => Sym::INSTANCEOF,
+            Self::Import => Sym::IMPORT,
+            Self::Let => Sym::LET,
+            Self::New => Sym::NEW,
+            Self::Null => Sym::NULL,
+            Self::Of => Sym::OF,
+            Self::Return => Sym::RETURN,
+            Self::Super => Sym::SUPER,
+            Self::Switch => Sym::SWITCH,
+            Self::This => Sym::THIS,
+            Self::Throw => Sym::THROW,
+            Self::True => Sym::TRUE,
+            Self::Try => Sym::TRY,
+            Self::TypeOf => Sym::TYPEOF,
+            Self::Var => Sym::VAR,
+            Self::Void => Sym::VOID,
+            Self::While => Sym::WHILE,
+            Self::With => Sym::WITH,
+            Self::Yield => Sym::YIELD,
+        }
     }
 }
 

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -1518,7 +1518,10 @@ fn test_conditional_op() {
 #[test]
 fn test_identifier_op() {
     let scenario = "break = 1";
-    assert_eq!(&exec(scenario), "SyntaxError: expected token \'identifier\', got \'=\' in binding identifier at line 1, col 7");
+    assert_eq!(
+        &exec(scenario),
+        "SyntaxError: expected token \'identifier\', got \'=\' in identifier parsing at line 1, col 7"
+    );
 }
 
 #[test]

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -93,8 +93,6 @@
 
 extern crate alloc;
 
-extern crate static_assertions as sa;
-
 mod fixed_string;
 mod interned_str;
 mod raw;

--- a/boa_interner/src/sym.rs
+++ b/boa_interner/src/sym.rs
@@ -38,7 +38,7 @@ impl Sym {
         }
     }
 
-    /// Checks if this symbol is one of the [reserved words][spec] of the ECMAScript
+    /// Checks if this symbol is one of the [reserved identifiers][spec] of the ECMAScript
     /// specification, excluding `await` and `yield`
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-ReservedWord
@@ -48,7 +48,7 @@ impl Sym {
         (Self::BREAK..=Self::WITH).contains(&self)
     }
 
-    /// Checks if this symbol is one of the [strict reserved words][spec] of the ECMAScript
+    /// Checks if this symbol is one of the [strict reserved identifiers][spec] of the ECMAScript
     /// specification.
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-ReservedWord
@@ -106,9 +106,9 @@ static_syms! {
     "void",
     "while",
     "with",
-    // End reserved words
+    // End reserved identifier
 
-    // strict reserved words.
+    // strict reserved identifiers.
     // See: <https://tc39.es/ecma262/#prod-Identifier>
     // Note, they must all be together.
     "implements",
@@ -120,7 +120,7 @@ static_syms! {
     "public",
     "static",
     "yield",
-    // End reserved words
+    // End strict reserved identifiers
 
     "",
     "prototype",

--- a/boa_parser/src/error.rs
+++ b/boa_parser/src/error.rs
@@ -45,7 +45,7 @@ pub enum Error {
     /// When a token is unexpected
     Unexpected {
         /// The error message.
-        message: Option<&'static str>,
+        message: Box<str>,
 
         /// The token that was not expected.
         found: Box<str>,
@@ -101,11 +101,11 @@ impl Error {
         }
     }
 
-    /// Creates an `Expected` parsing error.
+    /// Creates an `Unexpected` parsing error.
     pub(crate) fn unexpected<F, C>(found: F, span: Span, message: C) -> Self
     where
         F: Into<Box<str>>,
-        C: Into<Option<&'static str>>,
+        C: Into<Box<str>>,
     {
         Self::Unexpected {
             found: found.into(),
@@ -187,8 +187,7 @@ impl fmt::Display for Error {
                 message,
             } => write!(
                 f,
-                "unexpected token '{found}'{} at line {}, col {}",
-                message.map_or_else(String::new, |m| format!(", {m}")),
+                "unexpected token '{found}', {message} at line {}, col {}",
                 span.start().line_number(),
                 span.start().column_number()
             ),

--- a/boa_parser/src/parser/cursor/mod.rs
+++ b/boa_parser/src/parser/cursor/mod.rs
@@ -36,6 +36,9 @@ pub(super) struct Cursor<R> {
 
     /// Indicate if the cursor is used in `JSON.parse`.
     json_parse: bool,
+
+    /// Indicate if the cursor's **goal symbol** is a Module.
+    module: bool,
 }
 
 impl<R> Cursor<R>
@@ -50,7 +53,19 @@ where
             private_environment_root_index: 0,
             arrow: false,
             json_parse: false,
+            module: false,
         }
+    }
+
+    /// Sets the goal symbol of the cursor to `Module`.
+    #[allow(unused)]
+    pub(super) fn set_module_mode(&mut self) {
+        self.module = true;
+    }
+
+    /// Returns `true` if the cursor is currently parsing a `Module`.
+    pub(super) const fn module_mode(&self) -> bool {
+        self.module
     }
 
     pub(super) fn set_goal(&mut self, elm: InputElement) {

--- a/boa_parser/src/parser/expression/left_hand_side/arguments.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/arguments.rs
@@ -72,10 +72,11 @@ where
                     let next_token = cursor.next(interner)?.expect(", token vanished"); // Consume the token.
 
                     if args.is_empty() {
-                        return Err(Error::unexpected(
+                        return Err(Error::expected(
+                            [String::from("expression")],
                             next_token.to_string(interner),
                             next_token.span(),
-                            None,
+                            "call",
                         ));
                     }
 

--- a/boa_parser/src/parser/expression/left_hand_side/call.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/call.rs
@@ -102,7 +102,7 @@ where
                             SimplePropertyAccess::new(lhs, *name).into()
                         }
                         TokenKind::Keyword((kw, _)) => {
-                            SimplePropertyAccess::new(lhs, kw.to_sym(interner)).into()
+                            SimplePropertyAccess::new(lhs, kw.to_sym()).into()
                         }
                         TokenKind::BooleanLiteral(true) => {
                             SimplePropertyAccess::new(lhs, Sym::TRUE).into()

--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -126,7 +126,7 @@ where
                                 SuperPropertyAccess::new(PropertyAccessField::from(*name))
                             }
                             TokenKind::Keyword((kw, _)) => {
-                                SuperPropertyAccess::new(kw.to_sym(interner).into())
+                                SuperPropertyAccess::new(kw.to_sym().into())
                             }
                             TokenKind::BooleanLiteral(true) => {
                                 SuperPropertyAccess::new(Sym::TRUE.into())
@@ -188,7 +188,7 @@ where
                             SimplePropertyAccess::new(lhs, *name).into()
                         }
                         TokenKind::Keyword((kw, _)) => {
-                            SimplePropertyAccess::new(lhs, kw.to_sym(interner)).into()
+                            SimplePropertyAccess::new(lhs, kw.to_sym()).into()
                         }
                         TokenKind::BooleanLiteral(true) => {
                             SimplePropertyAccess::new(lhs, Sym::TRUE).into()

--- a/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -72,7 +72,7 @@ where
                     }
                 }
                 TokenKind::Keyword((kw, _)) => OptionalOperationKind::SimplePropertyAccess {
-                    field: PropertyAccessField::Const(kw.to_sym(interner)),
+                    field: PropertyAccessField::Const(kw.to_sym()),
                 },
                 TokenKind::BooleanLiteral(true) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(Sym::TRUE),

--- a/boa_parser/src/parser/statement/switch/mod.rs
+++ b/boa_parser/src/parser/statement/switch/mod.rs
@@ -186,7 +186,7 @@ where
                         return Err(Error::unexpected(
                             token.to_string(interner),
                             token.span(),
-                            Some("more than one switch default"),
+                            "more than one switch default",
                         ));
                     }
 

--- a/boa_parser/src/parser/statement/try_stm/catch.rs
+++ b/boa_parser/src/parser/statement/try_stm/catch.rs
@@ -173,10 +173,11 @@ where
                     .parse(cursor, interner)?;
                 Ok(Binding::Identifier(ident))
             }
-            _ => Err(Error::unexpected(
+            _ => Err(Error::expected(
+                [String::from("pattern"), String::from("binding identifier")],
                 token.to_string(interner),
                 token.span(),
-                None,
+                "catch parameter",
             )),
         }
     }


### PR DESCRIPTION
Another change extracted from #2411.

This PR changes the following:

- Improves our identifier parsing with a new `Identifier` parser that unifies parsing for `IdentifierReference`, `BindingIdentifier` and `LabelIdentifier`.
- Slightly improves some error messages.
- Extracts our manual initialization of static `Sym`s with a new `static_syms` proc macro.
- Adds `set_module_mode` and `module_mode` to the cursor to prepare for modules.
