### PR TITLE
[Merged by Bors] - Remove Syntax Errors from Bytecompiler

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -250,7 +250,7 @@ impl Eval {
         // TODO: check if private identifiers inside `eval` are valid.
 
         // Compile and execute the eval statement list.
-        let code_block = context.compile_with_new_declarative(&body, strict)?;
+        let code_block = context.compile_with_new_declarative(&body, strict);
         // Indirect calls don't need extensions, because a non-strict indirect call modifies only
         // the global object.
         // Strict direct calls also don't need extensions, since all strict eval calls push a new

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -605,7 +605,7 @@ impl BuiltInFunctionObject {
                 .name(Sym::ANONYMOUS)
                 .generator(generator)
                 .r#async(r#async)
-                .compile(&parameters, &body, context)?;
+                .compile(&parameters, &body, context);
 
             let environments = context.realm.environments.pop_to_global();
 
@@ -633,7 +633,7 @@ impl BuiltInFunctionObject {
                     &FormalParameterList::default(),
                     &StatementList::default(),
                     context,
-                )?;
+                );
 
             let environments = context.realm.environments.pop_to_global();
             let function_object =
@@ -646,7 +646,7 @@ impl BuiltInFunctionObject {
                 &FormalParameterList::default(),
                 &StatementList::default(),
                 context,
-            )?;
+            );
 
             let environments = context.realm.environments.pop_to_global();
             let function_object = crate::vm::create_function_object(

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -206,7 +206,7 @@ impl Json {
         let mut parser = Parser::new(Source::from_bytes(&script_string));
         parser.set_json_parse();
         let statement_list = parser.parse_script(context.interner_mut())?;
-        let code_block = context.compile_json_parse(&statement_list)?;
+        let code_block = context.compile_json_parse(&statement_list);
         let unfiltered = context.execute(code_block)?;
 
         // 11. If IsCallable(reviver) is true, then

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -1,12 +1,10 @@
-use boa_ast::{
-    pattern::{ArrayPatternElement, ObjectPatternElement, Pattern},
-    property::PropertyName,
-};
-
 use crate::{
     bytecompiler::{Access, ByteCompiler, Literal},
     vm::{BindingOpcode, Opcode},
-    JsResult,
+};
+use boa_ast::{
+    pattern::{ArrayPatternElement, ObjectPatternElement, Pattern},
+    property::PropertyName,
 };
 
 impl ByteCompiler<'_, '_> {
@@ -14,7 +12,7 @@ impl ByteCompiler<'_, '_> {
         &mut self,
         pattern: &Pattern,
         def: BindingOpcode,
-    ) -> JsResult<()> {
+    ) {
         match pattern {
             Pattern::Object(pattern) => {
                 self.emit_opcode(Opcode::ValueNotNullOrUndefined);
@@ -44,7 +42,7 @@ impl ByteCompiler<'_, '_> {
                                     self.emit(Opcode::GetPropertyByName, &[index]);
                                 }
                                 PropertyName::Computed(node) => {
-                                    self.compile_expr(node, true)?;
+                                    self.compile_expr(node, true);
                                     if rest_exits {
                                         self.emit_opcode(Opcode::GetPropertyByValuePush);
                                     } else {
@@ -56,7 +54,7 @@ impl ByteCompiler<'_, '_> {
                             if let Some(init) = default_init {
                                 let skip =
                                     self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                                self.compile_expr(init, true)?;
+                                self.compile_expr(init, true);
                                 self.patch_jump(skip);
                             }
                             self.emit_binding(def, *ident);
@@ -101,7 +99,7 @@ impl ByteCompiler<'_, '_> {
                                 Access::Property { access },
                                 false,
                                 ByteCompiler::access_set_top_of_stack_expr_fn,
-                            )?;
+                            );
                         }
                         AssignmentPropertyAccess {
                             name,
@@ -115,7 +113,7 @@ impl ByteCompiler<'_, '_> {
                                     self.emit(Opcode::GetPropertyByName, &[index]);
                                 }
                                 PropertyName::Computed(node) => {
-                                    self.compile_expr(node, true)?;
+                                    self.compile_expr(node, true);
                                     if rest_exits {
                                         self.emit_opcode(Opcode::GetPropertyByValuePush);
                                     } else {
@@ -127,7 +125,7 @@ impl ByteCompiler<'_, '_> {
                             if let Some(init) = default_init {
                                 let skip =
                                     self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                                self.compile_expr(init, true)?;
+                                self.compile_expr(init, true);
                                 self.patch_jump(skip);
                             }
 
@@ -135,7 +133,7 @@ impl ByteCompiler<'_, '_> {
                                 Access::Property { access },
                                 false,
                                 ByteCompiler::access_set_top_of_stack_expr_fn,
-                            )?;
+                            );
 
                             if rest_exits && name.computed().is_some() {
                                 self.emit_opcode(Opcode::Swap);
@@ -154,7 +152,7 @@ impl ByteCompiler<'_, '_> {
                                     self.emit(Opcode::GetPropertyByName, &[index]);
                                 }
                                 PropertyName::Computed(node) => {
-                                    self.compile_expr(node, true)?;
+                                    self.compile_expr(node, true);
                                     self.emit_opcode(Opcode::GetPropertyByValue);
                                 }
                             }
@@ -162,11 +160,11 @@ impl ByteCompiler<'_, '_> {
                             if let Some(init) = default_init {
                                 let skip =
                                     self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                                self.compile_expr(init, true)?;
+                                self.compile_expr(init, true);
                                 self.patch_jump(skip);
                             }
 
-                            self.compile_declaration_pattern(pattern, def)?;
+                            self.compile_declaration_pattern(pattern, def);
                         }
                     }
                 }
@@ -200,7 +198,7 @@ impl ByteCompiler<'_, '_> {
                             if let Some(init) = default_init {
                                 let skip =
                                     self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                                self.compile_expr(init, true)?;
+                                self.compile_expr(init, true);
                                 self.patch_jump(skip);
                             }
                             self.emit_binding(def, *ident);
@@ -211,7 +209,7 @@ impl ByteCompiler<'_, '_> {
                                 Access::Property { access },
                                 false,
                                 ByteCompiler::access_set_top_of_stack_expr_fn,
-                            )?;
+                            );
                         }
                         // BindingElement : BindingPattern Initializer[opt]
                         Pattern {
@@ -223,11 +221,11 @@ impl ByteCompiler<'_, '_> {
                             if let Some(init) = default_init {
                                 let skip =
                                     self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                                self.compile_expr(init, true)?;
+                                self.compile_expr(init, true);
                                 self.patch_jump(skip);
                             }
 
-                            self.compile_declaration_pattern(pattern, def)?;
+                            self.compile_declaration_pattern(pattern, def);
                         }
                         // BindingRestElement : ... BindingIdentifier
                         SingleNameRest { ident } => {
@@ -240,12 +238,12 @@ impl ByteCompiler<'_, '_> {
                                 Access::Property { access },
                                 false,
                                 ByteCompiler::access_set_top_of_stack_expr_fn,
-                            )?;
+                            );
                         }
                         // BindingRestElement : ... BindingPattern
                         PatternRest { pattern } => {
                             self.emit_opcode(Opcode::IteratorToArray);
-                            self.compile_declaration_pattern(pattern, def)?;
+                            self.compile_declaration_pattern(pattern, def);
                         }
                     }
                 }
@@ -253,6 +251,5 @@ impl ByteCompiler<'_, '_> {
                 self.emit_opcode(Opcode::IteratorClose);
             }
         }
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -1,7 +1,6 @@
 use crate::{
     bytecompiler::{Access, ByteCompiler},
     vm::{BindingOpcode, Opcode},
-    JsResult,
 };
 use boa_ast::expression::{
     access::{PropertyAccess, PropertyAccessField},
@@ -9,19 +8,18 @@ use boa_ast::expression::{
 };
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_assign(&mut self, assign: &Assign, use_expr: bool) -> JsResult<()> {
+    pub(crate) fn compile_assign(&mut self, assign: &Assign, use_expr: bool) {
         if assign.op() == AssignOp::Assign {
             match Access::from_assign_target(assign.lhs()) {
                 Ok(access) => self.access_set(access, use_expr, |compiler, _| {
-                    compiler.compile_expr(assign.rhs(), true)?;
-                    Ok(())
-                })?,
+                    compiler.compile_expr(assign.rhs(), true);
+                }),
                 Err(pattern) => {
-                    self.compile_expr(assign.rhs(), true)?;
+                    self.compile_expr(assign.rhs(), true);
                     if use_expr {
                         self.emit_opcode(Opcode::Dup);
                     }
-                    self.compile_declaration_pattern(pattern, BindingOpcode::SetName)?;
+                    self.compile_declaration_pattern(pattern, BindingOpcode::SetName);
                 }
             }
         } else {
@@ -62,9 +60,9 @@ impl ByteCompiler<'_, '_> {
 
                     if short_circuit {
                         early_exit = Some(self.emit_opcode_with_operand(opcode));
-                        self.compile_expr(assign.rhs(), true)?;
+                        self.compile_expr(assign.rhs(), true);
                     } else {
-                        self.compile_expr(assign.rhs(), true)?;
+                        self.compile_expr(assign.rhs(), true);
                         self.emit_opcode(opcode);
                     }
                     if use_expr {
@@ -79,7 +77,7 @@ impl ByteCompiler<'_, '_> {
                     PropertyAccess::Simple(access) => match access.field() {
                         PropertyAccessField::Const(name) => {
                             let index = self.get_or_insert_name((*name).into());
-                            self.compile_expr(access.target(), true)?;
+                            self.compile_expr(access.target(), true);
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
 
@@ -87,9 +85,9 @@ impl ByteCompiler<'_, '_> {
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                             } else {
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                                 self.emit_opcode(opcode);
                             }
 
@@ -99,17 +97,17 @@ impl ByteCompiler<'_, '_> {
                             }
                         }
                         PropertyAccessField::Expr(expr) => {
-                            self.compile_expr(access.target(), true)?;
+                            self.compile_expr(access.target(), true);
                             self.emit_opcode(Opcode::Dup);
-                            self.compile_expr(expr, true)?;
+                            self.compile_expr(expr, true);
 
                             self.emit_opcode(Opcode::GetPropertyByValuePush);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                             } else {
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                                 self.emit_opcode(opcode);
                             }
 
@@ -121,16 +119,16 @@ impl ByteCompiler<'_, '_> {
                     },
                     PropertyAccess::Private(access) => {
                         let index = self.get_or_insert_private_name(access.field());
-                        self.compile_expr(access.target(), true)?;
+                        self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
 
                         self.emit(Opcode::GetPrivateField, &[index]);
                         if short_circuit {
                             pop_count = 1;
                             early_exit = Some(self.emit_opcode_with_operand(opcode));
-                            self.compile_expr(assign.rhs(), true)?;
+                            self.compile_expr(assign.rhs(), true);
                         } else {
-                            self.compile_expr(assign.rhs(), true)?;
+                            self.compile_expr(assign.rhs(), true);
                             self.emit_opcode(opcode);
                         }
 
@@ -151,9 +149,9 @@ impl ByteCompiler<'_, '_> {
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                             } else {
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                                 self.emit_opcode(opcode);
                             }
 
@@ -165,15 +163,15 @@ impl ByteCompiler<'_, '_> {
                         PropertyAccessField::Expr(expr) => {
                             self.emit_opcode(Opcode::Super);
                             self.emit_opcode(Opcode::Dup);
-                            self.compile_expr(expr, true)?;
+                            self.compile_expr(expr, true);
 
                             self.emit_opcode(Opcode::GetPropertyByValuePush);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                             } else {
-                                self.compile_expr(assign.rhs(), true)?;
+                                self.compile_expr(assign.rhs(), true);
                                 self.emit_opcode(opcode);
                             }
 
@@ -201,7 +199,5 @@ impl ByteCompiler<'_, '_> {
                 }
             }
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/binary.rs
+++ b/boa_engine/src/bytecompiler/expression/binary.rs
@@ -3,14 +3,14 @@ use boa_ast::expression::operator::{
     Binary, BinaryInPrivate,
 };
 
-use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode};
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_binary(&mut self, binary: &Binary, use_expr: bool) -> JsResult<()> {
-        self.compile_expr(binary.lhs(), true)?;
+    pub(crate) fn compile_binary(&mut self, binary: &Binary, use_expr: bool) {
+        self.compile_expr(binary.lhs(), true);
         match binary.op() {
             BinaryOp::Arithmetic(op) => {
-                self.compile_expr(binary.rhs(), true)?;
+                self.compile_expr(binary.rhs(), true);
                 match op {
                     ArithmeticOp::Add => self.emit_opcode(Opcode::Add),
                     ArithmeticOp::Sub => self.emit_opcode(Opcode::Sub),
@@ -25,7 +25,7 @@ impl ByteCompiler<'_, '_> {
                 }
             }
             BinaryOp::Bitwise(op) => {
-                self.compile_expr(binary.rhs(), true)?;
+                self.compile_expr(binary.rhs(), true);
                 match op {
                     BitwiseOp::And => self.emit_opcode(Opcode::BitAnd),
                     BitwiseOp::Or => self.emit_opcode(Opcode::BitOr),
@@ -40,7 +40,7 @@ impl ByteCompiler<'_, '_> {
                 }
             }
             BinaryOp::Relational(op) => {
-                self.compile_expr(binary.rhs(), true)?;
+                self.compile_expr(binary.rhs(), true);
                 match op {
                     RelationalOp::Equal => self.emit_opcode(Opcode::Eq),
                     RelationalOp::NotEqual => self.emit_opcode(Opcode::NotEq),
@@ -64,17 +64,17 @@ impl ByteCompiler<'_, '_> {
                 match op {
                     LogicalOp::And => {
                         let exit = self.emit_opcode_with_operand(Opcode::LogicalAnd);
-                        self.compile_expr(binary.rhs(), true)?;
+                        self.compile_expr(binary.rhs(), true);
                         self.patch_jump(exit);
                     }
                     LogicalOp::Or => {
                         let exit = self.emit_opcode_with_operand(Opcode::LogicalOr);
-                        self.compile_expr(binary.rhs(), true)?;
+                        self.compile_expr(binary.rhs(), true);
                         self.patch_jump(exit);
                     }
                     LogicalOp::Coalesce => {
                         let exit = self.emit_opcode_with_operand(Opcode::Coalesce);
-                        self.compile_expr(binary.rhs(), true)?;
+                        self.compile_expr(binary.rhs(), true);
                         self.patch_jump(exit);
                     }
                 };
@@ -85,30 +85,22 @@ impl ByteCompiler<'_, '_> {
             }
             BinaryOp::Comma => {
                 self.emit(Opcode::Pop, &[]);
-                self.compile_expr(binary.rhs(), true)?;
+                self.compile_expr(binary.rhs(), true);
 
                 if !use_expr {
                     self.emit(Opcode::Pop, &[]);
                 }
             }
         };
-
-        Ok(())
     }
 
-    pub(crate) fn compile_binary_in_private(
-        &mut self,
-        binary: &BinaryInPrivate,
-        use_expr: bool,
-    ) -> JsResult<()> {
+    pub(crate) fn compile_binary_in_private(&mut self, binary: &BinaryInPrivate, use_expr: bool) {
         let index = self.get_or_insert_private_name(*binary.lhs());
-        self.compile_expr(binary.rhs(), true)?;
+        self.compile_expr(binary.rhs(), true);
         self.emit(Opcode::InPrivate, &[index]);
 
         if !use_expr {
             self.emit_opcode(Opcode::Pop);
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -1,32 +1,27 @@
+use crate::{
+    bytecompiler::{Access, ByteCompiler, NodeKind},
+    vm::Opcode,
+};
 use boa_ast::{
     expression::literal::ObjectLiteral,
     property::{MethodDefinition, PropertyDefinition, PropertyName},
 };
 use boa_interner::Sym;
 
-use crate::{
-    bytecompiler::{Access, ByteCompiler, NodeKind},
-    vm::Opcode,
-    JsNativeError, JsResult,
-};
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_object_literal(
-        &mut self,
-        object: &ObjectLiteral,
-        use_expr: bool,
-    ) -> JsResult<()> {
+    pub(crate) fn compile_object_literal(&mut self, object: &ObjectLiteral, use_expr: bool) {
         self.emit_opcode(Opcode::PushEmptyObject);
         for property in object.properties() {
             self.emit_opcode(Opcode::Dup);
             match property {
                 PropertyDefinition::IdentifierReference(ident) => {
                     let index = self.get_or_insert_name(*ident);
-                    self.access_get(Access::Variable { name: *ident }, true)?;
+                    self.access_get(Access::Variable { name: *ident }, true);
                     self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                 }
                 PropertyDefinition::Property(name, expr) => match name {
                     PropertyName::Literal(name) => {
-                        self.compile_expr(expr, true)?;
+                        self.compile_expr(expr, true);
                         let index = self.get_or_insert_name((*name).into());
                         if *name == Sym::__PROTO__ && !self.json_parse {
                             self.emit_opcode(Opcode::SetPrototype);
@@ -35,15 +30,15 @@ impl ByteCompiler<'_, '_> {
                         }
                     }
                     PropertyName::Computed(name_node) => {
-                        self.compile_expr(name_node, true)?;
+                        self.compile_expr(name_node, true);
                         self.emit_opcode(Opcode::ToPropertyKey);
                         if expr.is_anonymous_function_definition() {
                             self.emit_opcode(Opcode::Dup);
-                            self.compile_expr(expr, true)?;
+                            self.compile_expr(expr, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
                         } else {
-                            self.compile_expr(expr, true)?;
+                            self.compile_expr(expr, true);
                         }
                         self.emit_opcode(Opcode::DefineOwnPropertyByValue);
                     }
@@ -51,15 +46,15 @@ impl ByteCompiler<'_, '_> {
                 PropertyDefinition::MethodDefinition(name, kind) => match kind {
                     MethodDefinition::Get(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::SetPropertyGetterByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(1);
                             self.emit_opcode(Opcode::SetPropertyGetterByValue);
@@ -67,15 +62,15 @@ impl ByteCompiler<'_, '_> {
                     },
                     MethodDefinition::Set(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::SetPropertySetterByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(2);
                             self.emit_opcode(Opcode::SetPropertySetterByValue);
@@ -83,15 +78,15 @@ impl ByteCompiler<'_, '_> {
                     },
                     MethodDefinition::Ordinary(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
                             self.emit_opcode(Opcode::DefineOwnPropertyByValue);
@@ -99,15 +94,15 @@ impl ByteCompiler<'_, '_> {
                     },
                     MethodDefinition::Async(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
                             self.emit_opcode(Opcode::DefineOwnPropertyByValue);
@@ -115,15 +110,15 @@ impl ByteCompiler<'_, '_> {
                     },
                     MethodDefinition::Generator(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
                             self.emit_opcode(Opcode::DefineOwnPropertyByValue);
@@ -131,15 +126,15 @@ impl ByteCompiler<'_, '_> {
                     },
                     MethodDefinition::AsyncGenerator(expr) => match name {
                         PropertyName::Literal(name) => {
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             let index = self.get_or_insert_name((*name).into());
                             self.emit(Opcode::DefineOwnPropertyByName, &[index]);
                         }
                         PropertyName::Computed(name_node) => {
-                            self.compile_expr(name_node, true)?;
+                            self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
                             self.emit_opcode(Opcode::Dup);
-                            self.function(expr.into(), NodeKind::Expression, true)?;
+                            self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
                             self.emit_opcode(Opcode::DefineOwnPropertyByValue);
@@ -147,16 +142,13 @@ impl ByteCompiler<'_, '_> {
                     },
                 },
                 PropertyDefinition::SpreadObject(expr) => {
-                    self.compile_expr(expr, true)?;
+                    self.compile_expr(expr, true);
                     self.emit_opcode(Opcode::Swap);
                     self.emit(Opcode::CopyDataProperties, &[0, 0]);
                     self.emit_opcode(Opcode::Pop);
                 }
-                // TODO: Promote to early errors
                 PropertyDefinition::CoverInitializedName(_, _) => {
-                    return Err(JsNativeError::syntax()
-                        .with_message("invalid assignment pattern in object literal")
-                        .into())
+                    unreachable!("invalid assignment pattern in object literal")
                 }
             }
         }
@@ -164,7 +156,5 @@ impl ByteCompiler<'_, '_> {
         if !use_expr {
             self.emit(Opcode::Pop, &[]);
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -6,17 +6,16 @@ use boa_ast::{
 use crate::{
     bytecompiler::{Access, ByteCompiler},
     vm::Opcode,
-    JsResult,
 };
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_unary(&mut self, unary: &Unary, use_expr: bool) -> JsResult<()> {
+    pub(crate) fn compile_unary(&mut self, unary: &Unary, use_expr: bool) {
         let opcode = match unary.op() {
             UnaryOp::Delete => {
                 if let Some(access) = Access::from_expression(unary.target()) {
-                    self.access_delete(access)?;
+                    self.access_delete(access);
                 } else {
-                    self.compile_expr(unary.target(), false)?;
+                    self.compile_expr(unary.target(), false);
                     self.emit(Opcode::PushTrue, &[]);
                 }
                 None
@@ -32,7 +31,7 @@ impl ByteCompiler<'_, '_> {
                         let index = self.get_or_insert_binding(binding);
                         self.emit(Opcode::GetNameOrUndefined, &[index]);
                     }
-                    expr => self.compile_expr(expr, true)?,
+                    expr => self.compile_expr(expr, true),
                 }
                 self.emit_opcode(Opcode::TypeOf);
                 None
@@ -41,14 +40,12 @@ impl ByteCompiler<'_, '_> {
         };
 
         if let Some(opcode) = opcode {
-            self.compile_expr(unary.target(), true)?;
+            self.compile_expr(unary.target(), true);
             self.emit(opcode, &[]);
         }
 
         if !use_expr {
             self.emit(Opcode::Pop, &[]);
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -1,53 +1,46 @@
 use crate::{
     bytecompiler::{Access, ByteCompiler},
     vm::Opcode,
-    JsResult,
 };
 use boa_ast::expression::operator::{update::UpdateOp, Update};
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_update(&mut self, update: &Update, use_expr: bool) -> JsResult<()> {
+    pub(crate) fn compile_update(&mut self, update: &Update, use_expr: bool) {
         let access = Access::from_update_target(update.target());
 
         match update.op() {
             UpdateOp::IncrementPre => {
                 self.access_set(access, true, |compiler, _| {
-                    compiler.access_get(access, true)?;
+                    compiler.access_get(access, true);
                     compiler.emit_opcode(Opcode::Inc);
-                    Ok(())
-                })?;
+                });
             }
             UpdateOp::DecrementPre => {
                 self.access_set(access, true, |compiler, _| {
-                    compiler.access_get(access, true)?;
+                    compiler.access_get(access, true);
                     compiler.emit_opcode(Opcode::Dec);
-                    Ok(())
-                })?;
+                });
             }
             UpdateOp::IncrementPost => {
                 self.access_set(access, false, |compiler, level| {
-                    compiler.access_get(access, true)?;
+                    compiler.access_get(access, true);
                     compiler.emit_opcode(Opcode::IncPost);
                     compiler.emit_opcode(Opcode::RotateRight);
                     compiler.emit_u8(level + 2);
-                    Ok(())
-                })?;
+                });
             }
             UpdateOp::DecrementPost => {
                 self.access_set(access, false, |compiler, level| {
-                    compiler.access_get(access, true)?;
+                    compiler.access_get(access, true);
                     compiler.emit_opcode(Opcode::DecPost);
                     compiler.emit_opcode(Opcode::RotateRight);
                     compiler.emit_u8(level + 2);
-                    Ok(())
-                })?;
+                });
             }
         }
 
         if !use_expr {
             self.emit_opcode(Opcode::Pop);
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::function::ThisMode,
     bytecompiler::ByteCompiler,
     vm::{BindingOpcode, CodeBlock, Opcode},
-    Context, JsResult,
+    Context,
 };
 use boa_ast::{
     declaration::Binding, function::FormalParameterList, operations::bound_names, StatementList,
@@ -91,7 +91,7 @@ impl FunctionCompiler {
         parameters: &FormalParameterList,
         body: &StatementList,
         context: &mut Context<'_>,
-    ) -> JsResult<Gc<CodeBlock>> {
+    ) -> Gc<CodeBlock> {
         self.strict = self.strict || body.strict();
 
         let length = parameters.length();
@@ -159,7 +159,7 @@ impl FunctionCompiler {
                     // TODO: throw custom error if ident is in init
                     if let Some(init) = parameter.variable().init() {
                         let skip = compiler.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                        compiler.compile_expr(init, true)?;
+                        compiler.compile_expr(init, true);
                         compiler.patch_jump(skip);
                     }
                     compiler.emit_binding(BindingOpcode::InitArg, *ident);
@@ -171,10 +171,10 @@ impl FunctionCompiler {
                     // TODO: throw custom error if ident is in init
                     if let Some(init) = parameter.variable().init() {
                         let skip = compiler.emit_opcode_with_operand(Opcode::JumpIfNotUndefined);
-                        compiler.compile_expr(init, true)?;
+                        compiler.compile_expr(init, true);
                         compiler.patch_jump(skip);
                     }
-                    compiler.compile_declaration_pattern(pattern, BindingOpcode::InitArg)?;
+                    compiler.compile_declaration_pattern(pattern, BindingOpcode::InitArg);
                 }
             }
         }
@@ -200,7 +200,7 @@ impl FunctionCompiler {
         }
 
         compiler.create_script_decls(body, false);
-        compiler.compile_statement_list(body, false, false)?;
+        compiler.compile_statement_list(body, false, false);
 
         if let Some(env_label) = env_label {
             let (num_bindings, compile_environment) =
@@ -234,6 +234,6 @@ impl FunctionCompiler {
         compiler.emit(Opcode::PushUndefined, &[]);
         compiler.emit(Opcode::Return, &[]);
 
-        Ok(Gc::new(compiler.finish()))
+        Gc::new(compiler.finish())
     }
 }

--- a/boa_engine/src/bytecompiler/module.rs
+++ b/boa_engine/src/bytecompiler/module.rs
@@ -1,36 +1,24 @@
-use boa_ast::{ModuleItem, ModuleItemList};
-
-use crate::JsResult;
-
 use super::ByteCompiler;
+use boa_ast::{ModuleItem, ModuleItemList};
 
 impl ByteCompiler<'_, '_> {
     /// Compiles a [`ModuleItemList`].
     #[inline]
-    pub fn compile_module_item_list(
-        &mut self,
-        list: &ModuleItemList,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
+    pub fn compile_module_item_list(&mut self, list: &ModuleItemList, configurable_globals: bool) {
         for node in list.items() {
-            self.compile_module_item(node, configurable_globals)?;
+            self.compile_module_item(node, configurable_globals);
         }
-        Ok(())
     }
 
     /// Compiles a [`ModuleItem`].
     #[inline]
     #[allow(unused_variables, clippy::missing_panics_doc)] // Unimplemented
-    pub fn compile_module_item(
-        &mut self,
-        item: &ModuleItem,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
+    pub fn compile_module_item(&mut self, item: &ModuleItem, configurable_globals: bool) {
         match item {
             ModuleItem::ImportDeclaration(import) => todo!("import declaration compilation"),
             ModuleItem::ExportDeclaration(export) => todo!("export declaration compilation"),
             ModuleItem::StatementListItem(stmt) => {
-                self.compile_stmt_list_item(stmt, false, configurable_globals)
+                self.compile_stmt_list_item(stmt, false, configurable_globals);
             }
         }
     }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -1,4 +1,4 @@
-use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode};
 
 use boa_ast::statement::Block;
 
@@ -9,12 +9,12 @@ impl ByteCompiler<'_, '_> {
         block: &Block,
         use_expr: bool,
         configurable_globals: bool,
-    ) -> JsResult<()> {
+    ) {
         self.context.push_compile_time_environment(false);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
         self.create_script_decls(block.statement_list(), configurable_globals);
-        self.compile_statement_list(block.statement_list(), use_expr, configurable_globals)?;
+        self.compile_statement_list(block.statement_list(), use_expr, configurable_globals);
 
         let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
         let index_compile_environment = self.push_compile_environment(compile_environment);
@@ -22,7 +22,5 @@ impl ByteCompiler<'_, '_> {
         self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
 
         self.emit_opcode(Opcode::PopEnvironment);
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/if.rs
+++ b/boa_engine/src/bytecompiler/statement/if.rs
@@ -1,12 +1,12 @@
-use crate::{bytecompiler::ByteCompiler, JsResult};
+use crate::bytecompiler::ByteCompiler;
 use boa_ast::statement::If;
 
 impl ByteCompiler<'_, '_> {
-    pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) -> JsResult<()> {
-        self.compile_expr(node.cond(), true)?;
+    pub(crate) fn compile_if(&mut self, node: &If, configurable_globals: bool) {
+        self.compile_expr(node.cond(), true);
         let jelse = self.jump_if_false();
 
-        self.compile_stmt(node.body(), false, configurable_globals)?;
+        self.compile_stmt(node.body(), false, configurable_globals);
 
         match node.else_node() {
             None => {
@@ -15,11 +15,9 @@ impl ByteCompiler<'_, '_> {
             Some(else_body) => {
                 let exit = self.jump();
                 self.patch_jump(jelse);
-                self.compile_stmt(else_body, false, configurable_globals)?;
+                self.compile_stmt(else_body, false, configurable_globals);
                 self.patch_jump(exit);
             }
         }
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -1,12 +1,10 @@
-use boa_ast::{
-    statement::{Labelled, LabelledItem},
-    Statement,
-};
-
 use crate::{
     bytecompiler::{ByteCompiler, NodeKind},
     vm::Opcode,
-    JsResult,
+};
+use boa_ast::{
+    statement::{Labelled, LabelledItem},
+    Statement,
 };
 
 impl ByteCompiler<'_, '_> {
@@ -16,7 +14,7 @@ impl ByteCompiler<'_, '_> {
         labelled: &Labelled,
         use_expr: bool,
         configurable_globals: bool,
-    ) -> JsResult<()> {
+    ) {
         let labelled_loc = self.next_opcode_location();
         let end_label = self.emit_opcode_with_operand(Opcode::LabelledStart);
         self.push_labelled_control_info(labelled.label(), labelled_loc);
@@ -24,40 +22,40 @@ impl ByteCompiler<'_, '_> {
         match labelled.item() {
             LabelledItem::Statement(stmt) => match stmt {
                 Statement::ForLoop(for_loop) => {
-                    self.compile_for_loop(for_loop, Some(labelled.label()), configurable_globals)?;
+                    self.compile_for_loop(for_loop, Some(labelled.label()), configurable_globals);
                 }
                 Statement::ForInLoop(for_in_loop) => {
                     self.compile_for_in_loop(
                         for_in_loop,
                         Some(labelled.label()),
                         configurable_globals,
-                    )?;
+                    );
                 }
                 Statement::ForOfLoop(for_of_loop) => {
                     self.compile_for_of_loop(
                         for_of_loop,
                         Some(labelled.label()),
                         configurable_globals,
-                    )?;
+                    );
                 }
                 Statement::WhileLoop(while_loop) => {
                     self.compile_while_loop(
                         while_loop,
                         Some(labelled.label()),
                         configurable_globals,
-                    )?;
+                    );
                 }
                 Statement::DoWhileLoop(do_while_loop) => {
                     self.compile_do_while_loop(
                         do_while_loop,
                         Some(labelled.label()),
                         configurable_globals,
-                    )?;
+                    );
                 }
-                stmt => self.compile_stmt(stmt, use_expr, configurable_globals)?,
+                stmt => self.compile_stmt(stmt, use_expr, configurable_globals),
             },
             LabelledItem::Function(f) => {
-                self.function(f.into(), NodeKind::Declaration, false)?;
+                self.function(f.into(), NodeKind::Declaration, false);
             }
         }
 
@@ -65,7 +63,5 @@ impl ByteCompiler<'_, '_> {
         self.patch_jump_with_target(end_label, labelled_end);
         self.pop_labelled_control_info();
         self.emit_opcode(Opcode::LabelledEnd);
-
-        Ok(())
     }
 }

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -1,4 +1,4 @@
-use crate::{bytecompiler::ByteCompiler, vm::Opcode, JsResult};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode};
 
 use boa_ast::Statement;
 
@@ -13,57 +13,51 @@ mod r#try;
 
 impl ByteCompiler<'_, '_> {
     /// Compiles a [`Statement`] `boa_ast` node.
-    pub fn compile_stmt(
-        &mut self,
-        node: &Statement,
-        use_expr: bool,
-        configurable_globals: bool,
-    ) -> JsResult<()> {
+    pub fn compile_stmt(&mut self, node: &Statement, use_expr: bool, configurable_globals: bool) {
         match node {
-            Statement::Var(var) => self.compile_var_decl(var)?,
-            Statement::If(node) => self.compile_if(node, configurable_globals)?,
+            Statement::Var(var) => self.compile_var_decl(var),
+            Statement::If(node) => self.compile_if(node, configurable_globals),
             Statement::ForLoop(for_loop) => {
-                self.compile_for_loop(for_loop, None, configurable_globals)?;
+                self.compile_for_loop(for_loop, None, configurable_globals);
             }
             Statement::ForInLoop(for_in_loop) => {
-                self.compile_for_in_loop(for_in_loop, None, configurable_globals)?;
+                self.compile_for_in_loop(for_in_loop, None, configurable_globals);
             }
             Statement::ForOfLoop(for_of_loop) => {
-                self.compile_for_of_loop(for_of_loop, None, configurable_globals)?;
+                self.compile_for_of_loop(for_of_loop, None, configurable_globals);
             }
             Statement::WhileLoop(while_loop) => {
-                self.compile_while_loop(while_loop, None, configurable_globals)?;
+                self.compile_while_loop(while_loop, None, configurable_globals);
             }
             Statement::DoWhileLoop(do_while_loop) => {
-                self.compile_do_while_loop(do_while_loop, None, configurable_globals)?;
+                self.compile_do_while_loop(do_while_loop, None, configurable_globals);
             }
             Statement::Block(block) => {
-                self.compile_block(block, use_expr, configurable_globals)?;
+                self.compile_block(block, use_expr, configurable_globals);
             }
             Statement::Labelled(labelled) => {
-                self.compile_labelled(labelled, use_expr, configurable_globals)?;
+                self.compile_labelled(labelled, use_expr, configurable_globals);
             }
-            Statement::Continue(node) => self.compile_continue(*node)?,
-            Statement::Break(node) => self.compile_break(*node)?,
+            Statement::Continue(node) => self.compile_continue(*node),
+            Statement::Break(node) => self.compile_break(*node),
             Statement::Throw(throw) => {
-                self.compile_expr(throw.target(), true)?;
+                self.compile_expr(throw.target(), true);
                 self.emit(Opcode::Throw, &[]);
             }
             Statement::Switch(switch) => {
-                self.compile_switch(switch, configurable_globals)?;
+                self.compile_switch(switch, configurable_globals);
             }
             Statement::Return(ret) => {
                 if let Some(expr) = ret.target() {
-                    self.compile_expr(expr, true)?;
+                    self.compile_expr(expr, true);
                 } else {
                     self.emit(Opcode::PushUndefined, &[]);
                 }
                 self.emit(Opcode::Return, &[]);
             }
-            Statement::Try(t) => self.compile_try(t, use_expr, configurable_globals)?,
+            Statement::Try(t) => self.compile_try(t, use_expr, configurable_globals),
             Statement::Empty => {}
-            Statement::Expression(expr) => self.compile_expr(expr, use_expr)?,
+            Statement::Expression(expr) => self.compile_expr(expr, use_expr),
         }
-        Ok(())
     }
 }

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -231,7 +231,7 @@ impl Context<'_> {
         let _timer = Profiler::global().start_event("Script compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
         compiler.create_script_decls(statement_list, false);
-        compiler.compile_statement_list(statement_list, true, false)?;
+        compiler.compile_statement_list(statement_list, true, false);
         Ok(Gc::new(compiler.finish()))
     }
 
@@ -241,7 +241,7 @@ impl Context<'_> {
 
         let mut compiler = ByteCompiler::new(Sym::MAIN, true, false, self);
         compiler.create_module_decls(statement_list, false);
-        compiler.compile_module_item_list(statement_list, false)?;
+        compiler.compile_module_item_list(statement_list, false);
         Ok(Gc::new(compiler.finish()))
     }
 
@@ -465,15 +465,12 @@ impl Context<'_> {
     }
 
     /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
-    pub(crate) fn compile_json_parse(
-        &mut self,
-        statement_list: &StatementList,
-    ) -> JsResult<Gc<CodeBlock>> {
+    pub(crate) fn compile_json_parse(&mut self, statement_list: &StatementList) -> Gc<CodeBlock> {
         let _timer = Profiler::global().start_event("Compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), true, self);
         compiler.create_script_decls(statement_list, false);
-        compiler.compile_statement_list(statement_list, true, false)?;
-        Ok(Gc::new(compiler.finish()))
+        compiler.compile_statement_list(statement_list, true, false);
+        Gc::new(compiler.finish())
     }
 
     /// Compile the AST into a `CodeBlock` with an additional declarative environment.
@@ -481,11 +478,11 @@ impl Context<'_> {
         &mut self,
         statement_list: &StatementList,
         strict: bool,
-    ) -> JsResult<Gc<CodeBlock>> {
+    ) -> Gc<CodeBlock> {
         let _timer = Profiler::global().start_event("Compilation", "Main");
         let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
-        compiler.compile_statement_list_with_new_declarative(statement_list, true, strict)?;
-        Ok(Gc::new(compiler.finish()))
+        compiler.compile_statement_list_with_new_declarative(statement_list, true, strict);
+        Gc::new(compiler.finish())
     }
 }
 

--- a/boa_engine/src/tests.rs
+++ b/boa_engine/src/tests.rs
@@ -471,7 +471,7 @@ fn test_invalid_break() {
     let string = forward(&mut context, src);
     assert_eq!(
         string,
-        "Uncaught SyntaxError: unlabeled break must be inside loop or switch"
+        "Uncaught SyntaxError: Syntax Error: illegal break statement at position: 1:1"
     );
 }
 
@@ -486,7 +486,7 @@ fn test_invalid_continue_target() {
     let string = forward(&mut context, src);
     assert_eq!(
         string,
-        "Uncaught SyntaxError: Cannot use the undeclared label 'nonexistent'"
+        "Uncaught SyntaxError: Syntax Error: undefined continue target: nonexistent at position: 1:1"
     );
 }
 
@@ -494,7 +494,10 @@ fn test_invalid_continue_target() {
 fn test_invalid_continue() {
     let mut context = Context::default();
     let string = forward(&mut context, r"continue;");
-    assert_eq!(string, "Uncaught SyntaxError: continue must be inside loop");
+    assert_eq!(
+        string,
+        "Uncaught SyntaxError: Syntax Error: illegal continue statement at position: 1:1"
+    );
 }
 
 #[test]

--- a/boa_parser/src/parser/function/mod.rs
+++ b/boa_parser/src/parser/function/mod.rs
@@ -19,6 +19,10 @@ use crate::{
     },
     Error,
 };
+use ast::{
+    operations::{check_labels, contains_invalid_object_literal},
+    Position,
+};
 use boa_ast::{
     self as ast,
     declaration::Variable,
@@ -448,7 +452,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("FunctionStatementList", "Parsing");
 
-        StatementList::new(
+        let statement_list = StatementList::new(
             self.allow_yield,
             self.allow_await,
             true,
@@ -456,6 +460,22 @@ where
             true,
             false,
         )
-        .parse(cursor, interner)
+        .parse(cursor, interner)?;
+
+        if let Some(error) = check_labels(&statement_list, interner) {
+            return Err(Error::lex(LexError::Syntax(
+                error.into_boxed_str(),
+                Position::new(1, 1),
+            )));
+        }
+
+        if contains_invalid_object_literal(&statement_list) {
+            return Err(Error::lex(LexError::Syntax(
+                "invalid object literal in function statement list".into(),
+                Position::new(1, 1),
+            )));
+        }
+
+        Ok(statement_list)
     }
 }

--- a/boa_parser/src/parser/function/mod.rs
+++ b/boa_parser/src/parser/function/mod.rs
@@ -462,9 +462,9 @@ where
         )
         .parse(cursor, interner)?;
 
-        if let Some(error) = check_labels(&statement_list, interner) {
+        if let Err(error) = check_labels(&statement_list) {
             return Err(Error::lex(LexError::Syntax(
-                error.into_boxed_str(),
+                error.message(interner).into(),
                 Position::new(1, 1),
             )));
         }

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -334,9 +334,9 @@ where
             }
         }
 
-        if let Some(error) = check_labels(&body, interner) {
+        if let Err(error) = check_labels(&body) {
             return Err(Error::lex(LexError::Syntax(
-                error.into_boxed_str(),
+                error.message(interner).into(),
                 Position::new(1, 1),
             )));
         }

--- a/boa_parser/src/parser/statement/break_stm/tests.rs
+++ b/boa_parser/src/parser/statement/break_stm/tests.rs
@@ -1,7 +1,7 @@
 use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
-    statement::{Block, Break, WhileLoop},
+    statement::{Block, Break, Labelled, LabelledItem, WhileLoop},
     Statement, StatementListItem,
 };
 use boa_interner::{Interner, Sym};
@@ -54,15 +54,18 @@ fn inline_block_semicolon_insertion() {
 fn new_line_semicolon_insertion() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "test: while (true) {
             break test
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Break(
-                Break::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Break(
+                    Break::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
+                ))])
+                .into(),
+            ))),
+            interner.get_or_intern_static("test", utf16!("test")),
         ))
         .into()],
         interner,
@@ -89,15 +92,18 @@ fn inline_block() {
 fn new_line_block() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "test: while (true) {
             break test;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Break(
-                Break::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Break(
+                    Break::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
+                ))])
+                .into(),
+            ))),
+            interner.get_or_intern_static("test", utf16!("test")),
         ))
         .into()],
         interner,
@@ -108,15 +114,18 @@ fn new_line_block() {
 fn reserved_label() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "await: while (true) {
             break await;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Break(
-                Break::new(Some(Sym::AWAIT)),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Break(
+                    Break::new(Some(Sym::AWAIT)),
+                ))])
+                .into(),
+            ))),
+            Sym::AWAIT,
         ))
         .into()],
         interner,
@@ -124,15 +133,18 @@ fn reserved_label() {
 
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "yield: while (true) {
             break yield;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Break(
-                Break::new(Some(Sym::YIELD)),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Break(
+                    Break::new(Some(Sym::YIELD)),
+                ))])
+                .into(),
+            ))),
+            Sym::YIELD,
         ))
         .into()],
         interner,

--- a/boa_parser/src/parser/statement/continue_stm/tests.rs
+++ b/boa_parser/src/parser/statement/continue_stm/tests.rs
@@ -1,7 +1,7 @@
 use crate::parser::tests::check_script_parser;
 use boa_ast::{
     expression::literal::Literal,
-    statement::{Block, Continue, WhileLoop},
+    statement::{Block, Continue, Labelled, LabelledItem, WhileLoop},
     Statement, StatementListItem,
 };
 use boa_interner::{Interner, Sym};
@@ -54,15 +54,18 @@ fn inline_block_semicolon_insertion() {
 fn new_line_semicolon_insertion() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "test: while (true) {
             continue test
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Continue(
-                Continue::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Continue(
+                    Continue::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
+                ))])
+                .into(),
+            ))),
+            interner.get_or_intern_static("test", utf16!("test")),
         ))
         .into()],
         interner,
@@ -89,15 +92,18 @@ fn inline_block() {
 fn new_line_block() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "test: while (true) {
             continue test;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Continue(
-                Continue::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Continue(
+                    Continue::new(Some(interner.get_or_intern_static("test", utf16!("test")))),
+                ))])
+                .into(),
+            ))),
+            interner.get_or_intern_static("test", utf16!("test")),
         ))
         .into()],
         interner,
@@ -108,15 +114,18 @@ fn new_line_block() {
 fn reserved_label() {
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "await: while (true) {
             continue await;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Continue(
-                Continue::new(Some(Sym::AWAIT)),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Continue(
+                    Continue::new(Some(Sym::AWAIT)),
+                ))])
+                .into(),
+            ))),
+            Sym::AWAIT,
         ))
         .into()],
         interner,
@@ -124,15 +133,18 @@ fn reserved_label() {
 
     let interner = &mut Interner::default();
     check_script_parser(
-        "while (true) {
+        "yield: while (true) {
             continue yield;
         }",
-        vec![Statement::WhileLoop(WhileLoop::new(
-            Literal::from(true).into(),
-            Block::from(vec![StatementListItem::Statement(Statement::Continue(
-                Continue::new(Some(Sym::YIELD)),
-            ))])
-            .into(),
+        vec![Statement::Labelled(Labelled::new(
+            LabelledItem::Statement(Statement::WhileLoop(WhileLoop::new(
+                Literal::from(true).into(),
+                Block::from(vec![StatementListItem::Statement(Statement::Continue(
+                    Continue::new(Some(Sym::YIELD)),
+                ))])
+                .into(),
+            ))),
+            Sym::YIELD,
         ))
         .into()],
         interner,

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -1377,9 +1377,9 @@ where
                     }
                 }
 
-                if let Some(error) = check_labels(block, interner) {
+                if let Err(error) = check_labels(block) {
                     return Err(Error::lex(LexError::Syntax(
-                        error.into_boxed_str(),
+                        error.message(interner).into(),
                         position,
                     )));
                 }

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -897,9 +897,9 @@ where
         while cursor.peek(0, interner)?.is_some() {
             let item = ModuleItem.parse(cursor, interner)?;
 
-            if let Some(error) = check_labels(&item, interner) {
+            if let Err(error) = check_labels(&item) {
                 return Err(Error::lex(LexError::Syntax(
-                    error.into_boxed_str(),
+                    error.message(interner).into(),
                     Position::new(1, 1),
                 )));
             }

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -47,6 +47,10 @@ use crate::{
     },
     Error,
 };
+use ast::{
+    operations::{check_labels, contains_invalid_object_literal},
+    Position,
+};
 use boa_ast::{
     self as ast,
     pattern::{ArrayPattern, ArrayPatternElement, ObjectPatternElement},
@@ -193,7 +197,8 @@ where
                 cursor.advance(interner);
                 Ok(ast::Statement::Empty)
             }
-            TokenKind::IdentifierName(_) => {
+            TokenKind::IdentifierName(_)
+            | TokenKind::Keyword((Keyword::Await | Keyword::Yield, false)) => {
                 // Labelled Statement check
                 cursor.set_goal(InputElement::Div);
                 let tok = cursor.peek(1, interner)?;
@@ -890,7 +895,23 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let mut list = Vec::new();
         while cursor.peek(0, interner)?.is_some() {
-            list.push(ModuleItem.parse(cursor, interner)?);
+            let item = ModuleItem.parse(cursor, interner)?;
+
+            if let Some(error) = check_labels(&item, interner) {
+                return Err(Error::lex(LexError::Syntax(
+                    error.into_boxed_str(),
+                    Position::new(1, 1),
+                )));
+            }
+
+            if contains_invalid_object_literal(&item) {
+                return Err(Error::lex(LexError::Syntax(
+                    "invalid object literal in module item list".into(),
+                    Position::new(1, 1),
+                )));
+            }
+
+            list.push(item);
         }
 
         Ok(list.into())


### PR DESCRIPTION
This Pull Request closes #1907.

It changes the following:

- Implement several early errors relating to labels, `break` and `continue` in the parser.
- Implement an early error for invalid cover grammar of object literals in the parser.
- Remove all remaining syntax errors from the bytecompiler.
