### PR TITLE
[Merged by Bors] - Fix doc tests and add CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,8 @@ jobs:
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features intl
+      - name: Test docs
+        run: cargo test --doc --profile ci --features intl
 
   misc:
     name: Misc

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -3,10 +3,11 @@
 //! Native classes are implemented through the [`Class`][class-trait] trait.
 //! ```
 //! # use boa_engine::{
+//! #    NativeFunction,
 //! #    property::Attribute,
 //! #    class::{Class, ClassBuilder},
 //! #    Context, JsResult, JsValue,
-//! #    builtins::JsArgs,
+//! #    JsArgs,
 //! # };
 //! # use boa_gc::{Finalize, Trace};
 //! #

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -31,7 +31,7 @@ use super::intrinsics::Intrinsics;
 ///     }
 /// }
 /// let hooks = Hooks; // Can have additional state.
-/// let context = &mut ContextBuilder::new().host_hooks(&hooks).build();
+/// let context = &mut ContextBuilder::new().host_hooks(&hooks).build().unwrap();
 /// let result = context.eval_script(Source::from_bytes(r#"eval("let a = 5")"#));
 /// assert_eq!(result.unwrap_err().to_string(), "TypeError: eval calls not available");
 /// ```

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -172,11 +172,12 @@ impl Context<'_> {
         result
     }
 
+    // TODO: remove `ignore` after we implement module execution
     /// Evaluates the given module `src` by compiling down to bytecode, then interpreting the
     /// bytecode into a value.
     ///
     /// # Examples
-    /// ```
+    /// ```ignore
     /// # use boa_engine::{Context, Source};
     /// let mut context = Context::default();
     ///

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -135,6 +135,7 @@ mod tests;
 pub mod prelude {
     pub use crate::{
         error::{JsError, JsNativeError, JsNativeErrorKind},
+        native_function::NativeFunction,
         object::JsObject,
         Context, JsBigInt, JsResult, JsString, JsValue,
     };
@@ -149,6 +150,7 @@ pub use crate::{
     bigint::JsBigInt,
     context::Context,
     error::{JsError, JsNativeError, JsNativeErrorKind},
+    native_function::NativeFunction,
     string::JsString,
     symbol::JsSymbol,
     value::JsValue,

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -2037,12 +2037,18 @@ impl<'ctx, 'host> FunctionObjectBuilder<'ctx, 'host> {
 /// # Examples
 ///
 /// ```
-/// # use boa_engine::{Context, JsValue, object::ObjectInitializer, property::Attribute};
+/// # use boa_engine::{
+/// #     Context,
+/// #     JsValue,
+/// #     NativeFunction,
+/// #     object::ObjectInitializer,
+/// #     property::Attribute
+/// # };
 /// let mut context = Context::default();
 /// let object = ObjectInitializer::new(&mut context)
 ///     .property("hello", "world", Attribute::all())
 ///     .property(1, 1, Attribute::all())
-///     .function(|_, _, _| Ok(JsValue::undefined()), "func", 0)
+///     .function(NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())), "func", 0)
 ///     .build();
 /// ```
 ///


### PR DESCRIPTION
This Pull Request fixes #2605.

It changes the following:

- Adds a CI check to run `cargo test --doc` since `nextest` doesn't support doc tests at the moment.
- Fixes the failing doc tests.
