### PR TITLE
[Merged by Bors] - Optimize Get/SetPropertyByName

### DIFF
--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -21,9 +21,9 @@ use crate::{
         Number,
     },
     error::JsNativeError,
-    js_string,
     object::{JsObject, ObjectData},
     property::{PropertyDescriptor, PropertyKey},
+    string::utf16,
     symbol::JsSymbol,
     Context, JsBigInt, JsResult, JsString,
 };
@@ -526,7 +526,7 @@ impl JsValue {
                     JsObject::from_proto_and_data(prototype, ObjectData::string(string.clone()));
                 // Make sure the correct length is set on our new string object
                 object.insert_property(
-                    js_string!("length"),
+                    utf16!("length"),
                     PropertyDescriptor::builder()
                         .value(string.len())
                         .writable(false)

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -1,7 +1,7 @@
 use crate::{
     property::PropertyKey,
     vm::{opcode::Operation, ShouldExit},
-    Context, JsResult, JsString,
+    Context, JsResult,
 };
 
 /// `GetPropertyByName` implements the Opcode Operation for `Opcode::GetPropertyByName`
@@ -28,7 +28,7 @@ impl Operation for GetPropertyByName {
         let key: PropertyKey = context
             .interner()
             .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+            .utf16()
             .into();
         let result = object.__get__(&key, value, context)?;
 

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -25,11 +25,8 @@ impl Operation for GetPropertyByName {
             value.to_object(context)?
         };
 
-        let key: PropertyKey = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .utf16()
-            .into();
+        let name = context.vm.frame().code_block.names[index as usize];
+        let key: PropertyKey = context.interner().resolve_expect(name.sym()).utf16().into();
         let result = object.__get__(&key, value, context)?;
 
         context.vm.push(result);

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -29,11 +29,7 @@ impl Operation for SetPropertyByName {
         };
 
         let name = context.vm.frame().code_block.names[index as usize];
-        let name: PropertyKey = context
-            .interner()
-            .resolve_expect(name.sym())
-            .into_common::<JsString>(false)
-            .into();
+        let name: PropertyKey = context.interner().resolve_expect(name.sym()).utf16().into();
 
         //object.set(name, value.clone(), context.vm.frame().code.strict, context)?;
         let succeeded = object.__set__(name.clone(), value.clone(), receiver, context)?;


### PR DESCRIPTION
Similar to #2604, `GetPropertyByName`/`SetPropertyByName` has only string property key. So, we can skip index and utf16 conversions.

This improves QuickJS benchmark score 5.8% on average.
Richards: 37.0 -> 41.2
DeltaBlue: 38.1 -> 41.4
Crypto: 59.6 -> 59.8
RayTrace: 146 -> 159
EarleyBoyer: 138 -> 142
Splay: 104 -> 106
NavierStokes: 10.2 -> 10.3 