### PR TITLE
[Merged by Bors] - Bump bitflags to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f6e5df9abedba5099a01a6567c6086a6fbcff57af07c360d356737f9e0c644"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,7 +304,7 @@ name = "boa_ast"
 version = "0.16.0"
 dependencies = [
  "arbitrary",
- "bitflags",
+ "bitflags 2.0.0",
  "boa_interner",
  "boa_macros",
  "num-bigint",
@@ -324,7 +333,7 @@ dependencies = [
 name = "boa_engine"
 version = "0.16.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "boa_ast",
  "boa_gc",
  "boa_icu_provider",
@@ -433,7 +442,7 @@ dependencies = [
 name = "boa_parser"
 version = "0.16.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -459,7 +468,7 @@ dependencies = [
 name = "boa_tester"
 version = "0.16.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.0",
  "boa_engine",
  "boa_gc",
  "clap 4.1.8",
@@ -648,7 +657,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
  "unicode-width",
@@ -661,7 +670,7 @@ version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap",
  "textwrap 0.16.0",
@@ -673,7 +682,7 @@ version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex 0.3.2",
  "is-terminal",
@@ -1158,7 +1167,7 @@ version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "proc-macro-error",
@@ -2589,7 +2598,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "static_assertions",
@@ -2735,7 +2744,7 @@ version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -3132,7 +3141,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3179,7 +3188,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76e189c2369884dce920945e2ddf79b3dff49e071a167dd1817fa9c4c00d512e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "mach",
  "winapi",
@@ -3320,7 +3329,7 @@ version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -3340,7 +3349,7 @@ version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfc8644681285d1fb67a467fb3021bfea306b99b4146b166a1fe3ada965eece"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "clipboard-win",
  "dirs-next",
@@ -3423,7 +3432,7 @@ version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -11,14 +11,14 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-serde = ["dep:serde", "boa_interner/serde"]
+serde = ["dep:serde", "boa_interner/serde", "bitflags/serde"]
 arbitrary = ["dep:arbitrary", "boa_interner/arbitrary", "num-bigint/arbitrary"]
 
 [dependencies]
 boa_interner.workspace = true
 boa_macros.workspace = true
 rustc-hash = "1.1.0"
-bitflags = { version = "2.0.0", features = ["serde"] }
+bitflags = "2.0.0"
 num-bigint = "0.4.3"
 serde = { version = "1.0.155", features = ["derive"], optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -18,7 +18,7 @@ arbitrary = ["dep:arbitrary", "boa_interner/arbitrary", "num-bigint/arbitrary"]
 boa_interner.workspace = true
 boa_macros.workspace = true
 rustc-hash = "1.1.0"
-bitflags = "1.3.2"
+bitflags = { version = "2.0.0", features = ["serde"] }
 num-bigint = "0.4.3"
 serde = { version = "1.0.155", features = ["derive"], optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -176,7 +176,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FormalParameterList {
 
 bitflags! {
     /// Flags for a [`FormalParameterList`].
-    #[allow(clippy::unsafe_derive_deserialize)]
+    #[derive(Debug, Copy, Clone, PartialEq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct FormalParameterListFlags: u8 {
         /// Has only identifier parameters with no initialization expressions.

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -51,7 +51,7 @@ regress = "0.5.0"
 rustc-hash = "1.1.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-integer = "0.1.45"
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 indexmap = "1.9.2"
 ryu-js = "0.2.2"
 chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "wasmbind"] }

--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -26,6 +26,7 @@ pub(crate) struct JumpControlInfo {
 
 bitflags! {
     /// A bitflag that contains the type flags and relevant booleans for `JumpControlInfo`.
+    #[derive(Debug, Clone, Copy)]
     pub(crate) struct JumpControlInfoFlags: u8 {
         const LOOP = 0b0000_0001;
         const SWITCH = 0b0000_0010;

--- a/boa_engine/src/property/attribute/mod.rs
+++ b/boa_engine/src/property/attribute/mod.rs
@@ -15,6 +15,7 @@ bitflags! {
     ///  - `[[Configurable]]` (`CONFIGURABLE`) - If `false`, attempts to delete the property,
     /// change the property to be an `accessor property`, or change its attributes (other than `[[Value]]`,
     /// or changing `[[Writable]]` to `false`) will fail.
+    #[derive(Debug, Clone, Copy)]
     pub struct Attribute: u8 {
         /// The `Writable` attribute decides whether the value associated with the property can be changed or not, from its initial value.
         const WRITABLE = 0b0000_0001;
@@ -40,7 +41,7 @@ impl Attribute {
     /// Clear all flags.
     #[inline]
     pub fn clear(&mut self) {
-        self.bits = 0;
+        *self.0.bits_mut() = 0;
     }
 
     /// Sets the `writable` flag.

--- a/boa_parser/Cargo.toml
+++ b/boa_parser/Cargo.toml
@@ -19,6 +19,6 @@ boa_unicode.workspace = true
 rustc-hash = "1.1.0"
 fast-float = "0.2.0"
 num-traits = "0.2.15"
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 num-bigint = "0.4.3"
 regress = "0.5.0"

--- a/boa_parser/src/lexer/regex.rs
+++ b/boa_parser/src/lexer/regex.rs
@@ -146,7 +146,7 @@ impl<R> Tokenizer<R> for RegexLiteral {
 
 bitflags! {
     /// Flags of a regular expression.
-    #[derive(Default)]
+    #[derive(Debug, Default, Copy, Clone)]
     pub struct RegExpFlags: u8 {
         /// Whether to test the regular expression against all possible matches in a string,
         /// or only against the first.

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 serde = { version = "1.0.155", features = ["derive"] }
 serde_yaml = "0.9.19"
 serde_json = "1.0.94"
-bitflags = "1.3.2"
+bitflags = "2.0.0"
 regex = "1.7.1"
 once_cell = "1.17.1"
 colored = "2.0.0"

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -444,6 +444,7 @@ impl From<Option<Negative>> for Outcome {
 }
 
 bitflags! {
+    #[derive(Debug, Clone, Copy)]
     struct TestFlags: u16 {
         const STRICT = 0b0_0000_0001;
         const NO_STRICT = 0b0_0000_0010;


### PR DESCRIPTION
Updated `bitflags`, overrides #2665.
