### PR TITLE
[Merged by Bors] - Avoid unneeded bounds checks in bytecode address patching

### DIFF
--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -547,12 +547,17 @@ impl<'b, 'host> ByteCompiler<'b, 'host> {
         let Label { index } = label;
 
         let index = index as usize;
-
         let bytes = target.to_ne_bytes();
-        self.bytecode[index + 1] = bytes[0];
-        self.bytecode[index + 2] = bytes[1];
-        self.bytecode[index + 3] = bytes[2];
-        self.bytecode[index + 4] = bytes[3];
+
+        // This is done to avoid unneeded bounds checks.
+        assert!(self.bytecode.len() > index + std::mem::size_of::<u32>());
+        // SAFETY: We already checked that it is not out-of-bounds.
+        unsafe {
+            *self.bytecode.get_unchecked_mut(index + 1) = bytes[0];
+            *self.bytecode.get_unchecked_mut(index + 2) = bytes[1];
+            *self.bytecode.get_unchecked_mut(index + 3) = bytes[2];
+            *self.bytecode.get_unchecked_mut(index + 4) = bytes[3];
+        }
     }
 
     fn patch_jump(&mut self, label: Label) {


### PR DESCRIPTION
As discussed in this comment https://github.com/boa-dev/boa/pull/2669#discussion_r1137618027,
`rustc` doesn't seem to optimize out the bounds checks.