### PR TITLE
[Merged by Bors] - Fix exponent operator

### DIFF
--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -212,7 +212,7 @@ impl JsValue {
                 }
             }
             (Self::Integer(x), Self::Rational(y)) => {
-                if x.abs() == 1 && y.is_infinite() {
+                if x.wrapping_abs() == 1 && y.is_infinite() {
                     Self::nan()
                 } else {
                     Self::new(f64::from(*x).powf(*y))


### PR DESCRIPTION
When `abs(base) == 1` and `y == +/- Infinity` result should be `NaN`

Fixes the remaining failing tests in the `exponentiation` test suite
