### PR TITLE
[Merged by Bors] - Fix incorrect `Number.MIN_VALUE` value

### DIFF
--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -170,7 +170,7 @@ impl Number {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number.min_value
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE
-    pub(crate) const MIN_VALUE: f64 = f64::MIN_POSITIVE;
+    pub(crate) const MIN_VALUE: f64 = 5e-324;
 
     /// This function returns a `JsResult` of the number `Value`.
     ///

--- a/boa_engine/src/builtins/number/tests.rs
+++ b/boa_engine/src/builtins/number/tests.rs
@@ -294,7 +294,7 @@ fn number_constants() {
         TestAction::assert_eq("Number.MAX_SAFE_INTEGER", Number::MAX_SAFE_INTEGER),
         TestAction::assert_eq("Number.MIN_SAFE_INTEGER", Number::MIN_SAFE_INTEGER),
         TestAction::assert_eq("Number.MAX_VALUE", f64::MAX),
-        TestAction::assert_eq("Number.MIN_VALUE", f64::MIN_POSITIVE),
+        TestAction::assert_eq("Number.MIN_VALUE", Number::MIN_VALUE),
         TestAction::assert_eq("Number.POSITIVE_INFINITY", f64::INFINITY),
         TestAction::assert_eq("Number.NEGATIVE_INFINITY", -f64::INFINITY),
     ]);


### PR DESCRIPTION
This will fix the remaining test of the `multiplication` and `division` test suite

It changes the following:
- Change `Number.MIN_VALUE` from `f64::MIN_POSITIVE` to `5e-324` value
