### PR TITLE
[Merged by Bors] - Add `--strict` flag to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ Arguments:
           The JavaScript file(s) to be evaluated
 
 Options:
+      --strict
+          Run in strict mode
+
   -a, --dump-ast [<FORMAT>]
           Dump the AST to stdout with the given format
 

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -94,6 +94,10 @@ struct Opt {
     #[arg(name = "FILE", value_hint = ValueHint::FilePath)]
     files: Vec<PathBuf>,
 
+    /// Run in strict mode.
+    #[arg(long)]
+    strict: bool,
+
     /// Dump the AST to stdout with the given format.
     #[arg(
         long,
@@ -255,6 +259,9 @@ fn main() -> Result<(), io::Error> {
         .job_queue(&queue)
         .build()
         .expect("cannot fail with default global object");
+
+    // Strict mode
+    context.strict(args.strict);
 
     // Trace Output
     context.set_trace(args.trace);


### PR DESCRIPTION
This PR adds the `--strict` flag to the CLI that enables strict mode on file/interactive mode execution. 

It's a bit annoying to have to prefix with `'use strict';`  when trying to debug in interactive mode
```js
>>> 'use strict'; .... // :(
```

It changes the following:
- Adds `--strict` flag to CLI
- update `README.md`
