### PR TITLE
[Merged by Bors] - Add ES5 and ES6 Conformance calculation to boa_tester

### DIFF
--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -57,16 +57,35 @@ impl TestSuite {
             println!();
         }
 
-        // Count passed tests
+        // Count passed tests and es specs
         let mut passed = 0;
         let mut ignored = 0;
         let mut panic = 0;
+        let mut es5_passed = 0;
+        let mut es6_passed = 0;
+        let mut es5_total = 0;
+        let mut es6_total = 0;
+
         for test in &tests {
             match test.result {
-                TestOutcomeResult::Passed => passed += 1,
+                TestOutcomeResult::Passed => {
+                    passed += 1;
+                    if test.es5 {
+                        es5_passed += 1;
+                    }
+                    if test.es6 {
+                        es6_passed += 1;
+                    }
+                }
                 TestOutcomeResult::Ignored => ignored += 1,
                 TestOutcomeResult::Panic => panic += 1,
                 TestOutcomeResult::Failed => {}
+            }
+            if test.es5 {
+                es5_total += 1;
+            }
+            if test.es6 {
+                es6_total += 1;
             }
         }
 
@@ -77,6 +96,10 @@ impl TestSuite {
             passed += suite.passed;
             ignored += suite.ignored;
             panic += suite.panic;
+            es5_total += suite.es5_total;
+            es6_total += suite.es6_total;
+            es5_passed += suite.es5_passed;
+            es6_passed += suite.es6_passed;
             features.append(&mut suite.features.clone());
         }
 
@@ -105,6 +128,10 @@ impl TestSuite {
             ignored,
             panic,
             suites,
+            es5_total,
+            es6_total,
+            es5_passed,
+            es6_passed,
             tests,
             features,
         }
@@ -141,6 +168,9 @@ impl Test {
             }
             return TestResult {
                 name: self.name.clone(),
+                es5: self.es5id.is_some(),
+                es6: self.es5id.is_some(),
+                spec_version: self.spec_version,
                 strict,
                 result: TestOutcomeResult::Failed,
                 result_text: Box::from("Could not read test file.")
@@ -159,6 +189,9 @@ impl Test {
             }
             return TestResult {
                 name: self.name.clone(),
+                es5: self.es5id.is_some(),
+                es6: self.es6id.is_some(),
+                spec_version: self.spec_version,
                 strict,
                 result: TestOutcomeResult::Ignored,
                 result_text: Box::default(),
@@ -357,6 +390,9 @@ impl Test {
 
         TestResult {
             name: self.name.clone(),
+            es5: self.es5id.is_some(),
+            es6: self.es6id.is_some(),
+            spec_version: self.spec_version,
             strict,
             result,
             result_text: result_text.into_boxed_str(),

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -361,11 +361,10 @@ impl Add for Statistics {
 struct SuiteResult {
     #[serde(rename = "n")]
     name: Box<str>,
-    #[serde(rename = "a")]
     all_stats: Statistics,
-    #[serde(rename = "a5")]
+    #[serde(rename = "a5", default)]
     es5_stats: Statistics,
-    #[serde(rename = "a6")]
+    #[serde(rename = "a6", default)]
     es6_stats: Statistics,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     #[serde(rename = "s")]

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -361,6 +361,7 @@ impl Add for Statistics {
 struct SuiteResult {
     #[serde(rename = "n")]
     name: Box<str>,
+    #[serde(rename = "a")]
     all_stats: Statistics,
     #[serde(rename = "a5", default)]
     es5_stats: Statistics,

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -384,7 +384,7 @@ struct SuiteResult {
 struct TestResult {
     #[serde(rename = "n")]
     name: Box<str>,
-    #[serde(rename = "v")]
+    #[serde(rename = "v", default)]
     spec_version: SpecVersion,
     #[serde(rename = "s", default)]
     strict: bool,
@@ -406,11 +406,12 @@ enum TestOutcomeResult {
     Panic,
 }
 
-#[derive(Debug, Serialize, Clone, Copy, Deserialize, PartialEq)]
+#[derive(Debug, Serialize, Clone, Copy, Deserialize, PartialEq, Default)]
 #[serde(untagged)]
 enum SpecVersion {
     ES5 = 5,
     ES6 = 6,
+    #[default]
     ES13 = 13,
 }
 

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -27,11 +27,10 @@ struct ReducedResultInfo {
     commit: Box<str>,
     #[serde(rename = "u")]
     test262_commit: Box<str>,
-    #[serde(rename = "a")]
     all_stats: Statistics,
-    #[serde(rename = "a5")]
+    #[serde(rename = "a5", default)]
     es5_stats: Statistics,
-    #[serde(rename = "a6")]
+    #[serde(rename = "a6", default)]
     es6_stats: Statistics,
 }
 

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -27,6 +27,7 @@ struct ReducedResultInfo {
     commit: Box<str>,
     #[serde(rename = "u")]
     test262_commit: Box<str>,
+    #[serde(rename = "a")]
     all_stats: Statistics,
     #[serde(rename = "a5", default)]
     es5_stats: Statistics,

--- a/boa_tester/src/results.rs
+++ b/boa_tester/src/results.rs
@@ -1,3 +1,5 @@
+use crate::Statistics;
+
 use super::SuiteResult;
 use color_eyre::{eyre::WrapErr, Result};
 use serde::{Deserialize, Serialize};
@@ -25,14 +27,12 @@ struct ReducedResultInfo {
     commit: Box<str>,
     #[serde(rename = "u")]
     test262_commit: Box<str>,
-    #[serde(rename = "t")]
-    total: usize,
-    #[serde(rename = "o")]
-    passed: usize,
-    #[serde(rename = "i")]
-    ignored: usize,
-    #[serde(rename = "p")]
-    panic: usize,
+    #[serde(rename = "a")]
+    all_stats: Statistics,
+    #[serde(rename = "a5")]
+    es5_stats: Statistics,
+    #[serde(rename = "a6")]
+    es6_stats: Statistics,
 }
 
 impl From<ResultInfo> for ReducedResultInfo {
@@ -41,10 +41,9 @@ impl From<ResultInfo> for ReducedResultInfo {
         Self {
             commit: info.commit,
             test262_commit: info.test262_commit,
-            total: info.results.total,
-            passed: info.results.passed,
-            ignored: info.results.ignored,
-            panic: info.results.panic,
+            all_stats: info.results.all_stats,
+            es5_stats: info.results.es5_stats,
+            es6_stats: info.results.es6_stats,
         }
     }
 }
@@ -220,24 +219,24 @@ pub(crate) fn compare_results(base: &Path, new: &Path, markdown: bool) -> Result
     ))
     .wrap_err("could not read the new results")?;
 
-    let base_total = base_results.results.total as isize;
-    let new_total = new_results.results.total as isize;
+    let base_total = base_results.results.all_stats.total as isize;
+    let new_total = new_results.results.all_stats.total as isize;
     let total_diff = new_total - base_total;
 
-    let base_passed = base_results.results.passed as isize;
-    let new_passed = new_results.results.passed as isize;
+    let base_passed = base_results.results.all_stats.passed as isize;
+    let new_passed = new_results.results.all_stats.passed as isize;
     let passed_diff = new_passed - base_passed;
 
-    let base_ignored = base_results.results.ignored as isize;
-    let new_ignored = new_results.results.ignored as isize;
+    let base_ignored = base_results.results.all_stats.ignored as isize;
+    let new_ignored = new_results.results.all_stats.ignored as isize;
     let ignored_diff = new_ignored - base_ignored;
 
     let base_failed = base_total - base_passed - base_ignored;
     let new_failed = new_total - new_passed - new_ignored;
     let failed_diff = new_failed - base_failed;
 
-    let base_panics = base_results.results.panic as isize;
-    let new_panics = new_results.results.panic as isize;
+    let base_panics = base_results.results.all_stats.panic as isize;
+    let new_panics = new_results.results.all_stats.panic as isize;
     let panic_diff = new_panics - base_panics;
 
     let base_conformance = (base_passed as f64 / base_total as f64) * 100_f64;


### PR DESCRIPTION
This is calculated based the tests `es5id` or `es6id`.  

Judging by [this](https://github.com/tc39/test262/issues/1557) it's probably not the best method of doing it, but the alternative would require a lot of rework on the boa_tester so that it can pull an older version of the test262 spec which has it's own problems since there's not really an "ES5" only version.
 
I would think that if we're 100% passing on es5id's then it's safe to assume boa supports es5 (assuming test262's es5id is covering all the es5 cases)

This Pull Request fixes/closes #2629.

It changes the following:
- Store `spec_version` in TestResult based on the tests `es[6/5]id`
- Count all es5, es6 and their test outcome during `TestSuite::run()`
- Print the conformance.

I'm serializing the `spec_version` outcomes so that it can be displayed in test262 github page. I'd like to work on that too if possible. Let me know if there's anything more I should cover in this PR, I'll gladly do it :)