### PR TITLE
Add a switch to hide passing test suites

### DIFF
--- a/test262/index.html
+++ b/test262/index.html
@@ -30,6 +30,10 @@
         margin-top: 1em;
       }
 
+      #info-options {
+        margin-top: 1em;
+      }
+
       #info {
         margin-top: 1em;
       }
@@ -136,6 +140,14 @@
       </div>
       <div class="row">
         <div class="col-md-12" id="progress-info"></div>
+      </div>
+      <div class="row">
+        <div class="col-md-12 d-none" id="info-options">
+          <div class="form-check form-switch">
+            <input class="form-check-input" type="checkbox" role="switch" id="info-options-hide-passing-switch">
+            <label class="form-check-label" for="info-options-hide-passing-switch">Hide passing test suites</label>
+          </div>
+        </div>
       </div>
       <div class="row">
         <div class="accordion col-md-12" id="info"></div>

--- a/test262/results.js
+++ b/test262/results.js
@@ -1,5 +1,18 @@
 const formatter = new Intl.NumberFormat("en-GB");
 
+let hidePassingSuites = false;
+let currentData = null;
+
+document
+  .getElementById("info-options-hide-passing-switch")
+  .checked = false;
+document
+  .getElementById("info-options-hide-passing-switch")
+  .addEventListener("change", () => {
+    hidePassingSuites = !hidePassingSuites;
+    showData(currentData);
+  });
+
 loadMainData();
 loadMainResults();
 
@@ -222,7 +235,10 @@ function createInfoFromResults(resultsData, nodeID) {
 
 // Shows the full test data.
 function showData(data) {
+  currentData = data;
+
   const infoContainer = document.getElementById("info");
+  const infoOptionsContainer = document.getElementById("info-options");
   const progressInfoContainer = document.getElementById("progress-info");
 
   const totalTests = data.r.c;
@@ -231,6 +247,7 @@ function showData(data) {
   const failedTests = totalTests - passedTests - ignoredTests;
 
   infoContainer.innerHTML = "";
+  infoOptionsContainer.classList.remove("d-none");
   progressInfoContainer.innerHTML = `<div class="progress g-0">
     <div
       class="progress-bar progress-bar bg-success"
@@ -264,6 +281,10 @@ function showData(data) {
 }
 
 function addSuite(suite, parentID, namespace, upstream) {
+  if (hidePassingSuites && suite.o === suite.c) {
+    return;
+  }
+
   const newID = (parentID + suite.n).replaceAll(".", "-");
   const newInnerID = newID + "-inner";
   const headerID = newID + "header";


### PR DESCRIPTION
This Pull Request  changes the following:

- Add a switch to hide passing test suites on the conformance page

![image](https://user-images.githubusercontent.com/32105367/226156532-e6a51cc2-240e-418c-8d6a-23672f592b4e.png)
