### PR TITLE
[Merged by Bors] - [Merged by Bors] - Fix get function opcode traces

### DIFF
--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -280,7 +280,7 @@ impl CodeBlock {
                 let operand = self.read::<u32>(*pc);
                 *pc += size_of::<u32>() + size_of::<u8>();
                 format!(
-                    "{operand:04}: '{:?}' (length: {})",
+                    "{operand:04}: '{}' (length: {})",
                     interner.resolve_expect(self.functions[operand as usize].name),
                     self.functions[operand as usize].length
                 )


### PR DESCRIPTION
 Fix get function opcode traces (`GetFunction`, `GetGenerator`, etc)

```js
function x() {
    let y = 0;
}
```
Before:
```
000000    0000    GetFunction                0000: 'JSInternedStrRef { utf8: Some("x"), utf16: [120] }' (length: 0)
000006    0001    DefInitVar                 0000: 'x'
```

After:
```
000000    0000    GetFunction                0000: 'x' (length: 0)
000006    0001    DefInitVar                 0000: 'x'
```
