### PR TITLE
[Merged by Bors] - Add early errors to dynamic function constructors

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -584,6 +584,20 @@ impl BuiltInFunctionObject {
                     .into());
             }
 
+            // It is a Syntax Error if FunctionBody Contains SuperProperty is true.
+            if contains(&body, ContainsSymbol::SuperProperty) {
+                return Err(JsNativeError::syntax()
+                    .with_message("invalid `super` reference")
+                    .into());
+            }
+
+            // It is a Syntax Error if FunctionBody Contains SuperCall is true.
+            if contains(&body, ContainsSymbol::SuperCall) {
+                return Err(JsNativeError::syntax()
+                    .with_message("invalid `super` call")
+                    .into());
+            }
+
             // It is a Syntax Error if any element of the BoundNames of FormalParameters
             // also occurs in the LexicallyDeclaredNames of FunctionBody.
             // https://tc39.es/ecma262/#sec-function-definitions-static-semantics-early-errors

--- a/boa_engine/src/builtins/function/tests.rs
+++ b/boa_engine/src/builtins/function/tests.rs
@@ -175,3 +175,19 @@ fn closure_capture_clone() {
         TestAction::assert_eq("closure()", "Hello world!"),
     ]);
 }
+
+#[test]
+fn function_constructor_early_errors_super() {
+    run_test_actions([
+        TestAction::assert_native_error(
+            "Function('super()')()",
+            ErrorKind::Syntax,
+            "invalid `super` call",
+        ),
+        TestAction::assert_native_error(
+            "Function('super.a')()",
+            ErrorKind::Syntax,
+            "invalid `super` reference",
+        ),
+    ]);
+}


### PR DESCRIPTION
This Pull Request fixes #2673.

It changes the following:

- Add early errors to dynamic function constructors.
- Add tests that check for syntax errors when `super` is passed to the function constructor.
