### PR TITLE
[Merged by Bors] - Implement `Hidden classes`

### DIFF
--- a/boa_cli/src/debug/mod.rs
+++ b/boa_cli/src/debug/mod.rs
@@ -8,10 +8,12 @@ mod gc;
 mod object;
 mod optimizer;
 mod realm;
+mod shape;
 
 fn create_boa_object(context: &mut Context<'_>) -> JsObject {
     let function_module = function::create_object(context);
     let object_module = object::create_object(context);
+    let shape_module = shape::create_object(context);
     let optimizer_module = optimizer::create_object(context);
     let gc_module = gc::create_object(context);
     let realm_module = realm::create_object(context);
@@ -25,6 +27,11 @@ fn create_boa_object(context: &mut Context<'_>) -> JsObject {
         .property(
             "object",
             object_module,
+            Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+        )
+        .property(
+            "shape",
+            shape_module,
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
         )
         .property(

--- a/boa_cli/src/debug/shape.rs
+++ b/boa_cli/src/debug/shape.rs
@@ -1,0 +1,66 @@
+use boa_engine::{
+    js_string, object::ObjectInitializer, Context, JsArgs, JsNativeError, JsObject, JsResult,
+    JsValue, NativeFunction,
+};
+
+fn get_object(args: &[JsValue], position: usize) -> JsResult<&JsObject> {
+    let value = args.get_or_undefined(position);
+
+    let Some(object) = value.as_object() else {
+        return Err(JsNativeError::typ()
+        .with_message(format!("expected object in argument position {position}, got {}", value.type_of()))
+        .into());
+    };
+
+    Ok(object)
+}
+
+/// Returns object's shape pointer in memory.
+fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    let object = get_object(args, 0)?;
+    let object = object.borrow();
+    let shape = object.shape();
+    Ok(format!("0x{:X}", shape.to_addr_usize()).into())
+}
+
+/// Returns object's shape type.
+fn r#type(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    let object = get_object(args, 0)?;
+    let object = object.borrow();
+    let shape = object.shape();
+
+    Ok(if shape.is_shared() {
+        js_string!("shared")
+    } else {
+        js_string!("unique")
+    }
+    .into())
+}
+
+/// Returns object's shape type.
+fn same(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    let lhs = get_object(args, 0)?;
+    let rhs = get_object(args, 1)?;
+
+    let lhs_shape_ptr = {
+        let object = lhs.borrow();
+        let shape = object.shape();
+        shape.to_addr_usize()
+    };
+
+    let rhs_shape_ptr = {
+        let object = rhs.borrow();
+        let shape = object.shape();
+        shape.to_addr_usize()
+    };
+
+    Ok(JsValue::new(lhs_shape_ptr == rhs_shape_ptr))
+}
+
+pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+    ObjectInitializer::new(context)
+        .function(NativeFunction::from_fn_ptr(id), "id", 1)
+        .function(NativeFunction::from_fn_ptr(r#type), "type", 1)
+        .function(NativeFunction::from_fn_ptr(same), "same", 2)
+        .build()
+}

--- a/boa_engine/benches/full.rs
+++ b/boa_engine/benches/full.rs
@@ -1,7 +1,8 @@
 //! Benchmarks of the whole execution engine in Boa.
 
 use boa_engine::{
-    context::DefaultHooks, optimizer::OptimizerOptions, realm::Realm, Context, Source,
+    context::DefaultHooks, object::shape::SharedShape, optimizer::OptimizerOptions, realm::Realm,
+    Context, Source,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
@@ -15,7 +16,8 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn create_realm(c: &mut Criterion) {
     c.bench_function("Create Realm", move |b| {
-        b.iter(|| Realm::create(&DefaultHooks))
+        let root_shape = SharedShape::root();
+        b.iter(|| Realm::create(&DefaultHooks, &root_shape))
     });
 }
 

--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -84,7 +84,8 @@ impl ArrayIterator {
         kind: PropertyNameKind,
         context: &Context<'_>,
     ) -> JsValue {
-        let array_iterator = JsObject::from_proto_and_data(
+        let array_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().objects().iterator_prototypes().array(),
             ObjectData::array_iterator(Self::new(array, kind)),
         );

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -53,13 +53,11 @@ impl IntrinsicObject for ArrayBuffer {
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(realm)
-            .callable(Self::get_byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length)
             .name("get byteLength")
             .build();
 
@@ -355,7 +353,8 @@ impl ArrayBuffer {
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObject::from_proto_and_data(
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::array_buffer(Self {
                 array_buffer_data: Some(block),

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -68,7 +68,11 @@ impl BuiltInConstructor for Boolean {
         }
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::boolean, context)?;
-        let boolean = JsObject::from_proto_and_data(prototype, ObjectData::boolean(data));
+        let boolean = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::boolean(data),
+        );
 
         Ok(boolean.into())
     }

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -35,18 +35,15 @@ impl IntrinsicObject for DataView {
     fn init(realm: &Realm) {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_buffer = BuiltInBuilder::new(realm)
-            .callable(Self::get_buffer)
+        let get_buffer = BuiltInBuilder::callable(realm, Self::get_buffer)
             .name("get buffer")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(realm)
-            .callable(Self::get_byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::get_byte_length)
             .name("get byteLength")
             .build();
 
-        let get_byte_offset = BuiltInBuilder::new(realm)
-            .callable(Self::get_byte_offset)
+        let get_byte_offset = BuiltInBuilder::callable(realm, Self::get_byte_offset)
             .name("get byteOffset")
             .build();
 
@@ -194,7 +191,8 @@ impl BuiltInConstructor for DataView {
                 .into());
         }
 
-        let obj = JsObject::from_proto_and_data(
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::data_view(Self {
                 // 11. Set O.[[ViewedArrayBuffer]] to buffer.

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -96,14 +96,12 @@ impl IntrinsicObject for Date {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let to_utc_string = BuiltInBuilder::new(realm)
-            .callable(Self::to_utc_string)
+        let to_utc_string = BuiltInBuilder::callable(realm, Self::to_utc_string)
             .name("toUTCString")
             .length(0)
             .build();
 
-        let to_primitive = BuiltInBuilder::new(realm)
-            .callable(Self::to_primitive)
+        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive)
             .name("[Symbol.toPrimitive]")
             .length(1)
             .build();
@@ -289,7 +287,11 @@ impl BuiltInConstructor for Date {
             get_prototype_from_constructor(new_target, StandardConstructors::date, context)?;
 
         // 7. Set O.[[DateValue]] to dv.
-        let obj = JsObject::from_proto_and_data(prototype, ObjectData::date(dv));
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::date(dv),
+        );
 
         // 8. Return O.
         Ok(obj.into())

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -83,7 +83,11 @@ impl BuiltInConstructor for AggregateError {
             StandardConstructors::aggregate_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Aggregate));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Aggregate),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(1);

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -82,7 +82,11 @@ impl BuiltInConstructor for EvalError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::eval_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Eval));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Eval),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -177,7 +177,11 @@ impl BuiltInConstructor for Error {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%Error.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Error));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Error),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -80,7 +80,11 @@ impl BuiltInConstructor for RangeError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::range_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Range));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Range),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -82,7 +82,11 @@ impl BuiltInConstructor for ReferenceError {
             StandardConstructors::reference_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Reference));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Reference),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -85,7 +85,11 @@ impl BuiltInConstructor for SyntaxError {
             StandardConstructors::syntax_error,
             context,
         )?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Syntax));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Syntax),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -90,7 +90,11 @@ impl BuiltInConstructor for TypeError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::type_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Type));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Type),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -81,7 +81,11 @@ impl BuiltInConstructor for UriError {
         // 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::uri_error, context)?;
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(ErrorKind::Uri));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(ErrorKind::Uri),
+        );
 
         // 3. If message is not undefined, then
         let message = args.get_or_undefined(0);

--- a/boa_engine/src/builtins/escape/mod.rs
+++ b/boa_engine/src/builtins/escape/mod.rs
@@ -23,8 +23,7 @@ pub(crate) struct Escape;
 
 impl IntrinsicObject for Escape {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(escape)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, escape)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -96,8 +95,7 @@ pub(crate) struct Unescape;
 
 impl IntrinsicObject for Unescape {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(unescape)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, unescape)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -31,8 +31,7 @@ impl IntrinsicObject for Eval {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(Self::eval)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, Self::eval)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/boa_engine/src/builtins/intl/collator/mod.rs
+++ b/boa_engine/src/builtins/intl/collator/mod.rs
@@ -163,8 +163,7 @@ impl IntrinsicObject for Collator {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let compare = BuiltInBuilder::new(realm)
-            .callable(Self::compare)
+        let compare = BuiltInBuilder::callable(realm, Self::compare)
             .name("get compare")
             .build();
 
@@ -364,7 +363,8 @@ impl BuiltInConstructor for Collator {
 
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::collator, context)?;
-        let collator = JsObject::from_proto_and_data(
+        let collator = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::collator(Self {
                 locale,
@@ -509,10 +509,11 @@ impl Collator {
         })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
-        let options = JsObject::from_proto_and_data(
-            context.intrinsics().constructors().object().prototype(),
-            ObjectData::ordinary(),
-        );
+        let options = context
+            .intrinsics()
+            .templates()
+            .ordinary_object()
+            .create(ObjectData::ordinary(), vec![]);
 
         // 4. For each row of Table 4, except the header row, in table order, do
         //     a. Let p be the Property value of the current row.

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -122,7 +122,8 @@ impl BuiltInConstructor for DateTimeFormat {
         // « [[InitializedDateTimeFormat]], [[Locale]], [[Calendar]], [[NumberingSystem]], [[TimeZone]], [[Weekday]],
         // [[Era]], [[Year]], [[Month]], [[Day]], [[DayPeriod]], [[Hour]], [[Minute]], [[Second]],
         // [[FractionalSecondDigits]], [[TimeZoneName]], [[HourCycle]], [[Pattern]], [[BoundFormat]] »).
-        let date_time_format = JsObject::from_proto_and_data(
+        let date_time_format = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::date_time_format(Box::new(Self {
                 initialized_date_time_format: true,
@@ -192,7 +193,11 @@ pub(crate) fn to_date_time_options(
     } else {
         Some(options.to_object(context)?)
     };
-    let options = JsObject::from_proto_and_data(options, ObjectData::ordinary());
+    let options = JsObject::from_proto_and_data_with_shared_shape(
+        context.root_shape(),
+        options,
+        ObjectData::ordinary(),
+    );
 
     // 3. Let needDefaults be true.
     let mut need_defaults = true;

--- a/boa_engine/src/builtins/intl/list_format/mod.rs
+++ b/boa_engine/src/builtins/intl/list_format/mod.rs
@@ -147,7 +147,8 @@ impl BuiltInConstructor for ListFormat {
         // 2. Let listFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%ListFormat.prototype%", « [[InitializedListFormat]], [[Locale]], [[Type]], [[Style]], [[Templates]] »).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::list_format, context)?;
-        let list_format = JsObject::from_proto_and_data(
+        let list_format = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::list_format(Self {
                 formatter: context
@@ -358,10 +359,11 @@ impl ListFormat {
         // 4. For each Record { [[Type]], [[Value]] } part in parts, do
         for (n, part) in parts.0.into_iter().enumerate() {
             // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
-            let o = JsObject::from_proto_and_data(
-                context.intrinsics().constructors().object().prototype(),
-                ObjectData::ordinary(),
-            );
+            let o = context
+                .intrinsics()
+                .templates()
+                .ordinary_object()
+                .create(ObjectData::ordinary(), vec![]);
 
             // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
             o.create_data_property_or_throw(utf16!("type"), part.typ(), context)
@@ -410,10 +412,11 @@ impl ListFormat {
         })?;
 
         // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
-        let options = JsObject::from_proto_and_data(
-            context.intrinsics().constructors().object().prototype(),
-            ObjectData::ordinary(),
-        );
+        let options = context
+            .intrinsics()
+            .templates()
+            .ordinary_object()
+            .create(ObjectData::ordinary(), vec![]);
 
         // 4. For each row of Table 11, except the header row, in table order, do
         //     a. Let p be the Property value of the current row.

--- a/boa_engine/src/builtins/intl/locale/mod.rs
+++ b/boa_engine/src/builtins/intl/locale/mod.rs
@@ -35,53 +35,43 @@ impl IntrinsicObject for Locale {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let base_name = BuiltInBuilder::new(realm)
-            .callable(Self::base_name)
+        let base_name = BuiltInBuilder::callable(realm, Self::base_name)
             .name("get baseName")
             .build();
 
-        let calendar = BuiltInBuilder::new(realm)
-            .callable(Self::calendar)
+        let calendar = BuiltInBuilder::callable(realm, Self::calendar)
             .name("get calendar")
             .build();
 
-        let case_first = BuiltInBuilder::new(realm)
-            .callable(Self::case_first)
+        let case_first = BuiltInBuilder::callable(realm, Self::case_first)
             .name("get caseFirst")
             .build();
 
-        let collation = BuiltInBuilder::new(realm)
-            .callable(Self::collation)
+        let collation = BuiltInBuilder::callable(realm, Self::collation)
             .name("get collation")
             .build();
 
-        let hour_cycle = BuiltInBuilder::new(realm)
-            .callable(Self::hour_cycle)
+        let hour_cycle = BuiltInBuilder::callable(realm, Self::hour_cycle)
             .name("get hourCycle")
             .build();
 
-        let numeric = BuiltInBuilder::new(realm)
-            .callable(Self::numeric)
+        let numeric = BuiltInBuilder::callable(realm, Self::numeric)
             .name("get numeric")
             .build();
 
-        let numbering_system = BuiltInBuilder::new(realm)
-            .callable(Self::numbering_system)
+        let numbering_system = BuiltInBuilder::callable(realm, Self::numbering_system)
             .name("get numberingSystem")
             .build();
 
-        let language = BuiltInBuilder::new(realm)
-            .callable(Self::language)
+        let language = BuiltInBuilder::callable(realm, Self::language)
             .name("get language")
             .build();
 
-        let script = BuiltInBuilder::new(realm)
-            .callable(Self::script)
+        let script = BuiltInBuilder::callable(realm, Self::script)
             .name("get script")
             .build();
 
-        let region = BuiltInBuilder::new(realm)
-            .callable(Self::region)
+        let region = BuiltInBuilder::callable(realm, Self::region)
             .name("get region")
             .build();
 
@@ -391,7 +381,11 @@ impl BuiltInConstructor for Locale {
         // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Locale.prototype%", internalSlotsList).
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::locale, context)?;
-        let locale = JsObject::from_proto_and_data(prototype, ObjectData::locale(tag));
+        let locale = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::locale(tag),
+        );
 
         // 37. Return locale.
         Ok(locale.into())
@@ -429,7 +423,12 @@ impl Locale {
 
         // 4. Return ! Construct(%Locale%, maximal).
         let prototype = context.intrinsics().constructors().locale().prototype();
-        Ok(JsObject::from_proto_and_data(prototype, ObjectData::locale(loc)).into())
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::locale(loc),
+        )
+        .into())
     }
 
     /// [`Intl.Locale.prototype.minimize ( )`][spec]
@@ -462,7 +461,12 @@ impl Locale {
 
         // 4. Return ! Construct(%Locale%, minimal).
         let prototype = context.intrinsics().constructors().locale().prototype();
-        Ok(JsObject::from_proto_and_data(prototype, ObjectData::locale(loc)).into())
+        Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::locale(loc),
+        )
+        .into())
     }
 
     /// [`Intl.Locale.prototype.toString ( )`][spec].

--- a/boa_engine/src/builtins/intl/options.rs
+++ b/boa_engine/src/builtins/intl/options.rs
@@ -244,7 +244,11 @@ pub(super) fn coerce_options_to_object(
     // If options is undefined, then
     if options.is_undefined() {
         // a. Return OrdinaryObjectCreate(null).
-        return Ok(JsObject::from_proto_and_data(None, ObjectData::ordinary()));
+        return Ok(JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            None,
+            ObjectData::ordinary(),
+        ));
     }
 
     // 2. Return ? ToObject(options).

--- a/boa_engine/src/builtins/intl/segmenter/iterator.rs
+++ b/boa_engine/src/builtins/intl/segmenter/iterator.rs
@@ -87,7 +87,8 @@ impl SegmentIterator {
         // 4. Set iterator.[[IteratedString]] to string.
         // 5. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to 0.
         // 6. Return iterator.
-        JsObject::from_proto_and_data(
+        JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context
                 .intrinsics()
                 .objects()

--- a/boa_engine/src/builtins/intl/segmenter/mod.rs
+++ b/boa_engine/src/builtins/intl/segmenter/mod.rs
@@ -163,7 +163,11 @@ impl BuiltInConstructor for Segmenter {
         let proto =
             get_prototype_from_constructor(new_target, StandardConstructors::segmenter, context)?;
 
-        let segmenter = JsObject::from_proto_and_data(proto, ObjectData::segmenter(segmenter));
+        let segmenter = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            proto,
+            ObjectData::segmenter(segmenter),
+        );
 
         // 14. Return segmenter.
         Ok(segmenter.into())

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -65,7 +65,8 @@ impl AsyncFromSyncIterator {
     ) -> IteratorRecord {
         // 1. Let asyncIterator be OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, « [[SyncIteratorRecord]] »).
         // 2. Set asyncIterator.[[SyncIteratorRecord]] to syncIteratorRecord.
-        let async_iterator = JsObject::from_proto_and_data(
+        let async_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context
                 .intrinsics()
                 .objects()

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     js_string,
-    object::JsObject,
+    object::{JsObject, ObjectData},
     realm::Realm,
     symbol::JsSymbol,
     Context, JsResult, JsValue,
@@ -201,14 +201,14 @@ pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Conte
 
     // 1. Assert: Type(done) is Boolean.
     // 2. Let obj be ! OrdinaryObjectCreate(%Object.prototype%).
-    let obj = JsObject::with_object_proto(context.intrinsics());
-
     // 3. Perform ! CreateDataPropertyOrThrow(obj, "value", value).
-    obj.create_data_property_or_throw(js_string!("value"), value, context)
-        .expect("this CreateDataPropertyOrThrow call must not fail");
     // 4. Perform ! CreateDataPropertyOrThrow(obj, "done", done).
-    obj.create_data_property_or_throw(js_string!("done"), done, context)
-        .expect("this CreateDataPropertyOrThrow call must not fail");
+    let obj = context
+        .intrinsics()
+        .templates()
+        .iterator_result()
+        .create(ObjectData::ordinary(), vec![value, done.into()]);
+
     // 5. Return obj.
     obj.into()
 }

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -85,7 +85,8 @@ impl MapIterator {
                     map_iteration_kind: kind,
                     lock,
                 };
-                let map_iterator = JsObject::from_proto_and_data(
+                let map_iterator = JsObject::from_proto_and_data_with_shared_shape(
+                    context.root_shape(),
                     context.intrinsics().objects().iterator_prototypes().map(),
                     ObjectData::map_iterator(iter),
                 );

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -41,18 +41,15 @@ impl IntrinsicObject for Map {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_size = BuiltInBuilder::new(realm)
-            .callable(Self::get_size)
+        let get_size = BuiltInBuilder::callable(realm, Self::get_size)
             .name("get size")
             .build();
 
-        let entries_function = BuiltInBuilder::new(realm)
-            .callable(Self::entries)
+        let entries_function = BuiltInBuilder::callable(realm, Self::entries)
             .name("entries")
             .build();
 
@@ -136,7 +133,11 @@ impl BuiltInConstructor for Map {
         // 3. Set map.[[MapData]] to a new empty List.
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::map, context)?;
-        let map = JsObject::from_proto_and_data(prototype, ObjectData::map(OrderedMap::new()));
+        let map = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::map(OrderedMap::new()),
+        );
 
         // 4. If iterable is either undefined or null, return map.
         let iterable = match args.get_or_undefined(0) {

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -95,8 +95,9 @@ use crate::{
     js_string,
     native_function::{NativeFunction, NativeFunctionPointer},
     object::{
-        FunctionBinding, JsFunction, JsObject, JsPrototype, Object, ObjectData, CONSTRUCTOR,
-        PROTOTYPE,
+        shape::{property_table::PropertyTableInner, slot::SlotAttributes},
+        FunctionBinding, JsFunction, JsObject, JsPrototype, Object, ObjectData, ObjectKind,
+        CONSTRUCTOR, PROTOTYPE,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
     realm::Realm,
@@ -584,17 +585,17 @@ struct BuiltInBuilder<'ctx, Kind> {
 }
 
 impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
-    fn new(realm: &'ctx Realm) -> BuiltInBuilder<'ctx, OrdinaryObject> {
-        BuiltInBuilder {
-            realm,
-            object: BuiltInObjectInitializer::Unique {
-                object: Object::default(),
-                data: ObjectData::ordinary(),
-            },
-            kind: OrdinaryObject,
-            prototype: realm.intrinsics().constructors().object().prototype(),
-        }
-    }
+    // fn new(realm: &'ctx Realm) -> BuiltInBuilder<'ctx, OrdinaryObject> {
+    //     BuiltInBuilder {
+    //         realm,
+    //         object: BuiltInObjectInitializer::Unique {
+    //             object: Object::default(),
+    //             data: ObjectData::ordinary(),
+    //         },
+    //         kind: OrdinaryObject,
+    //         prototype: realm.intrinsics().constructors().object().prototype(),
+    //     }
+    // }
 
     fn with_intrinsic<I: IntrinsicObject>(
         realm: &'ctx Realm,
@@ -606,38 +607,373 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
             prototype: realm.intrinsics().constructors().object().prototype(),
         }
     }
+}
 
-    fn with_object(realm: &'ctx Realm, object: JsObject) -> BuiltInBuilder<'ctx, OrdinaryObject> {
-        BuiltInBuilder {
-            realm,
-            object: BuiltInObjectInitializer::Shared(object),
-            kind: OrdinaryObject,
-            prototype: realm.intrinsics().constructors().object().prototype(),
+struct BuiltInConstructorWithPrototype<'ctx> {
+    realm: &'ctx Realm,
+    function: NativeFunctionPointer,
+    name: JsString,
+    length: usize,
+
+    object_property_table: PropertyTableInner,
+    object_storage: Vec<JsValue>,
+    object: JsObject,
+
+    prototype_property_table: PropertyTableInner,
+    prototype_storage: Vec<JsValue>,
+    prototype: JsObject,
+    __proto__: JsPrototype,
+    inherits: Option<JsObject>,
+    attributes: Attribute,
+}
+
+#[allow(dead_code)]
+impl BuiltInConstructorWithPrototype<'_> {
+    /// Specify how many arguments the constructor function takes.
+    ///
+    /// Default is `0`.
+    #[inline]
+    const fn length(mut self, length: usize) -> Self {
+        self.length = length;
+        self
+    }
+
+    /// Specify the name of the constructor function.
+    ///
+    /// Default is `""`
+    fn name<N: Into<JsString>>(mut self, name: N) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    /// Adds a new static method to the builtin object.
+    fn static_method<B>(
+        mut self,
+        function: NativeFunctionPointer,
+        binding: B,
+        length: usize,
+    ) -> Self
+    where
+        B: Into<FunctionBinding>,
+    {
+        let binding = binding.into();
+        let function = BuiltInBuilder::callable(self.realm, function)
+            .name(binding.name)
+            .length(length)
+            .build();
+
+        debug_assert!(self
+            .object_property_table
+            .map
+            .get(&binding.binding)
+            .is_none());
+        self.object_property_table.insert(
+            binding.binding,
+            SlotAttributes::WRITABLE | SlotAttributes::CONFIGURABLE,
+        );
+        self.object_storage.push(function.into());
+        self
+    }
+
+    /// Adds a new static data property to the builtin object.
+    fn static_property<K, V>(mut self, key: K, value: V, attribute: Attribute) -> Self
+    where
+        K: Into<PropertyKey>,
+        V: Into<JsValue>,
+    {
+        let key = key.into();
+
+        debug_assert!(self.object_property_table.map.get(&key).is_none());
+        self.object_property_table
+            .insert(key, SlotAttributes::from_bits_truncate(attribute.bits()));
+        self.object_storage.push(value.into());
+        self
+    }
+
+    /// Adds a new static accessor property to the builtin object.
+    fn static_accessor<K>(
+        mut self,
+        key: K,
+        get: Option<JsFunction>,
+        set: Option<JsFunction>,
+        attribute: Attribute,
+    ) -> Self
+    where
+        K: Into<PropertyKey>,
+    {
+        let mut attributes = SlotAttributes::from_bits_truncate(attribute.bits());
+        debug_assert!(!attributes.contains(SlotAttributes::WRITABLE));
+        attributes.set(SlotAttributes::GET, get.is_some());
+        attributes.set(SlotAttributes::SET, set.is_some());
+
+        let key = key.into();
+
+        debug_assert!(self.object_property_table.map.get(&key).is_none());
+        self.object_property_table.insert(key, attributes);
+        self.object_storage.extend([
+            get.map(JsValue::new).unwrap_or_default(),
+            set.map(JsValue::new).unwrap_or_default(),
+        ]);
+        self
+    }
+
+    /// Specify the `[[Prototype]]` internal field of the builtin object.
+    ///
+    /// Default is `Function.prototype` for constructors and `Object.prototype` for statics.
+    fn prototype(mut self, prototype: JsObject) -> Self {
+        self.__proto__ = Some(prototype);
+        self
+    }
+
+    /// Adds a new method to the constructor's prototype.
+    fn method<B>(mut self, function: NativeFunctionPointer, binding: B, length: usize) -> Self
+    where
+        B: Into<FunctionBinding>,
+    {
+        let binding = binding.into();
+        let function = BuiltInBuilder::callable(self.realm, function)
+            .name(binding.name)
+            .length(length)
+            .build();
+
+        debug_assert!(self
+            .prototype_property_table
+            .map
+            .get(&binding.binding)
+            .is_none());
+        self.prototype_property_table.insert(
+            binding.binding,
+            SlotAttributes::WRITABLE | SlotAttributes::CONFIGURABLE,
+        );
+        self.prototype_storage.push(function.into());
+        self
+    }
+
+    /// Adds a new data property to the constructor's prototype.
+    fn property<K, V>(mut self, key: K, value: V, attribute: Attribute) -> Self
+    where
+        K: Into<PropertyKey>,
+        V: Into<JsValue>,
+    {
+        let key = key.into();
+
+        debug_assert!(self.prototype_property_table.map.get(&key).is_none());
+        self.prototype_property_table
+            .insert(key, SlotAttributes::from_bits_truncate(attribute.bits()));
+        self.prototype_storage.push(value.into());
+        self
+    }
+
+    /// Adds new accessor property to the constructor's prototype.
+    fn accessor<K>(
+        mut self,
+        key: K,
+        get: Option<JsFunction>,
+        set: Option<JsFunction>,
+        attribute: Attribute,
+    ) -> Self
+    where
+        K: Into<PropertyKey>,
+    {
+        let mut attributes = SlotAttributes::from_bits_truncate(attribute.bits());
+        debug_assert!(!attributes.contains(SlotAttributes::WRITABLE));
+        attributes.set(SlotAttributes::GET, get.is_some());
+        attributes.set(SlotAttributes::SET, set.is_some());
+
+        let key = key.into();
+
+        debug_assert!(self.prototype_property_table.map.get(&key).is_none());
+        self.prototype_property_table.insert(key, attributes);
+        self.prototype_storage.extend([
+            get.map(JsValue::new).unwrap_or_default(),
+            set.map(JsValue::new).unwrap_or_default(),
+        ]);
+        self
+    }
+
+    /// Specifies the parent prototype which objects created by this constructor inherit from.
+    ///
+    /// Default is `Object.prototype`.
+    #[allow(clippy::missing_const_for_fn)]
+    fn inherits(mut self, prototype: JsPrototype) -> Self {
+        self.inherits = prototype;
+        self
+    }
+
+    /// Specifies the property attributes of the prototype's "constructor" property.
+    const fn constructor_attributes(mut self, attributes: Attribute) -> Self {
+        self.attributes = attributes;
+        self
+    }
+
+    fn build(mut self) {
+        let function = function::Function::new(
+            function::FunctionKind::Native {
+                function: NativeFunction::from_fn_ptr(self.function),
+                constructor: (true).then_some(function::ConstructorKind::Base),
+            },
+            self.realm.clone(),
+        );
+
+        let length = self.length;
+        let name = self.name.clone();
+        let prototype = self.prototype.clone();
+        self = self.static_property("length", length, Attribute::CONFIGURABLE);
+        self = self.static_property("name", name, Attribute::CONFIGURABLE);
+        self = self.static_property(PROTOTYPE, prototype, Attribute::empty());
+
+        let attributes = self.attributes;
+        let object = self.object.clone();
+        self = self.property(CONSTRUCTOR, object, attributes);
+
+        {
+            let mut prototype = self.prototype.borrow_mut();
+            prototype
+                .properties_mut()
+                .shape
+                .as_unique()
+                .expect("The object should have a unique shape")
+                .override_internal(self.prototype_property_table, self.inherits);
+
+            let prototype_old_storage = std::mem::replace(
+                &mut prototype.properties_mut().storage,
+                self.prototype_storage,
+            );
+
+            debug_assert_eq!(prototype_old_storage.len(), 0);
         }
+
+        let mut object = self.object.borrow_mut();
+        *object.kind_mut() = ObjectKind::Function(function);
+        object
+            .properties_mut()
+            .shape
+            .as_unique()
+            .expect("The object should have a unique shape")
+            .override_internal(self.object_property_table, self.__proto__);
+
+        let object_old_storage =
+            std::mem::replace(&mut object.properties_mut().storage, self.object_storage);
+
+        debug_assert_eq!(object_old_storage.len(), 0);
+    }
+
+    fn build_without_prototype(mut self) {
+        let function = function::Function::new(
+            function::FunctionKind::Native {
+                function: NativeFunction::from_fn_ptr(self.function),
+                constructor: (true).then_some(function::ConstructorKind::Base),
+            },
+            self.realm.clone(),
+        );
+
+        let length = self.length;
+        let name = self.name.clone();
+        self = self.static_property("length", length, Attribute::CONFIGURABLE);
+        self = self.static_property("name", name, Attribute::CONFIGURABLE);
+
+        let mut object = self.object.borrow_mut();
+        *object.kind_mut() = ObjectKind::Function(function);
+        object
+            .properties_mut()
+            .shape
+            .as_unique()
+            .expect("The object should have a unique shape")
+            .override_internal(self.object_property_table, self.__proto__);
+
+        let object_old_storage =
+            std::mem::replace(&mut object.properties_mut().storage, self.object_storage);
+
+        debug_assert_eq!(object_old_storage.len(), 0);
+    }
+}
+
+struct BuiltInCallable<'ctx> {
+    realm: &'ctx Realm,
+    function: NativeFunctionPointer,
+    name: JsString,
+    length: usize,
+}
+
+impl BuiltInCallable<'_> {
+    /// Specify how many arguments the constructor function takes.
+    ///
+    /// Default is `0`.
+    #[inline]
+    const fn length(mut self, length: usize) -> Self {
+        self.length = length;
+        self
+    }
+
+    /// Specify the name of the constructor function.
+    ///
+    /// Default is `""`
+    fn name<N: Into<JsString>>(mut self, name: N) -> Self {
+        self.name = name.into();
+        self
+    }
+
+    fn build(self) -> JsFunction {
+        let function = function::FunctionKind::Native {
+            function: NativeFunction::from_fn_ptr(self.function),
+            constructor: None,
+        };
+
+        let function = function::Function::new(function, self.realm.clone());
+
+        let object = self.realm.intrinsics().templates().function().create(
+            ObjectData::function(function),
+            vec![JsValue::new(self.length), JsValue::new(self.name)],
+        );
+
+        JsFunction::from_object_unchecked(object)
     }
 }
 
 impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
-    fn callable(
-        self,
+    fn callable(realm: &'ctx Realm, function: NativeFunctionPointer) -> BuiltInCallable<'ctx> {
+        BuiltInCallable {
+            realm,
+            function,
+            length: 0,
+            name: js_string!(""),
+        }
+    }
+
+    fn callable_with_intrinsic<I: IntrinsicObject>(
+        realm: &'ctx Realm,
         function: NativeFunctionPointer,
     ) -> BuiltInBuilder<'ctx, Callable<OrdinaryFunction>> {
         BuiltInBuilder {
-            realm: self.realm,
-            object: self.object,
+            realm,
+            object: BuiltInObjectInitializer::Shared(I::get(realm.intrinsics())),
             kind: Callable {
                 function,
                 name: js_string!(""),
                 length: 0,
                 kind: OrdinaryFunction,
-                realm: self.realm.clone(),
+                realm: realm.clone(),
             },
-            prototype: self
-                .realm
-                .intrinsics()
-                .constructors()
-                .function()
-                .prototype(),
+            prototype: realm.intrinsics().constructors().function().prototype(),
+        }
+    }
+
+    fn callable_with_object(
+        realm: &'ctx Realm,
+        object: JsObject,
+        function: NativeFunctionPointer,
+    ) -> BuiltInBuilder<'ctx, Callable<OrdinaryFunction>> {
+        BuiltInBuilder {
+            realm,
+            object: BuiltInObjectInitializer::Shared(object),
+            kind: Callable {
+                function,
+                name: js_string!(""),
+                length: 0,
+                kind: OrdinaryFunction,
+                realm: realm.clone(),
+            },
+            prototype: realm.intrinsics().constructors().function().prototype(),
         }
     }
 }
@@ -645,38 +981,22 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
 impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
     fn from_standard_constructor<SC: BuiltInConstructor>(
         realm: &'ctx Realm,
-    ) -> BuiltInBuilder<'ctx, Callable<Constructor>> {
+    ) -> BuiltInConstructorWithPrototype<'ctx> {
         let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
-        BuiltInBuilder {
+        BuiltInConstructorWithPrototype {
             realm,
-            object: BuiltInObjectInitializer::Shared(constructor.constructor()),
-            kind: Callable {
-                function: SC::constructor,
-                name: js_string!(SC::NAME),
-                length: SC::LENGTH,
-                kind: Constructor {
-                    prototype: constructor.prototype(),
-                    inherits: Some(realm.intrinsics().constructors().object().prototype()),
-                    attributes: Attribute::WRITABLE | Attribute::CONFIGURABLE,
-                },
-                realm: realm.clone(),
-            },
-            prototype: realm.intrinsics().constructors().function().prototype(),
-        }
-    }
-
-    fn no_proto(self) -> BuiltInBuilder<'ctx, Callable<ConstructorNoProto>> {
-        BuiltInBuilder {
-            realm: self.realm,
-            object: self.object,
-            kind: Callable {
-                function: self.kind.function,
-                name: self.kind.name,
-                length: self.kind.length,
-                kind: ConstructorNoProto,
-                realm: self.realm.clone(),
-            },
-            prototype: self.prototype,
+            function: SC::constructor,
+            name: js_string!(SC::NAME),
+            length: SC::LENGTH,
+            object_property_table: PropertyTableInner::default(),
+            object_storage: Vec::default(),
+            object: constructor.constructor(),
+            prototype_property_table: PropertyTableInner::default(),
+            prototype_storage: Vec::default(),
+            prototype: constructor.prototype(),
+            __proto__: Some(realm.intrinsics().constructors().function().prototype()),
+            inherits: Some(realm.intrinsics().constructors().object().prototype()),
+            attributes: Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
         }
     }
 }
@@ -693,8 +1013,7 @@ impl<T> BuiltInBuilder<'_, T> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::new(self.realm)
-            .callable(function)
+        let function = BuiltInBuilder::callable(self.realm, function)
             .name(binding.name)
             .length(length)
             .build();
@@ -725,106 +1044,11 @@ impl<T> BuiltInBuilder<'_, T> {
         self
     }
 
-    /// Adds a new static accessor property to the builtin object.
-    fn static_accessor<K>(
-        mut self,
-        key: K,
-        get: Option<JsFunction>,
-        set: Option<JsFunction>,
-        attribute: Attribute,
-    ) -> Self
-    where
-        K: Into<PropertyKey>,
-    {
-        let property = PropertyDescriptor::builder()
-            .maybe_get(get)
-            .maybe_set(set)
-            .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.object.insert(key, property);
-        self
-    }
-
     /// Specify the `[[Prototype]]` internal field of the builtin object.
     ///
     /// Default is `Function.prototype` for constructors and `Object.prototype` for statics.
     fn prototype(mut self, prototype: JsObject) -> Self {
         self.prototype = prototype;
-        self
-    }
-}
-
-impl BuiltInBuilder<'_, Callable<Constructor>> {
-    /// Adds a new method to the constructor's prototype.
-    fn method<B>(self, function: NativeFunctionPointer, binding: B, length: usize) -> Self
-    where
-        B: Into<FunctionBinding>,
-    {
-        let binding = binding.into();
-        let function = BuiltInBuilder::new(self.realm)
-            .callable(function)
-            .name(binding.name)
-            .length(length)
-            .build();
-
-        self.kind.kind.prototype.borrow_mut().insert(
-            binding.binding,
-            PropertyDescriptor::builder()
-                .value(function)
-                .writable(true)
-                .enumerable(false)
-                .configurable(true),
-        );
-        self
-    }
-
-    /// Adds a new data property to the constructor's prototype.
-    fn property<K, V>(self, key: K, value: V, attribute: Attribute) -> Self
-    where
-        K: Into<PropertyKey>,
-        V: Into<JsValue>,
-    {
-        let property = PropertyDescriptor::builder()
-            .value(value)
-            .writable(attribute.writable())
-            .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.kind.kind.prototype.borrow_mut().insert(key, property);
-        self
-    }
-
-    /// Adds new accessor property to the constructor's prototype.
-    fn accessor<K>(
-        self,
-        key: K,
-        get: Option<JsFunction>,
-        set: Option<JsFunction>,
-        attribute: Attribute,
-    ) -> Self
-    where
-        K: Into<PropertyKey>,
-    {
-        let property = PropertyDescriptor::builder()
-            .maybe_get(get)
-            .maybe_set(set)
-            .enumerable(attribute.enumerable())
-            .configurable(attribute.configurable());
-        self.kind.kind.prototype.borrow_mut().insert(key, property);
-        self
-    }
-
-    /// Specifies the parent prototype which objects created by this constructor inherit from.
-    ///
-    /// Default is `Object.prototype`.
-    #[allow(clippy::missing_const_for_fn)]
-    fn inherits(mut self, prototype: JsPrototype) -> Self {
-        self.kind.kind.inherits = prototype;
-        self
-    }
-
-    /// Specifies the property attributes of the prototype's "constructor" property.
-    const fn constructor_attributes(mut self, attributes: Attribute) -> Self {
-        self.kind.kind.attributes = attributes;
         self
     }
 }

--- a/boa_engine/src/builtins/number/globals.rs
+++ b/boa_engine/src/builtins/number/globals.rs
@@ -38,8 +38,7 @@ pub(crate) struct IsFinite;
 
 impl IntrinsicObject for IsFinite {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(is_finite)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_finite)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -85,8 +84,7 @@ pub(crate) struct IsNaN;
 
 impl IntrinsicObject for IsNaN {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(is_nan)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, is_nan)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -227,8 +225,7 @@ pub(crate) struct ParseInt;
 
 impl IntrinsicObject for ParseInt {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(parse_int)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_int)
             .name(Self::NAME)
             .length(2)
             .build();
@@ -301,8 +298,7 @@ pub(crate) struct ParseFloat;
 
 impl IntrinsicObject for ParseFloat {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(parse_float)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, parse_float)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -121,7 +121,11 @@ impl BuiltInConstructor for Number {
         }
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::number, context)?;
-        let this = JsObject::from_proto_and_data(prototype, ObjectData::number(data));
+        let this = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::number(data),
+        );
         Ok(this.into())
     }
 }

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -77,7 +77,8 @@ impl ForInIterator {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createforiniterator
     pub(crate) fn create_for_in_iterator(object: JsValue, context: &Context<'_>) -> JsObject {
-        JsObject::from_proto_and_data(
+        JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context
                 .intrinsics()
                 .objects()

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -311,8 +311,7 @@ impl IntrinsicObject for Promise {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
@@ -384,7 +383,8 @@ impl BuiltInConstructor for Promise {
         let promise =
             get_prototype_from_constructor(new_target, StandardConstructors::promise, context)?;
 
-        let promise = JsObject::from_proto_and_data(
+        let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             promise,
             // 4. Set promise.[[PromiseState]] to pending.
             // 5. Set promise.[[PromiseFulfillReactions]] to a new empty List.

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -36,9 +36,8 @@ impl IntrinsicObject for Proxy {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         BuiltInBuilder::from_standard_constructor::<Self>(realm)
-            .no_proto()
             .static_method(Self::revocable, "revocable", 2)
-            .build();
+            .build_without_prototype();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -126,7 +125,8 @@ impl Proxy {
         // i. Set P.[[Construct]] as specified in 10.5.13.
         // 6. Set P.[[ProxyTarget]] to target.
         // 7. Set P.[[ProxyHandler]] to handler.
-        let p = JsObject::from_proto_and_data(
+        let p = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             ObjectData::proxy(
                 Self::new(target.clone(), handler.clone()),

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -51,47 +51,37 @@ impl IntrinsicObject for RegExp {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_has_indices = BuiltInBuilder::new(realm)
-            .callable(Self::get_has_indices)
+        let get_has_indices = BuiltInBuilder::callable(realm, Self::get_has_indices)
             .name("get hasIndices")
             .build();
-        let get_global = BuiltInBuilder::new(realm)
-            .callable(Self::get_global)
+        let get_global = BuiltInBuilder::callable(realm, Self::get_global)
             .name("get global")
             .build();
-        let get_ignore_case = BuiltInBuilder::new(realm)
-            .callable(Self::get_ignore_case)
+        let get_ignore_case = BuiltInBuilder::callable(realm, Self::get_ignore_case)
             .name("get ignoreCase")
             .build();
-        let get_multiline = BuiltInBuilder::new(realm)
-            .callable(Self::get_multiline)
+        let get_multiline = BuiltInBuilder::callable(realm, Self::get_multiline)
             .name("get multiline")
             .build();
-        let get_dot_all = BuiltInBuilder::new(realm)
-            .callable(Self::get_dot_all)
+        let get_dot_all = BuiltInBuilder::callable(realm, Self::get_dot_all)
             .name("get dotAll")
             .build();
-        let get_unicode = BuiltInBuilder::new(realm)
-            .callable(Self::get_unicode)
+        let get_unicode = BuiltInBuilder::callable(realm, Self::get_unicode)
             .name("get unicode")
             .build();
-        let get_sticky = BuiltInBuilder::new(realm)
-            .callable(Self::get_sticky)
+        let get_sticky = BuiltInBuilder::callable(realm, Self::get_sticky)
             .name("get sticky")
             .build();
-        let get_flags = BuiltInBuilder::new(realm)
-            .callable(Self::get_flags)
+        let get_flags = BuiltInBuilder::callable(realm, Self::get_flags)
             .name("get flags")
             .build();
-        let get_source = BuiltInBuilder::new(realm)
-            .callable(Self::get_source)
+        let get_source = BuiltInBuilder::callable(realm, Self::get_source)
             .name("get source")
             .build();
         let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm)
@@ -238,7 +228,11 @@ impl RegExp {
         // 1. Let obj be ? OrdinaryCreateFromConstructor(newTarget, "%RegExp.prototype%", « [[RegExpMatcher]], [[OriginalSource]], [[OriginalFlags]] »).
         let proto =
             get_prototype_from_constructor(new_target, StandardConstructors::regexp, context)?;
-        let obj = JsObject::from_proto_and_data(proto, ObjectData::ordinary());
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            proto,
+            ObjectData::ordinary(),
+        );
 
         // 2. Perform ! DefinePropertyOrThrow(obj, "lastIndex", PropertyDescriptor { [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
         obj.define_property_or_throw(

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -103,7 +103,8 @@ impl RegExpStringIterator {
 
         // 5. Return ! CreateIteratorFromClosure(closure, "%RegExpStringIteratorPrototype%", %RegExpStringIteratorPrototype%).
 
-        let regexp_string_iterator = JsObject::from_proto_and_data(
+        let regexp_string_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context
                 .intrinsics()
                 .objects()

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -44,18 +44,15 @@ impl IntrinsicObject for Set {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let size_getter = BuiltInBuilder::new(realm)
-            .callable(Self::size_getter)
+        let size_getter = BuiltInBuilder::callable(realm, Self::size_getter)
             .name("get size")
             .build();
 
-        let values_function = BuiltInBuilder::new(realm)
-            .callable(Self::values)
+        let values_function = BuiltInBuilder::callable(realm, Self::values)
             .name("values")
             .build();
 
@@ -127,7 +124,11 @@ impl BuiltInConstructor for Set {
         // 3. Set set.[[SetData]] to a new empty List.
         let prototype =
             get_prototype_from_constructor(new_target, StandardConstructors::set, context)?;
-        let set = JsObject::from_proto_and_data(prototype, ObjectData::set(OrderedSet::default()));
+        let set = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::set(OrderedSet::default()),
+        );
 
         // 4. If iterable is either undefined or null, return set.
         let iterable = args.get_or_undefined(0);
@@ -173,7 +174,11 @@ impl Set {
         let prototype =
             prototype.unwrap_or_else(|| context.intrinsics().constructors().set().prototype());
 
-        JsObject::from_proto_and_data(prototype, ObjectData::set(OrderedSet::new()))
+        JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::set(OrderedSet::new()),
+        )
     }
 
     /// Utility for constructing `Set` objects from an iterator of `JsValue`'s.

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -87,7 +87,8 @@ impl SetIterator {
         lock: SetLock,
         context: &Context<'_>,
     ) -> JsValue {
-        let set_iterator = JsObject::from_proto_and_data(
+        let set_iterator = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().objects().iterator_prototypes().set(),
             ObjectData::set_iterator(Self::new(set, kind, lock)),
         );

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -80,14 +80,12 @@ impl IntrinsicObject for String {
 
         let symbol_iterator = JsSymbol::iterator();
 
-        let trim_start = BuiltInBuilder::new(realm)
-            .callable(Self::trim_start)
+        let trim_start = BuiltInBuilder::callable(realm, Self::trim_start)
             .length(0)
             .name("trimStart")
             .build();
 
-        let trim_end = BuiltInBuilder::new(realm)
-            .callable(Self::trim_end)
+        let trim_end = BuiltInBuilder::callable(realm, Self::trim_end)
             .length(0)
             .name("trimEnd")
             .build();
@@ -255,7 +253,11 @@ impl String {
         // 4. Set S.[[GetOwnProperty]] as specified in 10.4.3.1.
         // 5. Set S.[[DefineOwnProperty]] as specified in 10.4.3.2.
         // 6. Set S.[[OwnPropertyKeys]] as specified in 10.4.3.3.
-        let s = JsObject::from_proto_and_data(prototype, ObjectData::string(value));
+        let s = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::string(value),
+        );
 
         // 8. Perform ! DefinePropertyOrThrow(S, "length", PropertyDescriptor { [[Value]]: 𝔽(length),
         // [[Writable]]: false, [[Enumerable]]: false, [[Configurable]]: false }).

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -60,7 +60,8 @@ impl IntrinsicObject for StringIterator {
 impl StringIterator {
     /// Create a new `StringIterator`.
     pub fn create_string_iterator(string: JsString, context: &mut Context<'_>) -> JsObject {
-        JsObject::from_proto_and_data(
+        JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context
                 .intrinsics()
                 .objects()

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -111,14 +111,12 @@ impl IntrinsicObject for Symbol {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        let to_primitive = BuiltInBuilder::new(realm)
-            .callable(Self::to_primitive)
+        let to_primitive = BuiltInBuilder::callable(realm, Self::to_primitive)
             .name("[Symbol.toPrimitive]")
             .length(1)
             .build();
 
-        let get_description = BuiltInBuilder::new(realm)
-            .callable(Self::get_description)
+        let get_description = BuiltInBuilder::callable(realm, Self::get_description)
             .name("get description")
             .build();
 

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -51,8 +51,7 @@ macro_rules! typed_array {
             fn init(realm: &Realm) {
                 let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-                let get_species = BuiltInBuilder::new(realm)
-                    .callable(TypedArray::get_species)
+                let get_species = BuiltInBuilder::callable(realm, TypedArray::get_species)
                     .name("get [Symbol.species]")
                     .build();
 
@@ -241,38 +240,31 @@ pub(crate) struct TypedArray;
 
 impl IntrinsicObject for TypedArray {
     fn init(realm: &Realm) {
-        let get_species = BuiltInBuilder::new(realm)
-            .callable(Self::get_species)
+        let get_species = BuiltInBuilder::callable(realm, Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_buffer = BuiltInBuilder::new(realm)
-            .callable(Self::buffer)
+        let get_buffer = BuiltInBuilder::callable(realm, Self::buffer)
             .name("get buffer")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(realm)
-            .callable(Self::byte_length)
+        let get_byte_length = BuiltInBuilder::callable(realm, Self::byte_length)
             .name("get byteLength")
             .build();
 
-        let get_byte_offset = BuiltInBuilder::new(realm)
-            .callable(Self::byte_offset)
+        let get_byte_offset = BuiltInBuilder::callable(realm, Self::byte_offset)
             .name("get byteOffset")
             .build();
 
-        let get_length = BuiltInBuilder::new(realm)
-            .callable(Self::length)
+        let get_length = BuiltInBuilder::callable(realm, Self::length)
             .name("get length")
             .build();
 
-        let get_to_string_tag = BuiltInBuilder::new(realm)
-            .callable(Self::to_string_tag)
+        let get_to_string_tag = BuiltInBuilder::callable(realm, Self::to_string_tag)
             .name("get [Symbol.toStringTag]")
             .build();
 
-        let values_function = BuiltInBuilder::new(realm)
-            .callable(Self::values)
+        let values_function = BuiltInBuilder::callable(realm, Self::values)
             .name("values")
             .length(0)
             .build();
@@ -283,11 +275,6 @@ impl IntrinsicObject for TypedArray {
                 Some(get_species),
                 None,
                 Attribute::CONFIGURABLE,
-            )
-            .property(
-                utf16!("length"),
-                0,
-                Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
             )
             .property(
                 JsSymbol::iterator(),
@@ -3205,7 +3192,11 @@ impl TypedArray {
         }
 
         // 2. Let obj be ! IntegerIndexedObjectCreate(proto).
-        let obj = JsObject::from_proto_and_data(proto, ObjectData::integer_indexed(indexed));
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            proto,
+            ObjectData::integer_indexed(indexed),
+        );
 
         // 9. Return obj.
         Ok(obj)

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -82,8 +82,7 @@ pub(crate) struct DecodeUri;
 
 impl IntrinsicObject for DecodeUri {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(decode_uri)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -101,8 +100,7 @@ pub(crate) struct DecodeUriComponent;
 
 impl IntrinsicObject for DecodeUriComponent {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(decode_uri_component)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, decode_uri_component)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -124,8 +122,7 @@ pub(crate) struct EncodeUri;
 
 impl IntrinsicObject for EncodeUri {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(encode_uri)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri)
             .name(Self::NAME)
             .length(1)
             .build();
@@ -142,8 +139,7 @@ pub(crate) struct EncodeUriComponent;
 
 impl IntrinsicObject for EncodeUriComponent {
     fn init(realm: &Realm) {
-        BuiltInBuilder::with_intrinsic::<Self>(realm)
-            .callable(encode_uri_component)
+        BuiltInBuilder::callable_with_intrinsic::<Self>(realm, encode_uri_component)
             .name(Self::NAME)
             .length(1)
             .build();

--- a/boa_engine/src/builtins/weak_map/mod.rs
+++ b/boa_engine/src/builtins/weak_map/mod.rs
@@ -82,7 +82,8 @@ impl BuiltInConstructor for WeakMap {
 
         // 2. Let map be ? OrdinaryCreateFromConstructor(NewTarget, "%WeakMap.prototype%", « [[WeakMapData]] »).
         // 3. Set map.[[WeakMapData]] to a new empty List.
-        let map = JsObject::from_proto_and_data(
+        let map = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             get_prototype_from_constructor(new_target, StandardConstructors::weak_map, context)?,
             ObjectData::weak_map(boa_gc::WeakMap::new()),
         );

--- a/boa_engine/src/builtins/weak_set/mod.rs
+++ b/boa_engine/src/builtins/weak_set/mod.rs
@@ -78,7 +78,8 @@ impl BuiltInConstructor for WeakSet {
 
         // 2. Let set be ? OrdinaryCreateFromConstructor(NewTarget, "%WeakSet.prototype%", « [[WeakSetData]] »).
         // 3. Set set.[[WeakSetData]] to a new empty List.
-        let weak_set = JsObject::from_proto_and_data(
+        let weak_set = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             get_prototype_from_constructor(new_target, StandardConstructors::weak_set, context)?,
             ObjectData::weak_set(WeakMap::new()),
         );

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -151,8 +151,11 @@ impl<T: Class> ClassConstructor for T {
             .unwrap_or_else(|| class_prototype.clone());
 
         let native_instance = Self::constructor(this, args, context)?;
-        let object_instance =
-            JsObject::from_proto_and_data(prototype, ObjectData::native_object(native_instance));
+        let object_instance = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::native_object(native_instance),
+        );
         Ok(object_instance.into())
     }
 }

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -709,7 +709,11 @@ impl JsNativeError {
             }
         };
 
-        let o = JsObject::from_proto_and_data(prototype, ObjectData::error(tag));
+        let o = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::error(tag),
+        );
 
         o.create_non_enumerable_data_property_or_throw(utf16!("message"), &**message, context);
 

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -101,7 +101,8 @@ impl JsArrayBuffer {
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObject::from_proto_and_data(
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::array_buffer(ArrayBuffer {
                 array_buffer_data: Some(block),

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -97,7 +97,8 @@ impl JsDataView {
         let prototype =
             get_prototype_from_constructor(&constructor, StandardConstructors::data_view, context)?;
 
-        let obj = JsObject::from_proto_and_data(
+        let obj = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::data_view(DataView {
                 viewed_array_buffer: (**array_buffer).clone(),

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -43,7 +43,8 @@ impl JsDate {
     #[inline]
     pub fn new(context: &mut Context<'_>) -> Self {
         let prototype = context.intrinsics().constructors().date().prototype();
-        let inner = JsObject::from_proto_and_data(
+        let inner = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             prototype,
             ObjectData::date(Date::utc_now(&*context.host_hooks())),
         );
@@ -574,7 +575,11 @@ impl JsDate {
         let date_time = Date::new(Some(date_time.naive_local().timestamp_millis()));
 
         Ok(Self {
-            inner: JsObject::from_proto_and_data(prototype, ObjectData::date(date_time)),
+            inner: JsObject::from_proto_and_data_with_shared_shape(
+                context.root_shape(),
+                prototype,
+                ObjectData::date(date_time),
+            ),
         })
     }
 }

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -185,7 +185,11 @@ impl JsMap {
         let prototype = context.intrinsics().constructors().map().prototype();
 
         // Create a default map object with [[MapData]] as a new empty list
-        JsObject::from_proto_and_data(prototype, ObjectData::map(OrderedMap::new()))
+        JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::map(OrderedMap::new()),
+        )
     }
 
     /// Returns a new [`JsMapIterator`] object that yields the `[key, value]` pairs within the [`JsMap`] in insertion order.

--- a/boa_engine/src/object/builtins/jspromise.rs
+++ b/boa_engine/src/object/builtins/jspromise.rs
@@ -154,7 +154,8 @@ impl JsPromise {
     where
         F: FnOnce(&ResolvingFunctions, &mut Context<'_>) -> JsResult<JsValue>,
     {
-        let promise = JsObject::from_proto_and_data(
+        let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().constructors().promise().prototype(),
             ObjectData::promise(Promise::new()),
         );
@@ -201,7 +202,8 @@ impl JsPromise {
     /// ```
     #[inline]
     pub fn new_pending(context: &mut Context<'_>) -> (JsPromise, ResolvingFunctions) {
-        let promise = JsObject::from_proto_and_data(
+        let promise = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().constructors().promise().prototype(),
             ObjectData::promise(Promise::new()),
         );

--- a/boa_engine/src/object/builtins/jsproxy.rs
+++ b/boa_engine/src/object/builtins/jsproxy.rs
@@ -518,7 +518,8 @@ impl JsProxyBuilder {
         let callable = self.target.is_callable();
         let constructor = self.target.is_constructor();
 
-        let proxy = JsObject::from_proto_and_data(
+        let proxy = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
             ObjectData::proxy(Proxy::new(self.target, handler), callable, constructor),
         );

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -273,30 +273,19 @@ pub(crate) fn integer_indexed_exotic_own_property_keys(
         vec![]
     } else {
         // 2. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is false, then
-        // a. For each integer i starting with 0 such that i < O.[[ArrayLength]], in ascending order, do
-        // i. Add ! ToString(𝔽(i)) as the last element of keys.
+        //     a. For each integer i starting with 0 such that i < O.[[ArrayLength]], in ascending order, do
+        //         i. Add ! ToString(𝔽(i)) as the last element of keys.
         (0..inner.array_length())
             .map(|index| PropertyKey::Index(index as u32))
             .collect()
     };
 
     // 3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.properties
-            .string_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
-
+    //     a. Add P as the last element of keys.
+    //
     // 4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.properties
-            .symbol_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
+    //     a. Add P as the last element of keys.
+    keys.extend(obj.properties.shape.keys());
 
     // 5. Return keys.
     Ok(keys)

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -340,14 +340,12 @@ pub(crate) fn ordinary_set_prototype_of(
     _: &mut Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: Either Type(V) is Object or Type(V) is Null.
-    {
-        // 2. Let current be O.[[Prototype]].
-        let current = obj.prototype();
+    // 2. Let current be O.[[Prototype]].
+    let current = obj.prototype();
 
-        // 3. If SameValue(V, current) is true, return true.
-        if val == *current {
-            return Ok(true);
-        }
+    // 3. If SameValue(V, current) is true, return true.
+    if val == current {
+        return Ok(true);
     }
 
     // 4. Let extensible be O.[[Extensible]].
@@ -375,7 +373,7 @@ pub(crate) fn ordinary_set_prototype_of(
             break;
         }
         // ii. Else, set p to p.[[Prototype]].
-        p = proto.prototype().clone();
+        p = proto.prototype();
     }
 
     // 9. Set O.[[Prototype]] to V.
@@ -705,24 +703,11 @@ pub(crate) fn ordinary_own_property_keys(
     keys.extend(ordered_indexes.into_iter().map(Into::into));
 
     // 3. For each own property key P of O such that Type(P) is String and P is not an array index, in ascending chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.borrow()
-            .properties
-            .string_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
-
+    //     a. Add P as the last element of keys.
+    //
     // 4. For each own property key P of O such that Type(P) is Symbol, in ascending chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.borrow()
-            .properties
-            .symbol_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
+    //     a. Add P as the last element of keys.
+    keys.extend(obj.borrow().properties.shape.keys());
 
     // 5. Return keys.
     Ok(keys)

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -101,12 +101,12 @@ pub(crate) fn string_exotic_own_property_keys(
     let mut keys = Vec::with_capacity(len);
 
     // 5. For each integer i starting with 0 such that i < len, in ascending order, do
-    // a. Add ! ToString(𝔽(i)) as the last element of keys.
+    //      a. Add ! ToString(𝔽(i)) as the last element of keys.
     keys.extend((0..len).map(Into::into));
 
     // 6. For each own property key P of O such that P is an array index
     // and ! ToIntegerOrInfinity(P) ≥ len, in ascending numeric index order, do
-    // a. Add P as the last element of keys.
+    //      a. Add P as the last element of keys.
     let mut remaining_indices: Vec<_> = obj
         .properties
         .index_property_keys()
@@ -117,23 +117,12 @@ pub(crate) fn string_exotic_own_property_keys(
 
     // 7. For each own property key P of O such that Type(P) is String and P is not
     // an array index, in ascending chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.properties
-            .string_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
+    //      a. Add P as the last element of keys.
 
     // 8. For each own property key P of O such that Type(P) is Symbol, in ascending
     // chronological order of property creation, do
-    // a. Add P as the last element of keys.
-    keys.extend(
-        obj.properties
-            .symbol_property_keys()
-            .cloned()
-            .map(Into::into),
-    );
+    //      a. Add P as the last element of keys.
+    keys.extend(obj.properties.shape.keys());
 
     // 9. Return keys.
     Ok(keys)

--- a/boa_engine/src/object/shape/mod.rs
+++ b/boa_engine/src/object/shape/mod.rs
@@ -1,0 +1,217 @@
+//! Implements object shapes.
+
+pub(crate) mod property_table;
+pub(crate) mod shared_shape;
+pub(crate) mod slot;
+pub(crate) mod unique_shape;
+
+pub use shared_shape::SharedShape;
+pub(crate) use unique_shape::UniqueShape;
+
+use std::fmt::Debug;
+
+use boa_gc::{Finalize, Trace};
+
+use crate::property::PropertyKey;
+
+use self::{shared_shape::TransitionKey, slot::Slot};
+
+use super::JsPrototype;
+
+/// Action to be performed after a property attribute change
+//
+// Example: of { get/set x() { ... }, y: ... } into { x: ..., y: ... }
+//
+//                 0       1       2
+//    Storage: | get x | set x |   y   |
+//
+// We delete at position of x which is index 0 (it spans two elements) + 1:
+//
+//                 0      1
+//    Storage: |   x  |   y   |
+pub(crate) enum ChangeTransitionAction {
+    /// Do nothing to storage.
+    Nothing,
+
+    /// Remove element at (index + 1) from storage.
+    Remove,
+
+    /// Insert element at (index + 1) into storage.
+    Insert,
+}
+
+/// The result of a change property attribute transition.
+pub(crate) struct ChangeTransition<T> {
+    /// The shape after transition.
+    pub(crate) shape: T,
+
+    /// The needed action to be performed after transition to the object storage.
+    pub(crate) action: ChangeTransitionAction,
+}
+
+/// The internal representation of [`Shape`].
+#[derive(Debug, Trace, Finalize, Clone)]
+enum Inner {
+    Unique(UniqueShape),
+    Shared(SharedShape),
+}
+
+/// Represents the shape of an object.
+#[derive(Debug, Trace, Finalize, Clone)]
+pub struct Shape {
+    inner: Inner,
+}
+
+impl Default for Shape {
+    fn default() -> Self {
+        Shape::unique(UniqueShape::default())
+    }
+}
+
+impl Shape {
+    /// The max transition count of a [`SharedShape`] from the root node,
+    /// before the shape will be converted into a [`UniqueShape`]
+    ///
+    /// NOTE: This only applies to [`SharedShape`].
+    const TRANSITION_COUNT_MAX: u16 = 1024;
+
+    /// Create a [`Shape`] from a [`SharedShape`].
+    pub(crate) fn shared(inner: SharedShape) -> Self {
+        Self {
+            inner: Inner::Shared(inner),
+        }
+    }
+
+    /// Create a [`Shape`] from a [`UniqueShape`].
+    pub(crate) const fn unique(shape: UniqueShape) -> Self {
+        Self {
+            inner: Inner::Unique(shape),
+        }
+    }
+
+    /// Returns `true` if it's a shared shape, `false` otherwise.
+    #[inline]
+    pub const fn is_shared(&self) -> bool {
+        matches!(self.inner, Inner::Shared(_))
+    }
+
+    /// Returns `true` if it's a unique shape, `false` otherwise.
+    #[inline]
+    pub const fn is_unique(&self) -> bool {
+        matches!(self.inner, Inner::Unique(_))
+    }
+
+    pub(crate) const fn as_unique(&self) -> Option<&UniqueShape> {
+        if let Inner::Unique(shape) = &self.inner {
+            return Some(shape);
+        }
+        None
+    }
+
+    /// Create an insert property transitions returning the new transitioned [`Shape`].
+    ///
+    /// NOTE: This assumes that there is no property with the given key!
+    pub(crate) fn insert_property_transition(&self, key: TransitionKey) -> Self {
+        match &self.inner {
+            Inner::Shared(shape) => {
+                let shape = shape.insert_property_transition(key);
+                if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
+                    return Self::unique(shape.to_unique());
+                }
+                Self::shared(shape)
+            }
+            Inner::Unique(shape) => Self::unique(shape.insert_property_transition(key)),
+        }
+    }
+
+    /// Create a change attribute property transitions returning [`ChangeTransition`] containing the new [`Shape`]
+    /// and actions to be performed
+    ///
+    /// NOTE: This assumes that there already is a property with the given key!
+    pub(crate) fn change_attributes_transition(
+        &self,
+        key: TransitionKey,
+    ) -> ChangeTransition<Shape> {
+        match &self.inner {
+            Inner::Shared(shape) => {
+                let change_transition = shape.change_attributes_transition(key);
+                let shape =
+                    if change_transition.shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
+                        Self::unique(change_transition.shape.to_unique())
+                    } else {
+                        Self::shared(change_transition.shape)
+                    };
+                ChangeTransition {
+                    shape,
+                    action: change_transition.action,
+                }
+            }
+            Inner::Unique(shape) => shape.change_attributes_transition(&key),
+        }
+    }
+
+    /// Remove a property property from the [`Shape`] returning the new transitioned [`Shape`].
+    ///
+    /// NOTE: This assumes that there already is a property with the given key!
+    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
+        match &self.inner {
+            Inner::Shared(shape) => {
+                let shape = shape.remove_property_transition(key);
+                if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
+                    return Self::unique(shape.to_unique());
+                }
+                Self::shared(shape)
+            }
+            Inner::Unique(shape) => Self::unique(shape.remove_property_transition(key)),
+        }
+    }
+
+    /// Create a prototype transitions returning the new transitioned [`Shape`].
+    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
+        match &self.inner {
+            Inner::Shared(shape) => {
+                let shape = shape.change_prototype_transition(prototype);
+                if shape.transition_count() >= Self::TRANSITION_COUNT_MAX {
+                    return Self::unique(shape.to_unique());
+                }
+                Self::shared(shape)
+            }
+            Inner::Unique(shape) => Self::unique(shape.change_prototype_transition(prototype)),
+        }
+    }
+
+    /// Get the [`JsPrototype`] of the [`Shape`].
+    pub fn prototype(&self) -> JsPrototype {
+        match &self.inner {
+            Inner::Shared(shape) => shape.prototype(),
+            Inner::Unique(shape) => shape.prototype(),
+        }
+    }
+
+    /// Lookup a property in the shape
+    #[inline]
+    pub(crate) fn lookup(&self, key: &PropertyKey) -> Option<Slot> {
+        match &self.inner {
+            Inner::Shared(shape) => shape.lookup(key),
+            Inner::Unique(shape) => shape.lookup(key),
+        }
+    }
+
+    /// Returns the keys of the [`Shape`], in insertion order.
+    #[inline]
+    pub fn keys(&self) -> Vec<PropertyKey> {
+        match &self.inner {
+            Inner::Shared(shape) => shape.keys(),
+            Inner::Unique(shape) => shape.keys(),
+        }
+    }
+
+    /// Return location in memory of the [`Shape`].
+    #[inline]
+    pub fn to_addr_usize(&self) -> usize {
+        match &self.inner {
+            Inner::Shared(shape) => shape.to_addr_usize(),
+            Inner::Unique(shape) => shape.to_addr_usize(),
+        }
+    }
+}

--- a/boa_engine/src/object/shape/property_table.rs
+++ b/boa_engine/src/object/shape/property_table.rs
@@ -1,0 +1,149 @@
+use std::{cell::RefCell, rc::Rc};
+
+use rustc_hash::FxHashMap;
+
+use crate::{
+    object::shape::slot::{Slot, SlotAttributes},
+    property::PropertyKey,
+};
+
+/// The internal representation of [`PropertyTable`].
+#[derive(Default, Debug, Clone)]
+pub(crate) struct PropertyTableInner {
+    pub(crate) map: FxHashMap<PropertyKey, (u32, Slot)>,
+    pub(crate) keys: Vec<(PropertyKey, Slot)>,
+}
+
+impl PropertyTableInner {
+    /// Returns all the keys, in insertion order.
+    pub(crate) fn keys(&self) -> Vec<PropertyKey> {
+        self.keys_cloned_n(self.keys.len() as u32)
+    }
+
+    /// Returns `n` cloned keys, in insertion order.
+    pub(crate) fn keys_cloned_n(&self, n: u32) -> Vec<PropertyKey> {
+        let n = n as usize;
+
+        self.keys
+            .iter()
+            .take(n)
+            .map(|(key, _)| key)
+            .filter(|key| matches!(key, PropertyKey::String(_)))
+            .chain(
+                self.keys
+                    .iter()
+                    .take(n)
+                    .map(|(key, _)| key)
+                    .filter(|key| matches!(key, PropertyKey::Symbol(_))),
+            )
+            .cloned()
+            .collect()
+    }
+
+    /// Returns a new table with `n` cloned properties.
+    pub(crate) fn clone_count(&self, n: u32) -> Self {
+        let n = n as usize;
+
+        let mut keys = Vec::with_capacity(n);
+        let mut map = FxHashMap::default();
+
+        for (index, (key, slot)) in self.keys.iter().take(n).enumerate() {
+            keys.push((key.clone(), *slot));
+            map.insert(key.clone(), (index as u32, *slot));
+        }
+
+        Self { map, keys }
+    }
+
+    /// Insert a property entry into the table.
+    pub(crate) fn insert(&mut self, key: PropertyKey, attributes: SlotAttributes) {
+        let slot = Slot::from_previous(self.keys.last().map(|x| x.1), attributes);
+        let index = self.keys.len() as u32;
+        self.keys.push((key.clone(), slot));
+        let value = self.map.insert(key, (index, slot));
+        debug_assert!(value.is_none());
+    }
+}
+
+/// Represents an ordered property table, that maps [`PropertyTable`] to [`Slot`].
+///
+/// This is shared between [`crate::object::shape::SharedShape`].
+#[derive(Default, Debug, Clone)]
+pub(crate) struct PropertyTable {
+    pub(super) inner: Rc<RefCell<PropertyTableInner>>,
+}
+
+impl PropertyTable {
+    /// Returns the inner representation of a [`PropertyTable`].
+    pub(super) fn inner(&self) -> &RefCell<PropertyTableInner> {
+        &self.inner
+    }
+
+    /// Add a property to the [`PropertyTable`] or deep clone it,
+    /// if there already is a property or the property has attributes that are not the same.
+    pub(crate) fn add_property_deep_clone_if_needed(
+        &self,
+        key: PropertyKey,
+        attributes: SlotAttributes,
+        property_count: u32,
+    ) -> Self {
+        {
+            let mut inner = self.inner.borrow_mut();
+            if (property_count as usize) == inner.keys.len() && !inner.map.contains_key(&key) {
+                inner.insert(key, attributes);
+                return self.clone();
+            }
+        }
+
+        // property is already present need to make deep clone of property table.
+        let this = self.deep_clone(property_count);
+        {
+            let mut inner = this.inner.borrow_mut();
+            inner.insert(key, attributes);
+        }
+        this
+    }
+
+    /// Deep clone the [`PropertyTable`] in insertion order with the first n properties.
+    pub(crate) fn deep_clone(&self, n: u32) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(self.inner.borrow().clone_count(n))),
+        }
+    }
+
+    /// Deep clone the [`PropertyTable`].
+    pub(crate) fn deep_clone_all(&self) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new((*self.inner.borrow()).clone())),
+        }
+    }
+
+    /// Change the attributes of a property.
+    pub(crate) fn set_attributes_at_index(
+        &self,
+        key: &PropertyKey,
+        property_attributes: SlotAttributes,
+    ) {
+        let mut inner = self.inner.borrow_mut();
+        let Some((index, slot)) = inner.map.get_mut(key) else {
+            unreachable!("There should already be a property!")
+        };
+        slot.attributes = property_attributes;
+        let index = *index as usize;
+
+        inner.keys[index].1.attributes = property_attributes;
+    }
+
+    /// Get a property from the [`PropertyTable`].
+    ///
+    /// Panics:
+    ///
+    /// If it is not in the [`PropertyTable`].
+    pub(crate) fn get_expect(&self, key: &PropertyKey) -> Slot {
+        let inner = self.inner.borrow();
+        let Some((_, slot)) = inner.map.get(key) else {
+            unreachable!("There should already be a property!")
+        };
+        *slot
+    }
+}

--- a/boa_engine/src/object/shape/shared_shape/forward_transition.rs
+++ b/boa_engine/src/object/shape/shared_shape/forward_transition.rs
@@ -1,0 +1,58 @@
+use boa_gc::{Finalize, Gc, GcRefCell, Trace, WeakGc};
+use rustc_hash::FxHashMap;
+
+use crate::object::JsPrototype;
+
+use super::{Inner as SharedShapeInner, TransitionKey};
+
+/// Maps transition key type to a [`SharedShapeInner`] transition.
+type TransitionMap<T> = FxHashMap<T, WeakGc<SharedShapeInner>>;
+
+/// The internal representation of [`ForwardTransition`].
+#[derive(Default, Debug, Trace, Finalize)]
+struct Inner {
+    properties: Option<Box<TransitionMap<TransitionKey>>>,
+    prototypes: Option<Box<TransitionMap<JsPrototype>>>,
+}
+
+/// Holds a forward reference to a previously created transition.
+///
+/// The reference is weak, therefore it can be garbage collected if it is not in use.
+#[derive(Default, Debug, Trace, Finalize)]
+pub(super) struct ForwardTransition {
+    inner: GcRefCell<Inner>,
+}
+
+impl ForwardTransition {
+    /// Insert a property transition.
+    pub(super) fn insert_property(&self, key: TransitionKey, value: &Gc<SharedShapeInner>) {
+        let mut this = self.inner.borrow_mut();
+        let properties = this.properties.get_or_insert_with(Box::default);
+        properties.insert(key, WeakGc::new(value));
+    }
+
+    /// Insert a prototype transition.
+    pub(super) fn insert_prototype(&self, key: JsPrototype, value: &Gc<SharedShapeInner>) {
+        let mut this = self.inner.borrow_mut();
+        let prototypes = this.prototypes.get_or_insert_with(Box::default);
+        prototypes.insert(key, WeakGc::new(value));
+    }
+
+    /// Get a property transition, return [`None`] otherwise.
+    pub(super) fn get_property(&self, key: &TransitionKey) -> Option<WeakGc<SharedShapeInner>> {
+        let this = self.inner.borrow();
+        let Some(transitions) = this.properties.as_ref() else {
+            return None;
+        };
+        transitions.get(key).cloned()
+    }
+
+    /// Get a prototype transition, return [`None`] otherwise.
+    pub(super) fn get_prototype(&self, key: &JsPrototype) -> Option<WeakGc<SharedShapeInner>> {
+        let this = self.inner.borrow();
+        let Some(transitions) = this.prototypes.as_ref() else {
+            return None;
+        };
+        transitions.get(key).cloned()
+    }
+}

--- a/boa_engine/src/object/shape/shared_shape/mod.rs
+++ b/boa_engine/src/object/shape/shared_shape/mod.rs
@@ -1,0 +1,469 @@
+mod forward_transition;
+pub(crate) mod template;
+
+use std::{collections::hash_map::RandomState, hash::Hash};
+
+use bitflags::bitflags;
+use boa_gc::{empty_trace, Finalize, Gc, Trace};
+use indexmap::IndexMap;
+
+use crate::{object::JsPrototype, property::PropertyKey, JsObject};
+
+use self::forward_transition::ForwardTransition;
+
+use super::{
+    property_table::PropertyTable, slot::SlotAttributes, ChangeTransition, ChangeTransitionAction,
+    Slot, UniqueShape,
+};
+
+/// Represent a [`SharedShape`] property transition.
+#[derive(Debug, Finalize, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TransitionKey {
+    pub(crate) property_key: PropertyKey,
+    pub(crate) attributes: SlotAttributes,
+}
+
+// SAFETY: Non of the member of this struct are garbage collected,
+//         so this should be fine.
+unsafe impl Trace for TransitionKey {
+    empty_trace!();
+}
+
+const INSERT_PROPERTY_TRANSITION_TYPE: u8 = 0b0000_0000;
+const CONFIGURE_PROPERTY_TRANSITION_TYPE: u8 = 0b0000_0001;
+const PROTOTYPE_TRANSITION_TYPE: u8 = 0b0000_0010;
+
+// Reserved for future use!
+#[allow(unused)]
+const RESEREVED_TRANSITION_TYPE: u8 = 0b0000_0011;
+
+bitflags! {
+    /// Flags of a shape.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Finalize)]
+    pub struct ShapeFlags: u8 {
+        /// Represents the transition type of a [`SharedShape`].
+        const TRANSITION_TYPE = 0b0000_0011;
+    }
+}
+
+impl Default for ShapeFlags {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl ShapeFlags {
+    // NOTE: Remove type bits and set the new ones.
+    fn insert_property_transition_from(previous: ShapeFlags) -> Self {
+        previous.difference(Self::TRANSITION_TYPE)
+            | Self::from_bits_retain(INSERT_PROPERTY_TRANSITION_TYPE)
+    }
+    fn configure_property_transition_from(previous: ShapeFlags) -> Self {
+        previous.difference(Self::TRANSITION_TYPE)
+            | Self::from_bits_retain(CONFIGURE_PROPERTY_TRANSITION_TYPE)
+    }
+    fn prototype_transition_from(previous: ShapeFlags) -> Self {
+        previous.difference(Self::TRANSITION_TYPE)
+            | Self::from_bits_retain(PROTOTYPE_TRANSITION_TYPE)
+    }
+
+    const fn is_insert_transition_type(self) -> bool {
+        self.intersection(Self::TRANSITION_TYPE).bits() == INSERT_PROPERTY_TRANSITION_TYPE
+    }
+    const fn is_prototype_transition_type(self) -> bool {
+        self.intersection(Self::TRANSITION_TYPE).bits() == PROTOTYPE_TRANSITION_TYPE
+    }
+}
+
+// SAFETY: Non of the member of this struct are garbage collected,
+//         so this should be fine.
+unsafe impl Trace for ShapeFlags {
+    empty_trace!();
+}
+
+/// The internal representation of a [`SharedShape`].
+#[derive(Debug, Trace, Finalize)]
+struct Inner {
+    /// See [`ForwardTransition`].
+    forward_transitions: ForwardTransition,
+
+    /// The count of how many properties this [`SharedShape`] holds.
+    property_count: u32,
+
+    /// Instance prototype `__proto__`.
+    prototype: JsPrototype,
+
+    // SAFETY: This is safe because nothing in [`PropertyTable`]
+    //         needs tracing
+    #[unsafe_ignore_trace]
+    property_table: PropertyTable,
+
+    /// The previous shape in the transition chain.
+    ///
+    /// [`None`] if it is the root shape.
+    previous: Option<SharedShape>,
+
+    /// How many transitions have happened from the root node.
+    transition_count: u16,
+
+    /// Flags about the shape.
+    flags: ShapeFlags,
+}
+
+/// Represents a shared object shape.
+#[derive(Debug, Trace, Finalize, Clone)]
+pub struct SharedShape {
+    inner: Gc<Inner>,
+}
+
+impl SharedShape {
+    fn property_table(&self) -> &PropertyTable {
+        &self.inner.property_table
+    }
+    /// Return the property count that this shape owns in the [`PropertyTable`].
+    fn property_count(&self) -> u32 {
+        self.inner.property_count
+    }
+    /// Return the index to the property in the the [`PropertyTable`].
+    fn property_index(&self) -> u32 {
+        self.inner.property_count.saturating_sub(1)
+    }
+    /// Getter for the transition count field.
+    pub fn transition_count(&self) -> u16 {
+        self.inner.transition_count
+    }
+    /// Getter for the previous field.
+    pub fn previous(&self) -> Option<&SharedShape> {
+        self.inner.previous.as_ref()
+    }
+    /// Get the prototype of the shape.
+    pub fn prototype(&self) -> JsPrototype {
+        self.inner.prototype.clone()
+    }
+    /// Get the property this [`SharedShape`] refers to.
+    pub(crate) fn property(&self) -> (PropertyKey, Slot) {
+        let inner = self.property_table().inner().borrow();
+        let (key, slot) = inner
+            .keys
+            .get(self.property_index() as usize)
+            .expect("There should be a property");
+        (key.clone(), *slot)
+    }
+    /// Get the flags of the shape.
+    fn flags(&self) -> ShapeFlags {
+        self.inner.flags
+    }
+    /// Getter for the [`ForwardTransition`] field.
+    fn forward_transitions(&self) -> &ForwardTransition {
+        &self.inner.forward_transitions
+    }
+    /// Check if the shape has the given prototype.
+    pub fn has_prototype(&self, prototype: &JsObject) -> bool {
+        self.inner
+            .prototype
+            .as_ref()
+            .map_or(false, |this| this == prototype)
+    }
+
+    /// Create a new [`SharedShape`].
+    fn new(inner: Inner) -> Self {
+        Self {
+            inner: Gc::new(inner),
+        }
+    }
+
+    /// Create a root [`SharedShape`].
+    #[must_use]
+    pub fn root() -> Self {
+        Self::new(Inner {
+            forward_transitions: ForwardTransition::default(),
+            prototype: None,
+            property_count: 0,
+            property_table: PropertyTable::default(),
+            previous: None,
+            flags: ShapeFlags::default(),
+            transition_count: 0,
+        })
+    }
+
+    /// Create a [`SharedShape`] change prototype transition.
+    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
+        if let Some(shape) = self.forward_transitions().get_prototype(&prototype) {
+            if let Some(inner) = shape.upgrade() {
+                return Self { inner };
+            }
+        }
+        let new_inner_shape = Inner {
+            forward_transitions: ForwardTransition::default(),
+            prototype: prototype.clone(),
+            property_table: self.property_table().clone(),
+            property_count: self.property_count(),
+            previous: Some(self.clone()),
+            transition_count: self.transition_count() + 1,
+            flags: ShapeFlags::prototype_transition_from(self.flags()),
+        };
+        let new_shape = Self::new(new_inner_shape);
+
+        self.forward_transitions()
+            .insert_prototype(prototype, &new_shape.inner);
+
+        new_shape
+    }
+
+    /// Create a [`SharedShape`] insert property transition.
+    pub(crate) fn insert_property_transition(&self, key: TransitionKey) -> Self {
+        // Check if we have already created such a transition, if so use it!
+        if let Some(shape) = self.forward_transitions().get_property(&key) {
+            if let Some(inner) = shape.upgrade() {
+                return Self { inner };
+            }
+        }
+
+        let property_table = self.property_table().add_property_deep_clone_if_needed(
+            key.property_key.clone(),
+            key.attributes,
+            self.property_count(),
+        );
+        let new_inner_shape = Inner {
+            prototype: self.prototype(),
+            forward_transitions: ForwardTransition::default(),
+            property_table,
+            property_count: self.property_count() + 1,
+            previous: Some(self.clone()),
+            transition_count: self.transition_count() + 1,
+            flags: ShapeFlags::insert_property_transition_from(self.flags()),
+        };
+        let new_shape = Self::new(new_inner_shape);
+
+        self.forward_transitions()
+            .insert_property(key, &new_shape.inner);
+
+        new_shape
+    }
+
+    /// Create a [`SharedShape`] change prototype transition, returning [`ChangeTransition`].
+    pub(crate) fn change_attributes_transition(
+        &self,
+        key: TransitionKey,
+    ) -> ChangeTransition<SharedShape> {
+        let slot = self.property_table().get_expect(&key.property_key);
+
+        // Check if we have already created such a transition, if so use it!
+        if let Some(shape) = self.forward_transitions().get_property(&key) {
+            if let Some(inner) = shape.upgrade() {
+                let action = if slot.attributes.width_match(key.attributes) {
+                    ChangeTransitionAction::Nothing
+                } else if slot.attributes.is_accessor_descriptor() {
+                    // Accessor property --> Data property
+                    ChangeTransitionAction::Remove
+                } else {
+                    // Data property --> Accessor property
+                    ChangeTransitionAction::Insert
+                };
+
+                return ChangeTransition {
+                    shape: Self { inner },
+                    action,
+                };
+            }
+        }
+
+        // The attribute change transitions, didn't change from accessor to data property or vice-versa.
+        if slot.attributes.width_match(key.attributes) {
+            let property_table = self.property_table().deep_clone_all();
+            property_table.set_attributes_at_index(&key.property_key, key.attributes);
+            let inner_shape = Inner {
+                forward_transitions: ForwardTransition::default(),
+                prototype: self.prototype(),
+                property_table,
+                property_count: self.property_count(),
+                previous: Some(self.clone()),
+                transition_count: self.transition_count() + 1,
+                flags: ShapeFlags::configure_property_transition_from(self.flags()),
+            };
+            let shape = Self::new(inner_shape);
+
+            self.forward_transitions()
+                .insert_property(key, &shape.inner);
+
+            return ChangeTransition {
+                shape,
+                action: ChangeTransitionAction::Nothing,
+            };
+        }
+
+        // Rollback before the property has added.
+        let (mut base, prototype, transitions) = self.rollback_before(&key.property_key);
+
+        // Apply prototype transition, if it was found.
+        if let Some(prototype) = prototype {
+            base = base.change_prototype_transition(prototype);
+        }
+
+        // Apply this property.
+        base = base.insert_property_transition(key);
+
+        // Apply previous properties.
+        for (property_key, attributes) in transitions.into_iter().rev() {
+            let transition = TransitionKey {
+                property_key,
+                attributes,
+            };
+            base = base.insert_property_transition(transition);
+        }
+
+        // Determine action to be performed on the storage.
+        let action = if slot.attributes.is_accessor_descriptor() {
+            // Accessor property --> Data property
+            ChangeTransitionAction::Remove
+        } else {
+            // Data property --> Accessor property
+            ChangeTransitionAction::Insert
+        };
+
+        ChangeTransition {
+            shape: base,
+            action,
+        }
+    }
+
+    /// Rollback to shape before the insertion of the [`PropertyKey`] that is provided.
+    ///
+    /// This returns the shape before the insertion, if it sees a prototype transition it will return the lastest one,
+    /// ignoring any others, [`None`] otherwise. It also will return the property transitions ordered from
+    /// latest to oldest that it sees.
+    ///
+    /// NOTE: In the transitions it does not include the property that we are rolling back.
+    ///
+    /// NOTE: The prototype transitions if it sees a property insert and then later an attribute change it will condense
+    /// into one property insert transition with the new attribute in the change attribute transition,
+    /// in the same place that the property was inserted initially.
+    //
+    // For example with the following chain:
+    //
+    //        INSERT(x)             INSERT(y)                INSERT(z)
+    // { }  ------------>  { x }  ------------>  { x, y }  ------------>  { x, y, z }
+    //
+    // Then we call rollback on `y`:
+    //
+    //        INSERT(x)             INSERT(y)                INSERT(z)
+    // { }  ------------>  { x }  ------------>  { x, y }  ------------>  { x, y, z }
+    //                       ^
+    //                       \--- base (with array of transitions to be performed: INSERT(z),
+    //                                                 and protortype: None )
+    fn rollback_before(
+        &self,
+        key: &PropertyKey,
+    ) -> (
+        SharedShape,
+        Option<JsPrototype>,
+        IndexMap<PropertyKey, SlotAttributes>,
+    ) {
+        let mut prototype = None;
+        let mut transitions: IndexMap<PropertyKey, SlotAttributes, RandomState> =
+            IndexMap::default();
+
+        let mut current = Some(self);
+        let base = loop {
+            let Some(current_shape) = current else {
+                unreachable!("The chain should have insert transition type!")
+            };
+
+            // We only take the latest prototype change it, if it exists.
+            if current_shape.flags().is_prototype_transition_type() {
+                if prototype.is_none() {
+                    prototype = Some(current_shape.prototype().clone());
+                }
+
+                // Skip when it is a prototype transition.
+                current = current_shape.previous();
+                continue;
+            }
+
+            let (current_property_key, slot) = current_shape.property();
+
+            if current_shape.flags().is_insert_transition_type() && &current_property_key == key {
+                let base = if let Some(base) = current_shape.previous() {
+                    base.clone()
+                } else {
+                    // It's the root, because it doesn't have previous.
+                    current_shape.clone()
+                };
+                break base;
+            }
+
+            // Do not add property that we are trying to delete.
+            // this can happen if a configure was called after inserting it into the shape
+            if &current_property_key != key {
+                // Only take the latest changes to a property. To try to build a smaller tree.
+                transitions
+                    .entry(current_property_key)
+                    .or_insert(slot.attributes);
+            }
+
+            current = current_shape.previous();
+        };
+
+        (base, prototype, transitions)
+    }
+
+    /// Remove a property from [`SharedShape`], returning the new [`SharedShape`].
+    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
+        let (mut base, prototype, transitions) = self.rollback_before(key);
+
+        // Apply prototype transition, if it was found.
+        if let Some(prototype) = prototype {
+            base = base.change_prototype_transition(prototype);
+        }
+
+        for (property_key, attributes) in transitions.into_iter().rev() {
+            let transition = TransitionKey {
+                property_key,
+                attributes,
+            };
+            base = base.insert_property_transition(transition);
+        }
+
+        base
+    }
+
+    /// Do a property lookup, returns [`None`] if property not found.
+    pub(crate) fn lookup(&self, key: &PropertyKey) -> Option<Slot> {
+        let property_count = self.property_count();
+        if property_count == 0 {
+            return None;
+        }
+
+        let property_table_inner = self.property_table().inner().borrow();
+        if let Some((property_table_index, slot)) = property_table_inner.map.get(key) {
+            // Check if we are trying to access properties that belong to another shape.
+            if *property_table_index < self.property_count() {
+                return Some(*slot);
+            }
+        }
+        None
+    }
+
+    /// Gets all keys first strings then symbols in creation order.
+    pub(crate) fn keys(&self) -> Vec<PropertyKey> {
+        let property_table = self.property_table().inner().borrow();
+        property_table.keys_cloned_n(self.property_count())
+    }
+
+    /// Returns a new [`UniqueShape`] with the properties of the [`SharedShape`].
+    pub(crate) fn to_unique(&self) -> UniqueShape {
+        UniqueShape::new(
+            self.prototype(),
+            self.property_table()
+                .inner()
+                .borrow()
+                .clone_count(self.property_count()),
+        )
+    }
+
+    /// Return location in memory of the [`UniqueShape`].
+    pub(crate) fn to_addr_usize(&self) -> usize {
+        let ptr: *const _ = self.inner.as_ref();
+        ptr as usize
+    }
+}

--- a/boa_engine/src/object/shape/shared_shape/template.rs
+++ b/boa_engine/src/object/shape/shared_shape/template.rs
@@ -1,0 +1,141 @@
+use boa_gc::{Finalize, Trace};
+use thin_vec::ThinVec;
+
+use crate::{
+    object::{
+        shape::{slot::SlotAttributes, Shape},
+        JsObject, Object, ObjectData, PropertyMap,
+    },
+    property::{Attribute, PropertyKey},
+    JsValue,
+};
+
+use super::{SharedShape, TransitionKey};
+
+/// Represent a template of an objects properties and prototype.
+/// This is used to construct as many objects  as needed from a predefined [`SharedShape`].
+#[derive(Debug, Clone, Trace, Finalize)]
+pub(crate) struct ObjectTemplate {
+    shape: SharedShape,
+}
+
+impl ObjectTemplate {
+    /// Create a new [`ObjectTemplate`]
+    pub(crate) fn new(root_shape: &SharedShape) -> Self {
+        Self {
+            shape: root_shape.clone(),
+        }
+    }
+
+    /// Create and [`ObjectTemplate`] with a prototype.
+    pub(crate) fn with_prototype(root_shape: &SharedShape, prototype: JsObject) -> Self {
+        let shape = root_shape.change_prototype_transition(Some(prototype));
+        Self { shape }
+    }
+
+    /// Check if the shape has a specific, prototype.
+    pub(crate) fn has_prototype(&self, prototype: &JsObject) -> bool {
+        self.shape.has_prototype(prototype)
+    }
+
+    /// Set the prototype of the [`ObjectTemplate`].
+    ///
+    /// This assumes that the prototype has not been set yet.
+    pub(crate) fn set_prototype(&mut self, prototype: JsObject) -> &mut Self {
+        self.shape = self.shape.change_prototype_transition(Some(prototype));
+        self
+    }
+
+    /// Add a data property to the [`ObjectTemplate`].
+    ///
+    /// This assumes that the property with the given key was not previously set
+    /// and that it's a string or symbol.
+    pub(crate) fn property(&mut self, key: PropertyKey, attributes: Attribute) -> &mut Self {
+        debug_assert!(!matches!(&key, PropertyKey::Index(_)));
+
+        let attributes = SlotAttributes::from_bits_truncate(attributes.bits());
+        self.shape = self.shape.insert_property_transition(TransitionKey {
+            property_key: key,
+            attributes,
+        });
+
+        self
+    }
+
+    /// Add a accessor property to the [`ObjectTemplate`].
+    ///
+    /// This assumes that the property with the given key was not previously set
+    /// and that it's a string or symbol.
+    pub(crate) fn accessor(
+        &mut self,
+        key: PropertyKey,
+        get: bool,
+        set: bool,
+        attributes: Attribute,
+    ) -> &mut Self {
+        // TOOD: We don't support indexed keys.
+        debug_assert!(!matches!(&key, PropertyKey::Index(_)));
+
+        let attributes = {
+            let mut result = SlotAttributes::empty();
+            result.set(
+                SlotAttributes::CONFIGURABLE,
+                attributes.contains(Attribute::CONFIGURABLE),
+            );
+            result.set(
+                SlotAttributes::ENUMERABLE,
+                attributes.contains(Attribute::ENUMERABLE),
+            );
+
+            result.set(SlotAttributes::GET, get);
+            result.set(SlotAttributes::SET, set);
+
+            result
+        };
+
+        self.shape = self.shape.insert_property_transition(TransitionKey {
+            property_key: key,
+            attributes,
+        });
+
+        self
+    }
+
+    /// Create an object from the [`ObjectTemplate`]
+    ///
+    /// The storage must match the properties provided.
+    pub(crate) fn create(&self, data: ObjectData, storage: Vec<JsValue>) -> JsObject {
+        let mut object = Object {
+            kind: data.kind,
+            extensible: true,
+            properties: PropertyMap::new(Shape::shared(self.shape.clone()), ThinVec::default()),
+            private_elements: ThinVec::new(),
+        };
+
+        object.properties.storage = storage;
+
+        JsObject::from_object_and_vtable(object, data.internal_methods)
+    }
+
+    /// Create an object from the [`ObjectTemplate`]
+    ///
+    /// The storage must match the properties provided. It does not apply to
+    /// the indexed propeties.
+    pub(crate) fn create_with_indexed_properties(
+        &self,
+        data: ObjectData,
+        storage: Vec<JsValue>,
+        elements: ThinVec<JsValue>,
+    ) -> JsObject {
+        let mut object = Object {
+            kind: data.kind,
+            extensible: true,
+            properties: PropertyMap::new(Shape::shared(self.shape.clone()), elements),
+            private_elements: ThinVec::new(),
+        };
+
+        object.properties.storage = storage;
+
+        JsObject::from_object_and_vtable(object, data.internal_methods)
+    }
+}

--- a/boa_engine/src/object/shape/slot.rs
+++ b/boa_engine/src/object/shape/slot.rs
@@ -1,0 +1,77 @@
+use bitflags::bitflags;
+pub(crate) type SlotIndex = u32;
+
+bitflags! {
+    /// Attributes of a slot.
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub(crate) struct SlotAttributes: u8 {
+        const WRITABLE = 0b0000_0001;
+        const ENUMERABLE = 0b0000_0010;
+        const CONFIGURABLE = 0b0000_0100;
+        const GET = 0b0000_1000;
+        const SET = 0b0001_0000;
+    }
+}
+
+impl SlotAttributes {
+    pub(crate) const fn is_accessor_descriptor(self) -> bool {
+        self.contains(Self::GET) || self.contains(Self::SET)
+    }
+
+    pub(crate) const fn has_get(self) -> bool {
+        self.contains(Self::GET)
+    }
+    pub(crate) const fn has_set(self) -> bool {
+        self.contains(Self::SET)
+    }
+
+    /// Check if slot type width matches, this can only happens,
+    /// if they are both accessors, or both data properties.
+    pub(crate) const fn width_match(self, other: Self) -> bool {
+        self.is_accessor_descriptor() == other.is_accessor_descriptor()
+    }
+
+    /// Get the width of the slot.
+    pub(crate) fn width(self) -> u32 {
+        // accessor take 2 positions in the storage to accomodate for the `get` and `set` fields.
+        1 + u32::from(self.is_accessor_descriptor())
+    }
+}
+
+/// Represents an [`u32`] index and it's slot attributes of an element in a object storage.
+///
+/// Slots can have different width depending on its attributes, accessors properties have width `2`,
+/// while data properties have width `1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Slot {
+    pub(crate) index: SlotIndex,
+    pub(crate) attributes: SlotAttributes,
+}
+
+impl Slot {
+    /// Get the width of the slot.
+    pub(crate) fn width(self) -> u32 {
+        self.attributes.width()
+    }
+
+    /// Calculate next slot from previous one.
+    ///
+    /// This is needed because slots do not have the same width.
+    pub(crate) fn from_previous(
+        previous_slot: Option<Slot>,
+        new_attributes: SlotAttributes,
+    ) -> Self {
+        // If there was no previous slot then return 0 as the index.
+        let Some(previous_slot) = previous_slot else {
+            return Self {
+                index: 0,
+                attributes: new_attributes,
+            }
+        };
+
+        Self {
+            index: previous_slot.index + previous_slot.width(),
+            attributes: new_attributes,
+        }
+    }
+}

--- a/boa_engine/src/object/shape/unique_shape.rs
+++ b/boa_engine/src/object/shape/unique_shape.rs
@@ -1,0 +1,241 @@
+use std::{cell::RefCell, fmt::Debug};
+
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
+
+use crate::property::PropertyKey;
+
+use super::{
+    property_table::PropertyTableInner, shared_shape::TransitionKey, ChangeTransition,
+    ChangeTransitionAction, JsPrototype, Shape, Slot,
+};
+
+/// The internal representation of [`UniqueShape`].
+#[derive(Default, Debug, Trace, Finalize)]
+struct Inner {
+    /// The property table that maps a [`PropertyKey`] to a slot in the objects storage.
+    //
+    // SAFETY: This is safe becasue nothing in this field needs tracing.
+    #[unsafe_ignore_trace]
+    property_table: RefCell<PropertyTableInner>,
+
+    /// The prototype of the shape.
+    prototype: GcRefCell<JsPrototype>,
+}
+
+/// Represents a [`Shape`] that is not shared with any other object.
+///
+/// This is useful for objects that are inherently unique like,
+/// the builtin object.
+///
+/// Cloning this does a shallow clone.
+#[derive(Default, Debug, Clone, Trace, Finalize)]
+pub(crate) struct UniqueShape {
+    inner: Gc<Inner>,
+}
+
+impl UniqueShape {
+    /// Create a new [`UniqueShape`].
+    pub(crate) fn new(prototype: JsPrototype, property_table: PropertyTableInner) -> Self {
+        Self {
+            inner: Gc::new(Inner {
+                property_table: RefCell::new(property_table),
+                prototype: GcRefCell::new(prototype),
+            }),
+        }
+    }
+
+    pub(crate) fn override_internal(
+        &self,
+        property_table: PropertyTableInner,
+        prototype: JsPrototype,
+    ) {
+        *self.inner.property_table.borrow_mut() = property_table;
+        *self.inner.prototype.borrow_mut() = prototype;
+    }
+
+    /// Get the prototype of the [`UniqueShape`].
+    pub(crate) fn prototype(&self) -> JsPrototype {
+        self.inner.prototype.borrow().clone()
+    }
+
+    /// Get the property table of the [`UniqueShape`].
+    pub(crate) fn property_table(&self) -> &RefCell<PropertyTableInner> {
+        &self.inner.property_table
+    }
+
+    /// Inserts a new property into the [`UniqueShape`].
+    pub(crate) fn insert_property_transition(&self, key: TransitionKey) -> Self {
+        let mut property_table = self.property_table().borrow_mut();
+        property_table.insert(key.property_key, key.attributes);
+        self.clone()
+    }
+
+    /// Remove a property from the [`UniqueShape`].
+    ///
+    /// This will cause the current shape to be invalidated, and a new [`UniqueShape`] will be returned.
+    pub(crate) fn remove_property_transition(&self, key: &PropertyKey) -> Self {
+        let mut property_table = self.property_table().borrow_mut();
+        let Some((index, _attributes)) = property_table.map.remove(key) else {
+            return self.clone();
+        };
+
+        let index = index as usize;
+
+        // shift elements
+        property_table.keys.remove(index);
+
+        // The property that was deleted was not the last property added.
+        // Therefore we need to create a new unique shape,
+        // to invalidate any pointers to this shape i.e inline caches.
+        let mut property_table = std::mem::take(&mut *property_table);
+
+        // If it is not the last property that was deleted,
+        // then update all the property slots that are after it.
+        if index != property_table.keys.len() {
+            // Get the previous value before the value at index,
+            //
+            // NOTE: calling wrapping_sub when usize index is 0 will wrap into usize::MAX
+            //       which will return None, avoiding unneeded checks.
+            let mut previous_slot = property_table.keys.get(index.wrapping_sub(1)).map(|x| x.1);
+
+            // Update all slot positions
+            for (index, (key, slot)) in property_table.keys.iter_mut().enumerate().skip(index) {
+                *slot = Slot::from_previous(previous_slot, slot.attributes);
+
+                let Some((map_index, map_slot)) = property_table.map.get_mut(key) else {
+                    unreachable!("There should already be a property")
+                };
+                *map_index = index as u32;
+                *map_slot = *slot;
+
+                previous_slot = Some(*slot);
+            }
+        }
+
+        let prototype = self.inner.prototype.borrow_mut().take();
+        Self::new(prototype, property_table)
+    }
+
+    /// Does a property lookup on the [`UniqueShape`] returning the [`Slot`] where it's
+    /// located or [`None`] otherwise.
+    pub(crate) fn lookup(&self, key: &PropertyKey) -> Option<Slot> {
+        let property_table = self.property_table().borrow();
+        if let Some((_, slot)) = property_table.map.get(key) {
+            return Some(*slot);
+        }
+
+        None
+    }
+
+    /// Change the attributes of a property from the [`UniqueShape`].
+    ///
+    /// This will cause the current shape to be invalidated, and a new [`UniqueShape`] will be returned.
+    ///
+    /// NOTE: This assumes that the property had already been inserted.
+    pub(crate) fn change_attributes_transition(
+        &self,
+        key: &TransitionKey,
+    ) -> ChangeTransition<Shape> {
+        let mut property_table = self.property_table().borrow_mut();
+        let Some((index, slot)) = property_table.map.get_mut(&key.property_key) else {
+            unreachable!("Attribute change can only happen on existing property")
+        };
+
+        let index = *index as usize;
+
+        // If property does not change type, there is no need to shift.
+        if slot.attributes.width_match(key.attributes) {
+            slot.attributes = key.attributes;
+            property_table.keys[index].1.attributes = key.attributes;
+            // TODO: invalidate the pointer.
+            return ChangeTransition {
+                shape: Shape::unique(self.clone()),
+                action: ChangeTransitionAction::Nothing,
+            };
+        }
+        slot.attributes = key.attributes;
+
+        let mut previous_slot = *slot;
+
+        property_table.keys[index].1.attributes = key.attributes;
+
+        let action = if key.attributes.is_accessor_descriptor() {
+            // Data --> Accessor
+            ChangeTransitionAction::Insert
+        } else {
+            // Accessor --> Data
+            ChangeTransitionAction::Remove
+        };
+
+        // The property that was deleted was not the last property added.
+        // Therefore we need to create a new unique shape,
+        // to invalidate any pointers to this shape i.e inline caches.
+        let mut property_table = std::mem::take(&mut *property_table);
+
+        // Update all slot positions, after the target property.
+        //
+        // Example: Change 2nd one from accessor to data
+        //
+        // | Idx: 0, DATA  | Idx: 1, ACCESSOR | Idx: 3, DATA |
+        //                         \----- target
+        //
+        // Change attributes of target (given trough arguments).
+        //
+        // | Idx: 0, DATA  | Idx: 1, DATA | Idx: 3, DATA |
+        //                         \----- target
+        //
+        // The target becomes the previous pointer and next is target_index + 1,
+        // continue until we reach the end.
+        //
+        // | Idx: 0, DATA  | Idx: 1, DATA | Idx: 3, DATA |
+        //           previous ----/               \-------- next
+        //
+        // When next is out of range we quit, everything has been set.
+        //
+        // | Idx: 0, DATA  | Idx: 1, DATA | Idx: 2, DATA |    EMPTY   |
+        //                          previous ----/              \-------- next
+        //
+        let next = index + 1;
+        for (key, slot) in property_table.keys.iter_mut().skip(next) {
+            *slot = Slot::from_previous(Some(previous_slot), slot.attributes);
+
+            let Some((_, map_slot)) = property_table.map.get_mut(key) else {
+                unreachable!("There should already be a property")
+            };
+            *map_slot = *slot;
+
+            previous_slot = *slot;
+        }
+
+        let prototype = self.inner.prototype.borrow_mut().take();
+        let shape = Self::new(prototype, property_table);
+
+        ChangeTransition {
+            shape: Shape::unique(shape),
+            action,
+        }
+    }
+
+    /// Change the prototype of the [`UniqueShape`].
+    ///
+    /// This will cause the current shape to be invalidated, and a new [`UniqueShape`] will be returned.
+    pub(crate) fn change_prototype_transition(&self, prototype: JsPrototype) -> Self {
+        let mut property_table = self.inner.property_table.borrow_mut();
+
+        // We need to create a new unique shape,
+        // to invalidate any pointers to this shape i.e inline caches.
+        let property_table = std::mem::take(&mut *property_table);
+        Self::new(prototype, property_table)
+    }
+
+    /// Gets all keys first strings then symbols in creation order.
+    pub(crate) fn keys(&self) -> Vec<PropertyKey> {
+        self.property_table().borrow().keys()
+    }
+
+    /// Return location in memory of the [`UniqueShape`].
+    pub(crate) fn to_addr_usize(&self) -> usize {
+        let ptr: *const _ = self.inner.as_ref();
+        ptr as usize
+    }
+}

--- a/boa_engine/src/property/attribute/mod.rs
+++ b/boa_engine/src/property/attribute/mod.rs
@@ -15,7 +15,7 @@ bitflags! {
     ///  - `[[Configurable]]` (`CONFIGURABLE`) - If `false`, attempts to delete the property,
     /// change the property to be an `accessor property`, or change its attributes (other than `[[Value]]`,
     /// or changing `[[Writable]]` to `false`) will fail.
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct Attribute: u8 {
         /// The `Writable` attribute decides whether the value associated with the property can be changed or not, from its initial value.
         const WRITABLE = 0b0000_0001;

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -9,7 +9,7 @@
 use crate::{
     context::{intrinsics::Intrinsics, HostHooks},
     environments::DeclarativeEnvironment,
-    object::JsObject,
+    object::{shape::shared_shape::SharedShape, JsObject},
 };
 use boa_gc::{Finalize, Gc, Trace};
 use boa_profiler::Profiler;
@@ -39,10 +39,10 @@ struct Inner {
 impl Realm {
     /// Create a new Realm.
     #[inline]
-    pub fn create(hooks: &dyn HostHooks) -> Self {
+    pub fn create(hooks: &dyn HostHooks, root_shape: &SharedShape) -> Self {
         let _timer = Profiler::global().start_event("Realm::create", "realm");
 
-        let intrinsics = Intrinsics::default();
+        let intrinsics = Intrinsics::new(root_shape);
         let global_object = hooks.create_global_object(&intrinsics);
         let global_this = hooks
             .create_global_this(&intrinsics)

--- a/boa_engine/src/value/conversions/serde_json.rs
+++ b/boa_engine/src/value/conversions/serde_json.rs
@@ -137,8 +137,8 @@ impl JsValue {
                     Ok(Value::Array(arr))
                 } else {
                     let mut map = Map::new();
-                    for (key, property) in obj.borrow().properties().iter() {
-                        let key = match &key {
+                    for property_key in obj.borrow().properties().shape.keys() {
+                        let key = match &property_key {
                             PropertyKey::String(string) => string.to_std_string_escaped(),
                             PropertyKey::Index(i) => i.to_string(),
                             PropertyKey::Symbol(_sym) => {
@@ -148,7 +148,12 @@ impl JsValue {
                             }
                         };
 
-                        let value = match property.value() {
+                        let value = match obj
+                            .borrow()
+                            .properties()
+                            .get(&property_key)
+                            .and_then(|x| x.value().cloned())
+                        {
                             Some(val) => val.to_json(context)?,
                             None => Value::Null,
                         };

--- a/boa_engine/src/value/hash.rs
+++ b/boa_engine/src/value/hash.rs
@@ -45,7 +45,7 @@ impl Hash for JsValue {
             Self::BigInt(ref bigint) => bigint.hash(state),
             Self::Rational(rational) => RationalHashable(*rational).hash(state),
             Self::Symbol(ref symbol) => Hash::hash(symbol, state),
-            Self::Object(ref object) => std::ptr::hash(object.as_ref(), state),
+            Self::Object(ref object) => object.hash(state),
         }
     }
 }

--- a/boa_engine/src/value/tests.rs
+++ b/boa_engine/src/value/tests.rs
@@ -1,3 +1,4 @@
+use boa_macros::utf16;
 use indoc::indoc;
 
 use super::*;

--- a/boa_engine/src/vm/opcode/get/function.rs
+++ b/boa_engine/src/vm/opcode/get/function.rs
@@ -1,5 +1,5 @@
 use crate::{
-    vm::{code_block::create_function_object, opcode::Operation, CompletionType},
+    vm::{code_block::create_function_object_fast, opcode::Operation, CompletionType},
     Context, JsResult,
 };
 
@@ -18,7 +18,7 @@ impl Operation for GetArrowFunction {
         let index = context.vm.read::<u32>();
         context.vm.read::<u8>();
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, false, true, None, false, context);
+        let function = create_function_object_fast(code, false, true, false, context);
         context.vm.push(function);
         Ok(CompletionType::Normal)
     }
@@ -39,7 +39,7 @@ impl Operation for GetAsyncArrowFunction {
         let index = context.vm.read::<u32>();
         context.vm.read::<u8>();
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, true, true, None, false, context);
+        let function = create_function_object_fast(code, true, true, false, context);
         context.vm.push(function);
         Ok(CompletionType::Normal)
     }
@@ -60,7 +60,7 @@ impl Operation for GetFunction {
         let index = context.vm.read::<u32>();
         let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, false, false, None, method, context);
+        let function = create_function_object_fast(code, false, false, method, context);
         context.vm.push(function);
         Ok(CompletionType::Normal)
     }
@@ -81,7 +81,7 @@ impl Operation for GetFunctionAsync {
         let index = context.vm.read::<u32>();
         let method = context.vm.read::<u8>() != 0;
         let code = context.vm.frame().code_block.functions[index as usize].clone();
-        let function = create_function_object(code, true, false, None, method, context);
+        let function = create_function_object_fast(code, true, false, method, context);
         context.vm.push(function);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/array.rs
+++ b/boa_engine/src/vm/opcode/push/array.rs
@@ -1,8 +1,9 @@
 use crate::{
     builtins::{iterable::IteratorRecord, Array},
+    object::ObjectData,
     string::utf16,
     vm::{opcode::Operation, CompletionType},
-    Context, JsResult,
+    Context, JsResult, JsValue,
 };
 
 /// `PushNewArray` implements the Opcode Operation for `Opcode::PushNewArray`
@@ -17,8 +18,11 @@ impl Operation for PushNewArray {
     const INSTRUCTION: &'static str = "INST - PushNewArray";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let array = Array::array_create(0, None, context)
-            .expect("Array creation with 0 length should never fail");
+        let array = context
+            .intrinsics()
+            .templates()
+            .array()
+            .create(ObjectData::array(), vec![JsValue::new(0)]);
         context.vm.push(array);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/object.rs
+++ b/boa_engine/src/vm/opcode/push/object.rs
@@ -1,5 +1,5 @@
 use crate::{
-    object::JsObject,
+    object::ObjectData,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
 };
@@ -16,7 +16,11 @@ impl Operation for PushEmptyObject {
     const INSTRUCTION: &'static str = "INST - PushEmptyObject";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let o = JsObject::with_object_proto(context.intrinsics());
+        let o = context
+            .intrinsics()
+            .templates()
+            .ordinary_object()
+            .create(ObjectData::ordinary(), Vec::default());
         context.vm.push(o);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/set/class_prototype.rs
+++ b/boa_engine/src/vm/opcode/set/class_prototype.rs
@@ -25,7 +25,11 @@ impl Operation for SetClassPrototype {
             _ => unreachable!(),
         };
 
-        let proto = JsObject::from_proto_and_data(prototype, ObjectData::ordinary());
+        let proto = JsObject::from_proto_and_data_with_shared_shape(
+            context.root_shape(),
+            prototype,
+            ObjectData::ordinary(),
+        );
         let class = context.vm.pop();
 
         {

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -78,7 +78,7 @@ impl Operation for SetPropertyByValue {
                         break 'fast_path;
                     }
 
-                    let prototype = object_borrowed.prototype().clone();
+                    let shape = object_borrowed.shape().clone();
 
                     if let Some(dense_elements) = object_borrowed
                         .properties_mut()
@@ -93,6 +93,7 @@ impl Operation for SetPropertyByValue {
                             // Cannot use fast path if the [[prototype]] is a proxy object,
                             // because we have to the call prototypes [[set]] on non-existing property,
                             // and proxy objects can override [[set]].
+                            let prototype = shape.prototype();
                             if prototype.map_or(false, |x| x.is_proxy()) {
                                 break 'fast_path;
                             }

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -201,3 +201,42 @@ let global = $boa.realm.create();
 
 Object != global.Object; // true
 ```
+
+## Module `$boa.shape`
+
+This module contains helpful functions for getting information about a shape of an object.
+
+### Function `$boa.shape.id(object)`
+
+Returns the pointer of the object's shape in memory as a string encoded in hexadecimal format.
+
+```JavaScript
+$boa.shape.id(Number) // '0x7FC35A073868'
+$boa.shape.id({}) // '0x7FC35A046258'
+```
+
+### Function `$boa.shape.type(object)`
+
+Returns the object's shape type.
+
+```JavaScript
+$boa.shape.type({x: 3}) // 'shared'
+$boa.shape.type(Number) // 'unique'
+```
+
+### Function `$boa.shape.same(o1, o2)`
+
+Returns `true` if both objects have the same shape.
+
+```JavaScript
+// The values of the properties are not important!
+let o1 = { x: 10 }
+let o2 = {}
+$boa.shape.same(o1, o2) // false
+
+o2.x = 20
+$boa.shape.same(o1, o2) // true
+
+o2.y = 200
+$boa.shape.same(o1, o2) // false
+```

--- a/docs/shapes.md
+++ b/docs/shapes.md
@@ -1,0 +1,220 @@
+# Shapes (Hidden Classes)
+
+The best way to explain object shapes is through examples. It all begins with the root shape.
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+
+    Root(<b>Root Shape</b>\n<b>Prototype:</i> <i>None</i>) -->| Property Count 0 | PropertyTable(PropertyTable\n)
+```
+
+The root shape is where the transition chain starts from, it has a pointer to a `PropertyTable`,
+we will explain what it is and does later on!
+
+**NOTE:** We will annotate the shapes with `S` followed by a number.
+
+If we have an example of JavaScript code like:
+
+```js
+let o = {};
+```
+
+The following chain is created:
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\n<b>Prototype:</b> <i>None</i>) -->|Property Count: 0| PropertyTable(PropertyTable\n)
+
+    ObjectPrototype(<b>S1: Prototype Shape</b>\n<b>Prototype:</b> Object.prototype) -->|Property Count: 0|PropertyTable
+    ObjectPrototype:::New -->|Previous| Root
+```
+
+We transition, the object `o` has `S1` shape. The root shape does not have a prototype. So we transition into a shape that has the
+`Object.prototype` as `__proto__`. We can see that the shapes inherited the `PropertyTable` from the `root`.
+
+Ok, Let us add a property `x`:
+
+```js
+o.x = 100; // The value is not important!
+```
+
+Then this happens:
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\nPrototype: <i>None</i>) -->|Property Count: 0| PropertyTable(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable)
+
+    ObjectPrototype(<b>S1: Prototype Shape</b>\n<b>Prototype:</b> <i>Object.prototype</i>) -->|Property Count: 0|PropertyTable
+    ObjectPrototype -->|Previous| Root
+
+    InsertX(<b>S2: Insert Shape</b>\n<b>Property:</b> '<i>x</i>') --> |Property Count: 1|PropertyTable
+    InsertX:::New -->|Previous| ObjectPrototype
+```
+
+The object `o` has shape `S2` shape now, we can see that it also inherited the `PropertyTable`, but it's property count is `1` and
+an entry has been added into the `PropertyTable`.
+
+We can see that the property added is `writable`, `configurable`, and `enumerable`, but we also see `Slot 0`,
+this is the index into the dense storage in the object itself.
+
+Here is how it would look with the `o` object:
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\n<b>Prototype:</b> <i>None</i>) -->| Property Count: 0 | PropertyTable(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable)
+
+    ObjectPrototype(<b>S1: Prototype Shape</b>\n<b>Prototype:</b> <i>Object.prototype</i>) -->| Property Count: 0 |PropertyTable
+    ObjectPrototype -->|Previous| Root
+
+    InsertX(<b>S2: Insert Shape</b>\n<b>Property:</b> '<i>x</i>') --> | Property Count: 1 | PropertyTable
+    InsertX -->|Previous| ObjectPrototype
+
+    O(<b>Object o</b>\n<b>Element 0:</b> JsValue: <i>100</i>)
+    O:::New --> InsertX
+```
+
+Let's define a getter and setter `y`
+
+```js
+// What the getter/setter are not important!
+Object.defineProperty(o, "y", {
+  enumerable: true,
+  configurable: true,
+  get: function () {
+    return this.x;
+  },
+  set: function (value) {
+    this.x = value;
+  },
+});
+```
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\n<b>Prototype:</b> <i>None</i>) -->|Property Count: 0| PropertyTable(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable\ny: Slot 1, has_get, has_set, configurable, enumerable)
+
+    ObjectPrototype(<b>S1: Prototype Shape</b>\n<b>Prototype:</b> <i>Object.prototype</i>) -->| Property Count: 0 |PropertyTable
+    ObjectPrototype -->|Previous| Root
+
+    InsertX(<b>S2: Insert Shape</b>\n<b>Property:</b> '<i>x</i>') --> |Property Count: 1| PropertyTable
+    InsertX -->|Previous| ObjectPrototype
+
+    InsertY(<b>S3: Insert Shape</b>\n<b>Property:</b> '<i>y</i>') --> |Property Count: 2| PropertyTable
+    InsertY:::New -->|Previous| InsertX
+
+    O(<b>Object o\nElement 0:</b> JsValue: 100\n<b>Element 1:</b> JsValue: func\n<b>Element 2:</b> JsValue: func) --> InsertY
+```
+
+We can see that the property has been added into the property table, it has the `has_get` and `has_set` flags set,
+in the object there are two elements added, the first is the `get` function and the second is the `set` function.
+
+Slots are varying in length, two for accessor properties and one for data properties, the index points to the first
+value in the object storage.
+
+What would happen if an object had `S2` shape and we tried to access a property `y` how does it know if it
+has or doesn't have a property named `y`? By the property count on the shape, it has property count `1`,
+all the object in the `PropertyTable` are stored in a map that preserves the order and and can be indexed.
+
+When we do a lookup the on property table, if the index of the property is greater than the property count (`1`),
+than it does not belong to the shape.
+
+Now, Let's create a new object `o2`, with property `x`:
+
+```js
+let o2 = { x: 200 };
+```
+
+After this `o2` would have the `S2` shape.
+
+How does the shape know that it can reuse `S1` then to go to `S2`? This is not the real structure!
+Every shape has pointers to forward transitions that happened, these are weak pointers so we don't keep
+alive unused shapes. The pointers have been omitted, so the diagrams are clearer (too many arrows).
+
+Ok, now let us define a property `z` instead of `y`:
+
+```js
+o2.z = 300;
+```
+
+The following changes accure to the shape tree:
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+    style PropertyTableFork fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\n<b>Prototype:</b> <i>None</i>) -->| Property Count: 0 | PropertyTable(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable\ny: Slot 1, has_get, has_set, configurable, enumerable)
+
+    ObjectPrototype(<b>S1: Prototype Shape\nPrototype:</b> <i>Object.prototype</i>) -->| Property Count: 0 |PropertyTable
+    ObjectPrototype -->|Previous| Root
+
+    InsertX(<b>S2: Insert Shape\nProperty:</b> '<i>x</i>') --> | Property Count: 1 | PropertyTable
+    InsertX -->|Previous| ObjectPrototype
+
+    InsertY(<b>S3: Insert Shape\nProperty:</b> '<i>y</i>') --> | Property Count: 2 | PropertyTable
+    InsertY -->|Previous| InsertX
+
+    PropertyTableFork(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable\nz: Slot 1, writable, configurable, enumerable)
+    InsertZ(<b>S4: Insert Shape\nProperty:</b> '<i>z</i>') --> | Property Count: 2 | PropertyTableFork:::New
+    InsertZ:::New -->|Previous| InsertX
+
+    O(<b>Object o\nElement 0:</b> JsValue: 100\n<b>Element 1:</b> JsValue: func\n<b>Element 2:</b> JsValue: func) --> InsertY
+    O2(<b>Object o2\nElement 0:</b> JsValue: 200\n<b>Element 1:</b> JsValue: 300)
+    O2:::New --> InsertZ
+```
+
+Now `o2` has `S4` shape. We can also see that `PropertyTable` has been forked, because we can no longer add a property at position `1`.
+
+What would happen if we wanted to delete a property `x` from object `o`:
+
+```js
+delete o.x;
+```
+
+```mermaid
+flowchart LR
+    classDef New style id2 fill:#bbf,stroke:#f66,stroke-width:2px,color:#fff,stroke-dasharray: 5 5
+    style Root stroke:#000,stroke-width:5px
+    style PropertyTable fill:#071E22
+    style PropertyTableFork fill:#071E22
+
+    Root(<b>S0: Root Shape</b>\n<b>Prototype:</b> <i>None</i>) -->| Property Count: 0 | PropertyTable(<b>PropertyTable</b>\nx: Slot 0, writable, configurable, enumerable\ny: Slot 1, has_get, has_set, configurable, enumerable)
+
+    ObjectPrototype(<b>S1: Prototype Shape\nPrototype:</b> <i>Object.prototype</i>) -->| Property Count: 0 |PropertyTable
+    ObjectPrototype -->|Previous| Root
+
+
+    PropertyTableFork(<b>PropertyTable</b>\ny: Slot 0, has_get, has_set, configurable, enumerable)
+    InsertYNew(<b>S3: Insert Shape\nProperty:</b> <i>y</i>) --> | Property Count: 1 |PropertyTableFork:::New
+    InsertYNew:::New -->|Previous| ObjectPrototype
+
+    O(<b>Object o</b>\n<b>Element 0:</b> JsValue: func\n<b>Element 1:</b> JsValue: func) --> InsertYNew
+    O:::New
+```
+
+**NOTE:**: `o2` and its shape have been omitted from the diagram.
+
+When a deletion happens, we find the node in the chain where we added the property, and get it's parent (`base`),
+we also remember that what transitions happened after the property insertion, then we apply them
+one by one until we construct the chain and return the last shape in that chain.


### PR DESCRIPTION
This PR implements `Hidden Classes`, I named them as `Shapes` (like Spidermonkey does), calling them maps like v8 seems confusing because there already is a JS builtin, likewise with `Hidden classes` since there are already classes in JS.

There are two types of shapes:  `shared` shapes that create the transition tree, and are shared between objects, this is mainly intended for user defined objects this makes more sense because shapes can create transitions trees, doing that for the builtins seems wasteful (unless users wanted  to creating an object with the same property names and the same property attributes in the same order... which seems unlikely). That's why I added  `unique` shapes, only one object has it. This is similar to previous solution, but this architecture enables us to use inline caching.

There will probably be a performance hit until we implement inline caching.

There still a lot of work that needs to be done, on this:

- [x] Move Property Attributes to shape
- [x] Move Prototype to shape
- [x] ~~Move extensible flag  to shape~~,  On further evaluation this doesn't give any benefit (at least right now), since it isn't used by inline caching also adding one more transition.
- [x] Implement delete for unique shapes.
- [x] If the chain is too long we should probably convert it into a `unique` shape
    - [x] Figure out threshold ~~(maybe more that 256 properties ?)~~ curently set to an arbitrary number (`1024`)
- [x] Implement shared property table between shared shapes
- [x] Add  code Document
- [x] Varying size storage for  properties (get+set = 2, data = 1)
- [x] Add shapes to more object:
    - [x] ordinary object
    - [x] Arrays
    - [x] Functions
    - [x] Other builtins
- [x] Add `shapes.md` doc explaining shapes in depth with mermaid diagrams :)
- [x] Add `$boa.shape` module
- [x] `$boa.shape.id(o)`
- [x] `$boa.shape.type(o)`
- [x] `$boa.shape.same(o1, o2)`
- [x] add doc to `boa_object.md`