### PR TITLE
[Merged by Bors] - Fix super call execution order

### DIFF
--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -255,6 +255,8 @@ impl ByteCompiler<'_, '_> {
             }
             Expression::Class(class) => self.class(class, true),
             Expression::SuperCall(super_call) => {
+                self.emit_opcode(Opcode::SuperCallPrepare);
+
                 let contains_spread = super_call
                     .arguments()
                     .iter()

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -447,6 +447,7 @@ impl CodeBlock {
             | Opcode::SuperCallDerived
             | Opcode::Await
             | Opcode::PushNewTarget
+            | Opcode::SuperCallPrepare
             | Opcode::CallEvalSpread
             | Opcode::CallSpread
             | Opcode::NewSpread

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -525,6 +525,7 @@ impl CodeBlock {
                 | Opcode::CallSpread
                 | Opcode::NewSpread
                 | Opcode::SuperCallSpread
+                | Opcode::SuperCallPrepare
                 | Opcode::SetPrototype
                 | Opcode::IsObject
                 | Opcode::Nop

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1200,18 +1200,25 @@ generate_impl! {
         /// Stack: **=>** super
         Super,
 
+        /// Get the super constructor and the new target of the current environment.
+        ///
+        /// Operands:
+        ///
+        /// Stack: **=>** super_constructor, new_target
+        SuperCallPrepare,
+
         /// Execute the `super()` method.
         ///
         /// Operands: argument_count: `u32`
         ///
-        /// Stack: argument_1, ... argument_n **=>**
+        /// Stack: super_constructor, new_target, argument_1, ... argument_n **=>**
         SuperCall,
 
         /// Execute the `super()` method where the arguments contain spreads.
         ///
         /// Operands:
         ///
-        /// Stack: arguments_array **=>**
+        /// Stack: super_constructor, new_target, arguments_array **=>**
         SuperCallSpread,
 
         /// Execute the `super()` method when no constructor of the class is defined.

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -1,4 +1,4 @@
-use crate::{run_test_actions, JsValue, TestAction};
+use crate::{builtins::error::ErrorKind, run_test_actions, JsValue, TestAction};
 use indoc::indoc;
 
 #[test]
@@ -176,6 +176,35 @@ fn get_reference_by_super() {
         "#},
         "ab",
     )]);
+}
+
+#[test]
+fn super_call_constructor_null() {
+    run_test_actions([TestAction::assert_native_error(
+        indoc! {r#"
+            class A extends Object {
+                constructor() {
+                    Object.setPrototypeOf(A, null);
+                    super(A);
+                }
+            }
+            new A();
+        "#},
+        ErrorKind::Type,
+        "super constructor object must be constructor",
+    )]);
+}
+
+#[test]
+fn super_call_get_constructor_before_arguments_execution() {
+    run_test_actions([TestAction::assert(indoc! {r#"
+        class A extends Object {
+            constructor() {
+                super(Object.setPrototypeOf(A, null));
+            }
+        }
+        new A() instanceof A;
+    "#})]);
 }
 
 #[test]


### PR DESCRIPTION
This Pull Request fixes/closes #2672.

It changes the following:

- Get the super constructor and the new target before executing arguments in super calls.
