### PR TITLE
Fix remaining `Set` tests

### DIFF
--- a/boa_engine/src/builtins/map/ordered_map.rs
+++ b/boa_engine/src/builtins/map/ordered_map.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 #[derive(PartialEq, Eq, Clone, Debug)]
-enum MapKey {
+pub(crate) enum MapKey {
     Key(JsValue),
     Empty(usize), // Necessary to ensure empty keys are still unique.
 }

--- a/boa_engine/src/builtins/set/ordered_set.rs
+++ b/boa_engine/src/builtins/set/ordered_set.rs
@@ -1,55 +1,48 @@
 //! Implements a set type that preserves insertion order.
 
+use crate::{builtins::map::ordered_map::MapKey, object::JsObject, JsValue};
 use boa_gc::{custom_trace, Finalize, Trace};
-use indexmap::{
-    set::{IntoIter, Iter},
-    IndexSet,
-};
-use std::{
-    collections::hash_map::RandomState,
-    fmt::Debug,
-    hash::{BuildHasher, Hash},
-};
+use indexmap::IndexSet;
+use std::{collections::hash_map::RandomState, fmt::Debug, hash::BuildHasher};
 
 /// A type wrapping `indexmap::IndexSet`
-#[derive(Clone)]
-pub struct OrderedSet<V, S = RandomState>
-where
-    V: Hash + Eq,
-{
-    inner: IndexSet<V, S>,
+#[derive(Clone, Finalize)]
+pub struct OrderedSet<S = RandomState> {
+    inner: IndexSet<MapKey, S>,
+    lock: u32,
+    empty_count: usize,
 }
 
-impl<V: Eq + Hash + Trace, S: BuildHasher> Finalize for OrderedSet<V, S> {}
-unsafe impl<V: Eq + Hash + Trace, S: BuildHasher> Trace for OrderedSet<V, S> {
+unsafe impl<S: BuildHasher> Trace for OrderedSet<S> {
     custom_trace!(this, {
         for v in this.inner.iter() {
-            mark(v);
+            if let MapKey::Key(v) = v {
+                mark(v);
+            }
         }
     });
 }
 
-impl<V: Hash + Eq + Debug> Debug for OrderedSet<V> {
+impl Debug for OrderedSet {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.inner.fmt(formatter)
     }
 }
 
-impl<V: Hash + Eq> Default for OrderedSet<V> {
+impl Default for OrderedSet {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<V> OrderedSet<V>
-where
-    V: Hash + Eq,
-{
+impl OrderedSet {
     /// Creates a new empty `OrderedSet`.
     #[must_use]
     pub fn new() -> Self {
         Self {
             inner: IndexSet::new(),
+            lock: 0,
+            empty_count: 0,
         }
     }
 
@@ -58,18 +51,28 @@ where
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             inner: IndexSet::with_capacity(capacity),
+            lock: 0,
+            empty_count: 0,
         }
     }
 
-    /// Return the number of key-value pairs in the map.
+    /// Return the number of elements in the set, including empty elements.
     ///
     /// Computes in **O(1)** time.
     #[must_use]
-    pub fn size(&self) -> usize {
+    pub fn full_len(&self) -> usize {
         self.inner.len()
     }
 
-    /// Returns true if the map contains no elements.
+    /// Return the number of elements in the set.
+    ///
+    /// Computes in **O(1)** time.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.len() - self.empty_count
+    }
+
+    /// Returns true if the set contains no elements.
     ///
     /// Computes in **O(1)** time.
     #[must_use]
@@ -85,23 +88,33 @@ where
     /// inserted, last in order, and false
     ///
     /// Computes in **O(1)** time (amortized average).
-    pub fn add(&mut self, value: V) -> bool {
-        self.inner.insert(value)
+    pub fn add(&mut self, value: JsValue) -> bool {
+        self.inner.insert(MapKey::Key(value))
     }
 
     /// Delete the `value` from the set and return true if successful
     ///
-    /// Return `false` if `value` is not in map.
+    /// Return `false` if `value` is not in set.
     ///
     /// Computes in **O(n)** time (average).
-    pub fn delete(&mut self, value: &V) -> bool {
-        self.inner.shift_remove(value)
+    pub fn delete(&mut self, value: &JsValue) -> bool {
+        if self.lock == 0 {
+            self.inner.shift_remove(value)
+        } else if self.inner.contains(value) {
+            self.inner.insert(MapKey::Empty(self.empty_count));
+            self.empty_count += 1;
+            self.inner.swap_remove(value)
+        } else {
+            false
+        }
     }
 
     /// Removes all elements in the set, while preserving its capacity.
     #[inline]
     pub fn clear(&mut self) {
         self.inner.clear();
+        self.inner.shrink_to_fit();
+        self.empty_count = 0;
     }
 
     /// Checks if a given value is present in the set
@@ -109,7 +122,7 @@ where
     /// Return `true` if `value` is present in set, false otherwise.
     ///
     /// Computes in **O(n)** time (average).
-    pub fn contains(&self, value: &V) -> bool {
+    pub fn contains(&self, value: &JsValue) -> bool {
         self.inner.contains(value)
     }
 
@@ -117,37 +130,60 @@ where
     /// Valid indices are 0 <= index < self.len()
     /// Computes in O(1) time.
     #[must_use]
-    pub fn get_index(&self, index: usize) -> Option<&V> {
-        self.inner.get_index(index)
+    pub fn get_index(&self, index: usize) -> Option<&JsValue> {
+        if let MapKey::Key(value) = self.inner.get_index(index)? {
+            Some(value)
+        } else {
+            None
+        }
     }
 
     /// Return an iterator over the values of the set, in their order
-    #[must_use]
-    pub fn iter(&self) -> Iter<'_, V> {
-        self.inner.iter()
+    pub fn iter(&self) -> impl Iterator<Item = &JsValue> {
+        self.inner.iter().filter_map(|v| {
+            if let MapKey::Key(v) = v {
+                Some(v)
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Increases the lock counter and returns a lock object that will decrement the counter when dropped.
+    ///
+    /// This allows objects to be removed from the set during iteration without affecting the indexes until the iteration has completed.
+    pub(crate) fn lock(&mut self, set: JsObject) -> SetLock {
+        self.lock += 1;
+        SetLock(set)
+    }
+
+    /// Decreases the lock counter and, if 0, removes all empty entries.
+    fn unlock(&mut self) {
+        self.lock -= 1;
+        if self.lock == 0 {
+            self.inner.retain(|k| matches!(k, MapKey::Key(_)));
+            self.empty_count = 0;
+        }
     }
 }
 
-impl<'a, V, S> IntoIterator for &'a OrderedSet<V, S>
-where
-    V: Hash + Eq,
-    S: BuildHasher,
-{
-    type Item = &'a V;
-    type IntoIter = Iter<'a, V>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.iter()
+/// Increases the lock count of the set for the lifetime of the guard.
+/// This should not be dropped until iteration has completed.
+#[derive(Debug, Trace)]
+pub(crate) struct SetLock(JsObject);
+
+impl Clone for SetLock {
+    fn clone(&self) -> Self {
+        let mut set = self.0.borrow_mut();
+        let set = set.as_set_mut().expect("SetLock does not point to a set");
+        set.lock(self.0.clone())
     }
 }
 
-impl<V, S> IntoIterator for OrderedSet<V, S>
-where
-    V: Hash + Eq,
-    S: BuildHasher,
-{
-    type Item = V;
-    type IntoIter = IntoIter<V>;
-    fn into_iter(self) -> IntoIter<V> {
-        self.inner.into_iter()
+impl Finalize for SetLock {
+    fn finalize(&self) {
+        let mut set = self.0.borrow_mut();
+        let set = set.as_set_mut().expect("SetLock does not point to a set");
+        set.unlock();
     }
 }

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -226,7 +226,7 @@ pub enum ObjectKind {
     GeneratorFunction(Function),
 
     /// The `Set` object kind.
-    Set(OrderedSet<JsValue>),
+    Set(OrderedSet),
 
     /// The `SetIterator` object kind.
     SetIterator(SetIterator),
@@ -519,7 +519,7 @@ impl ObjectData {
 
     /// Create the `Set` object data
     #[must_use]
-    pub fn set(set: OrderedSet<JsValue>) -> Self {
+    pub fn set(set: OrderedSet) -> Self {
         Self {
             kind: ObjectKind::Set(set),
             internal_methods: &ORDINARY_INTERNAL_METHODS,
@@ -1089,7 +1089,7 @@ impl Object {
 
     /// Gets the set data if the object is a `Set`.
     #[inline]
-    pub const fn as_set(&self) -> Option<&OrderedSet<JsValue>> {
+    pub const fn as_set(&self) -> Option<&OrderedSet> {
         match self.data {
             ObjectData {
                 kind: ObjectKind::Set(ref set),
@@ -1101,7 +1101,7 @@ impl Object {
 
     /// Gets the mutable set data if the object is a `Set`.
     #[inline]
-    pub fn as_set_mut(&mut self) -> Option<&mut OrderedSet<JsValue>> {
+    pub fn as_set_mut(&mut self) -> Option<&mut OrderedSet> {
         match &mut self.data {
             ObjectData {
                 kind: ObjectKind::Set(set),

--- a/boa_engine/src/value/display.rs
+++ b/boa_engine/src/value/display.rs
@@ -183,7 +183,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
                     }
                 }
                 ObjectKind::Set(ref set) => {
-                    let size = set.size();
+                    let size = set.len();
 
                     if size == 0 {
                         return String::from("Set(0)");


### PR DESCRIPTION
This Pull Request changes the following:

- Add locking for `Set`s during iteration. We already do this for `Map`s.
- Properly implement negative zero handling for `add`, `has` and `delete`.
- Refactor some `Set` functions and add spec comments.
