### PR TITLE
[Merged by Bors] - Add boa logo to remaining hosted docs

### DIFF
--- a/boa_icu_provider/src/bin/datagen.rs
+++ b/boa_icu_provider/src/bin/datagen.rs
@@ -1,3 +1,8 @@
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
+
 use std::{error::Error, fs::File};
 
 use boa_icu_provider::data_root;

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -15,6 +15,10 @@
 //! [`BufferProvider`]: icu_provider::BufferProvider
 //! [`AnyProvider`]: icu_provider::AnyProvider
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
 #![deny(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -25,6 +25,10 @@
 //! [boa-web]: https://boa-dev.github.io/
 //! [boa-playground]: https://boa-dev.github.io/boa/playground/
 
+#![doc(
+    html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
+    html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
+)]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 #![warn(missing_docs, clippy::dbg_macro)]
 #![deny(


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This pr adds the boa doc `html_logo_url` and `html_favicon_url` on the pages missing the logo for boa's hosted docs.
