### PR TITLE
[Merged by Bors] - Fix documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1087,7 +1087,7 @@ Cargo has great support for workspaces, so this shouldn't be an issue.
 
 ## Benchmarks
 
-We now have [benchmarks which run against master](https://boa-dev.github.io/boa/dev/bench)!
+We now have [benchmarks which run against master](https://boajs.dev/boa/dev/bench/)!
 Thanks to Github Actions these will run automatically a commit is merged.
 
 Feature enhancements:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,11 @@ be more readable if you disable parallelism with the `-d` flag. All together it 
 cargo run --release --bin boa_tester -- run -vv -d -s test/language/types/number 2> error.log
 ```
 
+## Documentation
+
+We have specific documentation for development, updated on each commit to the `main` branch, with all the private
+methods visible here: <https://boajs.dev/boa/doc/>
+
 ## Communication
 
 We have a Discord server, feel free to ask questions here:

--- a/README.md
+++ b/README.md
@@ -22,17 +22,14 @@ Currently, it has support for some of the language.
 
 ## Live Demo (WASM)
 
-<https://boa-dev.github.io/boa/playground/>
+<https://boajs.dev/boa/playground/>
 
 You can get more verbose errors when running from the command line.
 
-## Development documentation
-
-You can check the internal development docs at <https://boa-dev.github.io/boa/doc>.
-
 ## Conformance
 
-To know how much of the _ECMAScript_ specification does Boa cover, you can check out results running the _ECMASCript Test262_ test suite [here](https://boa-dev.github.io/boa/test262/).
+To know how much of the _ECMAScript_ specification does Boa cover, you can check out results
+running the _ECMASCript Test262_ test suite [here](https://boajs.dev/boa/test262/).
 
 ## Contributing
 
@@ -124,7 +121,7 @@ See [Milestones](https://github.com/boa-dev/boa/milestones).
 
 ## Benchmarks
 
-See [Benchmarks](https://boa-dev.github.io/boa/dev/bench/).
+See [Benchmarks](https://boajs.dev/boa/dev/bench/).
 
 ## Profiling
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,9 @@
 
 ## Supported Versions
 
-Until we reach the 1.0 version, we only support the lates released 0.x version and the current
-`main` branch. You can find the latest released version of Boa in the [GitHub releases][gh_releases]
-page or on [crates.io][crate].
+Until we reach the 1.0 version, we only support the latest 0.x release and the current `main`
+branch. You can find the latest release of Boa in the [GitHub releases][gh_releases] page or
+on [crates.io][crate].
 
 [gh_releases]: https://github.com/boa-dev/boa/releases
 [crate]: https://crates.io/crates/boa_engine/versions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Until we reach the 1.0 version, we only support the lates released 0.x version and the current
+`main` branch. You can find the latest released version of Boa in the [GitHub releases][gh_releases]
+page or on [crates.io][crate].
+
+[gh_releases]: https://github.com/boa-dev/boa/releases
+[crate]: https://crates.io/crates/boa_engine/versions
+
+## Reporting a Vulnerability
+
+If you find any potential vulnerability, join our [discord](https://discord.gg/tUFFk9Y) channel
+and contact anyone in the _@boa_dev_ group (check the yellow usernames). Explain how to trigger
+the vulnerability, where can it be found and any recommendation you might have to fix it.

--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -28,9 +28,9 @@
 //!
 //! [grammar]: https://tc39.es/ecma262/#sec-syntactic-grammar
 //! [early]: https://tc39.es/ecma262/#sec-static-semantic-rules
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -25,9 +25,9 @@
 //!
 //! [whatwg]: https://console.spec.whatwg.org
 //! [ecma-402]: https://tc39.es/ecma402
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -20,9 +20,9 @@
 //!  - **`boa_unicode`** - Boa's Unicode identifier.
 //!  - **`boa_icu_provider`** - Boa's ICU4X data provider.
 //!
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -25,9 +25,9 @@
 //!  - **`boa_unicode`** - Boa's Unicode identifier.
 //!  - **`boa_icu_provider`** - Boa's ICU4X data provider.
 //!
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -24,9 +24,9 @@
 //! [spec]: https://tc39.es/ecma262
 //! [lex]: https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar
 //! [grammar]: https://tc39.es/ecma262/#sec-ecmascript-language-expressions
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -21,9 +21,9 @@
 //!  - **`boa_icu_provider`** - Boa's ICU4X data provider.
 //!
 //! [profiler-md]: https://github.com/boa-dev/boa/blob/main/docs/profiling.md
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_unicode/src/lib.rs
+++ b/boa_unicode/src/lib.rs
@@ -26,9 +26,9 @@
 //!  - **`boa_icu_provider`** - Boa's ICU4X data provider.
 //!
 //! [uax31]: http://unicode.org/reports/tr31
-//! [boa-conformance]: https://boa-dev.github.io/boa/test262/
-//! [boa-web]: https://boa-dev.github.io/
-//! [boa-playground]: https://boa-dev.github.io/boa/playground/
+//! [boa-conformance]: https://boajs.dev/boa/test262/
+//! [boa-web]: https://boajs.dev/
+//! [boa-playground]: https://boajs.dev/boa/playground/
 
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",


### PR DESCRIPTION
This PR changes the following:

- Adds a new (very simple) security policy, to comply with GitHub standards
- Changes the internal links of the documentation to point to the new boajs.dev domain
- The developer documentation link now lies in the CONTRIBUTING.md file
