### PR TITLE
[Merged by Bors] - Fix deserialization of `SpecEdition`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serde_repr",
  "serde_yaml",
  "toml 0.7.3",
 ]
@@ -3614,6 +3615,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
 ]
 
 [[package]]

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.7.3"
 color-eyre = "0.6.2"
 phf = { version = "0.11.1", features = ["macros"] }
 comfy-table = "6.1.4"
+serde_repr = "0.1.12"
 
 [features]
 default = ["intl"]

--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::Display;
 
-use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
 
 use crate::read::{MetaData, TestFlag};
 
@@ -270,11 +270,11 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     PartialOrd,
     Ord,
     Default,
-    Serialize,
-    Deserialize,
+    Serialize_repr,
+    Deserialize_repr,
     clap::ValueEnum,
 )]
-#[serde(untagged)]
+#[repr(u8)]
 pub(crate) enum SpecEdition {
     /// ECMAScript 5.1 Edition
     ///


### PR DESCRIPTION
`boa_tester` wasn't deserializing `SpecEdition` correcly. This was because the attribute `serde(untagged)` just removes the u8 tag instead of trying to deserialize as a number. This PR fixes this using the `serde_repr` crate.

This needs #2763 to be merged for it to pass CI.