### PR TITLE
Implement `Inline Caching`

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -20,7 +20,10 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData, CONSTRUCTOR},
+    object::{
+        internal_methods::{get_prototype_from_constructor, InternalMethodContext},
+        JsObject, ObjectData, CONSTRUCTOR,
+    },
     property::{Attribute, PropertyDescriptor, PropertyNameKind},
     realm::Realm,
     string::common::StaticJsStrings,
@@ -349,7 +352,7 @@ impl Array {
                 .enumerable(false)
                 .configurable(false)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
 
         Ok(array)

--- a/boa_engine/src/builtins/function/tests.rs
+++ b/boa_engine/src/builtins/function/tests.rs
@@ -153,7 +153,10 @@ fn closure_capture_clone() {
                         let hw = js_string!(
                             string,
                             &object
-                                .__get_own_property__(&js_string!("key").into(), context)?
+                                .__get_own_property__(
+                                    &js_string!("key").into(),
+                                    &mut context.into()
+                                )?
                                 .and_then(|prop| prop.value().cloned())
                                 .and_then(|val| val.as_string().cloned())
                                 .ok_or_else(

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     js_string,
-    object::JsObject,
+    object::{internal_methods::InternalMethodContext, JsObject},
     property::{Attribute, PropertyNameKind},
     realm::Realm,
     string::{common::StaticJsStrings, utf16, CodePoint},
@@ -197,7 +197,7 @@ impl Json {
                     // 3. If newElement is undefined, then
                     if new_element.is_undefined() {
                         // a. Perform ? val.[[Delete]](prop).
-                        obj.__delete__(&i.into(), context)?;
+                        obj.__delete__(&i.into(), &mut InternalMethodContext::new(context))?;
                     }
                     // 4. Else,
                     else {
@@ -226,7 +226,7 @@ impl Json {
                     // 2. If newElement is undefined, then
                     if new_element.is_undefined() {
                         // a. Perform ? val.[[Delete]](P).
-                        obj.__delete__(&p.into(), context)?;
+                        obj.__delete__(&p.into(), &mut InternalMethodContext::new(context))?;
                     }
                     // 3. Else,
                     else {

--- a/boa_engine/src/builtins/temporal/calendar/mod.rs
+++ b/boa_engine/src/builtins/temporal/calendar/mod.rs
@@ -1181,7 +1181,7 @@ pub(crate) fn to_temporal_calendar_slot_value(
 fn object_implements_calendar_protocol(calendar_like: &JsObject, context: &mut Context) -> bool {
     CALENDAR_PROTOCOL_METHODS.into_iter().all(|method| {
         calendar_like
-            .__has_property__(&JsString::from(method).into(), context)
+            .__has_property__(&JsString::from(method).into(), &mut context.into())
             .unwrap_or(false)
     })
 }

--- a/boa_engine/src/builtins/temporal/calendar/object.rs
+++ b/boa_engine/src/builtins/temporal/calendar/object.rs
@@ -847,7 +847,7 @@ impl CalendarProtocol for CustomRuntimeCalendar {
             .__get__(
                 &PropertyKey::from(utf16!("id")),
                 JsValue::undefined(),
-                context,
+                &mut context.into(),
             )
             .expect("method must exist on a object that implements the CalendarProtocol.");
 

--- a/boa_engine/src/builtins/temporal/mod.rs
+++ b/boa_engine/src/builtins/temporal/mod.rs
@@ -597,7 +597,7 @@ pub(crate) fn copy_data_properties(
         // c. If excluded is false, then
         if !excluded {
             // i. Let desc be ? from.[[GetOwnProperty]](nextKey).
-            let desc = from.__get_own_property__(&next_key, context)?;
+            let desc = from.__get_own_property__(&next_key, &mut context.into())?;
             // ii. If desc is not undefined and desc.[[Enumerable]] is true, then
             match desc {
                 Some(d)

--- a/boa_engine/src/builtins/typed_array/builtin.rs
+++ b/boa_engine/src/builtins/typed_array/builtin.rs
@@ -2262,7 +2262,7 @@ impl BuiltinTypedArray {
             let target_index = target_offset + k;
 
             // d. Perform ? IntegerIndexedElementSet(target, targetIndex, value).
-            integer_indexed_element_set(target, target_index as f64, &value, context)?;
+            integer_indexed_element_set(target, target_index as f64, &value, &mut context.into())?;
 
             // e. Set k to k + 1.
         }

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -39,11 +39,7 @@ impl ByteCompiler<'_> {
                             self.emit_opcode(Opcode::Dup);
                             match name {
                                 PropertyName::Literal(name) => {
-                                    let index = self.get_or_insert_name((*name).into());
-                                    self.emit_with_varying_operand(
-                                        Opcode::GetPropertyByName,
-                                        index,
-                                    );
+                                    self.emit_get_property_by_name(*name);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -123,11 +119,7 @@ impl ByteCompiler<'_> {
                             self.emit_opcode(Opcode::Dup);
                             match name {
                                 PropertyName::Literal(name) => {
-                                    let index = self.get_or_insert_name((*name).into());
-                                    self.emit_with_varying_operand(
-                                        Opcode::GetPropertyByName,
-                                        index,
-                                    );
+                                    self.emit_get_property_by_name(*name);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -166,11 +158,7 @@ impl ByteCompiler<'_> {
                             self.emit_opcode(Opcode::Dup);
                             match name {
                                 PropertyName::Literal(name) => {
-                                    let index = self.get_or_insert_name((*name).into());
-                                    self.emit_with_varying_operand(
-                                        Opcode::GetPropertyByName,
-                                        index,
-                                    );
+                                    self.emit_get_property_by_name(*name);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -99,13 +99,12 @@ impl ByteCompiler<'_> {
                 Access::Property { access } => match access {
                     PropertyAccess::Simple(access) => match access.field() {
                         PropertyAccessField::Const(name) => {
-                            let index = self.get_or_insert_name((*name).into());
                             self.compile_expr(access.target(), true);
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
 
-                            self.emit_with_varying_operand(Opcode::GetPropertyByName, index);
+                            self.emit_get_property_by_name(*name);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -115,7 +114,7 @@ impl ByteCompiler<'_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit_with_varying_operand(Opcode::SetPropertyByName, index);
+                            self.emit_set_property_by_name(*name);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }
@@ -165,14 +164,13 @@ impl ByteCompiler<'_> {
                     }
                     PropertyAccess::Super(access) => match access.field() {
                         PropertyAccessField::Const(name) => {
-                            let index = self.get_or_insert_name((*name).into());
                             self.emit_opcode(Opcode::Super);
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::This);
                             self.emit_opcode(Opcode::Swap);
                             self.emit_opcode(Opcode::This);
 
-                            self.emit_with_varying_operand(Opcode::GetPropertyByName, index);
+                            self.emit_get_property_by_name(*name);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -182,7 +180,7 @@ impl ByteCompiler<'_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit_with_varying_operand(Opcode::SetPropertyByName, index);
+                            self.emit_set_property_by_name(*name);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -239,8 +239,7 @@ impl ByteCompiler<'_> {
                         self.emit_opcode(Opcode::Dup);
                         match access.field() {
                             PropertyAccessField::Const(field) => {
-                                let index = self.get_or_insert_name((*field).into());
-                                self.emit_with_varying_operand(Opcode::GetPropertyByName, index);
+                                self.emit_get_property_by_name(*field);
                             }
                             PropertyAccessField::Expr(field) => {
                                 self.compile_expr(field, true);

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -63,19 +63,18 @@ impl ByteCompiler<'_> {
             Access::Property { access } => match access {
                 PropertyAccess::Simple(access) => match access.field() {
                     PropertyAccessField::Const(name) => {
-                        let index = self.get_or_insert_name((*name).into());
                         self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit_with_varying_operand(Opcode::GetPropertyByName, index);
+                        self.emit_get_property_by_name(*name);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(4)]);
                         }
 
-                        self.emit_with_varying_operand(Opcode::SetPropertyByName, index);
+                        self.emit_set_property_by_name(*name);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -117,20 +116,19 @@ impl ByteCompiler<'_> {
                 }
                 PropertyAccess::Super(access) => match access.field() {
                     PropertyAccessField::Const(name) => {
-                        let index = self.get_or_insert_name((*name).into());
                         self.emit_opcode(Opcode::Super);
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::This);
                         self.emit_opcode(Opcode::Swap);
                         self.emit_opcode(Opcode::This);
 
-                        self.emit_with_varying_operand(Opcode::GetPropertyByName, index);
+                        self.emit_get_property_by_name(*name);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                         }
 
-                        self.emit_with_varying_operand(Opcode::SetPropertyByName, index);
+                        self.emit_set_property_by_name(*name);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -616,7 +616,7 @@ impl Context {
 
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
         let name = name.clone().into();
-        let existing_prop = global_object.__get_own_property__(&name, self)?;
+        let existing_prop = global_object.__get_own_property__(&name, &mut self.into())?;
 
         // 4. If existingProp is undefined, return ? IsExtensible(globalObject).
         let Some(existing_prop) = existing_prop else {
@@ -723,7 +723,8 @@ impl Context {
         let global_object = self.realm().global_object().clone();
 
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let existing_prop = global_object.__get_own_property__(&name.clone().into(), self)?;
+        let existing_prop =
+            global_object.__get_own_property__(&name.clone().into(), &mut self.into())?;
 
         // 4. If existingProp is undefined or existingProp.[[Configurable]] is true, then
         let desc = if existing_prop.is_none()
@@ -770,7 +771,7 @@ impl Context {
 
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
         let name = name.clone().into();
-        let existing_prop = global_object.__get_own_property__(&name, self)?;
+        let existing_prop = global_object.__get_own_property__(&name, &mut self.into())?;
 
         // 4. If existingProp is undefined, return false.
         let Some(existing_prop) = existing_prop else {

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use crate::{
     environments::CompileTimeEnvironment,
-    object::{JsObject, PrivateName},
+    object::{internal_methods::InternalMethodContext, JsObject, PrivateName},
     Context, JsResult, JsString, JsSymbol, JsValue,
 };
 use boa_gc::{empty_trace, Finalize, Gc, Trace};
@@ -630,7 +630,8 @@ impl Context {
     pub(crate) fn delete_binding(&mut self, locator: &BindingLocator) -> JsResult<bool> {
         if locator.is_global() {
             let key = locator.name().clone();
-            self.global_object().__delete__(&key.into(), self)
+            self.global_object()
+                .__delete__(&key.into(), &mut self.into())
         } else {
             match self.environment_expect(locator.environment_index) {
                 Environment::Declarative(_) => Ok(false),
@@ -638,7 +639,7 @@ impl Context {
                     let obj = obj.clone();
                     let key = locator.name().clone();
 
-                    obj.__delete__(&key.into(), self)
+                    obj.__delete__(&key.into(), &mut InternalMethodContext::new(self))
                 }
             }
         }

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -1,10 +1,10 @@
 use crate::{
     object::JsObject,
     property::{DescriptorKind, PropertyDescriptor, PropertyKey},
-    Context, JsResult, JsValue,
+    JsResult, JsValue,
 };
 
-use super::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
+use super::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 
 pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
     InternalObjectMethods {
@@ -25,7 +25,7 @@ pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let desc be OrdinaryGetOwnProperty(args, P).
     // 2. If desc is undefined, return desc.
@@ -70,7 +70,7 @@ pub(crate) fn arguments_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 2. Let isMapped be HasOwnProperty(map, P).
     let mapped = if let &PropertyKey::Index(index) = &key {
@@ -161,7 +161,7 @@ pub(crate) fn arguments_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<JsValue> {
     if let PropertyKey::Index(index) = key {
         // 1. Let map be args.[[ParameterMap]].
@@ -194,7 +194,7 @@ pub(crate) fn arguments_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. If SameValue(args, Receiver) is false, then
     // a. Let isMapped be false.
@@ -226,7 +226,7 @@ pub(crate) fn arguments_exotic_set(
 pub(crate) fn arguments_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 3. Let result be ? OrdinaryDelete(args, P).
     let result = super::ordinary_delete(obj, key, context)?;

--- a/boa_engine/src/object/internal_methods/array.rs
+++ b/boa_engine/src/object/internal_methods/array.rs
@@ -3,10 +3,10 @@ use crate::{
     object::JsObject,
     property::{PropertyDescriptor, PropertyKey},
     string::utf16,
-    Context, JsResult,
+    JsResult,
 };
 
-use super::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
+use super::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 
 /// Definitions of the internal object methods for array exotic objects.
 ///
@@ -29,7 +29,7 @@ pub(crate) fn array_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     match key {
@@ -111,7 +111,7 @@ pub(crate) fn array_exotic_define_own_property(
 fn array_set_length(
     obj: &JsObject,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. If Desc.[[Value]] is absent, then
     let Some(new_len_val) = desc.value() else {

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -9,7 +9,7 @@ use crate::{
     Context, JsResult, JsString, JsValue,
 };
 
-use super::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
+use super::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 
 /// Definitions of the internal object methods for integer-indexed exotic objects.
 ///
@@ -62,7 +62,7 @@ fn canonical_numeric_index_string(argument: &JsString) -> Option<f64> {
 pub(crate) fn integer_indexed_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -104,7 +104,7 @@ pub(crate) fn integer_indexed_exotic_get_own_property(
 pub(crate) fn integer_indexed_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -135,7 +135,7 @@ pub(crate) fn integer_indexed_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -197,7 +197,7 @@ pub(crate) fn integer_indexed_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<JsValue> {
     let p = match key {
         PropertyKey::String(key) => {
@@ -230,7 +230,7 @@ pub(crate) fn integer_indexed_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     let p = match &key {
         PropertyKey::String(key) => {
@@ -272,7 +272,7 @@ pub(crate) fn integer_indexed_exotic_set(
 pub(crate) fn integer_indexed_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     let p = match &key {
         PropertyKey::String(key) => {
@@ -388,7 +388,7 @@ pub(crate) fn integer_indexed_element_set(
     obj: &JsObject,
     index: f64,
     value: &JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<()> {
     let obj_borrow = obj.borrow();
     let inner = obj_borrow.as_typed_array().expect(

--- a/boa_engine/src/object/internal_methods/module_namespace.rs
+++ b/boa_engine/src/object/internal_methods/module_namespace.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::{
     immutable_prototype, ordinary_define_own_property, ordinary_delete, ordinary_get,
     ordinary_get_own_property, ordinary_has_property, ordinary_own_property_keys,
-    InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
+    InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS,
 };
 
 /// Definitions of the internal object methods for [**Module Namespace Exotic Objects**][spec].
@@ -84,7 +84,7 @@ fn module_namespace_exotic_prevent_extensions(_: &JsObject, _: &mut Context) -> 
 fn module_namespace_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. If P is a Symbol, return OrdinaryGetOwnProperty(O, P).
     let key = match key {
@@ -128,7 +128,7 @@ fn module_namespace_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
     if let PropertyKey::Symbol(_) = key {
@@ -164,7 +164,7 @@ fn module_namespace_exotic_define_own_property(
 fn module_namespace_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryHasProperty(O, P).
     let key = match key {
@@ -193,7 +193,7 @@ fn module_namespace_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<JsValue> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryGet(O, P, Receiver).
@@ -273,7 +273,7 @@ fn module_namespace_exotic_set(
     _key: PropertyKey,
     _value: JsValue,
     _receiver: JsValue,
-    _context: &mut Context,
+    _context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. Return false.
     Ok(false)
@@ -285,7 +285,7 @@ fn module_namespace_exotic_set(
 fn module_namespace_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryDelete(O, P).

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -5,7 +5,7 @@ use crate::{
     Context, JsResult,
 };
 
-use super::{InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
+use super::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS};
 
 /// Definitions of the internal object methods for string exotic objects.
 ///
@@ -29,7 +29,7 @@ pub(crate) static STRING_EXOTIC_INTERNAL_METHODS: InternalObjectMethods = Intern
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let desc be OrdinaryGetOwnProperty(S, P).
@@ -54,7 +54,7 @@ pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context,
+    context: &mut InternalMethodContext<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let stringDesc be ! StringGetOwnProperty(S, P).

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -4,7 +4,7 @@
 
 use super::{
     internal_methods::{
-        non_existant_call, non_existant_construct, InternalObjectMethods,
+        non_existant_call, non_existant_construct, InternalMethodContext, InternalObjectMethods,
         ARRAY_EXOTIC_INTERNAL_METHODS,
     },
     shape::RootShape,
@@ -1000,6 +1000,8 @@ Cannot both specify accessors and a value or writable attribute",
     where
         K: Into<PropertyKey>,
     {
+        let context = &mut InternalMethodContext::new(context);
+
         // 1. Assert: Type(target) is Object.
         // 2. Assert: excludedItems is a List of property keys.
         // 3. If source is undefined or null, return target.

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -39,6 +39,7 @@ pub(crate) use {
     call_frame::CallFrameFlags,
     code_block::{
         create_function_object, create_function_object_fast, CodeBlockFlags, Constant, Handler,
+        InlineCache,
     },
     completion_record::CompletionRecord,
     opcode::BindingOpcode,

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::function::set_function_name,
+    object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsString,
@@ -35,7 +36,7 @@ impl DefineClassStaticGetterByName {
             function_mut.set_home_object(class.clone());
         }
         let set = class
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -47,7 +48,7 @@ impl DefineClassStaticGetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -104,7 +105,7 @@ impl DefineClassGetterByName {
             function_mut.set_home_object(class_proto.clone());
         }
         let set = class_proto
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -116,7 +117,7 @@ impl DefineClassGetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -174,8 +175,9 @@ impl Operation for DefineClassStaticGetterByValue {
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
         }
+
         let set = class
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -225,7 +227,7 @@ impl Operation for DefineClassGetterByValue {
             function_mut.set_home_object(class_proto.clone());
         }
         let set = class_proto
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::set)
             .cloned();
@@ -237,7 +239,7 @@ impl Operation for DefineClassGetterByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::function::set_function_name,
+    object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
@@ -43,7 +44,7 @@ impl DefineClassStaticMethodByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -108,7 +109,7 @@ impl DefineClassMethodByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -221,7 +222,7 @@ impl Operation for DefineClassMethodByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -1,5 +1,6 @@
 use crate::{
     builtins::function::set_function_name,
+    object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsString,
@@ -35,7 +36,7 @@ impl DefineClassStaticSetterByName {
             function_mut.set_home_object(class.clone());
         }
         let get = class
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -48,7 +49,7 @@ impl DefineClassStaticSetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -105,7 +106,7 @@ impl DefineClassSetterByName {
             function_mut.set_home_object(class_proto.clone());
         }
         let get = class_proto
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -118,7 +119,7 @@ impl DefineClassSetterByName {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
 
         Ok(CompletionType::Normal)
@@ -178,7 +179,7 @@ impl Operation for DefineClassStaticSetterByValue {
             function_mut.set_home_object(class.clone());
         }
         let get = class
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -230,7 +231,7 @@ impl Operation for DefineClassSetterByValue {
             function_mut.set_home_object(class_proto.clone());
         }
         let get = class_proto
-            .__get_own_property__(&key, context)?
+            .__get_own_property__(&key, &mut InternalMethodContext::new(context))?
             .as_ref()
             .and_then(PropertyDescriptor::get)
             .cloned();
@@ -243,7 +244,7 @@ impl Operation for DefineClassSetterByValue {
                 .enumerable(false)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
 
         Ok(CompletionType::Normal)

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -1,4 +1,5 @@
 use crate::{
+    object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsNativeError, JsResult,
@@ -29,7 +30,7 @@ impl DefineOwnPropertyByName {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         Ok(CompletionType::Normal)
     }
@@ -86,7 +87,7 @@ impl Operation for DefineOwnPropertyByValue {
                 .enumerable(true)
                 .configurable(true)
                 .build(),
-            context,
+            &mut InternalMethodContext::new(context),
         )?;
         if !success {
             return Err(JsNativeError::typ()

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::JsNativeError,
+    object::internal_methods::InternalMethodContext,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
 };
@@ -21,8 +22,9 @@ impl DeletePropertyByName {
             .code_block()
             .constant_string(index)
             .into();
-        let result = object.__delete__(&key, context)?;
-        if !result && context.vm.frame().code_block.strict() {
+
+        let result = object.__delete__(&key, &mut InternalMethodContext::new(context))?;
+        if !result && context.vm.frame().code_block().strict() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
                 .into());
@@ -70,8 +72,9 @@ impl Operation for DeletePropertyByValue {
         let value = context.vm.pop();
         let object = value.to_object(context)?;
         let property_key = key_value.to_property_key(context)?;
-        let result = object.__delete__(&property_key, context)?;
-        if !result && context.vm.frame().code_block.strict() {
+
+        let result = object.__delete__(&property_key, &mut InternalMethodContext::new(context))?;
+        if !result && context.vm.frame().code_block().strict() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
                 .into());

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::JsNativeError,
+    object::internal_methods::InternalMethodContext,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsValue,
 };
@@ -54,7 +55,7 @@ impl Operation for Super {
         };
 
         let value = home_object
-            .map(|o| o.__get_prototype_of__(context))
+            .map(|o| o.__get_prototype_of__(&mut InternalMethodContext::new(context)))
             .transpose()?
             .flatten()
             .map_or_else(JsValue::null, JsValue::from);
@@ -85,7 +86,7 @@ impl Operation for SuperCallPrepare {
             .expect("super call must be in function environment");
         let active_function = this_env.slots().function_object().clone();
         let super_constructor = active_function
-            .__get_prototype_of__(context)
+            .__get_prototype_of__(&mut InternalMethodContext::new(context))
             .expect("function object must have prototype");
 
         context
@@ -242,7 +243,7 @@ impl Operation for SuperCallDerived {
             .clone();
         let active_function = this_env.slots().function_object().clone();
         let super_constructor = active_function
-            .__get_prototype_of__(context)
+            .__get_prototype_of__(&mut InternalMethodContext::new(context))
             .expect("function object must have prototype")
             .expect("function object must have prototype");
 

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -1,4 +1,5 @@
 use crate::{
+    object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
     property::PropertyKey,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
@@ -21,13 +22,51 @@ impl GetPropertyByName {
             value.to_object(context)?
         };
 
-        let key = context
-            .vm
-            .frame()
-            .code_block()
-            .constant_string(index)
-            .into();
+        let ic = &context.vm.frame().code_block().ic[index];
+        let mut slot = ic.slot();
+        if slot.is_cachable() {
+            let object_borrowed = object.borrow();
+            if ic.matches(object_borrowed.shape()) {
+                let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
+                    let prototype = object
+                        .borrow()
+                        .properties()
+                        .shape
+                        .prototype()
+                        .expect("prototype should have value");
+                    let prototype = prototype.borrow();
+                    prototype.properties().storage[slot.index as usize].clone()
+                } else {
+                    object_borrowed.properties().storage[slot.index as usize].clone()
+                };
+
+                drop(object_borrowed);
+                if slot.attributes.has_get() && result.is_object() {
+                    result = result.as_object().expect("should contain getter").call(
+                        &receiver,
+                        &[],
+                        context,
+                    )?;
+                }
+                context.vm.push(result);
+                return Ok(CompletionType::Normal);
+            }
+        }
+
+        let key: PropertyKey = ic.name.clone().into();
+
+        let context = &mut InternalMethodContext::new(context);
         let result = object.__get__(&key, receiver, context)?;
+
+        slot = *context.slot();
+
+        // Cache the property.
+        if slot.attributes.is_cachable() {
+            let ic = &context.vm.frame().code_block.ic[index];
+            let object_borrowed = object.borrow();
+            let shape = object_borrowed.shape();
+            ic.set(shape, slot);
+        }
 
         context.vm.push(result);
         Ok(CompletionType::Normal)
@@ -95,7 +134,7 @@ impl Operation for GetPropertyByValue {
         }
 
         // Slow path:
-        let result = object.__get__(&key, receiver, context)?;
+        let result = object.__get__(&key, receiver, &mut InternalMethodContext::new(context))?;
 
         context.vm.push(result);
         Ok(CompletionType::Normal)
@@ -143,7 +182,7 @@ impl Operation for GetPropertyByValuePush {
         }
 
         // Slow path:
-        let result = object.__get__(&key, receiver, context)?;
+        let result = object.__get__(&key, receiver, &mut InternalMethodContext::new(context))?;
 
         context.vm.push(key);
         context.vm.push(result);

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -1,6 +1,6 @@
 use crate::{
     js_string,
-    object::PrivateElement,
+    object::{internal_methods::InternalMethodContext, PrivateElement},
     property::PropertyDescriptor,
     string::utf16,
     vm::{opcode::Operation, CompletionType},
@@ -29,7 +29,11 @@ impl PushClassPrivateMethod {
             .configurable(true)
             .build();
         method_object
-            .__define_own_property__(&utf16!("name").into(), desc, context)
+            .__define_own_property__(
+                &utf16!("name").into(),
+                desc,
+                &mut InternalMethodContext::new(context),
+            )
             .expect("failed to set name property on private method");
 
         let class = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/class_prototype.rs
+++ b/boa_engine/src/vm/opcode/set/class_prototype.rs
@@ -1,5 +1,7 @@
 use crate::{
-    object::{JsObject, ObjectData, CONSTRUCTOR, PROTOTYPE},
+    object::{
+        internal_methods::InternalMethodContext, JsObject, ObjectData, CONSTRUCTOR, PROTOTYPE,
+    },
     property::PropertyDescriptorBuilder,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsValue,
@@ -63,7 +65,7 @@ impl Operation for SetClassPrototype {
                     .enumerable(false)
                     .configurable(true)
                     .build(),
-                context,
+                &mut InternalMethodContext::new(context),
             )
             .expect("cannot fail per spec");
 

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -122,7 +122,7 @@ impl SetPrivateMethod {
             .configurable(true)
             .build();
         value
-            .__define_own_property__(&js_string!("name").into(), desc, context)
+            .__define_own_property__(&js_string!("name").into(), desc, &mut context.into())
             .expect("failed to set name property on private method");
 
         let object = context.vm.pop();

--- a/boa_engine/src/vm/opcode/set/prototype.rs
+++ b/boa_engine/src/vm/opcode/set/prototype.rs
@@ -1,4 +1,5 @@
 use crate::{
+    object::internal_methods::InternalMethodContext,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
 };
@@ -29,7 +30,7 @@ impl Operation for SetPrototype {
 
         let object = object.as_object().expect("object is not an object");
         object
-            .__set_prototype_of__(prototype, context)
+            .__set_prototype_of__(prototype, &mut InternalMethodContext::new(context))
             .expect("cannot fail per spec");
 
         Ok(CompletionType::Normal)


### PR DESCRIPTION
~~Depends on #2723~~ 

This PR i~~currently just a POC~~ implements inline caching. ~~This merges into #2723 so the changes can be easily  seen, will switch to `main`,  once `Hidden classes` gets merged.~~

~~Because the `Proxy` internal methods are not implement this will introduce a lot of panics ( will fix ), Was curious about the benchmarks since,  we don't have proxys in the benchmarks they shouldn't fail.~~ The inline caching is now internal method aware so it knows what can be cached.

It changes the following:

- [x] Fix incorrect handling of `Proxy` internal methods
- [x] Make inline caching internal method aware
- [x] Add inline caching to `GetPropertyByName`
- [x] Add inline caching to `SetPropertyByName`
- [ ] ~~Add inline caching to `GetName`~~
- [ ] ~~Add inline caching to `SetName`~~

