### PR TITLE
[Merged by Bors] - Add `json-parse-with-source` feature to `boa_tester`

### DIFF
--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -47,6 +47,10 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-json-modules
     "json-modules"  => SpecEdition::ESNext,
 
+    // JSON.parse with source
+    // https://github.com/tc39/proposal-json-parse-with-source
+    "json-parse-with-source" => SpecEdition::ESNext,
+
     // Resizable Arraybuffer
     // https://github.com/tc39/proposal-resizablearraybuffer
     "resizable-arraybuffer" => SpecEdition::ESNext,


### PR DESCRIPTION
This PR resolves the failing CI in #2777

It changes the following:

- Adds `json-parse-with-source` feature to `boa_tester`
- Bumps `test262` module to `be0abd9`
