### PR TITLE
Create new `Runtime` API

### DIFF
--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -62,11 +62,10 @@ mod helper;
 
 use boa_ast::StatementList;
 use boa_engine::{
-    context::ContextBuilder,
     job::{FutureJob, JobQueue, NativeJob},
     optimizer::OptimizerOptions,
     vm::flowgraph::{Direction, Graph},
-    Context, JsResult, Source,
+    Context, JsResult, Runtime, Source,
 };
 use clap::{Parser, ValueEnum, ValueHint};
 use colored::{Color, Colorize};
@@ -296,9 +295,10 @@ fn evaluate_files(args: &Opt, context: &mut Context<'_>) -> Result<(), io::Error
 fn main() -> Result<(), io::Error> {
     let args = Opt::parse();
 
-    let queue = Jobs::default();
-    let mut context = ContextBuilder::new()
-        .job_queue(&queue)
+    let runtime = &Runtime::default();
+    let queue = &Jobs::default();
+    let mut context = Context::builder(runtime)
+        .job_queue(queue)
         .build()
         .expect("cannot fail with default global object");
 

--- a/boa_engine/benches/full.rs
+++ b/boa_engine/benches/full.rs
@@ -1,8 +1,6 @@
 //! Benchmarks of the whole execution engine in Boa.
 
-use boa_engine::{
-    context::DefaultHooks, optimizer::OptimizerOptions, realm::Realm, Context, Source,
-};
+use boa_engine::{optimizer::OptimizerOptions, realm::Realm, runtime::Runtime, Context, Source};
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
 
@@ -15,7 +13,7 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 fn create_realm(c: &mut Criterion) {
     c.bench_function("Create Realm", move |b| {
-        b.iter(|| Realm::create(&DefaultHooks))
+        b.iter(|| Realm::create(&Runtime::default()))
     });
 }
 
@@ -25,7 +23,8 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let mut context = Context::default();
+                    let rt = &Runtime::default();
+                    let mut context = Context::builder(&rt).build().unwrap();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());
@@ -40,7 +39,8 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let mut context = Context::default();
+                    let rt = &Runtime::default();
+                    let mut context = Context::builder(&rt).build().unwrap();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());
@@ -58,7 +58,8 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let mut context = Context::default();
+                    let rt = &Runtime::default();
+                    let mut context = Context::builder(&rt).build().unwrap();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());

--- a/boa_engine/src/builtins/intl/collator/mod.rs
+++ b/boa_engine/src/builtins/intl/collator/mod.rs
@@ -12,16 +12,14 @@ use icu_provider::DataLocale;
 
 use crate::{
     builtins::{BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
-    context::{
-        intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
-        BoaProvider,
-    },
+    context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     native_function::NativeFunction,
     object::{
         internal_methods::get_prototype_from_constructor, FunctionObjectBuilder, JsFunction,
         JsObject, ObjectData,
     },
     property::Attribute,
+    runtime::BoaProvider,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsValue,

--- a/boa_engine/src/builtins/intl/locale/tests.rs
+++ b/boa_engine/src/builtins/intl/locale/tests.rs
@@ -15,7 +15,7 @@ use crate::{
         options::{IntlOptions, LocaleMatcher},
         Service,
     },
-    context::icu::{BoaProvider, Icu},
+    runtime::{icu::Icu, BoaProvider},
 };
 
 #[derive(Debug)]

--- a/boa_engine/src/builtins/intl/locale/utils.rs
+++ b/boa_engine/src/builtins/intl/locale/utils.rs
@@ -6,8 +6,8 @@ use crate::{
         },
         Array,
     },
-    context::{icu::Icu, BoaProvider},
     object::JsObject,
+    runtime::{icu::Icu, BoaProvider},
     string::utf16,
     Context, JsNativeError, JsResult, JsValue,
 };
@@ -553,7 +553,7 @@ mod tests {
         builtins::intl::locale::utils::{
             best_available_locale, best_fit_matcher, default_locale, lookup_matcher,
         },
-        context::icu::{BoaProvider, Icu},
+        runtime::{icu::Icu, BoaProvider},
     };
 
     #[test]

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -11,9 +11,10 @@
 
 use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInObject, IntrinsicObject},
-    context::{intrinsics::Intrinsics, BoaProvider},
+    context::intrinsics::Intrinsics,
     object::JsObject,
     property::Attribute,
+    runtime::BoaProvider,
     symbol::JsSymbol,
     Context, JsArgs, JsResult, JsValue,
 };

--- a/boa_engine/src/builtins/promise/tests.rs
+++ b/boa_engine/src/builtins/promise/tests.rs
@@ -1,10 +1,11 @@
-use crate::{context::ContextBuilder, job::SimpleJobQueue, run_test_actions_with, TestAction};
+use crate::{job::SimpleJobQueue, run_test_actions_with, Context, Runtime, TestAction};
 use indoc::indoc;
 
 #[test]
 fn promise() {
+    let rt = &Runtime::default();
     let queue = SimpleJobQueue::new();
-    let context = &mut ContextBuilder::new().job_queue(&queue).build().unwrap();
+    let context = &mut Context::builder(rt).job_queue(&queue).build().unwrap();
     run_test_actions_with(
         [
             TestAction::run(indoc! {r#"

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -85,7 +85,7 @@ impl BuiltInConstructor for WeakRef {
         );
 
         // 4. Perform AddToKeptObjects(target).
-        context.kept_alive.push(target.clone());
+        context.add_to_kept_objects(target.clone());
 
         // 6. Return weakRef.
         Ok(weak_ref.into())
@@ -128,7 +128,7 @@ impl WeakRef {
             let object = JsObject::from(object);
 
             // a. Perform AddToKeptObjects(target).
-            context.kept_alive.push(object.clone());
+            context.add_to_kept_objects(object.clone());
 
             // b. Return target.
             Ok(object.into())

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -470,6 +470,7 @@ impl<'host> Context<'host> {
 
 // ==== Private API ====
 
+#[allow(single_use_lifetimes)]
 impl<'host> Context<'host> {
     /// Abstract operation [`AddToKeptObjects ( object )`][add].
     ///

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -151,7 +151,7 @@ impl JsError {
     ///
     /// ```rust
     /// # use boa_engine::{Context, JsError, JsNativeError};
-    /// let context = &mut Context::default();
+    /// let context = &mut test_context();
     /// let error: JsError = JsNativeError::eval().with_message("invalid script").into();
     /// let error_val = error.to_opaque(context);
     ///
@@ -190,7 +190,7 @@ impl JsError {
     ///
     /// ```rust
     /// # use boa_engine::{Context, JsError, JsNativeError, JsNativeErrorKind};
-    /// let context = &mut Context::default();
+    /// let context = &mut test_context();
     ///
     /// // create a new, opaque Error object
     /// let error: JsError = JsNativeError::typ().with_message("type error!").into();
@@ -629,7 +629,7 @@ impl JsNativeError {
     ///
     /// ```rust
     /// # use boa_engine::{Context, JsError, JsNativeError};
-    /// let context = &mut Context::default();
+    /// let context = &mut test_context();
     ///
     /// let error = JsNativeError::error().with_message("error!");
     /// let error_obj = error.to_opaque(context);

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -153,6 +153,7 @@ pub mod native_function;
 pub mod object;
 pub mod property;
 pub mod realm;
+pub mod runtime;
 pub mod string;
 pub mod symbol;
 pub mod value;
@@ -173,7 +174,7 @@ pub mod prelude {
         error::{JsError, JsNativeError, JsNativeErrorKind},
         native_function::NativeFunction,
         object::JsObject,
-        Context, JsBigInt, JsResult, JsString, JsValue,
+        Context, JsBigInt, JsResult, JsString, JsValue, Runtime,
     };
     pub use boa_parser::Source;
 }
@@ -188,6 +189,7 @@ pub use crate::{
     error::{JsError, JsNativeError, JsNativeErrorKind},
     native_function::NativeFunction,
     object::JsObject,
+    runtime::Runtime,
     string::JsString,
     symbol::JsSymbol,
     value::JsValue,
@@ -348,7 +350,8 @@ impl TestAction {
 #[cfg(test)]
 #[track_caller]
 pub(crate) fn run_test_actions(actions: impl IntoIterator<Item = TestAction>) {
-    let context = &mut Context::default();
+    let rt = &Runtime::default();
+    let context = &mut Context::builder(rt).build().unwrap();
     run_test_actions_with(actions, context);
 }
 

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -27,7 +27,7 @@ impl JsArrayBuffer {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // Creates a blank array buffer of n bytes
     /// let array_buffer = JsArrayBuffer::new(4, context)?;
     ///
@@ -65,7 +65,7 @@ impl JsArrayBuffer {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     ///
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
@@ -135,7 +135,7 @@ impl JsArrayBuffer {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;
@@ -166,7 +166,7 @@ impl JsArrayBuffer {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Initialize context
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // Create a buffer from a chunk of data
     /// let data_block: Vec<u8> = (0..5).collect();
     /// let array_buffer = JsArrayBuffer::from_byte_block(data_block, context)?;

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -22,7 +22,7 @@ use std::ops::Deref;
 /// # };
 /// # fn main() -> JsResult<()> {
 /// // Create a new context and ArrayBuffer
-/// let context = &mut Context::default();
+/// let context = &mut test_context();
 /// let array_buffer = JsArrayBuffer::new(4, context)?;
 ///
 /// // Create a new Dataview from pre-existing ArrayBuffer

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -21,7 +21,7 @@ use crate::{
 ///
 /// fn main() -> JsResult<()> {
 /// // JS mutable Context
-/// let context = &mut Context::default();
+/// let context = &mut test_context();
 ///
 /// let date = JsDate::new(context);
 ///

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -23,7 +23,7 @@ use std::ops::Deref;
 /// # };
 /// # fn main() -> JsResult<()> {
 /// // Create default `Context`
-/// let context = &mut Context::default();
+/// let context = &mut test_context();
 ///
 /// // Create a new empty `JsMap`.
 /// let map = JsMap::new(context);
@@ -45,7 +45,7 @@ use std::ops::Deref;
 /// # };
 /// # fn main() -> JsResult<()> {
 /// // Create a default `Context`
-/// let context = &mut Context::default();
+/// let context = &mut test_context();
 ///
 /// // Create an array of two `[key, value]` pairs
 /// let js_array = JsArray::new(context);
@@ -82,7 +82,7 @@ impl JsMap {
     /// #    Context, JsValue,
     /// # };
     /// # // Create a new context.
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // Create a new empty `JsMap`.
     /// let map = JsMap::new(context);
     /// ```
@@ -102,7 +102,7 @@ impl JsMap {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// # // Create a default `Context`
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // Create an array of two `[key, value]` pairs
     /// let js_array = JsArray::new(context);
     ///
@@ -142,7 +142,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// // `some_object` can be any JavaScript `Map` object.
     /// let some_object = JsObject::from_proto_and_data(
     ///     context.intrinsics().constructors().map().prototype(),
@@ -161,7 +161,7 @@ impl JsMap {
     /// #    object::{JsObject, builtins::{JsArray, JsMap}},
     /// #    Context, JsResult, JsValue,
     /// # };
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let some_object = JsArray::new(context);
     ///
     /// // `some_object` is an Array object, not a map object
@@ -215,7 +215,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     ///
     /// js_map.set("foo", "bar", context)?;
@@ -248,7 +248,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     ///
     /// js_map.set("foo", "bar", context)?;
@@ -274,7 +274,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     /// js_map.set("foo", "bar", context)?;
     /// js_map.set("hello", "world", context)?;
@@ -303,7 +303,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     /// js_map.set("foo", "bar", context)?;
     ///
@@ -330,7 +330,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     /// js_map.set("foo", "bar", context)?;
     /// js_map.set("hello", "world", context)?;
@@ -356,7 +356,7 @@ impl JsMap {
     /// #    Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let js_map = JsMap::new(context);
     /// js_map.set("foo", "bar", context)?;
     ///

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -21,7 +21,7 @@ use std::ops::Deref;
 /// # };
 /// # fn main() -> JsResult<()> {
 /// // Initialize the `Context`
-/// let context = &mut Context::default();
+/// let context = &mut test_context();
 ///
 /// // Create a new RegExp with pattern and flags
 /// let regexp = JsRegExp::new("foo", "gi", context)?;
@@ -49,7 +49,7 @@ impl JsRegExp {
     /// # };
     /// # fn main() -> JsResult<()> {
     /// // Initialize the `Context`
-    /// let context = &mut Context::default();
+    /// let context = &mut test_context();
     ///
     /// // Create a new RegExp with pattern and flags
     /// let regexp = JsRegExp::new("foo", "gi", context)?;
@@ -144,7 +144,7 @@ impl JsRegExp {
     /// #  Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let regexp = JsRegExp::new("foo", "gi", context)?;
     ///
     /// let flags = regexp.flags(context)?;
@@ -169,7 +169,7 @@ impl JsRegExp {
     /// #  Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let regexp = JsRegExp::new("foo", "gi", context)?;
     ///
     /// let src = regexp.source(context)?;
@@ -194,7 +194,7 @@ impl JsRegExp {
     /// #  Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let regexp = JsRegExp::new("foo", "gi", context)?;
     ///
     /// let test_result = regexp.test("football", context)?;
@@ -236,7 +236,7 @@ impl JsRegExp {
     /// #  Context, JsValue, JsResult,
     /// # };
     /// # fn main() -> JsResult<()> {
-    /// # let context = &mut Context::default();
+    /// # let context = &mut test_context();
     /// let regexp = JsRegExp::new("foo", "gi", context)?;
     ///
     /// let to_string = regexp.to_string(context)?;

--- a/boa_engine/src/runtime/hooks.rs
+++ b/boa_engine/src/runtime/hooks.rs
@@ -1,11 +1,10 @@
 use crate::{
     builtins::promise::OperationType,
+    context::intrinsics::Intrinsics,
     job::JobCallback,
     object::{JsFunction, JsObject, ObjectData},
     Context, JsResult, JsValue,
 };
-
-use super::intrinsics::Intrinsics;
 
 /// [`Host Hooks`] customizable by the host code or engine.
 ///

--- a/boa_engine/src/runtime/icu.rs
+++ b/boa_engine/src/runtime/icu.rs
@@ -137,9 +137,7 @@ impl Debug for Icu<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Icu")
             .field("provider", &self.provider)
-            .field("locale_canonicalizer", &"LocaleCanonicalizer")
-            .field("locale_expander", &"LocaleExpander")
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/boa_engine/src/runtime/mod.rs
+++ b/boa_engine/src/runtime/mod.rs
@@ -1,0 +1,197 @@
+//! Runtime and host related types.
+
+mod hooks;
+pub use hooks::{DefaultHooks, HostHooks};
+#[cfg(feature = "intl")]
+pub(crate) mod icu;
+#[cfg(feature = "intl")]
+pub use icu::BoaProvider;
+
+use std::cell::{RefCell, RefMut};
+
+use crate::object::JsObject;
+
+/// A runtime context.
+///
+/// [`Runtime`] is a representation of global data shared between execution
+/// contexts (see [`Context`]); this is roughly equivalent to what the specification defines as an
+/// [**Agent**].
+///
+/// This is the place where [**Hosts**] can define hooks (see [`HostHooks`]) to customize the behaviour
+/// of the engine for their specific implementation of ECMAScript. It's also where hosts
+/// initialize the [`ICU4X`] data provider to enable `Intl` support for any `Context` constructed
+/// from this runtime, provided that the `intl` feature flag is enabled.
+#[cfg_attr(feature = "intl", doc = "(See [`RuntimeBuilder::icu_provider`])")]
+///
+/// [`Context`]: crate::Context
+/// [**Agent**]: https://tc39.es/ecma262/#sec-agents
+/// [**Hosts**]: https://tc39.es/ecma262/#sec-hosts-and-implementations
+/// [`ICU4X`]: https://github.com/unicode-org/icu4x
+pub struct Runtime<'host> {
+    /// Objects kept alive by `WeakRef`s.
+    kept_alive: RefCell<Vec<JsObject>>,
+
+    /// ICU related utilities.
+    #[cfg(feature = "intl")]
+    icu: icu::Icu<'host>,
+
+    /// Hooks defined by the host environment.
+    host_hooks: &'host dyn HostHooks,
+}
+
+impl Default for Runtime<'_> {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl std::fmt::Debug for Runtime<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("Runtime");
+
+        debug.field("hooks", &"HostHooks");
+
+        #[cfg(feature = "intl")]
+        debug.field("icu", &self.icu);
+
+        debug.finish_non_exhaustive()
+    }
+}
+
+impl<'host> Runtime<'host> {
+    /// Create a new [`RuntimeBuilder`] to specify the host
+    /// hooks and other additional config.
+    #[must_use]
+    pub fn builder() -> RuntimeBuilder<'static, 'static> {
+        RuntimeBuilder::default()
+    }
+
+    /// Gets a reference to the runtime's host hooks.
+    pub fn host_hooks(&self) -> &'host dyn HostHooks {
+        self.host_hooks
+    }
+
+    /// Abstract operation [`AddToKeptObjects ( object )`][add].
+    ///
+    /// Adds `object` to the `[[KeptAlive]]` field of the current [`surrounding agent`][agent], which
+    /// is represented by the `Runtime`.
+    ///
+    /// [add]: https://tc39.es/ecma262/#sec-addtokeptobjects
+    /// [agent]: https://tc39.es/ecma262/#sec-agents
+    pub(crate) fn add_to_kept_objects(&self, object: JsObject) {
+        self.kept_alive_mut().push(object);
+    }
+
+    /// Abstract operation [`ClearKeptObjects`][clear].
+    ///
+    /// Clears all objects maintained alive by calls to the [`AddToKeptObjects`][add] abstract
+    /// operation, used within the [`WeakRef`][weak] constructor.
+    ///
+    /// [clear]: https://tc39.es/ecma262/#sec-clear-kept-objects
+    /// [add]: https://tc39.es/ecma262/#sec-addtokeptobjects
+    /// [weak]: https://tc39.es/ecma262/#sec-weak-ref-objects
+    #[inline]
+    pub fn clear_kept_objects(&self) {
+        self.kept_alive_mut().clear();
+    }
+
+    /// Gets a mutable reference to the kept alive objects.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the kept alive objects are currently borrowed.
+    pub(crate) fn kept_alive_mut(&self) -> RefMut<'_, Vec<JsObject>> {
+        self.kept_alive.borrow_mut()
+    }
+
+    /// Gets a reference to the runtime's ICU4X data.
+    #[cfg(feature = "intl")]
+    pub(crate) const fn icu(&self) -> &icu::Icu<'host> {
+        &self.icu
+    }
+}
+
+/// Builder for the [`Runtime`] type.
+#[derive(Default)]
+pub struct RuntimeBuilder<'icu, 'hooks> {
+    host_hooks: Option<&'hooks dyn HostHooks>,
+    icu: Option<icu::Icu<'icu>>,
+    #[cfg(not(feature = "intl"))]
+    icu: PhantomData<&'icu ()>,
+}
+
+impl std::fmt::Debug for RuntimeBuilder<'_, '_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut out = f.debug_struct("RuntimeBuilder");
+
+        out.field("host_hooks", &"HostHooks");
+
+        #[cfg(feature = "intl")]
+        out.field("icu", &self.icu);
+
+        out.finish()
+    }
+}
+
+impl<'icu, 'hooks> RuntimeBuilder<'icu, 'hooks> {
+    /// Creates a new [`ContextBuilder`] with a default empty [`Interner`]
+    /// and a default [`BoaProvider`] if the `intl` feature is enabled.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Provides an icu data provider to the [`Context`].
+    ///
+    /// This function is only available if the `intl` feature is enabled.
+    ///
+    /// # Errors
+    ///
+    /// This returns `Err` if the provided provider doesn't have the required locale information
+    /// to construct both a [`LocaleCanonicalizer`] and a [`LocaleExpander`]. Note that this doesn't
+    /// mean that the provider will successfully construct all `Intl` services; that check is made
+    /// until the creation of an instance of a service.
+    ///
+    /// [`LocaleCanonicalizer`]: icu_locid_transform::LocaleCanonicalizer
+    /// [`LocaleExpander`]: icu_locid_transform::LocaleExpander
+    #[cfg(feature = "intl")]
+    pub fn icu_provider(
+        self,
+        provider: BoaProvider<'_>,
+    ) -> Result<RuntimeBuilder<'_, 'hooks>, icu_locid_transform::LocaleTransformError> {
+        Ok(RuntimeBuilder {
+            icu: Some(icu::Icu::new(provider)?),
+            ..self
+        })
+    }
+
+    /// Initializes the [`HostHooks`] for the context.
+    ///
+    /// [`Host Hooks`]: https://tc39.es/ecma262/#sec-host-hooks-summary
+    #[must_use]
+    pub fn host_hooks(self, host_hooks: &dyn HostHooks) -> RuntimeBuilder<'icu, '_> {
+        RuntimeBuilder {
+            host_hooks: Some(host_hooks),
+            ..self
+        }
+    }
+
+    /// Builds a new [`Context`] with the provided parameters, and defaults
+    /// all missing parameters to their default values.
+    #[must_use]
+    pub fn build<'host>(self) -> Runtime<'host>
+    where
+        'icu: 'host,
+        'hooks: 'host,
+    {
+        Runtime {
+            kept_alive: RefCell::new(Vec::new()),
+            #[cfg(feature = "intl")]
+            icu: self.icu.unwrap_or_else(|| {
+                let provider = BoaProvider::Buffer(boa_icu_provider::buffer());
+                icu::Icu::new(provider).expect("Failed to initialize default icu data.")
+            }),
+            host_hooks: self.host_hooks.unwrap_or(&DefaultHooks),
+        }
+    }
+}

--- a/boa_engine/src/runtime/mod.rs
+++ b/boa_engine/src/runtime/mod.rs
@@ -115,9 +115,10 @@ impl<'host> Runtime<'host> {
 #[derive(Default)]
 pub struct RuntimeBuilder<'icu, 'hooks> {
     host_hooks: Option<&'hooks dyn HostHooks>,
+    #[cfg(feature = "intl")]
     icu: Option<icu::Icu<'icu>>,
     #[cfg(not(feature = "intl"))]
-    icu: PhantomData<&'icu ()>,
+    icu: std::marker::PhantomData<&'icu ()>,
 }
 
 impl std::fmt::Debug for RuntimeBuilder<'_, '_> {

--- a/boa_engine/src/tests/promise.rs
+++ b/boa_engine/src/tests/promise.rs
@@ -1,12 +1,13 @@
 use indoc::indoc;
 
-use crate::{job::SimpleJobQueue, run_test_actions_with, Context, TestAction};
+use crate::{job::SimpleJobQueue, run_test_actions_with, Context, Runtime, TestAction};
 
 #[test]
 #[allow(clippy::redundant_closure_for_method_calls)]
 fn issue_2658() {
+    let rt = &Runtime::default();
     let queue = &SimpleJobQueue::new();
-    let context = &mut Context::builder().job_queue(queue).build().unwrap();
+    let context = &mut Context::builder(rt).job_queue(queue).build().unwrap();
     run_test_actions_with(
         [
             TestAction::run(indoc! {

--- a/boa_engine/src/value/conversions/serde_json.rs
+++ b/boa_engine/src/value/conversions/serde_json.rs
@@ -30,7 +30,7 @@ impl JsValue {
     ///
     /// let json: serde_json::Value = serde_json::from_str(data).unwrap();
     ///
-    /// let mut context = Context::default();
+    /// let mut context = test_context();
     /// let value = JsValue::from_json(&json, &mut context).unwrap();
     /// #
     /// # assert_eq!(json, value.to_json(&mut context).unwrap());
@@ -98,7 +98,7 @@ impl JsValue {
     ///
     /// let json: serde_json::Value = serde_json::from_str(data).unwrap();
     ///
-    /// let mut context = Context::default();
+    /// let mut context = test_context();
     /// let value = JsValue::from_json(&json, &mut context).unwrap();
     ///
     /// let back_to_json = value.to_json(&mut context).unwrap();

--- a/boa_examples/src/bin/classes.rs
+++ b/boa_examples/src/bin/classes.rs
@@ -4,7 +4,7 @@ use boa_engine::{
     error::JsNativeError,
     native_function::NativeFunction,
     property::Attribute,
-    Context, JsArgs, JsResult, JsString, JsValue, Source,
+    Context, JsArgs, JsResult, JsString, JsValue, Runtime, Source,
 };
 
 use boa_gc::{Finalize, Trace};
@@ -126,7 +126,8 @@ impl Class for Person {
 
 fn main() {
     // First we need to create a Javascript context.
-    let mut context = Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // Then we need to register the global class `Person` inside `context`.
     context.register_global_class::<Person>().unwrap();

--- a/boa_examples/src/bin/commuter_visitor.rs
+++ b/boa_examples/src/bin/commuter_visitor.rs
@@ -10,7 +10,7 @@ use boa_ast::{
     visitor::{VisitWith, VisitorMut},
     Expression,
 };
-use boa_engine::{Context, Source};
+use boa_engine::{Context, Runtime, Source};
 use boa_interner::ToInternedString;
 use boa_parser::Parser;
 use core::ops::ControlFlow;
@@ -67,7 +67,8 @@ impl<'ast> VisitorMut<'ast> for CommutorVisitor {
 fn main() {
     let mut parser =
         Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
-    let mut ctx = Context::default();
+    let runtime = &Runtime::default();
+    let mut ctx = Context::builder(runtime).build().unwrap();
 
     let mut statements = parser.parse_script(ctx.interner_mut()).unwrap();
 

--- a/boa_examples/src/bin/derive.rs
+++ b/boa_examples/src/bin/derive.rs
@@ -1,4 +1,4 @@
-use boa_engine::{value::TryFromJs, Context, JsNativeError, JsResult, JsValue, Source};
+use boa_engine::{value::TryFromJs, Context, JsNativeError, JsResult, JsValue, Runtime, Source};
 
 /// You can easily derive `TryFromJs` for structures with base Rust types.
 ///
@@ -25,8 +25,8 @@ fn main() {
     x;
     "#;
     let js = Source::from_bytes(js_str);
-
-    let mut context = Context::default();
+    let runtime = &Runtime::default();
+    let mut context = Context::builder(runtime).build().unwrap();
     let res = context.eval_script(js).unwrap();
 
     let str = TestStruct::try_from_js(&res, &mut context)

--- a/boa_examples/src/bin/futures.rs
+++ b/boa_examples/src/bin/futures.rs
@@ -5,10 +5,9 @@ use std::{
 };
 
 use boa_engine::{
-    context::ContextBuilder,
     job::{FutureJob, JobQueue, NativeJob},
     native_function::NativeFunction,
-    Context, JsArgs, JsResult, JsValue, Source,
+    Context, JsArgs, JsResult, JsValue, Runtime, Source,
 };
 use futures_util::{stream::FuturesUnordered, Future};
 use smol::{future, stream::StreamExt, LocalExecutor};
@@ -132,7 +131,8 @@ fn main() {
     // Initialize the required executors and the context
     let executor = LocalExecutor::new();
     let queue = Queue::new(executor);
-    let context = &mut ContextBuilder::new().job_queue(&queue).build().unwrap();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).job_queue(&queue).build().unwrap();
 
     // Bind the defined async function to the ECMAScript function "delay".
     context.register_global_builtin_callable("delay", 1, NativeFunction::from_async_fn(delay));

--- a/boa_examples/src/bin/jsarray.rs
+++ b/boa_examples/src/bin/jsarray.rs
@@ -4,12 +4,13 @@ use boa_engine::{
     native_function::NativeFunction,
     object::{builtins::JsArray, FunctionObjectBuilder},
     string::utf16,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsValue, Runtime,
 };
 
 fn main() -> JsResult<()> {
     // We create a new `Context` to create a new Javascript executor.
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // Create an empty array.
     let array = JsArray::new(context);

--- a/boa_examples/src/bin/jsarraybuffer.rs
+++ b/boa_examples/src/bin/jsarraybuffer.rs
@@ -3,12 +3,13 @@
 use boa_engine::{
     object::builtins::{JsArrayBuffer, JsDataView, JsUint32Array, JsUint8Array},
     property::Attribute,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsValue, Runtime,
 };
 
 fn main() -> JsResult<()> {
     // We create a new `Context` to create a new Javascript executor.
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // This create an array buffer of byte length 4
     let array_buffer = JsArrayBuffer::new(4, context)?;

--- a/boa_examples/src/bin/jsdate.rs
+++ b/boa_examples/src/bin/jsdate.rs
@@ -1,7 +1,8 @@
-use boa_engine::{object::builtins::JsDate, Context, JsResult, JsValue};
+use boa_engine::{object::builtins::JsDate, Context, JsResult, JsValue, Runtime};
 
 fn main() -> JsResult<()> {
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     let date = JsDate::new(context);
 

--- a/boa_examples/src/bin/jsmap.rs
+++ b/boa_examples/src/bin/jsmap.rs
@@ -1,11 +1,12 @@
 use boa_engine::{
     object::{builtins::JsArray, builtins::JsMap},
-    Context, JsResult, JsValue,
+    Context, JsResult, JsValue, Runtime,
 };
 
 fn main() -> JsResult<()> {
     // Create a `Context` for the Javascript executor.
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // Create a new empty map.
     let map = JsMap::new(context);

--- a/boa_examples/src/bin/jsregexp.rs
+++ b/boa_examples/src/bin/jsregexp.rs
@@ -1,7 +1,8 @@
-use boa_engine::{object::builtins::JsRegExp, Context, JsResult};
+use boa_engine::{object::builtins::JsRegExp, Context, JsResult, Runtime};
 
 fn main() -> JsResult<()> {
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     let regexp = JsRegExp::new("foo", "gi", context)?;
 

--- a/boa_examples/src/bin/jsset.rs
+++ b/boa_examples/src/bin/jsset.rs
@@ -1,10 +1,11 @@
 // This example shows how to manipulate a Javascript Set using Rust code.
 #![allow(clippy::bool_assert_comparison)]
-use boa_engine::{object::builtins::JsSet, Context, JsError, JsValue};
+use boa_engine::{object::builtins::JsSet, Context, JsError, JsValue, Runtime};
 
 fn main() -> Result<(), JsError> {
     // New `Context` for a new Javascript executor.
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // Create an empty set.
     let set = JsSet::new(context);

--- a/boa_examples/src/bin/jstypedarray.rs
+++ b/boa_examples/src/bin/jstypedarray.rs
@@ -4,12 +4,13 @@ use boa_engine::{
     native_function::NativeFunction,
     object::{builtins::JsUint8Array, FunctionObjectBuilder},
     property::Attribute,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsValue, Runtime,
 };
 
 fn main() -> JsResult<()> {
     // We create a new `Context` to create a new Javascript executor.
-    let context = &mut Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     let data: Vec<u8> = (0..=255).collect();
 

--- a/boa_examples/src/bin/loadfile.rs
+++ b/boa_examples/src/bin/loadfile.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use boa_engine::{Context, Source};
+use boa_engine::{Context, Runtime, Source};
 
 fn main() {
     let js_file_path = "./scripts/helloworld.js";
@@ -11,13 +11,14 @@ fn main() {
     match Source::from_filepath(Path::new(js_file_path)) {
         Ok(src) => {
             // Instantiate the execution context
-            let mut context = Context::default();
+            let runtime = &Runtime::default();
+            let context = &mut Context::builder(runtime).build().unwrap();
             // Parse the source code
             match context.eval_script(src) {
                 Ok(res) => {
                     println!(
                         "{}",
-                        res.to_string(&mut context).unwrap().to_std_string_escaped()
+                        res.to_string(context).unwrap().to_std_string_escaped()
                     );
                 }
                 Err(e) => {

--- a/boa_examples/src/bin/loadstring.rs
+++ b/boa_examples/src/bin/loadstring.rs
@@ -1,19 +1,20 @@
 // This example loads, parses and executes a JS code string
 
-use boa_engine::{Context, Source};
+use boa_engine::{Context, Runtime, Source};
 
 fn main() {
     let js_code = "console.log('Hello World from a JS code string!')";
 
     // Instantiate the execution context
-    let mut context = Context::default();
+    let runtime = &Runtime::default();
+    let context = &mut Context::builder(runtime).build().unwrap();
 
     // Parse the source code
     match context.eval_script(Source::from_bytes(js_code)) {
         Ok(res) => {
             println!(
                 "{}",
-                res.to_string(&mut context).unwrap().to_std_string_escaped()
+                res.to_string(context).unwrap().to_std_string_escaped()
             );
         }
         Err(e) => {

--- a/boa_examples/src/bin/modulehandler.rs
+++ b/boa_examples/src/bin/modulehandler.rs
@@ -3,7 +3,7 @@
 
 use boa_engine::{
     native_function::NativeFunction, prelude::JsObject, property::Attribute, Context, JsResult,
-    JsValue, Source,
+    JsValue, Runtime, Source,
 };
 use std::fs::read_to_string;
 
@@ -17,7 +17,8 @@ fn main() {
     }
 
     // Creating the execution context
-    let mut ctx = Context::default();
+    let runtime = &Runtime::default();
+    let ctx = &mut Context::builder(runtime).build().unwrap();
 
     // Adding custom implementation that mimics 'require'
     ctx.register_global_callable("require", 0, NativeFunction::from_fn_ptr(require));
@@ -25,7 +26,7 @@ fn main() {
     // Adding custom object that mimics 'module.exports'
     let moduleobj = JsObject::default();
     moduleobj
-        .set("exports", JsValue::from(" "), false, &mut ctx)
+        .set("exports", JsValue::from(" "), false, ctx)
         .unwrap();
     ctx.register_global_property("module", JsValue::from(moduleobj), Attribute::default());
 

--- a/boa_examples/src/bin/symbol_visitor.rs
+++ b/boa_examples/src/bin/symbol_visitor.rs
@@ -3,7 +3,7 @@
 // which mutates the AST.
 
 use boa_ast::visitor::Visitor;
-use boa_engine::{Context, Source};
+use boa_engine::{Context, Runtime, Source};
 use boa_interner::Sym;
 use boa_parser::Parser;
 use core::ops::ControlFlow;
@@ -26,7 +26,8 @@ impl<'ast> Visitor<'ast> for SymbolVisitor {
 fn main() {
     let mut parser =
         Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
-    let mut ctx = Context::default();
+    let runtime = &Runtime::default();
+    let mut ctx = Context::builder(runtime).build().unwrap();
 
     let statements = parser.parse_script(ctx.interner_mut()).unwrap();
 

--- a/boa_tester/src/exec/js262.rs
+++ b/boa_tester/src/exec/js262.rs
@@ -40,8 +40,10 @@ pub(super) fn register_js262(context: &mut Context<'_>) -> JsObject {
 /// Creates a new ECMAScript Realm, defines this API on the new realm's global object, and
 /// returns the `$262` property of the new realm's global object.
 #[allow(clippy::unnecessary_wraps)]
-fn create_realm(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
-    let context = &mut Context::default();
+fn create_realm(_: &JsValue, _: &[JsValue], ctx: &mut Context<'_>) -> JsResult<JsValue> {
+    let context = &mut Context::builder(ctx.runtime())
+        .build()
+        .expect("cannot fail with default global");
 
     let js262 = register_js262(context);
 

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -7,9 +7,9 @@ use crate::{
     TestFlags, TestOutcomeResult, TestResult, TestSuite, VersionedStats,
 };
 use boa_engine::{
-    context::ContextBuilder, job::SimpleJobQueue, native_function::NativeFunction,
-    object::FunctionObjectBuilder, optimizer::OptimizerOptions, property::Attribute, Context,
-    JsArgs, JsNativeErrorKind, JsValue, Source,
+    job::SimpleJobQueue, native_function::NativeFunction, object::FunctionObjectBuilder,
+    optimizer::OptimizerOptions, property::Attribute, Context, JsArgs, JsNativeErrorKind, JsValue,
+    Runtime, Source,
 };
 use colored::Colorize;
 use fxhash::FxHashSet;
@@ -209,9 +209,10 @@ impl Test {
 
         let result = std::panic::catch_unwind(|| match self.expected_outcome {
             Outcome::Positive => {
+                let rt = &Runtime::default();
                 let async_result = AsyncResult::default();
                 let queue = SimpleJobQueue::new();
-                let context = &mut ContextBuilder::new()
+                let context = &mut Context::builder(rt)
                     .job_queue(&queue)
                     .build()
                     .expect("cannot fail with default global");
@@ -258,7 +259,10 @@ impl Test {
                     self.path.display()
                 );
 
-                let context = &mut Context::default();
+                let rt = &Runtime::default();
+                let context = &mut Context::builder(rt)
+                    .build()
+                    .expect("cannot fail with default global");
                 context.strict(strict);
                 context.set_optimizer_options(OptimizerOptions::OPTIMIZE_ALL);
 
@@ -288,7 +292,10 @@ impl Test {
                 phase: Phase::Runtime,
                 error_type,
             } => {
-                let context = &mut Context::default();
+                let rt = &Runtime::default();
+                let context = &mut Context::builder(rt)
+                    .build()
+                    .expect("cannot fail with default global");
                 context.strict(strict);
                 context.set_optimizer_options(optimizer_options);
 

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -57,7 +57,7 @@
     clippy::nursery,
 )]
 
-use boa_engine::{Context, Source};
+use boa_engine::{Context, Runtime, Source};
 use getrandom as _;
 use wasm_bindgen::prelude::*;
 
@@ -65,8 +65,9 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 pub fn evaluate(src: &str) -> Result<String, JsValue> {
     // Setup executor
-    Context::default()
-        .eval_script(Source::from_bytes(src))
+    Context::builder(&Runtime::default())
+        .build()
+        .and_then(|mut ctx| ctx.eval_script(Source::from_bytes(src)))
         .map_err(|e| JsValue::from(format!("Uncaught {e}")))
         .map(|v| v.display().to_string())
 }


### PR DESCRIPTION
Maybe the name isn't exactly right since #2743 exists, but I wanted to open the PR first to hear your comments about this.

This PR creates a new `Runtime` structure that holds common information that is shared between `Context`'s (`[[KeptAlive]]`, ICU data, `HostHooks`). This should technically allow us to make `Context` immutable, since `Runtime` would act as our "agent", which means it would be the one managing the `Vm` state, but I'll have to do some tests to see if it's worth doing so.

