### PR TITLE
[Merged by Bors] - Lift `InternalObjectMethods` from `Object`

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -54,7 +54,7 @@ impl IntrinsicObject for Array {
 
         let values_function = BuiltInBuilder::with_object(
             realm,
-            realm.intrinsics().objects().array_prototype_values(),
+            realm.intrinsics().objects().array_prototype_values().into(),
         )
         .callable(Self::values)
         .name("values")

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -22,12 +22,11 @@ use crate::{
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
-    native_function::NativeFunction,
-    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
+    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData, ObjectKind},
     property::Attribute,
     realm::Realm,
     string::utf16,
-    Context, JsArgs, JsResult, JsValue,
+    Context, JsArgs, JsResult, JsValue, NativeFunction,
 };
 use boa_profiler::Profiler;
 
@@ -134,7 +133,7 @@ impl IntrinsicObject for ThrowTypeError {
         let mut obj = obj.borrow_mut();
 
         obj.extensible = false;
-        obj.data = ObjectData::function(Function::new(
+        *obj.kind_mut() = ObjectKind::Function(Function::new(
             FunctionKind::Native {
                 function: NativeFunction::from_fn_ptr(throw_type_error),
                 constructor: None,

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -432,7 +432,10 @@ impl BuiltInObjectInitializer {
     fn set_data(&mut self, new_data: ObjectData) {
         match self {
             BuiltInObjectInitializer::Shared(obj) => {
-                assert!(std::ptr::eq(obj.vtable(), new_data.internal_methods));
+                assert!(
+                    std::ptr::eq(obj.vtable(), new_data.internal_methods),
+                    "intrinsic object's vtable didn't match with new data"
+                );
                 *obj.borrow_mut().kind_mut() = new_data.kind;
             }
             BuiltInObjectInitializer::Unique { ref mut data, .. } => *data = new_data,

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -14,7 +14,10 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData, CONSTRUCTOR},
+    object::{
+        internal_methods::get_prototype_from_constructor, JsObject, ObjectData, ObjectKind,
+        CONSTRUCTOR,
+    },
     property::{Attribute, PropertyDescriptorBuilder},
     realm::Realm,
     string::{utf16, CodePoint},
@@ -311,7 +314,9 @@ impl RegExp {
             original_source: p,
             original_flags: f,
         };
-        obj.borrow_mut().data = ObjectData::reg_exp(Box::new(regexp));
+
+        // Safe to directly initialize since previous assertions ensure `obj` is a `Regexp` object.
+        *obj.borrow_mut().kind_mut() = ObjectKind::RegExp(Box::new(regexp));
 
         // 16. Perform ? Set(obj, "lastIndex", +0𝔽, true).
         obj.set(utf16!("lastIndex"), 0, true, context)?;
@@ -367,7 +372,7 @@ impl RegExp {
 
             if JsObject::equals(
                 object,
-                &context.intrinsics().constructors().regexp().prototype,
+                &context.intrinsics().constructors().regexp().prototype(),
             ) {
                 return Ok(JsValue::undefined());
             }

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
-    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
+    object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData, ObjectKind},
     property::{Attribute, PropertyNameKind},
     realm::Realm,
     string::utf16,
@@ -3349,7 +3349,7 @@ impl TypedArray {
         // 18. Set O.[[ByteOffset]] to 0.
         // 19. Set O.[[ArrayLength]] to elementLength.
         drop(o_obj);
-        o.borrow_mut().data = ObjectData::integer_indexed(IntegerIndexed::new(
+        *o.borrow_mut().kind_mut() = ObjectKind::IntegerIndexed(IntegerIndexed::new(
             Some(data),
             constructor_name,
             0,

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -50,10 +50,10 @@ pub struct UriFunctions {
 impl Default for UriFunctions {
     fn default() -> Self {
         Self {
-            decode_uri: JsFunction::from_object_unchecked(JsObject::default()),
-            decode_uri_component: JsFunction::from_object_unchecked(JsObject::default()),
-            encode_uri: JsFunction::from_object_unchecked(JsObject::default()),
-            encode_uri_component: JsFunction::from_object_unchecked(JsObject::default()),
+            decode_uri: JsFunction::empty_intrinsic_function(false),
+            decode_uri_component: JsFunction::empty_intrinsic_function(false),
+            encode_uri: JsFunction::empty_intrinsic_function(false),
+            encode_uri_component: JsFunction::empty_intrinsic_function(false),
         }
     }
 }

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -36,14 +36,14 @@ impl Intrinsics {
 /// Store a builtin constructor (such as `Object`) and its corresponding prototype.
 #[derive(Debug, Trace, Finalize)]
 pub struct StandardConstructor {
-    pub(crate) constructor: JsObject,
-    pub(crate) prototype: JsObject,
+    constructor: JsFunction,
+    prototype: JsObject,
 }
 
 impl Default for StandardConstructor {
     fn default() -> Self {
         Self {
-            constructor: JsObject::with_null_proto(),
+            constructor: JsFunction::empty_intrinsic_function(true),
             prototype: JsObject::with_null_proto(),
         }
     }
@@ -53,7 +53,7 @@ impl StandardConstructor {
     /// Build a constructor with a defined prototype.
     fn with_prototype(prototype: JsObject) -> Self {
         Self {
-            constructor: JsObject::with_null_proto(),
+            constructor: JsFunction::empty_intrinsic_function(true),
             prototype,
         }
     }
@@ -71,7 +71,7 @@ impl StandardConstructor {
     /// This is the same as `Object`, `Array`, etc.
     #[inline]
     pub fn constructor(&self) -> JsObject {
-        self.constructor.clone()
+        self.constructor.clone().into()
     }
 }
 
@@ -138,7 +138,10 @@ impl Default for StandardConstructors {
             object: StandardConstructor::default(),
             proxy: StandardConstructor::default(),
             date: StandardConstructor::default(),
-            function: StandardConstructor::default(),
+            function: StandardConstructor {
+                constructor: JsFunction::empty_intrinsic_function(true),
+                prototype: JsFunction::empty_intrinsic_function(false).into(),
+            },
             async_function: StandardConstructor::default(),
             generator_function: StandardConstructor::default(),
             array: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
@@ -740,7 +743,7 @@ pub struct IntrinsicObjects {
     throw_type_error: JsFunction,
 
     /// [`%Array.prototype.values%`](https://tc39.es/ecma262/#sec-array.prototype.values)
-    array_prototype_values: JsObject,
+    array_prototype_values: JsFunction,
 
     /// Cached iterator prototypes.
     iterator_prototypes: IteratorPrototypes,
@@ -788,21 +791,21 @@ impl Default for IntrinsicObjects {
             reflect: JsObject::default(),
             math: JsObject::default(),
             json: JsObject::default(),
-            throw_type_error: JsFunction::from_object_unchecked(JsObject::default()),
-            array_prototype_values: JsObject::default(),
+            throw_type_error: JsFunction::empty_intrinsic_function(false),
+            array_prototype_values: JsFunction::empty_intrinsic_function(false),
             iterator_prototypes: IteratorPrototypes::default(),
             generator: JsObject::default(),
             async_generator: JsObject::default(),
-            eval: JsFunction::from_object_unchecked(JsObject::default()),
+            eval: JsFunction::empty_intrinsic_function(false),
             uri_functions: UriFunctions::default(),
-            is_finite: JsFunction::from_object_unchecked(JsObject::default()),
-            is_nan: JsFunction::from_object_unchecked(JsObject::default()),
-            parse_float: JsFunction::from_object_unchecked(JsObject::default()),
-            parse_int: JsFunction::from_object_unchecked(JsObject::default()),
+            is_finite: JsFunction::empty_intrinsic_function(false),
+            is_nan: JsFunction::empty_intrinsic_function(false),
+            parse_float: JsFunction::empty_intrinsic_function(false),
+            parse_int: JsFunction::empty_intrinsic_function(false),
             #[cfg(feature = "annex-b")]
-            escape: JsFunction::from_object_unchecked(JsObject::default()),
+            escape: JsFunction::empty_intrinsic_function(false),
             #[cfg(feature = "annex-b")]
-            unescape: JsFunction::from_object_unchecked(JsObject::default()),
+            unescape: JsFunction::empty_intrinsic_function(false),
             #[cfg(feature = "intl")]
             intl: JsObject::default(),
         }
@@ -822,7 +825,7 @@ impl IntrinsicObjects {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.values
     #[inline]
-    pub fn array_prototype_values(&self) -> JsObject {
+    pub fn array_prototype_values(&self) -> JsFunction {
         self.array_prototype_values.clone()
     }
 

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -587,7 +587,7 @@ impl std::fmt::Debug for ContextBuilder<'_, '_, '_> {
 
 impl<'icu, 'hooks, 'queue> ContextBuilder<'icu, 'hooks, 'queue> {
     /// Creates a new [`ContextBuilder`] with a default empty [`Interner`]
-    /// and a default [`BoaProvider`] if the `intl` feature is enabled.
+    /// and a default `BoaProvider` if the `intl` feature is enabled.
     #[must_use]
     pub fn new() -> Self {
         Self::default()

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -1,6 +1,9 @@
 //! A Rust API wrapper for Boa's `Function` Builtin ECMAScript Object
 use crate::{
-    object::{JsObject, JsObjectType},
+    object::{
+        internal_methods::function::{CONSTRUCTOR_INTERNAL_METHODS, FUNCTION_INTERNAL_METHODS},
+        JsObject, JsObjectType, Object,
+    },
     value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
@@ -14,11 +17,28 @@ pub struct JsFunction {
 }
 
 impl JsFunction {
+    /// Creates a new `JsFunction` from an object, without checking if the object is callable.
     pub(crate) fn from_object_unchecked(object: JsObject) -> Self {
         Self { inner: object }
     }
 
-    /// Create a [`JsFunction`] from a [`JsObject`], or return `None` if the object is not a function.
+    /// Creates a new, empty intrinsic function object with only its function internal methods set.
+    ///
+    /// Mainly used to initialize objects before a [`Context`] is available to do so.
+    pub(crate) fn empty_intrinsic_function(constructor: bool) -> Self {
+        Self {
+            inner: JsObject::from_object_and_vtable(
+                Object::default(),
+                if constructor {
+                    &CONSTRUCTOR_INTERNAL_METHODS
+                } else {
+                    &FUNCTION_INTERNAL_METHODS
+                },
+            ),
+        }
+    }
+
+    /// Creates a [`JsFunction`] from a [`JsObject`], or returns `None` if the object is not a function.
     ///
     /// This does not clone the fields of the function, it only does a shallow clone of the object.
     #[inline]

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -25,6 +25,8 @@ impl JsFunction {
     /// Creates a new, empty intrinsic function object with only its function internal methods set.
     ///
     /// Mainly used to initialize objects before a [`Context`] is available to do so.
+    ///
+    /// [`Context`]: crate::Context
     pub(crate) fn empty_intrinsic_function(constructor: bool) -> Self {
         Self {
             inner: JsObject::from_object_and_vtable(

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -35,8 +35,7 @@ impl JsObject {
     #[track_caller]
     pub(crate) fn __get_prototype_of__(&self, context: &mut Context<'_>) -> JsResult<JsPrototype> {
         let _timer = Profiler::global().start_event("Object::__get_prototype_of__", "object");
-        let func = self.borrow().data.internal_methods.__get_prototype_of__;
-        func(self, context)
+        (self.vtable().__get_prototype_of__)(self, context)
     }
 
     /// Internal method `[[SetPrototypeOf]]`
@@ -53,8 +52,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set_prototype_of__", "object");
-        let func = self.borrow().data.internal_methods.__set_prototype_of__;
-        func(self, val, context)
+        (self.vtable().__set_prototype_of__)(self, val, context)
     }
 
     /// Internal method `[[IsExtensible]]`
@@ -67,8 +65,7 @@ impl JsObject {
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
     pub(crate) fn __is_extensible__(&self, context: &mut Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__is_extensible__", "object");
-        let func = self.borrow().data.internal_methods.__is_extensible__;
-        func(self, context)
+        (self.vtable().__is_extensible__)(self, context)
     }
 
     /// Internal method `[[PreventExtensions]]`
@@ -81,8 +78,7 @@ impl JsObject {
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
     pub(crate) fn __prevent_extensions__(&self, context: &mut Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__prevent_extensions__", "object");
-        let func = self.borrow().data.internal_methods.__prevent_extensions__;
-        func(self, context)
+        (self.vtable().__prevent_extensions__)(self, context)
     }
 
     /// Internal method `[[GetOwnProperty]]`
@@ -99,8 +95,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<Option<PropertyDescriptor>> {
         let _timer = Profiler::global().start_event("Object::__get_own_property__", "object");
-        let func = self.borrow().data.internal_methods.__get_own_property__;
-        func(self, key, context)
+        (self.vtable().__get_own_property__)(self, key, context)
     }
 
     /// Internal method `[[DefineOwnProperty]]`
@@ -118,8 +113,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__define_own_property__", "object");
-        let func = self.borrow().data.internal_methods.__define_own_property__;
-        func(self, key, desc, context)
+        (self.vtable().__define_own_property__)(self, key, desc, context)
     }
 
     /// Internal method `[[hasProperty]]`.
@@ -136,8 +130,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__has_property__", "object");
-        let func = self.borrow().data.internal_methods.__has_property__;
-        func(self, key, context)
+        (self.vtable().__has_property__)(self, key, context)
     }
 
     /// Internal method `[[Get]]`
@@ -155,8 +148,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__get__", "object");
-        let func = self.borrow().data.internal_methods.__get__;
-        func(self, key, receiver, context)
+        (self.vtable().__get__)(self, key, receiver, context)
     }
 
     /// Internal method `[[Set]]`
@@ -175,8 +167,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set__", "object");
-        let func = self.borrow().data.internal_methods.__set__;
-        func(self, key, value, receiver, context)
+        (self.vtable().__set__)(self, key, value, receiver, context)
     }
 
     /// Internal method `[[Delete]]`
@@ -193,8 +184,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__delete__", "object");
-        let func = self.borrow().data.internal_methods.__delete__;
-        func(self, key, context)
+        (self.vtable().__delete__)(self, key, context)
     }
 
     /// Internal method `[[OwnPropertyKeys]]`
@@ -211,8 +201,7 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<Vec<PropertyKey>> {
         let _timer = Profiler::global().start_event("Object::__own_property_keys__", "object");
-        let func = self.borrow().data.internal_methods.__own_property_keys__;
-        func(self, context)
+        (self.vtable().__own_property_keys__)(self, context)
     }
 
     /// Internal method `[[Call]]`
@@ -231,9 +220,9 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__call__", "object");
-
-        let func = self.borrow().data.internal_methods.__call__;
-        func.expect("called `[[Call]]` for object without a `[[Call]]` internal method")(
+        self.vtable()
+            .__call__
+            .expect("called `[[Call]]` for object without a `[[Call]]` internal method")(
             self, this, args, context,
         )
     }
@@ -254,9 +243,9 @@ impl JsObject {
         context: &mut Context<'_>,
     ) -> JsResult<Self> {
         let _timer = Profiler::global().start_event("Object::__construct__", "object");
-
-        let func = self.borrow().data.internal_methods.__construct__;
-        func.expect("called `[[Construct]]` for object without a `[[Construct]]` internal method")(
+        self.vtable()
+            .__construct__
+            .expect("called `[[Construct]]` for object without a `[[Construct]]` internal method")(
             self, args, new_target, context,
         )
     }
@@ -379,8 +368,7 @@ pub(crate) fn ordinary_set_prototype_of(
         // c. Else,
         // i. If p.[[GetPrototypeOf]] is not the ordinary object internal method defined
         // in 10.1.1, set done to true.
-        else if proto.borrow().data.internal_methods.__get_prototype_of__ as usize
-            != ordinary_get_prototype_of as usize
+        else if proto.vtable().__get_prototype_of__ as usize != ordinary_get_prototype_of as usize
         {
             break;
         }

--- a/boa_engine/src/vm/opcode/set/class_prototype.rs
+++ b/boa_engine/src/vm/opcode/set/class_prototype.rs
@@ -21,14 +21,7 @@ impl Operation for SetClassPrototype {
         let prototype = match &prototype_value {
             JsValue::Object(proto) => Some(proto.clone()),
             JsValue::Null => None,
-            JsValue::Undefined => Some(
-                context
-                    .intrinsics()
-                    .constructors()
-                    .object()
-                    .prototype
-                    .clone(),
-            ),
+            JsValue::Undefined => Some(context.intrinsics().constructors().object().prototype()),
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
This Pull Request lifts the `InternalObjectMethods` vtable from `Object`, which should technically improve performance, since we now won't need to call `borrow` to use any of the internal methods, but let's see what the benchmarks show.

It changes the following:

- Adds a new `VTableObject` struct, containing the old `GcRefCell<Object>` and the lifted `InternalObjectMethods`.
- Changes the definition of `JsObject` to `Gc<VTableObject>`. Note that this means the `InternalObjectMethods` are accessible through the `Gc` pointer.
- Reestructures intrinsic initialization and initialization APIs to accommodate this change.
