### PR TITLE
Direct array length access

### DIFF
--- a/boa_engine/src/object/shape/shared_shape/template.rs
+++ b/boa_engine/src/object/shape/shared_shape/template.rs
@@ -46,6 +46,11 @@ impl ObjectTemplate {
         self
     }
 
+    /// Returns the inner shape of the [`ObjectTemplate`].
+    pub(crate) const fn shape(&self) -> &SharedShape {
+        &self.shape
+    }
+
     /// Add a data property to the [`ObjectTemplate`].
     ///
     /// This assumes that the property with the given key was not previously set
@@ -58,7 +63,6 @@ impl ObjectTemplate {
             property_key: key,
             attributes,
         });
-
         self
     }
 
@@ -97,7 +101,6 @@ impl ObjectTemplate {
             property_key: key,
             attributes,
         });
-
         self
     }
 


### PR DESCRIPTION
Depends on #2723 

This PR utilizes the change done in #2723 on how we store properties on a continues indexed array, this makes the positions of properties such as `"length"` predefined on an array, because it is constructed from an `ObjectTemplate`.

This can make access on such properties just an index lookup into an array, speeding up execution of common operations like `LengthOfArrayLike`.

Pointing to #2723 for easier review, once #2723 is merged I will rebase and point to main :)