### PR TITLE
[Merged by Bors] - Fix `Symbol.prototype[@@iterator]`

### DIFF
--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -2161,7 +2161,12 @@ impl String {
         _: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        Ok(StringIterator::create_string_iterator(this.clone(), context).into())
+        // 1. Let O be ? RequireObjectCoercible(this value).
+        let o = this.require_object_coercible()?;
+        // 2. Let s be ? ToString(O).
+        let s = o.to_string(context)?;
+
+        Ok(StringIterator::create_string_iterator(s, context).into())
     }
 }
 

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -543,6 +543,7 @@ impl ObjectData {
     }
 
     /// Create the `StringIterator` object data
+    #[must_use]
     pub fn string_iterator(string_iterator: StringIterator) -> Self {
         Self {
             kind: ObjectKind::StringIterator(string_iterator),


### PR DESCRIPTION
It changes the following:
- Fixes`Symbol.prototype[@@iterator]` so it calls `RequireObjectCoercible` and then `ToString`
- Makes string iterator store a `JsString` which should be faster, instead of `JsValue` then calling `ToString` on every iteration
