### PR TITLE
[Merged by Bors] - Make `Realm` shareable between functions

### DIFF
--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -13,6 +13,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsResult,
 };
@@ -35,11 +36,17 @@ pub struct ArrayIterator {
 }
 
 impl IntrinsicObject for ArrayIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("ArrayIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .static_property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::{IntegerOrInfinity, Numeric},
@@ -47,22 +48,22 @@ impl ArrayBuffer {
 }
 
 impl IntrinsicObject for ArrayBuffer {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_species = BuiltInBuilder::new(intrinsics)
+        let get_species = BuiltInBuilder::new(realm)
             .callable(Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(intrinsics)
+        let get_byte_length = BuiltInBuilder::new(realm)
             .callable(Self::get_byte_length)
             .name("get byteLength")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .accessor(
                 utf16!("byteLength"),
                 Some(get_byte_length),

--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     builtins::{function::BuiltInFunctionObject, BuiltInObject},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsResult, JsValue,
 };
@@ -23,12 +24,14 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct AsyncFunction;
 
 impl IntrinsicObject for AsyncFunction {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().function().constructor())
-            .inherits(Some(intrinsics.constructors().function().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().function().constructor())
+            .inherits(Some(
+                realm.intrinsics().constructors().function().prototype(),
+            ))
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/boa_engine/src/builtins/async_generator_function/mod.rs
+++ b/boa_engine/src/builtins/async_generator_function/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{JsObject, PROTOTYPE},
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     value::JsValue,
     Context, JsResult,
@@ -23,15 +24,17 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct AsyncGeneratorFunction;
 
 impl IntrinsicObject for AsyncGeneratorFunction {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .inherits(Some(intrinsics.constructors().function().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .inherits(Some(
+                realm.intrinsics().constructors().function().prototype(),
+            ))
             .constructor_attributes(Attribute::CONFIGURABLE)
             .property(
                 PROTOTYPE,
-                intrinsics.objects().async_generator(),
+                realm.intrinsics().objects().async_generator(),
                 Attribute::CONFIGURABLE,
             )
             .property(

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -18,6 +18,7 @@ use crate::{
     error::JsNativeError,
     object::JsObject,
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     value::{IntegerOrInfinity, PreferredType},
     Context, JsArgs, JsBigInt, JsResult, JsValue,
@@ -35,10 +36,10 @@ mod tests;
 pub struct BigInt;
 
 impl IntrinsicObject for BigInt {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::to_string, "toString", 0)
             .method(Self::value_of, "valueOf", 0)
             .static_method(Self::as_int_n, "asIntN", 2)

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
+    realm::Realm,
     Context, JsResult, JsValue,
 };
 use boa_profiler::Profiler;
@@ -28,10 +29,10 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub(crate) struct Boolean;
 
 impl IntrinsicObject for Boolean {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::to_string, "toString", 0)
             .method(Self::value_of, "valueOf", 0)
             .build();

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::JsValue,
@@ -31,25 +32,25 @@ pub struct DataView {
 }
 
 impl IntrinsicObject for DataView {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_buffer = BuiltInBuilder::new(intrinsics)
+        let get_buffer = BuiltInBuilder::new(realm)
             .callable(Self::get_buffer)
             .name("get buffer")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(intrinsics)
+        let get_byte_length = BuiltInBuilder::new(realm)
             .callable(Self::get_byte_length)
             .name("get byteLength")
             .build();
 
-        let get_byte_offset = BuiltInBuilder::new(intrinsics)
+        let get_byte_offset = BuiltInBuilder::new(realm)
             .callable(Self::get_byte_offset)
             .name("get byteOffset")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .accessor(utf16!("buffer"), Some(get_buffer), None, flag_attributes)
             .accessor(
                 utf16!("byteLength"),

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     error::JsNativeError,
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::{IntegerOrNan, JsValue, PreferredType},
@@ -100,10 +101,10 @@ impl Default for Date {
 }
 
 impl IntrinsicObject for Date {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::get_date::<true>, "getDate", 0)
             .method(Self::get_day::<true>, "getDay", 0)
             .method(Self::get_full_year::<true>, "getFullYear", 0)

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -15,6 +15,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::{Attribute, PropertyDescriptorBuilder},
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -26,13 +27,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct AggregateError;
 
 impl IntrinsicObject for AggregateError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -16,6 +16,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -28,13 +29,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct EvalError;
 
 impl IntrinsicObject for EvalError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -127,11 +128,11 @@ pub enum ErrorKind {
 pub(crate) struct Error;
 
 impl IntrinsicObject for Error {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .method(Self::to_string, "toString", 0)

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -14,6 +14,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -26,13 +27,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct RangeError;
 
 impl IntrinsicObject for RangeError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -14,6 +14,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -25,13 +26,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct ReferenceError;
 
 impl IntrinsicObject for ReferenceError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -16,6 +16,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -28,13 +29,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct SyntaxError;
 
 impl IntrinsicObject for SyntaxError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -25,6 +25,7 @@ use crate::{
     native_function::NativeFunction,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -37,13 +38,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct TypeError;
 
 impl IntrinsicObject for TypeError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();
@@ -114,7 +115,7 @@ impl BuiltInConstructor for TypeError {
 pub(crate) struct ThrowTypeError;
 
 impl IntrinsicObject for ThrowTypeError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         fn throw_type_error(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
             Err(JsNativeError::typ()
                 .with_message(
@@ -124,8 +125,8 @@ impl IntrinsicObject for ThrowTypeError {
                 .into())
         }
 
-        let obj = BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().function().prototype())
+        let obj = BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().function().prototype())
             .static_property(utf16!("name"), "ThrowTypeError", Attribute::empty())
             .static_property(utf16!("length"), 0, Attribute::empty())
             .build();
@@ -137,7 +138,7 @@ impl IntrinsicObject for ThrowTypeError {
                 function: NativeFunction::from_fn_ptr(throw_type_error),
                 constructor: None,
             },
-            intrinsics.clone(),
+            realm.clone(),
         ));
     }
 

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -15,6 +15,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -27,13 +28,13 @@ use super::{Error, ErrorKind};
 pub(crate) struct UriError;
 
 impl IntrinsicObject for UriError {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .prototype(intrinsics.constructors().error().constructor())
-            .inherits(Some(intrinsics.constructors().error().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .prototype(realm.intrinsics().constructors().error().constructor())
+            .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(utf16!("name"), Self::NAME, attribute)
             .property(utf16!("message"), "", attribute)
             .build();

--- a/boa_engine/src/builtins/escape/mod.rs
+++ b/boa_engine/src/builtins/escape/mod.rs
@@ -11,7 +11,8 @@
 //! [spec]: https://tc39.es/ecma262/#sec-additional-properties-of-the-global-object
 
 use crate::{
-    context::intrinsics::Intrinsics, js_string, Context, JsArgs, JsObject, JsResult, JsValue,
+    context::intrinsics::Intrinsics, js_string, realm::Realm, Context, JsArgs, JsObject, JsResult,
+    JsValue,
 };
 
 use super::{BuiltInBuilder, BuiltInObject, IntrinsicObject};
@@ -21,8 +22,8 @@ use super::{BuiltInBuilder, BuiltInObject, IntrinsicObject};
 pub(crate) struct Escape;
 
 impl IntrinsicObject for Escape {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(escape)
             .name(Self::NAME)
             .length(1)
@@ -94,8 +95,8 @@ fn escape(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<
 pub(crate) struct Unescape;
 
 impl IntrinsicObject for Unescape {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(unescape)
             .name(Self::NAME)
             .length(1)

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::PROTOTYPE,
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     value::JsValue,
     Context, JsResult,
@@ -28,15 +29,17 @@ use super::{BuiltInBuilder, BuiltInConstructor, IntrinsicObject};
 pub struct GeneratorFunction;
 
 impl IntrinsicObject for GeneratorFunction {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-            .inherits(Some(intrinsics.constructors().function().prototype()))
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .inherits(Some(
+                realm.intrinsics().constructors().function().prototype(),
+            ))
             .constructor_attributes(Attribute::CONFIGURABLE)
             .property(
                 PROTOTYPE,
-                intrinsics.objects().generator(),
+                realm.intrinsics().objects().generator(),
                 Attribute::CONFIGURABLE,
             )
             .property(

--- a/boa_engine/src/builtins/intl/collator/mod.rs
+++ b/boa_engine/src/builtins/intl/collator/mod.rs
@@ -22,6 +22,7 @@ use crate::{
         JsObject, ObjectData,
     },
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsValue,
@@ -159,15 +160,15 @@ impl Service for Collator {
 }
 
 impl IntrinsicObject for Collator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let compare = BuiltInBuilder::new(intrinsics)
+        let compare = BuiltInBuilder::new(realm)
             .callable(Self::compare)
             .name("get compare")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::supported_locales_of, "supportedLocalesOf", 1)
             .property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -13,6 +13,7 @@ use crate::{
     error::JsNativeError,
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
+    realm::Realm,
     string::utf16,
     Context, JsResult, JsString, JsValue,
 };
@@ -62,10 +63,10 @@ pub struct DateTimeFormat {
 }
 
 impl IntrinsicObject for DateTimeFormat {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics).build();
+        BuiltInBuilder::from_standard_constructor::<Self>(realm).build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {

--- a/boa_engine/src/builtins/intl/list_format/mod.rs
+++ b/boa_engine/src/builtins/intl/list_format/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
@@ -48,10 +49,10 @@ impl Service for ListFormat {
 }
 
 impl IntrinsicObject for ListFormat {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::supported_locales_of, "supportedLocalesOf", 1)
             .property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/intl/locale/mod.rs
+++ b/boa_engine/src/builtins/intl/locale/mod.rs
@@ -1,4 +1,4 @@
-use crate::string::utf16;
+use crate::{realm::Realm, string::utf16};
 use boa_profiler::Profiler;
 use icu_collator::CaseFirst;
 use icu_datetime::options::preferences::HourCycle;
@@ -32,60 +32,60 @@ use super::options::{coerce_options_to_object, get_option};
 pub(crate) struct Locale;
 
 impl IntrinsicObject for Locale {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let base_name = BuiltInBuilder::new(intrinsics)
+        let base_name = BuiltInBuilder::new(realm)
             .callable(Self::base_name)
             .name("get baseName")
             .build();
 
-        let calendar = BuiltInBuilder::new(intrinsics)
+        let calendar = BuiltInBuilder::new(realm)
             .callable(Self::calendar)
             .name("get calendar")
             .build();
 
-        let case_first = BuiltInBuilder::new(intrinsics)
+        let case_first = BuiltInBuilder::new(realm)
             .callable(Self::case_first)
             .name("get caseFirst")
             .build();
 
-        let collation = BuiltInBuilder::new(intrinsics)
+        let collation = BuiltInBuilder::new(realm)
             .callable(Self::collation)
             .name("get collation")
             .build();
 
-        let hour_cycle = BuiltInBuilder::new(intrinsics)
+        let hour_cycle = BuiltInBuilder::new(realm)
             .callable(Self::hour_cycle)
             .name("get hourCycle")
             .build();
 
-        let numeric = BuiltInBuilder::new(intrinsics)
+        let numeric = BuiltInBuilder::new(realm)
             .callable(Self::numeric)
             .name("get numeric")
             .build();
 
-        let numbering_system = BuiltInBuilder::new(intrinsics)
+        let numbering_system = BuiltInBuilder::new(realm)
             .callable(Self::numbering_system)
             .name("get numberingSystem")
             .build();
 
-        let language = BuiltInBuilder::new(intrinsics)
+        let language = BuiltInBuilder::new(realm)
             .callable(Self::language)
             .name("get language")
             .build();
 
-        let script = BuiltInBuilder::new(intrinsics)
+        let script = BuiltInBuilder::new(realm)
             .callable(Self::script)
             .name("get script")
             .build();
 
-        let region = BuiltInBuilder::new(intrinsics)
+        let region = BuiltInBuilder::new(realm)
             .callable(Self::region)
             .name("get region")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 "Intl.Locale",

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -14,6 +14,7 @@ use crate::{
     context::{intrinsics::Intrinsics, BoaProvider},
     object::JsObject,
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -39,10 +40,10 @@ mod options;
 pub(crate) struct Intl;
 
 impl IntrinsicObject for Intl {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -50,27 +51,35 @@ impl IntrinsicObject for Intl {
             )
             .static_property(
                 Collator::NAME,
-                intrinsics.constructors().collator().constructor(),
+                realm.intrinsics().constructors().collator().constructor(),
                 Collator::ATTRIBUTE,
             )
             .static_property(
                 ListFormat::NAME,
-                intrinsics.constructors().list_format().constructor(),
+                realm
+                    .intrinsics()
+                    .constructors()
+                    .list_format()
+                    .constructor(),
                 ListFormat::ATTRIBUTE,
             )
             .static_property(
                 Locale::NAME,
-                intrinsics.constructors().locale().constructor(),
+                realm.intrinsics().constructors().locale().constructor(),
                 Locale::ATTRIBUTE,
             )
             .static_property(
                 Segmenter::NAME,
-                intrinsics.constructors().segmenter().constructor(),
+                realm.intrinsics().constructors().segmenter().constructor(),
                 Segmenter::ATTRIBUTE,
             )
             .static_property(
                 DateTimeFormat::NAME,
-                intrinsics.constructors().date_time_format().constructor(),
+                realm
+                    .intrinsics()
+                    .constructors()
+                    .date_time_format()
+                    .constructor(),
                 DateTimeFormat::ATTRIBUTE,
             )
             .static_method(Self::get_canonical_locales, "getCanonicalLocales", 1)

--- a/boa_engine/src/builtins/intl/segmenter/mod.rs
+++ b/boa_engine/src/builtins/intl/segmenter/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     builtins::{BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::JsObject,
+    realm::Realm,
     Context, JsResult, JsValue,
 };
 
@@ -17,10 +18,10 @@ pub(crate) use options::*;
 pub(crate) struct Segmenter;
 
 impl IntrinsicObject for Segmenter {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics).build();
+        BuiltInBuilder::from_standard_constructor::<Self>(realm).build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -7,6 +7,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     native_function::NativeFunction,
     object::{FunctionObjectBuilder, JsObject, ObjectData},
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsNativeError, JsResult, JsValue,
 };
@@ -26,11 +27,17 @@ pub struct AsyncFromSyncIterator {
 }
 
 impl IntrinsicObject for AsyncFromSyncIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("AsyncFromSyncIteratorPrototype", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().async_iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .async_iterator(),
+            )
             .static_method(Self::next, "next", 1)
             .static_method(Self::r#return, "return", 1)
             .static_method(Self::throw, "throw", 1)

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     error::JsNativeError,
     object::JsObject,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsResult, JsValue,
@@ -135,10 +136,10 @@ impl IteratorPrototypes {
 pub(crate) struct Iterator;
 
 impl IntrinsicObject for Iterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("Iterator Prototype", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_method(
                 |v, _, _| Ok(v.clone()),
                 (JsSymbol::iterator(), "[Symbol.iterator]"),
@@ -161,10 +162,10 @@ impl IntrinsicObject for Iterator {
 pub(crate) struct AsyncIterator;
 
 impl IntrinsicObject for AsyncIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("AsyncIteratorPrototype", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_method(
                 |v, _, _| Ok(v.clone()),
                 (JsSymbol::async_iterator(), "[Symbol.asyncIterator]"),

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     js_string,
     object::{JsObject, RecursionLimiter},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     string::{utf16, CodePoint},
     symbol::JsSymbol,
     value::IntegerOrInfinity,
@@ -137,13 +138,13 @@ where
 pub(crate) struct Json;
 
 impl IntrinsicObject for Json {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let to_string_tag = JsSymbol::to_string_tag();
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_method(Self::parse, "parse", 2)
             .static_method(Self::stringify, "stringify", 3)
             .static_property(to_string_tag, Self::NAME, attribute)

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -14,6 +14,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsResult,
 };
@@ -36,11 +37,17 @@ pub struct MapIterator {
 }
 
 impl IntrinsicObject for MapIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("MapIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .static_property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsResult, JsValue,
@@ -37,25 +38,25 @@ mod tests;
 pub(crate) struct Map;
 
 impl IntrinsicObject for Map {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(intrinsics)
+        let get_species = BuiltInBuilder::new(realm)
             .callable(Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_size = BuiltInBuilder::new(intrinsics)
+        let get_size = BuiltInBuilder::new(realm)
             .callable(Self::get_size)
             .name("get size")
             .build();
 
-        let entries_function = BuiltInBuilder::new(intrinsics)
+        let entries_function = BuiltInBuilder::new(realm)
             .callable(Self::entries)
             .name("entries")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/boa_engine/src/builtins/math/mod.rs
+++ b/boa_engine/src/builtins/math/mod.rs
@@ -13,7 +13,8 @@
 
 use crate::{
     builtins::BuiltInObject, context::intrinsics::Intrinsics, object::JsObject,
-    property::Attribute, string::utf16, symbol::JsSymbol, Context, JsArgs, JsResult, JsValue,
+    property::Attribute, realm::Realm, string::utf16, symbol::JsSymbol, Context, JsArgs, JsResult,
+    JsValue,
 };
 use boa_profiler::Profiler;
 
@@ -27,11 +28,11 @@ mod tests;
 pub(crate) struct Math;
 
 impl IntrinsicObject for Math {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_property(utf16!("E"), std::f64::consts::E, attribute)
             .static_property(utf16!("LN10"), std::f64::consts::LN_10, attribute)
             .static_property(utf16!("LN2"), std::f64::consts::LN_2, attribute)

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -100,6 +100,7 @@ use crate::{
         FunctionBinding, JsFunction, JsObject, JsPrototype, ObjectData, CONSTRUCTOR, PROTOTYPE,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
+    realm::Realm,
     string::utf16,
     Context, JsResult, JsString, JsValue,
 };
@@ -118,7 +119,7 @@ pub(crate) trait IntrinsicObject {
     ///
     /// This is where the methods, properties, static methods and the constructor of a built-in must
     /// be initialized to be accessible from ECMAScript.
-    fn init(intrinsics: &Intrinsics);
+    fn init(realm: &Realm);
 
     /// Gets the intrinsic object.
     fn get(intrinsics: &Intrinsics) -> JsObject;
@@ -183,97 +184,93 @@ fn global_binding<B: BuiltInObject>(context: &mut Context<'_>) -> JsResult<()> {
     Ok(())
 }
 
-impl Intrinsics {
+impl Realm {
     /// Abstract operation [`CreateIntrinsics ( realmRec )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createintrinsics
-    pub(crate) fn new() -> Self {
-        let intrinsics = Self::default();
-
-        BuiltInFunctionObject::init(&intrinsics);
-        BuiltInObjectObject::init(&intrinsics);
-        Iterator::init(&intrinsics);
-        AsyncIterator::init(&intrinsics);
-        AsyncFromSyncIterator::init(&intrinsics);
-        ForInIterator::init(&intrinsics);
-        Math::init(&intrinsics);
-        Json::init(&intrinsics);
-        Array::init(&intrinsics);
-        ArrayIterator::init(&intrinsics);
-        Proxy::init(&intrinsics);
-        ArrayBuffer::init(&intrinsics);
-        BigInt::init(&intrinsics);
-        Boolean::init(&intrinsics);
-        Date::init(&intrinsics);
-        DataView::init(&intrinsics);
-        Map::init(&intrinsics);
-        MapIterator::init(&intrinsics);
-        IsFinite::init(&intrinsics);
-        IsNaN::init(&intrinsics);
-        ParseInt::init(&intrinsics);
-        ParseFloat::init(&intrinsics);
-        Number::init(&intrinsics);
-        Eval::init(&intrinsics);
-        Set::init(&intrinsics);
-        SetIterator::init(&intrinsics);
-        String::init(&intrinsics);
-        StringIterator::init(&intrinsics);
-        RegExp::init(&intrinsics);
-        RegExpStringIterator::init(&intrinsics);
-        TypedArray::init(&intrinsics);
-        Int8Array::init(&intrinsics);
-        Uint8Array::init(&intrinsics);
-        Uint8ClampedArray::init(&intrinsics);
-        Int16Array::init(&intrinsics);
-        Uint16Array::init(&intrinsics);
-        Int32Array::init(&intrinsics);
-        Uint32Array::init(&intrinsics);
-        BigInt64Array::init(&intrinsics);
-        BigUint64Array::init(&intrinsics);
-        Float32Array::init(&intrinsics);
-        Float64Array::init(&intrinsics);
-        Symbol::init(&intrinsics);
-        Error::init(&intrinsics);
-        RangeError::init(&intrinsics);
-        ReferenceError::init(&intrinsics);
-        TypeError::init(&intrinsics);
-        ThrowTypeError::init(&intrinsics);
-        SyntaxError::init(&intrinsics);
-        EvalError::init(&intrinsics);
-        UriError::init(&intrinsics);
-        AggregateError::init(&intrinsics);
-        Reflect::init(&intrinsics);
-        Generator::init(&intrinsics);
-        GeneratorFunction::init(&intrinsics);
-        Promise::init(&intrinsics);
-        AsyncFunction::init(&intrinsics);
-        AsyncGenerator::init(&intrinsics);
-        AsyncGeneratorFunction::init(&intrinsics);
-        EncodeUri::init(&intrinsics);
-        EncodeUriComponent::init(&intrinsics);
-        DecodeUri::init(&intrinsics);
-        DecodeUriComponent::init(&intrinsics);
-        WeakRef::init(&intrinsics);
-        WeakMap::init(&intrinsics);
-        WeakSet::init(&intrinsics);
+    pub(crate) fn initialize(&self) {
+        BuiltInFunctionObject::init(self);
+        BuiltInObjectObject::init(self);
+        Iterator::init(self);
+        AsyncIterator::init(self);
+        AsyncFromSyncIterator::init(self);
+        ForInIterator::init(self);
+        Math::init(self);
+        Json::init(self);
+        Array::init(self);
+        ArrayIterator::init(self);
+        Proxy::init(self);
+        ArrayBuffer::init(self);
+        BigInt::init(self);
+        Boolean::init(self);
+        Date::init(self);
+        DataView::init(self);
+        Map::init(self);
+        MapIterator::init(self);
+        IsFinite::init(self);
+        IsNaN::init(self);
+        ParseInt::init(self);
+        ParseFloat::init(self);
+        Number::init(self);
+        Eval::init(self);
+        Set::init(self);
+        SetIterator::init(self);
+        String::init(self);
+        StringIterator::init(self);
+        RegExp::init(self);
+        RegExpStringIterator::init(self);
+        TypedArray::init(self);
+        Int8Array::init(self);
+        Uint8Array::init(self);
+        Uint8ClampedArray::init(self);
+        Int16Array::init(self);
+        Uint16Array::init(self);
+        Int32Array::init(self);
+        Uint32Array::init(self);
+        BigInt64Array::init(self);
+        BigUint64Array::init(self);
+        Float32Array::init(self);
+        Float64Array::init(self);
+        Symbol::init(self);
+        Error::init(self);
+        RangeError::init(self);
+        ReferenceError::init(self);
+        TypeError::init(self);
+        ThrowTypeError::init(self);
+        SyntaxError::init(self);
+        EvalError::init(self);
+        UriError::init(self);
+        AggregateError::init(self);
+        Reflect::init(self);
+        Generator::init(self);
+        GeneratorFunction::init(self);
+        Promise::init(self);
+        AsyncFunction::init(self);
+        AsyncGenerator::init(self);
+        AsyncGeneratorFunction::init(self);
+        EncodeUri::init(self);
+        EncodeUriComponent::init(self);
+        DecodeUri::init(self);
+        DecodeUriComponent::init(self);
+        WeakRef::init(self);
+        WeakMap::init(self);
+        WeakSet::init(self);
 
         #[cfg(feature = "annex-b")]
         {
-            escape::Escape::init(&intrinsics);
-            escape::Unescape::init(&intrinsics);
+            escape::Escape::init(self);
+            escape::Unescape::init(self);
         }
 
         #[cfg(feature = "intl")]
         {
-            intl::Intl::init(&intrinsics);
-            intl::Collator::init(&intrinsics);
-            intl::ListFormat::init(&intrinsics);
-            intl::Locale::init(&intrinsics);
-            intl::DateTimeFormat::init(&intrinsics);
-            intl::Segmenter::init(&intrinsics);
+            intl::Intl::init(self);
+            intl::Collator::init(self);
+            intl::ListFormat::init(self);
+            intl::Locale::init(self);
+            intl::DateTimeFormat::init(self);
+            intl::Segmenter::init(self);
         }
-
-        intrinsics
     }
 }
 
@@ -286,7 +283,7 @@ pub(crate) fn set_default_global_bindings(context: &mut Context<'_>) -> JsResult
     global_object.define_property_or_throw(
         utf16!("globalThis"),
         PropertyDescriptor::builder()
-            .value(context.realm.global_this().clone())
+            .value(context.realm().global_this().clone())
             .writable(true)
             .enumerable(false)
             .configurable(true),
@@ -429,7 +426,7 @@ struct Callable<Kind> {
     name: JsString,
     length: usize,
     kind: Kind,
-    intrinsics: Intrinsics,
+    realm: Realm,
 }
 
 /// Marker for an ordinary object.
@@ -483,7 +480,7 @@ impl<S: ApplyToObject + IsConstructor> ApplyToObject for Callable<S> {
                 function: NativeFunction::from_fn_ptr(self.function),
                 constructor: S::IS_CONSTRUCTOR.then_some(function::ConstructorKind::Base),
             },
-            self.intrinsics,
+            self.realm,
         );
 
         let length = PropertyDescriptor::builder()
@@ -517,42 +514,39 @@ impl ApplyToObject for OrdinaryObject {
 #[derive(Debug)]
 #[must_use = "You need to call the `build` method in order for this to correctly assign the inner data"]
 struct BuiltInBuilder<'ctx, Kind> {
-    intrinsics: &'ctx Intrinsics,
+    realm: &'ctx Realm,
     object: JsObject,
     kind: Kind,
     prototype: JsObject,
 }
 
 impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
-    fn new(intrinsics: &'ctx Intrinsics) -> BuiltInBuilder<'ctx, OrdinaryObject> {
+    fn new(realm: &'ctx Realm) -> BuiltInBuilder<'ctx, OrdinaryObject> {
         BuiltInBuilder {
-            intrinsics,
+            realm,
             object: JsObject::with_null_proto(),
             kind: OrdinaryObject,
-            prototype: intrinsics.constructors().object().prototype(),
+            prototype: realm.intrinsics().constructors().object().prototype(),
         }
     }
 
     fn with_intrinsic<I: IntrinsicObject>(
-        intrinsics: &'ctx Intrinsics,
+        realm: &'ctx Realm,
     ) -> BuiltInBuilder<'ctx, OrdinaryObject> {
         BuiltInBuilder {
-            intrinsics,
-            object: I::get(intrinsics),
+            realm,
+            object: I::get(realm.intrinsics()),
             kind: OrdinaryObject,
-            prototype: intrinsics.constructors().object().prototype(),
+            prototype: realm.intrinsics().constructors().object().prototype(),
         }
     }
 
-    fn with_object(
-        intrinsics: &'ctx Intrinsics,
-        object: JsObject,
-    ) -> BuiltInBuilder<'ctx, OrdinaryObject> {
+    fn with_object(realm: &'ctx Realm, object: JsObject) -> BuiltInBuilder<'ctx, OrdinaryObject> {
         BuiltInBuilder {
-            intrinsics,
+            realm,
             object,
             kind: OrdinaryObject,
-            prototype: intrinsics.constructors().object().prototype(),
+            prototype: realm.intrinsics().constructors().object().prototype(),
         }
     }
 }
@@ -563,27 +557,32 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
         function: NativeFunctionPointer,
     ) -> BuiltInBuilder<'ctx, Callable<OrdinaryFunction>> {
         BuiltInBuilder {
-            intrinsics: self.intrinsics,
+            realm: self.realm,
             object: self.object,
             kind: Callable {
                 function,
                 name: js_string!(""),
                 length: 0,
                 kind: OrdinaryFunction,
-                intrinsics: self.intrinsics.clone(),
+                realm: self.realm.clone(),
             },
-            prototype: self.intrinsics.constructors().function().prototype(),
+            prototype: self
+                .realm
+                .intrinsics()
+                .constructors()
+                .function()
+                .prototype(),
         }
     }
 }
 
 impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
     fn from_standard_constructor<SC: BuiltInConstructor>(
-        intrinsics: &'ctx Intrinsics,
+        realm: &'ctx Realm,
     ) -> BuiltInBuilder<'ctx, Callable<Constructor>> {
-        let constructor = SC::STANDARD_CONSTRUCTOR(intrinsics.constructors());
+        let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
         BuiltInBuilder {
-            intrinsics,
+            realm,
             object: constructor.constructor(),
             kind: Callable {
                 function: SC::constructor,
@@ -591,25 +590,25 @@ impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
                 length: SC::LENGTH,
                 kind: Constructor {
                     prototype: constructor.prototype(),
-                    inherits: Some(intrinsics.constructors().object().prototype()),
+                    inherits: Some(realm.intrinsics().constructors().object().prototype()),
                     attributes: Attribute::WRITABLE | Attribute::CONFIGURABLE,
                 },
-                intrinsics: intrinsics.clone(),
+                realm: realm.clone(),
             },
-            prototype: intrinsics.constructors().function().prototype(),
+            prototype: realm.intrinsics().constructors().function().prototype(),
         }
     }
 
     fn no_proto(self) -> BuiltInBuilder<'ctx, Callable<ConstructorNoProto>> {
         BuiltInBuilder {
-            intrinsics: self.intrinsics,
+            realm: self.realm,
             object: self.object,
             kind: Callable {
                 function: self.kind.function,
                 name: self.kind.name,
                 length: self.kind.length,
                 kind: ConstructorNoProto,
-                intrinsics: self.intrinsics.clone(),
+                realm: self.realm.clone(),
             },
             prototype: self.prototype,
         }
@@ -623,7 +622,7 @@ impl<T> BuiltInBuilder<'_, T> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::new(self.intrinsics)
+        let function = BuiltInBuilder::new(self.realm)
             .callable(function)
             .name(binding.name)
             .length(length)
@@ -691,7 +690,7 @@ impl BuiltInBuilder<'_, Callable<Constructor>> {
         B: Into<FunctionBinding>,
     {
         let binding = binding.into();
-        let function = BuiltInBuilder::new(self.intrinsics)
+        let function = BuiltInBuilder::new(self.realm)
             .callable(function)
             .name(binding.name)
             .length(length)

--- a/boa_engine/src/builtins/number/globals.rs
+++ b/boa_engine/src/builtins/number/globals.rs
@@ -4,6 +4,7 @@ use crate::{
     builtins::{string::is_trimmable_whitespace, BuiltInBuilder, BuiltInObject, IntrinsicObject},
     context::intrinsics::Intrinsics,
     object::JsObject,
+    realm::Realm,
     string::Utf16Trim,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -36,8 +37,8 @@ fn is_finite(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResu
 pub(crate) struct IsFinite;
 
 impl IntrinsicObject for IsFinite {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(is_finite)
             .name(Self::NAME)
             .length(1)
@@ -83,8 +84,8 @@ pub(crate) fn is_nan(
 pub(crate) struct IsNaN;
 
 impl IntrinsicObject for IsNaN {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(is_nan)
             .name(Self::NAME)
             .length(1)
@@ -225,8 +226,8 @@ pub(crate) fn parse_int(
 pub(crate) struct ParseInt;
 
 impl IntrinsicObject for ParseInt {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(parse_int)
             .name(Self::NAME)
             .length(2)
@@ -299,8 +300,8 @@ pub(crate) fn parse_float(
 pub(crate) struct ParseFloat;
 
 impl IntrinsicObject for ParseFloat {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(parse_float)
             .name(Self::NAME)
             .length(1)

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -19,6 +19,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     value::{AbstractRelation, IntegerOrInfinity, JsValue},
     Context, JsArgs, JsResult,
@@ -45,12 +46,12 @@ const BUF_SIZE: usize = 2200;
 pub(crate) struct Number;
 
 impl IntrinsicObject for Number {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_property(utf16!("EPSILON"), f64::EPSILON, attribute)
             .static_property(
                 utf16!("MAX_SAFE_INTEGER"),
@@ -69,12 +70,12 @@ impl IntrinsicObject for Number {
             .static_property(utf16!("NaN"), f64::NAN, attribute)
             .static_property(
                 utf16!("parseInt"),
-                intrinsics.objects().parse_int(),
+                realm.intrinsics().objects().parse_int(),
                 Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
             )
             .static_property(
                 utf16!("parseFloat"),
-                intrinsics.objects().parse_float(),
+                realm.intrinsics().objects().parse_float(),
                 Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
             )
             .static_method(Self::number_is_finite, "isFinite", 1)

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -14,6 +14,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::PropertyKey,
+    realm::Realm,
     Context, JsResult, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
@@ -37,11 +38,17 @@ pub struct ForInIterator {
 }
 
 impl IntrinsicObject for ForInIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("ForInIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .build();
     }

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -27,6 +27,7 @@ use crate::{
         JsObject, ObjectData, ObjectKind,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey, PropertyNameKind},
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::JsValue,
@@ -44,20 +45,20 @@ mod tests;
 pub struct Object;
 
 impl IntrinsicObject for Object {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let legacy_proto_getter = BuiltInBuilder::new(intrinsics)
+        let legacy_proto_getter = BuiltInBuilder::new(realm)
             .callable(Self::legacy_proto_getter)
             .name("get __proto__")
             .build();
 
-        let legacy_setter_proto = BuiltInBuilder::new(intrinsics)
+        let legacy_setter_proto = BuiltInBuilder::new(realm)
             .callable(Self::legacy_proto_setter)
             .name("set __proto__")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .inherits(None)
             .accessor(
                 utf16!("__proto__"),

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     error::JsNativeError,
     native_function::NativeFunction,
     object::{FunctionObjectBuilder, JsFunction, JsObject, ObjectData},
+    realm::Realm,
     string::utf16,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -31,10 +32,10 @@ pub struct Proxy {
 }
 
 impl IntrinsicObject for Proxy {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .no_proto()
             .static_method(Self::revocable, "revocable", 2)
             .build();

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -17,6 +17,7 @@ use crate::{
     error::JsNativeError,
     object::JsObject,
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsArgs, JsResult, JsValue,
 };
@@ -30,12 +31,12 @@ mod tests;
 pub(crate) struct Reflect;
 
 impl IntrinsicObject for Reflect {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let to_string_tag = JsSymbol::to_string_tag();
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .static_method(Self::apply, "apply", 3)
             .static_method(Self::construct, "construct", 2)
             .static_method(Self::define_property, "defineProperty", 3)

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData, CONSTRUCTOR},
     property::{Attribute, PropertyDescriptorBuilder},
+    realm::Realm,
     string::{utf16, CodePoint},
     symbol::JsSymbol,
     value::JsValue,
@@ -44,53 +45,53 @@ pub struct RegExp {
 }
 
 impl IntrinsicObject for RegExp {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(intrinsics)
+        let get_species = BuiltInBuilder::new(realm)
             .callable(Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
         let flag_attributes = Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE;
 
-        let get_has_indices = BuiltInBuilder::new(intrinsics)
+        let get_has_indices = BuiltInBuilder::new(realm)
             .callable(Self::get_has_indices)
             .name("get hasIndices")
             .build();
-        let get_global = BuiltInBuilder::new(intrinsics)
+        let get_global = BuiltInBuilder::new(realm)
             .callable(Self::get_global)
             .name("get global")
             .build();
-        let get_ignore_case = BuiltInBuilder::new(intrinsics)
+        let get_ignore_case = BuiltInBuilder::new(realm)
             .callable(Self::get_ignore_case)
             .name("get ignoreCase")
             .build();
-        let get_multiline = BuiltInBuilder::new(intrinsics)
+        let get_multiline = BuiltInBuilder::new(realm)
             .callable(Self::get_multiline)
             .name("get multiline")
             .build();
-        let get_dot_all = BuiltInBuilder::new(intrinsics)
+        let get_dot_all = BuiltInBuilder::new(realm)
             .callable(Self::get_dot_all)
             .name("get dotAll")
             .build();
-        let get_unicode = BuiltInBuilder::new(intrinsics)
+        let get_unicode = BuiltInBuilder::new(realm)
             .callable(Self::get_unicode)
             .name("get unicode")
             .build();
-        let get_sticky = BuiltInBuilder::new(intrinsics)
+        let get_sticky = BuiltInBuilder::new(realm)
             .callable(Self::get_sticky)
             .name("get sticky")
             .build();
-        let get_flags = BuiltInBuilder::new(intrinsics)
+        let get_flags = BuiltInBuilder::new(realm)
             .callable(Self::get_flags)
             .name("get flags")
             .build();
-        let get_source = BuiltInBuilder::new(intrinsics)
+        let get_source = BuiltInBuilder::new(realm)
             .callable(Self::get_source)
             .name("get source")
             .build();
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -16,6 +16,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsResult, JsString, JsValue,
@@ -40,11 +41,17 @@ pub struct RegExpStringIterator {
 }
 
 impl IntrinsicObject for RegExpStringIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("RegExpStringIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .static_property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsResult, JsValue,
@@ -40,25 +41,25 @@ impl IntrinsicObject for Set {
     fn get(intrinsics: &Intrinsics) -> JsObject {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-        let get_species = BuiltInBuilder::new(intrinsics)
+        let get_species = BuiltInBuilder::new(realm)
             .callable(Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let size_getter = BuiltInBuilder::new(intrinsics)
+        let size_getter = BuiltInBuilder::new(realm)
             .callable(Self::size_getter)
             .name("get size")
             .build();
 
-        let values_function = BuiltInBuilder::new(intrinsics)
+        let values_function = BuiltInBuilder::new(realm)
             .callable(Self::values)
             .name("values")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -14,6 +14,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsResult,
 };
@@ -36,11 +37,17 @@ pub struct SetIterator {
 }
 
 impl IntrinsicObject for SetIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("SetIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .static_property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::{Attribute, PropertyDescriptor},
+    realm::Realm,
     string::utf16,
     string::{CodePoint, Utf16Trim},
     symbol::JsSymbol,
@@ -64,13 +65,13 @@ pub(crate) const fn is_trimmable_whitespace(c: char) -> bool {
 pub(crate) struct String;
 
 impl IntrinsicObject for String {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let symbol_iterator = JsSymbol::iterator();
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(utf16!("length"), 0, attribute)
             .static_method(Self::raw, "raw", 1)
             .static_method(Self::from_char_code, "fromCharCode", 1)

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -11,6 +11,7 @@ use crate::{
     error::JsNativeError,
     object::{JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsResult, JsValue,
 };
@@ -30,11 +31,17 @@ pub struct StringIterator {
 }
 
 impl IntrinsicObject for StringIterator {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event("StringIterator", "init");
 
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
-            .prototype(intrinsics.objects().iterator_prototypes().iterator())
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
+            .prototype(
+                realm
+                    .intrinsics()
+                    .objects()
+                    .iterator_prototypes()
+                    .iterator(),
+            )
             .static_method(Self::next, "next", 0)
             .static_property(
                 JsSymbol::to_string_tag(),

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -27,6 +27,7 @@ use crate::{
     js_string,
     object::JsObject,
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::JsValue,
@@ -91,7 +92,7 @@ impl GlobalSymbolRegistry {
 pub struct Symbol;
 
 impl IntrinsicObject for Symbol {
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
 
         let symbol_async_iterator = JsSymbol::async_iterator();
@@ -110,18 +111,18 @@ impl IntrinsicObject for Symbol {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        let to_primitive = BuiltInBuilder::new(intrinsics)
+        let to_primitive = BuiltInBuilder::new(realm)
             .callable(Self::to_primitive)
             .name("[Symbol.toPrimitive]")
             .length(1)
             .build();
 
-        let get_description = BuiltInBuilder::new(intrinsics)
+        let get_description = BuiltInBuilder::new(realm)
             .callable(Self::get_description)
             .name("get description")
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::for_, "for", 1)
             .static_method(Self::key_for, "keyFor", 1)
             .static_property(utf16!("asyncIterator"), symbol_async_iterator, attribute)

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     js_string,
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::{Attribute, PropertyNameKind},
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     value::{IntegerOrInfinity, JsValue},
@@ -47,17 +48,25 @@ macro_rules! typed_array {
                 Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
             }
 
-            fn init(intrinsics: &Intrinsics) {
+            fn init(realm: &Realm) {
                 let _timer = Profiler::global().start_event(Self::NAME, "init");
 
-                let get_species = BuiltInBuilder::new(intrinsics)
+                let get_species = BuiltInBuilder::new(realm)
                     .callable(TypedArray::get_species)
                     .name("get [Symbol.species]")
                     .build();
 
-                BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
-                    .prototype(intrinsics.constructors().typed_array().constructor())
-                    .inherits(Some(intrinsics.constructors().typed_array().prototype()))
+                BuiltInBuilder::from_standard_constructor::<Self>(realm)
+                    .prototype(
+                        realm
+                            .intrinsics()
+                            .constructors()
+                            .typed_array()
+                            .constructor(),
+                    )
+                    .inherits(Some(
+                        realm.intrinsics().constructors().typed_array().prototype(),
+                    ))
                     .static_accessor(
                         JsSymbol::species(),
                         Some(get_species),
@@ -231,44 +240,44 @@ macro_rules! typed_array {
 pub(crate) struct TypedArray;
 
 impl IntrinsicObject for TypedArray {
-    fn init(intrinsics: &Intrinsics) {
-        let get_species = BuiltInBuilder::new(intrinsics)
+    fn init(realm: &Realm) {
+        let get_species = BuiltInBuilder::new(realm)
             .callable(Self::get_species)
             .name("get [Symbol.species]")
             .build();
 
-        let get_buffer = BuiltInBuilder::new(intrinsics)
+        let get_buffer = BuiltInBuilder::new(realm)
             .callable(Self::buffer)
             .name("get buffer")
             .build();
 
-        let get_byte_length = BuiltInBuilder::new(intrinsics)
+        let get_byte_length = BuiltInBuilder::new(realm)
             .callable(Self::byte_length)
             .name("get byteLength")
             .build();
 
-        let get_byte_offset = BuiltInBuilder::new(intrinsics)
+        let get_byte_offset = BuiltInBuilder::new(realm)
             .callable(Self::byte_offset)
             .name("get byteOffset")
             .build();
 
-        let get_length = BuiltInBuilder::new(intrinsics)
+        let get_length = BuiltInBuilder::new(realm)
             .callable(Self::length)
             .name("get length")
             .build();
 
-        let get_to_string_tag = BuiltInBuilder::new(intrinsics)
+        let get_to_string_tag = BuiltInBuilder::new(realm)
             .callable(Self::to_string_tag)
             .name("get [Symbol.toStringTag]")
             .build();
 
-        let values_function = BuiltInBuilder::new(intrinsics)
+        let values_function = BuiltInBuilder::new(realm)
             .callable(Self::values)
             .name("values")
             .length(0)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     context::intrinsics::Intrinsics,
     js_string,
     object::{JsFunction, JsObject},
+    realm::Realm,
     string::CodePoint,
     Context, JsArgs, JsNativeError, JsResult, JsString, JsValue,
 };
@@ -80,8 +81,8 @@ impl UriFunctions {
 pub(crate) struct DecodeUri;
 
 impl IntrinsicObject for DecodeUri {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(decode_uri)
             .name(Self::NAME)
             .length(1)
@@ -99,8 +100,8 @@ impl BuiltInObject for DecodeUri {
 pub(crate) struct DecodeUriComponent;
 
 impl IntrinsicObject for DecodeUriComponent {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(decode_uri_component)
             .name(Self::NAME)
             .length(1)
@@ -122,8 +123,8 @@ impl BuiltInObject for DecodeUriComponent {
 pub(crate) struct EncodeUri;
 
 impl IntrinsicObject for EncodeUri {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(encode_uri)
             .name(Self::NAME)
             .length(1)
@@ -140,8 +141,8 @@ impl BuiltInObject for EncodeUri {
 pub(crate) struct EncodeUriComponent;
 
 impl IntrinsicObject for EncodeUriComponent {
-    fn init(intrinsics: &Intrinsics) {
-        BuiltInBuilder::with_intrinsic::<Self>(intrinsics)
+    fn init(realm: &Realm) {
+        BuiltInBuilder::with_intrinsic::<Self>(realm)
             .callable(encode_uri_component)
             .name(Self::NAME)
             .length(1)

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -6,6 +6,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsValue,
 };
@@ -28,9 +29,9 @@ impl IntrinsicObject for WeakRef {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 "WeakRef",

--- a/boa_engine/src/builtins/weak_map/mod.rs
+++ b/boa_engine/src/builtins/weak_map/mod.rs
@@ -15,6 +15,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsValue,
@@ -30,9 +31,9 @@ impl IntrinsicObject for WeakMap {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/boa_engine/src/builtins/weak_set/mod.rs
+++ b/boa_engine/src/builtins/weak_set/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     object::{internal_methods::get_prototype_from_constructor, JsObject, ObjectData},
     property::Attribute,
+    realm::Realm,
     string::utf16,
     symbol::JsSymbol,
     Context, JsArgs, JsNativeError, JsResult, JsValue,
@@ -27,9 +28,9 @@ impl IntrinsicObject for WeakSet {
         Self::STANDARD_CONSTRUCTOR(intrinsics.constructors()).constructor()
     }
 
-    fn init(intrinsics: &Intrinsics) {
+    fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(Self::NAME, "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(intrinsics)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -1,0 +1,150 @@
+use boa_ast::expression::Identifier;
+use boa_gc::{Gc, GcRefCell};
+
+use crate::{
+    environments::{BindingLocator, CompileTimeEnvironment},
+    property::PropertyDescriptor,
+    JsString, JsValue,
+};
+
+use super::ByteCompiler;
+
+/// Info returned by the [`ByteCompiler::pop_compile_environment`] method.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PopEnvironmentInfo {
+    /// Number of bindings declared.
+    pub(crate) num_bindings: usize,
+    /// Index in the compile time envs array.
+    pub(crate) index: usize,
+}
+
+impl ByteCompiler<'_, '_> {
+    /// Push either a new declarative or function environment on the compile time environment stack.
+    pub(crate) fn push_compile_environment(&mut self, function_scope: bool) {
+        self.current_environment = Gc::new(GcRefCell::new(CompileTimeEnvironment::new(
+            self.current_environment.clone(),
+            function_scope,
+        )));
+    }
+
+    /// Pops the top compile time environment and returns its index and number of bindings.
+    #[track_caller]
+    pub(crate) fn pop_compile_environment(&mut self) -> PopEnvironmentInfo {
+        let index = self.compile_environments.len();
+        self.compile_environments
+            .push(self.current_environment.clone());
+
+        let (num_bindings, outer) = {
+            let env = self.current_environment.borrow();
+            (
+                env.num_bindings(),
+                env.outer().expect("cannot pop the global environment"),
+            )
+        };
+        self.current_environment = outer;
+
+        PopEnvironmentInfo {
+            num_bindings,
+            index,
+        }
+    }
+
+    /// Get the binding locator of the binding at bytecode compile time.
+    pub(crate) fn get_binding_value(&self, name: Identifier) -> BindingLocator {
+        self.current_environment
+            .borrow()
+            .get_binding_recursive(name)
+    }
+
+    /// Return if a declarative binding exists at bytecode compile time.
+    /// This does not include bindings on the global object.
+    pub(crate) fn has_binding(&self, name: Identifier) -> bool {
+        self.current_environment
+            .borrow()
+            .has_binding_recursive(name)
+    }
+
+    /// Create a mutable binding at bytecode compile time.
+    /// This function returns a syntax error, if the binding is a redeclaration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the global environment is not function scoped.
+    pub(crate) fn create_mutable_binding(
+        &mut self,
+        name: Identifier,
+        function_scope: bool,
+        configurable: bool,
+    ) {
+        if !self
+            .current_environment
+            .borrow_mut()
+            .create_mutable_binding(name, function_scope)
+        {
+            let name_str = self
+                .context
+                .interner()
+                .resolve_expect(name.sym())
+                .into_common::<JsString>(false);
+
+            let global_obj = self.context.global_object();
+
+            // TODO: defer global initialization to execution time.
+            if !global_obj
+                .has_own_property(name_str.clone(), self.context)
+                .unwrap_or_default()
+            {
+                global_obj.borrow_mut().insert(
+                    name_str,
+                    PropertyDescriptor::builder()
+                        .value(JsValue::Undefined)
+                        .writable(true)
+                        .enumerable(true)
+                        .configurable(configurable)
+                        .build(),
+                );
+            }
+        }
+    }
+
+    /// Initialize a mutable binding at bytecode compile time and return it's binding locator.
+    pub(crate) fn initialize_mutable_binding(
+        &self,
+        name: Identifier,
+        function_scope: bool,
+    ) -> BindingLocator {
+        self.current_environment
+            .borrow()
+            .initialize_mutable_binding(name, function_scope)
+    }
+
+    /// Create an immutable binding at bytecode compile time.
+    /// This function returns a syntax error, if the binding is a redeclaration.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the global environment does not exist.
+    pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
+        self.current_environment
+            .borrow_mut()
+            .create_immutable_binding(name, strict);
+    }
+
+    /// Initialize an immutable binding at bytecode compile time and return it's binding locator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the global environment does not exist or a the binding was not created on the current environment.
+    pub(crate) fn initialize_immutable_binding(&self, name: Identifier) -> BindingLocator {
+        self.current_environment
+            .borrow()
+            .initialize_immutable_binding(name)
+    }
+
+    /// Return the binding locator for a set operation on an existing binding.
+    pub(crate) fn set_mutable_binding(&self, name: Identifier) -> BindingLocator {
+        self.current_environment
+            .borrow()
+            .set_mutable_binding_recursive(name)
+    }
+}

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -54,7 +54,7 @@ impl ByteCompiler<'_, '_> {
 
             match access {
                 Access::Variable { name } => {
-                    let binding = self.context.get_binding_value(name);
+                    let binding = self.get_binding_value(name);
                     let index = self.get_or_insert_binding(binding);
                     self.emit(Opcode::GetName, &[index]);
 
@@ -69,7 +69,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Dup);
                     }
 
-                    let binding = self.context.set_mutable_binding(name);
+                    let binding = self.set_mutable_binding(name);
                     let index = self.get_or_insert_binding(binding);
                     self.emit(Opcode::SetName, &[index]);
                 }

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -27,7 +27,7 @@ impl ByteCompiler<'_, '_> {
             UnaryOp::TypeOf => {
                 match unary.target().flatten() {
                     Expression::Identifier(identifier) => {
-                        let binding = self.context.get_binding_value(*identifier);
+                        let binding = self.get_binding_value(*identifier);
                         let index = self.get_or_insert_binding(binding);
                         self.emit(Opcode::GetNameOrUndefined, &[index]);
                     }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -22,7 +22,7 @@ impl ByteCompiler<'_, '_> {
 
         match Access::from_update_target(update.target()) {
             Access::Variable { name } => {
-                let binding = self.context.get_binding_value(name);
+                let binding = self.get_binding_value(name);
                 let index = self.get_or_insert_binding(binding);
                 self.emit(Opcode::GetName, &[index]);
 
@@ -33,7 +33,7 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::Dup);
                 }
 
-                let binding = self.context.set_mutable_binding(name);
+                let binding = self.set_mutable_binding(name);
                 let index = self.get_or_insert_binding(binding);
                 self.emit(Opcode::SetName, &[index]);
             }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -10,16 +10,15 @@ impl ByteCompiler<'_, '_> {
         use_expr: bool,
         configurable_globals: bool,
     ) {
-        self.context.push_compile_time_environment(false);
+        self.push_compile_environment(false);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
         self.create_script_decls(block.statement_list(), configurable_globals);
         self.compile_statement_list(block.statement_list(), use_expr, configurable_globals);
 
-        let (num_bindings, compile_environment) = self.context.pop_compile_time_environment();
-        let index_compile_environment = self.push_compile_environment(compile_environment);
-        self.patch_jump_with_target(push_env.0, num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, index_compile_environment as u32);
+        let env_info = self.pop_compile_environment();
+        self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
+        self.patch_jump_with_target(push_env.1, env_info.index as u32);
 
         self.emit_opcode(Opcode::PopEnvironment);
     }

--- a/boa_engine/src/bytecompiler/statement/with.rs
+++ b/boa_engine/src/bytecompiler/statement/with.rs
@@ -5,10 +5,10 @@ impl ByteCompiler<'_, '_> {
     /// Compile a [`With`] `boa_ast` node
     pub(crate) fn compile_with(&mut self, with: &With, configurable_globals: bool) {
         self.compile_expr(with.expression(), true);
-        self.context.push_compile_time_environment(false);
+        self.push_compile_environment(false);
         self.emit_opcode(Opcode::PushObjectEnvironment);
         self.compile_stmt(with.statement(), false, configurable_globals);
-        self.context.pop_compile_time_environment();
+        self.pop_compile_environment();
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -2,6 +2,7 @@ use crate::{
     builtins::promise::OperationType,
     job::JobCallback,
     object::{JsFunction, JsObject},
+    realm::Realm,
     Context, JsResult, JsValue,
 };
 
@@ -99,9 +100,11 @@ pub trait HostHooks {
     /// containing unused. This is already ensured by the return type.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hostensurecancompilestrings
+    // TODO: Track https://github.com/tc39/ecma262/issues/938
     fn ensure_can_compile_strings(
         &self,
-        /* Realm (WIP), */ _context: &mut Context<'_>,
+        _realm: Realm,
+        _context: &mut Context<'_>,
     ) -> JsResult<()> {
         // The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(unused).
         Ok(())

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -19,13 +19,20 @@ use super::intrinsics::Intrinsics;
 /// need to be redefined:
 ///
 /// ```
-/// use boa_engine::{JsNativeError, JsResult, context::{Context, ContextBuilder, HostHooks}, Source};
+/// use boa_engine::{
+///     context::{Context, ContextBuilder, HostHooks},
+///     JsNativeError,
+///     JsResult,
+///     realm::Realm,
+///     Source
+/// };
 ///
 /// struct Hooks;
 ///
 /// impl HostHooks for Hooks {
 ///     fn ensure_can_compile_strings(
 ///         &self,
+///         _realm: Realm,
 ///         context: &mut Context<'_>,
 ///     ) -> JsResult<()> {
 ///         Err(JsNativeError::typ().with_message("eval calls not available").into())

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -1,6 +1,6 @@
 //! Data structures that contain intrinsic objects and constructors.
 
-use boa_gc::{Finalize, Gc, Trace};
+use boa_gc::{Finalize, Trace};
 
 use crate::{
     builtins::{iterable::IteratorPrototypes, uri::UriFunctions},
@@ -11,28 +11,8 @@ use crate::{
 ///
 /// `Intrinsics` is internally stored using a `Gc`, which makes it cheapily clonable
 /// for multiple references to the same set of intrinsic objects.
-#[derive(Default, Clone, Trace, Finalize)]
+#[derive(Debug, Default, Trace, Finalize)]
 pub struct Intrinsics {
-    inner: Gc<Inner>,
-}
-
-impl PartialEq for Intrinsics {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(&*self.inner, &*other.inner)
-    }
-}
-
-impl std::fmt::Debug for Intrinsics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Intrinsics")
-            .field("constructors", self.constructors())
-            .field("objects", self.objects())
-            .finish()
-    }
-}
-
-#[derive(Default, Trace, Finalize)]
-struct Inner {
     /// Cached standard constructors
     pub(super) constructors: StandardConstructors,
     /// Cached intrinsic objects
@@ -42,19 +22,19 @@ struct Inner {
 impl Intrinsics {
     /// Return the cached intrinsic objects.
     #[inline]
-    pub fn objects(&self) -> &IntrinsicObjects {
-        &self.inner.objects
+    pub const fn objects(&self) -> &IntrinsicObjects {
+        &self.objects
     }
 
     /// Return the cached standard constructors.
     #[inline]
-    pub fn constructors(&self) -> &StandardConstructors {
-        &self.inner.constructors
+    pub const fn constructors(&self) -> &StandardConstructors {
+        &self.constructors
     }
 }
 
 /// Store a builtin constructor (such as `Object`) and its corresponding prototype.
-#[derive(Debug, Clone, Trace, Finalize)]
+#[derive(Debug, Trace, Finalize)]
 pub struct StandardConstructor {
     pub(crate) constructor: JsObject,
     pub(crate) prototype: JsObject,
@@ -96,7 +76,7 @@ impl StandardConstructor {
 }
 
 /// Cached core standard constructors.
-#[derive(Debug, Clone, Trace, Finalize)]
+#[derive(Debug, Trace, Finalize)]
 pub struct StandardConstructors {
     object: StandardConstructor,
     proxy: StandardConstructor,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -536,24 +536,9 @@ impl<'host> Context<'host> {
 
 // ==== Private API ====
 
+#[cfg(feature = "intl")]
 impl<'host> Context<'host> {
-    /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
-    pub(crate) fn compile_json_parse(&mut self, statement_list: &StatementList) -> Gc<CodeBlock> {
-        let _timer = Profiler::global().start_event("Compilation", "Main");
-        let mut compiler = ByteCompiler::new(
-            Sym::MAIN,
-            statement_list.strict(),
-            true,
-            self.realm.environment().compile_env(),
-            self,
-        );
-        compiler.create_script_decls(statement_list, false);
-        compiler.compile_statement_list(statement_list, true, false);
-        Gc::new(compiler.finish())
-    }
-
     /// Get the ICU related utilities
-    #[cfg(feature = "intl")]
     pub(crate) const fn icu(&self) -> &icu::Icu<'host> {
         &self.icu
     }

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -79,7 +79,7 @@ use boa_profiler::Profiler;
 /// ```
 pub struct Context<'host> {
     /// realm holds both the global object and the environment
-    pub(crate) realm: Realm,
+    realm: Realm,
 
     /// String interner in the context.
     interner: Interner,
@@ -135,7 +135,7 @@ impl Default for Context<'_> {
 }
 
 // ==== Public API ====
-impl Context<'_> {
+impl<'host> Context<'host> {
     /// Create a new [`ContextBuilder`] to specify the [`Interner`] and/or
     /// the icu data provider.
     #[must_use]
@@ -245,7 +245,13 @@ impl Context<'_> {
     /// Compile the script AST into a `CodeBlock` ready to be executed by the VM.
     pub fn compile_script(&mut self, statement_list: &StatementList) -> JsResult<Gc<CodeBlock>> {
         let _timer = Profiler::global().start_event("Script compilation", "Main");
-        let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
+        let mut compiler = ByteCompiler::new(
+            Sym::MAIN,
+            statement_list.strict(),
+            false,
+            self.realm.environment().compile_env(),
+            self,
+        );
         compiler.create_script_decls(statement_list, false);
         compiler.compile_statement_list(statement_list, true, false);
         Ok(Gc::new(compiler.finish()))
@@ -255,7 +261,13 @@ impl Context<'_> {
     pub fn compile_module(&mut self, statement_list: &ModuleItemList) -> JsResult<Gc<CodeBlock>> {
         let _timer = Profiler::global().start_event("Module compilation", "Main");
 
-        let mut compiler = ByteCompiler::new(Sym::MAIN, true, false, self);
+        let mut compiler = ByteCompiler::new(
+            Sym::MAIN,
+            true,
+            false,
+            self.realm.environment().compile_env(),
+            self,
+        );
         compiler.create_module_decls(statement_list, false);
         compiler.compile_module_item_list(statement_list, false);
         Ok(Gc::new(compiler.finish()))
@@ -276,7 +288,9 @@ impl Context<'_> {
 
         self.vm.push_frame(CallFrame::new(code_block));
 
-        self.realm.set_global_binding_number();
+        // TODO: Here should be https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
+
+        self.realm().resize_global_env();
         let record = self.run();
         self.vm.pop_frame();
         self.clear_kept_objects();
@@ -446,10 +460,16 @@ impl Context<'_> {
         self.realm.global_object().clone()
     }
 
-    /// Returns the intrinsic constructors and objects.
+    /// Returns the currently active intrinsic constructors and objects.
     #[inline]
-    pub const fn intrinsics(&self) -> &Intrinsics {
-        &self.realm.intrinsics
+    pub fn intrinsics(&self) -> &Intrinsics {
+        self.realm.intrinsics()
+    }
+
+    /// Returns the currently active realm.
+    #[inline]
+    pub const fn realm(&self) -> &Realm {
+        &self.realm
     }
 
     /// Set the value of trace on the context
@@ -494,42 +514,42 @@ impl Context<'_> {
     pub fn clear_kept_objects(&mut self) {
         self.kept_alive.clear();
     }
-}
 
-// ==== Private API ====
-
-impl Context<'_> {
-    /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
-    pub(crate) fn compile_json_parse(&mut self, statement_list: &StatementList) -> Gc<CodeBlock> {
-        let _timer = Profiler::global().start_event("Compilation", "Main");
-        let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), true, self);
-        compiler.create_script_decls(statement_list, false);
-        compiler.compile_statement_list(statement_list, true, false);
-        Gc::new(compiler.finish())
+    /// Replaces the currently active realm with `realm`, and returns the old realm.
+    pub fn enter_realm(&mut self, realm: Realm) -> Realm {
+        self.vm
+            .environments
+            .replace_global(realm.environment().clone());
+        std::mem::replace(&mut self.realm, realm)
     }
 
-    /// Compile the AST into a `CodeBlock` with an additional declarative environment.
-    pub(crate) fn compile_with_new_declarative(
-        &mut self,
-        statement_list: &StatementList,
-        strict: bool,
-    ) -> Gc<CodeBlock> {
-        let _timer = Profiler::global().start_event("Compilation", "Main");
-        let mut compiler = ByteCompiler::new(Sym::MAIN, statement_list.strict(), false, self);
-        compiler.compile_statement_list_with_new_declarative(statement_list, true, strict);
-        Gc::new(compiler.finish())
-    }
-}
-
-impl<'host> Context<'host> {
-    /// Get the host hooks.
+    /// Gets the host hooks.
     pub fn host_hooks(&self) -> &'host dyn HostHooks {
         self.host_hooks
     }
 
-    /// Get the job queue.
+    /// Gets the job queue.
     pub fn job_queue(&mut self) -> &'host dyn JobQueue {
         self.job_queue
+    }
+}
+
+// ==== Private API ====
+
+impl<'host> Context<'host> {
+    /// Compile the AST into a `CodeBlock` ready to be executed by the VM in a `JSON.parse` context.
+    pub(crate) fn compile_json_parse(&mut self, statement_list: &StatementList) -> Gc<CodeBlock> {
+        let _timer = Profiler::global().start_event("Compilation", "Main");
+        let mut compiler = ByteCompiler::new(
+            Sym::MAIN,
+            statement_list.strict(),
+            true,
+            self.realm.environment().compile_env(),
+            self,
+        );
+        compiler.create_script_decls(statement_list, false);
+        compiler.compile_statement_list(statement_list, true, false);
+        Gc::new(compiler.finish())
     }
 
     /// Get the ICU related utilities
@@ -662,11 +682,13 @@ impl<'icu, 'hooks, 'queue> ContextBuilder<'icu, 'hooks, 'queue> {
         'queue: 'host,
     {
         let host_hooks = self.host_hooks.unwrap_or(&DefaultHooks);
+        let realm = Realm::create(host_hooks);
+        let vm = Vm::new(realm.environment().clone());
 
         let mut context = Context {
-            realm: Realm::create(host_hooks),
+            realm,
             interner: self.interner.unwrap_or_default(),
-            vm: Vm::default(),
+            vm,
             strict: false,
             #[cfg(feature = "intl")]
             icu: self.icu.unwrap_or_else(|| {

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -928,16 +928,16 @@ where
     // The corresponding object must be an intrinsic that is intended to be used
     // as the [[Prototype]] value of an object.
     // 2. Let proto be ? Get(constructor, "prototype").
-    let intrinsics = if let Some(constructor) = constructor.as_object() {
+    let realm = if let Some(constructor) = constructor.as_object() {
         if let Some(proto) = constructor.get(PROTOTYPE, context)?.as_object() {
             return Ok(proto.clone());
         }
         // 3. If Type(proto) is not Object, then
         // a. Let realm be ? GetFunctionRealm(constructor).
-        // b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
         constructor.get_function_realm(context)?
     } else {
-        context.intrinsics().clone()
+        context.realm().clone()
     };
-    Ok(default(intrinsics.constructors()).prototype())
+    // b. Set proto to realm's intrinsic object named intrinsicDefaultProto.
+    Ok(default(realm.intrinsics().constructors()).prototype())
 }

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -2003,7 +2003,7 @@ impl<'ctx, 'host> FunctionObjectBuilder<'ctx, 'host> {
                     function: self.function,
                     constructor: self.constructor,
                 },
-                self.context.intrinsics().clone(),
+                self.context.realm().clone(),
             )),
         );
         let property = PropertyDescriptor::builder()
@@ -2399,7 +2399,7 @@ impl<'ctx, 'host> ConstructorBuilder<'ctx, 'host> {
                 function: self.function,
                 constructor: self.constructor,
             },
-            self.context.intrinsics().clone(),
+            self.context.realm().clone(),
         );
 
         let length = PropertyDescriptor::builder()

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -1,9 +1,10 @@
 use crate::{
     builtins::{function::ClassFieldDefinition, Array},
-    context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
+    context::intrinsics::{StandardConstructor, StandardConstructors},
     error::JsNativeError,
     object::{JsObject, PrivateElement, PROTOTYPE},
     property::{PropertyDescriptor, PropertyDescriptorBuilder, PropertyKey, PropertyNameKind},
+    realm::Realm,
     string::utf16,
     value::Type,
     Context, JsResult, JsSymbol, JsValue,
@@ -658,10 +659,10 @@ impl JsObject {
     /// Abstract operation [`GetFunctionRealm`][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getfunctionrealm
-    pub(crate) fn get_function_realm(&self, context: &mut Context<'_>) -> JsResult<Intrinsics> {
+    pub(crate) fn get_function_realm(&self, context: &mut Context<'_>) -> JsResult<Realm> {
         let constructor = self.borrow();
         if let Some(fun) = constructor.as_function() {
-            return Ok(fun.realm_intrinsics().clone());
+            return Ok(fun.realm().clone());
         }
 
         if let Some(bound) = constructor.as_bound_function() {
@@ -676,7 +677,7 @@ impl JsObject {
             return fun.get_function_realm(context);
         }
 
-        Ok(context.intrinsics().clone())
+        Ok(context.realm().clone())
     }
 
     // todo: CopyDataProperties

--- a/boa_engine/src/tests/env.rs
+++ b/boa_engine/src/tests/env.rs
@@ -1,0 +1,32 @@
+use indoc::indoc;
+
+use crate::{run_test_actions, TestAction};
+
+#[test]
+// https://github.com/boa-dev/boa/issues/2317
+fn fun_block_eval_2317() {
+    run_test_actions([
+        TestAction::assert_eq(
+            indoc! {r#"
+                (function(y){
+                    {
+                        eval("var x = 'inner';");
+                    }
+                    return y + x;
+                })("arg");
+            "#},
+            "arginner",
+        ),
+        TestAction::assert_eq(
+            indoc! {r#"
+                (function(y = "default"){
+                    {
+                        eval("var x = 'inner';");
+                    }
+                    return y + x;
+                })();
+            "#},
+            "defaultinner",
+        ),
+    ]);
+}

--- a/boa_engine/src/tests/mod.rs
+++ b/boa_engine/src/tests/mod.rs
@@ -1,6 +1,7 @@
 use indoc::indoc;
 
 mod control_flow;
+mod env;
 mod function;
 mod operators;
 mod promise;

--- a/boa_engine/src/vm/opcode/await_stm/mod.rs
+++ b/boa_engine/src/vm/opcode/await_stm/mod.rs
@@ -34,11 +34,11 @@ impl Operation for Await {
         )?;
 
         let generator_context = GeneratorContext {
-            environments: context.realm.environments.clone(),
+            environments: context.vm.environments.clone(),
             call_frame: context.vm.frame().clone(),
             stack: context.vm.stack.clone(),
             active_function: context.vm.active_function.clone(),
-            realm_intrinsics: context.realm.intrinsics.clone(),
+            realm: context.realm().clone(),
         };
 
         // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
@@ -57,7 +57,7 @@ impl Operation for Await {
                     // f. Return undefined.
 
                     std::mem::swap(
-                        &mut context.realm.environments,
+                        &mut context.vm.environments,
                         &mut generator_context.environments,
                     );
                     std::mem::swap(&mut context.vm.stack, &mut generator_context.stack);
@@ -65,10 +65,7 @@ impl Operation for Await {
                         &mut context.vm.active_function,
                         &mut generator_context.active_function,
                     );
-                    std::mem::swap(
-                        &mut context.realm.intrinsics,
-                        &mut generator_context.realm_intrinsics,
-                    );
+                    let old_realm = context.enter_realm(generator_context.realm.clone());
                     context.vm.push_frame(generator_context.call_frame.clone());
 
                     context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Normal;
@@ -80,7 +77,7 @@ impl Operation for Await {
                         .pop_frame()
                         .expect("generator call frame must exist");
                     std::mem::swap(
-                        &mut context.realm.environments,
+                        &mut context.vm.environments,
                         &mut generator_context.environments,
                     );
                     std::mem::swap(&mut context.vm.stack, &mut generator_context.stack);
@@ -88,10 +85,7 @@ impl Operation for Await {
                         &mut context.vm.active_function,
                         &mut generator_context.active_function,
                     );
-                    std::mem::swap(
-                        &mut context.realm.intrinsics,
-                        &mut generator_context.realm_intrinsics,
-                    );
+                    context.enter_realm(old_realm);
 
                     Ok(JsValue::undefined())
                 },
@@ -118,7 +112,7 @@ impl Operation for Await {
                     // f. Return undefined.
 
                     std::mem::swap(
-                        &mut context.realm.environments,
+                        &mut context.vm.environments,
                         &mut generator_context.environments,
                     );
                     std::mem::swap(&mut context.vm.stack, &mut generator_context.stack);
@@ -126,10 +120,7 @@ impl Operation for Await {
                         &mut context.vm.active_function,
                         &mut generator_context.active_function,
                     );
-                    std::mem::swap(
-                        &mut context.realm.intrinsics,
-                        &mut generator_context.realm_intrinsics,
-                    );
+                    let old_realm = context.enter_realm(generator_context.realm.clone());
                     context.vm.push_frame(generator_context.call_frame.clone());
 
                     context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Throw;
@@ -141,7 +132,7 @@ impl Operation for Await {
                         .pop_frame()
                         .expect("generator call frame must exist");
                     std::mem::swap(
-                        &mut context.realm.environments,
+                        &mut context.vm.environments,
                         &mut generator_context.environments,
                     );
                     std::mem::swap(&mut context.vm.stack, &mut generator_context.stack);
@@ -149,10 +140,7 @@ impl Operation for Await {
                         &mut context.vm.active_function,
                         &mut generator_context.active_function,
                     );
-                    std::mem::swap(
-                        &mut context.realm.intrinsics,
-                        &mut generator_context.realm_intrinsics,
-                    );
+                    context.enter_realm(old_realm);
 
                     Ok(JsValue::undefined())
                 },

--- a/boa_engine/src/vm/opcode/control_flow/break.rs
+++ b/boa_engine/src/vm/opcode/control_flow/break.rs
@@ -34,8 +34,8 @@ impl Operation for Break {
             context.vm.frame_mut().env_stack.pop();
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         // 2. Register target address in AbruptCompletionRecord.
         let new_record = AbruptCompletionRecord::new_break().with_initial_target(target_address);

--- a/boa_engine/src/vm/opcode/control_flow/catch.rs
+++ b/boa_engine/src/vm/opcode/control_flow/catch.rs
@@ -50,8 +50,8 @@ impl Operation for CatchEnd {
             }
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         Ok(CompletionType::Normal)
     }
@@ -77,11 +77,11 @@ impl Operation for CatchEnd2 {
             .filter(|entry| entry.is_catch_env())
         {
             let env_truncation_len = context
-                .realm
+                .vm
                 .environments
                 .len()
                 .saturating_sub(catch_entry.env_num());
-            context.realm.environments.truncate(env_truncation_len);
+            context.vm.environments.truncate(env_truncation_len);
 
             context.vm.frame_mut().env_stack.pop();
         }

--- a/boa_engine/src/vm/opcode/control_flow/continue.rs
+++ b/boa_engine/src/vm/opcode/control_flow/continue.rs
@@ -42,8 +42,8 @@ impl Operation for Continue {
             context.vm.frame_mut().env_stack.pop();
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         // 2. Register target address in AbruptCompletionRecord.
         let new_record = AbruptCompletionRecord::new_continue().with_initial_target(target_address);

--- a/boa_engine/src/vm/opcode/control_flow/finally.rs
+++ b/boa_engine/src/vm/opcode/control_flow/finally.rs
@@ -64,9 +64,8 @@ impl Operation for FinallyEnd {
                     context.vm.frame_mut().env_stack.pop();
                 }
 
-                let env_truncation_len =
-                    context.realm.environments.len().saturating_sub(envs_to_pop);
-                context.realm.environments.truncate(env_truncation_len);
+                let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+                context.vm.environments.truncate(env_truncation_len);
             }
             Some(record)
                 if record.is_break() && context.vm.frame().pc < record.target() as usize =>
@@ -84,9 +83,8 @@ impl Operation for FinallyEnd {
 
                 context.vm.frame_mut().abrupt_completion = None;
 
-                let env_truncation_len =
-                    context.realm.environments.len().saturating_sub(envs_to_pop);
-                context.realm.environments.truncate(env_truncation_len);
+                let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+                context.vm.environments.truncate(env_truncation_len);
             }
             Some(record)
                 if record.is_continue() && context.vm.frame().pc > record.target() as usize =>
@@ -102,9 +100,8 @@ impl Operation for FinallyEnd {
                 }
 
                 context.vm.frame_mut().abrupt_completion = None;
-                let env_truncation_len =
-                    context.realm.environments.len().saturating_sub(envs_to_pop);
-                context.realm.environments.truncate(env_truncation_len);
+                let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+                context.vm.environments.truncate(env_truncation_len);
             }
             Some(record) if record.is_return() => {
                 return Ok(CompletionType::Return);
@@ -121,9 +118,8 @@ impl Operation for FinallyEnd {
                     }
                 }
                 context.vm.frame_mut().abrupt_completion = None;
-                let env_truncation_len =
-                    context.realm.environments.len().saturating_sub(envs_to_pop);
-                context.realm.environments.truncate(env_truncation_len);
+                let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+                context.vm.environments.truncate(env_truncation_len);
             }
             Some(record) if !record.is_throw_with_target() => {
                 let current_stack = context
@@ -134,11 +130,11 @@ impl Operation for FinallyEnd {
                     .expect("Popping current finally stack.");
 
                 let env_truncation_len = context
-                    .realm
+                    .vm
                     .environments
                     .len()
                     .saturating_sub(current_stack.env_num());
-                context.realm.environments.truncate(env_truncation_len);
+                context.vm.environments.truncate(env_truncation_len);
 
                 let err = JsError::from_opaque(context.vm.pop());
                 context.vm.err = Some(err);

--- a/boa_engine/src/vm/opcode/control_flow/labelled.rs
+++ b/boa_engine/src/vm/opcode/control_flow/labelled.rs
@@ -47,8 +47,8 @@ impl Operation for LabelledEnd {
             }
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/control_flow/return.rs
+++ b/boa_engine/src/vm/opcode/control_flow/return.rs
@@ -36,8 +36,8 @@ impl Operation for Return {
             context.vm.frame_mut().env_stack.pop();
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(env_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(env_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         let record = AbruptCompletionRecord::new_return();
         context.vm.frame_mut().abrupt_completion = Some(record);

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -59,8 +59,8 @@ impl Operation for Throw {
                 context.vm.frame_mut().env_stack.pop();
             }
 
-            let env_truncation_len = context.realm.environments.len().saturating_sub(env_to_pop);
-            context.realm.environments.truncate(env_truncation_len);
+            let env_truncation_len = context.vm.environments.len().saturating_sub(env_to_pop);
+            context.vm.environments.truncate(env_truncation_len);
 
             if target_address == catch_target {
                 context.vm.frame_mut().pc = catch_target as usize;
@@ -110,8 +110,8 @@ impl Operation for Throw {
                 context.vm.frame_mut().env_stack.pop();
             }
 
-            let env_truncation_len = context.realm.environments.len().saturating_sub(env_to_pop);
-            context.realm.environments.truncate(env_truncation_len);
+            let env_truncation_len = context.vm.environments.len().saturating_sub(env_to_pop);
+            context.vm.environments.truncate(env_truncation_len);
 
             let previous_stack_size = context
                 .vm

--- a/boa_engine/src/vm/opcode/control_flow/try.rs
+++ b/boa_engine/src/vm/opcode/control_flow/try.rs
@@ -58,8 +58,8 @@ impl Operation for TryEnd {
             }
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -28,7 +28,7 @@ impl Operation for DefVar {
         if binding_locator.is_global() {
             // already initialized at compile time
         } else {
-            context.realm.environments.put_value_if_uninitialized(
+            context.vm.environments.put_value_if_uninitialized(
                 binding_locator.environment_index(),
                 binding_locator.binding_index(),
                 JsValue::Undefined,
@@ -72,7 +72,7 @@ impl Operation for DefInitVar {
                 )?;
             }
         } else {
-            context.realm.environments.put_value(
+            context.vm.environments.put_value(
                 binding_locator.environment_index(),
                 binding_locator.binding_index(),
                 value,
@@ -96,7 +96,7 @@ impl Operation for DefLet {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        context.realm.environments.put_value(
+        context.vm.environments.put_value(
             binding_locator.environment_index(),
             binding_locator.binding_index(),
             JsValue::Undefined,
@@ -105,7 +105,7 @@ impl Operation for DefLet {
     }
 }
 
-macro_rules! implement_declaritives {
+macro_rules! implement_declaratives {
     ($name:ident, $doc_string:literal) => {
         #[doc= concat!("`", stringify!($name), "` implements the OpCode Operation for `Opcode::", stringify!($name), "`\n")]
         #[doc= "\n"]
@@ -122,7 +122,7 @@ macro_rules! implement_declaritives {
                 let index = context.vm.read::<u32>();
                 let value = context.vm.pop();
                 let binding_locator = context.vm.frame().code_block.bindings[index as usize];
-                context.realm.environments.put_value(
+                context.vm.environments.put_value(
                     binding_locator.environment_index(),
                     binding_locator.binding_index(),
                     value,
@@ -133,6 +133,6 @@ macro_rules! implement_declaritives {
     };
 }
 
-implement_declaritives!(DefInitLet, "Declare and initialize `let` type variable");
-implement_declaritives!(DefInitConst, "Declare and initialize `const` type variable");
-implement_declaritives!(DefInitArg, "Declare and initialize function arguments");
+implement_declaratives!(DefInitLet, "Declare and initialize `let` type variable");
+implement_declaratives!(DefInitConst, "Declare and initialize `const` type variable");
+implement_declaratives!(DefInitArg, "Declare and initialize function arguments");

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -81,7 +81,7 @@ impl Operation for DeleteName {
 
         let deleted = if binding_locator.is_global()
             && !context
-                .realm
+                .vm
                 .environments
                 .binding_in_poisoned_environment(binding_locator.name())
         {
@@ -111,7 +111,7 @@ impl Operation for DeleteName {
             deleted
         } else {
             context
-                .realm
+                .vm
                 .environments
                 .get_value_optional(
                     binding_locator.environment_index(),

--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -17,7 +17,7 @@ impl Operation for This {
     const INSTRUCTION: &'static str = "INST - This";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let env = context.realm.environments.get_this_environment();
+        let env = context.vm.environments.get_this_environment();
         match env {
             EnvironmentSlots::Function(env) => {
                 let binding_result = match env.borrow().get_this_binding() {
@@ -28,7 +28,7 @@ impl Operation for This {
                 context.vm.push(function_binding);
             }
             EnvironmentSlots::Global => {
-                let this = context.realm.global_this();
+                let this = context.realm().global_this();
                 context.vm.push(this.clone());
             }
         }
@@ -50,7 +50,7 @@ impl Operation for Super {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let home_result = {
             let env = context
-                .realm
+                .vm
                 .environments
                 .get_this_environment()
                 .as_function_slots()
@@ -97,7 +97,7 @@ impl Operation for SuperCallPrepare {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let this_env = context
-            .realm
+            .vm
             .environments
             .get_this_environment()
             .as_function_slots()
@@ -159,7 +159,7 @@ impl Operation for SuperCall {
         let result = super_constructor.__construct__(&arguments, new_target, context)?;
 
         let this_env = context
-            .realm
+            .vm
             .environments
             .get_this_environment()
             .as_function_slots()
@@ -220,7 +220,7 @@ impl Operation for SuperCallSpread {
         let result = super_constructor.__construct__(&arguments, new_target, context)?;
 
         let this_env = context
-            .realm
+            .vm
             .environments
             .get_this_environment()
             .as_function_slots()
@@ -262,7 +262,7 @@ impl Operation for SuperCallDerived {
 
         let (new_target, active_function) = {
             let this_env = context
-                .realm
+                .vm
                 .environments
                 .get_this_environment()
                 .as_function_slots()
@@ -289,7 +289,7 @@ impl Operation for SuperCallDerived {
         let result = super_constructor.__construct__(&arguments, &new_target, context)?;
 
         let this_env = context
-            .realm
+            .vm
             .environments
             .get_this_environment()
             .as_function_slots()

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -92,7 +92,7 @@ impl Operation for AsyncGeneratorNext {
             .queue
             .pop_front()
             .expect("must have item in queue");
-        AsyncGenerator::complete_step(&next, completion, false, context);
+        AsyncGenerator::complete_step(&next, completion, false, None, context);
 
         let mut generator_object_mut = generator_object.borrow_mut();
         let gen = generator_object_mut

--- a/boa_engine/src/vm/opcode/iteration/iterator.rs
+++ b/boa_engine/src/vm/opcode/iteration/iterator.rs
@@ -106,7 +106,7 @@ impl Operation for IteratorUnwrapNextOrJump {
         if next_result.complete(context)? {
             context.vm.frame_mut().pc = address as usize;
             context.vm.frame_mut().dec_frame_env_stack();
-            context.realm.environments.pop();
+            context.vm.environments.pop();
             context.vm.push(true);
         } else {
             context.vm.push(false);

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -51,11 +51,11 @@ impl Operation for LoopContinue {
             .filter(|entry| entry.exit_address() == exit)
         {
             let env_truncation_len = context
-                .realm
+                .vm
                 .environments
                 .len()
                 .saturating_sub(entry.env_num());
-            context.realm.environments.truncate(env_truncation_len);
+            context.vm.environments.truncate(env_truncation_len);
 
             context.vm.frame_mut().env_stack.pop();
         }
@@ -92,8 +92,8 @@ impl Operation for LoopEnd {
             }
         }
 
-        let env_truncation_len = context.realm.environments.len().saturating_sub(envs_to_pop);
-        context.realm.environments.truncate(env_truncation_len);
+        let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
+        context.vm.environments.truncate(env_truncation_len);
 
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/pop/mod.rs
+++ b/boa_engine/src/vm/opcode/pop/mod.rs
@@ -55,7 +55,7 @@ impl Operation for PopEnvironment {
     const INSTRUCTION: &'static str = "INST - PopEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        context.realm.environments.pop();
+        context.vm.environments.pop();
         context.vm.frame_mut().dec_frame_env_stack();
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -21,7 +21,7 @@ impl Operation for PushDeclarativeEnvironment {
             [compile_environments_index as usize]
             .clone();
         context
-            .realm
+            .vm
             .environments
             .push_declarative(num_bindings as usize, compile_environment);
         context.vm.frame_mut().inc_frame_env_stack();
@@ -47,7 +47,7 @@ impl Operation for PushFunctionEnvironment {
             [compile_environments_index as usize]
             .clone();
         context
-            .realm
+            .vm
             .environments
             .push_function_inherit(num_bindings as usize, compile_environment);
         Ok(CompletionType::Normal)
@@ -69,7 +69,7 @@ impl Operation for PushObjectEnvironment {
         let object = context.vm.pop();
         let object = object.to_object(context)?;
 
-        context.realm.environments.push_object(object);
+        context.vm.environments.push_object(object);
         context.vm.frame_mut().inc_frame_env_stack();
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/new_target.rs
+++ b/boa_engine/src/vm/opcode/push/new_target.rs
@@ -15,20 +15,18 @@ impl Operation for PushNewTarget {
     const INSTRUCTION: &'static str = "INST - PushNewTarget";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        if let Some(env) = context
-            .realm
+        let new_target = if let Some(new_target) = context
+            .vm
             .environments
             .get_this_environment()
             .as_function_slots()
+            .and_then(|env| env.borrow().new_target().cloned())
         {
-            if let Some(new_target) = env.borrow().new_target() {
-                context.vm.push(new_target.clone());
-            } else {
-                context.vm.push(JsValue::undefined());
-            }
+            new_target.into()
         } else {
-            context.vm.push(JsValue::undefined());
-        }
+            JsValue::undefined()
+        };
+        context.vm.push(new_target);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_examples/src/bin/derive.rs
+++ b/boa_examples/src/bin/derive.rs
@@ -21,7 +21,6 @@ fn main() {
         hello: "World",
         my_float: 2.9,
     };
-    
     x;
     "#;
     let js = Source::from_bytes(js_str);


### PR DESCRIPTION
This Pull Request fixes #2317 and #1835, finally giving our engine proper realms 🥳.

It changes the following:

- Extracts the compile environment stack from `Realm` and into `Vm`.
- Adjusts the bytecompiler to accommodate this change.
- Adjusts `call/construct_internal` to accommodate this change. This also coincidentally fixed #2317, which I'm pretty happy about.
- Adjusts several APIs (`NativeJob`, `Realm`) and builtins (`eval`, initializers) to accommodate this change. 
- Adjusts `JsNativeError`s to hold a reference to the Realm from which they were created. This only affects errors created within calls to function objects. Native calls don't need to set the realm because it's inherited by the next outer active function object. TLDR: `JsError` API stays the same, we just set the origin Realm of errors in `JsObject::call/construct_internal`.
