### PR TITLE
[Merged by Bors] - Fix destructive for-of loop assignments

### DIFF
--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -33,6 +33,9 @@ pub struct CallFrame {
     // When an async generator is resumed, the generator object is needed
     // to fulfill the steps 4.e-j in [AsyncGeneratorStart](https://tc39.es/ecma262/#sec-asyncgeneratorstart).
     pub(crate) async_generator: Option<JsObject>,
+
+    // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
+    pub(crate) iterators: Vec<(JsObject, bool)>,
 }
 
 /// ---- `CallFrame` creation methods ----
@@ -52,6 +55,7 @@ impl CallFrame {
             arg_count: 0,
             generator_resume_kind: GeneratorResumeKind::Normal,
             async_generator: None,
+            iterators: Vec::new(),
         }
     }
 

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -2,14 +2,16 @@
 //!
 //! This module will provides everything needed to implement the `CallFrame`
 
-use crate::{object::JsObject, vm::CodeBlock};
-use boa_gc::{Finalize, Gc, Trace};
-
 mod abrupt_record;
 mod env_stack;
 
+use crate::{object::JsObject, vm::CodeBlock};
+use boa_gc::{Finalize, Gc, Trace};
+use thin_vec::ThinVec;
+
 pub(crate) use abrupt_record::AbruptCompletionRecord;
 pub(crate) use env_stack::EnvStackEntry;
+
 /// A `CallFrame` holds the state of a function call.
 #[derive(Clone, Debug, Finalize, Trace)]
 pub struct CallFrame {
@@ -35,7 +37,7 @@ pub struct CallFrame {
     pub(crate) async_generator: Option<JsObject>,
 
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
-    pub(crate) iterators: Vec<(JsObject, bool)>,
+    pub(crate) iterators: ThinVec<(JsObject, bool)>,
 }
 
 /// ---- `CallFrame` creation methods ----
@@ -55,7 +57,7 @@ impl CallFrame {
             arg_count: 0,
             generator_resume_kind: GeneratorResumeKind::Normal,
             async_generator: None,
-            iterators: Vec::new(),
+            iterators: ThinVec::new(),
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -448,9 +448,12 @@ impl CodeBlock {
             | Opcode::GetIterator
             | Opcode::GetAsyncIterator
             | Opcode::IteratorNext
+            | Opcode::IteratorNextSetDone
             | Opcode::IteratorUnwrapNext
             | Opcode::IteratorUnwrapValue
             | Opcode::IteratorToArray
+            | Opcode::IteratorClosePush
+            | Opcode::IteratorClosePop
             | Opcode::RequireObjectCoercible
             | Opcode::ValueNotNullOrUndefined
             | Opcode::RestParameterInit

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -502,9 +502,12 @@ impl CodeBlock {
                 | Opcode::GetIterator
                 | Opcode::GetAsyncIterator
                 | Opcode::IteratorNext
+                | Opcode::IteratorNextSetDone
                 | Opcode::IteratorUnwrapNext
                 | Opcode::IteratorUnwrapValue
                 | Opcode::IteratorToArray
+                | Opcode::IteratorClosePush
+                | Opcode::IteratorClosePop
                 | Opcode::RequireObjectCoercible
                 | Opcode::ValueNotNullOrUndefined
                 | Opcode::RestParameterInit

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -3,6 +3,7 @@ use crate::{
     vm::{call_frame::AbruptCompletionRecord, opcode::Operation, CompletionType},
     Context, JsError, JsNativeError, JsResult,
 };
+use thin_vec::ThinVec;
 
 /// `Throw` implements the Opcode Operation for `Opcode::Throw`
 ///
@@ -23,7 +24,7 @@ impl Operation for Throw {
         };
 
         // Close all iterators that are still open.
-        let mut iterators = Vec::new();
+        let mut iterators = ThinVec::new();
         std::mem::swap(&mut iterators, &mut context.vm.frame_mut().iterators);
         for (iterator, done) in iterators {
             if done {

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -1,4 +1,5 @@
 use crate::{
+    js_string,
     vm::{call_frame::AbruptCompletionRecord, opcode::Operation, CompletionType},
     Context, JsError, JsNativeError, JsResult,
 };
@@ -20,6 +21,20 @@ impl Operation for Throw {
         } else {
             JsError::from_opaque(context.vm.pop())
         };
+
+        // Close all iterators that are still open.
+        let mut iterators = Vec::new();
+        std::mem::swap(&mut iterators, &mut context.vm.frame_mut().iterators);
+        for (iterator, done) in iterators {
+            if done {
+                continue;
+            }
+            if let Ok(Some(f)) = iterator.get_method(js_string!("return"), context) {
+                drop(f.call(&iterator.into(), &[], context));
+            }
+        }
+        context.vm.err.take();
+
         // 1. Find the viable catch and finally blocks
         let current_address = context.vm.frame().pc;
         let viable_catch_candidates = context

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1423,6 +1423,14 @@ generate_impl! {
         /// Stack: iterator, next_method **=>** iterator, next_method, next_value
         IteratorNext,
 
+        /// Calls the `next` method of `iterator`, puts its return value on the stack
+        /// and sets the `[[Done]]` value of the iterator on the call frame.
+        ///
+        /// Operands:
+        ///
+        /// Stack: iterator, next_method **=>** iterator, next_method, next_value
+        IteratorNextSetDone,
+
         /// Gets the `value` and `done` properties of an iterator result.
         ///
         /// Stack: next_result **=>** done, next_value
@@ -1447,6 +1455,20 @@ generate_impl! {
         ///
         /// Stack: iterator, next_method **=>** iterator, next_method, array
         IteratorToArray,
+
+        /// Push an iterator to the call frame close iterator stack.
+        ///
+        /// Operands:
+        ///
+        /// Stack: iterator, next_method => iterator, next_method
+        IteratorClosePush,
+
+        /// Pop an iterator from the call frame close iterator stack.
+        ///
+        /// Operands:
+        ///
+        /// Stack:
+        IteratorClosePop,
 
         /// Concat multiple stack objects into a string.
         ///


### PR DESCRIPTION
This Pull Request changes the following:

- Fix the assignment of variables in destructive for-of initializers.
- Fix the environment handling in the compilation of `for-of/in` loops.
- Close iterators in destructive for-of loop assignments, when the code throws during the assignment.
