### PR TITLE
[Merged by Bors] - Implement `TryFromJs` for `JsObject` wrappers

### DIFF
--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -40,7 +40,7 @@ impl JsArray {
     /// This does not clone the fields of the array, it only does a shallow clone of the object.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_array() {
+        if object.is_array() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -3,7 +3,7 @@ use crate::{
     builtins::Array,
     error::JsNativeError,
     object::{JsFunction, JsObject, JsObjectType},
-    value::IntoOrUndefined,
+    value::{IntoOrUndefined, TryFromJs},
     Context, JsResult, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
@@ -399,3 +399,14 @@ impl Deref for JsArray {
 }
 
 impl JsObjectType for JsArray {}
+
+impl TryFromJs for JsArray {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not an Array object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -118,7 +118,7 @@ impl JsArrayBuffer {
     /// This does not clone the fields of the array buffer, it only does a shallow clone of the object.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_array_buffer() {
+        if object.is_array_buffer() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -6,6 +6,7 @@ use crate::{
     object::{
         internal_methods::get_prototype_from_constructor, JsObject, JsObjectType, ObjectData,
     },
+    value::TryFromJs,
     Context, JsResult, JsValue,
 };
 use boa_gc::{Finalize, Trace};
@@ -222,3 +223,14 @@ impl Deref for JsArrayBuffer {
 }
 
 impl JsObjectType for JsArrayBuffer {}
+
+impl TryFromJs for JsArrayBuffer {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not an ArrayBuffer object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -112,7 +112,7 @@ impl JsDataView {
     /// Create a new `JsDataView` object from an existing object.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_data_view() {
+        if object.is_data_view() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -6,6 +6,7 @@ use crate::{
         internal_methods::get_prototype_from_constructor, JsArrayBuffer, JsObject, JsObjectType,
         ObjectData,
     },
+    value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
 
@@ -485,3 +486,14 @@ impl Deref for JsDataView {
 }
 
 impl JsObjectType for JsDataView {}
+
+impl TryFromJs for JsDataView {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not an DataView object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -48,7 +48,7 @@ impl JsDate {
         Self { inner }
     }
 
-    /// Create a new `JsDataView` object from an existing object.
+    /// Create a new `JsDate` object from an existing object.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.is_date() {

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -51,7 +51,7 @@ impl JsDate {
     /// Create a new `JsDataView` object from an existing object.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_date() {
+        if object.is_date() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -1,7 +1,8 @@
 //! A Rust API wrapper for Boa's `Function` Builtin ECMAScript Object
 use crate::{
     object::{JsObject, JsObjectType},
-    JsValue,
+    value::TryFromJs,
+    Context, JsNativeError, JsResult, JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use std::ops::Deref;
@@ -52,3 +53,18 @@ impl Deref for JsFunction {
 }
 
 impl JsObjectType for JsFunction {}
+
+impl TryFromJs for JsFunction {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()).ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("object is not a function")
+                    .into()
+            }),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a Function object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -2,6 +2,7 @@
 use crate::{
     builtins::generator::{Generator, GeneratorState},
     object::{JsObject, JsObjectType, ObjectData},
+    value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
 
@@ -99,3 +100,14 @@ impl Deref for JsGenerator {
 }
 
 impl JsObjectType for JsGenerator {}
+
+impl TryFromJs for JsGenerator {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a Generator object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -35,7 +35,7 @@ impl JsGenerator {
     /// Create a `JsGenerator` from a regular expression `JsObject`
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_generator() {
+        if object.is_generator() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -170,7 +170,7 @@ impl JsMap {
     /// ```
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_map() {
+        if object.is_map() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -5,6 +5,7 @@ use crate::{
     error::JsNativeError,
     object::{JsFunction, JsMapIterator, JsObject, JsObjectType, ObjectData},
     string::utf16,
+    value::TryFromJs,
     Context, JsResult, JsValue,
 };
 
@@ -422,3 +423,14 @@ impl Deref for JsMap {
 }
 
 impl JsObjectType for JsMap {}
+
+impl TryFromJs for JsMap {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a Map object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsmap_iterator.rs
+++ b/boa_engine/src/object/builtins/jsmap_iterator.rs
@@ -20,7 +20,7 @@ impl JsMapIterator {
     /// Create a [`JsMapIterator`] from a [`JsObject`]. If object is not a `MapIterator`, throw `TypeError`
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_map_iterator() {
+        if object.is_map_iterator() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsmap_iterator.rs
+++ b/boa_engine/src/object/builtins/jsmap_iterator.rs
@@ -3,6 +3,7 @@ use crate::{
     builtins::map::MapIterator,
     error::JsNativeError,
     object::{JsObject, JsObjectType},
+    value::TryFromJs,
     Context, JsResult, JsValue,
 };
 
@@ -58,3 +59,14 @@ impl Deref for JsMapIterator {
 }
 
 impl JsObjectType for JsMapIterator {}
+
+impl TryFromJs for JsMapIterator {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a MapIterator object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jspromise.rs
+++ b/boa_engine/src/object/builtins/jspromise.rs
@@ -11,6 +11,7 @@ use crate::{
     },
     context::intrinsics::StandardConstructors,
     object::{JsObject, JsObjectType, ObjectData},
+    value::TryFromJs,
     Context, JsError, JsNativeError, JsResult, JsValue,
 };
 
@@ -243,13 +244,13 @@ impl JsPromise {
     /// # }
     /// ```
     #[inline]
-    pub fn from_object(object: JsObject) -> JsResult<JsPromise> {
+    pub fn from_object(object: JsObject) -> JsResult<Self> {
         if !object.is_promise() {
             return Err(JsNativeError::typ()
                 .with_message("`object` is not a Promise")
                 .into());
         }
-        Ok(JsPromise { inner: object })
+        Ok(Self { inner: object })
     }
 
     /// Resolves a `JsValue` into a `JsPromise`.
@@ -883,3 +884,14 @@ impl std::ops::Deref for JsPromise {
 }
 
 impl JsObjectType for JsPromise {}
+
+impl TryFromJs for JsPromise {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a Promise object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsproxy.rs
+++ b/boa_engine/src/object/builtins/jsproxy.rs
@@ -79,7 +79,7 @@ impl TryFromJs for JsProxy {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()
-                .with_message("value is not a TypedArray object")
+                .with_message("value is not a Proxy object")
                 .into()),
         }
     }

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -80,7 +80,7 @@ impl JsRegExp {
     /// Create a `JsRegExp` from a regular expression `JsObject`
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_regexp() {
+        if object.is_regexp() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -2,6 +2,7 @@
 use crate::{
     builtins::RegExp,
     object::{JsArray, JsObject, JsObjectType},
+    value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
 
@@ -279,3 +280,14 @@ impl Deref for JsRegExp {
 }
 
 impl JsObjectType for JsRegExp {}
+
+impl TryFromJs for JsRegExp {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a RegExp object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -144,7 +144,7 @@ impl JsSet {
     /// Utility: Creates `JsSet` from `JsObject`, if not a Set throw `TypeError`.
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_set() {
+        if object.is_set() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -7,6 +7,7 @@ use crate::{
     builtins::Set,
     error::JsNativeError,
     object::{JsFunction, JsObject, JsObjectType, JsSetIterator},
+    value::TryFromJs,
     Context, JsResult, JsValue,
 };
 
@@ -185,3 +186,14 @@ impl Deref for JsSet {
 }
 
 impl JsObjectType for JsSet {}
+
+impl TryFromJs for JsSet {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a Set object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jsset_iterator.rs
+++ b/boa_engine/src/object/builtins/jsset_iterator.rs
@@ -21,7 +21,7 @@ impl JsSetIterator {
     /// Create a `JsSetIterator` from a `JsObject`.
     /// If object is not a `SetIterator`, throw `TypeError`.
     pub fn from_object(object: JsObject) -> JsResult<Self> {
-        if object.borrow().is_set_iterator() {
+        if object.is_set_iterator() {
             Ok(Self { inner: object })
         } else {
             Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsset_iterator.rs
+++ b/boa_engine/src/object/builtins/jsset_iterator.rs
@@ -7,6 +7,7 @@ use crate::{
     builtins::set::SetIterator,
     error::JsNativeError,
     object::{JsObject, JsObjectType},
+    value::TryFromJs,
     Context, JsResult, JsValue,
 };
 
@@ -58,3 +59,14 @@ impl Deref for JsSetIterator {
 }
 
 impl JsObjectType for JsSetIterator {}
+
+impl TryFromJs for JsSetIterator {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a SetIterator object")
+                .into()),
+        }
+    }
+}

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::BuiltInConstructor,
     error::JsNativeError,
     object::{JsArrayBuffer, JsFunction, JsObject, JsObjectType},
-    value::IntoOrUndefined,
+    value::{IntoOrUndefined, TryFromJs},
     Context, JsResult, JsString, JsValue,
 };
 use boa_gc::{Finalize, Trace};
@@ -345,6 +345,17 @@ impl Deref for JsTypedArray {
 }
 
 impl JsObjectType for JsTypedArray {}
+
+impl TryFromJs for JsTypedArray {
+    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Self::from_object(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("value is not a TypedArray object")
+                .into()),
+        }
+    }
+}
 
 macro_rules! JsTypedArrayType {
     ($name:ident, $constructor_function:ident, $constructor_object:ident, $element:ty) => {

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -309,6 +309,17 @@ impl JsObject {
         self.borrow().is_array()
     }
 
+    /// Checks if it's a `DataView` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_data_view(&self) -> bool {
+        self.borrow().is_data_view()
+    }
+
     /// Checks if it is an `ArrayIterator` object.
     ///
     /// # Panics
@@ -463,6 +474,17 @@ impl JsObject {
         self.borrow().is_bigint()
     }
 
+    /// Checks if it's a `Date` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_date(&self) -> bool {
+        self.borrow().is_date()
+    }
+
     /// Checks if it's a `RegExp` object.
     ///
     /// # Panics
@@ -485,6 +507,94 @@ impl JsObject {
         self.borrow().is_typed_array()
     }
 
+    /// Checks if it's a `Uint8Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_uint8_array(&self) -> bool {
+        self.borrow().is_typed_uint8_array()
+    }
+
+    /// Checks if it's a `Int8Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_int8_array(&self) -> bool {
+        self.borrow().is_typed_int8_array()
+    }
+
+    /// Checks if it's a `Uint16Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_uint16_array(&self) -> bool {
+        self.borrow().is_typed_uint16_array()
+    }
+
+    /// Checks if it's a `Int16Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_int16_array(&self) -> bool {
+        self.borrow().is_typed_int16_array()
+    }
+
+    /// Checks if it's a `Uint32Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_uint32_array(&self) -> bool {
+        self.borrow().is_typed_uint32_array()
+    }
+
+    /// Checks if it's a `Int32Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_int32_array(&self) -> bool {
+        self.borrow().is_typed_int32_array()
+    }
+
+    /// Checks if it's a `Float32Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_float32_array(&self) -> bool {
+        self.borrow().is_typed_float32_array()
+    }
+
+    /// Checks if it's a `Float64Array` object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_typed_float64_array(&self) -> bool {
+        self.borrow().is_typed_float64_array()
+    }
+
     /// Checks if it's a `Promise` object.
     ///
     /// # Panics
@@ -505,6 +615,17 @@ impl JsObject {
     #[track_caller]
     pub fn is_ordinary(&self) -> bool {
         self.borrow().is_ordinary()
+    }
+
+    /// Checks if it's a proxy object.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the object is currently mutably borrowed.
+    #[inline]
+    #[track_caller]
+    pub fn is_proxy(&self) -> bool {
+        self.borrow().is_proxy()
     }
 
     /// Returns `true` if it holds an Rust type that implements `NativeObject`.

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -45,7 +45,7 @@ use crate::{
         set::ordered_set::OrderedSet,
         set::SetIterator,
         string::StringIterator,
-        typed_array::integer_indexed_object::IntegerIndexed,
+        typed_array::{integer_indexed_object::IntegerIndexed, TypedArrayKind},
         DataView, Date, Promise, RegExp,
     },
     js_string,
@@ -1427,6 +1427,118 @@ impl Object {
                 ..
             }
         )
+    }
+
+    /// Checks if it a `Uint8Array` object.
+    #[inline]
+    pub const fn is_typed_uint8_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Uint8)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Int8Array` object.
+    #[inline]
+    pub const fn is_typed_int8_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Int8)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Uint16Array` object.
+    #[inline]
+    pub const fn is_typed_uint16_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Uint16)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Int16Array` object.
+    #[inline]
+    pub const fn is_typed_int16_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Int16)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Uint32Array` object.
+    #[inline]
+    pub const fn is_typed_uint32_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Uint32)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Int32Array` object.
+    #[inline]
+    pub const fn is_typed_int32_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Int32)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Float32Array` object.
+    #[inline]
+    pub const fn is_typed_float32_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Float32)
+        } else {
+            false
+        }
+    }
+
+    /// Checks if it a `Float64Array` object.
+    #[inline]
+    pub const fn is_typed_float64_array(&self) -> bool {
+        if let ObjectData {
+            kind: ObjectKind::IntegerIndexed(ref int),
+            ..
+        } = self.data
+        {
+            matches!(int.typed_array_name(), TypedArrayKind::Float64)
+        } else {
+            false
+        }
     }
 
     /// Gets the data view data if the object is a `DataView`.

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -320,8 +320,9 @@ impl JsObject {
     ) -> JsResult<JsValue> {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         // 2. If IsCallable(F) is false, throw a TypeError exception.
-        let function = JsFunction::from_object(self.clone())
-            .ok_or_else(|| JsNativeError::typ().with_message("object is not a function"))?;
+        let function = JsFunction::from_object(self.clone()).ok_or_else(|| {
+            JsNativeError::typ().with_message("only callable objects / functions can be called")
+        })?;
 
         // 3. Return ? F.[[Call]](V, argumentsList).
         function.__call__(this, args, context)

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -300,13 +300,16 @@ impl JsObject {
         Ok(desc.is_some())
     }
 
-    /// Call this object.
+    /// `Call ( F, V [ , argumentsList ] )`
     ///
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
-    // <https://tc39.es/ecma262/#sec-prepareforordinarycall>
-    // <https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist>
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-call
     #[track_caller]
     #[inline]
     pub fn call(
@@ -318,7 +321,7 @@ impl JsObject {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         // 2. If IsCallable(F) is false, throw a TypeError exception.
         let function = JsFunction::from_object(self.clone())
-            .ok_or_else(|| JsNativeError::typ().with_message("not a function"))?;
+            .ok_or_else(|| JsNativeError::typ().with_message("object is not a function"))?;
 
         // 3. Return ? F.[[Call]](V, argumentsList).
         function.__call__(this, args, context)


### PR DESCRIPTION
This change allows using built-in `JsObject` wrappers with the `TryFromJs` logic, which makes it easier to derive it in complex objects containing known built-ins, being able to use all the power of the wrappers even inside complex structures.

It changes the following:

 * Implements `TryFromJs` for all `JsObject` wrappers ~, except for `JsProxy` and `Js<Int>Array` wrappers~ -> This has now been added.
 *  Adds checker functions for individual typed array objects.
 * Adds some missing checker functions from `Object` to `JsObject`

~The reason for not implementing it for `JsProxy` is that we don't have a way (as far as I can tell) to know if a `JsObject` is a `Proxy` object. The reason for the typed arrays (note that `JsTypedArray` implements `TryFromJs`) is that I didn't find an easy way to know which type of typed array a `JsObject` was. Do we have a way of using a `JsObject` to create a Rust `JsUint8Array` or the like?~
