### PR TITLE
[Merged by Bors] - Make the `wasmbind` feature of the `chrono` crate optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -560,6 +560,7 @@ name = "boa_wasm"
 version = "0.16.0"
 dependencies = [
  "boa_engine",
+ "chrono",
  "getrandom",
  "wasm-bindgen",
 ]

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -42,6 +42,9 @@ console = []
 # Enable Boa's additional ECMAScript features for web browsers.
 annex-b = []
 
+# Enables the wasmbind dependency of the `chrono` crate.
+wasmbind = ["chrono/wasmbind"]
+
 [dependencies]
 boa_interner.workspace = true
 boa_gc = { workspace = true, features = [ "thinvec" ] }
@@ -60,7 +63,7 @@ num-integer = "0.1.45"
 bitflags = "2.1.0"
 indexmap = "1.9.3"
 ryu-js = "0.2.2"
-chrono = { version = "0.4.24", default-features = false, features = ["clock", "std", "wasmbind"] }
+chrono = { version = "0.4.24", default-features = false, features = ["clock", "std"] }
 fast-float = "0.2.0"
 unicode-normalization = "0.1.22"
 once_cell = "1.17.1"

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -42,9 +42,6 @@ console = []
 # Enable Boa's additional ECMAScript features for web browsers.
 annex-b = []
 
-# Enables the wasmbind dependency of the `chrono` crate.
-wasmbind = ["chrono/wasmbind"]
-
 [dependencies]
 boa_interner.workspace = true
 boa_gc = { workspace = true, features = [ "thinvec" ] }

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -45,9 +45,6 @@
 //!  - **console** - Enables `boa`'s [WHATWG `console`][whatwg] object implementation.
 //!  - **profiler** - Enables profiling with measureme (this is mostly internal).
 //!  - **intl** - Enables `boa`'s [ECMA-402 Internationalization API][ecma-402] (`Intl` object)
-//!  - **wasmbind** - Enables the `wasmbind` feature in the `chrono` crate, to enable retrieving
-//!    real-time clocks in web browsers. Note that enabling this feature can make build fail if
-//!    `wasm-bindgen` is not available in a Webassembly platform.
 //!
 //! # Boa Crates
 //!  - **`boa_ast`** - Boa's ECMAScript Abstract Syntax Tree.

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -45,6 +45,9 @@
 //!  - **console** - Enables `boa`'s [WHATWG `console`][whatwg] object implementation.
 //!  - **profiler** - Enables profiling with measureme (this is mostly internal).
 //!  - **intl** - Enables `boa`'s [ECMA-402 Internationalization API][ecma-402] (`Intl` object)
+//!  - **wasmbind** - Enables the `wasmbind` feature in the `chrono` crate, to enable retrieving
+//!    real-time clocks in web browsers. Note that enabling this feature can make build fail if
+//!    `wasm-bindgen` is not available in a Webassembly platform.
 //!
 //! # Boa Crates
 //!  - **`boa_ast`** - Boa's ECMAScript Abstract Syntax Tree.

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["console", "annex-b"] }
+boa_engine = { workspace = true, features = ["console", "annex-b", "wasmbind"] }
 wasm-bindgen = "0.2.84"
 getrandom = { version = "0.2.9", features = ["js"] }
 

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -12,9 +12,10 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["console", "annex-b", "wasmbind"] }
+boa_engine = { workspace = true, features = ["console", "annex-b"] }
 wasm-bindgen = "0.2.84"
 getrandom = { version = "0.2.9", features = ["js"] }
+chrono = { version = "0.4.24", features = ["clock", "std", "wasmbind"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -58,6 +58,7 @@
 )]
 
 use boa_engine::{Context, Source};
+use chrono as _;
 use getrandom as _;
 use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
This Pull Request fixes/closes #2475.

It changes the following:

- Do not use the `wasmbind` feature by default in the `chrono` crate. This can be enabled selectively if needed.
- Updated the `boa_wasm` crate to use this new approach.

I'm interested on knowing if this fixes @lastmjs's issue, and on checking with the team if this is the best approach to solve it.