### PR TITLE
[Merged by Bors] - Implement HTML comments and gate behind the `annex-b` feature

### DIFF
--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -40,7 +40,7 @@ trace = []
 console = []
 
 # Enable Boa's additional ECMAScript features for web browsers.
-annex-b = []
+annex-b = ["boa_parser/annex-b"]
 
 [dependencies]
 boa_interner.workspace = true

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -614,10 +614,9 @@ impl BuiltInFunctionObject {
             } else {
                 let mut parameters = Vec::with_capacity(args.len());
                 for arg in args {
-                    parameters.push(arg.to_string(context)?.as_slice().to_owned());
+                    parameters.push(arg.to_string(context)?);
                 }
-                let mut parameters = parameters.join(utf16!(","));
-                parameters.push(u16::from(b')'));
+                let parameters = parameters.join(utf16!(","));
 
                 // TODO: make parser generic to u32 iterators
                 let parameters =

--- a/boa_parser/Cargo.toml
+++ b/boa_parser/Cargo.toml
@@ -22,3 +22,6 @@ num-traits = "0.2.15"
 bitflags = "2.1.0"
 num-bigint = "0.4.3"
 regress = "0.5.0"
+
+[features]
+annex-b = []

--- a/boa_parser/src/lexer/comment.rs
+++ b/boa_parser/src/lexer/comment.rs
@@ -6,6 +6,8 @@ use boa_interner::Interner;
 use boa_profiler::Profiler;
 use std::io::Read;
 
+use super::is_whitespace;
+
 /// Lexes a single line comment.
 ///
 /// Assumes that the initial '//' is already consumed.
@@ -46,24 +48,28 @@ impl<R> Tokenizer<R> for SingleLineComment {
     }
 }
 
-/// Lexes a block (multi-line) comment.
+/// Lexes a delimited (`/* */`) comment.
 ///
 /// Assumes that the initial '/*' is already consumed.
+///
+/// If `multiline` is `true`, this is equivalent to the [`MultiLineComment`][mlc] token
+/// from the spec. Otherwise, it is equivalent to the [`SingleLineDelimitedComment`][sldc] token,
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
 ///  - [MDN documentation][mdn]
 ///
-/// [spec]: https://tc39.es/ecma262/#sec-comments
+/// [mlc]: https://tc39.es/ecma262/#prod-MultiLineComment
+/// [sldc]: https://tc39.es/ecma262/#prod-annexB-SingleLineDelimitedComment
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
-pub(super) struct MultiLineComment;
+pub(super) struct DelimitedComment;
 
-impl<R> Tokenizer<R> for MultiLineComment {
+impl<R> Tokenizer<R> for DelimitedComment {
     fn lex(
         &mut self,
         cursor: &mut Cursor<R>,
         start_pos: Position,
-        _interner: &mut Interner,
+        interner: &mut Interner,
     ) -> Result<Token, Error>
     where
         R: Read,
@@ -77,6 +83,7 @@ impl<R> Tokenizer<R> for MultiLineComment {
                 Ok(c) if c == '*' && cursor.next_is(b'/')? => {
                     return Ok(Token::new(
                         if new_line {
+                            HTMLCloseComment.lex(cursor, start_pos, interner)?;
                             TokenKind::LineTerminator
                         } else {
                             TokenKind::Comment
@@ -98,7 +105,7 @@ impl<R> Tokenizer<R> for MultiLineComment {
     }
 }
 
-///Lexes a first line Hashbang comment
+/// Lexes a first line Hashbang comment
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
@@ -126,6 +133,66 @@ impl<R> Tokenizer<R> for HashbangComment {
                 _ => {}
             };
         }
+
+        Ok(Token::new(
+            TokenKind::Comment,
+            Span::new(start_pos, cursor.pos()),
+        ))
+    }
+}
+
+/// Lexes a single line HTML close comment
+///
+/// More information:
+///  - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-html-like-comments
+pub(super) struct HTMLCloseComment;
+
+impl<R> Tokenizer<R> for HTMLCloseComment {
+    fn lex(
+        &mut self,
+        cursor: &mut Cursor<R>,
+        start_pos: Position,
+        interner: &mut Interner,
+    ) -> Result<Token, Error>
+    where
+        R: Read,
+    {
+        let _timer = Profiler::global().start_event("HTML close", "Lexing");
+
+        while cursor.peek_char()?.map_or(false, is_whitespace) {
+            let _next = cursor.next_char();
+        }
+
+        while cursor.peek_n(2)? == [b'/', b'*'] {
+            let _next = cursor.next_byte();
+            let _next = cursor.next_byte();
+
+            let start = cursor.pos();
+            let comment = DelimitedComment.lex(cursor, start, interner)?;
+            if comment.kind() == &TokenKind::LineTerminator {
+                return Ok(comment)
+            }
+
+            while cursor.peek_char()?.map_or(false, is_whitespace) {
+                let _next = cursor.next_char();
+            }
+        }
+
+        if cursor.peek_n(3)? != [b'-', b'-', b'>'] {
+            return Ok(Token::new(
+                TokenKind::Comment,
+                Span::new(start_pos, cursor.pos()),
+            ));
+        }
+
+        let _next = cursor.next_byte();
+        let _next = cursor.next_byte();
+        let _next = cursor.next_byte();
+
+        let start = cursor.pos();
+        SingleLineComment.lex(cursor, start, interner)?;
 
         Ok(Token::new(
             TokenKind::Comment,

--- a/boa_parser/src/lexer/comment.rs
+++ b/boa_parser/src/lexer/comment.rs
@@ -6,8 +6,6 @@ use boa_interner::Interner;
 use boa_profiler::Profiler;
 use std::io::Read;
 
-use super::is_whitespace;
-
 /// Lexes a single line comment.
 ///
 /// Assumes that the initial '//' is already consumed.
@@ -48,28 +46,24 @@ impl<R> Tokenizer<R> for SingleLineComment {
     }
 }
 
-/// Lexes a delimited (`/* */`) comment.
+/// Lexes a block (multi-line) comment.
 ///
 /// Assumes that the initial '/*' is already consumed.
-///
-/// If `multiline` is `true`, this is equivalent to the [`MultiLineComment`][mlc] token
-/// from the spec. Otherwise, it is equivalent to the [`SingleLineDelimitedComment`][sldc] token,
 ///
 /// More information:
 ///  - [ECMAScript reference][spec]
 ///  - [MDN documentation][mdn]
 ///
-/// [mlc]: https://tc39.es/ecma262/#prod-MultiLineComment
-/// [sldc]: https://tc39.es/ecma262/#prod-annexB-SingleLineDelimitedComment
+/// [spec]: https://tc39.es/ecma262/#sec-comments
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
-pub(super) struct DelimitedComment;
+pub(super) struct MultiLineComment;
 
-impl<R> Tokenizer<R> for DelimitedComment {
+impl<R> Tokenizer<R> for MultiLineComment {
     fn lex(
         &mut self,
         cursor: &mut Cursor<R>,
         start_pos: Position,
-        interner: &mut Interner,
+        _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
         R: Read,
@@ -83,7 +77,6 @@ impl<R> Tokenizer<R> for DelimitedComment {
                 Ok(c) if c == '*' && cursor.next_is(b'/')? => {
                     return Ok(Token::new(
                         if new_line {
-                            HTMLCloseComment.lex(cursor, start_pos, interner)?;
                             TokenKind::LineTerminator
                         } else {
                             TokenKind::Comment
@@ -133,66 +126,6 @@ impl<R> Tokenizer<R> for HashbangComment {
                 _ => {}
             };
         }
-
-        Ok(Token::new(
-            TokenKind::Comment,
-            Span::new(start_pos, cursor.pos()),
-        ))
-    }
-}
-
-/// Lexes a single line HTML close comment
-///
-/// More information:
-///  - [ECMAScript reference][spec]
-///
-/// [spec]: https://tc39.es/ecma262/#sec-html-like-comments
-pub(super) struct HTMLCloseComment;
-
-impl<R> Tokenizer<R> for HTMLCloseComment {
-    fn lex(
-        &mut self,
-        cursor: &mut Cursor<R>,
-        start_pos: Position,
-        interner: &mut Interner,
-    ) -> Result<Token, Error>
-    where
-        R: Read,
-    {
-        let _timer = Profiler::global().start_event("HTML close", "Lexing");
-
-        while cursor.peek_char()?.map_or(false, is_whitespace) {
-            let _next = cursor.next_char();
-        }
-
-        while cursor.peek_n(2)? == [b'/', b'*'] {
-            let _next = cursor.next_byte();
-            let _next = cursor.next_byte();
-
-            let start = cursor.pos();
-            let comment = DelimitedComment.lex(cursor, start, interner)?;
-            if comment.kind() == &TokenKind::LineTerminator {
-                return Ok(comment)
-            }
-
-            while cursor.peek_char()?.map_or(false, is_whitespace) {
-                let _next = cursor.next_char();
-            }
-        }
-
-        if cursor.peek_n(3)? != [b'-', b'-', b'>'] {
-            return Ok(Token::new(
-                TokenKind::Comment,
-                Span::new(start_pos, cursor.pos()),
-            ));
-        }
-
-        let _next = cursor.next_byte();
-        let _next = cursor.next_byte();
-        let _next = cursor.next_byte();
-
-        let start = cursor.pos();
-        SingleLineComment.lex(cursor, start, interner)?;
 
         Ok(Token::new(
             TokenKind::Comment,

--- a/boa_parser/src/lexer/cursor.rs
+++ b/boa_parser/src/lexer/cursor.rs
@@ -8,7 +8,8 @@ use std::io::{self, Bytes, Error, ErrorKind, Read};
 pub(super) struct Cursor<R> {
     iter: InnerIter<R>,
     pos: Position,
-    strict_mode: bool,
+    module: bool,
+    strict: bool,
 }
 
 impl<R> Cursor<R> {
@@ -31,13 +32,24 @@ impl<R> Cursor<R> {
     }
 
     /// Returns if strict mode is currently active.
-    pub(super) const fn strict_mode(&self) -> bool {
-        self.strict_mode
+    pub(super) const fn strict(&self) -> bool {
+        self.strict
     }
 
     /// Sets the current strict mode.
-    pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
-        self.strict_mode = strict_mode;
+    pub(super) fn set_strict(&mut self, strict: bool) {
+        self.strict = strict;
+    }
+
+    /// Returns if the module mode is currently active.
+    pub(super) const fn module(&self) -> bool {
+        self.module
+    }
+
+    /// Sets the current goal symbol to module.
+    pub(super) fn set_module(&mut self, module: bool) {
+        self.module = module;
+        self.strict = module;
     }
 }
 
@@ -50,7 +62,8 @@ where
         Self {
             iter: InnerIter::new(inner.bytes()),
             pos: Position::new(1, 1),
-            strict_mode: false,
+            strict: false,
+            module: false,
         }
     }
 
@@ -59,7 +72,8 @@ where
         Self {
             iter: InnerIter::new(inner.bytes()),
             pos,
-            strict_mode: false,
+            strict: false,
+            module: false,
         }
     }
 

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -30,7 +30,7 @@ mod template;
 mod tests;
 
 use self::{
-    comment::{HashbangComment, MultiLineComment, SingleLineComment},
+    comment::{DelimitedComment, HTMLCloseComment, HashbangComment, SingleLineComment},
     cursor::Cursor,
     identifier::Identifier,
     number::NumberLiteral,
@@ -71,23 +71,6 @@ pub struct Lexer<R> {
 }
 
 impl<R> Lexer<R> {
-    /// Checks if a character is whitespace as per ECMAScript standards.
-    ///
-    /// The Rust `char::is_whitespace` function and the ECMAScript standard use different sets of
-    /// characters as whitespaces:
-    ///  * Rust uses `\p{White_Space}`,
-    ///  * ECMAScript standard uses `\{Space_Separator}` + `\u{0009}`, `\u{000B}`, `\u{000C}`, `\u{FEFF}`
-    ///
-    /// [More information](https://tc39.es/ecma262/#table-32)
-    const fn is_whitespace(ch: u32) -> bool {
-        matches!(
-            ch,
-            0x0020 | 0x0009 | 0x000B | 0x000C | 0x00A0 | 0xFEFF |
-            // Unicode Space_Seperator category (minus \u{0020} and \u{00A0} which are allready stated above)
-            0x1680 | 0x2000..=0x200A | 0x202F | 0x205F | 0x3000
-        )
-    }
-
     /// Sets the goal symbol for the lexer.
     pub(crate) fn set_goal(&mut self, elm: InputElement) {
         self.goal_symbol = elm;
@@ -99,13 +82,23 @@ impl<R> Lexer<R> {
     }
 
     /// Returns if strict mode is currently active.
-    pub(super) const fn strict_mode(&self) -> bool {
-        self.cursor.strict_mode()
+    pub(super) const fn strict(&self) -> bool {
+        self.cursor.strict()
     }
 
     /// Sets the current strict mode.
-    pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
-        self.cursor.set_strict_mode(strict_mode);
+    pub(super) fn set_strict(&mut self, strict: bool) {
+        self.cursor.set_strict(strict);
+    }
+
+    /// Returns if module mode is currently active.
+    pub(super) const fn module(&self) -> bool {
+        self.cursor.module()
+    }
+
+    /// Signals that the goal symbol is a module
+    pub(super) fn set_module(&mut self, module: bool) {
+        self.cursor.set_module(module);
     }
 
     /// Creates a new lexer.
@@ -144,7 +137,7 @@ impl<R> Lexer<R> {
                 }
                 b'*' => {
                     self.cursor.next_byte()?.expect("* token vanished"); // Consume the '*'
-                    MultiLineComment.lex(&mut self.cursor, start, interner)
+                    DelimitedComment.lex(&mut self.cursor, start, interner)
                 }
                 ch => {
                     match self.get_goal() {
@@ -197,7 +190,7 @@ impl<R> Lexer<R> {
             let start = self.cursor.pos();
             if let Some(next_ch) = self.cursor.next_char()? {
                 // Ignore whitespace
-                if !Self::is_whitespace(next_ch) {
+                if !is_whitespace(next_ch) {
                     break (start, next_ch);
                 }
             } else {
@@ -218,10 +211,12 @@ impl<R> Lexer<R> {
 
         if let Ok(c) = char::try_from(next_ch) {
             let token = match c {
-                '\r' | '\n' | '\u{2028}' | '\u{2029}' => Ok(Token::new(
-                    TokenKind::LineTerminator,
-                    Span::new(start, self.cursor.pos()),
-                )),
+                '\r' | '\n' | '\u{2028}' | '\u{2029}' => {
+                    let end = self.cursor.pos();
+                    HTMLCloseComment.lex(&mut self.cursor, start, interner)?;
+
+                    Ok(Token::new(TokenKind::LineTerminator, Span::new(start, end)))
+                }
                 '"' | '\'' => StringLiteral::new(c).lex(&mut self.cursor, start, interner),
                 '`' => TemplateLiteral.lex(&mut self.cursor, start, interner),
                 ';' => Ok(Token::new(
@@ -269,6 +264,14 @@ impl<R> Lexer<R> {
                 )),
                 '#' => PrivateIdentifier::new().lex(&mut self.cursor, start, interner),
                 '/' => self.lex_slash_token(start, interner),
+                #[cfg(feature = "annex-b")]
+                '<' if !self.module() && self.cursor.peek_n(3)? == [b'!', b'-', b'-'] => {
+                    let _next = self.cursor.next_byte();
+                    let _next = self.cursor.next_byte();
+                    let _next = self.cursor.next_byte();
+                    let start = self.cursor.pos();
+                    SingleLineComment.lex(&mut self.cursor, start, interner)
+                }
                 #[allow(clippy::cast_possible_truncation)]
                 '=' | '*' | '+' | '-' | '%' | '|' | '&' | '^' | '<' | '>' | '!' | '~' | '?' => {
                     Operator::new(next_ch as u8).lex(&mut self.cursor, start, interner)
@@ -338,4 +341,21 @@ impl Default for InputElement {
     fn default() -> Self {
         Self::RegExp
     }
+}
+
+/// Checks if a character is whitespace as per ECMAScript standards.
+///
+/// The Rust `char::is_whitespace` function and the ECMAScript standard use different sets of
+/// characters as whitespaces:
+///  * Rust uses `\p{White_Space}`,
+///  * ECMAScript standard uses `\{Space_Separator}` + `\u{0009}`, `\u{000B}`, `\u{000C}`, `\u{FEFF}`
+///
+/// [More information](https://tc39.es/ecma262/#table-32)
+const fn is_whitespace(ch: u32) -> bool {
+    matches!(
+        ch,
+        0x0020 | 0x0009 | 0x000B | 0x000C | 0x00A0 | 0xFEFF |
+            // Unicode Space_Seperator category (minus \u{0020} and \u{00A0} which are allready stated above)
+            0x1680 | 0x2000..=0x200A | 0x202F | 0x205F | 0x3000
+    )
 }

--- a/boa_parser/src/lexer/number.rs
+++ b/boa_parser/src/lexer/number.rs
@@ -255,7 +255,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
                         let ch = char::from(byte);
                         if ch.is_digit(8) {
                             // LegacyOctalIntegerLiteral, or a number with leading 0s.
-                            if cursor.strict_mode() {
+                            if cursor.strict() {
                                 // LegacyOctalIntegerLiteral is forbidden with strict mode true.
                                 return Err(Error::syntax(
                                     "implicit octal literals are not allowed in strict mode",
@@ -278,7 +278,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
                             // Indicates a numerical digit comes after then 0 but it isn't an octal digit
                             // so therefore this must be a number with an unneeded leading 0. This is
                             // forbidden in strict mode.
-                            if cursor.strict_mode() {
+                            if cursor.strict() {
                                 return Err(Error::syntax(
                                     "leading 0's are not allowed in strict mode",
                                     start_pos,

--- a/boa_parser/src/lexer/string.rs
+++ b/boa_parser/src/lexer/string.rs
@@ -116,7 +116,7 @@ impl StringLiteral {
         cursor: &mut Cursor<R>,
         start_pos: Position,
         terminator: StringTerminator,
-        is_strict_mode: bool,
+        strict: bool,
     ) -> Result<(Vec<u16>, Span, Option<EscapeSequence>), Error>
     where
         R: Read,
@@ -139,7 +139,7 @@ impl StringLiteral {
                         Self::take_escape_sequence_or_line_continuation(
                             cursor,
                             ch_start_pos,
-                            is_strict_mode,
+                            strict,
                             false,
                         )?
                     {
@@ -167,7 +167,7 @@ impl StringLiteral {
     pub(super) fn take_escape_sequence_or_line_continuation<R>(
         cursor: &mut Cursor<R>,
         start_pos: Position,
-        is_strict_mode: bool,
+        strict: bool,
         is_template_literal: bool,
     ) -> Result<Option<(u32, Option<EscapeSequence>)>, Error>
     where
@@ -208,7 +208,7 @@ impl StringLiteral {
                         "\\8 and \\9 are not allowed in template literal",
                         start_pos,
                     ));
-                } else if is_strict_mode {
+                } else if strict {
                     return Err(Error::syntax(
                         "\\8 and \\9 are not allowed in strict mode",
                         start_pos,
@@ -224,7 +224,7 @@ impl StringLiteral {
                     ));
                 }
 
-                if is_strict_mode {
+                if strict {
                     return Err(Error::syntax(
                         "octal escape sequences are not allowed in strict mode",
                         start_pos,

--- a/boa_parser/src/lexer/string.rs
+++ b/boa_parser/src/lexer/string.rs
@@ -89,7 +89,7 @@ impl<R> Tokenizer<R> for StringLiteral {
         let _timer = Profiler::global().start_event("StringLiteral", "Lexing");
 
         let (lit, span, escape_sequence) =
-            Self::take_string_characters(cursor, start_pos, self.terminator, cursor.strict_mode())?;
+            Self::take_string_characters(cursor, start_pos, self.terminator, cursor.strict())?;
 
         Ok(Token::new(
             TokenKind::string_literal(interner.get_or_intern(&lit[..]), escape_sequence),

--- a/boa_parser/src/lexer/tests.rs
+++ b/boa_parser/src/lexer/tests.rs
@@ -1048,7 +1048,7 @@ fn string_legacy_octal_escape() {
     for (s, _) in &test_cases {
         let mut lexer = Lexer::new(s.as_bytes());
         let interner = &mut Interner::default();
-        lexer.set_strict_mode(true);
+        lexer.set_strict(true);
 
         if let Error::Syntax(_, pos) = lexer
             .next(interner)
@@ -1096,7 +1096,7 @@ fn string_non_octal_decimal_escape() {
     for (s, _) in &test_cases {
         let mut lexer = Lexer::new(s.as_bytes());
         let interner = &mut Interner::default();
-        lexer.set_strict_mode(true);
+        lexer.set_strict(true);
 
         if let Error::Syntax(_, pos) = lexer
             .next(interner)

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -132,10 +132,13 @@ where
                 // We don't want to have multiple contiguous line terminators in the buffer, since
                 // they have no meaning.
                 let next = loop {
-                    let next = self.lexer.next(interner)?;
+                    self.lexer.skip_html_close(interner)?;
+                    let next = self.lexer.next_no_skip(interner)?;
                     if let Some(ref token) = next {
-                        if token.kind() != &TokenKind::LineTerminator {
-                            break next;
+                        match token.kind() {
+                            TokenKind::LineTerminator => { /* skip */ }
+                            TokenKind::Comment => self.lexer.skip_html_close(interner)?,
+                            _ => break next,
                         }
                     } else {
                         break None;

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -100,12 +100,12 @@ where
             .map_err(Error::from)
     }
 
-    pub(super) const fn strict_mode(&self) -> bool {
+    pub(super) const fn strict(&self) -> bool {
         self.lexer.strict()
     }
 
-    pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
-        self.lexer.set_strict(strict_mode);
+    pub(super) fn set_strict(&mut self, strict: bool) {
+        self.lexer.set_strict(strict);
     }
 
     pub(super) const fn module(&self) -> bool {

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -101,11 +101,19 @@ where
     }
 
     pub(super) const fn strict_mode(&self) -> bool {
-        self.lexer.strict_mode()
+        self.lexer.strict()
     }
 
     pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
-        self.lexer.set_strict_mode(strict_mode);
+        self.lexer.set_strict(strict_mode);
+    }
+
+    pub(super) const fn module(&self) -> bool {
+        self.lexer.module()
+    }
+
+    pub(super) fn set_module(&mut self, module: bool) {
+        self.lexer.set_module(module);
     }
 
     /// Fills the peeking buffer with the next token.

--- a/boa_parser/src/parser/cursor/mod.rs
+++ b/boa_parser/src/parser/cursor/mod.rs
@@ -112,13 +112,13 @@ where
     }
 
     /// Gets the current strict mode for the cursor.
-    pub(super) const fn strict_mode(&self) -> bool {
-        self.buffered_lexer.strict_mode()
+    pub(super) const fn strict(&self) -> bool {
+        self.buffered_lexer.strict()
     }
 
     /// Sets the strict mode to strict or non-strict.
-    pub(super) fn set_strict_mode(&mut self, strict_mode: bool) {
-        self.buffered_lexer.set_strict_mode(strict_mode);
+    pub(super) fn set_strict(&mut self, strict: bool) {
+        self.buffered_lexer.set_strict(strict);
     }
 
     /// Returns if the cursor is currently in an arrow function declaration.

--- a/boa_parser/src/parser/cursor/mod.rs
+++ b/boa_parser/src/parser/cursor/mod.rs
@@ -36,9 +36,6 @@ pub(super) struct Cursor<R> {
 
     /// Indicate if the cursor is used in `JSON.parse`.
     json_parse: bool,
-
-    /// Indicate if the cursor's **goal symbol** is a Module.
-    module: bool,
 }
 
 impl<R> Cursor<R>
@@ -53,19 +50,18 @@ where
             private_environment_root_index: 0,
             arrow: false,
             json_parse: false,
-            module: false,
         }
     }
 
     /// Sets the goal symbol of the cursor to `Module`.
     #[allow(unused)]
-    pub(super) fn set_module_mode(&mut self) {
-        self.module = true;
+    pub(super) fn set_module(&mut self) {
+        self.buffered_lexer.set_module(true);
     }
 
     /// Returns `true` if the cursor is currently parsing a `Module`.
-    pub(super) const fn module_mode(&self) -> bool {
-        self.module
+    pub(super) const fn module(&self) -> bool {
+        self.buffered_lexer.module()
     }
 
     pub(super) fn set_goal(&mut self, elm: InputElement) {

--- a/boa_parser/src/parser/expression/assignment/mod.rs
+++ b/boa_parser/src/parser/expression/assignment/mod.rs
@@ -240,8 +240,7 @@ where
                     cursor.advance(interner);
                     cursor.set_goal(InputElement::RegExp);
 
-                    if let Some(target) = AssignTarget::from_expression(&lhs, cursor.strict_mode())
-                    {
+                    if let Some(target) = AssignTarget::from_expression(&lhs, cursor.strict()) {
                         if let AssignTarget::Identifier(ident) = target {
                             self.name = Some(ident);
                         }
@@ -257,7 +256,7 @@ where
                 TokenKind::Punctuator(p) if p.as_assign_op().is_some() => {
                     cursor.advance(interner);
                     if let Some(target) =
-                        AssignTarget::from_expression_simple(&lhs, cursor.strict_mode())
+                        AssignTarget::from_expression_simple(&lhs, cursor.strict())
                     {
                         let assignop = p.as_assign_op().expect("assignop disappeared");
                         if assignop == AssignOp::BoolAnd

--- a/boa_parser/src/parser/expression/identifiers.rs
+++ b/boa_parser/src/parser/expression/identifiers.rs
@@ -189,7 +189,7 @@ where
             ));
         }
 
-        if cursor.module_mode() && ident == Sym::AWAIT {
+        if cursor.module() && ident == Sym::AWAIT {
             return Err(Error::unexpected(
                 "await",
                 tok.span(),

--- a/boa_parser/src/parser/expression/identifiers.rs
+++ b/boa_parser/src/parser/expression/identifiers.rs
@@ -109,7 +109,7 @@ where
         let span = cursor.peek(0, interner).or_abrupt()?.span();
         let ident = Identifier.parse(cursor, interner)?;
         match ident.sym() {
-            Sym::ARGUMENTS | Sym::EVAL if cursor.strict_mode() => {
+            Sym::ARGUMENTS | Sym::EVAL if cursor.strict() => {
                 let name = interner
                     .resolve_expect(ident.sym())
                     .utf8()
@@ -178,7 +178,7 @@ where
             }
         };
 
-        if cursor.strict_mode() && ident.is_strict_reserved_identifier() {
+        if cursor.strict() && ident.is_strict_reserved_identifier() {
             return Err(Error::unexpected(
                 interner
                     .resolve_expect(ident)

--- a/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_function_expression/mod.rs
@@ -97,7 +97,7 @@ where
 
         // Early Error: If the source code matching FormalParameters is strict mode code,
         // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates() {
+        if (cursor.strict() || body.strict()) && params.has_duplicates() {
             return Err(Error::lex(LexError::Syntax(
                 "Duplicate parameter name not allowed in this context".into(),
                 params_start_position,
@@ -116,7 +116,7 @@ where
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
         if let Some(name) = name {
-            if (cursor.strict_mode() || body.strict())
+            if (cursor.strict() || body.strict())
                 && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
             {
                 return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -135,7 +135,7 @@ where
 
         // Early Error: If the source code matching FormalParameters is strict mode code,
         // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates() {
+        if (cursor.strict() || body.strict()) && params.has_duplicates() {
             return Err(Error::lex(LexError::Syntax(
                 "Duplicate parameter name not allowed in this context".into(),
                 params_start_position,
@@ -154,7 +154,7 @@ where
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
         if let Some(name) = name {
-            if (cursor.strict_mode() || body.strict())
+            if (cursor.strict() || body.strict())
                 && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
             {
                 return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/class_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/class_expression/mod.rs
@@ -47,8 +47,8 @@ where
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("ClassExpression", "Parsing");
-        let strict = cursor.strict_mode();
-        cursor.set_strict_mode(true);
+        let strict = cursor.strict();
+        cursor.set_strict(true);
 
         let mut has_binding_identifier = false;
         let token = cursor.peek(0, interner).or_abrupt()?;
@@ -62,7 +62,7 @@ where
             }
             _ => self.name,
         };
-        cursor.set_strict_mode(strict);
+        cursor.set_strict(strict);
 
         ClassTail::new(
             name,

--- a/boa_parser/src/parser/expression/primary/function_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/function_expression/mod.rs
@@ -92,7 +92,7 @@ where
 
         // Early Error: If the source code matching FormalParameters is strict mode code,
         // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates() {
+        if (cursor.strict() || body.strict()) && params.has_duplicates() {
             return Err(Error::lex(LexError::Syntax(
                 "Duplicate parameter name not allowed in this context".into(),
                 params_start_position,
@@ -111,7 +111,7 @@ where
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
         if let Some(name) = name {
-            if (cursor.strict_mode() || body.strict())
+            if (cursor.strict() || body.strict())
                 && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
             {
                 return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
+++ b/boa_parser/src/parser/expression/primary/generator_expression/mod.rs
@@ -99,7 +99,7 @@ where
         // If the source text matched by FormalParameters is strict mode code,
         // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
         // https://tc39.es/ecma262/#sec-generator-function-definitions-static-semantics-early-errors
-        if (cursor.strict_mode() || body.strict()) && params.has_duplicates() {
+        if (cursor.strict() || body.strict()) && params.has_duplicates() {
             return Err(Error::lex(LexError::Syntax(
                 "Duplicate parameter name not allowed in this context".into(),
                 params_start_position,
@@ -119,7 +119,7 @@ where
         // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
         // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
         if let Some(name) = name {
-            if (cursor.strict_mode() || body.strict())
+            if (cursor.strict() || body.strict())
                 && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
             {
                 return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -515,7 +515,7 @@ where
                     expression_to_formal_parameters(
                         &node,
                         &mut parameters,
-                        cursor.strict_mode(),
+                        cursor.strict(),
                         start_span,
                     )?;
                 }

--- a/boa_parser/src/parser/expression/unary.rs
+++ b/boa_parser/src/parser/expression/unary.rs
@@ -79,7 +79,7 @@ where
                 let target = self.parse(cursor, interner)?;
 
                 match target.flatten() {
-                    Expression::Identifier(_) if cursor.strict_mode() => {
+                    Expression::Identifier(_) if cursor.strict() => {
                         return Err(Error::lex(LexError::Syntax(
                             "cannot delete variables in strict mode".into(),
                             token_start,

--- a/boa_parser/src/parser/expression/update.rs
+++ b/boa_parser/src/parser/expression/update.rs
@@ -106,7 +106,7 @@ where
                     .parse(cursor, interner)?;
 
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                return (as_simple(&target, position, cursor.strict_mode())?).map_or_else(
+                return (as_simple(&target, position, cursor.strict())?).map_or_else(
                     || {
                         Err(Error::lex(LexError::Syntax(
                             "Invalid left-hand side in assignment".into(),
@@ -125,7 +125,7 @@ where
                     .parse(cursor, interner)?;
 
                 // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                return (as_simple(&target, position, cursor.strict_mode())?).map_or_else(
+                return (as_simple(&target, position, cursor.strict())?).map_or_else(
                     || {
                         Err(Error::lex(LexError::Syntax(
                             "Invalid left-hand side in assignment".into(),
@@ -154,7 +154,7 @@ where
                         .expect("Punctuator::Inc token disappeared");
 
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    return (as_simple(&lhs, position, cursor.strict_mode())?).map_or_else(
+                    return (as_simple(&lhs, position, cursor.strict())?).map_or_else(
                         || {
                             Err(Error::lex(LexError::Syntax(
                                 "Invalid left-hand side in assignment".into(),
@@ -170,7 +170,7 @@ where
                         .expect("Punctuator::Dec token disappeared");
 
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    return (as_simple(&lhs, position, cursor.strict_mode())?).map_or_else(
+                    return (as_simple(&lhs, position, cursor.strict())?).map_or_else(
                         || {
                             Err(Error::lex(LexError::Syntax(
                                 "Invalid left-hand side in assignment".into(),

--- a/boa_parser/src/parser/function/mod.rs
+++ b/boa_parser/src/parser/function/mod.rs
@@ -11,7 +11,7 @@
 mod tests;
 
 use crate::{
-    lexer::{Error as LexError, InputElement, TokenKind},
+    lexer::{Error as LexError, InputElement, Token, TokenKind},
     parser::{
         expression::{BindingIdentifier, Initializer},
         statement::{ArrayBindingPattern, ObjectBindingPattern, StatementList},
@@ -21,7 +21,7 @@ use crate::{
 };
 use ast::{
     operations::{check_labels, contains_invalid_object_literal},
-    Position,
+    Keyword, Position,
 };
 use boa_ast::{
     self as ast,
@@ -68,16 +68,29 @@ where
     type Output = FormalParameterList;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
+        /// Checks if the peeked token is the beginning of a parameter
+        const fn probe_parameter(token: &Token) -> bool {
+            matches!(
+                token.kind(),
+                TokenKind::Punctuator(
+                    Punctuator::Spread | Punctuator::OpenBracket | Punctuator::OpenBlock
+                ) | TokenKind::IdentifierName(_)
+                    | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _))
+            )
+        }
+
         let _timer = Profiler::global().start_event("FormalParameters", "Parsing");
+
         cursor.set_goal(InputElement::RegExp);
 
-        let mut params = Vec::new();
-
-        let next_token = cursor.peek(0, interner).or_abrupt()?;
-        if next_token.kind() == &TokenKind::Punctuator(Punctuator::CloseParen) {
+        let Some(start_position) = cursor
+            .peek(0, interner)?
+            .filter(|&tok| probe_parameter(tok))
+            .map(|tok| tok.span().start()) else {
             return Ok(FormalParameterList::default());
-        }
-        let start_position = next_token.span().start();
+        };
+
+        let mut params = Vec::new();
 
         loop {
             let mut rest_param = false;
@@ -101,9 +114,9 @@ where
 
             params.push(next_param);
 
-            if cursor.peek(0, interner).or_abrupt()?.kind()
-                == &TokenKind::Punctuator(Punctuator::CloseParen)
-            {
+            if cursor.peek(0, interner)?.map_or(true, |tok| {
+                tok.kind() != &TokenKind::Punctuator(Punctuator::Comma)
+            }) {
                 break;
             }
 
@@ -117,8 +130,9 @@ where
             }
 
             cursor.expect(Punctuator::Comma, "parameter list", interner)?;
-            if cursor.peek(0, interner).or_abrupt()?.kind()
-                == &TokenKind::Punctuator(Punctuator::CloseParen)
+            if cursor
+                .peek(0, interner)?
+                .map_or(true, |tok| !probe_parameter(tok))
             {
                 break;
             }

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -208,7 +208,7 @@ impl<R> Parser<'_, R> {
     where
         R: Read,
     {
-        self.cursor.set_strict_mode(true);
+        self.cursor.set_strict(true);
     }
 
     /// Set the parser JSON mode to true.
@@ -246,8 +246,8 @@ where
     type Output = StatementList;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
-        let statement_list = ScriptBody::new(true, cursor.strict_mode(), self.direct_eval)
-            .parse(cursor, interner)?;
+        let statement_list =
+            ScriptBody::new(true, cursor.strict(), self.direct_eval).parse(cursor, interner)?;
 
         // It is a Syntax Error if the LexicallyDeclaredNames of ScriptBody contains any duplicate entries.
         let mut lexical_names = FxHashSet::default();

--- a/boa_parser/src/parser/mod.rs
+++ b/boa_parser/src/parser/mod.rs
@@ -401,7 +401,7 @@ where
     type Output = ModuleItemList;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
-        cursor.set_module_mode();
+        cursor.set_module();
 
         let items = if cursor.peek(0, interner)?.is_some() {
             self::statement::ModuleItemList.parse(cursor, interner)?

--- a/boa_parser/src/parser/statement/block/mod.rs
+++ b/boa_parser/src/parser/statement/block/mod.rs
@@ -103,7 +103,7 @@ where
         let mut lexical_names = FxHashMap::default();
         for (name, is_fn) in lexically_declared_names_legacy(&statement_list) {
             if let Some(is_fn_previous) = lexical_names.insert(name, is_fn) {
-                match (cursor.strict_mode(), is_fn, is_fn_previous) {
+                match (cursor.strict(), is_fn, is_fn_previous) {
                     (false, true, true) => {}
                     _ => {
                         return Err(Error::general(

--- a/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/mod.rs
@@ -184,7 +184,7 @@ fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
 
     // If the source text matched by FormalParameters is strict mode code,
     // the Early Error rules for UniqueFormalParameters : FormalParameters are applied.
-    if (cursor.strict_mode() || body.strict()) && params.has_duplicates() {
+    if (cursor.strict() || body.strict()) && params.has_duplicates() {
         return Err(Error::lex(LexError::Syntax(
             "Duplicate parameter name not allowed in this context".into(),
             params_start_position,
@@ -202,8 +202,7 @@ fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
 
     // Early Error: If BindingIdentifier is present and the source code matching BindingIdentifier is strict mode code,
     // it is a Syntax Error if the StringValue of BindingIdentifier is "eval" or "arguments".
-    if (cursor.strict_mode() || body.strict()) && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym())
-    {
+    if (cursor.strict() || body.strict()) && [Sym::EVAL, Sym::ARGUMENTS].contains(&name.sym()) {
         return Err(Error::lex(LexError::Syntax(
             "unexpected identifier 'eval' or 'arguments' in strict mode".into(),
             name_span.start(),

--- a/boa_parser/src/parser/statement/if_stm/mod.rs
+++ b/boa_parser/src/parser/statement/if_stm/mod.rs
@@ -71,7 +71,7 @@ where
             .span()
             .end();
 
-        let strict = cursor.strict_mode();
+        let strict = cursor.strict();
         let token = cursor.peek(0, interner).or_abrupt()?;
         let then_node = match token.kind() {
             TokenKind::Keyword((Keyword::Function, _)) => {
@@ -110,7 +110,7 @@ where
                 TokenKind::Keyword((Keyword::Else, false)) => {
                     cursor.advance(interner);
 
-                    let strict = cursor.strict_mode();
+                    let strict = cursor.strict();
                     let token = cursor.peek(0, interner).or_abrupt()?;
                     let position = token.span().start();
                     let stmt = match token.kind() {

--- a/boa_parser/src/parser/statement/iteration/for_statement.rs
+++ b/boa_parser/src/parser/statement/iteration/for_statement.rs
@@ -159,7 +159,7 @@ where
             (Some(init), TokenKind::Keyword((kw @ (Keyword::In | Keyword::Of), false))) => {
                 let kw = *kw;
                 let init =
-                    initializer_to_iterable_loop_initializer(init, position, cursor.strict_mode())?;
+                    initializer_to_iterable_loop_initializer(init, position, cursor.strict())?;
 
                 cursor.advance(interner);
                 let expr = Expression::new(None, true, self.allow_yield, self.allow_await)

--- a/boa_parser/src/parser/statement/labelled_stm/mod.rs
+++ b/boa_parser/src/parser/statement/labelled_stm/mod.rs
@@ -58,7 +58,7 @@ where
 
         cursor.expect(Punctuator::Colon, "Labelled Statement", interner)?;
 
-        let strict = cursor.strict_mode();
+        let strict = cursor.strict();
         let next_token = cursor.peek(0, interner).or_abrupt()?;
 
         let labelled_item = match next_token.kind() {

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -294,7 +294,7 @@ where
         let _timer = Profiler::global().start_event("StatementList", "Parsing");
         let mut items = Vec::new();
 
-        let global_strict = cursor.strict_mode();
+        let global_strict = cursor.strict();
         let mut directive_prologues = self.directive_prologues;
         let mut strict = self.strict;
         let mut string_literal_escape_sequence = None;
@@ -326,7 +326,7 @@ where
                         |g| g == utf16!("use strict"),
                         true,
                     ) {
-                        cursor.set_strict_mode(true);
+                        cursor.set_strict(true);
                         strict = true;
 
                         if let Some((position, escape_sequence)) = string_literal_escape_sequence {
@@ -354,7 +354,7 @@ where
 
         items.sort_by(ast::StatementListItem::hoistable_order);
 
-        cursor.set_strict_mode(global_strict);
+        cursor.set_strict(global_strict);
 
         Ok(ast::StatementList::new(items, strict))
     }

--- a/boa_parser/src/parser/statement/switch/mod.rs
+++ b/boa_parser/src/parser/statement/switch/mod.rs
@@ -84,7 +84,7 @@ where
         let mut lexical_names = FxHashMap::default();
         for (name, is_fn) in lexically_declared_names_legacy(&switch) {
             if let Some(is_fn_previous) = lexical_names.insert(name, is_fn) {
-                match (cursor.strict_mode(), is_fn, is_fn_previous) {
+                match (cursor.strict(), is_fn, is_fn_previous) {
                     (false, true, true) => {}
                     _ => {
                         return Err(Error::general(

--- a/boa_parser/src/parser/statement/with/mod.rs
+++ b/boa_parser/src/parser/statement/with/mod.rs
@@ -62,7 +62,7 @@ where
             .start();
 
         // It is a Syntax Error if the source text matched by this production is contained in strict mode code.
-        if cursor.strict_mode() {
+        if cursor.strict() {
             return Err(Error::general(
                 "with statement not allowed in strict mode",
                 position,


### PR DESCRIPTION
Small steps towards ES5 conformance.

This PR changes the following:

- Implements HTML comments parsing (`<!--`, `-->`).
- Gates the functionality behind a new `annex-b` feature for `boa_parser`.
- Renames `strict_mode` to `strict` to be consistent with `Parser::set_strict`.
