### PR TITLE
[Merged by Bors] - Implement async functions using generators

### DIFF
--- a/boa_cli/src/debug/function.rs
+++ b/boa_cli/src/debug/function.rs
@@ -159,10 +159,26 @@ fn trace(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<J
     result
 }
 
+fn traceable(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    let value = args.get_or_undefined(0);
+    let traceable = args.get_or_undefined(1).to_boolean();
+
+    let Some(callable) = value.as_callable() else {
+        return Err(JsNativeError::typ()
+        .with_message("expected callable object")
+        .into());
+    };
+
+    set_trace_flag_in_function_object(callable, traceable)?;
+
+    Ok(value.clone())
+}
+
 pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(flowgraph), "flowgraph", 1)
         .function(NativeFunction::from_fn_ptr(bytecode), "bytecode", 1)
         .function(NativeFunction::from_fn_ptr(trace), "trace", 1)
+        .function(NativeFunction::from_fn_ptr(traceable), "traceable", 2)
         .build()
 }

--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -70,7 +70,7 @@ impl BuiltInConstructor for AsyncFunction {
             context
                 .intrinsics()
                 .constructors()
-                .generator_function()
+                .async_function()
                 .constructor()
         });
         BuiltInFunctionObject::create_dynamic_function(

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -416,18 +416,6 @@ impl Function {
         }
     }
 
-    /// Returns the promise capability if the function is an async function.
-    pub(crate) const fn get_promise_capability(&self) -> Option<&PromiseCapability> {
-        if let FunctionKind::Async {
-            promise_capability, ..
-        } = &self.kind
-        {
-            Some(promise_capability)
-        } else {
-            None
-        }
-    }
-
     ///  Sets the class object.
     pub(crate) fn set_class_object(&mut self, object: JsObject) {
         match &mut self.kind {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -536,6 +536,13 @@ impl<'host> Context<'host> {
 
 // ==== Private API ====
 
+impl Context<'_> {
+    /// Swaps the currently active realm with `realm`.
+    pub(crate) fn swap_realm(&mut self, realm: &mut Realm) {
+        std::mem::swap(&mut self.realm, realm);
+    }
+}
+
 #[cfg(feature = "intl")]
 impl<'host> Context<'host> {
     /// Get the ICU related utilities

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -552,26 +552,6 @@ impl DeclarativeEnvironmentStack {
             .expect("environment stack is cannot be empty")
     }
 
-    /// Get the most outer function environment slots.
-    ///
-    /// # Panics
-    ///
-    /// Panics if no environment exists on the stack.
-    pub(crate) fn current_function_slots(&self) -> &EnvironmentSlots {
-        for env in self
-            .stack
-            .iter()
-            .filter_map(Environment::as_declarative)
-            .rev()
-        {
-            if let Some(slots) = &env.slots {
-                return slots;
-            }
-        }
-
-        panic!("global environment must exist")
-    }
-
     /// Get the most outer environment.
     ///
     /// # Panics

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     error::JsNativeError,
     string::utf16,
     vm::{
-        call_frame::{AbruptCompletionRecord, EarlyReturnType, GeneratorResumeKind},
+        call_frame::{AbruptCompletionRecord, GeneratorResumeKind},
         opcode::Operation,
         CompletionType,
     },
@@ -155,7 +155,7 @@ impl Operation for GeneratorNextDelegate {
                 context.vm.push(iterator.clone());
                 context.vm.push(next_method.clone());
                 context.vm.push(value);
-                context.vm.frame_mut().early_return = Some(EarlyReturnType::Yield);
+                context.vm.frame_mut().r#yield = true;
                 Ok(CompletionType::Return)
             }
             GeneratorResumeKind::Throw => {
@@ -177,7 +177,7 @@ impl Operation for GeneratorNextDelegate {
                     context.vm.push(iterator.clone());
                     context.vm.push(next_method.clone());
                     context.vm.push(value);
-                    context.vm.frame_mut().early_return = Some(EarlyReturnType::Yield);
+                    context.vm.frame_mut().r#yield = true;
                     return Ok(CompletionType::Return);
                 }
                 context.vm.frame_mut().pc = done_address as usize;
@@ -207,7 +207,7 @@ impl Operation for GeneratorNextDelegate {
                     context.vm.push(iterator.clone());
                     context.vm.push(next_method.clone());
                     context.vm.push(value);
-                    context.vm.frame_mut().early_return = Some(EarlyReturnType::Yield);
+                    context.vm.frame_mut().r#yield = true;
                     return Ok(CompletionType::Return);
                 }
                 context.vm.frame_mut().pc = done_address as usize;

--- a/boa_engine/src/vm/opcode/generator/yield_stm.rs
+++ b/boa_engine/src/vm/opcode/generator/yield_stm.rs
@@ -1,5 +1,5 @@
 use crate::{
-    vm::{call_frame::EarlyReturnType, opcode::Operation, CompletionType},
+    vm::{opcode::Operation, CompletionType},
     Context, JsResult,
 };
 
@@ -15,7 +15,7 @@ impl Operation for Yield {
     const INSTRUCTION: &'static str = "INST - Yield";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        context.vm.frame_mut().early_return = Some(EarlyReturnType::Yield);
+        context.vm.frame_mut().r#yield = true;
         Ok(CompletionType::Return)
     }
 }

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -76,6 +76,45 @@ their instructions aren't traced.
 
 The `this` value can be changed as well as the arguments that are passed to the function.
 
+### Function `$boa.function.traceable(func, mode)`
+
+Marks a single function as traceable on all future executions of the function. Both useful to mark
+several functions as traceable and to trace functions that suspend their execution (async functions,
+generators, async generators).
+
+#### Input
+
+```Javascript
+function* g() {
+    yield 1;
+    yield 2;
+    yield 3;
+}
+$boa.function.traceable(g, true);
+var iter = g();
+iter.next();
+iter.next();
+iter.next();
+```
+
+#### Output
+
+```bash
+1μs           RestParameterPop                                      <empty>
+1μs           PushUndefined                                         undefined
+2μs           Yield                                                 undefined
+4μs           GetName                    0000: 'a'                  1
+0μs           Yield                                                 1
+1μs           GeneratorNext                                         undefined
+1μs           Pop                                                   <empty>
+15μs          GetName                    0001: 'b'                  2
+1μs           Yield                                                 2
+1μs           GeneratorNext                                         undefined
+1μs           Pop                                                   <empty>
+4μs           GetName                    0002: 'c'                  3
+1μs           Yield                                                 3
+```
+
 ## Function `$boa.function.flowgraph(func, options)`
 
 It can be used to get the instruction flowgraph, like the command-line flag.


### PR DESCRIPTION
This should hopefully fix more async/futures issues related to resuming execution in the future, since we can leverage generator logic to handle this for us.

It changes the following:

- Refactors `GeneratorContext` to handle context preparation.
- Reuses the functionality of `GeneratorContext` in `Await`.
- Removes `EarlyReturnType` in favour of a single `r#await` bool flag in `CallFrame`.
