### PR TITLE
[Merged by Bors] - Add hooks to get the current time and timezone

### DIFF
--- a/boa_engine/src/builtins/date/tests.rs
+++ b/boa_engine/src/builtins/date/tests.rs
@@ -44,21 +44,6 @@ fn timestamp_from_utc(
 }
 
 #[test]
-fn date_display() {
-    let dt = super::Date(None);
-    assert_eq!("[Invalid Date]", format!("[{dt}]"));
-
-    let cd = super::Date::default();
-    assert_eq!(
-        format!(
-            "[{}]",
-            cd.to_local().unwrap().format("%a %b %d %Y %H:%M:%S GMT%:z")
-        ),
-        format!("[{cd}]")
-    );
-}
-
-#[test]
 fn date_this_time_value() {
     run_test_actions([TestAction::assert_native_error(
         "({toString: Date.prototype.toString}).toString()",

--- a/boa_engine/src/builtins/date/utils.rs
+++ b/boa_engine/src/builtins/date/utils.rs
@@ -1,4 +1,4 @@
-use chrono::{Datelike, Local, NaiveDateTime, TimeZone, Timelike};
+use chrono::{Datelike, FixedOffset, NaiveDateTime, TimeZone, Timelike};
 
 use crate::value::IntegerOrNan;
 
@@ -136,7 +136,7 @@ pub(super) struct DateParameters {
 pub(super) fn replace_params(
     datetime: NaiveDateTime,
     params: DateParameters,
-    local: bool,
+    offset: Option<FixedOffset>,
 ) -> Option<NaiveDateTime> {
     let DateParameters {
         year,
@@ -148,8 +148,8 @@ pub(super) fn replace_params(
         millisecond,
     } = params;
 
-    let datetime = if local {
-        Local.from_utc_datetime(&datetime).naive_local()
+    let datetime = if let Some(offset) = offset {
+        offset.from_utc_datetime(&datetime).naive_local()
     } else {
         datetime
     };
@@ -187,8 +187,8 @@ pub(super) fn replace_params(
     let new_time = make_time(hour, minute, second, millisecond)?;
     let mut ts = make_date(new_day, new_time)?;
 
-    if local {
-        ts = Local
+    if let Some(offset) = offset {
+        ts = offset
             .from_local_datetime(&NaiveDateTime::from_timestamp_millis(ts)?)
             .earliest()?
             .naive_utc()

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -1,3 +1,5 @@
+use chrono::{FixedOffset, Local, NaiveDateTime, Utc};
+
 use crate::{
     builtins::promise::OperationType,
     job::JobCallback,
@@ -169,6 +171,26 @@ pub trait HostHooks {
     /// [ihdr]: https://tc39.es/ecma262/#sec-initializehostdefinedrealm
     fn create_global_this(&self, _intrinsics: &Intrinsics) -> Option<JsObject> {
         None
+    }
+
+    /// Gets the current UTC time of the host.
+    ///
+    /// Defaults to using [`Utc::now`] on all targets, which can cause panics if your platform
+    /// doesn't support [`SystemTime::now`][time].
+    ///
+    /// [time]: std::time::SystemTime::now
+    fn utc_now(&self) -> NaiveDateTime {
+        Utc::now().naive_utc()
+    }
+
+    /// Gets the current timezone as a fixed offset from UTC.
+    ///
+    /// Defaults to using [`Local::now`] on all targets, which can cause panics if your platform
+    /// doesn't support [`SystemTime::now`][time].
+    ///
+    /// [time]: std::time::SystemTime::now
+    fn tz_offset(&self) -> FixedOffset {
+        *Local::now().offset()
     }
 }
 

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -1,4 +1,3 @@
-use chrono::{FixedOffset, Local, NaiveDateTime, Utc};
 use crate::{
     builtins::promise::OperationType,
     job::JobCallback,
@@ -6,6 +5,7 @@ use crate::{
     realm::Realm,
     Context, JsResult, JsValue,
 };
+use chrono::{FixedOffset, Local, NaiveDateTime, Utc};
 
 use super::intrinsics::Intrinsics;
 

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -1,5 +1,4 @@
 use chrono::{FixedOffset, Local, NaiveDateTime, Utc};
-
 use crate::{
     builtins::promise::OperationType,
     job::JobCallback,

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -43,7 +43,10 @@ impl JsDate {
     #[inline]
     pub fn new(context: &mut Context<'_>) -> Self {
         let prototype = context.intrinsics().constructors().date().prototype();
-        let inner = JsObject::from_proto_and_data(prototype, ObjectData::date(Date::default()));
+        let inner = JsObject::from_proto_and_data(
+            prototype,
+            ObjectData::date(Date::utc_now(&*context.host_hooks())),
+        );
 
         Self { inner }
     }
@@ -468,7 +471,7 @@ impl JsDate {
     #[deprecated]
     #[inline]
     pub fn to_gmt_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
-        Date::to_gmt_string(&self.inner.clone().into(), &[JsValue::Null], context)
+        Date::to_utc_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
     /// Returns the given date in the ISO 8601 format according to universal


### PR DESCRIPTION
This Pull Request changes the following:

- Adds two new hooks to `HostHooks` to access the current UTC time and the current timezone offset.
- Replaces usages of `Local` with the host hook.
- Replaces usages of `Utc::now` and `Local::now` with the hooks.

cc @lastmjs 