### PR TITLE
Add loop and switch return values

### DIFF
--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -162,6 +162,17 @@ impl Statement {
             _ => false,
         }
     }
+
+    /// Returns `true` if the statement returns a value.
+    #[inline]
+    #[must_use]
+    pub const fn returns_value(&self) -> bool {
+        match self {
+            Self::Block(block) if block.statement_list().statements().is_empty() => false,
+            Self::Empty | Self::Var(_) | Self::Break(_) | Self::Continue(_) => false,
+            _ => true,
+        }
+    }
 }
 
 impl ToIndentedString for Statement {

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -17,19 +17,19 @@ impl ByteCompiler<'_, '_> {
         match labelled.item() {
             LabelledItem::Statement(stmt) => match stmt {
                 Statement::ForLoop(for_loop) => {
-                    self.compile_for_loop(for_loop, Some(labelled.label()));
+                    self.compile_for_loop(for_loop, Some(labelled.label()), use_expr);
                 }
                 Statement::ForInLoop(for_in_loop) => {
-                    self.compile_for_in_loop(for_in_loop, Some(labelled.label()));
+                    self.compile_for_in_loop(for_in_loop, Some(labelled.label()), use_expr);
                 }
                 Statement::ForOfLoop(for_of_loop) => {
-                    self.compile_for_of_loop(for_of_loop, Some(labelled.label()));
+                    self.compile_for_of_loop(for_of_loop, Some(labelled.label()), use_expr);
                 }
                 Statement::WhileLoop(while_loop) => {
-                    self.compile_while_loop(while_loop, Some(labelled.label()));
+                    self.compile_while_loop(while_loop, Some(labelled.label()), use_expr);
                 }
                 Statement::DoWhileLoop(do_while_loop) => {
-                    self.compile_do_while_loop(do_while_loop, Some(labelled.label()));
+                    self.compile_do_while_loop(do_while_loop, Some(labelled.label()), use_expr);
                 }
                 stmt => self.compile_stmt(stmt, use_expr),
             },

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -19,19 +19,19 @@ impl ByteCompiler<'_, '_> {
             Statement::Var(var) => self.compile_var_decl(var),
             Statement::If(node) => self.compile_if(node, use_expr),
             Statement::ForLoop(for_loop) => {
-                self.compile_for_loop(for_loop, None);
+                self.compile_for_loop(for_loop, None, use_expr);
             }
             Statement::ForInLoop(for_in_loop) => {
-                self.compile_for_in_loop(for_in_loop, None);
+                self.compile_for_in_loop(for_in_loop, None, use_expr);
             }
             Statement::ForOfLoop(for_of_loop) => {
-                self.compile_for_of_loop(for_of_loop, None);
+                self.compile_for_of_loop(for_of_loop, None, use_expr);
             }
             Statement::WhileLoop(while_loop) => {
-                self.compile_while_loop(while_loop, None);
+                self.compile_while_loop(while_loop, None, use_expr);
             }
             Statement::DoWhileLoop(do_while_loop) => {
-                self.compile_do_while_loop(do_while_loop, None);
+                self.compile_do_while_loop(do_while_loop, None, use_expr);
             }
             Statement::Block(block) => {
                 self.compile_block(block, use_expr);
@@ -46,7 +46,7 @@ impl ByteCompiler<'_, '_> {
                 self.emit(Opcode::Throw, &[]);
             }
             Statement::Switch(switch) => {
-                self.compile_switch(switch);
+                self.compile_switch(switch, use_expr);
             }
             Statement::Return(ret) => {
                 if let Some(expr) = ret.target() {
@@ -58,7 +58,7 @@ impl ByteCompiler<'_, '_> {
             }
             Statement::Try(t) => self.compile_try(t, use_expr),
             Statement::Expression(expr) => self.compile_expr(expr, use_expr),
-            Statement::With(with) => self.compile_with(with),
+            Statement::With(with) => self.compile_with(with, use_expr),
             Statement::Empty => {}
         }
     }

--- a/boa_engine/src/bytecompiler/statement/with.rs
+++ b/boa_engine/src/bytecompiler/statement/with.rs
@@ -3,12 +3,21 @@ use boa_ast::statement::With;
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`With`] `boa_ast` node
-    pub(crate) fn compile_with(&mut self, with: &With) {
+    pub(crate) fn compile_with(&mut self, with: &With, use_expr: bool) {
         self.compile_expr(with.expression(), true);
         self.push_compile_environment(false);
         self.emit_opcode(Opcode::PushObjectEnvironment);
-        self.compile_stmt(with.statement(), false);
+
+        if !with.statement().returns_value() {
+            self.emit_opcode(Opcode::PushUndefined);
+        }
+        self.compile_stmt(with.statement(), true);
+
         self.pop_compile_environment();
         self.emit_opcode(Opcode::PopEnvironment);
+
+        if !use_expr {
+            self.emit_opcode(Opcode::Pop);
+        }
     }
 }

--- a/boa_engine/src/vm/call_frame/env_stack.rs
+++ b/boa_engine/src/vm/call_frame/env_stack.rs
@@ -1,11 +1,17 @@
 //! Module for implementing a `CallFrame`'s environment stacks
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+use crate::JsValue;
+use boa_gc::{Finalize, Trace};
+
+#[derive(Clone, Debug, Finalize, Trace)]
 pub(crate) enum EnvEntryKind {
     Global,
     Loop {
         /// This is used to keep track of how many iterations a loop has done.
         iteration_count: u64,
+
+        // This is the latest return value of the loop.
+        value: JsValue,
     },
     Try,
     Catch,
@@ -13,8 +19,22 @@ pub(crate) enum EnvEntryKind {
     Labelled,
 }
 
-/// The `EnvStackEntry` tracks the environment count and relavant information for the current environment.
-#[derive(Copy, Clone, Debug)]
+impl PartialEq for EnvEntryKind {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Global, Self::Global)
+                | (Self::Loop { .. }, Self::Loop { .. })
+                | (Self::Try, Self::Try)
+                | (Self::Catch, Self::Catch)
+                | (Self::Finally, Self::Finally)
+                | (Self::Labelled, Self::Labelled)
+        )
+    }
+}
+
+/// The `EnvStackEntry` tracks the environment count and relevant information for the current environment.
+#[derive(Clone, Debug, Finalize, Trace)]
 pub(crate) struct EnvStackEntry {
     start: u32,
     exit: u32,
@@ -46,32 +66,35 @@ impl EnvStackEntry {
     }
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Try`.
-    pub(crate) const fn with_try_flag(mut self) -> Self {
+    pub(crate) fn with_try_flag(mut self) -> Self {
         self.kind = EnvEntryKind::Try;
         self
     }
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Loop`.
     /// And the loop iteration set to zero.
-    pub(crate) const fn with_loop_flag(mut self, iteration_count: u64) -> Self {
-        self.kind = EnvEntryKind::Loop { iteration_count };
+    pub(crate) fn with_loop_flag(mut self, iteration_count: u64) -> Self {
+        self.kind = EnvEntryKind::Loop {
+            iteration_count,
+            value: JsValue::undefined(),
+        };
         self
     }
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Catch`.
-    pub(crate) const fn with_catch_flag(mut self) -> Self {
+    pub(crate) fn with_catch_flag(mut self) -> Self {
         self.kind = EnvEntryKind::Catch;
         self
     }
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Finally`.
-    pub(crate) const fn with_finally_flag(mut self) -> Self {
+    pub(crate) fn with_finally_flag(mut self) -> Self {
         self.kind = EnvEntryKind::Finally;
         self
     }
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Labelled`.
-    pub(crate) const fn with_labelled_flag(mut self) -> Self {
+    pub(crate) fn with_labelled_flag(mut self) -> Self {
         self.kind = EnvEntryKind::Labelled;
         self
     }
@@ -98,14 +121,31 @@ impl EnvStackEntry {
         self.kind == EnvEntryKind::Global
     }
 
-    /// Returns true if an `EnvStackEntry` is a loop
-    pub(crate) const fn is_loop_env(&self) -> bool {
-        matches!(self.kind, EnvEntryKind::Loop { .. })
+    /// Returns the loop iteration count if `EnvStackEntry` is a loop.
+    pub(crate) const fn as_loop_iteration_count(&self) -> Option<u64> {
+        if let EnvEntryKind::Loop {
+            iteration_count, ..
+        } = self.kind
+        {
+            return Some(iteration_count);
+        }
+        None
     }
 
-    pub(crate) const fn as_loop_iteration_count(self) -> Option<u64> {
-        if let EnvEntryKind::Loop { iteration_count } = self.kind {
-            return Some(iteration_count);
+    /// Increases loop iteration count if `EnvStackEntry` is a loop.
+    pub(crate) fn increase_loop_iteration_count(&mut self) {
+        if let EnvEntryKind::Loop {
+            iteration_count, ..
+        } = &mut self.kind
+        {
+            *iteration_count = iteration_count.wrapping_add(1);
+        }
+    }
+
+    /// Returns the loop return value if `EnvStackEntry` is a loop.
+    pub(crate) const fn loop_env_value(&self) -> Option<&JsValue> {
+        if let EnvEntryKind::Loop { value, .. } = &self.kind {
+            return Some(value);
         }
         None
     }
@@ -150,5 +190,15 @@ impl EnvStackEntry {
     /// Decrements the `env_num` field for current `EnvEntryStack`.
     pub(crate) fn dec_env_num(&mut self) {
         self.env_num -= 1;
+    }
+
+    /// Set the loop return value for the current `EnvStackEntry`.
+    pub(crate) fn set_loop_return_value(&mut self, value: &JsValue) -> bool {
+        if let EnvEntryKind::Loop { value: v, .. } = &mut self.kind {
+            *v = value.clone();
+            true
+        } else {
+            false
+        }
     }
 }

--- a/boa_engine/src/vm/call_frame/env_stack.rs
+++ b/boa_engine/src/vm/call_frame/env_stack.rs
@@ -193,9 +193,9 @@ impl EnvStackEntry {
     }
 
     /// Set the loop return value for the current `EnvStackEntry`.
-    pub(crate) fn set_loop_return_value(&mut self, value: &JsValue) -> bool {
+    pub(crate) fn set_loop_return_value(&mut self, value: JsValue) -> bool {
         if let EnvEntryKind::Loop { value: v, .. } = &mut self.kind {
-            *v = value.clone();
+            *v = value;
             true
         } else {
             false

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -28,7 +28,6 @@ pub struct CallFrame {
     pub(crate) pop_on_return: usize,
     // Tracks the number of environments in environment entry.
     // On abrupt returns this is used to decide how many environments need to be pop'ed.
-    #[unsafe_ignore_trace]
     pub(crate) env_stack: Vec<EnvStackEntry>,
     pub(crate) param_count: usize,
     pub(crate) arg_count: usize,

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -290,7 +290,6 @@ impl CodeBlock {
             | Opcode::CopyDataProperties
             | Opcode::Break
             | Opcode::Continue
-            | Opcode::LoopContinue
             | Opcode::LoopStart
             | Opcode::TryStart
             | Opcode::AsyncGeneratorNext
@@ -460,6 +459,8 @@ impl CodeBlock {
             | Opcode::Return
             | Opcode::PopEnvironment
             | Opcode::LoopEnd
+            | Opcode::LoopContinue
+            | Opcode::LoopUpdateReturnValue
             | Opcode::LabelledEnd
             | Opcode::CreateForInIterator
             | Opcode::GetIterator

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -138,7 +138,7 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::Red);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Opcode::LoopContinue | Opcode::LoopStart => {
+                Opcode::LoopStart => {
                     let start_address = self.read::<u32>(pc);
                     pc += size_of::<u32>();
                     let end_address = self.read::<u32>(pc);
@@ -540,6 +540,8 @@ impl CodeBlock {
                 | Opcode::This
                 | Opcode::Super
                 | Opcode::LoopEnd
+                | Opcode::LoopContinue
+                | Opcode::LoopUpdateReturnValue
                 | Opcode::LabelledEnd
                 | Opcode::CreateForInIterator
                 | Opcode::GetIterator

--- a/boa_engine/src/vm/opcode/control_flow/break.rs
+++ b/boa_engine/src/vm/opcode/control_flow/break.rs
@@ -1,6 +1,6 @@
 use crate::{
     vm::{call_frame::AbruptCompletionRecord, opcode::Operation, CompletionType},
-    Context, JsResult,
+    Context, JsResult, JsValue,
 };
 
 /// `Break` implements the Opcode Operation for `Opcode::Break`
@@ -17,18 +17,39 @@ impl Operation for Break {
         let jump_address = context.vm.read::<u32>();
         let target_address = context.vm.read::<u32>();
 
+        let value = context.vm.stack.pop().unwrap_or(JsValue::undefined());
+
         // 1. Iterate through Env stack looking for exit address.
         let mut envs_to_pop = 0;
-        while let Some(env_entry) = context.vm.frame().env_stack.last() {
+        let mut set_loop_result = false;
+        let mut found_target = false;
+        for i in (0..context.vm.frame().env_stack.len()).rev() {
+            if found_target && set_loop_result {
+                break;
+            }
+
+            let Some(env_entry) = context.vm.frame_mut().env_stack.get_mut(i) else {
+                break;
+            };
+
+            if found_target {
+                set_loop_result = env_entry.set_loop_return_value(&value);
+                continue;
+            }
+
             if (jump_address == env_entry.exit_address())
                 || (env_entry.is_finally_env() && jump_address == env_entry.start_address())
             {
-                break;
+                found_target = true;
+                set_loop_result = env_entry.set_loop_return_value(&value);
+                continue;
             }
 
             // Checks for the break if we have jumped from inside of a finally block
             if jump_address == env_entry.exit_address() {
-                break;
+                found_target = true;
+                set_loop_result = env_entry.set_loop_return_value(&value);
+                continue;
             }
             envs_to_pop += env_entry.env_num();
             context.vm.frame_mut().env_stack.pop();

--- a/boa_engine/src/vm/opcode/control_flow/break.rs
+++ b/boa_engine/src/vm/opcode/control_flow/break.rs
@@ -33,7 +33,7 @@ impl Operation for Break {
             };
 
             if found_target {
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 continue;
             }
 
@@ -41,14 +41,14 @@ impl Operation for Break {
                 || (env_entry.is_finally_env() && jump_address == env_entry.start_address())
             {
                 found_target = true;
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 continue;
             }
 
             // Checks for the break if we have jumped from inside of a finally block
             if jump_address == env_entry.exit_address() {
                 found_target = true;
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 continue;
             }
             envs_to_pop += env_entry.env_num();

--- a/boa_engine/src/vm/opcode/control_flow/continue.rs
+++ b/boa_engine/src/vm/opcode/control_flow/continue.rs
@@ -1,6 +1,6 @@
 use crate::{
     vm::{call_frame::AbruptCompletionRecord, opcode::Operation, CompletionType},
-    Context, JsResult,
+    Context, JsResult, JsValue,
 };
 
 /// `Continue` implements the Opcode Operation for `Opcode::Continue`
@@ -21,23 +21,44 @@ impl Operation for Continue {
         let jump_address = context.vm.read::<u32>();
         let target_address = context.vm.read::<u32>();
 
+        let value = context.vm.stack.pop().unwrap_or(JsValue::undefined());
+
         // 1. Iterate through Env stack looking for exit address.
         let mut envs_to_pop = 0;
-        while let Some(env_entry) = context.vm.frame_mut().env_stack.last() {
+        let mut set_loop_result = false;
+        let mut found_target = false;
+        for i in (0..context.vm.frame().env_stack.len()).rev() {
+            if found_target && set_loop_result {
+                break;
+            }
+
+            let Some(env_entry) = context.vm.frame_mut().env_stack.get_mut(i) else {
+                break;
+            };
+
+            if found_target {
+                set_loop_result = env_entry.set_loop_return_value(&value);
+                continue;
+            }
+
             // We check two conditions here where continue actually jumps to a higher address.
             //   1. When we have reached a finally env that matches the jump address we are moving to.
             //   2. When there is no finally, and we have reached the continue location.
             if (env_entry.is_finally_env() && jump_address == env_entry.start_address())
                 || (jump_address == target_address && jump_address == env_entry.start_address())
             {
-                break;
+                found_target = true;
+                set_loop_result = env_entry.set_loop_return_value(&value);
+                continue;
             }
 
             envs_to_pop += env_entry.env_num();
             // The below check determines whether we have continued from inside of a finally block.
             if jump_address > target_address && jump_address == env_entry.exit_address() {
+                found_target = true;
+                set_loop_result = env_entry.set_loop_return_value(&value);
                 context.vm.frame_mut().env_stack.pop();
-                break;
+                continue;
             }
             context.vm.frame_mut().env_stack.pop();
         }

--- a/boa_engine/src/vm/opcode/control_flow/continue.rs
+++ b/boa_engine/src/vm/opcode/control_flow/continue.rs
@@ -37,7 +37,7 @@ impl Operation for Continue {
             };
 
             if found_target {
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 continue;
             }
 
@@ -48,7 +48,7 @@ impl Operation for Continue {
                 || (jump_address == target_address && jump_address == env_entry.start_address())
             {
                 found_target = true;
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 continue;
             }
 
@@ -56,7 +56,7 @@ impl Operation for Continue {
             // The below check determines whether we have continued from inside of a finally block.
             if jump_address > target_address && jump_address == env_entry.exit_address() {
                 found_target = true;
-                set_loop_result = env_entry.set_loop_return_value(&value);
+                set_loop_result = env_entry.set_loop_return_value(value.clone());
                 context.vm.frame_mut().env_stack.pop();
                 continue;
             }

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -80,7 +80,6 @@ impl Operation for LoopEnd {
     const INSTRUCTION: &'static str = "INST - LoopEnd";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        //cleanup_loop_environment(context);
         let mut envs_to_pop = 0_usize;
         while let Some(env_entry) = context.vm.frame_mut().env_stack.pop() {
             envs_to_pop += env_entry.env_num();
@@ -118,7 +117,7 @@ impl Operation for LoopUpdateReturnValue {
             .env_stack
             .last_mut()
             .expect("loop environment must be present")
-            .set_loop_return_value(&value);
+            .set_loop_return_value(value);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1168,14 +1168,14 @@ generate_impl! {
         ///
         /// Operands: Jump Address: u32, Target address: u32
         ///
-        /// Stack: **=>**
+        /// Stack: loop_return_value **=>**
         Break,
 
         /// Sets the `AbruptCompletionRecord` for a delayed continue
         ///
         /// Operands: Jump Address: u32, Target address: u32,
         ///
-        /// Stack: **=>**
+        /// Stack: loop_return_value **=>**
         Continue,
 
         /// Pops value converts it to boolean and pushes it back.
@@ -1370,17 +1370,24 @@ generate_impl! {
 
         /// Clean up environments when a loop continues.
         ///
-        /// Operands: Start Address: `u32`, Exit Address: `u32`
+        /// Operands:
         ///
         /// Stack: **=>**
         LoopContinue,
 
-        /// Clean up environments at the end of a loop.
+        /// Clean up environments at the end of a loop and return it's value.
         ///
         /// Operands:
         ///
-        /// Stack: **=>**
+        /// Stack: **=>** value
         LoopEnd,
+
+        /// Update the return value of a loop.
+        ///
+        /// Operands:
+        ///
+        /// Stack: loop_return_value **=>**
+        LoopUpdateReturnValue,
 
         /// Push labelled start marker.
         ///


### PR DESCRIPTION
This Pull Request changes the following:

- Return values for all loops and switch statements.
- Explicitly capture and update loop return values on the `env_stack` of the `CallFrames`.
- Update loop return values on `break` and `continue`.
- Adjust bytecode to handle statements that do not return any values.
