### PR TITLE
[Merged by Bors] - Improve strictness of `GeneratorState`

### DIFF
--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -1,7 +1,7 @@
 //! A Rust API wrapper for Boa's `Generator` Builtin ECMAScript Object
 use crate::{
-    builtins::generator::{Generator, GeneratorState},
-    object::{JsObject, JsObjectType, ObjectData},
+    builtins::generator::Generator,
+    object::{JsObject, JsObjectType},
     value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
@@ -16,23 +16,7 @@ pub struct JsGenerator {
 }
 
 impl JsGenerator {
-    /// Create a new `JsGenerator` object
-    #[inline]
-    pub fn new(context: &mut Context<'_>) -> Self {
-        let prototype = context.intrinsics().objects().generator();
-
-        let generator = JsObject::from_proto_and_data(
-            prototype,
-            ObjectData::generator(Generator {
-                state: GeneratorState::Undefined,
-                context: None,
-            }),
-        );
-
-        Self { inner: generator }
-    }
-
-    /// Create a `JsGenerator` from a regular expression `JsObject`
+    /// Creates a `JsGenerator` from a regular expression `JsObject`
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.is_generator() {

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -16,7 +16,7 @@ pub struct JsGenerator {
 }
 
 impl JsGenerator {
-    /// Creates a `JsGenerator` from a regular expression `JsObject`
+    /// Creates a `JsGenerator` from a generator `JsObject`
     #[inline]
     pub fn from_object(object: JsObject) -> JsResult<Self> {
         if object.is_generator() {

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1043,6 +1043,7 @@ impl JsObject {
                     },
                     Clone::clone,
                 );
+
             let data = if async_ {
                 ObjectData::async_generator(AsyncGenerator {
                     state: AsyncGeneratorState::SuspendedStart,
@@ -1057,14 +1058,15 @@ impl JsObject {
                 })
             } else {
                 ObjectData::generator(Generator {
-                    state: GeneratorState::SuspendedStart,
-                    context: Some(GeneratorContext::new(
-                        environments,
-                        stack,
-                        context.vm.active_function.clone(),
-                        call_frame,
-                        context.realm().clone(),
-                    )),
+                    state: GeneratorState::SuspendedStart {
+                        context: GeneratorContext::new(
+                            environments,
+                            stack,
+                            context.vm.active_function.clone(),
+                            call_frame,
+                            context.realm().clone(),
+                        ),
+                    },
                 })
             };
 


### PR DESCRIPTION
Just some small improvements that increase the strictness of our generator state handling.

Also rollbacks the implementation of `GeneratorValidate` because I forgot to remove it after I did modifications to #2821, and it doesn't make sense to have that if it isn't used by async functions.