### PR TITLE
[Merged by Bors] - Fix sync generator yield expressions

### DIFF
--- a/boa_engine/src/vm/opcode/generator/yield_stm.rs
+++ b/boa_engine/src/vm/opcode/generator/yield_stm.rs
@@ -1,4 +1,5 @@
 use crate::{
+    builtins::iterable::create_iter_result_object,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
 };
@@ -15,6 +16,9 @@ impl Operation for Yield {
     const INSTRUCTION: &'static str = "INST - Yield";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let value = context.vm.pop();
+        let value = create_iter_result_object(value, false, context);
+        context.vm.push(value);
         context.vm.frame_mut().r#yield = true;
         Ok(CompletionType::Return)
     }


### PR DESCRIPTION
Depends on #2837.

This Pull Request changes the following:

- Fix the remaining `language/expressions/yield` tests.
- Align the sync generator execution more to the spec.

This breaks one async generator test. We can ignore that one as async generators are currently very broken. I will try to fix async generators next.
