### PR TITLE
[Merged by Bors] - Fix more Annex B tests

### DIFF
--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -293,36 +293,27 @@ impl RegExp {
         };
 
         // 10. If u is true, then
-        let regexp = if flags.contains(RegExpFlags::UNICODE) {
-            //     a. Let patternText be StringToCodePoints(P).
-            Regex::from_unicode(
-                p.code_points().map(CodePoint::as_u32),
-                Flags::new(f.code_points().map(CodePoint::as_u32)),
-            )
-        } else {
-            // 11. Else,
-            //     a. Let patternText be the result of interpreting each of P's 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
-            Regex::from_unicode(
-                p.iter().map(|surr| u32::from(*surr)),
-                Flags::new(f.code_points().map(CodePoint::as_u32)),
-            )
-        };
-
-        // 9. Let parseResult be ParsePattern(patternText, u).
-        // 10. If parseResult is a non-empty List of SyntaxError objects, throw a SyntaxError exception.
-        // 11. Assert: parseResult is a Pattern Parse Node.
-        // 12. Set obj.[[OriginalSource]] to P.
-        // 13. Set obj.[[OriginalFlags]] to F.
-        // 14. NOTE: The definitions of DotAll, IgnoreCase, Multiline, and Unicode in 22.2.2.1 refer to this value of obj.[[OriginalFlags]].
-        // 15. Set obj.[[RegExpMatcher]] to CompilePattern of parseResult.
-        let matcher = match regexp {
-            Err(error) => {
-                return Err(JsNativeError::syntax()
-                    .with_message(format!("failed to create matcher: {}", error.text))
-                    .into());
-            }
-            Ok(val) => val,
-        };
+        //     a. Let patternText be StringToCodePoints(P).
+        // 11. Else,
+        //     a. Let patternText be the result of interpreting each of P's 16-bit elements as a Unicode BMP code point. UTF-16 decoding is not applied to the elements.
+        // 12. Let parseResult be ParsePattern(patternText, u).
+        // 13. If parseResult is a non-empty List of SyntaxError objects, throw a SyntaxError exception.
+        // 14. Assert: parseResult is a Pattern Parse Node.
+        // 15. Set obj.[[OriginalSource]] to P.
+        // 16. Set obj.[[OriginalFlags]] to F.
+        // 17. Let capturingGroupsCount be CountLeftCapturingParensWithin(parseResult).
+        // 18. Let rer be the RegExp Record { [[IgnoreCase]]: i, [[Multiline]]: m, [[DotAll]]: s, [[Unicode]]: u, [[CapturingGroupsCount]]: capturingGroupsCount }.
+        // 19. Set obj.[[RegExpRecord]] to rer.
+        // 20. Set obj.[[RegExpMatcher]] to CompilePattern of parseResult with argument rer.
+        let matcher =
+            match Regex::from_unicode(p.code_points().map(CodePoint::as_u32), Flags::from(flags)) {
+                Err(error) => {
+                    return Err(JsNativeError::syntax()
+                        .with_message(format!("failed to create matcher: {}", error.text))
+                        .into());
+                }
+                Ok(val) => val,
+            };
 
         let regexp = Self {
             matcher,

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -355,7 +355,7 @@ impl JsString {
     }
 
     /// Gets an iterator of all the Unicode codepoints of a [`JsString`].
-    pub fn code_points(&self) -> impl Iterator<Item = CodePoint> + '_ {
+    pub fn code_points(&self) -> impl Iterator<Item = CodePoint> + Clone + '_ {
         char::decode_utf16(self.iter().copied()).map(|res| match res {
             Ok(c) => CodePoint::Unicode(c),
             Err(e) => CodePoint::UnpairedSurrogate(e.unpaired_surrogate()),

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -318,12 +318,7 @@ impl<R> Lexer<R> {
                 }
             }?;
 
-            if token.kind() == &TokenKind::Comment {
-                // Skip comment
-                self.next(interner)
-            } else {
-                Ok(Some(token))
-            }
+            Ok(Some(token))
         } else {
             Err(Error::syntax(
                 format!(

--- a/boa_parser/src/lexer/regex.rs
+++ b/boa_parser/src/lexer/regex.rs
@@ -5,7 +5,7 @@ use bitflags::bitflags;
 use boa_ast::Position;
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use regress::Regex;
+use regress::{Flags, Regex};
 use std::{
     io::{self, ErrorKind, Read},
     str::{self, FromStr},
@@ -235,5 +235,17 @@ impl ToString for RegExpFlags {
             s.push('y');
         }
         s
+    }
+}
+
+impl From<RegExpFlags> for Flags {
+    fn from(value: RegExpFlags) -> Self {
+        Self {
+            icase: value.contains(RegExpFlags::IGNORE_CASE),
+            multiline: value.contains(RegExpFlags::MULTILINE),
+            dot_all: value.contains(RegExpFlags::DOT_ALL),
+            unicode: value.contains(RegExpFlags::UNICODE),
+            ..Self::default()
+        }
     }
 }

--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -152,8 +152,8 @@ where
         } else {
             self.peeked[self.write_index] = self.lexer.next(interner)?;
         }
-        self.write_index = (self.write_index + 1) % PEEK_BUF_SIZE;
 
+        self.write_index = (self.write_index + 1) % PEEK_BUF_SIZE;
         debug_assert_ne!(
             self.read_index, self.write_index,
             "we reached the read index with the write index"

--- a/test_ignore.toml
+++ b/test_ignore.toml
@@ -15,6 +15,7 @@ features = [
     "decorators",
     "array-grouping",
     "IsHTMLDDA",
+    "legacy-regexp",
 
     # Non-implemented Intl features
     "intl-normative-optional",


### PR DESCRIPTION
This Pull Request fixes some additional Annex B tests.

It changes the following:

- Fixes bugs related to parsing HTML closing comments (`-->`).
- Implements `RegExp::compile` behind the `annex-b` feature.
- Ignores the `legacy-regexp` feature flag, since it's still stage 3.
