### PR TITLE
[Merged by Bors] - Implement var initializers in for-in loops

### DIFF
--- a/boa_ast/src/statement/iteration/mod.rs
+++ b/boa_ast/src/statement/iteration/mod.rs
@@ -9,7 +9,7 @@ mod for_of_loop;
 mod while_loop;
 
 use crate::{
-    declaration::Binding,
+    declaration::{Binding, Variable},
     expression::{access::PropertyAccess, Identifier},
     pattern::Pattern,
 };
@@ -43,7 +43,7 @@ pub enum IterableLoopInitializer {
     /// A property access.
     Access(PropertyAccess),
     /// A new var declaration.
-    Var(Binding),
+    Var(Variable),
     /// A new let declaration.
     Let(Binding),
     /// A new const declaration.
@@ -58,12 +58,12 @@ impl ToInternedString for IterableLoopInitializer {
             Self::Identifier(ident) => return ident.to_interned_string(interner),
             Self::Pattern(pattern) => return pattern.to_interned_string(interner),
             Self::Access(access) => return access.to_interned_string(interner),
-            Self::Var(binding) => (binding, "var"),
-            Self::Let(binding) => (binding, "let"),
-            Self::Const(binding) => (binding, "const"),
+            Self::Var(binding) => (binding.to_interned_string(interner), "var"),
+            Self::Let(binding) => (binding.to_interned_string(interner), "let"),
+            Self::Const(binding) => (binding.to_interned_string(interner), "const"),
         };
 
-        format!("{pre} {}", binding.to_interned_string(interner))
+        format!("{pre} {binding}")
     }
 }
 
@@ -75,7 +75,8 @@ impl VisitWith for IterableLoopInitializer {
         match self {
             Self::Identifier(id) => visitor.visit_identifier(id),
             Self::Access(pa) => visitor.visit_property_access(pa),
-            Self::Var(b) | Self::Let(b) | Self::Const(b) => visitor.visit_binding(b),
+            Self::Var(b) => visitor.visit_variable(b),
+            Self::Let(b) | Self::Const(b) => visitor.visit_binding(b),
             Self::Pattern(p) => visitor.visit_pattern(p),
         }
     }
@@ -87,7 +88,8 @@ impl VisitWith for IterableLoopInitializer {
         match self {
             Self::Identifier(id) => visitor.visit_identifier_mut(id),
             Self::Access(pa) => visitor.visit_property_access_mut(pa),
-            Self::Var(b) | Self::Let(b) | Self::Const(b) => visitor.visit_binding_mut(b),
+            Self::Var(b) => visitor.visit_variable_mut(b),
+            Self::Let(b) | Self::Const(b) => visitor.visit_binding_mut(b),
             Self::Pattern(p) => visitor.visit_pattern_mut(p),
         }
     }

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["deser", "console", "flowgraph", "trace", "annex-b"] }
+boa_engine = { workspace = true, features = ["deser", "flowgraph", "trace", "console"] }
 boa_ast = { workspace = true, features = ["serde"] }
 boa_parser.workspace = true
 boa_gc.workspace = true
@@ -26,8 +26,7 @@ phf = { version = "0.11.1", features = ["macros"] }
 pollster = "0.3.0"
 
 [features]
-default = ["intl"]
-intl = ["boa_engine/intl"]
+default = ["boa_engine/annex-b", "boa_engine/intl"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator = "0.5.0"

--- a/boa_parser/src/error.rs
+++ b/boa_parser/src/error.rs
@@ -125,11 +125,11 @@ impl Error {
         }
     }
 
-    /// Creates a "general" parsing error with the specific error message for a wrong function declaration in an if statement.
-    pub(crate) fn function_declaration_in_if(position: Position, strict: bool) -> Self {
+    /// Creates a "general" parsing error with the specific error message for a misplaced function declaration.
+    pub(crate) fn misplaced_function_declaration(position: Position, strict: bool) -> Self {
         Self::General {
             message: format!(
-                "{}functions can only be declared at top level or inside a block.",
+                "{}functions can only be declared at the top level or inside a block.",
                 if strict { "in strict mode code, " } else { "" }
             )
             .into(),
@@ -140,7 +140,7 @@ impl Error {
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration with label.
     pub(crate) fn wrong_labelled_function_declaration(position: Position) -> Self {
         Self::General {
-            message: "labelled functions can only be declared at top level or inside a block"
+            message: "labelled functions can only be declared at the top level or inside a block"
                 .into(),
             position,
         }

--- a/boa_parser/src/error.rs
+++ b/boa_parser/src/error.rs
@@ -125,18 +125,22 @@ impl Error {
         }
     }
 
-    /// Creates a "general" parsing error with the specific error message for a wrong function declaration in non-strict mode.
-    pub(crate) fn wrong_function_declaration_non_strict(position: Position) -> Self {
+    /// Creates a "general" parsing error with the specific error message for a wrong function declaration in an if statement.
+    pub(crate) fn function_declaration_in_if(position: Position, strict: bool) -> Self {
         Self::General {
-            message: "In non-strict mode code, functions can only be declared at top level, inside a block, or as the body of an if statement.".into(),
-            position
+            message: format!(
+                "{}functions can only be declared at top level or inside a block.",
+                if strict { "in strict mode code, " } else { "" }
+            )
+            .into(),
+            position,
         }
     }
 
     /// Creates a "general" parsing error with the specific error message for a wrong function declaration with label.
     pub(crate) fn wrong_labelled_function_declaration(position: Position) -> Self {
         Self::General {
-            message: "Labelled functions can only be declared at top level or inside a block"
+            message: "labelled functions can only be declared at top level or inside a block"
                 .into(),
             position,
         }

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -178,7 +178,7 @@ impl<R> Lexer<R> {
     where
         R: Read,
     {
-        if !cfg!(feature = "annex-b") || self.module() {
+        if cfg!(not(feature = "annex-b")) || self.module() {
             return Ok(());
         }
 

--- a/boa_parser/src/parser/statement/if_stm/mod.rs
+++ b/boa_parser/src/parser/statement/if_stm/mod.rs
@@ -78,7 +78,7 @@ where
                 // FunctionDeclarations in IfStatement Statement Clauses
                 // https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses
                 if cfg!(not(feature = "annex-b")) || strict {
-                    return Err(Error::function_declaration_in_if(position, strict));
+                    return Err(Error::misplaced_function_declaration(position, strict));
                 }
                 // Source text matched by this production is processed as if each matching
                 // occurrence of FunctionDeclaration[?Yield, ?Await, ~Default] was the sole
@@ -117,7 +117,9 @@ where
                             // FunctionDeclarations in IfStatement Statement Clauses
                             // https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses
                             if cfg!(not(feature = "annex-b")) || strict {
-                                return Err(Error::function_declaration_in_if(position, strict));
+                                return Err(Error::misplaced_function_declaration(
+                                    position, strict,
+                                ));
                             }
 
                             // Source text matched by this production is processed as if each matching

--- a/boa_parser/src/parser/statement/if_stm/mod.rs
+++ b/boa_parser/src/parser/statement/if_stm/mod.rs
@@ -77,9 +77,8 @@ where
             TokenKind::Keyword((Keyword::Function, _)) => {
                 // FunctionDeclarations in IfStatement Statement Clauses
                 // https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses
-                if strict {
-                    // This production only applies when parsing non-strict code.
-                    return Err(Error::wrong_function_declaration_non_strict(position));
+                if cfg!(not(feature = "annex-b")) || strict {
+                    return Err(Error::function_declaration_in_if(position, strict));
                 }
                 // Source text matched by this production is processed as if each matching
                 // occurrence of FunctionDeclaration[?Yield, ?Await, ~Default] was the sole
@@ -117,8 +116,8 @@ where
                         TokenKind::Keyword((Keyword::Function, _)) => {
                             // FunctionDeclarations in IfStatement Statement Clauses
                             // https://tc39.es/ecma262/#sec-functiondeclarations-in-ifstatement-statement-clauses
-                            if strict {
-                                return Err(Error::wrong_function_declaration_non_strict(position));
+                            if cfg!(not(feature = "annex-b")) || strict {
+                                return Err(Error::function_declaration_in_if(position, strict));
                             }
 
                             // Source text matched by this production is processed as if each matching

--- a/boa_parser/src/parser/statement/labelled_stm/mod.rs
+++ b/boa_parser/src/parser/statement/labelled_stm/mod.rs
@@ -68,12 +68,9 @@ where
             TokenKind::Keyword((Keyword::Function, _))
                 if cfg!(not(feature = "annex-b")) || strict =>
             {
-                return Err(Error::general(
-                    format!(
-                        "{}functions can only be declared at top level or inside a block.",
-                        if strict { "in strict mode code, " } else { "" },
-                    ),
+                return Err(Error::misplaced_function_declaration(
                     next_token.span().start(),
+                    strict,
                 ))
             }
             TokenKind::Keyword((Keyword::Function, _)) => {

--- a/boa_parser/src/parser/statement/labelled_stm/mod.rs
+++ b/boa_parser/src/parser/statement/labelled_stm/mod.rs
@@ -65,18 +65,25 @@ where
             // Early Error: It is a Syntax Error if any strict mode source code matches this rule.
             // https://tc39.es/ecma262/#sec-labelled-statements-static-semantics-early-errors
             // https://tc39.es/ecma262/#sec-labelled-function-declarations
-            TokenKind::Keyword((Keyword::Function, _)) if strict => {
+            TokenKind::Keyword((Keyword::Function, _))
+                if cfg!(not(feature = "annex-b")) || strict =>
+            {
                 return Err(Error::general(
-                    "In strict mode code, functions can only be declared at top level or inside a block.",
-                    next_token.span().start()
+                    format!(
+                        "{}functions can only be declared at top level or inside a block.",
+                        if strict { "in strict mode code, " } else { "" },
+                    ),
+                    next_token.span().start(),
                 ))
             }
             TokenKind::Keyword((Keyword::Function, _)) => {
                 FunctionDeclaration::new(self.allow_yield, self.allow_await, false)
-                .parse(cursor, interner)?
-                .into()
+                    .parse(cursor, interner)?
+                    .into()
             }
-            _ => Statement::new(self.allow_yield, self.allow_await, self.allow_return).parse(cursor, interner)?.into()
+            _ => Statement::new(self.allow_yield, self.allow_await, self.allow_return)
+                .parse(cursor, interner)?
+                .into(),
         };
 
         Ok(ast::statement::Labelled::new(labelled_item, label))

--- a/boa_parser/src/parser/statement/variable/mod.rs
+++ b/boa_parser/src/parser/statement/variable/mod.rs
@@ -214,8 +214,13 @@ where
                     .is_some()
                 {
                     Some(
-                        Initializer::new(Some(ident), true, self.allow_yield, self.allow_await)
-                            .parse(cursor, interner)?,
+                        Initializer::new(
+                            Some(ident),
+                            self.allow_in,
+                            self.allow_yield,
+                            self.allow_await,
+                        )
+                        .parse(cursor, interner)?,
                     )
                 } else {
                     None

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -12,7 +12,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["annex-b"] }
+boa_engine.workspace = true
 boa_gc.workspace = true
 clap = { version = "4.2.4", features = ["derive"] }
 serde = { version = "1.0.160", features = ["derive"] }
@@ -31,5 +31,4 @@ comfy-table = "6.1.4"
 serde_repr = "0.1.12"
 
 [features]
-default = ["intl"]
-intl = ["boa_engine/intl"]
+default = ["boa_engine/intl", "boa_engine/annex-b"]

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -12,10 +12,13 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
-boa_engine = { workspace = true, features = ["console", "annex-b"] }
+boa_engine = { workspace = true, features = ["console"] }
 wasm-bindgen = "0.2.84"
 getrandom = { version = "0.2.9", features = ["js"] }
 chrono = { version = "0.4.24", features = ["clock", "std", "wasmbind"] }
+
+[features]
+default = ["boa_engine/annex-b"]
 
 [lib]
 crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
This Pull Request implements [Initializers in ForIn Statement Heads](https://tc39.es/ecma262/#sec-initializers-in-forin-statement-heads) from the Annex B. This also cleans up the "annex-b" feature to be able to disable it with `--no-default-features`, since I couldn't test the error messages when the feature is disabled.
