### PR TITLE
Apply new clippy lints for rustc 1.69.0

### DIFF
--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -176,7 +176,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FormalParameterList {
 
 bitflags! {
     /// Flags for a [`FormalParameterList`].
-    #[derive(Debug, Copy, Clone, PartialEq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
     pub struct FormalParameterListFlags: u8 {
         /// Has only identifier parameters with no initialization expressions.

--- a/boa_ast/src/position.rs
+++ b/boa_ast/src/position.rs
@@ -204,9 +204,9 @@ mod tests {
         let a = Position::new(10, 30);
         let b = Position::new(10, 50);
 
-        let _ = Span::new(a, b);
-        let _ = Span::new(a, a);
-        let _ = Span::from(a);
+        Span::new(a, b);
+        Span::new(a, a);
+        Span::from(a);
     }
 
     /// Checks that the `PartialEq` implementation of `Span` is consistent.

--- a/boa_parser/src/lexer/cursor.rs
+++ b/boa_parser/src/lexer/cursor.rs
@@ -104,7 +104,7 @@ where
 
         Ok(match self.peek()? {
             Some(next) if next == byte => {
-                let _ = self.next_byte()?;
+                self.next_byte()?;
                 true
             }
             _ => false,

--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -128,7 +128,7 @@ impl Identifier {
                     }
                 }
                 Some(ch) if Self::is_identifier_part(ch) => {
-                    let _ = cursor.next_char()?;
+                    cursor.next_char()?;
                     ch
                 },
                 _ => break,

--- a/boa_parser/src/lexer/operator.rs
+++ b/boa_parser/src/lexer/operator.rs
@@ -121,7 +121,7 @@ impl<R> Tokenizer<R> for Operator {
                 );
                 match first {
                     Some(b'?') => {
-                        let _ = cursor.next_byte()?.expect("? vanished");
+                        cursor.next_byte()?.expect("? vanished");
                         op!(
                             cursor,
                             start_pos,
@@ -130,7 +130,7 @@ impl<R> Tokenizer<R> for Operator {
                         )
                     }
                     Some(b'.') if !matches!(second, Some(second) if second.is_ascii_digit()) => {
-                        let _ = cursor.next_byte()?.expect(". vanished");
+                        cursor.next_byte()?.expect(". vanished");
                         Ok(Token::new(
                             TokenKind::Punctuator(Punctuator::Optional),
                             Span::new(start_pos, cursor.pos()),

--- a/boa_parser/src/lexer/string.rs
+++ b/boa_parser/src/lexer/string.rs
@@ -329,14 +329,14 @@ impl StringLiteral {
         // Grammar: FourToSeven OctalDigit
         if let Some(byte) = cursor.peek()? {
             if (b'0'..=b'7').contains(&byte) {
-                let _ = cursor.next_byte()?;
+                cursor.next_byte()?;
                 code_point = (code_point * 8) + u32::from(byte - b'0');
 
                 if (b'0'..=b'3').contains(&init_byte) {
                     // Grammar: ZeroToThree OctalDigit OctalDigit
                     if let Some(byte) = cursor.peek()? {
                         if (b'0'..=b'7').contains(&byte) {
-                            let _ = cursor.next_byte()?;
+                            cursor.next_byte()?;
                             code_point = (code_point * 8) + u32::from(byte - b'0');
                         }
                     }

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -125,6 +125,7 @@ impl Profiler {
             .start_recording_interval_event(kind, id, thread_id)
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     fn get_or_alloc_string(&self, s: &str) -> StringId {
         {
             // Check the cache only with the read lock first.


### PR DESCRIPTION
This applies the newest `cargo clippy` from rustc 1.69.0 to fix our CI.
