### PR TITLE
[Merged by Bors] - Allow `Date` object to store invalid `NativeDateTime`

### DIFF
--- a/boa_engine/src/builtins/date/utils.rs
+++ b/boa_engine/src/builtins/date/utils.rs
@@ -134,10 +134,11 @@ pub(super) struct DateParameters {
 
 /// Replaces some (or all) parameters of `date` with the specified parameters
 pub(super) fn replace_params(
-    datetime: NaiveDateTime,
+    datetime: i64,
     params: DateParameters,
     offset: Option<FixedOffset>,
-) -> Option<NaiveDateTime> {
+) -> Option<i64> {
+    let datetime = NaiveDateTime::from_timestamp_millis(datetime)?;
     let DateParameters {
         year,
         month,
@@ -195,5 +196,5 @@ pub(super) fn replace_params(
             .timestamp_millis();
     }
 
-    NaiveDateTime::from_timestamp_millis(time_clip(ts)?)
+    time_clip(ts)
 }

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -571,7 +571,7 @@ impl JsDate {
             .map_err(|_| JsNativeError::typ().with_message("unpaired surrogate on date string"))?;
         let date_time = DateTime::parse_from_rfc3339(&string)
             .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
-        let date_time = Date::new(Some(date_time.naive_local()));
+        let date_time = Date::new(Some(date_time.naive_local().timestamp_millis()));
 
         Ok(Self {
             inner: JsObject::from_proto_and_data(prototype, ObjectData::date(date_time)),


### PR DESCRIPTION
Part of ES5. 

This PR allows `Date` objects to store an invalid `NativeDateTime` as a `i64` and check when `getMinutes` (or other methods) call and check if it's valid, like in the spec

This was failing some `Date` tests, when calling `new Date(8.64e15)` then calling `getTime()` it was returning `NaN` when it should return the passed value `8640000000000000` (as node does)
