### PR TITLE
[Merged by Bors] - Fix panic when calling toString with radix

### DIFF
--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -590,14 +590,12 @@ impl Number {
                         } else {
                             let c: u8 = frac_buf[fraction_cursor];
                             // Reconstruct digit.
-                            let digit_0 = (c as char)
-                                .to_digit(10)
-                                .expect("character was not a valid digit");
-                            if digit_0 + 1 >= u32::from(radix) {
+                            let digit = if c > b'9' { c - b'a' + 10 } else { c - b'0' };
+                            if digit + 1 >= radix {
                                 continue;
                             }
                             frac_buf[fraction_cursor] =
-                                std::char::from_digit(digit_0 + 1, u32::from(radix))
+                                std::char::from_digit(u32::from(digit + 1), u32::from(radix))
                                     .expect("digit was not a valid number in the given radix")
                                     as u8;
                             fraction_cursor += 1;

--- a/boa_engine/src/builtins/number/tests.rs
+++ b/boa_engine/src/builtins/number/tests.rs
@@ -475,3 +475,12 @@ fn number_is_safe_integer() {
         TestAction::assert("!Number.isSafeInteger(new Number(5))"),
     ]);
 }
+
+// https://github.com/boa-dev/boa/issues/2717
+#[test]
+fn issue_2717() {
+    run_test_actions([
+        TestAction::assert_eq("(0.1600057092765239).toString(36)", "0.5rd85dm1ixq"),
+        TestAction::assert_eq("(0.23046743672210102).toString(36)", "0.8aoosla2phj"),
+    ]);
+}


### PR DESCRIPTION
This Pull Request fixes/closes #2717 and related to #2479

This was caused by an incorrect to digit conversion.

Here are two examples that always cause a panic. They have been added as a test in `number/test.rs`
```js
(0.1600057092765239).toString(36)
(0.23046743672210102).toString(36)
```