### PR TITLE
Implement valid `RexExp` character sets in Annex-B

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3334,8 +3334,7 @@ dependencies = [
 [[package]]
 name = "regress"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d995d590bd8ec096d1893f414bf3f5e8b0ee4c9eed9a5642b9766ef2c8e2e8e9"
+source = "git+https://github.com/ridiculousfish/regress.git?branch=fix/valid-character-sets#8fdd10ced6b1d000c0766247250e764c8e34dbc4"
 dependencies = [
  "hashbrown 0.13.2",
  "memchr",

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -44,7 +44,7 @@ trace = []
 console = []
 
 # Enable Boa's additional ECMAScript features for web browsers.
-annex-b = ["boa_parser/annex-b"]
+annex-b = ["boa_parser/annex-b", "regress/annex-b"]
 
 [dependencies]
 boa_interner.workspace = true
@@ -57,7 +57,7 @@ serde = { version = "1.0.160", features = ["derive", "rc"] }
 serde_json = "1.0.96"
 rand = "0.8.5"
 num-traits = "0.2.15"
-regress = "0.5.0"
+regress = { git = "https://github.com/ridiculousfish/regress.git", branch = "fix/valid-character-sets" }
 rustc-hash = "1.1.0"
 num-bigint = { version = "0.4.3", features = ["serde"] }
 num-integer = "0.1.45"

--- a/boa_parser/Cargo.toml
+++ b/boa_parser/Cargo.toml
@@ -21,7 +21,7 @@ fast-float = "0.2.0"
 num-traits = "0.2.15"
 bitflags = "2.2.0"
 num-bigint = "0.4.3"
-regress = "0.5.0"
+regress = { git = "https://github.com/ridiculousfish/regress.git", branch = "fix/valid-character-sets" }
 
 [features]
-annex-b = []
+annex-b = ["regress/annex-b"]


### PR DESCRIPTION
~~Depends on https://github.com/ridiculousfish/regress/pull/62~~ has been merged :tada: 

The dependency is made to point to the bug fix branch, Once https://github.com/ridiculousfish/regress/pull/62 gets merged and published I will change to the released version :)
