### PR TITLE
[Merged by Bors] - Refactor binding handling APIs

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -213,7 +213,7 @@ impl Eval {
 
             // Poison the last parent function environment, because it may contain new declarations after/during eval.
             if !strict {
-                context.vm.environments.poison_last_function();
+                context.vm.environments.poison_until_last_function();
             }
 
             // Set the compile time environment to the current running environment and save the number of current environments.

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -952,7 +952,7 @@ impl JsObject {
             context
                 .vm
                 .environments
-                .put_value(index, 0, class_object.into());
+                .put_declarative_value(index, 0, class_object.into());
             last_env -= 1;
         }
 
@@ -964,7 +964,7 @@ impl JsObject {
             context
                 .vm
                 .environments
-                .put_value(index, 0, self.clone().into());
+                .put_declarative_value(index, 0, self.clone().into());
             last_env -= 1;
         }
 
@@ -994,11 +994,11 @@ impl JsObject {
                     &this_function_object,
                     &code.params,
                     args,
-                    &env,
+                    env.declarative_expect(),
                     context,
                 )
             };
-            context.vm.environments.put_value(
+            context.vm.environments.put_declarative_value(
                 binding.environment_index(),
                 binding.binding_index(),
                 arguments_obj.into(),
@@ -1202,7 +1202,7 @@ impl JsObject {
                     context
                         .vm
                         .environments
-                        .put_value(index, 0, self.clone().into());
+                        .put_declarative_value(index, 0, self.clone().into());
                     last_env -= 1;
                 }
 
@@ -1231,11 +1231,11 @@ impl JsObject {
                             &this_function_object,
                             &code.params,
                             args,
-                            &env,
+                            env.declarative_expect(),
                             context,
                         )
                     };
-                    context.vm.environments.put_value(
+                    context.vm.environments.put_declarative_value(
                         binding.environment_index(),
                         binding.binding_index(),
                         arguments_obj.into(),

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -25,7 +25,7 @@ impl Operation for GetName {
                 .interner()
                 .resolve_expect(binding_locator.name().sym())
                 .to_string();
-            JsNativeError::reference().with_message(format!("{name} is not initialized"))
+            JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -1,8 +1,7 @@
 use crate::{
     error::JsNativeError,
-    property::DescriptorKind,
     vm::{opcode::Operation, CompletionType},
-    Context, JsResult, JsString, JsValue,
+    Context, JsResult,
 };
 
 /// `GetName` implements the Opcode Operation for `Opcode::GetName`
@@ -18,57 +17,16 @@ impl Operation for GetName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
-        let binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
         binding_locator.throw_mutate_immutable(context)?;
-
-        let value = if binding_locator.is_global() {
-            if let Some(value) = context.get_value_if_global_poisoned(binding_locator.name())? {
-                value
-            } else {
-                let key: JsString = context
-                    .interner()
-                    .resolve_expect(binding_locator.name().sym())
-                    .into_common(false);
-                match context.global_object().get_property(&key.clone().into()) {
-                    Some(desc) => match desc.kind() {
-                        DescriptorKind::Data {
-                            value: Some(value), ..
-                        } => value.clone(),
-                        DescriptorKind::Accessor { get: Some(get), .. } if !get.is_undefined() => {
-                            let get = get.clone();
-                            get.call(&context.global_object().into(), &[], context)?
-                        }
-                        _ => {
-                            return Err(JsNativeError::reference()
-                                .with_message(format!(
-                                    "{} is not defined",
-                                    key.to_std_string_escaped()
-                                ))
-                                .into())
-                        }
-                    },
-                    _ => {
-                        return Err(JsNativeError::reference()
-                            .with_message(format!("{} is not defined", key.to_std_string_escaped()))
-                            .into())
-                    }
-                }
-            }
-        } else if let Some(value) = context.get_value_optional(
-            binding_locator.environment_index(),
-            binding_locator.binding_index(),
-            binding_locator.name(),
-        )? {
-            value
-        } else {
+        context.find_runtime_binding(&mut binding_locator)?;
+        let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
                 .interner()
                 .resolve_expect(binding_locator.name().sym())
                 .to_string();
-            return Err(JsNativeError::reference()
-                .with_message(format!("{name} is not initialized"))
-                .into());
-        };
+            JsNativeError::reference().with_message(format!("{name} is not initialized"))
+        })?;
 
         context.vm.push(value);
         Ok(CompletionType::Normal)
@@ -88,39 +46,12 @@ impl Operation for GetNameOrUndefined {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
-        let binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
         binding_locator.throw_mutate_immutable(context)?;
-        let value = if binding_locator.is_global() {
-            if let Some(value) = context.get_value_if_global_poisoned(binding_locator.name())? {
-                value
-            } else {
-                let key: JsString = context
-                    .interner()
-                    .resolve_expect(binding_locator.name().sym())
-                    .into_common(false);
-                match context.global_object().get_property(&key.into()) {
-                    Some(desc) => match desc.kind() {
-                        DescriptorKind::Data {
-                            value: Some(value), ..
-                        } => value.clone(),
-                        DescriptorKind::Accessor { get: Some(get), .. } if !get.is_undefined() => {
-                            let get = get.clone();
-                            get.call(&context.global_object().into(), &[], context)?
-                        }
-                        _ => JsValue::undefined(),
-                    },
-                    _ => JsValue::undefined(),
-                }
-            }
-        } else if let Some(value) = context.get_value_optional(
-            binding_locator.environment_index(),
-            binding_locator.binding_index(),
-            binding_locator.name(),
-        )? {
-            value
-        } else {
-            JsValue::undefined()
-        };
+
+        context.find_runtime_binding(&mut binding_locator)?;
+
+        let value = context.get_binding(binding_locator)?.unwrap_or_default();
 
         context.vm.push(value);
         Ok(CompletionType::Normal)


### PR DESCRIPTION
We have currently some bugs related to binding assignments on arithmetic operations (`+=`, `++`, `?=`, etc.), but fixing those was getting a bit complex with our current bindings APIs.

This PR refactors our binding handling APIs to be a bit easier to use.
