### PR TITLE
Make update operations reuse the last found binding locator

### DIFF
--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -12,7 +12,7 @@
 use crate::{
     builtins::iterable::create_iter_result_object,
     context::intrinsics::Intrinsics,
-    environments::{BindingLocator, DeclarativeEnvironmentStack},
+    environments::DeclarativeEnvironmentStack,
     error::JsNativeError,
     object::{JsObject, CONSTRUCTOR},
     property::Attribute,
@@ -63,7 +63,6 @@ pub(crate) struct GeneratorContext {
     pub(crate) active_function: Option<JsObject>,
     pub(crate) call_frame: Option<CallFrame>,
     pub(crate) realm: Realm,
-    pub(crate) bindings_stack: Vec<BindingLocator>,
 }
 
 impl GeneratorContext {
@@ -74,7 +73,6 @@ impl GeneratorContext {
         active_function: Option<JsObject>,
         call_frame: CallFrame,
         realm: Realm,
-        bindings_stack: Vec<BindingLocator>,
     ) -> Self {
         Self {
             environments,
@@ -82,7 +80,6 @@ impl GeneratorContext {
             active_function,
             call_frame: Some(call_frame),
             realm,
-            bindings_stack,
         }
     }
 
@@ -94,7 +91,6 @@ impl GeneratorContext {
             stack: context.vm.stack.clone(),
             active_function: context.vm.active_function.clone(),
             realm: context.realm().clone(),
-            bindings_stack: context.vm.bindings_stack.clone(),
         }
     }
 
@@ -108,7 +104,6 @@ impl GeneratorContext {
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
-        std::mem::swap(&mut context.vm.bindings_stack, &mut self.bindings_stack);
         context.swap_realm(&mut self.realm);
         context
             .vm
@@ -123,7 +118,6 @@ impl GeneratorContext {
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
-        std::mem::swap(&mut context.vm.bindings_stack, &mut self.bindings_stack);
         context.swap_realm(&mut self.realm);
         self.call_frame = context.vm.pop_frame();
         assert!(self.call_frame.is_some());

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -1,4 +1,4 @@
-//! Boa's 3tion of ECMAScript's global `Generator` object.
+//! Boa's implementation of ECMAScript's global `Generator` object.
 //!
 //! A Generator is an instance of a generator function and conforms to both the Iterator and Iterable interfaces.
 //!

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -1,4 +1,4 @@
-//! Boa's implementation of ECMAScript's global `Generator` object.
+//! Boa's 3tion of ECMAScript's global `Generator` object.
 //!
 //! A Generator is an instance of a generator function and conforms to both the Iterator and Iterable interfaces.
 //!
@@ -12,7 +12,7 @@
 use crate::{
     builtins::iterable::create_iter_result_object,
     context::intrinsics::Intrinsics,
-    environments::DeclarativeEnvironmentStack,
+    environments::{BindingLocator, DeclarativeEnvironmentStack},
     error::JsNativeError,
     object::{JsObject, CONSTRUCTOR},
     property::Attribute,
@@ -63,6 +63,7 @@ pub(crate) struct GeneratorContext {
     pub(crate) active_function: Option<JsObject>,
     pub(crate) call_frame: Option<CallFrame>,
     pub(crate) realm: Realm,
+    pub(crate) bindings_stack: Vec<BindingLocator>,
 }
 
 impl GeneratorContext {
@@ -73,6 +74,7 @@ impl GeneratorContext {
         active_function: Option<JsObject>,
         call_frame: CallFrame,
         realm: Realm,
+        bindings_stack: Vec<BindingLocator>,
     ) -> Self {
         Self {
             environments,
@@ -80,6 +82,7 @@ impl GeneratorContext {
             active_function,
             call_frame: Some(call_frame),
             realm,
+            bindings_stack,
         }
     }
 
@@ -91,6 +94,7 @@ impl GeneratorContext {
             stack: context.vm.stack.clone(),
             active_function: context.vm.active_function.clone(),
             realm: context.realm().clone(),
+            bindings_stack: context.vm.bindings_stack.clone(),
         }
     }
 
@@ -104,6 +108,7 @@ impl GeneratorContext {
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
+        std::mem::swap(&mut context.vm.bindings_stack, &mut self.bindings_stack);
         context.swap_realm(&mut self.realm);
         context
             .vm
@@ -118,6 +123,7 @@ impl GeneratorContext {
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
+        std::mem::swap(&mut context.vm.bindings_stack, &mut self.bindings_stack);
         context.swap_realm(&mut self.realm);
         self.call_frame = context.vm.pop_frame();
         assert!(self.call_frame.is_some());

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -123,7 +123,6 @@ impl Json {
                 context.realm().environment().compile_env(),
                 context,
             );
-            compiler.create_script_decls(&statement_list, false);
             compiler.compile_statement_list(&statement_list, true, false);
             Gc::new(compiler.finish())
         };

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -78,7 +78,6 @@ impl ByteCompiler<'_, '_> {
             } else {
                 None
             };
-            compiler.create_script_decls(expr.body(), false);
             compiler.compile_statement_list(expr.body(), false, false);
 
             let env_info = compiler.pop_compile_environment();
@@ -397,7 +396,7 @@ impl ByteCompiler<'_, '_> {
                     compiler.push_compile_environment(false);
                     compiler.create_immutable_binding(class_name.into(), true);
                     compiler.push_compile_environment(true);
-                    compiler.create_script_decls(statement_list, false);
+                    compiler.create_declarations(statement_list, false);
                     compiler.compile_statement_list(statement_list, false, false);
                     let env_info = compiler.pop_compile_environment();
                     compiler.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -56,7 +56,13 @@ impl ByteCompiler<'_, '_> {
                 Access::Variable { name } => {
                     let binding = self.get_binding_value(name);
                     let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::GetName, &[index]);
+                    let lex = self.current_environment.borrow().is_lex_binding(name);
+
+                    if lex {
+                        self.emit(Opcode::GetName, &[index]);
+                    } else {
+                        self.emit(Opcode::GetNameAndLocator, &[index]);
+                    }
 
                     if short_circuit {
                         early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -68,10 +74,13 @@ impl ByteCompiler<'_, '_> {
                     if use_expr {
                         self.emit_opcode(Opcode::Dup);
                     }
-
-                    let binding = self.set_mutable_binding(name);
-                    let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::SetName, &[index]);
+                    if lex {
+                        let binding = self.set_mutable_binding(name);
+                        let index = self.get_or_insert_binding(binding);
+                        self.emit(Opcode::SetName, &[index]);
+                    } else {
+                        self.emit_opcode(Opcode::SetNameByBinding);
+                    }
                 }
                 Access::Property { access } => match access {
                     PropertyAccess::Simple(access) => match access.field() {

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -79,7 +79,7 @@ impl ByteCompiler<'_, '_> {
                         let index = self.get_or_insert_binding(binding);
                         self.emit(Opcode::SetName, &[index]);
                     } else {
-                        self.emit_opcode(Opcode::SetNameByBinding);
+                        self.emit_opcode(Opcode::SetNameByLocator);
                     }
                 }
                 Access::Property { access } => match access {

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -24,7 +24,13 @@ impl ByteCompiler<'_, '_> {
             Access::Variable { name } => {
                 let binding = self.get_binding_value(name);
                 let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::GetName, &[index]);
+                let lex = self.current_environment.borrow().is_lex_binding(name);
+
+                if lex {
+                    self.emit(Opcode::GetName, &[index]);
+                } else {
+                    self.emit(Opcode::GetNameAndLocator, &[index]);
+                }
 
                 self.emit_opcode(opcode);
                 if post {
@@ -33,9 +39,13 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::Dup);
                 }
 
-                let binding = self.set_mutable_binding(name);
-                let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::SetName, &[index]);
+                if lex {
+                    let binding = self.set_mutable_binding(name);
+                    let index = self.get_or_insert_binding(binding);
+                    self.emit(Opcode::SetName, &[index]);
+                } else {
+                    self.emit_opcode(Opcode::SetNameByBinding);
+                }
             }
             Access::Property { access } => match access {
                 PropertyAccess::Simple(access) => match access.field() {

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -44,7 +44,7 @@ impl ByteCompiler<'_, '_> {
                     let index = self.get_or_insert_binding(binding);
                     self.emit(Opcode::SetName, &[index]);
                 } else {
-                    self.emit_opcode(Opcode::SetNameByBinding);
+                    self.emit_opcode(Opcode::SetNameByLocator);
                 }
             }
             Access::Property { access } => match access {

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -189,7 +189,6 @@ impl FunctionCompiler {
             compiler.emit_opcode(Opcode::Yield);
         }
 
-        compiler.create_script_decls(body, false);
         compiler.compile_statement_list(body, false, false);
 
         if let Some(env_label) = env_label {

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -736,6 +736,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         use_expr: bool,
         configurable_globals: bool,
     ) {
+        self.create_declarations(list, configurable_globals);
         if use_expr {
             let expr_index = list
                 .statements()
@@ -770,7 +771,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         self.push_compile_environment(strict);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
-        self.create_script_decls(list, true);
+        self.create_declarations(list, true);
 
         if use_expr {
             let expr_index = list
@@ -1349,7 +1350,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
     }
 
     /// Creates the declarations for a script.
-    pub(crate) fn create_script_decls(
+    pub(crate) fn create_declarations(
         &mut self,
         stmt_list: &StatementList,
         configurable_globals: bool,

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -13,7 +13,6 @@ impl ByteCompiler<'_, '_> {
         self.push_compile_environment(false);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
-        self.create_script_decls(block.statement_list(), configurable_globals);
         self.compile_statement_list(block.statement_list(), use_expr, configurable_globals);
 
         let env_info = self.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -23,7 +23,6 @@ impl ByteCompiler<'_, '_> {
         self.push_compile_environment(false);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
-        self.create_script_decls(t.block().statement_list(), configurable_globals);
         self.compile_statement_list(t.block().statement_list(), use_expr, configurable_globals);
 
         let env_info = self.pop_compile_environment();
@@ -89,7 +88,6 @@ impl ByteCompiler<'_, '_> {
             self.emit_opcode(Opcode::Pop);
         }
 
-        self.create_script_decls(catch.block().statement_list(), configurable_globals);
         self.compile_statement_list(
             catch.block().statement_list(),
             use_expr,
@@ -119,7 +117,6 @@ impl ByteCompiler<'_, '_> {
         self.push_compile_environment(false);
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
-        self.create_script_decls(finally.block().statement_list(), configurable_globals);
         self.compile_statement_list(
             finally.block().statement_list(),
             false,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -253,7 +253,6 @@ impl<'host> Context<'host> {
             self.realm.environment().compile_env(),
             self,
         );
-        compiler.create_script_decls(statement_list, false);
         compiler.compile_statement_list(statement_list, true, false);
         Ok(Gc::new(compiler.finish()))
     }

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -56,6 +56,17 @@ impl CompileTimeEnvironment {
             .map_or(false, |binding| binding.lex)
     }
 
+    /// Checks if `name` is a lexical binding.
+    pub(crate) fn is_lex_binding(&self, name: Identifier) -> bool {
+        if let Some(binding) = self.bindings.get(&name) {
+            binding.lex
+        } else if let Some(outer) = &self.outer {
+            outer.borrow().is_lex_binding(name)
+        } else {
+            false
+        }
+    }
+
     /// Returns the number of bindings in this environment.
     pub(crate) fn num_bindings(&self) -> usize {
         self.bindings.len()

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -695,7 +695,7 @@ impl BindingLocator {
     }
 
     /// Creates a binding locator that indicates that the binding is on the global object.
-    pub(crate) const fn global(name: Identifier) -> Self {
+    pub(super) const fn global(name: Identifier) -> Self {
         Self {
             name,
             environment_index: 0,

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -895,8 +895,6 @@ impl Context<'_> {
 
     /// Sets the value of a binding.
     ///
-    /// #
-    ///
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -5,8 +5,12 @@
 mod abrupt_record;
 mod env_stack;
 
-use crate::{builtins::promise::PromiseCapability, object::JsObject, vm::CodeBlock};
+use crate::{
+    builtins::promise::PromiseCapability, environments::BindingLocator, object::JsObject,
+    vm::CodeBlock,
+};
 use boa_gc::{Finalize, Gc, Trace};
+use boa_interner::Sym;
 use thin_vec::ThinVec;
 
 pub(crate) use abrupt_record::AbruptCompletionRecord;
@@ -39,6 +43,9 @@ pub struct CallFrame {
 
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
     pub(crate) iterators: ThinVec<(JsObject, bool)>,
+
+    // The current binding being updated.
+    pub(crate) current_binding: BindingLocator,
 }
 
 /// ---- `CallFrame` public API ----
@@ -69,6 +76,7 @@ impl CallFrame {
             promise_capability: None,
             async_generator: None,
             iterators: ThinVec::new(),
+            current_binding: BindingLocator::global(Sym::EMPTY_STRING.into()),
         }
     }
 

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -10,7 +10,6 @@ use crate::{
     vm::CodeBlock,
 };
 use boa_gc::{Finalize, Gc, Trace};
-use boa_interner::Sym;
 use thin_vec::ThinVec;
 
 pub(crate) use abrupt_record::AbruptCompletionRecord;
@@ -44,8 +43,8 @@ pub struct CallFrame {
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
     pub(crate) iterators: ThinVec<(JsObject, bool)>,
 
-    // The current binding being updated.
-    pub(crate) current_binding: BindingLocator,
+    // The stack of bindings being updated.
+    pub(crate) binding_stack: Vec<BindingLocator>,
 }
 
 /// ---- `CallFrame` public API ----
@@ -76,7 +75,7 @@ impl CallFrame {
             promise_capability: None,
             async_generator: None,
             iterators: ThinVec::new(),
-            current_binding: BindingLocator::global(Sym::EMPTY_STRING.into()),
+            binding_stack: Vec::new(),
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1101,7 +1101,6 @@ impl JsObject {
                         context.vm.active_function.clone(),
                         call_frame,
                         context.realm().clone(),
-                        context.vm.bindings_stack.clone(),
                     )),
                     queue: VecDeque::new(),
                 })
@@ -1114,7 +1113,6 @@ impl JsObject {
                             context.vm.active_function.clone(),
                             call_frame,
                             context.realm().clone(),
-                            context.vm.bindings_stack.clone(),
                         ),
                     },
                 })

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -496,7 +496,7 @@ impl CodeBlock {
             | Opcode::SetPrototype
             | Opcode::PushObjectEnvironment
             | Opcode::IsObject
-            | Opcode::SetNameByBinding
+            | Opcode::SetNameByLocator
             | Opcode::Nop => String::new(),
         }
     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -335,6 +335,7 @@ impl CodeBlock {
             | Opcode::DefInitLet
             | Opcode::DefInitConst
             | Opcode::GetName
+            | Opcode::GetLocator
             | Opcode::GetNameAndLocator
             | Opcode::GetNameOrUndefined
             | Opcode::SetName

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -335,6 +335,7 @@ impl CodeBlock {
             | Opcode::DefInitLet
             | Opcode::DefInitConst
             | Opcode::GetName
+            | Opcode::GetNameAndLocator
             | Opcode::GetNameOrUndefined
             | Opcode::SetName
             | Opcode::DeleteName => {
@@ -495,6 +496,7 @@ impl CodeBlock {
             | Opcode::SetPrototype
             | Opcode::PushObjectEnvironment
             | Opcode::IsObject
+            | Opcode::SetNameByBinding
             | Opcode::Nop => String::new(),
         }
     }
@@ -1099,6 +1101,7 @@ impl JsObject {
                         context.vm.active_function.clone(),
                         call_frame,
                         context.realm().clone(),
+                        context.vm.bindings_stack.clone(),
                     )),
                     queue: VecDeque::new(),
                 })
@@ -1111,6 +1114,7 @@ impl JsObject {
                             context.vm.active_function.clone(),
                             call_frame,
                             context.realm().clone(),
+                            context.vm.bindings_stack.clone(),
                         ),
                     },
                 })

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -403,6 +403,7 @@ impl CodeBlock {
                 | Opcode::DefInitLet
                 | Opcode::DefInitConst
                 | Opcode::GetName
+                | Opcode::GetLocator
                 | Opcode::GetNameAndLocator
                 | Opcode::GetNameOrUndefined
                 | Opcode::SetName

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -567,7 +567,7 @@ impl CodeBlock {
                 | Opcode::SuperCallPrepare
                 | Opcode::SetPrototype
                 | Opcode::IsObject
-                | Opcode::SetNameByBinding
+                | Opcode::SetNameByLocator
                 | Opcode::Nop
                 | Opcode::PushObjectEnvironment => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -403,6 +403,7 @@ impl CodeBlock {
                 | Opcode::DefInitLet
                 | Opcode::DefInitConst
                 | Opcode::GetName
+                | Opcode::GetNameAndLocator
                 | Opcode::GetNameOrUndefined
                 | Opcode::SetName
                 | Opcode::DeleteName => {
@@ -566,6 +567,7 @@ impl CodeBlock {
                 | Opcode::SuperCallPrepare
                 | Opcode::SetPrototype
                 | Opcode::IsObject
+                | Opcode::SetNameByBinding
                 | Opcode::Nop
                 | Opcode::PushObjectEnvironment => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
-    environments::{DeclarativeEnvironment, DeclarativeEnvironmentStack},
+    environments::{BindingLocator, DeclarativeEnvironment, DeclarativeEnvironmentStack},
     vm::code_block::Readable,
     Context, JsError, JsObject, JsResult, JsValue,
 };
@@ -40,6 +40,7 @@ pub(crate) use {
 
 #[cfg(test)]
 mod tests;
+
 /// Virtual Machine.
 #[derive(Debug)]
 pub struct Vm {
@@ -51,6 +52,7 @@ pub struct Vm {
     pub(crate) trace: bool,
     pub(crate) stack_size_limit: usize,
     pub(crate) active_function: Option<JsObject>,
+    pub(crate) bindings_stack: Vec<BindingLocator>,
 }
 
 impl Vm {
@@ -65,6 +67,7 @@ impl Vm {
             trace: false,
             stack_size_limit: 1024,
             active_function: None,
+            bindings_stack: Vec::default(),
         }
     }
 

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
-    environments::{BindingLocator, DeclarativeEnvironment, DeclarativeEnvironmentStack},
+    environments::{DeclarativeEnvironment, DeclarativeEnvironmentStack},
     vm::code_block::Readable,
     Context, JsError, JsObject, JsResult, JsValue,
 };
@@ -52,7 +52,6 @@ pub struct Vm {
     pub(crate) trace: bool,
     pub(crate) stack_size_limit: usize,
     pub(crate) active_function: Option<JsObject>,
-    pub(crate) bindings_stack: Vec<BindingLocator>,
 }
 
 impl Vm {
@@ -67,7 +66,6 @@ impl Vm {
             trace: false,
             stack_size_limit: 1024,
             active_function: None,
-            bindings_stack: Vec::with_capacity(16),
         }
     }
 

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -67,7 +67,7 @@ impl Vm {
             trace: false,
             stack_size_limit: 1024,
             active_function: None,
-            bindings_stack: Vec::default(),
+            bindings_stack: Vec::with_capacity(16),
         }
     }
 

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -49,7 +49,7 @@ impl Operation for GetLocator {
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
         context.find_runtime_binding(&mut binding_locator)?;
 
-        context.vm.frame_mut().current_binding = binding_locator;
+        context.vm.frame_mut().binding_stack.push(binding_locator);
 
         Ok(CompletionType::Normal)
     }
@@ -80,7 +80,7 @@ impl Operation for GetNameAndLocator {
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
-        context.vm.frame_mut().current_binding = binding_locator;
+        context.vm.frame_mut().binding_stack.push(binding_locator);
         context.vm.push(value);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -33,6 +33,28 @@ impl Operation for GetName {
     }
 }
 
+/// `GetLocator` implements the Opcode Operation for `Opcode::GetLocator`
+///
+/// Operation:
+///  - Find a binding on the environment and set the `current_binding` of the current frame.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetLocator;
+
+impl Operation for GetLocator {
+    const NAME: &'static str = "GetLocator";
+    const INSTRUCTION: &'static str = "INST - GetLocator";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        context.find_runtime_binding(&mut binding_locator)?;
+
+        context.vm.frame_mut().current_binding = binding_locator;
+
+        Ok(CompletionType::Normal)
+    }
+}
+
 /// `GetNameAndLocator` implements the Opcode Operation for `Opcode::GetNameAndLocator`
 ///
 /// Operation:

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -36,8 +36,8 @@ impl Operation for GetName {
 /// `GetNameAndLocator` implements the Opcode Operation for `Opcode::GetNameAndLocator`
 ///
 /// Operation:
-///  - Find a binding on the environment chain and push its value to the stack and its
-/// `BindingLocator` to the `bindings_stack`.
+///  - Find a binding on the environment chain and push its value to the stack, setting the
+/// `current_binding` of the current frame.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetNameAndLocator;
 
@@ -58,7 +58,7 @@ impl Operation for GetNameAndLocator {
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
-        context.vm.bindings_stack.push(binding_locator);
+        context.vm.frame_mut().current_binding = binding_locator;
         context.vm.push(value);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -36,7 +36,8 @@ impl Operation for GetName {
 /// `GetNameAndLocator` implements the Opcode Operation for `Opcode::GetNameAndLocator`
 ///
 /// Operation:
-///  - Find a binding on the environment chain and push its value.
+///  - Find a binding on the environment chain and push its value to the stack and its
+/// `BindingLocator` to the `bindings_stack`.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetNameAndLocator;
 

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -33,6 +33,36 @@ impl Operation for GetName {
     }
 }
 
+/// `GetNameAndLocator` implements the Opcode Operation for `Opcode::GetNameAndLocator`
+///
+/// Operation:
+///  - Find a binding on the environment chain and push its value.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetNameAndLocator;
+
+impl Operation for GetNameAndLocator {
+    const NAME: &'static str = "GetNameAndLocator";
+    const INSTRUCTION: &'static str = "INST - GetNameAndLocator";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        binding_locator.throw_mutate_immutable(context)?;
+        context.find_runtime_binding(&mut binding_locator)?;
+        let value = context.get_binding(binding_locator)?.ok_or_else(|| {
+            let name = context
+                .interner()
+                .resolve_expect(binding_locator.name().sym())
+                .to_string();
+            JsNativeError::reference().with_message(format!("{name} is not defined"))
+        })?;
+
+        context.vm.bindings_stack.push(binding_locator);
+        context.vm.push(value);
+        Ok(CompletionType::Normal)
+    }
+}
+
 /// `GetNameOrUndefined` implements the Opcode Operation for `Opcode::GetNameOrUndefined`
 ///
 /// Operation:

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -709,10 +709,10 @@ generate_impl! {
         /// Stack: value **=>**
         SetName,
 
-        /// Assigns a value to the binding pointed by the `current_binding` register.
+        /// Assigns a value to the binding pointed by the top of the `bindings_stack`.
         ///
         /// Stack: value **=>**
-        SetNameByBinding,
+        SetNameByLocator,
 
         /// Deletes a property of the global object.
         ///

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -687,6 +687,14 @@ generate_impl! {
         /// Stack: **=>** value
         GetName,
 
+        /// Find a binding on the environment chain and push its value, storing the found binding locator
+        /// in the `current_binding` register.
+        ///
+        /// Operands: name_index: `u32`
+        ///
+        /// Stack: **=>** value
+        GetNameAndLocator,
+
         /// Find a binding on the environment chain and push its value. If the binding does not exist push undefined.
         ///
         /// Operands: name_index: `u32`
@@ -700,6 +708,11 @@ generate_impl! {
         ///
         /// Stack: value **=>**
         SetName,
+
+        /// Assigns a value to the binding pointed by the `current_binding` register.
+        ///
+        /// Stack: value **=>**
+        SetNameByBinding,
 
         /// Deletes a property of the global object.
         ///

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -687,8 +687,8 @@ generate_impl! {
         /// Stack: **=>** value
         GetName,
 
-        /// Find a binding on the environment chain and push its value, storing the found binding locator
-        /// in the `current_binding` register.
+        ///  Find a binding on the environment chain and push its value to the stack and its
+        /// `BindingLocator` to the `bindings_stack`.
         ///
         /// Operands: name_index: `u32`
         ///

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -687,6 +687,13 @@ generate_impl! {
         /// Stack: **=>** value
         GetName,
 
+        /// Find a binding on the environment and set the `current_binding` of the current frame.
+        ///
+        /// Operands: name_index: `u32`
+        ///
+        /// Stack: **=>**
+        GetLocator,
+
         ///  Find a binding on the environment chain and push its value to the stack and its
         /// `BindingLocator` to the `bindings_stack`.
         ///

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -37,7 +37,7 @@ impl Operation for SetName {
 /// `SetNameByLocator` implements the Opcode Operation for `Opcode::SetNameByLocator`
 ///
 /// Operation:
-///  - Assigns a value to the binding pointed by the top of the `bindings_stack`.
+///  - Assigns a value to the binding pointed by the `current_binding` of the current frame.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetNameByLocator;
 
@@ -46,11 +46,7 @@ impl Operation for SetNameByLocator {
     const INSTRUCTION: &'static str = "INST - SetNameByLocator";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let binding_locator = context
-            .vm
-            .bindings_stack
-            .pop()
-            .expect("a binding should have been pushed before");
+        let binding_locator = context.vm.frame().current_binding;
         let value = context.vm.pop();
         if binding_locator.is_silent() {
             return Ok(CompletionType::Normal);

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -34,16 +34,16 @@ impl Operation for SetName {
     }
 }
 
-/// `SetNameByBinding` implements the Opcode Operation for `Opcode::SetNameByBinding`
+/// `SetNameByLocator` implements the Opcode Operation for `Opcode::SetNameByLocator`
 ///
 /// Operation:
-///  - Assigns a value to the binding pointed by the `current_binding` register.
+///  - Assigns a value to the binding pointed by the top of the `bindings_stack`.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct SetNameByBinding;
+pub(crate) struct SetNameByLocator;
 
-impl Operation for SetNameByBinding {
-    const NAME: &'static str = "SetNameByBinding";
-    const INSTRUCTION: &'static str = "INST - SetNameByBinding";
+impl Operation for SetNameByLocator {
+    const NAME: &'static str = "SetNameByLocator";
+    const INSTRUCTION: &'static str = "INST - SetNameByLocator";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let binding_locator = context

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -1,4 +1,5 @@
 use crate::{
+    environments::{BindingLocator, Environment},
     vm::{opcode::Operation, CompletionType},
     Context, JsNativeError, JsResult,
 };
@@ -25,34 +26,69 @@ impl Operation for SetName {
 
         context.find_runtime_binding(&mut binding_locator)?;
 
-        if !context.is_initialized_binding(&binding_locator)? {
-            if binding_locator.is_global() && context.vm.frame().code_block.strict {
-                let key = context
-                    .interner()
-                    .resolve_expect(binding_locator.name().sym())
-                    .to_string();
-
-                return Err(JsNativeError::reference()
-                    .with_message(format!(
-                        "cannot assign to uninitialized global property `{key}`"
-                    ))
-                    .into());
-            }
-
-            if !binding_locator.is_global() {
-                let key = context
-                    .interner()
-                    .resolve_expect(binding_locator.name().sym())
-                    .to_string();
-
-                return Err(JsNativeError::reference()
-                    .with_message(format!("cannot assign to uninitialized binding `{key}`"))
-                    .into());
-            }
-        }
+        verify_initialized(binding_locator, context)?;
 
         context.set_binding(binding_locator, value, context.vm.frame().code_block.strict)?;
 
         Ok(CompletionType::Normal)
     }
+}
+
+/// `SetNameByBinding` implements the Opcode Operation for `Opcode::SetNameByBinding`
+///
+/// Operation:
+///  - Assigns a value to the binding pointed by the `current_binding` register.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SetNameByBinding;
+
+impl Operation for SetNameByBinding {
+    const NAME: &'static str = "SetNameByBinding";
+    const INSTRUCTION: &'static str = "INST - SetNameByBinding";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let binding_locator = context
+            .vm
+            .bindings_stack
+            .pop()
+            .expect("a binding should have been pushed before");
+        let value = context.vm.pop();
+        if binding_locator.is_silent() {
+            return Ok(CompletionType::Normal);
+        }
+        binding_locator.throw_mutate_immutable(context)?;
+
+        verify_initialized(binding_locator, context)?;
+
+        context.set_binding(binding_locator, value, context.vm.frame().code_block.strict)?;
+
+        Ok(CompletionType::Normal)
+    }
+}
+
+/// Checks that the binding pointed by `locator` exists and is initialized.
+fn verify_initialized(locator: BindingLocator, context: &mut Context<'_>) -> JsResult<()> {
+    if !context.is_initialized_binding(&locator)? {
+        let key = context.interner().resolve_expect(locator.name().sym());
+        let strict = context.vm.frame().code_block.strict;
+
+        let message = if locator.is_global() {
+            strict.then(|| format!("cannot assign to uninitialized global property `{key}`"))
+        } else {
+            match context.environment_expect(locator.environment_index()) {
+                Environment::Declarative(_) => {
+                    Some(format!("cannot assign to uninitialized binding `{key}`"))
+                }
+                Environment::Object(_) if strict => {
+                    Some(format!("cannot assign to uninitialized property `{key}`"))
+                }
+                Environment::Object(_) => None,
+            }
+        };
+
+        if let Some(message) = message {
+            return Err(JsNativeError::reference().with_message(message).into());
+        }
+    }
+
+    Ok(())
 }

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -46,7 +46,12 @@ impl Operation for SetNameByLocator {
     const INSTRUCTION: &'static str = "INST - SetNameByLocator";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let binding_locator = context.vm.frame().current_binding;
+        let binding_locator = context
+            .vm
+            .frame_mut()
+            .binding_stack
+            .pop()
+            .expect("locator should have been popped before");
         let value = context.vm.pop();
         if binding_locator.is_silent() {
             return Ok(CompletionType::Normal);


### PR DESCRIPTION
This Pull Request fixes update operations by reusing the lvalue accessed by the update.

It changes the following:

- Creates ops `GetNameAndLocator` and `SetNameByLocator`.
- Use new ops on update operations (`++`, `+=`, `&&=`, etc.) only when the binding is not lexical.
