### PR TITLE
[Merged by Bors] - Bugfix/new.target is not understood by the parser as an expression #2793

### DIFF
--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -82,7 +82,7 @@ where
             TokenKind::Keyword((Keyword::New, false)) => {
                 cursor.advance(interner);
 
-                if cursor.next_if(Punctuator::Dot, interner)?.is_some() {
+                let lhs_new_target = if cursor.next_if(Punctuator::Dot, interner)?.is_some() {
                     let token = cursor.next(interner).or_abrupt()?;
                     match token.kind() {
                         TokenKind::IdentifierName((Sym::TARGET, ContainsEscapeSequence(true))) => {
@@ -92,7 +92,7 @@ where
                             ));
                         }
                         TokenKind::IdentifierName((Sym::TARGET, ContainsEscapeSequence(false))) => {
-                            return Ok(ast::Expression::NewTarget)
+                            ast::Expression::NewTarget
                         }
                         _ => {
                             return Err(Error::general(
@@ -101,19 +101,20 @@ where
                             ));
                         }
                     }
-                }
-
-                let lhs = self.parse(cursor, interner)?;
-                let args = match cursor.peek(0, interner)? {
-                    Some(next) if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) => {
-                        Arguments::new(self.allow_yield, self.allow_await)
-                            .parse(cursor, interner)?
-                    }
-                    _ => Box::new([]),
+                } else {
+                    let lhs_inner = self.parse(cursor, interner)?;
+                    let args = match cursor.peek(0, interner)? {
+                        Some(next) if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) => {
+                            Arguments::new(self.allow_yield, self.allow_await)
+                                .parse(cursor, interner)?
+                        }
+                        _ => Box::new([]),
+                    };
+                    let call_node = Call::new(lhs_inner, args);
+        
+                    ast::Expression::from(New::from(call_node))
                 };
-                let call_node = Call::new(lhs, args);
-
-                ast::Expression::from(New::from(call_node))
+                lhs_new_target
             }
             TokenKind::Keyword((Keyword::Super, _)) => {
                 cursor.advance(interner);

--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -104,14 +104,16 @@ where
                 } else {
                     let lhs_inner = self.parse(cursor, interner)?;
                     let args = match cursor.peek(0, interner)? {
-                        Some(next) if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) => {
+                        Some(next)
+                            if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) =>
+                        {
                             Arguments::new(self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)?
                         }
                         _ => Box::new([]),
                     };
                     let call_node = Call::new(lhs_inner, args);
-        
+
                     ast::Expression::from(New::from(call_node))
                 };
                 lhs_new_target

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -1,9 +1,9 @@
 use crate::parser::tests::check_script_parser;
 use boa_ast::{
-    expression::literal::Literal,
+    expression::{literal::Literal, Call, Identifier},
     function::{Class, ClassElement, FormalParameterList, Function},
     property::{MethodDefinition, PropertyName},
-    Declaration, StatementList,
+    Declaration, StatementList, Statement, Expression, StatementListItem,
 };
 use boa_interner::Interner;
 use boa_macros::utf16;
@@ -79,6 +79,74 @@ fn check_async_field() {
             async
          }
         ",
+        [Declaration::Class(Class::new(
+            Some(interner.get_or_intern_static("A", utf16!("A")).into()),
+            None,
+            None,
+            elements.into(),
+            true,
+        ))
+        .into()],
+        interner,
+    );
+}
+
+#[test]
+fn check_new_target_with_property_access() {
+    let interner = &mut Interner::default();
+
+    let constructor_body = StatementList {
+        statements: vec![
+            Statement::Expression(
+                Expression::Call(
+                    Call::new(
+                        Expression::Identifier(
+                            Identifier::new(
+                                interner.get_or_intern_static("console", utf16!("console")),
+                            ),
+                        ),
+                        vec![
+                            Expression::Member(
+                                Box::new(Expression::NewTarget),
+                                Box::new(Expression::Identifier(
+                                    Identifier::new(
+                                        interner.get_or_intern_static("name", utf16!("name")),
+                                    ),
+                                )),
+                            ),
+                        ]
+                        .into_iter()
+                        .collect::<Vec<_>>()
+                        .into_boxed_slice(),
+                    ),
+                ),
+            ),
+        ]
+        .into_iter()
+        .map(StatementListItem::from)
+        .collect::<Vec<_>>()
+        .into_boxed_slice(),
+        strict: false,
+    };
+    
+    let elements = vec![ClassElement::MethodDefinition(
+        PropertyName::Identifier(interner.get_or_intern_static("constructor", utf16!("constructor"))),
+        MethodDefinition::Ordinary(Function::new(
+            None,
+            Vec::new(),
+            constructor_body,
+        )),
+    )];
+
+    check_script_parser(
+        r#"
+            class A {
+                constructor() {
+                    console.log(new.target.name);
+                }
+            }
+            const a = new A();
+        "#,
         [Declaration::Class(Class::new(
             Some(interner.get_or_intern_static("A", utf16!("A")).into()),
             None,

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -1,9 +1,9 @@
 use crate::parser::tests::check_script_parser;
 use boa_ast::{
-    expression::{literal::Literal, Call, Identifier},
+    expression::literal::Literal,
     function::{Class, ClassElement, FormalParameterList, Function},
     property::{MethodDefinition, PropertyName},
-    Declaration, StatementList, Statement, Expression, StatementListItem,
+    Declaration, StatementList,
 };
 use boa_interner::Interner;
 use boa_macros::utf16;
@@ -91,70 +91,70 @@ fn check_async_field() {
     );
 }
 
-#[test]
-fn check_new_target_with_property_access() {
-    let interner = &mut Interner::default();
+// #[test]
+// fn check_new_target_with_property_access() {
+//     let interner = &mut Interner::default();
 
-    let constructor_body = StatementList {
-        statements: vec![
-            Statement::Expression(
-                Expression::Call(
-                    Call::new(
-                        Expression::Identifier(
-                            Identifier::new(
-                                interner.get_or_intern_static("console", utf16!("console")),
-                            ),
-                        ),
-                        vec![
-                            Expression::Member(
-                                Box::new(Expression::NewTarget),
-                                Box::new(Expression::Identifier(
-                                    Identifier::new(
-                                        interner.get_or_intern_static("name", utf16!("name")),
-                                    ),
-                                )),
-                            ),
-                        ]
-                        .into_iter()
-                        .collect::<Vec<_>>()
-                        .into_boxed_slice(),
-                    ),
-                ),
-            ),
-        ]
-        .into_iter()
-        .map(StatementListItem::from)
-        .collect::<Vec<_>>()
-        .into_boxed_slice(),
-        strict: false,
-    };
+//     let constructor_body = StatementList {
+//         statements: vec![
+//             Statement::Expression(
+//                 Expression::Call(
+//                     Call::new(
+//                         Expression::Identifier(
+//                             Identifier::new(
+//                                 interner.get_or_intern_static("console", utf16!("console")),
+//                             ),
+//                         ),
+//                         vec![
+//                             Expression::Member(
+//                                 Box::new(Expression::NewTarget),
+//                                 Box::new(Expression::Identifier(
+//                                     Identifier::new(
+//                                         interner.get_or_intern_static("name", utf16!("name")),
+//                                     ),
+//                                 )),
+//                             ),
+//                         ]
+//                         .into_iter()
+//                         .collect::<Vec<_>>()
+//                         .into_boxed_slice(),
+//                     ),
+//                 ),
+//             ),
+//         ]
+//         .into_iter()
+//         .map(StatementListItem::from)
+//         .collect::<Vec<_>>()
+//         .into_boxed_slice(),
+//         strict: false,
+//     };
     
-    let elements = vec![ClassElement::MethodDefinition(
-        PropertyName::Identifier(interner.get_or_intern_static("constructor", utf16!("constructor"))),
-        MethodDefinition::Ordinary(Function::new(
-            None,
-            Vec::new(),
-            constructor_body,
-        )),
-    )];
+//     let elements = vec![ClassElement::MethodDefinition(
+//         PropertyName::Identifier(interner.get_or_intern_static("constructor", utf16!("constructor"))),
+//         MethodDefinition::Ordinary(Function::new(
+//             None,
+//             Vec::new(),
+//             constructor_body,
+//         )),
+//     )];
 
-    check_script_parser(
-        r#"
-            class A {
-                constructor() {
-                    console.log(new.target.name);
-                }
-            }
-            const a = new A();
-        "#,
-        [Declaration::Class(Class::new(
-            Some(interner.get_or_intern_static("A", utf16!("A")).into()),
-            None,
-            None,
-            elements.into(),
-            true,
-        ))
-        .into()],
-        interner,
-    );
-}
+//     check_script_parser(
+//         r#"
+//             class A {
+//                 constructor() {
+//                     console.log(new.target.name);
+//                 }
+//             }
+//             const a = new A();
+//         "#,
+//         [Declaration::Class(Class::new(
+//             Some(interner.get_or_intern_static("A", utf16!("A")).into()),
+//             None,
+//             None,
+//             elements.into(),
+//             true,
+//         ))
+//         .into()],
+//         interner,
+//     );
+// }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2793.

It changes the following:

- Added a condition to the boa_parser/src/parser/expression/left_hand_side/member.rs parse function match operation for the new token that allows for the operation to continue evaluating more tokens when the TARGET keyword follows it.
- Added a test to validate the fix. (Could not figure out the structure of the test suite so it's commented for now). All other tests pass.

Please let me know if there's anything else I can do to improve the fix.
