### PR TITLE
[Merged by Bors] - Improve debug output of `JsNativeError` and `Realm`

### DIFF
--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -417,7 +417,7 @@ impl std::fmt::Display for JsError {
 ///
 /// assert_eq!(native_error.message(), "cannot decode uri");
 /// ```
-#[derive(Debug, Clone, Trace, Finalize, Error)]
+#[derive(Clone, Trace, Finalize, Error)]
 #[error("{kind}: {message}")]
 pub struct JsNativeError {
     /// The kind of native error (e.g. `TypeError`, `SyntaxError`, etc.)
@@ -426,6 +426,16 @@ pub struct JsNativeError {
     #[source]
     cause: Option<Box<JsError>>,
     realm: Option<Realm>,
+}
+
+impl std::fmt::Debug for JsNativeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JsNativeError")
+            .field("kind", &self.kind)
+            .field("message", &self.message)
+            .field("cause", &self.cause)
+            .finish_non_exhaustive()
+    }
 }
 
 impl JsNativeError {

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -6,6 +6,8 @@
 //!
 //! A realm is represented in this implementation as a Realm struct with the fields specified from the spec.
 
+use std::fmt;
+
 use crate::{
     context::{intrinsics::Intrinsics, HostHooks},
     environments::DeclarativeEnvironment,
@@ -17,9 +19,20 @@ use boa_profiler::Profiler;
 /// Representation of a Realm.
 ///
 /// In the specification these are called Realm Records.
-#[derive(Clone, Debug, Trace, Finalize)]
+#[derive(Clone, Trace, Finalize)]
 pub struct Realm {
     inner: Gc<Inner>,
+}
+
+impl fmt::Debug for Realm {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Realm")
+            .field("intrinsics", &self.inner.intrinsics)
+            .field("environment", &self.inner.environment)
+            .field("global_object", &self.inner.global_object)
+            .field("global_this", &self.inner.global_this)
+            .finish()
+    }
 }
 
 impl PartialEq for Realm {
@@ -28,7 +41,7 @@ impl PartialEq for Realm {
     }
 }
 
-#[derive(Debug, Trace, Finalize)]
+#[derive(Trace, Finalize)]
 struct Inner {
     intrinsics: Intrinsics,
     environment: Gc<DeclarativeEnvironment>,


### PR DESCRIPTION
It was reported that the `dbg!` output of native errors was too long. This PR skips printing the `Realm` of a `JsNativeError`. It also improves the `dbg!` output of `Realm` by skipping printing `Inner` and only printing the inner fields of `Inner`.
