### PR TITLE
Prevent allocation of field names

### DIFF
--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -14,6 +14,7 @@ mod utils;
 use crate::{
     builtins::function::ThisMode,
     environments::{BindingLocator, CompileTimeEnvironment},
+    js_string,
     vm::{BindingOpcode, CodeBlock, Opcode},
     Context, JsBigInt, JsString, JsValue,
 };
@@ -241,7 +242,7 @@ pub struct ByteCompiler<'ctx, 'host> {
     pub(crate) literals: Vec<JsValue>,
 
     /// Property field names.
-    pub(crate) names: Vec<Identifier>,
+    pub(crate) names: Vec<JsString>,
 
     /// Private names.
     pub(crate) private_names: Vec<PrivateName>,
@@ -363,8 +364,9 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             return *index;
         }
 
+        let string = self.interner().resolve_expect(name.sym()).utf16();
         let index = self.names.len() as u32;
-        self.names.push(name);
+        self.names.push(js_string!(string));
         self.names_map.insert(name, index);
         index
     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -18,10 +18,7 @@ use crate::{
     vm::CallFrame,
     Context, JsError, JsResult, JsString, JsValue,
 };
-use boa_ast::{
-    expression::Identifier,
-    function::{FormalParameterList, PrivateName},
-};
+use boa_ast::function::{FormalParameterList, PrivateName};
 use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_interner::Sym;
 use boa_profiler::Profiler;
@@ -89,8 +86,7 @@ pub struct CodeBlock {
     pub(crate) literals: Box<[JsValue]>,
 
     /// Property field names.
-    #[unsafe_ignore_trace]
-    pub(crate) names: Box<[Identifier]>,
+    pub(crate) names: Box<[JsString]>,
 
     /// Private names.
     #[unsafe_ignore_trace]
@@ -365,7 +361,7 @@ impl CodeBlock {
                 *pc += size_of::<u32>();
                 format!(
                     "{operand:04}: '{}'",
-                    interner.resolve_expect(self.names[operand as usize].sym()),
+                    self.names[operand as usize].to_std_string_escaped(),
                 )
             }
             Opcode::SetPrivateField

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -445,7 +445,7 @@ impl CodeBlock {
                     pc += size_of::<u32>();
                     let label = format!(
                         "{opcode_str} '{}'",
-                        interner.resolve_expect(self.names[operand as usize].sym()),
+                        self.names[operand as usize].to_std_string_escaped(),
                     );
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -22,10 +22,8 @@ impl Operation for DefineClassStaticGetterByName {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function
@@ -74,10 +72,8 @@ impl Operation for DefineClassGetterByName {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -3,7 +3,7 @@ use crate::{
     object::CONSTRUCTOR,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
-    Context, JsResult, JsString,
+    Context, JsResult,
 };
 
 /// `DefineClassStaticMethodByName` implements the Opcode Operation for `Opcode::DefineClassStaticMethodByName`
@@ -22,10 +22,8 @@ impl Operation for DefineClassStaticMethodByName {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function
@@ -70,10 +68,8 @@ impl Operation for DefineClassMethodByName {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -22,10 +22,8 @@ impl Operation for DefineClassStaticSetterByName {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function
@@ -75,10 +73,8 @@ impl Operation for DefineClassSetterByName {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context
-            .interner()
-            .resolve_expect(context.vm.frame().code_block.names[index as usize].sym())
-            .into_common::<JsString>(false)
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         {
             let function_object = function

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -1,7 +1,7 @@
 use crate::{
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
-    Context, JsNativeError, JsResult, JsString,
+    Context, JsNativeError, JsResult,
 };
 
 /// `DefineOwnPropertyByName` implements the Opcode Operation for `Opcode::DefineOwnPropertyByName`
@@ -24,11 +24,7 @@ impl Operation for DefineOwnPropertyByName {
         } else {
             object.to_object(context)?
         };
-        let name = context.vm.frame().code_block.names[index as usize];
-        let name = context
-            .interner()
-            .resolve_expect(name.sym())
-            .into_common::<JsString>(false);
+        let name = context.vm.frame().code_block.names[index as usize].clone();
         object.__define_own_property__(
             &name.into(),
             PropertyDescriptor::builder()

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::JsNativeError,
     vm::{opcode::Operation, CompletionType},
-    Context, JsResult, JsString,
+    Context, JsResult,
 };
 
 /// `DeletePropertyByName` implements the Opcode Operation for `Opcode::DeletePropertyByName`
@@ -17,14 +17,11 @@ impl Operation for DeletePropertyByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
-        let key = context.vm.frame().code_block.names[index as usize];
-        let key = context
-            .interner()
-            .resolve_expect(key.sym())
-            .into_common::<JsString>(false)
-            .into();
         let value = context.vm.pop();
         let object = value.to_object(context)?;
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
+            .into();
         let result = object.__delete__(&key, context)?;
         if !result && context.vm.frame().code_block.strict {
             return Err(JsNativeError::typ()

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -1,5 +1,4 @@
 use crate::{
-    js_string,
     property::PropertyKey,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsValue,
@@ -26,8 +25,9 @@ impl Operation for GetPropertyByName {
             value.to_object(context)?
         };
 
-        let name = context.vm.frame().code_block.names[index as usize];
-        let key: PropertyKey = context.interner().resolve_expect(name.sym()).utf16().into();
+        let key = context.vm.frame().code_block.names[index as usize]
+            .clone()
+            .into();
         let result = object.__get__(&key, value, context)?;
 
         context.vm.push(result);
@@ -93,8 +93,7 @@ impl Operation for GetMethod {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize];
-        let key = js_string!(context.interner().resolve_expect(name.sym()).utf16());
+        let key = context.vm.frame().code_block.names[index as usize].clone();
         let value = context.vm.pop();
 
         let method = value.get_method(key, context)?;

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -30,8 +30,9 @@ impl Operation for SetPropertyByName {
             object.to_object(context)?
         };
 
-        let name = context.vm.frame().code_block.names[index as usize];
-        let name: PropertyKey = context.interner().resolve_expect(name.sym()).utf16().into();
+        let name: PropertyKey = context.vm.frame().code_block.names[index as usize]
+            .clone()
+            .into();
 
         let succeeded = object.__set__(name.clone(), value.clone(), receiver, context)?;
         if !succeeded && context.vm.frame().code_block.strict {
@@ -163,11 +164,8 @@ impl Operation for SetPropertyGetterByName {
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = object.to_object(context)?;
-        let name = context.vm.frame().code_block.names[index as usize];
-        let name = context
-            .interner()
-            .resolve_expect(name.sym())
-            .into_common::<JsString>(false)
+        let name = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         let set = object
             .__get_own_property__(&name, context)?
@@ -240,11 +238,8 @@ impl Operation for SetPropertySetterByName {
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = object.to_object(context)?;
-        let name = context.vm.frame().code_block.names[index as usize];
-        let name = context
-            .interner()
-            .resolve_expect(name.sym())
-            .into_common::<JsString>(false)
+        let name = context.vm.frame().code_block.names[index as usize]
+            .clone()
             .into();
         let get = object
             .__get_own_property__(&name, context)?


### PR DESCRIPTION
This PR makes the `CodeBlock` store `JsString`s in the `names` field instead of `Identifier` (which is a wrapper around `Sym`), This is done because once we resolve the `sym` and get the `&[u16]` we allocate a `JsString` on every field access in the worst case and at best if it's part of the static strings array we do a `HashMap` lookup.

Ran the benchmarks locally and there was a `2%` to `10%` increase in performance in some of the benchmarks.

The performance increase can be better seen by running the `quickjs` benches:

<h3>Main</h3>

```
PROGRESS Richards
RESULT Richards 19.8
PROGRESS DeltaBlue
RESULT DeltaBlue 21.9
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 27.9
PROGRESS RayTrace
RESULT RayTrace 76.8
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 67.8
ERROR RegExp TypeError: not a constructor
undefined
PROGRESS RegExp
PROGRESS Splay
RESULT Splay 99.4
PROGRESS NavierStokes
RESULT NavierStokes 6.28
SCORE 32.6
Uncaught Error: Benchmark had 1 errors
```

<h3>PR</h3>

```
PROGRESS Richards
RESULT Richards 21.0
PROGRESS DeltaBlue
RESULT DeltaBlue 23.0
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 28.4
PROGRESS RayTrace
RESULT RayTrace 81.2
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 69.2
ERROR RegExp TypeError: not a constructor
undefined
PROGRESS RegExp
PROGRESS Splay
RESULT Splay 101
PROGRESS NavierStokes
RESULT NavierStokes 6.33
SCORE 33.7
Uncaught Error: Benchmark had 1 errors
```
