### PR TITLE
Fix value property assignment order

### DIFF
--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -335,7 +335,7 @@ impl ByteCompiler<'_, '_> {
                         }
                         PropertyName::Computed(name) => {
                             self.compile_expr(name, true);
-                            self.emit_opcode(Opcode::Swap);
+                            self.emit_opcode(Opcode::ToPropertyKey);
                             None
                         }
                     };

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -108,11 +108,14 @@ impl ByteCompiler<'_, '_> {
                         PropertyAccessField::Expr(expr) => {
                             self.compile_expr(access.target(), true);
                             self.emit_opcode(Opcode::Dup);
-                            self.compile_expr(expr, true);
 
-                            self.emit_opcode(Opcode::GetPropertyByValuePush);
+                            self.compile_expr(expr, true);
+                            self.emit_opcode(Opcode::ToPropertyKey);
+                            self.emit_opcode(Opcode::DupKey);
+
+                            self.emit_opcode(Opcode::GetPropertyByValue);
                             if short_circuit {
-                                pop_count = 2;
+                                pop_count = 1;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
                                 self.compile_expr(assign.rhs(), true);
                             } else {
@@ -172,11 +175,15 @@ impl ByteCompiler<'_, '_> {
                         PropertyAccessField::Expr(expr) => {
                             self.emit_opcode(Opcode::Super);
                             self.emit_opcode(Opcode::Dup);
-                            self.compile_expr(expr, true);
 
-                            self.emit_opcode(Opcode::GetPropertyByValuePush);
+                            self.compile_expr(expr, true);
+                            self.emit_opcode(Opcode::ToPropertyKey);
+                            self.emit_opcode(Opcode::DupKey);
+
+                            self.emit_opcode(Opcode::GetPropertyByValue);
+
                             if short_circuit {
-                                pop_count = 2;
+                                pop_count = 1;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
                                 self.compile_expr(assign.rhs(), true);
                             } else {
@@ -184,7 +191,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit(Opcode::SetPropertyByValue, &[]);
+                            self.emit_opcode(Opcode::SetPropertyByValue);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -230,7 +230,7 @@ impl ByteCompiler<'_, '_> {
                 match template.tag() {
                     Expression::PropertyAccess(PropertyAccess::Simple(access)) => {
                         self.compile_expr(access.target(), true);
-                        self.emit(Opcode::Dup, &[]);
+                        self.emit_opcode(Opcode::Dup);
                         match access.field() {
                             PropertyAccessField::Const(field) => {
                                 let index = self.get_or_insert_name((*field).into());
@@ -238,7 +238,8 @@ impl ByteCompiler<'_, '_> {
                             }
                             PropertyAccessField::Expr(field) => {
                                 self.compile_expr(field, true);
-                                self.emit(Opcode::GetPropertyByValue, &[]);
+                                self.emit_opcode(Opcode::ToPropertyKey);
+                                self.emit_opcode(Opcode::GetPropertyByValue);
                             }
                         }
                     }

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -32,8 +32,9 @@ impl ByteCompiler<'_, '_> {
                     PropertyName::Computed(name_node) => {
                         self.compile_expr(name_node, true);
                         self.emit_opcode(Opcode::ToPropertyKey);
+
                         if expr.is_anonymous_function_definition() {
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
                             self.compile_expr(expr, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
@@ -53,7 +54,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(1);
@@ -69,7 +71,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(2);
@@ -85,7 +88,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
@@ -101,7 +105,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
@@ -117,7 +122,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);
@@ -133,7 +139,8 @@ impl ByteCompiler<'_, '_> {
                         PropertyName::Computed(name_node) => {
                             self.compile_expr(name_node, true);
                             self.emit_opcode(Opcode::ToPropertyKey);
-                            self.emit_opcode(Opcode::Dup);
+                            self.emit_opcode(Opcode::DupKey);
+
                             self.function(expr.into(), NodeKind::Expression, true);
                             self.emit_opcode(Opcode::SetFunctionName);
                             self.emit_u8(0);

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -70,13 +70,16 @@ impl ByteCompiler<'_, '_> {
                     PropertyAccessField::Expr(expr) => {
                         self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
-                        self.compile_expr(expr, true);
 
-                        self.emit_opcode(Opcode::GetPropertyByValuePush);
+                        self.compile_expr(expr, true);
+                        self.emit_opcode(Opcode::ToPropertyKey);
+                        self.emit_opcode(Opcode::DupKey);
+
+                        self.emit_opcode(Opcode::GetPropertyByValue);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(4);
+                            self.emit_u8(3);
                         }
 
                         self.emit_opcode(Opcode::SetPropertyByValue);
@@ -125,13 +128,16 @@ impl ByteCompiler<'_, '_> {
                     PropertyAccessField::Expr(expr) => {
                         self.emit_opcode(Opcode::Super);
                         self.emit_opcode(Opcode::Dup);
-                        self.compile_expr(expr, true);
 
-                        self.emit_opcode(Opcode::GetPropertyByValuePush);
+                        self.compile_expr(expr, true);
+                        self.emit_opcode(Opcode::ToPropertyKey);
+                        self.emit_opcode(Opcode::DupKey);
+
+                        self.emit_opcode(Opcode::GetPropertyByValue);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(2);
+                            self.emit_u8(3);
                         }
 
                         self.emit_opcode(Opcode::SetPropertyByValue);

--- a/boa_engine/src/property/mod.rs
+++ b/boa_engine/src/property/mod.rs
@@ -18,7 +18,7 @@
 mod attribute;
 
 use crate::{js_string, object::shape::slot::SlotAttributes, JsString, JsSymbol, JsValue};
-use boa_gc::{Finalize, Trace};
+use boa_gc::{empty_trace, Finalize, Trace};
 use std::{fmt, iter::FusedIterator};
 
 pub use attribute::Attribute;
@@ -580,6 +580,12 @@ pub enum PropertyKey {
 
     /// A numeric property key.
     Index(u32),
+}
+
+// SAFETY: `PropertyKey` can only contain non-traceable types, making this
+// empty implementation safe.
+unsafe impl Trace for PropertyKey {
+    empty_trace!();
 }
 
 /// Utility function for parsing [`PropertyKey`].

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -7,7 +7,7 @@ mod env_stack;
 
 use crate::{
     builtins::promise::PromiseCapability, environments::BindingLocator, object::JsObject,
-    vm::CodeBlock,
+    property::PropertyKey, vm::CodeBlock,
 };
 use boa_gc::{Finalize, Gc, Trace};
 use thin_vec::ThinVec;
@@ -43,8 +43,11 @@ pub struct CallFrame {
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
     pub(crate) iterators: ThinVec<(JsObject, bool)>,
 
-    // The stack of bindings being updated.
-    pub(crate) binding_stack: Vec<BindingLocator>,
+    // Bindings being updated.
+    pub(crate) binding_stack: ThinVec<BindingLocator>,
+
+    // Property keys being accessed.
+    pub(crate) keys: ThinVec<PropertyKey>,
 }
 
 /// ---- `CallFrame` public API ----
@@ -75,7 +78,8 @@ impl CallFrame {
             promise_capability: None,
             async_generator: None,
             iterators: ThinVec::new(),
-            binding_stack: Vec::new(),
+            binding_stack: ThinVec::new(),
+            keys: ThinVec::new(),
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -389,6 +389,7 @@ impl CodeBlock {
             Opcode::Pop
             | Opcode::PopIfThrown
             | Opcode::Dup
+            | Opcode::DupKey
             | Opcode::Swap
             | Opcode::PushZero
             | Opcode::PushOne
@@ -436,7 +437,6 @@ impl CodeBlock {
             | Opcode::Dec
             | Opcode::DecPost
             | Opcode::GetPropertyByValue
-            | Opcode::GetPropertyByValuePush
             | Opcode::SetPropertyByValue
             | Opcode::DefineOwnPropertyByValue
             | Opcode::DefineClassStaticMethodByValue

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -465,6 +465,7 @@ impl CodeBlock {
                 Opcode::Pop
                 | Opcode::PopIfThrown
                 | Opcode::Dup
+                | Opcode::DupKey
                 | Opcode::Swap
                 | Opcode::PushZero
                 | Opcode::PushOne
@@ -512,7 +513,6 @@ impl CodeBlock {
                 | Opcode::Dec
                 | Opcode::DecPost
                 | Opcode::GetPropertyByValue
-                | Opcode::GetPropertyByValuePush
                 | Opcode::SetPropertyByValue
                 | Opcode::DefineOwnPropertyByValue
                 | Opcode::DefineClassStaticMethodByValue

--- a/boa_engine/src/vm/opcode/copy/mod.rs
+++ b/boa_engine/src/vm/opcode/copy/mod.rs
@@ -29,11 +29,13 @@ impl Operation for CopyDataProperties {
         let object = value.as_object().expect("not an object");
         let source = context.vm.pop();
         for _ in 0..excluded_key_count_computed {
-            let key = context.vm.pop();
-            excluded_keys.push(
-                key.to_property_key(context)
-                    .expect("key must be property key"),
-            );
+            let key = context
+                .vm
+                .frame_mut()
+                .keys
+                .pop()
+                .expect("property key should have been pushed");
+            excluded_keys.push(key);
         }
         object.copy_data_properties(&source, excluded_keys, context)?;
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -129,12 +129,14 @@ impl Operation for DefineClassStaticGetterByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()
@@ -179,12 +181,14 @@ impl Operation for DefineClassGetterByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -121,12 +121,14 @@ impl Operation for DefineClassStaticMethodByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()
@@ -167,12 +169,14 @@ impl Operation for DefineClassMethodByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -132,12 +132,14 @@ impl Operation for DefineClassStaticSetterByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()
@@ -184,12 +186,14 @@ impl Operation for DefineClassSetterByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let function = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = key
-            .to_property_key(context)
-            .expect("property key must already be valid");
         {
             let function_object = function
                 .as_object()

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -56,14 +56,18 @@ impl Operation for DefineOwnPropertyByValue {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let value = context.vm.pop();
-        let key = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let object = context.vm.pop();
         let object = if let Some(object) = object.as_object() {
             object.clone()
         } else {
             object.to_object(context)?
         };
-        let key = key.to_property_key(context)?;
         let success = object.__define_own_property__(
             &key,
             PropertyDescriptor::builder()

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -48,11 +48,15 @@ impl Operation for DeletePropertyByValue {
     const INSTRUCTION: &'static str = "INST - DeletePropertyByValue";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let key_value = context.vm.pop();
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .pop()
+            .expect("property key should have been pushed");
         let value = context.vm.pop();
         let object = value.to_object(context)?;
-        let property_key = key_value.to_property_key(context)?;
-        let result = object.__delete__(&property_key, context)?;
+        let result = object.__delete__(&key, context)?;
         if !result && context.vm.frame().code_block.strict {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")

--- a/boa_engine/src/vm/opcode/dup/mod.rs
+++ b/boa_engine/src/vm/opcode/dup/mod.rs
@@ -21,3 +21,28 @@ impl Operation for Dup {
         Ok(CompletionType::Normal)
     }
 }
+
+/// `DupKey` implements the Opcode Operation for `Opcode::DupKey`
+///
+/// Operation:
+/// - Duplicates the top of the property keys stack
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DupKey;
+
+impl Operation for DupKey {
+    const NAME: &'static str = "DupKey";
+    const INSTRUCTION: &'static str = "INST - DupKey";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let key = context
+            .vm
+            .frame_mut()
+            .keys
+            .last()
+            .expect("keys stack must not be empty")
+            .clone();
+
+        context.vm.frame_mut().keys.push(key);
+        Ok(CompletionType::Normal)
+    }
+}

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -621,7 +621,7 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: value **=>** (ToNumeric(value)), (value + 1)
+        /// Stack: value **=>** (value + 1), (ToNumeric(value))
         IncPost,
 
         /// Unary `--` operator.
@@ -635,7 +635,7 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: value **=>** (ToNumeric(value)), (value - 1)
+        /// Stack: value **=>** (value - 1), (ToNumeric(value))
         DecPost,
 
         /// Declare and initialize a function argument.
@@ -751,17 +751,9 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: object, key **=>** value
+        /// Stack: object **=>** value
+        /// Key stack: key **=>**
         GetPropertyByValue,
-
-        /// Get a property by value from an object an push the key and value on the stack.
-        ///
-        /// Like `object[key]`
-        ///
-        /// Operands:
-        ///
-        /// Stack: object, key **=>** key, value
-        GetPropertyByValuePush,
 
         /// Sets a property by name of an object.
         ///
@@ -815,28 +807,32 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>** value
+        /// Stack: object, value **=>** value
+        /// Key stack: key **=>**
         SetPropertyByValue,
 
         /// Defines a own property of an object by value.
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: object, value **=>**
+        /// Key stack: key **=>**
         DefineOwnPropertyByValue,
 
         /// Defines a static class method by value.
         ///
         /// Operands:
         ///
-        /// Stack: class, key, function **=>**
+        /// Stack: class, function **=>**
+        /// Key stack: key **=>**
         DefineClassStaticMethodByValue,
 
         /// Defines a class method by value.
         ///
         /// Operands:
         ///
-        /// Stack: class_proto, key, function **=>**
+        /// Stack: class_proto, function **=>**
+        /// Key stack: key **=>**
         DefineClassMethodByValue,
 
         /// Sets a getter property by name of an object.
@@ -872,7 +868,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: object, value **=>**
+        /// Key stack: key **=>**
         SetPropertyGetterByValue,
 
         /// Defines a static getter class method by value.
@@ -881,7 +878,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: class, key, function **=>**
+        /// Stack: class, function **=>**
+        /// Key stack: key **=>**
         DefineClassStaticGetterByValue,
 
         /// Defines a getter class method by value.
@@ -890,7 +888,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: class_proto, key, function **=>**
+        /// Stack: class_proto, function **=>**
+        /// Key stack: key **=>**
         DefineClassGetterByValue,
 
         /// Sets a setter property by name of an object.
@@ -926,7 +925,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: object, key, value **=>**
+        /// Stack: object, value **=>**
+        /// Key stack: key **=>**
         SetPropertySetterByValue,
 
         /// Defines a static setter class method by value.
@@ -935,7 +935,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: class, key, function **=>**
+        /// Stack: class, function **=>**
+        /// Key stack: key **=>**
         DefineClassStaticSetterByValue,
 
         /// Defines a setter class method by value.
@@ -944,7 +945,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: class_proto, key, function **=>**
+        /// Stack: class_proto, function **=>**
+        /// Key stack: key **=>**
         DefineClassSetterByValue,
 
         /// Set the value of a private property of an object by it's name.
@@ -1051,7 +1053,8 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: object, key **=>**
+        /// Stack: object **=>**
+        /// Key stack: key **=>**
         DeletePropertyByValue,
 
         /// Throws an error when trying to delete a property of `super`
@@ -1072,8 +1075,17 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: value **=>** key
+        /// Stack: value **=>**
+        ///
+        /// Key stack: **=>** key
         ToPropertyKey,
+
+        /// Duplicates the top of the property keys stack.
+        ///
+        /// Operands:
+        ///
+        /// Key stack: key **=>** key, key
+        DupKey,
 
         /// Unconditional jump to address.
         ///

--- a/boa_engine/src/vm/opcode/to/mod.rs
+++ b/boa_engine/src/vm/opcode/to/mod.rs
@@ -35,7 +35,7 @@ impl Operation for ToPropertyKey {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let key = value.to_property_key(context)?;
-        context.vm.push(key);
+        context.vm.frame_mut().keys.push(key);
         Ok(CompletionType::Normal)
     }
 }


### PR DESCRIPTION
This PR reorders assignments evaluation to conform to the spec... however, it seems to be undecided if the new assignment semantics are intended or a bug on the spec (see https://github.com/tc39/ecma262/issues/2659 and https://github.com/tc39/test262/issues/3407).

If it's indeed a bug on the spec, this should be closed in favour of the current semantics. Otherwise, this can be merged.

Per the previous explanation, this is blocked on https://github.com/tc39/ecma262/issues/2659)