### PR TITLE
Implement runtime limits for recursion

### DIFF
--- a/boa_cli/src/debug/limits.rs
+++ b/boa_cli/src/debug/limits.rs
@@ -1,7 +1,7 @@
 use boa_engine::{
     object::{FunctionObjectBuilder, ObjectInitializer},
     property::Attribute,
-    Context, JsArgs, JsObject, JsResult, JsValue, NativeFunction,
+    Context, JsArgs, JsNativeError, JsObject, JsResult, JsValue, NativeFunction,
 };
 
 fn get_loop(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
@@ -15,6 +15,22 @@ fn set_loop(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResul
     Ok(JsValue::undefined())
 }
 
+fn get_recursion(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    let max = context.runtime_limits().recursion_limit();
+    Ok(JsValue::from(max))
+}
+
+fn set_recursion(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    let value = args.get_or_undefined(0).to_length(context)?;
+    let Ok(value) = value.try_into() else {
+        return Err(
+            JsNativeError::range().with_message(format!("Argument {value} greater than usize::MAX")).into()
+        );
+    };
+    context.runtime_limits_mut().set_recursion_limit(value);
+    Ok(JsValue::undefined())
+}
+
 pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
     let get_loop = FunctionObjectBuilder::new(context, NativeFunction::from_fn_ptr(get_loop))
         .name("get loop")
@@ -24,11 +40,28 @@ pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
         .name("set loop")
         .length(1)
         .build();
+
+    let get_recursion =
+        FunctionObjectBuilder::new(context, NativeFunction::from_fn_ptr(get_recursion))
+            .name("get recursion")
+            .length(0)
+            .build();
+    let set_recursion =
+        FunctionObjectBuilder::new(context, NativeFunction::from_fn_ptr(set_recursion))
+            .name("set recursion")
+            .length(1)
+            .build();
     ObjectInitializer::new(context)
         .accessor(
             "loop",
             Some(get_loop),
             Some(set_loop),
+            Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
+        )
+        .accessor(
+            "recursion",
+            Some(get_recursion),
+            Some(set_recursion),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::NON_ENUMERABLE,
         )
         .build()

--- a/boa_engine/src/vm/opcode/call/mod.rs
+++ b/boa_engine/src/vm/opcode/call/mod.rs
@@ -17,6 +17,14 @@ impl Operation for CallEval {
     const INSTRUCTION: &'static str = "INST - CallEval";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
@@ -77,6 +85,14 @@ impl Operation for CallEvalSpread {
     const INSTRUCTION: &'static str = "INST - CallEvalSpread";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
@@ -143,6 +159,14 @@ impl Operation for Call {
     const INSTRUCTION: &'static str = "INST - Call";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
@@ -182,6 +206,14 @@ impl Operation for CallSpread {
     const INSTRUCTION: &'static str = "INST - CallSpread";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -86,7 +86,7 @@ impl Operation for LoopContinue {
                     cleanup_loop_environment(context);
 
                     return Err(JsNativeError::runtime_limit()
-                        .with_message(format!("max loop iteration limit {max} exceeded"))
+                        .with_message(format!("Maximum loop iteration limit {max} exceeded"))
                         .into());
                 }
             }

--- a/boa_engine/src/vm/opcode/new/mod.rs
+++ b/boa_engine/src/vm/opcode/new/mod.rs
@@ -16,6 +16,14 @@ impl Operation for New {
     const INSTRUCTION: &'static str = "INST - New";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
@@ -55,6 +63,14 @@ impl Operation for NewSpread {
     const INSTRUCTION: &'static str = "INST - NewSpread";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+            return Err(JsNativeError::runtime_limit()
+                .with_message(format!(
+                    "Maximum recursion limit {} exceeded",
+                    context.vm.runtime_limits.recursion_limit()
+                ))
+                .into());
+        }
         if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")

--- a/boa_engine/src/vm/runtime_limits.rs
+++ b/boa_engine/src/vm/runtime_limits.rs
@@ -6,6 +6,9 @@ pub struct RuntimeLimits {
 
     /// Max loop iterations before an error is thrown.
     loop_iteration_limit: u64,
+
+    /// Max function recursion limit
+    resursion_limit: usize,
 }
 
 impl Default for RuntimeLimits {
@@ -13,6 +16,7 @@ impl Default for RuntimeLimits {
     fn default() -> Self {
         Self {
             loop_iteration_limit: u64::MAX,
+            resursion_limit: 400,
             stack_size_limit: 1024,
         }
     }
@@ -57,5 +61,18 @@ impl RuntimeLimits {
     #[inline]
     pub fn set_stack_size_limit(&mut self, value: usize) {
         self.stack_size_limit = value;
+    }
+
+    /// Get recursion limit.
+    #[inline]
+    #[must_use]
+    pub const fn recursion_limit(&self) -> usize {
+        self.resursion_limit
+    }
+
+    /// Set recursion limit before an error is thrown.
+    #[inline]
+    pub fn set_recursion_limit(&mut self, value: usize) {
+        self.resursion_limit = value;
     }
 }

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -265,7 +265,7 @@ Its setter can be used to set the recursion limit.
 $boa.limits.recursion = 100;
 
 function x() {
-    return x();
+  return x();
 }
 x(); // RuntimeLimit: Maximum recursion limit 100 exceeded
 ```

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -255,3 +255,17 @@ $boa.limits.loop = 10;
 
 while (true) {} // RuntimeLimit: max loop iteration limit 10 exceeded
 ```
+
+### Getter & Setter `$boa.limits.recursion`
+
+This is an accessor property on the module, its getter returns the recursion limit before an error is thrown.
+Its setter can be used to set the recursion limit.
+
+```javascript
+$boa.limits.recursion = 100;
+
+function x() {
+    return x();
+}
+x(); // RuntimeLimit: Maximum recursion limit 100 exceeded
+```

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -253,7 +253,7 @@ Its setter can be used to set the loop iteration limit.
 ```javascript
 $boa.limits.loop = 10;
 
-while (true) {} // RuntimeLimit: max loop iteration limit 10 exceeded
+while (true) {} // RuntimeLimit: Maximum loop iteration limit 10 exceeded
 ```
 
 ### Getter & Setter `$boa.limits.recursion`

--- a/test_ignore.toml
+++ b/test_ignore.toml
@@ -7,7 +7,6 @@ features = [
     "SharedArrayBuffer",
     "resizable-arraybuffer",
     "Temporal",
-    "tail-call-optimization",
     "ShadowRealm",
     "FinalizationRegistry",
     "Atomics",


### PR DESCRIPTION
This Pull Request fixes/closes #809 and related to #2350 .

It changes the following:

- [x] Adds runtime limits on recursion
- [x] Adds getter & setter to `$boa.limits` module for debugging
- [x] Add test and example

Like #2857 the recursion limit can be controlled through the `.runtime_limits()`:
```rust
context.runtime_limits_mut().set_recursion_limit(123); // Set to an arbitrary number
```

Or using the `$boa` object for debugging:
```js
$boa.limits.recursion = 123

function x() {
    x()
}

x() // RuntimeLimit: maximum recursion limit 123 exceeded
```

Tried different values `400` seemed to not cause a stack-overflow, while `500` did, so I set it to `400`. This is in debug mode, In release we could probably set it to a higher value.

Removed `"tail-call-optimization"` feature from test262 ignore list, because it no longer causes a stack-overflow :)

Currently the way we do calls requires us to recurse in rust, this is not the ideal approach, we need to refactor it! That's why we are limited by our native stack size instead of heap size. This issue does not prevent this PR from being merged though.

I'll work on refactoring the way we call functions in a separate PR :)
