### PR TITLE
Fix wrong name of `Function.prototype[Symbol.hasInstance]`

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -443,7 +443,7 @@ impl IntrinsicObject for BuiltInFunctionObject {
         let _timer = Profiler::global().start_event("function", "init");
 
         let has_instance = BuiltInBuilder::callable(realm, Self::has_instance)
-            .name("[Symbol.iterator]")
+            .name("[Symbol.hasInstance]")
             .length(1)
             .build();
 


### PR DESCRIPTION
This Pull Request changes the following:

- Fix wrong name of `Function.prototype[Symbol.hasInstance]`

