### PR TITLE
Fix switch `default` execution

### DIFF
--- a/boa_ast/src/statement/switch.rs
+++ b/boa_ast/src/statement/switch.rs
@@ -27,7 +27,7 @@ pub struct Case {
 }
 
 impl Case {
-    /// Creates a `Case` AST node.
+    /// Creates a regular `Case` AST node.
     #[inline]
     #[must_use]
     pub const fn new(condition: Expression, body: StatementList) -> Self {
@@ -37,7 +37,7 @@ impl Case {
         }
     }
 
-    /// Creates a `Case` AST node.
+    /// Creates a default `Case` AST node.
     #[inline]
     #[must_use]
     pub const fn default(body: StatementList) -> Self {

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -174,7 +174,7 @@ enum Literal {
 }
 
 #[must_use]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct Label {
     index: u32,
 }
@@ -295,6 +295,7 @@ pub struct ByteCompiler<'ctx, 'host> {
 impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
     /// Represents a placeholder address that will be patched later.
     const DUMMY_ADDRESS: u32 = u32::MAX;
+    const DUMMY_LABLE: Label = Label { index: u32::MAX };
 
     /// Creates a new [`ByteCompiler`].
     #[inline]

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -295,7 +295,7 @@ pub struct ByteCompiler<'ctx, 'host> {
 impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
     /// Represents a placeholder address that will be patched later.
     const DUMMY_ADDRESS: u32 = u32::MAX;
-    const DUMMY_LABLE: Label = Label { index: u32::MAX };
+    const DUMMY_LABEL: Label = Label { index: u32::MAX };
 
     /// Creates a new [`ByteCompiler`].
     #[inline]

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -19,20 +19,35 @@ impl ByteCompiler<'_, '_> {
 
         let mut labels = Vec::with_capacity(switch.cases().len());
         for case in switch.cases() {
-            self.compile_expr(case.condition(), true);
-            labels.push(self.emit_opcode_with_operand(Opcode::Case));
+            // If it does not have a condition it is the default case.
+            let label = if let Some(condition) = case.condition() {
+                self.compile_expr(condition, true);
+
+                self.emit_opcode_with_operand(Opcode::Case)
+            } else {
+                Self::DUMMY_LABLE
+            };
+
+            labels.push(label);
         }
 
-        let exit = self.emit_opcode_with_operand(Opcode::Default);
+        let default_label = self.emit_opcode_with_operand(Opcode::Default);
+        let mut default_label_set = false;
 
         for (label, case) in labels.into_iter().zip(switch.cases()) {
+            // Check if it's the default case.
+            let label = if label == Self::DUMMY_LABLE {
+                default_label_set = true;
+                default_label
+            } else {
+                label
+            };
             self.patch_jump(label);
             self.compile_statement_list(case.body(), false);
         }
 
-        self.patch_jump(exit);
-        if let Some(body) = switch.default() {
-            self.compile_statement_list(body, false);
+        if !default_label_set {
+            self.patch_jump(default_label);
         }
 
         self.pop_switch_control_info();

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -25,7 +25,7 @@ impl ByteCompiler<'_, '_> {
 
                 self.emit_opcode_with_operand(Opcode::Case)
             } else {
-                Self::DUMMY_LABLE
+                Self::DUMMY_LABEL
             };
 
             labels.push(label);
@@ -36,7 +36,7 @@ impl ByteCompiler<'_, '_> {
 
         for (label, case) in labels.into_iter().zip(switch.cases()) {
             // Check if it's the default case.
-            let label = if label == Self::DUMMY_LABLE {
+            let label = if label == Self::DUMMY_LABEL {
                 default_label_set = true;
                 default_label
             } else {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -164,7 +164,7 @@ pub(crate) trait Operation {
 }
 
 generate_impl! {
-    #[derive(Debug, Clone, Copy, TryFromPrimitive)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, TryFromPrimitive)]
     #[repr(u8)]
     pub enum Opcode {
         /// Pop the top value from the stack.

--- a/boa_parser/src/parser/statement/switch/tests.rs
+++ b/boa_parser/src/parser/statement/switch/tests.rs
@@ -197,22 +197,23 @@ fn check_separated_switch() {
                         ]
                         .into(),
                     ),
-                ]
-                .into(),
-                Some(
-                    vec![Statement::Expression(Expression::from(Call::new(
-                        Expression::PropertyAccess(
-                            SimplePropertyAccess::new(Identifier::new(console).into(), log).into(),
-                        ),
-                        vec![Literal::from(
-                            interner.get_or_intern_static("Default", utf16!("Default")),
-                        )
+                    Case::default(
+                        vec![Statement::Expression(Expression::from(Call::new(
+                            Expression::PropertyAccess(
+                                SimplePropertyAccess::new(Identifier::new(console).into(), log)
+                                    .into(),
+                            ),
+                            vec![Literal::from(
+                                interner.get_or_intern_static("Default", utf16!("Default")),
+                            )
+                            .into()]
+                            .into(),
+                        )))
                         .into()]
                         .into(),
-                    )))
-                    .into()]
-                    .into(),
-                ),
+                    ),
+                ]
+                .into(),
             ))
             .into(),
         ],


### PR DESCRIPTION
Fixes switch `default` case execution, when a default case has regular switch cases below it (as in this test262 [test](https://github.com/tc39/test262/blob/72c0c5e16350a76bd41f7a1ceb7702588a2a39c6/test/language/statements/switch/S12.11_A1_T2.js) ) we execute the default case body at the end, we should execute the cases in order.
