### PR TITLE
Implement annexB Block-Level Function Declarations

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -234,7 +234,7 @@ impl Eval {
         let push_env = compiler.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
         compiler.eval_declaration_instantiation(&body, strict)?;
-        compiler.compile_statement_list(&body, true);
+        compiler.compile_statement_list(&body, true, false);
 
         let env_info = compiler.pop_compile_environment();
         compiler.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -123,7 +123,7 @@ impl Json {
                 context.realm().environment().compile_env(),
                 context,
             );
-            compiler.compile_statement_list(&statement_list, true);
+            compiler.compile_statement_list(&statement_list, true, false);
             Gc::new(compiler.finish())
         };
         let unfiltered = context.execute(code_block)?;

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -47,7 +47,7 @@ impl ByteCompiler<'_, '_> {
                 false,
             );
 
-            compiler.compile_statement_list(expr.body(), false);
+            compiler.compile_statement_list(expr.body(), false, false);
 
             let env_info = compiler.pop_compile_environment();
 
@@ -374,7 +374,7 @@ impl ByteCompiler<'_, '_> {
                         false,
                     );
 
-                    compiler.compile_statement_list(statement_list, false);
+                    compiler.compile_statement_list(statement_list, false, false);
                     let env_info = compiler.pop_compile_environment();
                     compiler.pop_compile_environment();
                     compiler.num_bindings = env_info.num_bindings;

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -66,6 +66,15 @@ impl ByteCompiler<'_, '_> {
             .has_binding_eval(name, strict)
     }
 
+    #[cfg(feature = "annex-b")]
+    /// Check if a binding name exists in a environment.
+    /// Stop when a function scope is reached.
+    pub(crate) fn has_binding_until_var(&self, name: Identifier) -> bool {
+        self.current_environment
+            .borrow()
+            .has_binding_until_var(name)
+    }
+
     /// Create a mutable binding at bytecode compile time.
     /// This function returns a syntax error, if the binding is a redeclaration.
     ///
@@ -118,5 +127,13 @@ impl ByteCompiler<'_, '_> {
         self.current_environment
             .borrow()
             .set_mutable_binding_recursive(name)
+    }
+
+    #[cfg(feature = "annex-b")]
+    /// Return the binding locator for a set operation on an existing var binding.
+    pub(crate) fn set_mutable_binding_var(&self, name: Identifier) -> BindingLocator {
+        self.current_environment
+            .borrow()
+            .set_mutable_binding_var_recursive(name)
     }
 }

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -125,7 +125,7 @@ impl FunctionCompiler {
             self.generator,
         );
 
-        compiler.compile_statement_list(body, false);
+        compiler.compile_statement_list(body, false, false);
 
         if let Some(env_labels) = env_labels {
             let env_info = compiler.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -421,12 +421,12 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             BindingOpcode::InitLet => {
                 let binding = self.initialize_mutable_binding(name, false);
                 let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::InitializeLexical, &[index]);
+                self.emit(Opcode::PutLexicalValue, &[index]);
             }
             BindingOpcode::InitConst => {
                 let binding = self.initialize_immutable_binding(name);
                 let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::InitializeLexical, &[index]);
+                self.emit(Opcode::PutLexicalValue, &[index]);
             }
             BindingOpcode::SetName => {
                 let binding = self.set_mutable_binding(name);

--- a/boa_engine/src/bytecompiler/module.rs
+++ b/boa_engine/src/bytecompiler/module.rs
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
     pub fn compile_module_item(&mut self, item: &ModuleItem) {
         match item {
             ModuleItem::StatementListItem(stmt) => {
-                self.compile_stmt_list_item(stmt, false);
+                self.compile_stmt_list_item(stmt, false, false);
             }
             _ => {
                 // TODO: Remove after implementing modules.

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -8,7 +8,7 @@ impl ByteCompiler<'_, '_> {
         let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
 
         self.block_declaration_instantiation(block);
-        self.compile_statement_list(block.statement_list(), use_expr);
+        self.compile_statement_list(block.statement_list(), use_expr, true);
 
         let env_info = self.pop_compile_environment();
         self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -43,7 +43,7 @@ impl ByteCompiler<'_, '_> {
                 label
             };
             self.patch_jump(label);
-            self.compile_statement_list(case.body(), false);
+            self.compile_statement_list(case.body(), false, true);
         }
 
         if !default_label_set {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -262,7 +262,7 @@ impl<'host> Context<'host> {
             self,
         );
         compiler.global_declaration_instantiation(statement_list)?;
-        compiler.compile_statement_list(statement_list, true);
+        compiler.compile_statement_list(statement_list, true, false);
         Ok(Gc::new(compiler.finish()))
     }
 

--- a/boa_engine/src/environments/runtime.rs
+++ b/boa_engine/src/environments/runtime.rs
@@ -613,13 +613,13 @@ impl DeclarativeEnvironmentStack {
         }
     }
 
-    /// Set the value of a declarative binding.
+    /// Set the value of a lexical binding.
     ///
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
     #[track_caller]
-    pub(crate) fn put_declarative_value(
+    pub(crate) fn put_lexical_value(
         &mut self,
         environment_index: usize,
         binding_index: usize,

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -330,12 +330,9 @@ impl CodeBlock {
                     self.functions[operand as usize].length
                 )
             }
-            Opcode::DefInitArg
-            | Opcode::DefVar
+            Opcode::DefVar
             | Opcode::DefInitVar
-            | Opcode::DefLet
-            | Opcode::DefInitLet
-            | Opcode::DefInitConst
+            | Opcode::InitializeLexical
             | Opcode::GetName
             | Opcode::GetLocator
             | Opcode::GetNameAndLocator

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -332,7 +332,7 @@ impl CodeBlock {
             }
             Opcode::DefVar
             | Opcode::DefInitVar
-            | Opcode::InitializeLexical
+            | Opcode::PutLexicalValue
             | Opcode::GetName
             | Opcode::GetLocator
             | Opcode::GetNameAndLocator
@@ -974,7 +974,7 @@ impl JsObject {
             context
                 .vm
                 .environments
-                .put_declarative_value(index, 0, class_object.into());
+                .put_lexical_value(index, 0, class_object.into());
             last_env -= 1;
         }
 
@@ -986,7 +986,7 @@ impl JsObject {
             context
                 .vm
                 .environments
-                .put_declarative_value(index, 0, self.clone().into());
+                .put_lexical_value(index, 0, self.clone().into());
             last_env -= 1;
         }
 
@@ -1020,7 +1020,7 @@ impl JsObject {
                     context,
                 )
             };
-            context.vm.environments.put_declarative_value(
+            context.vm.environments.put_lexical_value(
                 binding.environment_index(),
                 binding.binding_index(),
                 arguments_obj.into(),
@@ -1242,7 +1242,7 @@ impl JsObject {
                     context
                         .vm
                         .environments
-                        .put_declarative_value(index, 0, self.clone().into());
+                        .put_lexical_value(index, 0, self.clone().into());
                     last_env -= 1;
                 }
 
@@ -1275,7 +1275,7 @@ impl JsObject {
                             context,
                         )
                     };
-                    context.vm.environments.put_declarative_value(
+                    context.vm.environments.put_lexical_value(
                         binding.environment_index(),
                         binding.binding_index(),
                         arguments_obj.into(),

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -405,12 +405,9 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Opcode::DefInitArg
-                | Opcode::DefVar
+                Opcode::DefVar
                 | Opcode::DefInitVar
-                | Opcode::DefLet
-                | Opcode::DefInitLet
-                | Opcode::DefInitConst
+                | Opcode::InitializeLexical
                 | Opcode::GetName
                 | Opcode::GetLocator
                 | Opcode::GetNameAndLocator

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -407,7 +407,7 @@ impl CodeBlock {
                 }
                 Opcode::DefVar
                 | Opcode::DefInitVar
-                | Opcode::InitializeLexical
+                | Opcode::PutLexicalValue
                 | Opcode::GetName
                 | Opcode::GetLocator
                 | Opcode::GetNameAndLocator

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -66,22 +66,22 @@ impl Operation for DefInitVar {
     }
 }
 
-/// `InitializeLexical` implements the Opcode Operation for `Opcode::InitializeLexical`
+/// `PutLexicalValue` implements the Opcode Operation for `Opcode::PutLexicalValue`
 ///
 /// Operation:
 ///  - Initialize a lexical binding.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct InitializeLexical;
+pub(crate) struct PutLexicalValue;
 
-impl Operation for InitializeLexical {
-    const NAME: &'static str = "InitializeLexical";
-    const INSTRUCTION: &'static str = "INST - InitializeLexical";
+impl Operation for PutLexicalValue {
+    const NAME: &'static str = "PutLexicalValue";
+    const INSTRUCTION: &'static str = "INST - PutLexicalValue";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        context.vm.environments.put_declarative_value(
+        context.vm.environments.put_lexical_value(
             binding_locator.environment_index(),
             binding_locator.binding_index(),
             value,

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -638,13 +638,6 @@ generate_impl! {
         /// Stack: value **=>** (ToNumeric(value)), (value - 1)
         DecPost,
 
-        /// Declare and initialize a function argument.
-        ///
-        /// Operands: name_index: `u32`
-        ///
-        /// Stack: value **=>**
-        DefInitArg,
-
         /// Declare `var` type variable.
         ///
         /// Operands: name_index: `u32`
@@ -659,26 +652,12 @@ generate_impl! {
         /// Stack: value **=>**
         DefInitVar,
 
-        /// Declare `let` type variable.
-        ///
-        /// Operands: name_index: `u32`
-        ///
-        /// Stack: **=>**
-        DefLet,
-
-        /// Declare and initialize `let` type variable.
+        /// Initialize a lexical binding.
         ///
         /// Operands: name_index: `u32`
         ///
         /// Stack: value **=>**
-        DefInitLet,
-
-        /// Declare and initialize `const` type variable.
-        ///
-        /// Operands: name_index: `u32`
-        ///
-        /// Stack: value **=>**
-        DefInitConst,
+        InitializeLexical,
 
         /// Find a binding on the environment chain and push its value.
         ///
@@ -1633,7 +1612,6 @@ generate_impl! {
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum BindingOpcode {
     Var,
-    Let,
     InitVar,
     InitLet,
     InitConst,

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -657,7 +657,7 @@ generate_impl! {
         /// Operands: name_index: `u32`
         ///
         /// Stack: value **=>**
-        InitializeLexical,
+        PutLexicalValue,
 
         /// Find a binding on the environment chain and push its value.
         ///


### PR DESCRIPTION
This Pull Request changes the following:

- Implement annexB Block-Level Function Declarations
- Remove unused opcode `DefInitArg`
- Combine the similar opcodes `DefLet`, `DefInitLet` and `DefInitConst`

There are only two tests in the `annexB/language/eval-code` and `annexB/language/function-code` suites failing. I will look at fixing them after this.