### PR TITLE
Allow `let` name in for-in loop in non-strict mode

### DIFF
--- a/boa_parser/src/parser/statement/iteration/for_statement.rs
+++ b/boa_parser/src/parser/statement/iteration/for_statement.rs
@@ -116,7 +116,21 @@ where
                         .into(),
                 )
             }
-            TokenKind::Keyword((Keyword::Let | Keyword::Const, _)) => Some(
+            TokenKind::Keyword((Keyword::Let, _)) => Some('exit: {
+                if !cursor.strict() {
+                    if let Some(token) = cursor.peek(1, interner)? {
+                        if token.kind() == &TokenKind::Keyword((Keyword::In, false)) {
+                            cursor.advance(interner);
+                            break 'exit boa_ast::Expression::Identifier(Sym::LET.into()).into();
+                        }
+                    }
+                }
+
+                LexicalDeclaration::new(false, self.allow_yield, self.allow_await, true)
+                    .parse(cursor, interner)?
+                    .into()
+            }),
+            TokenKind::Keyword((Keyword::Const, _)) => Some(
                 LexicalDeclaration::new(false, self.allow_yield, self.allow_await, true)
                     .parse(cursor, interner)?
                     .into(),


### PR DESCRIPTION
Allow `let` variable name in `for-in` loop in non-strict mode.

Fixes: https://github.com/tc39/test262/blob/72c0c5e16350a76bd41f7a1ceb7702588a2a39c6/test/language/statements/for-in/identifier-let-allowed-as-lefthandside-expression-not-strict.js