### PR TITLE
Allow escaped `let` as expression

### DIFF
--- a/boa_parser/src/parser/statement/expression/mod.rs
+++ b/boa_parser/src/parser/statement/expression/mod.rs
@@ -47,10 +47,7 @@ where
 
         let next_token = cursor.peek(0, interner).or_abrupt()?;
         match next_token.kind() {
-            TokenKind::Keyword((
-                Keyword::Function | Keyword::Class | Keyword::Async | Keyword::Let,
-                true,
-            )) => {
+            TokenKind::Keyword((Keyword::Function | Keyword::Class | Keyword::Async, true)) => {
                 return Err(Error::general(
                     "Keyword must not contain escaped characters",
                     next_token.span().start(),

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -416,10 +416,9 @@ where
         let tok = cursor.peek(0, interner).or_abrupt()?;
 
         match *tok.kind() {
-            TokenKind::Keyword((
-                Keyword::Function | Keyword::Class | Keyword::Const | Keyword::Let,
-                _,
-            )) => Declaration::new(self.allow_yield, self.allow_await)
+            TokenKind::Keyword(
+                (Keyword::Function | Keyword::Class | Keyword::Const, _) | (Keyword::Let, false),
+            ) => Declaration::new(self.allow_yield, self.allow_await)
                 .parse(cursor, interner)
                 .map(ast::StatementListItem::from),
             TokenKind::Keyword((Keyword::Async, _)) => {


### PR DESCRIPTION
Fixes: https://github.com/tc39/test262/blob/72c0c5e16350a76bd41f7a1ceb7702588a2a39c6/test/language/statements/let/syntax/escaped-let.js