### PR TITLE
Separate declarative environment kinds

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -122,18 +122,12 @@ impl Eval {
         // 8. Let inDerivedConstructor be false.
         // 9. Let inClassFieldInitializer be false.
         // a. Let thisEnvRec be GetThisEnvironment().
-        let flags = match context
-            .vm
-            .environments
-            .get_this_environment()
-            .as_function_slots()
-        {
+        let flags = match context.vm.environments.get_this_environment().as_function() {
             // 10. If direct is true, then
             //     b. If thisEnvRec is a Function Environment Record, then
             Some(function_env) if direct => {
-                let function_env = function_env.borrow();
                 // i. Let F be thisEnvRec.[[FunctionObject]].
-                let function_object = function_env.function_object().borrow();
+                let function_object = function_env.slots().function_object().borrow();
 
                 // ii. Set inFunction to true.
                 let mut flags = Flags::IN_FUNCTION;

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -33,10 +33,8 @@ impl ParameterMap {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-makearggetter
     pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
-        if let Some(Some(binding_index)) = self.binding_indices.get(index) {
-            return Some(self.environment.get(*binding_index));
-        }
-        None
+        let binding_index = self.binding_indices.get(index).copied().flatten()?;
+        self.environment.get(binding_index)
     }
 
     /// Set the value of the binding at the given index in the function environment.
@@ -48,8 +46,8 @@ impl ParameterMap {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-makeargsetter
     pub(crate) fn set(&self, index: usize, value: &JsValue) {
-        if let Some(Some(binding_index)) = self.binding_indices.get(index) {
-            self.environment.set(*binding_index, value.clone());
+        if let Some(binding_index) = self.binding_indices.get(index).copied().flatten() {
+            self.environment.set(binding_index, value.clone());
         }
     }
 }

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     builtins::BuiltInObject,
     bytecompiler::FunctionCompiler,
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
-    environments::DeclarativeEnvironmentStack,
+    environments::EnvironmentStack,
     error::JsNativeError,
     js_string,
     native_function::NativeFunction,
@@ -160,7 +160,7 @@ pub(crate) enum FunctionKind {
         code: Gc<CodeBlock>,
 
         /// The `[[Environment]]` internal slot.
-        environments: DeclarativeEnvironmentStack,
+        environments: EnvironmentStack,
 
         /// The `[[ConstructorKind]]` internal slot.
         constructor_kind: ConstructorKind,
@@ -184,7 +184,7 @@ pub(crate) enum FunctionKind {
         code: Gc<CodeBlock>,
 
         /// The `[[Environment]]` internal slot.
-        environments: DeclarativeEnvironmentStack,
+        environments: EnvironmentStack,
 
         /// The `[[HomeObject]]` internal slot.
         home_object: Option<JsObject>,
@@ -199,7 +199,7 @@ pub(crate) enum FunctionKind {
         code: Gc<CodeBlock>,
 
         /// The `[[Environment]]` internal slot.
-        environments: DeclarativeEnvironmentStack,
+        environments: EnvironmentStack,
 
         /// The `[[HomeObject]]` internal slot.
         home_object: Option<JsObject>,
@@ -214,7 +214,7 @@ pub(crate) enum FunctionKind {
         code: Gc<CodeBlock>,
 
         /// The `[[Environment]]` internal slot.
-        environments: DeclarativeEnvironmentStack,
+        environments: EnvironmentStack,
 
         /// The `[[HomeObject]]` internal slot.
         home_object: Option<JsObject>,

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -12,7 +12,7 @@
 use crate::{
     builtins::iterable::create_iter_result_object,
     context::intrinsics::Intrinsics,
-    environments::DeclarativeEnvironmentStack,
+    environments::EnvironmentStack,
     error::JsNativeError,
     object::{JsObject, CONSTRUCTOR},
     property::Attribute,
@@ -58,7 +58,7 @@ unsafe impl Trace for GeneratorState {
 /// context/vm before the generator execution starts/resumes and after it has ended/yielded.
 #[derive(Debug, Clone, Trace, Finalize)]
 pub(crate) struct GeneratorContext {
-    pub(crate) environments: DeclarativeEnvironmentStack,
+    pub(crate) environments: EnvironmentStack,
     pub(crate) stack: Vec<JsValue>,
     pub(crate) active_function: Option<JsObject>,
     pub(crate) call_frame: Option<CallFrame>,
@@ -68,7 +68,7 @@ pub(crate) struct GeneratorContext {
 impl GeneratorContext {
     /// Creates a new `GeneratorContext` from the raw `Context` state components.
     pub(crate) fn new(
-        environments: DeclarativeEnvironmentStack,
+        environments: EnvironmentStack,
         stack: Vec<JsValue>,
         active_function: Option<JsObject>,
         call_frame: CallFrame,

--- a/boa_engine/src/environments/mod.rs
+++ b/boa_engine/src/environments/mod.rs
@@ -30,8 +30,8 @@ mod runtime;
 pub(crate) use {
     compile::CompileTimeEnvironment,
     runtime::{
-        BindingLocator, DeclarativeEnvironment, DeclarativeEnvironmentStack, Environment,
-        EnvironmentSlots,
+        BindingLocator, DeclarativeEnvironment, Environment, EnvironmentStack, FunctionSlots,
+        ThisBindingStatus,
     },
 };
 

--- a/boa_engine/src/environments/runtime/declarative/function.rs
+++ b/boa_engine/src/environments/runtime/declarative/function.rs
@@ -19,6 +19,7 @@ impl FunctionEnvironment {
         }
     }
 
+    /// Gets the slots of this function environment.
     pub(crate) const fn slots(&self) -> &FunctionSlots {
         &self.slots
     }
@@ -28,7 +29,7 @@ impl FunctionEnvironment {
         &self.inner
     }
 
-    /// Get the binding value from the environment by it's index.
+    /// Gets the binding value from the environment by it's index.
     ///
     /// # Panics
     ///
@@ -82,7 +83,7 @@ impl FunctionEnvironment {
 
     /// `HasSuperBinding`
     ///
-    /// Returns if the environment has a `super` binding.
+    /// Returns `true` if the environment has a `super` binding.
     ///
     /// More information:
     ///  - [ECMAScript specification][spec]
@@ -110,7 +111,7 @@ impl FunctionEnvironment {
 
     /// `HasThisBinding`
     ///
-    /// Returns if the environment has a `this` binding.
+    /// Returns `true` if the environment has a `this` binding.
     ///
     /// More information:
     ///  - [ECMAScript specification][spec]
@@ -123,7 +124,7 @@ impl FunctionEnvironment {
 
     /// `GetThisBinding`
     ///
-    /// Returns the `this` binding on the function environment.
+    /// Returns the `this` binding of the current environment.
     ///
     /// Differs slightly from the spec where lexical this (arrow functions) doesn't get asserted,
     /// but instead is returned as `None`.

--- a/boa_engine/src/environments/runtime/declarative/function.rs
+++ b/boa_engine/src/environments/runtime/declarative/function.rs
@@ -1,0 +1,207 @@
+use boa_gc::{custom_trace, Finalize, GcRefCell, Trace};
+
+use crate::{JsNativeError, JsObject, JsResult, JsValue};
+
+use super::PoisonableEnvironment;
+
+#[derive(Debug, Trace, Finalize)]
+pub(crate) struct FunctionEnvironment {
+    inner: PoisonableEnvironment,
+    slots: FunctionSlots,
+}
+
+impl FunctionEnvironment {
+    /// Creates a new `FunctionEnvironment`.
+    pub(crate) fn new(bindings: usize, poisoned: bool, with: bool, slots: FunctionSlots) -> Self {
+        Self {
+            inner: PoisonableEnvironment::new(bindings, poisoned, with),
+            slots,
+        }
+    }
+
+    pub(crate) const fn slots(&self) -> &FunctionSlots {
+        &self.slots
+    }
+
+    /// Gets the `poisonable_environment` of this function environment.
+    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
+        &self.inner
+    }
+
+    /// Get the binding value from the environment by it's index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range or not initialized.
+    #[track_caller]
+    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+        self.inner.get(index)
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        self.inner.set(index, value);
+    }
+
+    /// `BindThisValue`
+    ///
+    /// Sets the given value as the `this` binding of the environment.
+    /// Returns `false` if the `this` binding has already been initialized.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-bindthisvalue
+    pub(crate) fn bind_this_value(&self, value: JsObject) -> JsResult<()> {
+        let mut this = self.slots.this.borrow_mut();
+        match &*this {
+            ThisBindingStatus::Lexical => {
+                unreachable!("1. Assert: envRec.[[ThisBindingStatus]] is not lexical.")
+            }
+            ThisBindingStatus::Initialized(_) => {
+                // 2. If envRec.[[ThisBindingStatus]] is initialized, throw a ReferenceError exception.
+                return Err(JsNativeError::reference()
+                    .with_message("cannot reinitialize `this` binding")
+                    .into());
+            }
+            ThisBindingStatus::Uninitialized => {
+                // 3. Set envRec.[[ThisValue]] to V.
+                // 4. Set envRec.[[ThisBindingStatus]] to initialized.
+                *this = ThisBindingStatus::Initialized(value.into());
+            }
+        }
+
+        // 5. Return V.
+        Ok(())
+    }
+
+    /// `HasSuperBinding`
+    ///
+    /// Returns if the environment has a `super` binding.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hassuperbinding
+    ///
+    /// # Panics
+    ///
+    /// Panics if the function object of the environment is not a function.
+    pub(crate) fn has_super_binding(&self) -> bool {
+        // 1.If envRec.[[ThisBindingStatus]] is lexical, return false.
+        if matches!(&*self.slots.this.borrow(), ThisBindingStatus::Lexical) {
+            return false;
+        }
+
+        // 2. If envRec.[[FunctionObject]].[[HomeObject]] is undefined, return false; otherwise, return true.
+        self.slots
+            .function_object
+            .borrow()
+            .as_function()
+            .expect("function object must be function")
+            .get_home_object()
+            .is_some()
+    }
+
+    /// `HasThisBinding`
+    ///
+    /// Returns if the environment has a `this` binding.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hasthisbinding
+    pub(crate) fn has_this_binding(&self) -> bool {
+        // 1. If envRec.[[ThisBindingStatus]] is lexical, return false; otherwise, return true.
+        !matches!(&*self.slots.this.borrow(), ThisBindingStatus::Lexical)
+    }
+
+    /// `GetThisBinding`
+    ///
+    /// Returns the `this` binding on the function environment.
+    ///
+    /// Differs slightly from the spec where lexical this (arrow functions) doesn't get asserted,
+    /// but instead is returned as `None`.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+    pub(crate) fn get_this_binding(&self) -> JsResult<Option<JsValue>> {
+        match &*self.slots.this.borrow() {
+            ThisBindingStatus::Lexical => Ok(None),
+            // 2. If envRec.[[ThisBindingStatus]] is uninitialized, throw a ReferenceError exception.
+            ThisBindingStatus::Uninitialized => Err(JsNativeError::reference()
+                .with_message(
+                    "Must call super constructor in derived \
+                class before accessing 'this' or returning from derived constructor",
+                )
+                .into()),
+            // 3. Return envRec.[[ThisValue]].
+            ThisBindingStatus::Initialized(this) => Ok(Some(this.clone())),
+        }
+    }
+}
+
+/// Describes the status of a `this` binding in function environments.
+#[derive(Clone, Debug, Finalize)]
+pub(crate) enum ThisBindingStatus {
+    /// Function doesn't have a `this` binding. (arrow functions and async arrow functions)
+    Lexical,
+    /// Function has a `this` binding, but is uninitialized. (derived constructors)
+    Uninitialized,
+    /// Funciton has an initialized `this` binding. (base constructors and most callable objects)
+    Initialized(JsValue),
+}
+
+unsafe impl Trace for ThisBindingStatus {
+    custom_trace!(this, {
+        match this {
+            ThisBindingStatus::Initialized(obj) => mark(obj),
+            ThisBindingStatus::Lexical | ThisBindingStatus::Uninitialized => {}
+        }
+    });
+}
+
+/// Holds the internal slots of a function environment.
+#[derive(Clone, Debug, Trace, Finalize)]
+pub(crate) struct FunctionSlots {
+    /// The `[[ThisValue]]` and `[[ThisBindingStatus]]`  internal slots.
+    this: GcRefCell<ThisBindingStatus>,
+
+    /// The `[[FunctionObject]]` internal slot.
+    function_object: JsObject,
+
+    /// The `[[NewTarget]]` internal slot.
+    new_target: Option<JsObject>,
+}
+
+impl FunctionSlots {
+    /// Creates a new `FunctionSluts`.
+    pub(crate) fn new(
+        this: ThisBindingStatus,
+        function_object: JsObject,
+        new_target: Option<JsObject>,
+    ) -> Self {
+        Self {
+            this: GcRefCell::new(this),
+            function_object,
+            new_target,
+        }
+    }
+
+    /// Returns the value of the `[[FunctionObject]]` internal slot.
+    pub(crate) const fn function_object(&self) -> &JsObject {
+        &self.function_object
+    }
+
+    /// Returns the value of the `[[NewTarget]]` internal slot.
+    pub(crate) const fn new_target(&self) -> Option<&JsObject> {
+        self.new_target.as_ref()
+    }
+}

--- a/boa_engine/src/environments/runtime/declarative/global.rs
+++ b/boa_engine/src/environments/runtime/declarative/global.rs
@@ -24,7 +24,7 @@ impl GlobalEnvironment {
         &self.inner
     }
 
-    /// Get the binding value from the environment by it's index.
+    /// Gets the binding value from the environment by it's index.
     ///
     /// # Panics
     ///

--- a/boa_engine/src/environments/runtime/declarative/global.rs
+++ b/boa_engine/src/environments/runtime/declarative/global.rs
@@ -1,0 +1,58 @@
+use boa_gc::{Finalize, Trace};
+
+use crate::{JsObject, JsValue};
+
+use super::PoisonableEnvironment;
+
+#[derive(Debug, Trace, Finalize)]
+pub(crate) struct GlobalEnvironment {
+    inner: PoisonableEnvironment,
+    global_this: JsObject,
+}
+
+impl GlobalEnvironment {
+    /// Creates a new `GlobalEnvironment`.
+    pub(crate) fn new(global_this: JsObject) -> Self {
+        Self {
+            inner: PoisonableEnvironment::new(0, false, false),
+            global_this,
+        }
+    }
+
+    /// Gets the `poisonable_environment` of this global environment.
+    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
+        &self.inner
+    }
+
+    /// Get the binding value from the environment by it's index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range or not initialized.
+    #[track_caller]
+    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+        self.inner.get(index)
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        self.inner.set(index, value);
+    }
+
+    /// `GetThisBinding`
+    ///
+    /// Returns the `this` binding on the global environment.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+    pub(crate) fn get_this_binding(&self) -> JsObject {
+        self.global_this.clone()
+    }
+}

--- a/boa_engine/src/environments/runtime/declarative/lexical.rs
+++ b/boa_engine/src/environments/runtime/declarative/lexical.rs
@@ -22,7 +22,7 @@ impl LexicalEnvironment {
         &self.inner
     }
 
-    /// Get the binding value from the environment by it's index.
+    /// Gets the binding value from the environment by it's index.
     ///
     /// # Panics
     ///

--- a/boa_engine/src/environments/runtime/declarative/lexical.rs
+++ b/boa_engine/src/environments/runtime/declarative/lexical.rs
@@ -1,0 +1,44 @@
+use boa_gc::{Finalize, Trace};
+
+use crate::JsValue;
+
+use super::PoisonableEnvironment;
+
+#[derive(Debug, Trace, Finalize)]
+pub(crate) struct LexicalEnvironment {
+    inner: PoisonableEnvironment,
+}
+
+impl LexicalEnvironment {
+    /// Creates a new `LexicalEnvironment`.
+    pub(crate) fn new(bindings: usize, poisoned: bool, with: bool) -> Self {
+        Self {
+            inner: PoisonableEnvironment::new(bindings, poisoned, with),
+        }
+    }
+
+    /// Gets the `poisonable_environment` of this lexical environment.
+    pub(crate) const fn poisonable_environment(&self) -> &PoisonableEnvironment {
+        &self.inner
+    }
+
+    /// Get the binding value from the environment by it's index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range or not initialized.
+    #[track_caller]
+    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+        self.inner.get(index)
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        self.inner.set(index, value);
+    }
+}

--- a/boa_engine/src/environments/runtime/declarative/mod.rs
+++ b/boa_engine/src/environments/runtime/declarative/mod.rs
@@ -1,0 +1,303 @@
+mod function;
+mod global;
+mod lexical;
+
+use std::cell::Cell;
+
+use boa_gc::{Finalize, Gc, GcRefCell, Trace};
+pub(crate) use function::{FunctionEnvironment, FunctionSlots, ThisBindingStatus};
+pub(crate) use global::GlobalEnvironment;
+pub(crate) use lexical::LexicalEnvironment;
+
+use crate::{environments::CompileTimeEnvironment, JsObject, JsResult, JsValue};
+
+/// A declarative environment holds binding values at runtime.
+///
+/// Bindings are stored in a fixed size list of optional values.
+/// If a binding is not initialized, the value is `None`.
+///
+/// Optionally, an environment can hold a `this` value.
+/// The `this` value is present only if the environment is a function environment.
+///
+/// Code evaluation at runtime (e.g. the `eval` built-in function) can add
+/// bindings to existing, compiled function environments.
+/// This makes it impossible to determine the location of all bindings at compile time.
+/// To dynamically check for added bindings at runtime, a reference to the
+/// corresponding compile time environment is needed.
+///
+/// Checking all environments for potential added bindings at runtime on every get/set
+/// would offset the performance improvement of determining binding locations at compile time.
+/// To minimize this, each environment holds a `poisoned` flag.
+/// If bindings where added at runtime, the current environment and all inner environments
+/// are marked as poisoned.
+/// All poisoned environments have to be checked for added bindings.
+#[derive(Debug, Trace, Finalize)]
+pub(crate) struct DeclarativeEnvironment {
+    kind: DeclarativeEnvironmentKind,
+    compile: Gc<GcRefCell<CompileTimeEnvironment>>,
+}
+
+impl DeclarativeEnvironment {
+    /// Creates a new global `DeclarativeEnvironment`.
+    pub(crate) fn global(global_this: JsObject) -> Self {
+        DeclarativeEnvironment {
+            kind: DeclarativeEnvironmentKind::Global(GlobalEnvironment::new(global_this)),
+            compile: Gc::new(GcRefCell::new(CompileTimeEnvironment::new_global())),
+        }
+    }
+
+    /// Creates a new `DeclarativeEnvironment` from its kind and compile environment.
+    pub(crate) fn new(
+        kind: DeclarativeEnvironmentKind,
+        compile: Gc<GcRefCell<CompileTimeEnvironment>>,
+    ) -> Self {
+        Self { kind, compile }
+    }
+
+    /// Gets the compile time environment of this environment.
+    pub(crate) fn compile_env(&self) -> Gc<GcRefCell<CompileTimeEnvironment>> {
+        self.compile.clone()
+    }
+
+    /// Returns a reference to the the kind of the environment.
+    pub(crate) const fn kind(&self) -> &DeclarativeEnvironmentKind {
+        &self.kind
+    }
+
+    /// Gets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range or not initialized.
+    #[track_caller]
+    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+        self.kind.get(index)
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        self.kind.set(index, value);
+    }
+
+    /// `GetThisBinding`
+    ///
+    /// Returns the `this` binding of this environment.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+    pub(crate) fn get_this_binding(&self) -> JsResult<Option<JsValue>> {
+        self.kind.get_this_binding()
+    }
+
+    /// `HasThisBinding`
+    ///
+    /// Returns if the environment has a `this` binding.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hasthisbinding
+    pub(crate) fn has_this_binding(&self) -> bool {
+        self.kind.has_this_binding()
+    }
+
+    /// Returns `true` if this environment is poisoned.
+    pub(crate) fn poisoned(&self) -> bool {
+        self.kind.poisoned()
+    }
+
+    /// Returns `true` if this environment is inside a `with` environment.
+    pub(crate) fn with(&self) -> bool {
+        self.kind.with()
+    }
+
+    /// Poisons this environment for future binding searchs.
+    pub(crate) fn poison(&self) {
+        self.kind.poison();
+    }
+}
+
+/// The kind of the declarative environment.
+#[derive(Debug, Trace, Finalize)]
+pub(crate) enum DeclarativeEnvironmentKind {
+    /// Only stores lexical bindings.
+    Lexical(LexicalEnvironment),
+    /// Stores lexical bindings, global var bindings and the global this.
+    Global(GlobalEnvironment),
+    /// Stores lexical bindings, var bindings and the `FunctionSlots` of the function environment.
+    Function(FunctionEnvironment),
+}
+
+impl DeclarativeEnvironmentKind {
+    /// Unwraps the inner function environment if possible. Returns `None` otherwise.
+    pub(crate) const fn as_function(&self) -> Option<&FunctionEnvironment> {
+        if let Self::Function(fun) = &self {
+            Some(fun)
+        } else {
+            None
+        }
+    }
+
+    /// Unwraps the inner global environment if possible. Returns `None` otherwise.
+    pub(crate) const fn as_global(&self) -> Option<&GlobalEnvironment> {
+        if let Self::Global(fun) = &self {
+            Some(fun)
+        } else {
+            None
+        }
+    }
+
+    /// Get the binding value from the environment by it's index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range or not initialized.
+    #[track_caller]
+    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(inner) => inner.get(index),
+            DeclarativeEnvironmentKind::Global(inner) => inner.get(index),
+            DeclarativeEnvironmentKind::Function(inner) => inner.get(index),
+        }
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(inner) => inner.set(index, value),
+            DeclarativeEnvironmentKind::Global(inner) => inner.set(index, value),
+            DeclarativeEnvironmentKind::Function(inner) => inner.set(index, value),
+        }
+    }
+
+    /// `GetThisBinding`
+    ///
+    /// Returns the `this` binding of this environment.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-getthisbinding
+    pub(crate) fn get_this_binding(&self) -> JsResult<Option<JsValue>> {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(_) => Ok(None),
+            DeclarativeEnvironmentKind::Global(g) => Ok(Some(g.get_this_binding().into())),
+            DeclarativeEnvironmentKind::Function(f) => f.get_this_binding(),
+        }
+    }
+
+    /// `HasThisBinding`
+    ///
+    /// Returns if the environment has a `this` binding.
+    ///
+    /// More information:
+    ///  - [ECMAScript specification][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-function-environment-records-hasthisbinding
+    pub(crate) fn has_this_binding(&self) -> bool {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(_) => false,
+            DeclarativeEnvironmentKind::Global(_) => true,
+            DeclarativeEnvironmentKind::Function(f) => f.has_this_binding(),
+        }
+    }
+
+    /// Returns `true` if this environment is poisoned.
+    pub(crate) fn poisoned(&self) -> bool {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(lex) => lex.poisonable_environment().poisoned(),
+            DeclarativeEnvironmentKind::Global(g) => g.poisonable_environment().poisoned(),
+            DeclarativeEnvironmentKind::Function(f) => f.poisonable_environment().poisoned(),
+        }
+    }
+
+    /// Returns `true` if this environment is inside a `with` environment.
+    pub(crate) fn with(&self) -> bool {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(lex) => lex.poisonable_environment().with(),
+            DeclarativeEnvironmentKind::Global(g) => g.poisonable_environment().with(),
+            DeclarativeEnvironmentKind::Function(f) => f.poisonable_environment().with(),
+        }
+    }
+
+    /// Poisons this environment for future binding searchs.
+    pub(crate) fn poison(&self) {
+        match self {
+            DeclarativeEnvironmentKind::Lexical(lex) => lex.poisonable_environment().poison(),
+            DeclarativeEnvironmentKind::Global(g) => g.poisonable_environment().poison(),
+            DeclarativeEnvironmentKind::Function(f) => f.poisonable_environment().poison(),
+        }
+    }
+}
+
+#[derive(Debug, Trace, Finalize)]
+pub(crate) struct PoisonableEnvironment {
+    bindings: GcRefCell<Vec<Option<JsValue>>>,
+    #[unsafe_ignore_trace]
+    poisoned: Cell<bool>,
+    #[unsafe_ignore_trace]
+    with: Cell<bool>,
+}
+
+impl PoisonableEnvironment {
+    /// Creates a new `PoisonableEnvironment`.
+    pub(crate) fn new(bindings_count: usize, poisoned: bool, with: bool) -> Self {
+        PoisonableEnvironment {
+            bindings: GcRefCell::new(vec![None; bindings_count]),
+            poisoned: Cell::new(poisoned),
+            with: Cell::new(with),
+        }
+    }
+
+    /// Gets the bindings of this poisonable environment.
+    pub(crate) const fn bindings(&self) -> &GcRefCell<Vec<Option<JsValue>>> {
+        &self.bindings
+    }
+
+    /// Get the binding value from the environment by it's index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    fn get(&self, index: usize) -> Option<JsValue> {
+        self.bindings.borrow()[index].clone()
+    }
+
+    /// Sets the binding value from the environment by index.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the binding value is out of range.
+    #[track_caller]
+    pub(crate) fn set(&self, index: usize, value: JsValue) {
+        self.bindings.borrow_mut()[index] = Some(value);
+    }
+
+    /// Returns `true` if this environment is poisoned.
+    fn poisoned(&self) -> bool {
+        self.poisoned.get()
+    }
+
+    /// Returns `true` if this environment is inside a `with` environment.
+    fn with(&self) -> bool {
+        self.with.get()
+    }
+
+    /// Poisons this environment for future binding searchs.
+    fn poison(&self) {
+        self.poisoned.set(true);
+    }
+}

--- a/boa_engine/src/environments/runtime/declarative/mod.rs
+++ b/boa_engine/src/environments/runtime/declarative/mod.rs
@@ -232,7 +232,7 @@ impl DeclarativeEnvironmentKind {
         }
     }
 
-    /// Poisons this environment for future binding searchs.
+    /// Poisons this environment for future binding searches.
     pub(crate) fn poison(&self) {
         match self {
             DeclarativeEnvironmentKind::Lexical(lex) => lex.poisonable_environment().poison(),
@@ -266,7 +266,7 @@ impl PoisonableEnvironment {
         &self.bindings
     }
 
-    /// Get the binding value from the environment by it's index.
+    /// Gets the binding value from the environment by it's index.
     ///
     /// # Panics
     ///
@@ -296,7 +296,7 @@ impl PoisonableEnvironment {
         self.with.get()
     }
 
-    /// Poisons this environment for future binding searchs.
+    /// Poisons this environment for future binding searches.
     fn poison(&self) {
         self.poisoned.set(true);
     }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -8,7 +8,7 @@
 use crate::JsNativeError;
 use crate::{
     builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
-    environments::{DeclarativeEnvironment, DeclarativeEnvironmentStack},
+    environments::{DeclarativeEnvironment, EnvironmentStack},
     vm::code_block::Readable,
     Context, JsError, JsObject, JsResult, JsValue,
 };
@@ -53,7 +53,7 @@ pub struct Vm {
     pub(crate) frames: Vec<CallFrame>,
     pub(crate) stack: Vec<JsValue>,
     pub(crate) err: Option<JsError>,
-    pub(crate) environments: DeclarativeEnvironmentStack,
+    pub(crate) environments: EnvironmentStack,
     #[cfg(feature = "trace")]
     pub(crate) trace: bool,
     pub(crate) runtime_limits: RuntimeLimits,
@@ -66,7 +66,7 @@ impl Vm {
         Self {
             frames: Vec::with_capacity(16),
             stack: Vec::with_capacity(1024),
-            environments: DeclarativeEnvironmentStack::new(global),
+            environments: EnvironmentStack::new(global),
             err: None,
             #[cfg(feature = "trace")]
             trace: false,

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -23,7 +23,7 @@ impl Operation for PushDeclarativeEnvironment {
         context
             .vm
             .environments
-            .push_declarative(num_bindings as usize, compile_environment);
+            .push_lexical(num_bindings as usize, compile_environment);
         context.vm.frame_mut().inc_frame_env_stack();
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/new_target.rs
+++ b/boa_engine/src/vm/opcode/push/new_target.rs
@@ -19,8 +19,8 @@ impl Operation for PushNewTarget {
             .vm
             .environments
             .get_this_environment()
-            .as_function_slots()
-            .and_then(|env| env.borrow().new_target().cloned())
+            .as_function()
+            .and_then(|env| env.slots().new_target().cloned())
         {
             new_target.into()
         } else {


### PR DESCRIPTION
This Pull Request separates declarative environments into kinds, which makes it easier to add more kinds in the future (spoiler: module environments).