### PR TITLE
Fix ES5 selector

### DIFF
--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -341,7 +341,7 @@ impl SpecEdition {
     pub(crate) fn from_test_metadata(metadata: &MetaData) -> Result<Self, Vec<&str>> {
         let mut min_edition = if metadata.flags.contains(&TestFlag::Async) {
             Self::ES8
-        } else if metadata.flags.contains(&TestFlag::Module) {
+        } else if metadata.flags.contains(&TestFlag::Module) || metadata.es6id.is_some() {
             Self::ES6
         } else {
             Self::ES5

--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -341,7 +341,10 @@ impl SpecEdition {
     pub(crate) fn from_test_metadata(metadata: &MetaData) -> Result<Self, Vec<&str>> {
         let mut min_edition = if metadata.flags.contains(&TestFlag::Async) {
             Self::ES8
-        } else if metadata.flags.contains(&TestFlag::Module) || metadata.es6id.is_some() {
+        } else if metadata.flags.contains(&TestFlag::Module)
+            || metadata.esid.is_some()
+            || metadata.es6id.is_some()
+        {
             Self::ES6
         } else {
             Self::ES5


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #2886.

Previously, the code defaulted to ES5 without checking for es6id and esid. This PR selects ES6 if esid or es6id is found. 

Reference: [doc](https://chromium.googlesource.com/external/github.com/tc39/test262/+/HEAD/CONTRIBUTING.md#es6id).
