### PR TITLE
Throw Syntax Errors for Keywords With Unicode Escapes

### DIFF
--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -94,9 +94,15 @@ impl<R> Tokenizer<R> for Identifier {
             Self::take_identifier_name(cursor, start_pos, self.init)?;
 
         let token_kind = match identifier_name.parse() {
-            Ok(Keyword::True) => TokenKind::BooleanLiteral((true, ContainsEscapeSequence(contains_escaped_chars))),
-            Ok(Keyword::False) => TokenKind::BooleanLiteral((false, ContainsEscapeSequence(contains_escaped_chars))),
-            Ok(Keyword::Null) => TokenKind::NullLiteral,
+            Ok(Keyword::True) => {
+                TokenKind::BooleanLiteral((true, ContainsEscapeSequence(contains_escaped_chars)))
+            }
+            Ok(Keyword::False) => {
+                TokenKind::BooleanLiteral((false, ContainsEscapeSequence(contains_escaped_chars)))
+            }
+            Ok(Keyword::Null) => {
+                TokenKind::NullLiteral(ContainsEscapeSequence(contains_escaped_chars))
+            }
             Ok(keyword) => TokenKind::Keyword((keyword, contains_escaped_chars)),
             _ => TokenKind::IdentifierName((
                 interner.get_or_intern(identifier_name.as_str()),

--- a/boa_parser/src/lexer/identifier.rs
+++ b/boa_parser/src/lexer/identifier.rs
@@ -94,8 +94,8 @@ impl<R> Tokenizer<R> for Identifier {
             Self::take_identifier_name(cursor, start_pos, self.init)?;
 
         let token_kind = match identifier_name.parse() {
-            Ok(Keyword::True) => TokenKind::BooleanLiteral(true),
-            Ok(Keyword::False) => TokenKind::BooleanLiteral(false),
+            Ok(Keyword::True) => TokenKind::BooleanLiteral((true, ContainsEscapeSequence(contains_escaped_chars))),
+            Ok(Keyword::False) => TokenKind::BooleanLiteral((false, ContainsEscapeSequence(contains_escaped_chars))),
             Ok(Keyword::Null) => TokenKind::NullLiteral,
             Ok(keyword) => TokenKind::Keyword((keyword, contains_escaped_chars)),
             _ => TokenKind::IdentifierName((

--- a/boa_parser/src/lexer/token.rs
+++ b/boa_parser/src/lexer/token.rs
@@ -95,7 +95,7 @@ impl From<BigInt> for Numeric {
 #[derive(Clone, PartialEq, Debug)]
 pub enum TokenKind {
     /// A boolean literal, which is either `true` or `false`.
-    BooleanLiteral(bool),
+    BooleanLiteral((bool, ContainsEscapeSequence)),
 
     /// The end of the file.
     EOF,
@@ -152,7 +152,7 @@ pub enum TokenKind {
 impl From<bool> for TokenKind {
     #[inline]
     fn from(oth: bool) -> Self {
-        Self::BooleanLiteral(oth)
+        Self::BooleanLiteral((oth, ContainsEscapeSequence(false)))
     }
 }
 
@@ -182,7 +182,7 @@ impl TokenKind {
     #[inline]
     #[must_use]
     pub const fn boolean_literal(lit: bool) -> Self {
-        Self::BooleanLiteral(lit)
+        Self::BooleanLiteral((lit, ContainsEscapeSequence(false)))
     }
 
     /// Creates an `EOF` token kind.
@@ -261,7 +261,7 @@ impl TokenKind {
     #[must_use]
     pub fn to_string(&self, interner: &Interner) -> String {
         match *self {
-            Self::BooleanLiteral(val) => val.to_string(),
+            Self::BooleanLiteral((val, _)) => val.to_string(),
             Self::EOF => "end of file".to_owned(),
             Self::IdentifierName((ident, _)) => interner.resolve_expect(ident).to_string(),
             Self::PrivateIdentifier(ident) => format!("#{}", interner.resolve_expect(ident)),

--- a/boa_parser/src/lexer/token.rs
+++ b/boa_parser/src/lexer/token.rs
@@ -118,7 +118,7 @@ pub enum TokenKind {
     /// The [`null` literal][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-NullLiteral
-    NullLiteral,
+    NullLiteral(ContainsEscapeSequence),
 
     /// A numeric literal.
     NumericLiteral(Numeric),
@@ -266,7 +266,7 @@ impl TokenKind {
             Self::IdentifierName((ident, _)) => interner.resolve_expect(ident).to_string(),
             Self::PrivateIdentifier(ident) => format!("#{}", interner.resolve_expect(ident)),
             Self::Keyword((word, _)) => word.to_string(),
-            Self::NullLiteral => "null".to_owned(),
+            Self::NullLiteral(_) => "null".to_owned(),
             Self::NumericLiteral(Numeric::Rational(num)) => num.to_string(),
             Self::NumericLiteral(Numeric::Integer(num)) => num.to_string(),
             Self::NumericLiteral(Numeric::BigInt(ref num)) => format!("{num}n"),

--- a/boa_parser/src/parser/expression/assignment/yield.rs
+++ b/boa_parser/src/parser/expression/assignment/yield.rs
@@ -103,7 +103,7 @@ where
                 _,
             ))
             | TokenKind::BooleanLiteral(_)
-            | TokenKind::NullLiteral
+            | TokenKind::NullLiteral(_)
             | TokenKind::StringLiteral(_)
             | TokenKind::TemplateNoSubstitution(_)
             | TokenKind::NumericLiteral(_)

--- a/boa_parser/src/parser/expression/left_hand_side/call.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/call.rs
@@ -110,7 +110,9 @@ where
                         TokenKind::BooleanLiteral((false, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::FALSE).into()
                         }
-                        TokenKind::NullLiteral => SimplePropertyAccess::new(lhs, Sym::NULL).into(),
+                        TokenKind::NullLiteral(_) => {
+                            SimplePropertyAccess::new(lhs, Sym::NULL).into()
+                        }
                         TokenKind::PrivateIdentifier(name) => {
                             if !cursor.in_class() {
                                 return Err(Error::general(

--- a/boa_parser/src/parser/expression/left_hand_side/call.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/call.rs
@@ -104,10 +104,10 @@ where
                         TokenKind::Keyword((kw, _)) => {
                             SimplePropertyAccess::new(lhs, kw.to_sym()).into()
                         }
-                        TokenKind::BooleanLiteral(true) => {
+                        TokenKind::BooleanLiteral((true, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::TRUE).into()
                         }
-                        TokenKind::BooleanLiteral(false) => {
+                        TokenKind::BooleanLiteral((false, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::FALSE).into()
                         }
                         TokenKind::NullLiteral => SimplePropertyAccess::new(lhs, Sym::NULL).into(),

--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -131,10 +131,10 @@ where
                             TokenKind::Keyword((kw, _)) => {
                                 SuperPropertyAccess::new(kw.to_sym().into())
                             }
-                            TokenKind::BooleanLiteral(true) => {
+                            TokenKind::BooleanLiteral((true, _)) => {
                                 SuperPropertyAccess::new(Sym::TRUE.into())
                             }
-                            TokenKind::BooleanLiteral(false) => {
+                            TokenKind::BooleanLiteral((false, _)) => {
                                 SuperPropertyAccess::new(Sym::FALSE.into())
                             }
                             TokenKind::NullLiteral => SuperPropertyAccess::new(Sym::NULL.into()),
@@ -193,10 +193,10 @@ where
                         TokenKind::Keyword((kw, _)) => {
                             SimplePropertyAccess::new(lhs, kw.to_sym()).into()
                         }
-                        TokenKind::BooleanLiteral(true) => {
+                        TokenKind::BooleanLiteral((true, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::TRUE).into()
                         }
-                        TokenKind::BooleanLiteral(false) => {
+                        TokenKind::BooleanLiteral((false, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::FALSE).into()
                         }
                         TokenKind::NullLiteral => SimplePropertyAccess::new(lhs, Sym::NULL).into(),

--- a/boa_parser/src/parser/expression/left_hand_side/member.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/member.rs
@@ -137,7 +137,7 @@ where
                             TokenKind::BooleanLiteral((false, _)) => {
                                 SuperPropertyAccess::new(Sym::FALSE.into())
                             }
-                            TokenKind::NullLiteral => SuperPropertyAccess::new(Sym::NULL.into()),
+                            TokenKind::NullLiteral(_) => SuperPropertyAccess::new(Sym::NULL.into()),
                             TokenKind::PrivateIdentifier(_) => {
                                 return Err(Error::general(
                                     "unexpected private identifier",
@@ -199,7 +199,9 @@ where
                         TokenKind::BooleanLiteral((false, _)) => {
                             SimplePropertyAccess::new(lhs, Sym::FALSE).into()
                         }
-                        TokenKind::NullLiteral => SimplePropertyAccess::new(lhs, Sym::NULL).into(),
+                        TokenKind::NullLiteral(_) => {
+                            SimplePropertyAccess::new(lhs, Sym::NULL).into()
+                        }
                         TokenKind::PrivateIdentifier(name) => {
                             if !cursor.in_class() {
                                 return Err(Error::general(

--- a/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -74,13 +74,17 @@ where
                 TokenKind::Keyword((kw, _)) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(kw.to_sym()),
                 },
-                TokenKind::BooleanLiteral((true, _)) => OptionalOperationKind::SimplePropertyAccess {
-                    field: PropertyAccessField::Const(Sym::TRUE),
-                },
-                TokenKind::BooleanLiteral((false, _)) => OptionalOperationKind::SimplePropertyAccess {
-                    field: PropertyAccessField::Const(Sym::FALSE),
-                },
-                TokenKind::NullLiteral => OptionalOperationKind::SimplePropertyAccess {
+                TokenKind::BooleanLiteral((true, _)) => {
+                    OptionalOperationKind::SimplePropertyAccess {
+                        field: PropertyAccessField::Const(Sym::TRUE),
+                    }
+                }
+                TokenKind::BooleanLiteral((false, _)) => {
+                    OptionalOperationKind::SimplePropertyAccess {
+                        field: PropertyAccessField::Const(Sym::FALSE),
+                    }
+                }
+                TokenKind::NullLiteral(_) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(Sym::NULL),
                 },
                 TokenKind::PrivateIdentifier(name) => {

--- a/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -74,10 +74,10 @@ where
                 TokenKind::Keyword((kw, _)) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(kw.to_sym()),
                 },
-                TokenKind::BooleanLiteral(true) => OptionalOperationKind::SimplePropertyAccess {
+                TokenKind::BooleanLiteral((true, _)) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(Sym::TRUE),
                 },
-                TokenKind::BooleanLiteral(false) => OptionalOperationKind::SimplePropertyAccess {
+                TokenKind::BooleanLiteral((false, _)) => OptionalOperationKind::SimplePropertyAccess {
                     field: PropertyAccessField::Const(Sym::FALSE),
                 },
                 TokenKind::NullLiteral => OptionalOperationKind::SimplePropertyAccess {

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -27,7 +27,10 @@ use self::{
     object_initializer::ObjectLiteral,
 };
 use crate::{
-    lexer::{token::{Numeric, ContainsEscapeSequence}, InputElement, Token, TokenKind},
+    lexer::{
+        token::{ContainsEscapeSequence, Numeric},
+        InputElement, Token, TokenKind,
+    },
     parser::{
         expression::{
             identifiers::IdentifierReference, primary::template::TemplateLiteral,
@@ -202,7 +205,11 @@ where
                 cursor.advance(interner);
                 Ok(node)
             }
-            TokenKind::NullLiteral => {
+            TokenKind::NullLiteral(ContainsEscapeSequence(true)) => Err(Error::general(
+                "Keyword must not contain escaped characters",
+                tok_position,
+            )),
+            TokenKind::NullLiteral(_) => {
                 cursor.advance(interner);
                 Ok(Literal::Null.into())
             }

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -27,7 +27,7 @@ use self::{
     object_initializer::ObjectLiteral,
 };
 use crate::{
-    lexer::{token::Numeric, InputElement, Token, TokenKind},
+    lexer::{token::{Numeric, ContainsEscapeSequence}, InputElement, Token, TokenKind},
     parser::{
         expression::{
             identifiers::IdentifierReference, primary::template::TemplateLiteral,
@@ -193,7 +193,11 @@ where
                     .parse(cursor, interner)
                     .map(Into::into)
             }
-            TokenKind::BooleanLiteral(boolean) => {
+            TokenKind::BooleanLiteral((_, ContainsEscapeSequence(true))) => Err(Error::general(
+                "Keyword must not contain escaped characters",
+                tok_position,
+            )),
+            TokenKind::BooleanLiteral((boolean, _)) => {
                 let node = Literal::from(*boolean).into();
                 cursor.advance(interner);
                 Ok(node)

--- a/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
@@ -600,7 +600,7 @@ where
                 let (utf8, utf16) = word.as_str();
                 interner.get_or_intern_static(utf8, utf16).into()
             }
-            TokenKind::NullLiteral => (Sym::NULL).into(),
+            TokenKind::NullLiteral(_) => (Sym::NULL).into(),
             TokenKind::BooleanLiteral((bool, _)) => match bool {
                 true => Sym::TRUE.into(),
                 false => Sym::FALSE.into(),

--- a/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
@@ -601,7 +601,7 @@ where
                 interner.get_or_intern_static(utf8, utf16).into()
             }
             TokenKind::NullLiteral => (Sym::NULL).into(),
-            TokenKind::BooleanLiteral(bool) => match bool {
+            TokenKind::BooleanLiteral((bool, _)) => match bool {
                 true => Sym::TRUE.into(),
                 false => Sym::FALSE.into(),
             },

--- a/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -605,7 +605,7 @@ where
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
-                    | TokenKind::NullLiteral
+                    | TokenKind::NullLiteral(_)
                     | TokenKind::PrivateIdentifier(_)
                     | TokenKind::Punctuator(
                         Punctuator::OpenBracket | Punctuator::Mul | Punctuator::OpenBlock,
@@ -945,7 +945,7 @@ where
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
-                    | TokenKind::NullLiteral
+                    | TokenKind::NullLiteral(_)
                     | TokenKind::Punctuator(Punctuator::OpenBracket) => {
                         let name_position = token.span().start();
                         let name = PropertyName::new(self.allow_yield, self.allow_await)
@@ -1076,7 +1076,7 @@ where
                     | TokenKind::StringLiteral(_)
                     | TokenKind::NumericLiteral(_)
                     | TokenKind::Keyword(_)
-                    | TokenKind::NullLiteral
+                    | TokenKind::NullLiteral(_)
                     | TokenKind::Punctuator(Punctuator::OpenBracket) => {
                         let name_position = token.span().start();
                         let name = PropertyName::new(self.allow_yield, self.allow_await)
@@ -1237,7 +1237,7 @@ where
             | TokenKind::StringLiteral(_)
             | TokenKind::NumericLiteral(_)
             | TokenKind::Keyword(_)
-            | TokenKind::NullLiteral
+            | TokenKind::NullLiteral(_)
             | TokenKind::Punctuator(Punctuator::OpenBracket) => {
                 let name_position = token.span().start();
                 let name = PropertyName::new(self.allow_yield, self.allow_await)


### PR DESCRIPTION
This Pull Request fixes/closes #2771 .

This PR throws a syntax error for keywords with unicode escapes. Also, it removes all traces of `bool` (used to indicate presence of unicode escapes) from `TokenKind::Keyword`.

Conformance regresses to 77.56% from 78% at e74cf369cd15cb4b3f6e14ea6d6e1a67177af94d but I don't know why.
