### PR TITLE
Allow `async` as identifier name in certain contexts

### DIFF
--- a/boa_parser/src/parser/expression/assignment/mod.rs
+++ b/boa_parser/src/parser/expression/assignment/mod.rs
@@ -134,7 +134,7 @@ where
                 }
             }
             //  AsyncArrowFunction[?In, ?Yield, ?Await]
-            TokenKind::Keyword((Keyword::Async, _)) => {
+            TokenKind::Keyword((Keyword::Async, false)) => {
                 let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {
                     2
                 } else {

--- a/boa_parser/src/parser/expression/primary/mod.rs
+++ b/boa_parser/src/parser/expression/primary/mod.rs
@@ -143,14 +143,8 @@ where
 
                 match cursor.peek(1, interner)?.map(Token::kind) {
                     Some(TokenKind::Keyword((Keyword::Function, _)))
-                        if !is_line_terminator && contain_escaped_char =>
+                        if !is_line_terminator && !contain_escaped_char =>
                     {
-                        Err(Error::general(
-                            "Keyword must not contain escaped characters",
-                            tok_position,
-                        ))
-                    }
-                    Some(TokenKind::Keyword((Keyword::Function, _))) if !is_line_terminator => {
                         cursor.advance(interner);
                         match cursor.peek(1, interner)?.map(Token::kind) {
                             Some(TokenKind::Punctuator(Punctuator::Mul)) => {

--- a/boa_parser/src/parser/statement/expression/mod.rs
+++ b/boa_parser/src/parser/statement/expression/mod.rs
@@ -47,7 +47,7 @@ where
 
         let next_token = cursor.peek(0, interner).or_abrupt()?;
         match next_token.kind() {
-            TokenKind::Keyword((Keyword::Function | Keyword::Class | Keyword::Async, true)) => {
+            TokenKind::Keyword((Keyword::Function | Keyword::Class, true)) => {
                 return Err(Error::general(
                     "Keyword must not contain escaped characters",
                     next_token.span().start(),
@@ -69,9 +69,7 @@ where
                     .peek_is_line_terminator(skip_n, interner)?
                     .unwrap_or(true);
 
-                if is_line_terminator {
-                    {}
-                } else {
+                if !is_line_terminator {
                     let next_token = cursor.peek(1, interner).or_abrupt()?;
                     match next_token.kind() {
                         TokenKind::Keyword((Keyword::Function, true)) => {

--- a/boa_parser/src/parser/statement/iteration/for_statement.rs
+++ b/boa_parser/src/parser/statement/iteration/for_statement.rs
@@ -135,7 +135,7 @@ where
                     .parse(cursor, interner)?
                     .into(),
             ),
-            TokenKind::Keyword((Keyword::Async, false)) => {
+            TokenKind::Keyword((Keyword::Async, false)) if !r#await => {
                 match cursor.peek(1, interner).or_abrupt()?.kind() {
                     TokenKind::Keyword((Keyword::Of, _)) => {
                         return Err(Error::lex(LexError::Syntax(

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -421,7 +421,7 @@ where
             ) => Declaration::new(self.allow_yield, self.allow_await)
                 .parse(cursor, interner)
                 .map(ast::StatementListItem::from),
-            TokenKind::Keyword((Keyword::Async, _)) => {
+            TokenKind::Keyword((Keyword::Async, false)) => {
                 let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {
                     2
                 } else {


### PR DESCRIPTION
Just a small change in the parser to fix a couple of tests related to `async` as an identifier name.