### PR TITLE
Shrink environment binding locators

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -232,8 +232,8 @@ impl Eval {
         compiler.compile_statement_list(&body, true, false);
 
         let env_info = compiler.pop_compile_environment();
-        compiler.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-        compiler.patch_jump_with_target(push_env.1, env_info.index as u32);
+        compiler.patch_jump_with_target(push_env.0, env_info.num_bindings);
+        compiler.patch_jump_with_target(push_env.1, env_info.index);
         compiler.emit_opcode(Opcode::PopEnvironment);
 
         let code_block = Gc::new(compiler.finish());

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -12,14 +12,14 @@ use rustc_hash::FxHashMap;
 /// This struct stores all the data to access mapped function parameters in their environment.
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct ParameterMap {
-    binding_indices: Vec<Option<usize>>,
+    binding_indices: Vec<Option<u32>>,
     environment: Gc<DeclarativeEnvironment>,
 }
 
 impl ParameterMap {
     /// Deletes the binding with the given index from the parameter map.
-    pub(crate) fn delete(&mut self, index: usize) {
-        if let Some(binding) = self.binding_indices.get_mut(index) {
+    pub(crate) fn delete(&mut self, index: u32) {
+        if let Some(binding) = self.binding_indices.get_mut(index as usize) {
             *binding = None;
         }
     }
@@ -32,8 +32,12 @@ impl ParameterMap {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-makearggetter
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
-        let binding_index = self.binding_indices.get(index).copied().flatten()?;
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
+        let binding_index = self
+            .binding_indices
+            .get(index as usize)
+            .copied()
+            .flatten()?;
         self.environment.get(binding_index)
     }
 
@@ -45,8 +49,8 @@ impl ParameterMap {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-makeargsetter
-    pub(crate) fn set(&self, index: usize, value: &JsValue) {
-        if let Some(binding_index) = self.binding_indices.get(index).copied().flatten() {
+    pub(crate) fn set(&self, index: u32, value: &JsValue) {
+        if let Some(binding_index) = self.binding_indices.get(index as usize).copied().flatten() {
             self.environment.set(binding_index, value.clone());
         }
     }
@@ -174,7 +178,7 @@ impl Arguments {
             if property_index >= len {
                 break;
             }
-            let binding_index = bindings.len();
+            let binding_index = bindings.len() as u32;
             let entry = bindings
                 .entry(name)
                 .or_insert((binding_index, property_index));

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -52,8 +52,8 @@ impl ByteCompiler<'_, '_> {
             let env_info = compiler.pop_compile_environment();
 
             if let Some(env_labels) = env_labels {
-                compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings as u32);
-                compiler.patch_jump_with_target(env_labels.1, env_info.index as u32);
+                compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings);
+                compiler.patch_jump_with_target(env_labels.1, env_info.index);
                 compiler.pop_compile_environment();
             } else {
                 compiler.num_bindings = env_info.num_bindings;
@@ -548,8 +548,8 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(class_env) = class_env {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(class_env.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(class_env.1, env_info.index as u32);
+            self.patch_jump_with_target(class_env.0, env_info.num_bindings);
+            self.patch_jump_with_target(class_env.1, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -7,9 +7,9 @@ use boa_gc::{Gc, GcRefCell};
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PopEnvironmentInfo {
     /// Number of bindings declared.
-    pub(crate) num_bindings: usize,
+    pub(crate) num_bindings: u32,
     /// Index in the compile time envs array.
-    pub(crate) index: usize,
+    pub(crate) index: u32,
 }
 
 impl ByteCompiler<'_, '_> {
@@ -24,7 +24,7 @@ impl ByteCompiler<'_, '_> {
     /// Pops the top compile time environment and returns its index and number of bindings.
     #[track_caller]
     pub(crate) fn pop_compile_environment(&mut self) -> PopEnvironmentInfo {
-        let index = self.compile_environments.len();
+        let index = self.compile_environments.len() as u32;
         self.compile_environments
             .push(self.current_environment.clone());
 

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -129,8 +129,8 @@ impl FunctionCompiler {
 
         if let Some(env_labels) = env_labels {
             let env_info = compiler.pop_compile_environment();
-            compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings as u32);
-            compiler.patch_jump_with_target(env_labels.1, env_info.index as u32);
+            compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings);
+            compiler.patch_jump_with_target(env_labels.1, env_info.index);
         }
 
         if additional_env {

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -251,7 +251,7 @@ pub struct ByteCompiler<'ctx, 'host> {
     pub(crate) bindings: Vec<BindingLocator>,
 
     /// Number of binding for the function environment.
-    pub(crate) num_bindings: usize,
+    pub(crate) num_bindings: u32,
 
     /// Functions inside this function
     pub(crate) functions: Vec<Gc<CodeBlock>>,
@@ -278,7 +278,7 @@ pub struct ByteCompiler<'ctx, 'host> {
     pub(crate) current_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
 
     /// The number of bindings in the parameters environment.
-    pub(crate) parameters_env_bindings: Option<usize>,
+    pub(crate) parameters_env_bindings: Option<u32>,
 
     literals_map: FxHashMap<Literal, u32>,
     names_map: FxHashMap<Identifier, u32>,

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -11,8 +11,8 @@ impl ByteCompiler<'_, '_> {
         self.compile_statement_list(block.statement_list(), use_expr, true);
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, env_info.index as u32);
+        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
+        self.patch_jump_with_target(push_env.1, env_info.index);
 
         self.emit_opcode(Opcode::PopEnvironment);
     }

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -115,11 +115,11 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(env_labels) = env_labels {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(env_labels.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(env_labels.1, env_info.index as u32);
+            self.patch_jump_with_target(env_labels.0, env_info.num_bindings);
+            self.patch_jump_with_target(env_labels.1, env_info.index);
             if let Some(iteration_env_labels) = iteration_env_labels {
-                self.patch_jump_with_target(iteration_env_labels.0, env_info.num_bindings as u32);
-                self.patch_jump_with_target(iteration_env_labels.1, env_info.index as u32);
+                self.patch_jump_with_target(iteration_env_labels.0, env_info.num_bindings);
+                self.patch_jump_with_target(iteration_env_labels.1, env_info.index);
             }
             self.emit_opcode(Opcode::PopEnvironment);
         }
@@ -157,8 +157,8 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_in_loop.target(), true);
 
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(push_env.1, env_info.index as u32);
+            self.patch_jump_with_target(push_env.0, env_info.num_bindings);
+            self.patch_jump_with_target(push_env.1, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -239,8 +239,8 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(iteration_environment) = iteration_environment {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(iteration_environment.1, env_info.index as u32);
+            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings);
+            self.patch_jump_with_target(iteration_environment.1, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -289,8 +289,8 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_of_loop.iterable(), true);
 
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(push_env.1, env_info.index as u32);
+            self.patch_jump_with_target(push_env.0, env_info.num_bindings);
+            self.patch_jump_with_target(push_env.1, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -384,8 +384,8 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(iteration_environment) = iteration_environment {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings as u32);
-            self.patch_jump_with_target(iteration_environment.1, env_info.index as u32);
+            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings);
+            self.patch_jump_with_target(iteration_environment.1, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -61,8 +61,8 @@ impl ByteCompiler<'_, '_> {
         }
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, env_info.index as u32);
+        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
+        self.patch_jump_with_target(push_env.1, env_info.index);
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -88,8 +88,8 @@ impl ByteCompiler<'_, '_> {
         }
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings as u32);
-        self.patch_jump_with_target(push_env.1, env_info.index as u32);
+        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
+        self.patch_jump_with_target(push_env.1, env_info.index);
         self.emit_opcode(Opcode::PopEnvironment);
 
         if finally {

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -9,7 +9,7 @@ use rustc_hash::FxHashMap;
 /// It contains the binding index and a flag to indicate if this is a mutable binding or not.
 #[derive(Debug)]
 struct CompileTimeBinding {
-    index: usize,
+    index: u32,
     mutable: bool,
     lex: bool,
     strict: bool,
@@ -21,7 +21,7 @@ struct CompileTimeBinding {
 #[derive(Debug, Finalize, Trace)]
 pub(crate) struct CompileTimeEnvironment {
     outer: Option<Gc<GcRefCell<Self>>>,
-    environment_index: usize,
+    environment_index: u32,
     #[unsafe_ignore_trace]
     bindings: FxHashMap<Identifier, CompileTimeBinding>,
     function_scope: bool,
@@ -74,8 +74,8 @@ impl CompileTimeEnvironment {
     }
 
     /// Returns the number of bindings in this environment.
-    pub(crate) fn num_bindings(&self) -> usize {
-        self.bindings.len()
+    pub(crate) fn num_bindings(&self) -> u32 {
+        self.bindings.len() as u32
     }
 
     /// Check if the environment is a function environment.
@@ -157,7 +157,7 @@ impl CompileTimeEnvironment {
         if let Some(outer) = &self.outer {
             if !function_scope || self.function_scope {
                 if !self.bindings.contains_key(&name) {
-                    let binding_index = self.bindings.len();
+                    let binding_index = self.bindings.len() as u32;
                     self.bindings.insert(
                         name,
                         CompileTimeBinding {
@@ -178,7 +178,7 @@ impl CompileTimeEnvironment {
             false
         } else {
             if !self.bindings.contains_key(&name) {
-                let binding_index = self.bindings.len();
+                let binding_index = self.bindings.len() as u32;
                 self.bindings.insert(
                     name,
                     CompileTimeBinding {
@@ -195,7 +195,7 @@ impl CompileTimeEnvironment {
 
     /// Crate an immutable binding.
     pub(crate) fn create_immutable_binding(&mut self, name: Identifier, strict: bool) {
-        let binding_index = self.bindings.len();
+        let binding_index = self.bindings.len() as u32;
         self.bindings.insert(
             name,
             CompileTimeBinding {
@@ -288,7 +288,7 @@ impl CompileTimeEnvironment {
     }
 
     /// Gets the environment index of this environment.
-    pub(crate) const fn environment_index(&self) -> usize {
+    pub(crate) const fn environment_index(&self) -> u32 {
         self.environment_index
     }
 }

--- a/boa_engine/src/environments/runtime/declarative/function.rs
+++ b/boa_engine/src/environments/runtime/declarative/function.rs
@@ -12,7 +12,7 @@ pub(crate) struct FunctionEnvironment {
 
 impl FunctionEnvironment {
     /// Creates a new `FunctionEnvironment`.
-    pub(crate) fn new(bindings: usize, poisoned: bool, with: bool, slots: FunctionSlots) -> Self {
+    pub(crate) fn new(bindings: u32, poisoned: bool, with: bool, slots: FunctionSlots) -> Self {
         Self {
             inner: PoisonableEnvironment::new(bindings, poisoned, with),
             slots,
@@ -35,7 +35,7 @@ impl FunctionEnvironment {
     ///
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
         self.inner.get(index)
     }
 
@@ -45,7 +45,7 @@ impl FunctionEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
         self.inner.set(index, value);
     }
 

--- a/boa_engine/src/environments/runtime/declarative/global.rs
+++ b/boa_engine/src/environments/runtime/declarative/global.rs
@@ -30,7 +30,7 @@ impl GlobalEnvironment {
     ///
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
         self.inner.get(index)
     }
 
@@ -40,7 +40,7 @@ impl GlobalEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
         self.inner.set(index, value);
     }
 

--- a/boa_engine/src/environments/runtime/declarative/lexical.rs
+++ b/boa_engine/src/environments/runtime/declarative/lexical.rs
@@ -11,7 +11,7 @@ pub(crate) struct LexicalEnvironment {
 
 impl LexicalEnvironment {
     /// Creates a new `LexicalEnvironment`.
-    pub(crate) fn new(bindings: usize, poisoned: bool, with: bool) -> Self {
+    pub(crate) fn new(bindings: u32, poisoned: bool, with: bool) -> Self {
         Self {
             inner: PoisonableEnvironment::new(bindings, poisoned, with),
         }
@@ -28,7 +28,7 @@ impl LexicalEnvironment {
     ///
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
         self.inner.get(index)
     }
 
@@ -38,7 +38,7 @@ impl LexicalEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
         self.inner.set(index, value);
     }
 }

--- a/boa_engine/src/environments/runtime/declarative/mod.rs
+++ b/boa_engine/src/environments/runtime/declarative/mod.rs
@@ -72,7 +72,7 @@ impl DeclarativeEnvironment {
     ///
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
         self.kind.get(index)
     }
 
@@ -82,7 +82,7 @@ impl DeclarativeEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
         self.kind.set(index, value);
     }
 
@@ -173,7 +173,7 @@ impl DeclarativeEnvironmentKind {
     ///
     /// Panics if the binding value is out of range or not initialized.
     #[track_caller]
-    pub(crate) fn get(&self, index: usize) -> Option<JsValue> {
+    pub(crate) fn get(&self, index: u32) -> Option<JsValue> {
         match self {
             Self::Lexical(inner) => inner.get(index),
             Self::Global(inner) => inner.get(index),
@@ -188,7 +188,7 @@ impl DeclarativeEnvironmentKind {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
         match self {
             Self::Lexical(inner) => inner.set(index, value),
             Self::Global(inner) => inner.set(index, value),
@@ -274,9 +274,9 @@ pub(crate) struct PoisonableEnvironment {
 
 impl PoisonableEnvironment {
     /// Creates a new `PoisonableEnvironment`.
-    pub(crate) fn new(bindings_count: usize, poisoned: bool, with: bool) -> Self {
+    pub(crate) fn new(bindings_count: u32, poisoned: bool, with: bool) -> Self {
         Self {
-            bindings: GcRefCell::new(vec![None; bindings_count]),
+            bindings: GcRefCell::new(vec![None; bindings_count as usize]),
             poisoned: Cell::new(poisoned),
             with: Cell::new(with),
         }
@@ -293,8 +293,8 @@ impl PoisonableEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    fn get(&self, index: usize) -> Option<JsValue> {
-        self.bindings.borrow()[index].clone()
+    fn get(&self, index: u32) -> Option<JsValue> {
+        self.bindings.borrow()[index as usize].clone()
     }
 
     /// Sets the binding value from the environment by index.
@@ -303,8 +303,8 @@ impl PoisonableEnvironment {
     ///
     /// Panics if the binding value is out of range.
     #[track_caller]
-    pub(crate) fn set(&self, index: usize, value: JsValue) {
-        self.bindings.borrow_mut()[index] = Some(value);
+    pub(crate) fn set(&self, index: u32, value: JsValue) {
+        self.bindings.borrow_mut()[index as usize] = Some(value);
     }
 
     /// Returns `true` if this environment is poisoned.

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -41,7 +41,7 @@ pub(crate) fn arguments_exotic_get_own_property(
             .borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(*index as usize)
+            .get(*index)
         {
             // a. Set desc.[[Value]] to Get(map, P).
             return Ok(Some(
@@ -78,8 +78,8 @@ pub(crate) fn arguments_exotic_define_own_property(
         obj.borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(index as usize)
-            .map(|value| (index as usize, value))
+            .get(index)
+            .map(|value| (index, value))
     } else {
         None
     };
@@ -170,7 +170,7 @@ pub(crate) fn arguments_exotic_get(
             .borrow()
             .as_mapped_arguments()
             .expect("arguments exotic method must only be callable from arguments objects")
-            .get(*index as usize)
+            .get(*index)
         {
             // a. Assert: map contains a formal parameter mapping for P.
             // b. Return Get(map, P).
@@ -209,7 +209,7 @@ pub(crate) fn arguments_exotic_set(
             obj.borrow_mut()
                 .as_mapped_arguments_mut()
                 .expect("arguments exotic method must only be callable from arguments objects")
-                .set(index as usize, &value);
+                .set(index, &value);
         }
     }
 
@@ -240,7 +240,7 @@ pub(crate) fn arguments_exotic_delete(
             obj.borrow_mut()
                 .as_mapped_arguments_mut()
                 .expect("arguments exotic method must only be callable from arguments objects")
-                .delete(*index as usize);
+                .delete(*index);
         }
     }
 

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -116,8 +116,8 @@ impl Realm {
             .poisonable_environment();
         let mut bindings = env.bindings().borrow_mut();
 
-        if bindings.len() < binding_number {
-            bindings.resize(binding_number, None);
+        if bindings.len() < binding_number as usize {
+            bindings.resize(binding_number as usize, None);
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -97,7 +97,7 @@ pub struct CodeBlock {
     pub(crate) bindings: Box<[BindingLocator]>,
 
     /// Number of binding for the function environment.
-    pub(crate) num_bindings: usize,
+    pub(crate) num_bindings: u32,
 
     /// Functions inside this function
     pub(crate) functions: Box<[Gc<Self>]>,
@@ -123,7 +123,7 @@ pub struct CodeBlock {
     pub(crate) function_environment_push_location: u32,
 
     /// The number of bindings in the parameters environment.
-    pub(crate) parameters_env_bindings: Option<usize>,
+    pub(crate) parameters_env_bindings: Option<u32>,
 
     #[cfg(feature = "trace")]
     /// Trace instruction execution to `stdout`.

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -25,7 +25,7 @@ impl Operation for PushDeclarativeEnvironment {
         context
             .vm
             .environments
-            .push_lexical(num_bindings as usize, compile_environment);
+            .push_lexical(num_bindings, compile_environment);
         context.vm.frame_mut().inc_frame_env_stack();
         Ok(CompletionType::Normal)
     }
@@ -51,7 +51,7 @@ impl Operation for PushFunctionEnvironment {
         context
             .vm
             .environments
-            .push_function_inherit(num_bindings as usize, compile_environment);
+            .push_function_inherit(num_bindings, compile_environment);
         Ok(CompletionType::Normal)
     }
 }


### PR DESCRIPTION
Shrinks environments binding locators (which we were already doing when we truncate it to environment bytecode operands).