### PR TITLE
Fix remaining static module bugs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,24 @@
     {
       "type": "lldb",
       "request": "launch",
-      "name": "Launch",
+      "name": "Launch (Script)",
       "windows": {
         "program": "${workspaceFolder}/target/debug/boa.exe"
       },
       "program": "${workspaceFolder}/target/debug/boa",
       "args": ["${workspaceFolder}/tests/js/test.js", "--debug-object"],
+      "sourceLanguages": ["rust"],
+      "preLaunchTask": "Cargo Build"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Launch (Module)",
+      "windows": {
+        "program": "${workspaceFolder}/target/debug/boa.exe"
+      },
+      "program": "${workspaceFolder}/target/debug/boa",
+      "args": ["${workspaceFolder}/tests/js/test.js", "--debug-object", "-m", "-r", "tests/js"],
       "sourceLanguages": ["rust"],
       "preLaunchTask": "Cargo Build"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,7 +24,13 @@
         "program": "${workspaceFolder}/target/debug/boa.exe"
       },
       "program": "${workspaceFolder}/target/debug/boa",
-      "args": ["${workspaceFolder}/tests/js/test.js", "--debug-object", "-m", "-r", "tests/js"],
+      "args": [
+        "${workspaceFolder}/tests/js/test.js",
+        "--debug-object",
+        "-m",
+        "-r",
+        "tests/js"
+      ],
       "sourceLanguages": ["rust"],
       "preLaunchTask": "Cargo Build"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,7 @@ dependencies = [
  "bitflags 2.3.1",
  "boa_interner",
  "boa_macros",
+ "indexmap",
  "num-bigint",
  "rustc-hash",
  "serde",

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -22,3 +22,4 @@ bitflags = "2.3.1"
 num-bigint = "0.4.3"
 serde = { version = "1.0.163", features = ["derive"], optional = true }
 arbitrary = { version = "1", features = ["derive"], optional = true }
+indexmap = "1.9.3"

--- a/boa_ast/src/declaration/export.rs
+++ b/boa_ast/src/declaration/export.rs
@@ -174,16 +174,18 @@ impl VisitWith for ExportDeclaration {
 pub struct ExportSpecifier {
     alias: Sym,
     private_name: Sym,
+    string_literal: bool,
 }
 
 impl ExportSpecifier {
     /// Creates a new [`ExportSpecifier`].
     #[inline]
     #[must_use]
-    pub const fn new(alias: Sym, private_name: Sym) -> Self {
+    pub const fn new(alias: Sym, private_name: Sym, string_literal: bool) -> Self {
         Self {
             alias,
             private_name,
+            string_literal,
         }
     }
 
@@ -199,6 +201,13 @@ impl ExportSpecifier {
     #[must_use]
     pub const fn private_name(self) -> Sym {
         self.private_name
+    }
+
+    /// Returns `true` if the private name of the specifier was a `StringLiteral`.
+    #[inline]
+    #[must_use]
+    pub const fn string_literal(&self) -> bool {
+        self.string_literal
     }
 }
 

--- a/boa_ast/src/module_item_list/mod.rs
+++ b/boa_ast/src/module_item_list/mod.rs
@@ -5,10 +5,11 @@
 //!
 //! [spec]: https://tc39.es/ecma262/#sec-modules
 
-use std::{convert::Infallible, ops::ControlFlow};
+use std::{convert::Infallible, hash::BuildHasherDefault, ops::ControlFlow};
 
 use boa_interner::Sym;
-use rustc_hash::FxHashSet;
+use indexmap::IndexSet;
+use rustc_hash::{FxHashSet, FxHasher};
 
 use crate::{
     declaration::{
@@ -205,9 +206,9 @@ impl ModuleItemList {
     /// [spec]: https://tc39.es/ecma262/#sec-static-semantics-modulerequests
     #[inline]
     #[must_use]
-    pub fn requests(&self) -> FxHashSet<Sym> {
+    pub fn requests(&self) -> IndexSet<Sym, BuildHasherDefault<FxHasher>> {
         #[derive(Debug)]
-        struct RequestsVisitor<'vec>(&'vec mut FxHashSet<Sym>);
+        struct RequestsVisitor<'vec>(&'vec mut IndexSet<Sym, BuildHasherDefault<FxHasher>>);
 
         impl<'ast> Visitor<'ast> for RequestsVisitor<'_> {
             type BreakTy = Infallible;
@@ -227,7 +228,7 @@ impl ModuleItemList {
             }
         }
 
-        let mut requests = FxHashSet::default();
+        let mut requests = IndexSet::default();
 
         RequestsVisitor(&mut requests).visit_module_item_list(self);
 

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -351,16 +351,16 @@ impl ByteCompiler<'_, '_> {
         for d in &declarations {
             match d {
                 LexicallyScopedDeclaration::Function(function) => {
-                    self.function(function.into(), NodeKind::Declaration, false);
+                    self.function_with_binding(function.into(), NodeKind::Declaration, false);
                 }
                 LexicallyScopedDeclaration::Generator(function) => {
-                    self.function(function.into(), NodeKind::Declaration, false);
+                    self.function_with_binding(function.into(), NodeKind::Declaration, false);
                 }
                 LexicallyScopedDeclaration::AsyncFunction(function) => {
-                    self.function(function.into(), NodeKind::Declaration, false);
+                    self.function_with_binding(function.into(), NodeKind::Declaration, false);
                 }
                 LexicallyScopedDeclaration::AsyncGenerator(function) => {
-                    self.function(function.into(), NodeKind::Declaration, false);
+                    self.function_with_binding(function.into(), NodeKind::Declaration, false);
                 }
                 _ => {}
             }
@@ -1147,7 +1147,7 @@ impl ByteCompiler<'_, '_> {
             // a. Let fn be the sole element of the BoundNames of f.
             // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
             // c. Perform ! varEnv.SetMutableBinding(fn, fo, false).
-            self.function(function, NodeKind::Declaration, false);
+            self.function_with_binding(function, NodeKind::Declaration, false);
         }
 
         // 37. Return unused.

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -88,7 +88,7 @@ impl ByteCompiler<'_, '_> {
             .create_mutable_binding(name, function_scope));
     }
 
-    /// Initialize a mutable binding at bytecode compile time and return it's binding locator.
+    /// Initialize a mutable binding at bytecode compile time and return its binding locator.
     pub(crate) fn initialize_mutable_binding(
         &self,
         name: Identifier,

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -124,22 +124,22 @@ impl ByteCompiler<'_, '_> {
             }
             Expression::Spread(spread) => self.compile_expr(spread.target(), true),
             Expression::Function(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::ArrowFunction(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::AsyncArrowFunction(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::Generator(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::AsyncFunction(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::AsyncGenerator(function) => {
-                self.function(function.into(), NodeKind::Expression, use_expr);
+                self.function_with_binding(function.into(), NodeKind::Expression, use_expr);
             }
             Expression::Call(call) => self.call(Callable::Call(call), use_expr),
             Expression::New(new) => self.call(Callable::New(new), use_expr),

--- a/boa_engine/src/bytecompiler/statement/labelled.rs
+++ b/boa_engine/src/bytecompiler/statement/labelled.rs
@@ -34,7 +34,7 @@ impl ByteCompiler<'_, '_> {
                 stmt => self.compile_stmt(stmt, use_expr),
             },
             LabelledItem::Function(f) => {
-                self.function(f.into(), NodeKind::Declaration, false);
+                self.function_with_binding(f.into(), NodeKind::Declaration, false);
             }
         }
 

--- a/boa_engine/src/tests/mod.rs
+++ b/boa_engine/src/tests/mod.rs
@@ -422,8 +422,8 @@ fn strict_mode_reserved_name() {
         ("var protected = 10;", "unexpected token 'protected', strict reserved word cannot be an identifier at line 1, col 19"),
         ("var public = 10;", "unexpected token 'public', strict reserved word cannot be an identifier at line 1, col 19"),
         ("var static = 10;", "unexpected token 'static', strict reserved word cannot be an identifier at line 1, col 19"),
-        ("var eval = 10;", "unexpected token 'eval', binding identifier `eval` not allowed in strict mode at line 1, col 19"),
-        ("var arguments = 10;", "unexpected token 'arguments', binding identifier `arguments` not allowed in strict mode at line 1, col 19"),
+        ("var eval = 10;", "binding identifier `eval` not allowed in strict mode at line 1, col 19"),
+        ("var arguments = 10;", "binding identifier `arguments` not allowed in strict mode at line 1, col 19"),
         ("var let = 10;", "unexpected token 'let', strict reserved word cannot be an identifier at line 1, col 19"),
         ("var yield = 10;", "unexpected token 'yield', strict reserved word cannot be an identifier at line 1, col 19"),
     ];

--- a/boa_parser/src/parser/expression/identifiers.rs
+++ b/boa_parser/src/parser/expression/identifiers.rs
@@ -114,21 +114,18 @@ where
                     .resolve_expect(ident.sym())
                     .utf8()
                     .expect("keyword must be utf-8");
-                Err(Error::unexpected(
-                    name,
-                    span,
+                Err(Error::general(
                     format!("binding identifier `{name}` not allowed in strict mode"),
+                    span.start(),
                 ))
             }
-            Sym::YIELD if self.allow_yield.0 => Err(Error::unexpected(
-                "yield",
-                span,
+            Sym::YIELD if self.allow_yield.0 => Err(Error::general(
                 "keyword `yield` not allowed in this context",
+                span.start(),
             )),
-            Sym::AWAIT if self.allow_await.0 => Err(Error::unexpected(
-                "await",
-                span,
+            Sym::AWAIT if self.allow_await.0 => Err(Error::general(
                 "keyword `await` not allowed in this context",
+                span.start(),
             )),
             _ => Ok(ident),
         }

--- a/test_ignore.toml
+++ b/test_ignore.toml
@@ -30,6 +30,8 @@ features = [
     "Intl-enumeration",
     # https://github.com/tc39/proposal-array-from-async
     "Array.fromAsync",
+    # https://github.com/tc39/proposal-import-attributes
+    "import-assertions",
 
     # Non-standard
     "caller",


### PR DESCRIPTION
This Pull Request fixes our remaining module bugs in the `test/language/module-code` suite.
This leaves us with:

```bash
Results (ECMAScript Next):
Total tests: 581
Passed tests: 551
Ignored tests: 13
Failed tests: 17 (0 panics)
Conformance: 94.84%
```

16 tests are being fixed because they have an incorrect phase tag (https://github.com/tc39/test262/pull/3832), and the 13 ignored tests are import assertions, which are still stage 3. Our true conformance status would be:

```bash
Results (ECMAScript Next):
Total tests: 581
Passed tests: 567
Ignored tests: 13
Failed tests: 1 (0 panics)
Conformance: 97.59%
```

The last failing test (test/language/module-code/eval-export-dflt-expr-cls-name-meth.js) seems to be a spec bug, but I'll investigate further.
