### PR TITLE
show object kind, name and address when using dbg!

### DIFF
--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -1114,10 +1114,9 @@ impl Debug for JsObject {
                     None => JsString::default(),
                     Some(prop) => prop
                         .value()
-                        .expect("no name property")
-                        .as_string()
-                        .expect("cannot convert to string")
-                        .clone(),
+                        .and_then(JsValue::as_string)
+                        .cloned()
+                        .unwrap_or_default()
                 };
 
                 return f.write_fmt(format_args!("({:?}) {:?} 0x{:X}", kind, name, ptr as usize));

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -14,7 +14,7 @@ use crate::{
     property::{PropertyDescriptor, PropertyKey},
     string::utf16,
     value::PreferredType,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsString, JsValue,
 };
 use boa_gc::{self, Finalize, Gc, GcRefCell, Trace};
 use boa_interner::Sym;
@@ -1092,7 +1092,6 @@ impl RecursionLimiter {
 
 impl Debug for JsObject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        let ptr: *const _ = self.vtable();
         let limiter = RecursionLimiter::new(self.as_ref());
 
         // Typically, using `!limiter.live` would be good enough here.
@@ -1102,10 +1101,29 @@ impl Debug for JsObject {
         // Instead, we check if the object has appeared before in the entire graph. This means that objects will appear
         // at most once, hopefully making things a bit clearer.
         if !limiter.visited && !limiter.live {
-            f.debug_struct("JsObject")
-                .field("vtable", &ptr)
-                .field("object", &self.inner.object)
-                .finish()
+            let ptr: *const _ = self.as_ref();
+            let obj = self.borrow();
+            let kind = obj.kind();
+            let name_prop = self
+                .borrow()
+                .properties()
+                .get(&PropertyKey::String(JsString::from("name")));
+
+            if obj.is_function() {
+                let name = match name_prop {
+                    None => JsString::default(),
+                    Some(prop) => prop
+                        .value()
+                        .expect("no name property")
+                        .as_string()
+                        .expect("cannot convert to string")
+                        .clone(),
+                };
+
+                return f.write_fmt(format_args!("({:?}) {:?} 0x{:X}", kind, name, ptr as usize));
+            }
+
+            f.write_fmt(format_args!("({:?}) 0x{:X}", kind, ptr as usize))
         } else {
             f.write_str("{ ... }")
         }

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -1104,7 +1104,7 @@ impl Debug for JsObject {
             let ptr: *const _ = self.as_ref();
             let obj = self.borrow();
             let kind = obj.kind();
-            if obj.is_function() {            
+            if obj.is_function() {
                 let name_prop = obj
                     .properties()
                     .get(&PropertyKey::String(JsString::from("name")));
@@ -1114,7 +1114,7 @@ impl Debug for JsObject {
                         .value()
                         .and_then(JsValue::as_string)
                         .cloned()
-                        .unwrap_or_default()
+                        .unwrap_or_default(),
                 };
 
                 return f.write_fmt(format_args!("({:?}) {:?} 0x{:X}", kind, name, ptr as usize));

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -1104,12 +1104,10 @@ impl Debug for JsObject {
             let ptr: *const _ = self.as_ref();
             let obj = self.borrow();
             let kind = obj.kind();
-            let name_prop = self
-                .borrow()
-                .properties()
-                .get(&PropertyKey::String(JsString::from("name")));
-
-            if obj.is_function() {
+            if obj.is_function() {            
+                let name_prop = obj
+                    .properties()
+                    .get(&PropertyKey::String(JsString::from("name")));
                 let name = match name_prop {
                     None => JsString::default(),
                     Some(prop) => prop


### PR DESCRIPTION
This should implement Debug a bit better for objects, previously they recursed a lot and spewed out a lot of garbage. This shows the kind, name and address for each object, which should be enough when investigating issues.

Before:
<hot mess>

After:
`&func = (Function) "fib" 0x7F9A67F17218`