### PR TITLE
Remove unneded `num_bindings` in `Opcode`s and `CodeBlock`

### DIFF
--- a/boa_cli/src/debug/function.rs
+++ b/boa_cli/src/debug/function.rs
@@ -135,7 +135,7 @@ fn set_trace_flag_in_function_object(object: &JsObject, value: bool) -> JsResult
     let code = function.codeblock().ok_or_else(|| {
         JsNativeError::typ().with_message("native functions do not have bytecode")
     })?;
-    code.set_trace(value);
+    code.set_traceable(value);
     Ok(())
 }
 

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -232,14 +232,15 @@ impl Eval {
         );
 
         compiler.push_compile_environment(strict);
-        let push_env = compiler.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+
+        let push_env = compiler.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
         compiler.eval_declaration_instantiation(&body, strict)?;
         compiler.compile_statement_list(body.statements(), true, false);
 
         let env_info = compiler.pop_compile_environment();
-        compiler.patch_jump_with_target(push_env.0, env_info.num_bindings);
-        compiler.patch_jump_with_target(push_env.1, env_info.index);
+        compiler.patch_jump_with_target(push_env, env_info.index);
+
         compiler.emit_opcode(Opcode::PopEnvironment);
 
         let code_block = Gc::new(compiler.finish());

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -238,8 +238,8 @@ impl Eval {
         compiler.eval_declaration_instantiation(&body, strict)?;
         compiler.compile_statement_list(body.statements(), true, false);
 
-        let env_info = compiler.pop_compile_environment();
-        compiler.patch_jump_with_target(push_env, env_info.index);
+        let env_index = compiler.pop_compile_environment();
+        compiler.patch_jump_with_target(push_env, env_index);
 
         compiler.emit_opcode(Opcode::PopEnvironment);
 

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -56,15 +56,13 @@ impl ByteCompiler<'_, '_> {
                 compiler.patch_jump_with_target(env_labels.1, env_info.index);
                 compiler.pop_compile_environment();
             } else {
-                compiler.num_bindings = env_info.num_bindings;
                 compiler.is_class_constructor = true;
             }
         } else {
             if class.super_ref().is_some() {
                 compiler.emit_opcode(Opcode::SuperCallDerived);
             }
-            let env_info = compiler.pop_compile_environment();
-            compiler.num_bindings = env_info.num_bindings;
+            compiler.pop_compile_environment();
             compiler.is_class_constructor = true;
         }
 
@@ -266,9 +264,8 @@ impl ByteCompiler<'_, '_> {
                     } else {
                         field_compiler.emit_opcode(Opcode::PushUndefined);
                     }
-                    let env_info = field_compiler.pop_compile_environment();
                     field_compiler.pop_compile_environment();
-                    field_compiler.num_bindings = env_info.num_bindings;
+                    field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
                     let mut code = field_compiler.finish();
@@ -298,9 +295,8 @@ impl ByteCompiler<'_, '_> {
                     } else {
                         field_compiler.emit_opcode(Opcode::PushUndefined);
                     }
-                    let env_info = field_compiler.pop_compile_environment();
                     field_compiler.pop_compile_environment();
-                    field_compiler.num_bindings = env_info.num_bindings;
+                    field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
                     let mut code = field_compiler.finish();
@@ -340,9 +336,8 @@ impl ByteCompiler<'_, '_> {
                     } else {
                         field_compiler.emit_opcode(Opcode::PushUndefined);
                     }
-                    let env_info = field_compiler.pop_compile_environment();
                     field_compiler.pop_compile_environment();
-                    field_compiler.num_bindings = env_info.num_bindings;
+                    field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
                     let mut code = field_compiler.finish();
@@ -392,9 +387,8 @@ impl ByteCompiler<'_, '_> {
                     );
 
                     compiler.compile_statement_list(body.statements(), false, false);
-                    let env_info = compiler.pop_compile_environment();
                     compiler.pop_compile_environment();
-                    compiler.num_bindings = env_info.num_bindings;
+                    compiler.pop_compile_environment();
 
                     let code = Gc::new(compiler.finish());
                     let index = self.functions.len() as u32;

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -39,7 +39,7 @@ impl ByteCompiler<'_, '_> {
             compiler.length = expr.parameters().length();
             compiler.params = expr.parameters().clone();
 
-            let (env_labels, _) = compiler.function_declaration_instantiation(
+            let (env_label, _) = compiler.function_declaration_instantiation(
                 expr.body(),
                 expr.parameters(),
                 false,
@@ -51,9 +51,8 @@ impl ByteCompiler<'_, '_> {
 
             let env_info = compiler.pop_compile_environment();
 
-            if let Some(env_labels) = env_labels {
-                compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings);
-                compiler.patch_jump_with_target(env_labels.1, env_info.index);
+            if let Some(env_label) = env_label {
+                compiler.patch_jump_with_target(env_label, env_info.index);
                 compiler.pop_compile_environment();
             } else {
                 compiler.is_class_constructor = true;
@@ -79,11 +78,11 @@ impl ByteCompiler<'_, '_> {
         self.emit(Opcode::GetFunction, &[index]);
         self.emit_u8(0);
 
-        let class_env: Option<(super::Label, super::Label)> = match class.name() {
+        let class_env: Option<super::Label> = match class.name() {
             Some(name) if class.has_binding_identifier() => {
                 self.push_compile_environment(false);
                 self.create_immutable_binding(name, true);
-                Some(self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment))
+                Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment))
             }
             _ => None,
         };
@@ -542,8 +541,7 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(class_env) = class_env {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(class_env.0, env_info.num_bindings);
-            self.patch_jump_with_target(class_env.1, env_info.index);
+            self.patch_jump_with_target(class_env, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -49,10 +49,10 @@ impl ByteCompiler<'_, '_> {
 
             compiler.compile_statement_list(expr.body().statements(), false, false);
 
-            let env_info = compiler.pop_compile_environment();
+            let env_index = compiler.pop_compile_environment();
 
             if let Some(env_label) = env_label {
-                compiler.patch_jump_with_target(env_label, env_info.index);
+                compiler.patch_jump_with_target(env_label, env_index);
                 compiler.pop_compile_environment();
             } else {
                 compiler.is_class_constructor = true;
@@ -540,8 +540,8 @@ impl ByteCompiler<'_, '_> {
         self.emit_opcode(Opcode::Pop);
 
         if let Some(class_env) = class_env {
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(class_env, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(class_env, env_index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -1,5 +1,5 @@
 use super::{ByteCompiler, Literal};
-use crate::vm::{BindingOpcode, Opcode};
+use crate::vm::{BindingOpcode, CodeBlockFlags, Opcode};
 use boa_ast::{
     expression::Identifier,
     function::{Class, ClassElement, FormalParameterList},
@@ -27,7 +27,7 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(class_name) = class.name() {
             if class.has_binding_identifier() {
-                compiler.has_binding_identifier = true;
+                compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
                 compiler.push_compile_environment(false);
                 compiler.create_immutable_binding(class_name, true);
             }
@@ -55,14 +55,14 @@ impl ByteCompiler<'_, '_> {
                 compiler.patch_jump_with_target(env_label, env_index);
                 compiler.pop_compile_environment();
             } else {
-                compiler.is_class_constructor = true;
+                compiler.code_block_flags |= CodeBlockFlags::IS_CLASS_CONSTRUCTOR;
             }
         } else {
             if class.super_ref().is_some() {
                 compiler.emit_opcode(Opcode::SuperCallDerived);
             }
             compiler.pop_compile_environment();
-            compiler.is_class_constructor = true;
+            compiler.code_block_flags |= CodeBlockFlags::IS_CLASS_CONSTRUCTOR;
         }
 
         if class.name().is_some() && class.has_binding_identifier() {

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -987,7 +987,6 @@ impl ByteCompiler<'_, '_> {
             // b. Let varEnv be NewDeclarativeEnvironment(env).
             // c. Set the VariableEnvironment of calleeContext to varEnv.
             self.push_compile_environment(true);
-            self.function_environment_push_location = self.next_opcode_location();
             env_labels = Some(self.emit_opcode_with_two_operands(Opcode::PushFunctionEnvironment));
 
             // d. Let instantiatedVarNames be a new empty List.

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -260,7 +260,7 @@ impl ByteCompiler<'_, '_> {
                 .name(name.sym())
                 .generator(generator)
                 .r#async(r#async)
-                .strict(self.strict)
+                .strict(self.strict())
                 .binding_identifier(Some(name.sym()))
                 .compile(
                     parameters,
@@ -672,7 +672,7 @@ impl ByteCompiler<'_, '_> {
                 .name(name.sym())
                 .generator(generator)
                 .r#async(r#async)
-                .strict(self.strict)
+                .strict(self.strict())
                 .binding_identifier(Some(name.sym()))
                 .compile(
                     parameters,

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -777,8 +777,8 @@ impl ByteCompiler<'_, '_> {
         arrow: bool,
         strict: bool,
         generator: bool,
-    ) -> (Option<(Label, Label)>, bool) {
-        let mut env_labels = None;
+    ) -> (Option<Label>, bool) {
+        let mut env_label = None;
         let mut additional_env = false;
 
         // 1. Let calleeContext be the running execution context.
@@ -987,7 +987,7 @@ impl ByteCompiler<'_, '_> {
             // b. Let varEnv be NewDeclarativeEnvironment(env).
             // c. Set the VariableEnvironment of calleeContext to varEnv.
             self.push_compile_environment(true);
-            env_labels = Some(self.emit_opcode_with_two_operands(Opcode::PushFunctionEnvironment));
+            env_label = Some(self.emit_opcode_with_operand(Opcode::PushFunctionEnvironment));
 
             // d. Let instantiatedVarNames be a new empty List.
             let mut instantiated_var_names = Vec::new();
@@ -1051,7 +1051,6 @@ impl ByteCompiler<'_, '_> {
             }
 
             // d. Let varEnv be env.
-
             instantiated_var_names
         };
 
@@ -1150,6 +1149,6 @@ impl ByteCompiler<'_, '_> {
         }
 
         // 37. Return unused.
-        (env_labels, additional_env)
+        (env_label, additional_env)
     }
 }

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -7,7 +7,7 @@ use boa_gc::{Gc, GcRefCell};
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PopEnvironmentInfo {
     /// Number of bindings declared.
-    pub(crate) num_bindings: u32,
+    pub(crate) _num_bindings: u32,
     /// Index in the compile time envs array.
     pub(crate) index: u32,
 }
@@ -38,7 +38,7 @@ impl ByteCompiler<'_, '_> {
         self.current_environment = outer;
 
         PopEnvironmentInfo {
-            num_bindings,
+            _num_bindings: num_bindings,
             index,
         }
     }

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -3,15 +3,6 @@ use crate::environments::{BindingLocator, CompileTimeEnvironment};
 use boa_ast::expression::Identifier;
 use boa_gc::{Gc, GcRefCell};
 
-/// Info returned by the [`ByteCompiler::pop_compile_environment`] method.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PopEnvironmentInfo {
-    /// Number of bindings declared.
-    pub(crate) _num_bindings: u32,
-    /// Index in the compile time envs array.
-    pub(crate) index: u32,
-}
-
 impl ByteCompiler<'_, '_> {
     /// Push either a new declarative or function environment on the compile time environment stack.
     pub(crate) fn push_compile_environment(&mut self, function_scope: bool) {
@@ -21,26 +12,20 @@ impl ByteCompiler<'_, '_> {
         )));
     }
 
-    /// Pops the top compile time environment and returns its index and number of bindings.
+    /// Pops the top compile time environment and returns its index in the compile time environments array.
     #[track_caller]
-    pub(crate) fn pop_compile_environment(&mut self) -> PopEnvironmentInfo {
+    pub(crate) fn pop_compile_environment(&mut self) -> u32 {
         let index = self.compile_environments.len() as u32;
         self.compile_environments
             .push(self.current_environment.clone());
 
-        let (num_bindings, outer) = {
+        let outer = {
             let env = self.current_environment.borrow();
-            (
-                env.num_bindings(),
-                env.outer().expect("cannot pop the global environment"),
-            )
+            env.outer().expect("cannot pop the global environment")
         };
         self.current_environment = outer;
 
-        PopEnvironmentInfo {
-            _num_bindings: num_bindings,
-            index,
-        }
+        index
     }
 
     /// Get the binding locator of the binding at bytecode compile time.

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -138,7 +138,7 @@ impl FunctionCompiler {
                 Some(compiler.pop_compile_environment().num_bindings);
         }
 
-        compiler.num_bindings = compiler.pop_compile_environment().num_bindings;
+        compiler.pop_compile_environment();
 
         if self.binding_identifier.is_some() {
             compiler.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::function::ThisMode,
     bytecompiler::ByteCompiler,
     environments::CompileTimeEnvironment,
-    vm::{CodeBlock, Opcode},
+    vm::{CodeBlock, CodeBlockFlags, Opcode},
     Context,
 };
 use boa_ast::function::{FormalParameterList, FunctionBody};
@@ -109,7 +109,7 @@ impl FunctionCompiler {
         }
 
         if let Some(binding_identifier) = self.binding_identifier {
-            compiler.has_binding_identifier = true;
+            compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
             compiler.push_compile_environment(false);
             compiler.create_immutable_binding(binding_identifier.into(), self.strict);
         }
@@ -134,7 +134,7 @@ impl FunctionCompiler {
 
         if additional_env {
             compiler.pop_compile_environment();
-            compiler.parameters_env_bindings = true;
+            compiler.code_block_flags |= CodeBlockFlags::PARAMETERS_ENV_BINDINGS;
         }
 
         compiler.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -128,8 +128,8 @@ impl FunctionCompiler {
         compiler.compile_statement_list(body.statements(), false, false);
 
         if let Some(env_labels) = env_label {
-            let env_info = compiler.pop_compile_environment();
-            compiler.patch_jump_with_target(env_labels, env_info.index);
+            let env_index = compiler.pop_compile_environment();
+            compiler.patch_jump_with_target(env_labels, env_index);
         }
 
         if additional_env {

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -117,7 +117,7 @@ impl FunctionCompiler {
         // Function environment
         compiler.push_compile_environment(true);
 
-        let (env_labels, additional_env) = compiler.function_declaration_instantiation(
+        let (env_label, additional_env) = compiler.function_declaration_instantiation(
             body,
             parameters,
             self.arrow,
@@ -127,15 +127,14 @@ impl FunctionCompiler {
 
         compiler.compile_statement_list(body.statements(), false, false);
 
-        if let Some(env_labels) = env_labels {
+        if let Some(env_labels) = env_label {
             let env_info = compiler.pop_compile_environment();
-            compiler.patch_jump_with_target(env_labels.0, env_info.num_bindings);
-            compiler.patch_jump_with_target(env_labels.1, env_info.index);
+            compiler.patch_jump_with_target(env_labels, env_info.index);
         }
 
         if additional_env {
-            compiler.parameters_env_bindings =
-                Some(compiler.pop_compile_environment().num_bindings);
+            compiler.pop_compile_environment();
+            compiler.parameters_env_bindings = true;
         }
 
         compiler.pop_compile_environment();

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -244,9 +244,6 @@ pub struct ByteCompiler<'ctx, 'host> {
     /// Locators for all bindings in the codeblock.
     pub(crate) bindings: Vec<BindingLocator>,
 
-    /// Number of binding for the function environment.
-    pub(crate) num_bindings: u32,
-
     /// Functions inside this function
     pub(crate) functions: Vec<Gc<CodeBlock>>,
 
@@ -261,12 +258,6 @@ pub struct ByteCompiler<'ctx, 'host> {
 
     /// The `[[ClassFieldInitializerName]]` internal slot.
     pub(crate) class_field_initializer_name: Option<Sym>,
-
-    /// Marks the location in the code where the function environment in pushed.
-    /// This is only relevant for functions with expressions in the parameters.
-    /// We execute the parameter expressions in the function code and push the function environment afterward.
-    /// When the execution of the parameter expressions throws an error, we do not need to pop the function environment.
-    pub(crate) function_environment_push_location: u32,
 
     /// The environment that is currently active.
     pub(crate) current_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
@@ -313,7 +304,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             names: Vec::default(),
             private_names: Vec::default(),
             bindings: Vec::default(),
-            num_bindings: 0,
             functions: Vec::default(),
             has_binding_identifier: false,
             this_mode: ThisMode::Global,
@@ -322,7 +312,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             compile_environments: Vec::default(),
             is_class_constructor: false,
             class_field_initializer_name: None,
-            function_environment_push_location: 0,
             parameters_env_bindings: None,
 
             literals_map: FxHashMap::default(),
@@ -1369,13 +1358,11 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             names: self.names.into_boxed_slice(),
             private_names: self.private_names.into_boxed_slice(),
             bindings: self.bindings.into_boxed_slice(),
-            num_bindings: self.num_bindings,
             functions: self.functions.into_boxed_slice(),
             arguments_binding: self.arguments_binding,
             compile_environments: self.compile_environments.into_boxed_slice(),
             is_class_constructor: self.is_class_constructor,
             class_field_initializer_name: self.class_field_initializer_name,
-            function_environment_push_location: self.function_environment_push_location,
             parameters_env_bindings: self.parameters_env_bindings,
             #[cfg(feature = "trace")]
             trace: std::cell::Cell::new(false),

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -262,8 +262,8 @@ pub struct ByteCompiler<'ctx, 'host> {
     /// The environment that is currently active.
     pub(crate) current_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
 
-    /// The number of bindings in the parameters environment.
-    pub(crate) parameters_env_bindings: Option<u32>,
+    /// Does this function have a parameters environment.
+    pub(crate) parameters_env_bindings: bool,
 
     literals_map: FxHashMap<Literal, u32>,
     names_map: FxHashMap<Identifier, u32>,
@@ -312,7 +312,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             compile_environments: Vec::default(),
             is_class_constructor: false,
             class_field_initializer_name: None,
-            parameters_env_bindings: None,
+            parameters_env_bindings: false,
 
             literals_map: FxHashMap::default(),
             names_map: FxHashMap::default(),
@@ -515,7 +515,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
 
     /// Emit an opcode with a dummy operand.
     /// Return the `Label` of the operand.
-    fn emit_opcode_with_operand(&mut self, opcode: Opcode) -> Label {
+    pub(crate) fn emit_opcode_with_operand(&mut self, opcode: Opcode) -> Label {
         let index = self.next_opcode_location();
         self.emit(opcode, &[Self::DUMMY_ADDRESS]);
         Label { index }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -5,14 +5,13 @@ impl ByteCompiler<'_, '_> {
     /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(&mut self, block: &Block, use_expr: bool) {
         self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
         self.block_declaration_instantiation(block);
         self.compile_statement_list(block.statement_list(), use_expr, true);
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
-        self.patch_jump_with_target(push_env.1, env_info.index);
+        self.patch_jump_with_target(push_env, env_info.index);
 
         self.emit_opcode(Opcode::PopEnvironment);
     }

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -10,8 +10,8 @@ impl ByteCompiler<'_, '_> {
         self.block_declaration_instantiation(block);
         self.compile_statement_list(block.statement_list(), use_expr, true);
 
-        let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_info.index);
+        let env_index = self.pop_compile_environment();
+        self.patch_jump_with_target(push_env, env_index);
 
         self.emit_opcode(Opcode::PopEnvironment);
     }

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -113,10 +113,10 @@ impl ByteCompiler<'_, '_> {
         }
 
         if let Some(env_labels) = env_labels {
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(env_labels, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(env_labels, env_index);
             if let Some(iteration_env_labels) = iteration_env_labels {
-                self.patch_jump_with_target(iteration_env_labels, env_info.index);
+                self.patch_jump_with_target(iteration_env_labels, env_index);
             }
             self.emit_opcode(Opcode::PopEnvironment);
         }
@@ -153,8 +153,8 @@ impl ByteCompiler<'_, '_> {
             }
             self.compile_expr(for_in_loop.target(), true);
 
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(push_env, env_index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -234,8 +234,8 @@ impl ByteCompiler<'_, '_> {
         self.emit_opcode(Opcode::LoopUpdateReturnValue);
 
         if let Some(iteration_environment) = iteration_environment {
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(iteration_environment, env_index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -283,8 +283,8 @@ impl ByteCompiler<'_, '_> {
             }
             self.compile_expr(for_of_loop.iterable(), true);
 
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(push_env, env_index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -377,8 +377,8 @@ impl ByteCompiler<'_, '_> {
         self.emit_opcode(Opcode::LoopUpdateReturnValue);
 
         if let Some(iteration_environment) = iteration_environment {
-            let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment, env_info.index);
+            let env_index = self.pop_compile_environment();
+            self.patch_jump_with_target(iteration_environment, env_index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -32,9 +32,8 @@ impl ByteCompiler<'_, '_> {
                 }
                 ForLoopInitializer::Lexical(decl) => {
                     self.push_compile_environment(false);
-                    env_labels = Some(
-                        self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment),
-                    );
+                    env_labels =
+                        Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
 
                     let names = bound_names(decl);
                     if decl.is_const() {
@@ -74,7 +73,7 @@ impl ByteCompiler<'_, '_> {
             }
             self.emit_opcode(Opcode::PopEnvironment);
             iteration_env_labels =
-                Some(self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment));
+                Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
             for index in let_binding_indices.iter().rev() {
                 self.emit(Opcode::PutLexicalValue, &[*index]);
             }
@@ -115,11 +114,9 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(env_labels) = env_labels {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(env_labels.0, env_info.num_bindings);
-            self.patch_jump_with_target(env_labels.1, env_info.index);
+            self.patch_jump_with_target(env_labels, env_info.index);
             if let Some(iteration_env_labels) = iteration_env_labels {
-                self.patch_jump_with_target(iteration_env_labels.0, env_info.num_bindings);
-                self.patch_jump_with_target(iteration_env_labels.1, env_info.index);
+                self.patch_jump_with_target(iteration_env_labels, env_info.index);
             }
             self.emit_opcode(Opcode::PopEnvironment);
         }
@@ -149,7 +146,7 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_in_loop.target(), true);
         } else {
             self.push_compile_environment(false);
-            let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+            let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
             for name in &initializer_bound_names {
                 self.create_mutable_binding(*name, false);
@@ -157,8 +154,7 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_in_loop.target(), true);
 
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env.0, env_info.num_bindings);
-            self.patch_jump_with_target(push_env.1, env_info.index);
+            self.patch_jump_with_target(push_env, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -180,7 +176,7 @@ impl ByteCompiler<'_, '_> {
             None
         } else {
             self.push_compile_environment(false);
-            Some(self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment))
+            Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment))
         };
 
         match for_in_loop.initializer() {
@@ -239,8 +235,7 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(iteration_environment) = iteration_environment {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings);
-            self.patch_jump_with_target(iteration_environment.1, env_info.index);
+            self.patch_jump_with_target(iteration_environment, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -281,7 +276,7 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_of_loop.iterable(), true);
         } else {
             self.push_compile_environment(false);
-            let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+            let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
             for name in &initializer_bound_names {
                 self.create_mutable_binding(*name, false);
@@ -289,8 +284,7 @@ impl ByteCompiler<'_, '_> {
             self.compile_expr(for_of_loop.iterable(), true);
 
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(push_env.0, env_info.num_bindings);
-            self.patch_jump_with_target(push_env.1, env_info.index);
+            self.patch_jump_with_target(push_env, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
@@ -319,7 +313,7 @@ impl ByteCompiler<'_, '_> {
             None
         } else {
             self.push_compile_environment(false);
-            Some(self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment))
+            Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment))
         };
 
         match for_of_loop.initializer() {
@@ -384,8 +378,7 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(iteration_environment) = iteration_environment {
             let env_info = self.pop_compile_environment();
-            self.patch_jump_with_target(iteration_environment.0, env_info.num_bindings);
-            self.patch_jump_with_target(iteration_environment.1, env_info.index);
+            self.patch_jump_with_target(iteration_environment, env_info.index);
             self.emit_opcode(Opcode::PopEnvironment);
         }
 

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -7,7 +7,7 @@ impl ByteCompiler<'_, '_> {
         self.compile_expr(switch.val(), true);
 
         self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
         self.block_declaration_instantiation(switch);
 
@@ -61,8 +61,7 @@ impl ByteCompiler<'_, '_> {
         }
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
-        self.patch_jump_with_target(push_env.1, env_info.index);
+        self.patch_jump_with_target(push_env, env_info.index);
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -60,8 +60,8 @@ impl ByteCompiler<'_, '_> {
             self.emit_opcode(Opcode::Pop);
         }
 
-        let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_info.index);
+        let env_index = self.pop_compile_environment();
+        self.patch_jump_with_target(push_env, env_index);
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -87,8 +87,8 @@ impl ByteCompiler<'_, '_> {
             self.emit_opcode(Opcode::Pop);
         }
 
-        let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_info.index);
+        let env_index = self.pop_compile_environment();
+        self.patch_jump_with_target(push_env, env_index);
         self.emit_opcode(Opcode::PopEnvironment);
 
         if finally {

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -60,7 +60,7 @@ impl ByteCompiler<'_, '_> {
         let catch_end = self.emit_opcode_with_operand(Opcode::CatchStart);
 
         self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_two_operands(Opcode::PushDeclarativeEnvironment);
+        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
 
         if let Some(binding) = catch.parameter() {
             match binding {
@@ -88,8 +88,7 @@ impl ByteCompiler<'_, '_> {
         }
 
         let env_info = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env.0, env_info.num_bindings);
-        self.patch_jump_with_target(push_env.1, env_info.index);
+        self.patch_jump_with_target(push_env, env_info.index);
         self.emit_opcode(Opcode::PopEnvironment);
 
         if finally {

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -314,6 +314,7 @@ impl EnvironmentStack {
         compile_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
     ) {
         let num_bindings = compile_environment.borrow().num_bindings();
+
         debug_assert!(
             self.stack.len() as u32 == compile_environment.borrow().environment_index(),
             "tried to push an invalid compile environment"

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -266,10 +266,11 @@ impl EnvironmentStack {
     #[track_caller]
     pub(crate) fn push_function(
         &mut self,
-        num_bindings: u32,
         compile_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
         function_slots: FunctionSlots,
     ) {
+        let num_bindings = compile_environment.borrow().num_bindings();
+
         let (poisoned, with) = {
             let with = self
                 .stack

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -222,9 +222,10 @@ impl EnvironmentStack {
     #[track_caller]
     pub(crate) fn push_lexical(
         &mut self,
-        num_bindings: u32,
         compile_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
     ) -> u32 {
+        let num_bindings = compile_environment.borrow().num_bindings();
+
         let (poisoned, with) = {
             let with = self
                 .stack
@@ -310,9 +311,9 @@ impl EnvironmentStack {
     #[track_caller]
     pub(crate) fn push_function_inherit(
         &mut self,
-        num_bindings: u32,
         compile_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
     ) {
+        let num_bindings = compile_environment.borrow().num_bindings();
         debug_assert!(
             self.stack.len() as u32 == compile_environment.borrow().environment_index(),
             "tried to push an invalid compile environment"

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -56,7 +56,7 @@ unsafe impl Readable for f64 {}
 bitflags! {
     /// Flags for [`CodeBlock`].
     #[derive(Clone, Copy, Debug, Finalize)]
-    pub(crate) struct CodeBlockFlags: u32 {
+    pub(crate) struct CodeBlockFlags: u8 {
         /// Is this function in strict mode.
         const STRICT = 0b0000_0001;
 
@@ -167,6 +167,7 @@ impl CodeBlock {
         self.name
     }
 
+    /// Check if the function is traced.
     #[cfg(feature = "trace")]
     pub(crate) fn traceable(&self) -> bool {
         self.flags.get().contains(CodeBlockFlags::TRACEABLE)
@@ -180,19 +181,26 @@ impl CodeBlock {
         self.flags.set(flags);
     }
 
+    /// Check if the function is a class constructor.
     pub(crate) fn is_class_constructor(&self) -> bool {
         self.flags
             .get()
             .contains(CodeBlockFlags::IS_CLASS_CONSTRUCTOR)
     }
+
+    /// Check if the function is in strict mode.
     pub(crate) fn strict(&self) -> bool {
         self.flags.get().contains(CodeBlockFlags::STRICT)
     }
+
+    /// Indicates if the function is an expression and has a binding identifier.
     pub(crate) fn has_binding_identifier(&self) -> bool {
         self.flags
             .get()
             .contains(CodeBlockFlags::HAS_BINDING_IDENTIFIER)
     }
+
+    /// Does this function have a parameters environment.
     pub(crate) fn has_parameters_env_bindings(&self) -> bool {
         self.flags
             .get()

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -167,6 +167,7 @@ impl CodeBlock {
         self.name
     }
 
+    #[cfg(feature = "trace")]
     pub(crate) fn traceable(&self) -> bool {
         self.flags.get().contains(CodeBlockFlags::TRACEABLE)
     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1008,7 +1008,7 @@ impl JsObject {
             let index = context
                 .vm
                 .environments
-                .push_lexical(1, code.compile_environments[last_env].clone());
+                .push_lexical(code.compile_environments[last_env].clone());
             context
                 .vm
                 .environments
@@ -1020,7 +1020,7 @@ impl JsObject {
             let index = context
                 .vm
                 .environments
-                .push_lexical(1, code.compile_environments[last_env].clone());
+                .push_lexical(code.compile_environments[last_env].clone());
             context
                 .vm
                 .environments
@@ -1033,12 +1033,12 @@ impl JsObject {
             FunctionSlots::new(this, self.clone(), None),
         );
 
-        if let Some(bindings) = code.parameters_env_bindings {
+        if let Some(_bindings) = code.parameters_env_bindings {
             last_env -= 1;
             context
                 .vm
                 .environments
-                .push_lexical(bindings, code.compile_environments[last_env].clone());
+                .push_lexical(code.compile_environments[last_env].clone());
         }
 
         if let Some(binding) = code.arguments_binding {
@@ -1273,7 +1273,7 @@ impl JsObject {
                     let index = context
                         .vm
                         .environments
-                        .push_lexical(1, code.compile_environments[last_env].clone());
+                        .push_lexical(code.compile_environments[last_env].clone());
                     context
                         .vm
                         .environments
@@ -1292,11 +1292,11 @@ impl JsObject {
                     ),
                 );
 
-                if let Some(bindings) = code.parameters_env_bindings {
+                if let Some(_bindings) = code.parameters_env_bindings {
                     context
                         .vm
                         .environments
-                        .push_lexical(bindings, code.compile_environments[0].clone());
+                        .push_lexical(code.compile_environments[0].clone());
                 }
 
                 if let Some(binding) = code.arguments_binding {

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -359,7 +359,6 @@ impl CodeBlock {
                     environments.push((previous_pc, random));
 
                     pc += size_of::<u32>();
-                    pc += size_of::<u32>();
 
                     graph.add_node(
                         previous_pc,

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -40,6 +40,7 @@ pub(crate) use {
     call_frame::GeneratorResumeKind,
     code_block::{
         create_function_object, create_function_object_fast, create_generator_function_object,
+        CodeBlockFlags,
     },
     completion_record::CompletionRecord,
     opcode::BindingOpcode,
@@ -239,7 +240,7 @@ impl Context<'_> {
 
             // 1. Run the next instruction.
             #[cfg(feature = "trace")]
-            let result = if self.vm.trace || self.vm.frame().code_block.trace.get() {
+            let result = if self.vm.trace || self.vm.frame().code_block.traceable() {
                 let mut pc = self.vm.frame().pc as usize;
                 let opcode: Opcode = self
                     .vm

--- a/boa_engine/src/vm/opcode/call/mod.rs
+++ b/boa_engine/src/vm/opcode/call/mod.rs
@@ -58,7 +58,7 @@ impl Operation for CallEval {
             .map(|f| matches!(f.kind(), FunctionKind::Native { .. }))
             .unwrap_or_default();
 
-        let strict = context.vm.frame().code_block.strict;
+        let strict = context.vm.frame().code_block.strict();
 
         if eval {
             if let Some(x) = arguments.get(0) {
@@ -132,7 +132,7 @@ impl Operation for CallEvalSpread {
             .map(|f| matches!(f.kind(), FunctionKind::Native { .. }))
             .unwrap_or_default();
 
-        let strict = context.vm.frame().code_block.strict;
+        let strict = context.vm.frame().code_block.strict();
 
         if eval {
             if let Some(x) = arguments.get(0) {

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -60,7 +60,11 @@ impl Operation for DefInitVar {
 
         context.find_runtime_binding(&mut binding_locator)?;
 
-        context.set_binding(binding_locator, value, context.vm.frame().code_block.strict)?;
+        context.set_binding(
+            binding_locator,
+            value,
+            context.vm.frame().code_block.strict(),
+        )?;
 
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -23,7 +23,7 @@ impl Operation for DeletePropertyByName {
             .clone()
             .into();
         let result = object.__delete__(&key, context)?;
-        if !result && context.vm.frame().code_block.strict {
+        if !result && context.vm.frame().code_block.strict() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
                 .into());
@@ -50,7 +50,7 @@ impl Operation for DeletePropertyByValue {
         let object = value.to_object(context)?;
         let property_key = key_value.to_property_key(context)?;
         let result = object.__delete__(&property_key, context)?;
-        if !result && context.vm.frame().code_block.strict {
+        if !result && context.vm.frame().code_block.strict() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
                 .into());

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1348,7 +1348,7 @@ generate_impl! {
 
         /// Push a declarative environment.
         ///
-        /// Operands: num_bindings: `u32`, compile_environments_index: `u32`
+        /// Operands: compile_environments_index: `u32`
         ///
         /// Stack: **=>**
         PushDeclarativeEnvironment,
@@ -1362,7 +1362,7 @@ generate_impl! {
 
         /// Push a function environment.
         ///
-        /// Operands: num_bindings: `u32`, compile_environments_index: `u32`
+        /// Operands: compile_environments_index: `u32`
         ///
         /// Stack: **=>**
         PushFunctionEnvironment,

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -17,7 +17,6 @@ impl Operation for PushDeclarativeEnvironment {
     const INSTRUCTION: &'static str = "INST - PushDeclarativeEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let _num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]
@@ -40,7 +39,6 @@ impl Operation for PushFunctionEnvironment {
     const INSTRUCTION: &'static str = "INST - PushFunctionEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let _num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -17,15 +17,12 @@ impl Operation for PushDeclarativeEnvironment {
     const INSTRUCTION: &'static str = "INST - PushDeclarativeEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let num_bindings = context.vm.read::<u32>();
+        let _num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]
             .clone();
-        context
-            .vm
-            .environments
-            .push_lexical(num_bindings, compile_environment);
+        context.vm.environments.push_lexical(compile_environment);
         context.vm.frame_mut().inc_frame_env_stack();
         Ok(CompletionType::Normal)
     }
@@ -43,7 +40,7 @@ impl Operation for PushFunctionEnvironment {
     const INSTRUCTION: &'static str = "INST - PushFunctionEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let num_bindings = context.vm.read::<u32>();
+        let _num_bindings = context.vm.read::<u32>();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]
@@ -51,7 +48,7 @@ impl Operation for PushFunctionEnvironment {
         context
             .vm
             .environments
-            .push_function_inherit(num_bindings, compile_environment);
+            .push_function_inherit(compile_environment);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -28,7 +28,11 @@ impl Operation for SetName {
 
         verify_initialized(binding_locator, context)?;
 
-        context.set_binding(binding_locator, value, context.vm.frame().code_block.strict)?;
+        context.set_binding(
+            binding_locator,
+            value,
+            context.vm.frame().code_block.strict(),
+        )?;
 
         Ok(CompletionType::Normal)
     }
@@ -60,7 +64,11 @@ impl Operation for SetNameByLocator {
 
         verify_initialized(binding_locator, context)?;
 
-        context.set_binding(binding_locator, value, context.vm.frame().code_block.strict)?;
+        context.set_binding(
+            binding_locator,
+            value,
+            context.vm.frame().code_block.strict(),
+        )?;
 
         Ok(CompletionType::Normal)
     }
@@ -70,7 +78,7 @@ impl Operation for SetNameByLocator {
 fn verify_initialized(locator: BindingLocator, context: &mut Context<'_>) -> JsResult<()> {
     if !context.is_initialized_binding(&locator)? {
         let key = context.interner().resolve_expect(locator.name().sym());
-        let strict = context.vm.frame().code_block.strict;
+        let strict = context.vm.frame().code_block.strict();
 
         let message = if locator.is_global() {
             strict.then(|| format!("cannot assign to uninitialized global property `{key}`"))

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -35,7 +35,7 @@ impl Operation for SetPropertyByName {
             .into();
 
         let succeeded = object.__set__(name.clone(), value.clone(), receiver, context)?;
-        if !succeeded && context.vm.frame().code_block.strict {
+        if !succeeded && context.vm.frame().code_block.strict() {
             return Err(JsNativeError::typ()
                 .with_message(format!("cannot set non-writable property: {name}"))
                 .into());
@@ -126,7 +126,7 @@ impl Operation for SetPropertyByValue {
                                         .configurable(false)
                                         .build(),
                                 );
-                            } else if context.vm.frame().code_block.strict {
+                            } else if context.vm.frame().code_block.strict() {
                                 return Err(JsNativeError::typ().with_message("TypeError: Cannot assign to read only property 'length' of array object").into());
                             }
                             return Ok(CompletionType::Normal);
@@ -140,7 +140,7 @@ impl Operation for SetPropertyByValue {
         object.set(
             key,
             value.clone(),
-            context.vm.frame().code_block.strict,
+            context.vm.frame().code_block.strict(),
             context,
         )?;
         context.vm.stack.push(value);


### PR DESCRIPTION
Since the number of bindings is stored in the compiled envionments and when we create the environment we pass it, there is no need to store the num_bindings for the environments

It changes the following:

- Remove unneeded `function_environment_push_location` field on `CodeBlock`
- Remove unneeded `num_bindings` field on `CodeBlock`
- Remove unneeded `num_bindings` operand from `PushDeclarativeEnvironment` opcode
- Remove unneeded `num_bindings` operand from `PushFunctionEnvironment` opcode
- Make `ByteCompiler::push_compile_environment()` return only the index.
- Remove `num_bindings` field from environment stack methods that push environments.
- Move `CodeBlock` flags to `bitflags` field.
