### PR TITLE
Remove `arguments_binding` field from `CodeBlock`

### DIFF
--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -183,7 +183,7 @@ impl Arguments {
                 break;
             }
 
-            // NOTE(HaledOdat): Offset by +1 to account for the fitst binding ("argument").
+            // NOTE(HalidOdat): Offset by +1 to account for the first binding ("argument").
             let binding_index = bindings.len() as u32 + 1;
 
             let entry = bindings

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -155,18 +155,22 @@ impl Arguments {
         // We use indices to access environment bindings at runtime.
         // To map to function parameters to binding indices, we use the fact, that bindings in a
         // function environment start with all of the arguments in order:
+        //
+        // Note: The first binding (binding 0) is where "arguments" is stored.
+        //
         // `function f (a,b,c)`
         // | binding index | `arguments` property key | identifier |
-        // | 0             | 0                        | a          |
-        // | 1             | 1                        | b          |
-        // | 2             | 2                        | c          |
+        // | 1             | 0                        | a          |
+        // | 2             | 1                        | b          |
+        // | 3             | 2                        | c          |
         //
         // Notice that the binding index does not correspond to the argument index:
         // `function f (a,a,b)` => binding indices 0 (a), 1 (b), 2 (c)
         // | binding index | `arguments` property key | identifier |
         // | -             | 0                        | -          |
-        // | 0             | 1                        | a          |
-        // | 1             | 2                        | b          |
+        // | 1             | 1                        | a          |
+        // | 2             | 2                        | b          |
+        //
         // While the `arguments` object contains all arguments, they must not be all bound.
         // In the case of duplicate parameter names, the last one is bound as the environment binding.
         //
@@ -178,10 +182,14 @@ impl Arguments {
             if property_index >= len {
                 break;
             }
-            let binding_index = bindings.len() as u32;
+
+            // NOTE(HaledOdat): Offset by +1 to account for the fitst binding ("argument").
+            let binding_index = bindings.len() as u32 + 1;
+
             let entry = bindings
                 .entry(name)
                 .or_insert((binding_index, property_index));
+
             entry.1 = property_index;
             property_index += 1;
         }

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -1,6 +1,9 @@
 use crate::{
     bytecompiler::{ByteCompiler, FunctionCompiler, FunctionSpec, Label, NodeKind},
-    vm::{create_function_object_fast, create_generator_function_object, BindingOpcode, Opcode},
+    vm::{
+        create_function_object_fast, create_generator_function_object, BindingOpcode,
+        CodeBlockFlags, Opcode,
+    },
     JsNativeError, JsResult,
 };
 use boa_ast::{
@@ -844,7 +847,7 @@ impl ByteCompiler<'_, '_> {
         function_names.reverse();
         functions_to_initialize.reverse();
 
-        //15. Let argumentsObjectNeeded be true.
+        // 15. Let argumentsObjectNeeded be true.
         let mut arguments_object_needed = true;
 
         let arguments = Sym::ARGUMENTS.into();
@@ -884,7 +887,7 @@ impl ByteCompiler<'_, '_> {
 
         // 22. If argumentsObjectNeeded is true, then
         //
-        // NOTE(HalidOdat): Has been moved up, so "arguments" get registed as
+        // NOTE(HalidOdat): Has been moved up, so "arguments" gets registed as
         //     the first binding in the environment with index 0.
         if arguments_object_needed {
             // Note: This happens at runtime.
@@ -902,14 +905,14 @@ impl ByteCompiler<'_, '_> {
                 // ii. NOTE: In strict mode code early errors prevent attempting to assign
                 //           to this binding, so its mutability is not observable.
                 self.create_immutable_binding(arguments, false);
-                self.arguments_binding = Some(self.initialize_immutable_binding(arguments));
             }
             // d. Else,
             else {
                 // i. Perform ! env.CreateMutableBinding("arguments", false).
                 self.create_mutable_binding(arguments, false);
-                self.arguments_binding = Some(self.initialize_mutable_binding(arguments, false));
             }
+
+            self.code_block_flags |= CodeBlockFlags::NEEDS_ARGUMENTS_OBJECT;
         }
 
         // 21. For each String paramName of parameterNames, do

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -242,9 +242,6 @@ pub struct ByteCompiler<'ctx, 'host> {
     /// Functions inside this function
     pub(crate) functions: Vec<Gc<CodeBlock>>,
 
-    /// The `arguments` binding location of the function, if set.
-    pub(crate) arguments_binding: Option<BindingLocator>,
-
     /// Compile time environments in this function.
     pub(crate) compile_environments: Vec<Gc<GcRefCell<CompileTimeEnvironment>>>,
 
@@ -299,7 +296,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             functions: Vec::default(),
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
-            arguments_binding: None,
             compile_environments: Vec::default(),
             class_field_initializer_name: None,
             code_block_flags,
@@ -1349,7 +1345,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             private_names: self.private_names.into_boxed_slice(),
             bindings: self.bindings.into_boxed_slice(),
             functions: self.functions.into_boxed_slice(),
-            arguments_binding: self.arguments_binding,
             compile_environments: self.compile_environments.into_boxed_slice(),
             class_field_initializer_name: self.class_field_initializer_name,
             flags: Cell::new(self.code_block_flags),


### PR DESCRIPTION
This PR reorders a spec step to ensure that the `"arguments"` binding is always in the `0` position. This allows us to remove the `arguments_binding` field completely since we know in which environment it is (last pushed) and what index it has (`0`).

Removes `24` bytes from `CodeBlock` (from `184` bytes to `160` bytes)
