### PR TITLE
Unify async iterators and iterators compilation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
       "program": "${workspaceFolder}/target/debug/boa",
       "args": ["${workspaceFolder}/tests/js/test.js", "--debug-object"],
       "sourceLanguages": ["rust"],
-      "preLaunchTask": "Cargo Build"
+      "preLaunchTask": "Cargo Build boa_cli"
     },
     {
       "type": "lldb",
@@ -32,7 +32,7 @@
         "tests/js"
       ],
       "sourceLanguages": ["rust"],
-      "preLaunchTask": "Cargo Build"
+      "preLaunchTask": "Cargo Build boa_cli"
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,6 +15,16 @@
     },
     {
       "type": "process",
+      "label": "Cargo Build boa_cli",
+      "command": "cargo",
+      "args": ["build", "-p", "boa_cli"],
+      "group": "build",
+      "presentation": {
+        "clear": true
+      }
+    },
+    {
+      "type": "process",
       "label": "Cargo Run",
       "command": "cargo",
       "args": ["run", "--bin", "boa", "./tests/js/test.js"],

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -490,7 +490,7 @@ struct Jobs(RefCell<VecDeque<NativeJob>>);
 
 impl JobQueue for Jobs {
     fn enqueue_promise_job(&self, job: NativeJob, _: &mut Context<'_>) {
-        self.0.borrow_mut().push_front(job);
+        self.0.borrow_mut().push_back(job);
     }
 
     fn run_jobs(&self, context: &mut Context<'_>) {
@@ -509,6 +509,6 @@ impl JobQueue for Jobs {
 
     fn enqueue_future_job(&self, future: FutureJob, _: &mut Context<'_>) {
         let job = pollster::block_on(future);
-        self.0.borrow_mut().push_front(job);
+        self.0.borrow_mut().push_back(job);
     }
 }

--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -561,7 +561,7 @@ impl Array {
         };
 
         // c. Let iteratorRecord be ? GetIterator(items, sync, usingIterator).
-        let iterator_record =
+        let mut iterator_record =
             items.get_iterator(context, Some(IteratorHint::Sync), Some(using_iterator))?;
 
         // d. Let k be 0.
@@ -571,19 +571,16 @@ impl Array {
         //     x. Set k to k + 1.
         for k in 0..9_007_199_254_740_991_u64 {
             // iii. Let next be ? IteratorStep(iteratorRecord).
-            let next = iterator_record.step(context)?;
+            if iterator_record.step(context)? {
+                // 1. Perform ? Set(A, "length", 𝔽(k), true).
+                a.set(utf16!("length"), k, true, context)?;
+                // 2. Return A.
+                return Ok(a.into());
+            }
 
             // iv. If next is false, then
-            let Some(next) = next else {
-                    // 1. Perform ? Set(A, "length", 𝔽(k), true).
-                    a.set(utf16!("length"), k, true, context)?;
-
-                    // 2. Return A.
-                    return Ok(a.into());
-                };
-
             // v. Let nextValue be ? IteratorValue(next).
-            let next_value = next.value(context)?;
+            let next_value = iterator_record.value(context)?;
 
             // vi. If mapping is true, then
             let mapped_value = if let Some(mapfn) = mapping {

--- a/boa_engine/src/builtins/intl/list_format/mod.rs
+++ b/boa_engine/src/builtins/intl/list_format/mod.rs
@@ -469,7 +469,7 @@ fn string_list_from_iterable(
     }
 
     // 2. Let iteratorRecord be ? GetIterator(iterable).
-    let iterator = iterable.get_iterator(context, None, None)?;
+    let mut iterator = iterable.get_iterator(context, None, None)?;
 
     // 3. Let list be a new empty List.
     let mut list = Vec::new();
@@ -478,9 +478,9 @@ fn string_list_from_iterable(
     // 5. Repeat, while next is not false,
     //     a. Set next to ? IteratorStep(iteratorRecord).
     //     b. If next is not false, then
-    while let Some(item) = iterator.step(context)? {
+    while !iterator.step(context)? {
+        let item = iterator.value(context)?;
         //    i. Let nextValue be ? IteratorValue(next).
-        let item = item.value(context)?;
         //    ii. If Type(nextValue) is not String, then
         let Some(s) = item.as_string().cloned() else {
             //    1. Let error be ThrowCompletion(a newly created TypeError object).

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -542,20 +542,18 @@ pub(crate) fn add_entries_from_iterable(
     })?;
 
     // 2. Let iteratorRecord be ? GetIterator(iterable).
-    let iterator_record = iterable.get_iterator(context, None, None)?;
+    let mut iterator_record = iterable.get_iterator(context, None, None)?;
 
     // 3. Repeat,
     loop {
         // a. Let next be ? IteratorStep(iteratorRecord).
-        let next = iterator_record.step(context)?;
-
         // b. If next is false, return target.
         // c. Let nextItem be ? IteratorValue(next).
-        let Some(next_item) = next else {
+        if iterator_record.step(context)? {
             return Ok(target.clone().into());
         };
 
-        let next_item = next_item.value(context)?;
+        let next_item = iterator_record.value(context)?;
 
         let Some(next_item) = next_item.as_object() else {
             // d. If Type(nextItem) is not Object, then

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -145,7 +145,7 @@ impl BuiltInConstructor for Set {
         })?;
 
         // 7. Let iteratorRecord be ? GetIterator(iterable).
-        let iterator_record = iterable.clone().get_iterator(context, None, None)?;
+        let mut iterator_record = iterable.clone().get_iterator(context, None, None)?;
 
         // 8. Repeat,
         //     a. Let next be ? IteratorStep(iteratorRecord).
@@ -153,12 +153,12 @@ impl BuiltInConstructor for Set {
         //     c. Let nextValue be ? IteratorValue(next).
         //     d. Let status be Completion(Call(adder, set, « nextValue »)).
         //     e. IfAbruptCloseIterator(status, iteratorRecord).
-        while let Some(next) = iterator_record.step(context)? {
+        while !iterator_record.step(context)? {
+            let next = iterator_record.value(context)?;
             // c
-            let next_value = next.value(context)?;
 
             // d, e
-            if let Err(status) = adder.call(&set.clone().into(), &[next_value], context) {
+            if let Err(status) = adder.call(&set.clone().into(), &[next], context) {
                 return iterator_record.close(Err(status), context);
             }
         }

--- a/boa_engine/src/builtins/weak_set/mod.rs
+++ b/boa_engine/src/builtins/weak_set/mod.rs
@@ -101,17 +101,17 @@ impl BuiltInConstructor for WeakSet {
             .ok_or_else(|| JsNativeError::typ().with_message("WeakSet: 'add' is not a function"))?;
 
         // 7. Let iteratorRecord be ? GetIterator(iterable).
-        let iterator_record = iterable.clone().get_iterator(context, None, None)?;
+        let mut iterator_record = iterable.clone().get_iterator(context, None, None)?;
 
         // 8. Repeat,
         // a. Let next be ? IteratorStep(iteratorRecord).
-        while let Some(next) = iterator_record.step(context)? {
+        while !iterator_record.step(context)? {
             // c. Let nextValue be ? IteratorValue(next).
-            let next_value = next.value(context)?;
+            let next = iterator_record.value(context)?;
 
             // d. Let status be Completion(Call(adder, set, « nextValue »)).
             // e. IfAbruptCloseIterator(status, iteratorRecord).
-            if let Err(status) = adder.call(&weak_set.clone().into(), &[next_value], context) {
+            if let Err(status) = adder.call(&weak_set.clone().into(), &[next], context) {
                 return iterator_record.close(Err(status), context);
             }
         }

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -272,6 +272,9 @@ impl ByteCompiler<'_, '_> {
                     self.context,
                 );
 
+            // Ensures global functions are printed when generating the global flowgraph.
+            self.functions.push(code.clone());
+
             // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.
             let function = if generator {
                 create_generator_function_object(code, r#async, None, self.context)
@@ -686,6 +689,9 @@ impl ByteCompiler<'_, '_> {
 
             // c. If varEnv is a Global Environment Record, then
             if var_environment_is_global {
+                // Ensures global functions are printed when generating the global flowgraph.
+                self.functions.push(code.clone());
+
                 // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
                 let function = if generator {
                     create_generator_function_object(code, r#async, None, self.context)
@@ -988,7 +994,9 @@ impl ByteCompiler<'_, '_> {
         }
         if generator {
             self.emit_opcode(Opcode::PushUndefined);
-            self.emit_opcode(Opcode::Yield);
+            // Don't need to use `AsyncGeneratorYield` since
+            // we just want to stop the execution of the generator.
+            self.emit_opcode(Opcode::GeneratorYield);
         }
 
         // 27. If hasParameterExpressions is false, then

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -4,7 +4,7 @@ mod object_literal;
 mod unary;
 mod update;
 
-use super::{Access, Callable, Label, NodeKind};
+use super::{Access, Callable, NodeKind};
 use crate::{
     bytecompiler::{ByteCompiler, Literal},
     vm::Opcode,
@@ -161,47 +161,39 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::PushUndefined);
                 }
 
-                if r#yield.delegate() && self.in_async_generator {
-                    self.emit_opcode(Opcode::GetAsyncIterator);
-                    self.emit_opcode(Opcode::PushUndefined);
+                if r#yield.delegate() {
+                    if self.in_async_generator {
+                        self.emit_opcode(Opcode::GetAsyncIterator);
+                    } else {
+                        self.emit_opcode(Opcode::GetIterator);
+                    }
 
+                    self.emit_opcode(Opcode::PushUndefined);
                     let start_address = self.next_opcode_location();
                     let (throw_method_undefined, return_method_undefined) =
-                        self.emit_opcode_with_two_operands(Opcode::GeneratorAsyncDelegateNext);
-                    self.emit_opcode(Opcode::Await);
+                        self.emit_opcode_with_two_operands(Opcode::GeneratorDelegateNext);
 
-                    let skip_yield = Label {
-                        index: self.next_opcode_location(),
-                    };
-                    let exit = Label {
-                        index: self.next_opcode_location() + 8,
-                    };
-                    self.emit(
-                        Opcode::GeneratorAsyncDelegateResume,
-                        &[Self::DUMMY_ADDRESS, start_address, Self::DUMMY_ADDRESS],
-                    );
+                    if self.in_async_generator {
+                        self.emit_opcode(Opcode::Await);
+                    }
 
-                    self.emit_opcode(Opcode::PushUndefined);
-                    self.emit_opcode(Opcode::Yield);
+                    let (return_gen, exit) =
+                        self.emit_opcode_with_two_operands(Opcode::GeneratorDelegateResume);
                     self.emit(Opcode::Jump, &[start_address]);
 
-                    self.patch_jump(skip_yield);
+                    self.patch_jump(return_gen);
                     self.patch_jump(return_method_undefined);
-                    self.emit_opcode(Opcode::Await);
+                    if self.in_async_generator {
+                        self.emit_opcode(Opcode::Await);
+                    }
+                    self.close_active_iterators(true);
                     self.emit_opcode(Opcode::GeneratorResumeReturn);
 
                     self.patch_jump(throw_method_undefined);
-                    self.iterator_close(true);
+                    self.iterator_close(self.in_async_generator);
                     self.emit_opcode(Opcode::Throw);
 
                     self.patch_jump(exit);
-                } else if r#yield.delegate() {
-                    self.emit_opcode(Opcode::GetIterator);
-                    self.emit_opcode(Opcode::PushUndefined);
-                    let start_address = self.next_opcode_location();
-                    let start = self.emit_opcode_with_operand(Opcode::GeneratorNextDelegate);
-                    self.emit(Opcode::Jump, &[start_address]);
-                    self.patch_jump(start);
                 } else if self.in_async_generator {
                     self.emit_opcode(Opcode::Await);
                     let (skip_yield, skip_yield_await) =
@@ -212,6 +204,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode_with_operand(Opcode::GeneratorAsyncResumeYield);
                     self.patch_jump(skip_yield);
                     self.emit_opcode(Opcode::Await);
+                    self.close_active_iterators(true);
                     self.emit_opcode(Opcode::GeneratorResumeReturn);
 
                     self.patch_jump(skip_yield_await);

--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -151,7 +151,7 @@ impl JumpControlInfo {
     }
 
     pub(crate) const fn for_await_of_loop(&self) -> bool {
-        self.flags.contains(JumpControlInfoFlags::ITERATOR_LOOP)
+        self.flags.contains(JumpControlInfoFlags::FOR_AWAIT_OF_LOOP)
     }
 }
 

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -515,6 +515,28 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         (Label { index }, Label { index: index + 4 })
     }
 
+    /// Emit an opcode with three dummy operands.
+    /// Return the `Label`s of the three operands.
+    pub(crate) fn emit_opcode_with_three_operands(
+        &mut self,
+        opcode: Opcode,
+    ) -> (Label, Label, Label) {
+        let index = self.next_opcode_location();
+        self.emit(
+            opcode,
+            &[
+                Self::DUMMY_ADDRESS,
+                Self::DUMMY_ADDRESS,
+                Self::DUMMY_ADDRESS,
+            ],
+        );
+        (
+            Label { index },
+            Label { index: index + 4 },
+            Label { index: index + 8 },
+        )
+    }
+
     pub(crate) fn patch_jump_with_target(&mut self, label: Label, target: u32) {
         const U32_SIZE: usize = std::mem::size_of::<u32>();
 

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -495,10 +495,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         self.emit_opcode_with_operand(Opcode::JumpIfFalse)
     }
 
-    fn jump_if_not_undefined(&mut self) -> Label {
-        self.emit_opcode_with_operand(Opcode::JumpIfNotUndefined)
-    }
-
     fn jump_if_null_or_undefined(&mut self) -> Label {
         self.emit_opcode_with_operand(Opcode::JumpIfNullOrUndefined)
     }

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -51,6 +51,10 @@ impl ByteCompiler<'_, '_> {
             Statement::Return(ret) => {
                 if let Some(expr) = ret.target() {
                     self.compile_expr(expr, true);
+                    if self.in_async_generator {
+                        self.emit_opcode(Opcode::Await);
+                        self.emit_opcode(Opcode::GeneratorNext);
+                    }
                 } else {
                     self.emit(Opcode::PushUndefined, &[]);
                 }

--- a/boa_engine/src/job.rs
+++ b/boa_engine/src/job.rs
@@ -276,10 +276,6 @@ impl SimpleJobQueue {
 
 impl JobQueue for SimpleJobQueue {
     fn enqueue_promise_job(&self, job: NativeJob, _: &mut Context<'_>) {
-        // If realm is not null ...
-        // TODO
-        // Let scriptOrModule be ...
-        // TODO
         self.0.borrow_mut().push_back(job);
     }
 

--- a/boa_engine/src/tests/iterators.rs
+++ b/boa_engine/src/tests/iterators.rs
@@ -48,8 +48,7 @@ fn iterator_close_in_continue_before_jobs() {
         "#}),
         #[allow(clippy::redundant_closure_for_method_calls)]
         TestAction::inspect_context(|ctx| ctx.run_jobs()),
-        TestAction::assert(
-            r#"
+        TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,
                 [
@@ -62,8 +61,7 @@ fn iterator_close_in_continue_before_jobs() {
                     "tick 2",
                 ]
             )
-        "#,
-        ),
+            "#}),
     ]);
 }
 
@@ -97,7 +95,8 @@ fn async_iterator_close_in_continue_is_awaited() {
 
             Promise.resolve(0)
                 .then(() => actual.push("tick 1"))
-                .then(() => actual.push("tick 2"));
+                .then(() => actual.push("tick 2"))
+                .then(() => actual.push("tick 3"));
 
             void async function f() {
                 actual.push("async fn start");
@@ -113,8 +112,7 @@ fn async_iterator_close_in_continue_is_awaited() {
         "#}),
         #[allow(clippy::redundant_closure_for_method_calls)]
         TestAction::inspect_context(|ctx| ctx.run_jobs()),
-        TestAction::assert(
-            r#"
+        TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,
                 [
@@ -125,10 +123,10 @@ fn async_iterator_close_in_continue_is_awaited() {
                     "async return call",
                     "tick 2",
                     "async fn end",
+                    "tick 3"
                 ]
             )
-        "#,
-        ),
+        "#}),
     ]);
 }
 
@@ -183,7 +181,8 @@ fn mixed_iterators_close_in_continue() {
 
             Promise.resolve(0)
                 .then(() => actual.push("tick 1"))
-                .then(() => actual.push("tick 2"));
+                .then(() => actual.push("tick 2"))
+                .then(() => actual.push("tick 3"));
 
             void async function f() {
                 actual.push("async fn start");
@@ -201,8 +200,7 @@ fn mixed_iterators_close_in_continue() {
         "#}),
         #[allow(clippy::redundant_closure_for_method_calls)]
         TestAction::inspect_context(|ctx| ctx.run_jobs()),
-        TestAction::assert(
-            r#"
+        TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,
                 [
@@ -216,9 +214,9 @@ fn mixed_iterators_close_in_continue() {
                     "get return",
                     "return call",
                     "async fn end",
+                    "tick 3",
                 ]
             )
-        "#,
-        ),
+        "#}),
     ]);
 }

--- a/boa_engine/src/tests/iterators.rs
+++ b/boa_engine/src/tests/iterators.rs
@@ -1,0 +1,227 @@
+use indoc::indoc;
+
+use crate::{run_test_actions, TestAction};
+
+#[test]
+fn iterator_close_in_continue_before_jobs() {
+    run_test_actions([
+        TestAction::run_harness(),
+        TestAction::run(indoc! {r#"
+            var actual = [];
+
+            var iter = {
+                [Symbol.iterator]() {
+                    return this;
+                },
+                next() {
+                    actual.push("call next");
+                    return {
+                        done: false,
+                    };
+                },
+                get return() {
+                    actual.push("get return");
+                    return function () {
+                        actual.push("return call");
+                        return {
+                            done: true
+                        }
+                    }
+                }
+            };
+
+
+            Promise.resolve(0)
+                .then(() => actual.push("tick 1"))
+                .then(() => actual.push("tick 2"));
+
+            void async function f() {
+                actual.push("async fn start");
+                let count = 0;
+                loop: while (count === 0) {
+                    count++;
+                    for (_ of iter) {
+                        continue loop;
+                    }
+                }
+                actual.push("async fn end");
+            }();
+        "#}),
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::assert(
+            r#"
+            arrayEquals(
+                actual,
+                [
+                    "async fn start",
+                    "call next",
+                    "get return",
+                    "return call",
+                    "async fn end",
+                    "tick 1",
+                    "tick 2",
+                ]
+            )
+        "#,
+        ),
+    ]);
+}
+
+#[test]
+fn async_iterator_close_in_continue_is_awaited() {
+    run_test_actions([
+        TestAction::run_harness(),
+        TestAction::run(indoc! {r#"
+            var actual = [];
+
+            var asyncIter = {
+                [Symbol.asyncIterator]() {
+                    return this;
+                },
+                next() {
+                    actual.push("async call next");
+                    return {
+                        done: false,
+                    };
+                },
+                get return() {
+                    actual.push("get async return");
+                    return function () {
+                        actual.push("async return call");
+                        return {
+                            done: true
+                        };
+                    }
+                }
+            };
+
+
+            Promise.resolve(0)
+                .then(() => actual.push("tick 1"))
+                .then(() => actual.push("tick 2"));
+
+            void async function f() {
+                actual.push("async fn start");
+                let count = 0;
+                loop: while (count === 0) {
+                    count++;
+                    for await (__ of asyncIter) {
+                        continue loop;
+                    }
+                }
+                actual.push("async fn end");
+            }();
+        "#}),
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::assert(
+            r#"
+            arrayEquals(
+                actual,
+                [
+                    "async fn start",
+                    "async call next",
+                    "tick 1",
+                    "get async return",
+                    "async return call",
+                    "tick 2",
+                    "async fn end",
+                ]
+            )
+        "#,
+        ),
+    ]);
+}
+
+#[test]
+fn mixed_iterators_close_in_continue() {
+    run_test_actions([
+        TestAction::run_harness(),
+        TestAction::run(indoc! {r#"
+            var actual = [];
+
+            var iter = {
+                [Symbol.iterator]() {
+                    return this;
+                },
+                next() {
+                    actual.push("call next");
+                    return {
+                        done: false,
+                    };
+                },
+                get return() {
+                    actual.push("get return");
+                    return function () {
+                        actual.push("return call");
+                        return {
+                            done: true
+                        }
+                    }
+                }
+            };
+
+            var asyncIter = {
+                [Symbol.asyncIterator]() {
+                    return this;
+                },
+                next() {
+                    actual.push("async call next");
+                    return {
+                        done: false,
+                    };
+                },
+                get return() {
+                    actual.push("get async return");
+                    return function () {
+                        actual.push("async return call");
+                        return {
+                            done: true
+                        };
+                    }
+                }
+            };
+
+
+            Promise.resolve(0)
+                .then(() => actual.push("tick 1"))
+                .then(() => actual.push("tick 2"));
+
+            void async function f() {
+                actual.push("async fn start");
+                let count = 0;
+                loop: while (count === 0) {
+                    count++;
+                    for (_ of iter) {
+                        for await (__ of asyncIter) {
+                            continue loop;
+                        }
+                    }
+                }
+                actual.push("async fn end");
+            }();
+        "#}),
+        #[allow(clippy::redundant_closure_for_method_calls)]
+        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::assert(
+            r#"
+            arrayEquals(
+                actual,
+                [
+                    "async fn start",
+                    "call next",
+                    "async call next",
+                    "tick 1",
+                    "get async return",
+                    "async return call",
+                    "tick 2",
+                    "get return",
+                    "return call",
+                    "async fn end",
+                ]
+            )
+        "#,
+        ),
+    ]);
+}

--- a/boa_engine/src/tests/iterators.rs
+++ b/boa_engine/src/tests/iterators.rs
@@ -30,7 +30,6 @@ fn iterator_close_in_continue_before_jobs() {
                 }
             };
 
-
             Promise.resolve(0)
                 .then(() => actual.push("tick 1"))
                 .then(() => actual.push("tick 2"));
@@ -95,7 +94,6 @@ fn async_iterator_close_in_continue_is_awaited() {
                     }
                 }
             };
-
 
             Promise.resolve(0)
                 .then(() => actual.push("tick 1"))
@@ -182,7 +180,6 @@ fn mixed_iterators_close_in_continue() {
                     }
                 }
             };
-
 
             Promise.resolve(0)
                 .then(() => actual.push("tick 1"))

--- a/boa_engine/src/tests/mod.rs
+++ b/boa_engine/src/tests/mod.rs
@@ -3,6 +3,7 @@ use indoc::indoc;
 mod control_flow;
 mod env;
 mod function;
+mod iterators;
 mod operators;
 mod promise;
 mod spread;

--- a/boa_engine/src/vm/call_frame/env_stack.rs
+++ b/boa_engine/src/vm/call_frame/env_stack.rs
@@ -14,7 +14,7 @@ pub(crate) enum EnvEntryKind {
         value: JsValue,
 
         /// The index of the currently active iterator.
-        iterator: Option<usize>,
+        iterator: Option<u32>,
     },
     Try,
     Catch,
@@ -76,7 +76,7 @@ impl EnvStackEntry {
 
     /// Returns calling `EnvStackEntry` with `kind` field of `Loop`, loop iteration set to zero
     /// and iterator index set to `iterator`.
-    pub(crate) fn with_iterator_loop_flag(mut self, iteration_count: u64, iterator: usize) -> Self {
+    pub(crate) fn with_iterator_loop_flag(mut self, iteration_count: u64, iterator: u32) -> Self {
         self.kind = EnvEntryKind::Loop {
             iteration_count,
             value: JsValue::undefined(),
@@ -166,7 +166,7 @@ impl EnvStackEntry {
     }
 
     /// Returns the active iterator index if `EnvStackEntry` is an iterator loop.
-    pub(crate) const fn iterator(&self) -> Option<usize> {
+    pub(crate) const fn iterator(&self) -> Option<u32> {
         if let EnvEntryKind::Loop { iterator, .. } = self.kind {
             return iterator;
         }

--- a/boa_engine/src/vm/call_frame/env_stack.rs
+++ b/boa_engine/src/vm/call_frame/env_stack.rs
@@ -7,11 +7,14 @@ use boa_gc::{Finalize, Trace};
 pub(crate) enum EnvEntryKind {
     Global,
     Loop {
-        /// This is used to keep track of how many iterations a loop has done.
+        /// How many iterations a loop has done.
         iteration_count: u64,
 
-        // This is the latest return value of the loop.
+        /// The latest return value of the loop.
         value: JsValue,
+
+        /// The index of the currently active iterator.
+        iterator: Option<usize>,
     },
     Try,
     Catch,
@@ -71,12 +74,24 @@ impl EnvStackEntry {
         self
     }
 
+    /// Returns calling `EnvStackEntry` with `kind` field of `Loop`, loop iteration set to zero
+    /// and iterator index set to `iterator`.
+    pub(crate) fn with_iterator_loop_flag(mut self, iteration_count: u64, iterator: usize) -> Self {
+        self.kind = EnvEntryKind::Loop {
+            iteration_count,
+            value: JsValue::undefined(),
+            iterator: Some(iterator),
+        };
+        self
+    }
+
     /// Returns calling `EnvStackEntry` with `kind` field of `Loop`.
     /// And the loop iteration set to zero.
     pub(crate) fn with_loop_flag(mut self, iteration_count: u64) -> Self {
         self.kind = EnvEntryKind::Loop {
             iteration_count,
             value: JsValue::undefined(),
+            iterator: None,
         };
         self
     }
@@ -146,6 +161,14 @@ impl EnvStackEntry {
     pub(crate) const fn loop_env_value(&self) -> Option<&JsValue> {
         if let EnvEntryKind::Loop { value, .. } = &self.kind {
             return Some(value);
+        }
+        None
+    }
+
+    /// Returns the active iterator index if `EnvStackEntry` is an iterator loop.
+    pub(crate) const fn iterator(&self) -> Option<usize> {
+        if let EnvEntryKind::Loop { iterator, .. } = self.kind {
+            return iterator;
         }
         None
     }

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -6,7 +6,9 @@ mod abrupt_record;
 mod env_stack;
 
 use crate::{
-    builtins::promise::PromiseCapability, environments::BindingLocator, object::JsObject,
+    builtins::{iterable::IteratorRecord, promise::PromiseCapability},
+    environments::BindingLocator,
+    object::JsObject,
     vm::CodeBlock,
 };
 use boa_gc::{Finalize, Gc, Trace};
@@ -39,7 +41,7 @@ pub struct CallFrame {
     pub(crate) async_generator: Option<JsObject>,
 
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
-    pub(crate) iterators: ThinVec<(JsObject, bool)>,
+    pub(crate) iterators: ThinVec<IteratorRecord>,
 
     // The stack of bindings being updated.
     pub(crate) binding_stack: Vec<BindingLocator>,
@@ -110,8 +112,9 @@ impl CallFrame {
 }
 
 /// Indicates how a generator function that has been called/resumed should return.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Default)]
 pub(crate) enum GeneratorResumeKind {
+    #[default]
     Normal,
     Throw,
     Return,

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -317,10 +317,8 @@ impl CodeBlock {
             | Opcode::Call
             | Opcode::New
             | Opcode::SuperCall
-            | Opcode::IteratorUnwrapNextOrJump
             | Opcode::ConcatToString
-            | Opcode::GeneratorAsyncResumeYield
-            | Opcode::GeneratorNextDelegate => {
+            | Opcode::GeneratorAsyncResumeYield => {
                 let result = self.read::<u32>(*pc).to_string();
                 *pc += size_of::<u32>();
                 result
@@ -334,9 +332,11 @@ impl CodeBlock {
             | Opcode::Break
             | Opcode::Continue
             | Opcode::LoopStart
+            | Opcode::IteratorLoopStart
             | Opcode::TryStart
             | Opcode::AsyncGeneratorNext
-            | Opcode::GeneratorAsyncDelegateNext => {
+            | Opcode::GeneratorDelegateNext
+            | Opcode::GeneratorDelegateResume => {
                 let operand1 = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
                 let operand2 = self.read::<u32>(*pc);
@@ -349,15 +349,6 @@ impl CodeBlock {
                 let operand2 = self.read::<u64>(*pc);
                 *pc += size_of::<u64>();
                 format!("{operand1}, {operand2}")
-            }
-            Opcode::GeneratorAsyncDelegateResume => {
-                let operand1 = self.read::<u32>(*pc);
-                *pc += size_of::<u32>();
-                let operand2 = self.read::<u32>(*pc);
-                *pc += size_of::<u32>();
-                let operand3 = self.read::<u32>(*pc);
-                *pc += size_of::<u32>();
-                format!("{operand1}, {operand2}, {operand3}")
             }
             Opcode::GetArrowFunction
             | Opcode::GetAsyncArrowFunction
@@ -522,12 +513,14 @@ impl CodeBlock {
             | Opcode::GetAsyncIterator
             | Opcode::GeneratorResumeReturn
             | Opcode::IteratorNext
-            | Opcode::IteratorNextSetDone
-            | Opcode::IteratorUnwrapNext
-            | Opcode::IteratorUnwrapValue
+            | Opcode::IteratorFinishAsyncNext
+            | Opcode::IteratorValue
+            | Opcode::IteratorResult
+            | Opcode::IteratorDone
             | Opcode::IteratorToArray
-            | Opcode::IteratorClosePush
-            | Opcode::IteratorClosePop
+            | Opcode::IteratorPop
+            | Opcode::IteratorReturn
+            | Opcode::IteratorStackEmpty
             | Opcode::RequireObjectCoercible
             | Opcode::ValueNotNullOrUndefined
             | Opcode::RestParameterInit
@@ -611,8 +604,7 @@ impl CodeBlock {
             | Opcode::Reserved52
             | Opcode::Reserved53
             | Opcode::Reserved54
-            | Opcode::Reserved55
-            | Opcode::Reserved56 => unreachable!("Reserved opcodes are unrechable"),
+            | Opcode::Reserved55 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -617,9 +617,7 @@ impl CodeBlock {
             | Opcode::Reserved50
             | Opcode::Reserved51
             | Opcode::Reserved52
-            | Opcode::Reserved53
-            | Opcode::Reserved54
-            | Opcode::Reserved55 => unreachable!("Reserved opcodes are unrechable"),
+            | Opcode::Reserved53 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -139,12 +139,8 @@ impl CodeBlock {
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
                 Opcode::LoopStart | Opcode::IteratorLoopStart => {
-                    let start_address = self.read::<u32>(pc);
-                    pc += size_of::<u32>();
-                    let end_address = self.read::<u32>(pc);
-                    pc += size_of::<u32>();
+                    pc += size_of::<u32>() * 2;
 
-                    let label = format!("{opcode_str} {start_address}, {end_address}");
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::Red);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -714,9 +714,7 @@ impl CodeBlock {
                 | Opcode::Reserved50
                 | Opcode::Reserved51
                 | Opcode::Reserved52
-                | Opcode::Reserved53
-                | Opcode::Reserved54
-                | Opcode::Reserved55 => unreachable!("Reserved opcodes are unrechable"),
+                | Opcode::Reserved53 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -259,8 +259,8 @@ impl Context<'_> {
 
                 let instant = Instant::now();
                 let result = self.execute_instruction();
-                let duration = instant.elapsed();
 
+                let duration = instant.elapsed();
                 println!(
                     "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {}",
                     format!("{}μs", duration.as_micros()),
@@ -270,7 +270,7 @@ impl Context<'_> {
                         Some(value) if value.is_object() => "[object]".to_string(),
                         Some(value) => value.display().to_string(),
                         None => "<empty>".to_string(),
-                    }
+                    },
                 );
 
                 result
@@ -330,8 +330,8 @@ impl Context<'_> {
 
         // Early return immediately after loop.
         if self.vm.frame().r#yield {
-            let result = self.vm.pop();
             self.vm.frame_mut().r#yield = false;
+            let result = self.vm.pop();
             return CompletionRecord::Return(result);
         }
 

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -43,7 +43,7 @@ impl Operation for Throw {
                     .vm
                     .frame_mut()
                     .iterators
-                    .split_off(active_iterator + 1);
+                    .split_off(active_iterator as usize + 1);
                 for iterator in inactive {
                     if !iterator.done() {
                         drop(iterator.close(Ok(JsValue::undefined()), context));
@@ -146,7 +146,7 @@ impl Operation for Throw {
                     .vm
                     .frame_mut()
                     .iterators
-                    .split_off(active_iterator + 1);
+                    .split_off(active_iterator as usize + 1);
                 for iterator in inactive {
                     if !iterator.done() {
                         drop(iterator.close(Ok(JsValue::undefined()), context));

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -1,10 +1,7 @@
 pub(crate) mod yield_stm;
 
 use crate::{
-    builtins::{
-        async_generator::{AsyncGenerator, AsyncGeneratorState},
-        iterable::IteratorRecord,
-    },
+    builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
     error::JsNativeError,
     string::utf16,
     vm::{
@@ -163,135 +160,51 @@ impl Operation for GeneratorResumeReturn {
     }
 }
 
-/// `GeneratorNextDelegate` implements the Opcode Operation for `Opcode::GeneratorNextDelegate`
+/// `GeneratorDelegateNext` implements the Opcode Operation for `Opcode::GeneratorDelegateNext`
 ///
 /// Operation:
-///  - Delegates the current generator function another generator.
+///  - Delegates the current generator function to another iterator.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GeneratorNextDelegate;
+pub(crate) struct GeneratorDelegateNext;
 
-impl Operation for GeneratorNextDelegate {
-    const NAME: &'static str = "GeneratorNextDelegate";
-    const INSTRUCTION: &'static str = "INST - GeneratorNextDelegate";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let done_address = context.vm.read::<u32>();
-        let received = context.vm.pop();
-        let next_method = context.vm.pop();
-        let iterator = context.vm.pop();
-        let iterator = iterator.as_object().expect("iterator was not an object");
-
-        match context.vm.frame().generator_resume_kind {
-            GeneratorResumeKind::Normal => {
-                let result_value =
-                    next_method.call(&iterator.clone().into(), &[received], context)?;
-                let result = result_value.as_object().ok_or_else(|| {
-                    JsNativeError::typ().with_message("generator next method returned non-object")
-                })?;
-                let done = result.get(utf16!("done"), context)?.to_boolean();
-                if done {
-                    context.vm.frame_mut().pc = done_address;
-                    let value = result.get(utf16!("value"), context)?;
-                    context.vm.push(value);
-                    return Ok(CompletionType::Normal);
-                }
-                context.vm.push(iterator.clone());
-                context.vm.push(next_method.clone());
-                context.vm.push(result_value);
-                context.vm.frame_mut().r#yield = true;
-                Ok(CompletionType::Return)
-            }
-            GeneratorResumeKind::Throw => {
-                let throw = iterator.get_method(utf16!("throw"), context)?;
-                if let Some(throw) = throw {
-                    let result = throw.call(&iterator.clone().into(), &[received], context)?;
-                    let result_object = result.as_object().ok_or_else(|| {
-                        JsNativeError::typ()
-                            .with_message("generator throw method returned non-object")
-                    })?;
-                    let done = result_object.get(utf16!("done"), context)?.to_boolean();
-                    if done {
-                        context.vm.frame_mut().pc = done_address;
-                        let value = result_object.get(utf16!("value"), context)?;
-                        context.vm.push(value);
-                        return Ok(CompletionType::Normal);
-                    }
-                    context.vm.push(iterator.clone());
-                    context.vm.push(next_method.clone());
-                    context.vm.push(result);
-                    context.vm.frame_mut().r#yield = true;
-                    return Ok(CompletionType::Return);
-                }
-                context.vm.frame_mut().pc = done_address;
-                let iterator_record = IteratorRecord::new(iterator.clone(), next_method, false);
-                iterator_record.close(Ok(JsValue::Undefined), context)?;
-
-                Err(JsNativeError::typ()
-                    .with_message("iterator does not have a throw method")
-                    .into())
-            }
-            GeneratorResumeKind::Return => {
-                let r#return = iterator.get_method(utf16!("return"), context)?;
-                if let Some(r#return) = r#return {
-                    let result = r#return.call(&iterator.clone().into(), &[received], context)?;
-                    let result_object = result.as_object().ok_or_else(|| {
-                        JsNativeError::typ()
-                            .with_message("generator return method returned non-object")
-                    })?;
-                    let done = result_object.get(utf16!("done"), context)?.to_boolean();
-                    if done {
-                        let value = result_object.get(utf16!("value"), context)?;
-                        context.vm.push(value);
-                        return Return::execute(context);
-                    }
-                    context.vm.push(iterator.clone());
-                    context.vm.push(next_method.clone());
-                    context.vm.push(result);
-                    context.vm.frame_mut().r#yield = true;
-                    return Ok(CompletionType::Return);
-                }
-                context.vm.push(received);
-                Return::execute(context)
-            }
-        }
-    }
-}
-
-/// `GeneratorAsyncDelegateNext` implements the Opcode Operation for `Opcode::GeneratorAsyncDelegateNext`
-///
-/// Operation:
-///  - Delegates the current async generator function to another iterator.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct GeneratorAsyncDelegateNext;
-
-impl Operation for GeneratorAsyncDelegateNext {
-    const NAME: &'static str = "GeneratorAsyncDelegateNext";
-    const INSTRUCTION: &'static str = "INST - GeneratorAsyncDelegateNext";
+impl Operation for GeneratorDelegateNext {
+    const NAME: &'static str = "GeneratorDelegateNext";
+    const INSTRUCTION: &'static str = "INST - GeneratorDelegateNext";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let throw_method_undefined = context.vm.read::<u32>();
         let return_method_undefined = context.vm.read::<u32>();
         let received = context.vm.pop();
-        let next_method = context.vm.pop();
-        let iterator = context.vm.pop();
-        let iterator = iterator.as_object().expect("iterator was not an object");
 
-        match context.vm.frame().generator_resume_kind {
+        // Preemptively popping removes the iterator from the iterator stack if any operation
+        // throws, which avoids calling cleanup operations on the poisoned iterator.
+        let iterator_record = context
+            .vm
+            .frame_mut()
+            .iterators
+            .pop()
+            .expect("iterator stack should have at least an iterator");
+
+        match std::mem::take(&mut context.vm.frame_mut().generator_resume_kind) {
             GeneratorResumeKind::Normal => {
-                let result_value =
-                    next_method.call(&iterator.clone().into(), &[received], context)?;
-                context.vm.push(iterator.clone());
-                context.vm.push(next_method.clone());
+                let result = iterator_record.next_method().call(
+                    &iterator_record.iterator().clone().into(),
+                    &[received],
+                    context,
+                )?;
                 context.vm.push(false);
-                context.vm.push(result_value);
-                Ok(CompletionType::Normal)
+                context.vm.push(result);
             }
             GeneratorResumeKind::Throw => {
-                let throw = iterator.get_method(utf16!("throw"), context)?;
+                let throw = iterator_record
+                    .iterator()
+                    .get_method(utf16!("throw"), context)?;
                 if let Some(throw) = throw {
-                    let result = throw.call(&iterator.clone().into(), &[received], context)?;
-                    context.vm.push(iterator.clone());
-                    context.vm.push(next_method.clone());
+                    let result = throw.call(
+                        &iterator_record.iterator().clone().into(),
+                        &[received],
+                        context,
+                    )?;
                     context.vm.push(false);
                     context.vm.push(result);
                 } else {
@@ -299,82 +212,90 @@ impl Operation for GeneratorAsyncDelegateNext {
                         .with_message("iterator does not have a throw method")
                         .to_opaque(context);
                     context.vm.push(error);
-                    context.vm.push(iterator.clone());
-                    context.vm.push(next_method.clone());
-                    context.vm.push(false);
                     context.vm.frame_mut().pc = throw_method_undefined;
                 }
-
-                Ok(CompletionType::Normal)
             }
             GeneratorResumeKind::Return => {
-                let r#return = iterator.get_method(utf16!("return"), context)?;
+                let r#return = iterator_record
+                    .iterator()
+                    .get_method(utf16!("return"), context)?;
                 if let Some(r#return) = r#return {
-                    let result = r#return.call(&iterator.clone().into(), &[received], context)?;
-                    context.vm.push(iterator.clone());
-                    context.vm.push(next_method.clone());
+                    let result = r#return.call(
+                        &iterator_record.iterator().clone().into(),
+                        &[received],
+                        context,
+                    )?;
                     context.vm.push(true);
                     context.vm.push(result);
+                } else {
+                    context.vm.push(received);
+                    context.vm.frame_mut().pc = return_method_undefined;
+
+                    // The current iterator didn't have a cleanup `return` method, so we can
+                    // skip pushing it to the iterator stack for cleanup.
                     return Ok(CompletionType::Normal);
                 }
-                context.vm.push(iterator.clone());
-                context.vm.push(next_method.clone());
-                context.vm.push(received);
-                context.vm.frame_mut().pc = return_method_undefined;
-                Ok(CompletionType::Normal)
             }
         }
+
+        context.vm.frame_mut().iterators.push(iterator_record);
+
+        Ok(CompletionType::Normal)
     }
 }
 
-/// `GeneratorAsyncDelegateResume` implements the Opcode Operation for `Opcode::GeneratorAsyncDelegateResume`
+/// `GeneratorDelegateResume` implements the Opcode Operation for `Opcode::GeneratorDelegateResume`
 ///
 /// Operation:
-///  - Resume the async generator with yield delegate logic after it awaits a value.
+///  - Resume the generator with yield delegate logic after it awaits a value.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GeneratorAsyncDelegateResume;
+pub(crate) struct GeneratorDelegateResume;
 
-impl Operation for GeneratorAsyncDelegateResume {
-    const NAME: &'static str = "GeneratorAsyncDelegateResume";
-    const INSTRUCTION: &'static str = "INST - GeneratorAsyncDelegateResume";
+impl Operation for GeneratorDelegateResume {
+    const NAME: &'static str = "GeneratorDelegateResume";
+    const INSTRUCTION: &'static str = "INST - GeneratorDelegateResume";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let skip_yield = context.vm.read::<u32>();
-        let normal_completion = context.vm.read::<u32>();
+        let return_gen = context.vm.read::<u32>();
         let exit = context.vm.read::<u32>();
 
-        if context.vm.frame().generator_resume_kind == GeneratorResumeKind::Throw {
-            return Err(JsError::from_opaque(context.vm.pop()));
-        }
+        let mut iterator = context
+            .vm
+            .frame_mut()
+            .iterators
+            .pop()
+            .expect("iterator stack should have at least an iterator");
 
-        let received = context.vm.pop();
+        let result = context.vm.pop();
         let is_return = context.vm.pop().to_boolean();
 
-        let result = received.as_object().ok_or_else(|| {
-            JsNativeError::typ().with_message("generator next method returned non-object")
-        })?;
-        let done = result.get(utf16!("done"), context)?.to_boolean();
-        let value = result.get(utf16!("value"), context)?;
-        if done {
+        if context.vm.frame().generator_resume_kind == GeneratorResumeKind::Throw {
+            return Err(JsError::from_opaque(result));
+        }
+
+        iterator.update_result(result.clone(), context)?;
+
+        if iterator.done() {
+            let value = iterator.value(context)?;
             context.vm.push(value);
 
-            if is_return {
-                return Return::execute(context);
-            }
+            context.vm.frame_mut().pc = if is_return { return_gen } else { exit };
 
-            context.vm.frame_mut().pc = exit;
             return Ok(CompletionType::Normal);
         }
 
+        let Some(async_gen) = context.vm.frame().async_generator.clone() else {
+            context.vm.frame_mut().iterators.push(iterator);
+            context.vm.push(result);
+            context.vm.frame_mut().r#yield = true;
+            return Ok(CompletionType::Return);
+        };
+
+        let value = iterator.value(context)?;
+        context.vm.frame_mut().iterators.push(iterator);
+
         let completion = Ok(value);
-        let generator_object = context
-            .vm
-            .frame()
-            .async_generator
-            .as_ref()
-            .expect("must be in generator context here")
-            .clone();
-        let next = generator_object
+        let next = async_gen
             .borrow_mut()
             .as_async_generator_mut()
             .expect("must be async generator object")
@@ -383,7 +304,7 @@ impl Operation for GeneratorAsyncDelegateResume {
             .expect("must have item in queue");
         AsyncGenerator::complete_step(&next, completion, false, None, context);
 
-        let mut generator_object_mut = generator_object.borrow_mut();
+        let mut generator_object_mut = async_gen.borrow_mut();
         let gen = generator_object_mut
             .as_async_generator_mut()
             .expect("must be async generator object");
@@ -396,14 +317,16 @@ impl Operation for GeneratorAsyncDelegateResume {
                     Err(e) => e.clone().to_opaque(context),
                 };
                 context.vm.push(value);
-                context.vm.frame_mut().pc = skip_yield;
+                context.vm.frame_mut().pc = return_gen;
             } else {
                 context.vm.push(completion.clone()?);
-                context.vm.frame_mut().pc = normal_completion;
             }
+            Ok(CompletionType::Normal)
         } else {
             gen.state = AsyncGeneratorState::SuspendedYield;
+            context.vm.push(JsValue::undefined());
+            context.vm.frame_mut().r#yield = true;
+            Ok(CompletionType::Return)
         }
-        Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -1,15 +1,14 @@
 pub(crate) mod yield_stm;
 
 use crate::{
-    builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
     error::JsNativeError,
     string::utf16,
     vm::{
-        call_frame::{AbruptCompletionRecord, GeneratorResumeKind},
+        call_frame::GeneratorResumeKind,
         opcode::{control_flow::Return, Operation},
         CompletionType,
     },
-    Context, JsError, JsResult, JsValue,
+    Context, JsError, JsResult,
 };
 
 pub(crate) use yield_stm::*;
@@ -29,115 +28,50 @@ impl Operation for GeneratorNext {
         match context.vm.frame().generator_resume_kind {
             GeneratorResumeKind::Normal => Ok(CompletionType::Normal),
             GeneratorResumeKind::Throw => Err(JsError::from_opaque(context.vm.pop())),
-            GeneratorResumeKind::Return => {
-                let finally_entries = context
-                    .vm
-                    .frame()
-                    .env_stack
-                    .iter()
-                    .filter(|entry| entry.is_finally_env());
-                if let Some(next_finally) = finally_entries.rev().next() {
-                    if context.vm.frame().pc < next_finally.start_address() {
-                        context.vm.frame_mut().pc = next_finally.start_address();
-                        let return_record = AbruptCompletionRecord::new_return();
-                        context.vm.frame_mut().abrupt_completion = Some(return_record);
-                        return Ok(CompletionType::Normal);
-                    }
-                }
-
-                let return_record = AbruptCompletionRecord::new_return();
-                context.vm.frame_mut().abrupt_completion = Some(return_record);
-                Ok(CompletionType::Return)
-            }
+            GeneratorResumeKind::Return => Return::execute(context),
         }
     }
 }
 
-/// `AsyncGeneratorNext` implements the Opcode Operation for `Opcode::AsyncGeneratorNext`
+/// `GeneratorJumpOnResumeKind` implements the Opcode Operation for
+/// `Opcode::GeneratorJumpOnResumeKind`
 ///
 /// Operation:
-///  - Resumes the current generator function.
+///  - Jumps to the specified instruction if the current resume kind is `Return`.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct AsyncGeneratorNext;
+pub(crate) struct GeneratorJumpOnResumeKind;
 
-impl Operation for AsyncGeneratorNext {
-    const NAME: &'static str = "AsyncGeneratorNext";
-    const INSTRUCTION: &'static str = "INST - AsyncGeneratorNext";
+impl Operation for GeneratorJumpOnResumeKind {
+    const NAME: &'static str = "GeneratorJumpOnResumeKind";
+    const INSTRUCTION: &'static str = "INST - GeneratorJumpOnResumeKind";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let skip_yield = context.vm.read::<u32>();
-        let skip_yield_await = context.vm.read::<u32>();
-
-        if context.vm.frame().generator_resume_kind == GeneratorResumeKind::Throw {
-            return Err(JsError::from_opaque(context.vm.pop()));
-        }
-
-        let value = context.vm.pop();
-
-        let completion = Ok(value);
-        let generator_object = context
-            .vm
-            .frame()
-            .async_generator
-            .as_ref()
-            .expect("must be in generator context here")
-            .clone();
-        let next = generator_object
-            .borrow_mut()
-            .as_async_generator_mut()
-            .expect("must be async generator object")
-            .queue
-            .pop_front()
-            .expect("must have item in queue");
-        AsyncGenerator::complete_step(&next, completion, false, None, context);
-
-        let mut generator_object_mut = generator_object.borrow_mut();
-        let gen = generator_object_mut
-            .as_async_generator_mut()
-            .expect("must be async generator object");
-
-        if let Some(next) = gen.queue.front() {
-            let (completion, r#return) = &next.completion;
-            if *r#return {
-                let value = match completion {
-                    Ok(value) => value.clone(),
-                    Err(e) => e.clone().to_opaque(context),
-                };
-                context.vm.push(value);
-                context.vm.frame_mut().pc = skip_yield;
-            } else {
-                context.vm.push(completion.clone()?);
-                context.vm.frame_mut().pc = skip_yield_await;
-            }
-        } else {
-            gen.state = AsyncGeneratorState::SuspendedYield;
+        let normal = context.vm.read::<u32>();
+        let throw = context.vm.read::<u32>();
+        let r#return = context.vm.read::<u32>();
+        match context.vm.frame().generator_resume_kind {
+            GeneratorResumeKind::Normal => context.vm.frame_mut().pc = normal,
+            GeneratorResumeKind::Throw => context.vm.frame_mut().pc = throw,
+            GeneratorResumeKind::Return => context.vm.frame_mut().pc = r#return,
         }
         Ok(CompletionType::Normal)
     }
 }
 
-/// `GeneratorAsyncResumeYield` implements the Opcode Operation for `Opcode::GeneratorAsyncResumeYield`
+/// `GeneratorSetReturn` implements the Opcode Operation for `Opcode::GeneratorSetReturn`
 ///
 /// Operation:
-///  - Resumes the current async generator function after a yield.
+///  - Sets the current generator resume kind to `Return`.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GeneratorAsyncResumeYield;
+pub(crate) struct GeneratorSetReturn;
 
-impl Operation for GeneratorAsyncResumeYield {
-    const NAME: &'static str = "GeneratorAsyncResumeYield";
-    const INSTRUCTION: &'static str = "INST - GeneratorAsyncResumeYield";
+impl Operation for GeneratorSetReturn {
+    const NAME: &'static str = "GeneratorSetReturn";
+    const INSTRUCTION: &'static str = "INST - GeneratorSetReturn";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let normal_completion = context.vm.read::<u32>();
-
-        match context.vm.frame().generator_resume_kind {
-            GeneratorResumeKind::Normal => {
-                context.vm.frame_mut().pc = normal_completion;
-                Ok(CompletionType::Normal)
-            }
-            GeneratorResumeKind::Throw => Err(JsError::from_opaque(context.vm.pop())),
-            GeneratorResumeKind::Return => Ok(CompletionType::Normal),
-        }
+        context.vm.frame_mut().generator_resume_kind = GeneratorResumeKind::Return;
+        Ok(CompletionType::Normal)
     }
 }
 
@@ -273,7 +207,7 @@ impl Operation for GeneratorDelegateResume {
             return Err(JsError::from_opaque(result));
         }
 
-        iterator.update_result(result.clone(), context)?;
+        iterator.update_result(result, context)?;
 
         if iterator.done() {
             let value = iterator.value(context)?;
@@ -284,49 +218,8 @@ impl Operation for GeneratorDelegateResume {
             return Ok(CompletionType::Normal);
         }
 
-        let Some(async_gen) = context.vm.frame().async_generator.clone() else {
-            context.vm.frame_mut().iterators.push(iterator);
-            context.vm.push(result);
-            context.vm.frame_mut().r#yield = true;
-            return Ok(CompletionType::Return);
-        };
-
-        let value = iterator.value(context)?;
         context.vm.frame_mut().iterators.push(iterator);
 
-        let completion = Ok(value);
-        let next = async_gen
-            .borrow_mut()
-            .as_async_generator_mut()
-            .expect("must be async generator object")
-            .queue
-            .pop_front()
-            .expect("must have item in queue");
-        AsyncGenerator::complete_step(&next, completion, false, None, context);
-
-        let mut generator_object_mut = async_gen.borrow_mut();
-        let gen = generator_object_mut
-            .as_async_generator_mut()
-            .expect("must be async generator object");
-
-        if let Some(next) = gen.queue.front() {
-            let (completion, r#return) = &next.completion;
-            if *r#return {
-                let value = match completion {
-                    Ok(value) => value.clone(),
-                    Err(e) => e.clone().to_opaque(context),
-                };
-                context.vm.push(value);
-                context.vm.frame_mut().pc = return_gen;
-            } else {
-                context.vm.push(completion.clone()?);
-            }
-            Ok(CompletionType::Normal)
-        } else {
-            gen.state = AsyncGeneratorState::SuspendedYield;
-            context.vm.push(JsValue::undefined());
-            context.vm.frame_mut().r#yield = true;
-            Ok(CompletionType::Return)
-        }
+        Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/generator/yield_stm.rs
+++ b/boa_engine/src/vm/opcode/generator/yield_stm.rs
@@ -1,25 +1,87 @@
 use crate::{
-    builtins::iterable::create_iter_result_object,
-    vm::{opcode::Operation, CompletionType},
-    Context, JsResult,
+    builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
+    vm::{opcode::Operation, CompletionRecord, CompletionType, GeneratorResumeKind},
+    Context, JsResult, JsValue,
 };
 
-/// `Yield` implements the Opcode Operation for `Opcode::Yield`
+/// `GeneratorYield` implements the Opcode Operation for `Opcode::GeneratorYield`
 ///
 /// Operation:
-///  - Yield from the current execution.
+///  - Yield from the current generator execution.
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct Yield;
+pub(crate) struct GeneratorYield;
 
-impl Operation for Yield {
-    const NAME: &'static str = "Yield";
-    const INSTRUCTION: &'static str = "INST - Yield";
+impl Operation for GeneratorYield {
+    const NAME: &'static str = "GeneratorYield";
+    const INSTRUCTION: &'static str = "INST - GeneratorYield";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        context.vm.frame_mut().r#yield = true;
+        Ok(CompletionType::Return)
+    }
+}
+
+/// `AsyncGeneratorYield` implements the Opcode Operation for `Opcode::AsyncGeneratorYield`
+///
+/// Operation:
+///  - Yield from the current async generator execution.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct AsyncGeneratorYield;
+
+impl Operation for AsyncGeneratorYield {
+    const NAME: &'static str = "AsyncGeneratorYield";
+    const INSTRUCTION: &'static str = "INST - AsyncGeneratorYield";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let value = context.vm.pop();
-        let value = create_iter_result_object(value, false, context);
-        context.vm.push(value);
-        context.vm.frame_mut().r#yield = true;
-        Ok(CompletionType::Return)
+
+        let async_gen = context
+            .vm
+            .frame()
+            .async_generator
+            .clone()
+            .expect("`AsyncGeneratorYield` must only be called inside async generators");
+        let completion = Ok(value);
+        let next = async_gen
+            .borrow_mut()
+            .as_async_generator_mut()
+            .expect("must be async generator object")
+            .queue
+            .pop_front()
+            .expect("must have item in queue");
+
+        // TODO: 7. Let previousContext be the second to top element of the execution context stack.
+        AsyncGenerator::complete_step(&next, completion, false, None, context);
+
+        let mut generator_object_mut = async_gen.borrow_mut();
+        let gen = generator_object_mut
+            .as_async_generator_mut()
+            .expect("must be async generator object");
+
+        if let Some(next) = gen.queue.front() {
+            let resume_kind = match next.completion.clone() {
+                CompletionRecord::Normal(val) => {
+                    context.vm.push(val);
+                    GeneratorResumeKind::Normal
+                }
+                CompletionRecord::Return(val) => {
+                    context.vm.push(val);
+                    GeneratorResumeKind::Return
+                }
+                CompletionRecord::Throw(err) => {
+                    let err = err.to_opaque(context);
+                    context.vm.push(err);
+                    GeneratorResumeKind::Throw
+                }
+            };
+
+            context.vm.frame_mut().generator_resume_kind = resume_kind;
+
+            Ok(CompletionType::Normal)
+        } else {
+            gen.state = AsyncGeneratorState::SuspendedYield;
+            context.vm.push(JsValue::undefined());
+            GeneratorYield::execute(context)
+        }
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/for_in.rs
+++ b/boa_engine/src/vm/opcode/iteration/for_in.rs
@@ -1,5 +1,5 @@
 use crate::{
-    builtins::object::for_in_iterator::ForInIterator,
+    builtins::{iterable::IteratorRecord, object::for_in_iterator::ForInIterator},
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsValue,
 };
@@ -24,8 +24,12 @@ impl Operation for CreateForInIterator {
             .get("next", context)
             .expect("ForInIterator must have a `next` method");
 
-        context.vm.push(iterator);
-        context.vm.push(next_method);
+        context
+            .vm
+            .frame_mut()
+            .iterators
+            .push(IteratorRecord::new(iterator, next_method));
+
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/get.rs
+++ b/boa_engine/src/vm/opcode/iteration/get.rs
@@ -18,8 +18,7 @@ impl Operation for GetIterator {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let object = context.vm.pop();
         let iterator = object.get_iterator(context, None, None)?;
-        context.vm.push(iterator.iterator().clone());
-        context.vm.push(iterator.next_method().clone());
+        context.vm.frame_mut().iterators.push(iterator);
         Ok(CompletionType::Normal)
     }
 }
@@ -38,8 +37,7 @@ impl Operation for GetAsyncIterator {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let object = context.vm.pop();
         let iterator = object.get_iterator(context, Some(IteratorHint::Async), None)?;
-        context.vm.push(iterator.iterator().clone());
-        context.vm.push(iterator.next_method().clone());
+        context.vm.frame_mut().iterators.push(iterator);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/iterator.rs
+++ b/boa_engine/src/vm/opcode/iteration/iterator.rs
@@ -1,7 +1,7 @@
 use std::matches;
 
 use crate::{
-    builtins::Array,
+    builtins::{iterable::create_iter_result_object, Array},
     js_string,
     vm::{opcode::Operation, CompletionType, GeneratorResumeKind},
     Context, JsResult,
@@ -272,6 +272,29 @@ impl Operation for IteratorStackEmpty {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let is_empty = context.vm.frame().iterators.is_empty();
         context.vm.push(is_empty);
+        Ok(CompletionType::Normal)
+    }
+}
+
+/// `CreateIteratorResult` implements the Opcode Operation for `Opcode::CreateIteratorResult`
+///
+/// Operation:
+/// -  Creates a new iterator result object
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CreateIteratorResult;
+
+impl Operation for CreateIteratorResult {
+    const NAME: &'static str = "CreateIteratorResult";
+    const INSTRUCTION: &'static str = "INST - CreateIteratorResult";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let value = context.vm.pop();
+        let done = context.vm.read::<u8>() != 0;
+
+        let result = create_iter_result_object(value, done, context);
+
+        context.vm.push(result);
+
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -4,6 +4,29 @@ use crate::{
     Context, JsResult,
 };
 
+/// `IteratorLoopStart` implements the Opcode Operation for `Opcode::IteratorLoopStart`
+///
+/// Operation:
+///  - Push iterator loop start marker.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct IteratorLoopStart;
+
+impl Operation for IteratorLoopStart {
+    const NAME: &'static str = "IteratorLoopStart";
+    const INSTRUCTION: &'static str = "INST - IteratorLoopStart";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let start = context.vm.read::<u32>();
+        let exit = context.vm.read::<u32>();
+
+        // Create and push loop evironment entry.
+        let entry = EnvStackEntry::new(start, exit)
+            .with_iterator_loop_flag(1, context.vm.frame().iterators.len() - 1);
+        context.vm.frame_mut().env_stack.push(entry);
+        Ok(CompletionType::Normal)
+    }
+}
+
 /// `LoopStart` implements the Opcode Operation for `Opcode::LoopStart`
 ///
 /// Operation:

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -21,7 +21,7 @@ impl Operation for IteratorLoopStart {
 
         // Create and push loop evironment entry.
         let entry = EnvStackEntry::new(start, exit)
-            .with_iterator_loop_flag(1, context.vm.frame().iterators.len() - 1);
+            .with_iterator_loop_flag(1, (context.vm.frame().iterators.len() - 1) as u32);
         context.vm.frame_mut().env_stack.push(entry);
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1379,7 +1379,9 @@ generate_impl! {
 
         /// Push loop start marker.
         ///
-        /// Operands: Exit Address: `u32`
+        /// Operands:
+        /// - start: `u32`
+        /// - exit: `u32`
         ///
         /// Stack: **=>**
         LoopStart,
@@ -1428,7 +1430,9 @@ generate_impl! {
 
         /// Push iterator loop start marker.
         ///
-        /// Operands: Exit Address: `u32`
+        /// Operands:
+        /// - start: `u32`
+        /// - exit: `u32`
         ///
         /// Stack: **=>**
         IteratorLoopStart,

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1421,82 +1421,110 @@ generate_impl! {
 
         /// Creates the ForInIterator of an object.
         ///
-        /// Stack: object **=>** iterator, next_method
+        /// Stack: object **=>**
+        ///
+        /// Iterator Stack: `iterator`
         CreateForInIterator,
+
+        /// Push iterator loop start marker.
+        ///
+        /// Operands: Exit Address: `u32`
+        ///
+        /// Stack: **=>**
+        IteratorLoopStart,
 
         /// Gets the iterator of an object.
         ///
         /// Operands:
         ///
-        /// Stack: object **=>** iterator, next_method
+        /// Stack: object **=>**
+        ///
+        /// Iterator Stack: `iterator`
         GetIterator,
 
         /// Gets the async iterator of an object.
         ///
         /// Operands:
         ///
-        /// Stack: object **=>** iterator, next_method
+        /// Stack: object **=>**
+        ///
+        /// Iterator Stack: `iterator`
         GetAsyncIterator,
 
-        /// Calls the `next` method of `iterator` and puts its return value on the stack.
+        /// Calls the `next` method of `iterator`, updating its record with the next value.
         ///
         /// Operands:
         ///
-        /// Stack: iterator, next_method **=>** iterator, next_method, next_value
+        /// Iterator Stack: `iterator` **=>** `iterator`
         IteratorNext,
 
-        /// Calls the `next` method of `iterator`, puts its return value on the stack
-        /// and sets the `[[Done]]` value of the iterator on the call frame.
+        /// Returns `true` if the current iterator is done, or `false` otherwise
+        ///
+        /// Stack: **=>** done
+        ///
+        /// Iterator Stack: `iterator` **=>** `iterator`
+        IteratorDone,
+
+        /// Finishes the call to `Opcode::IteratorNext` within a `for await` loop by setting the current
+        /// result of the current iterator.
         ///
         /// Operands:
         ///
-        /// Stack: iterator, next_method **=>** iterator, next_method, next_value
-        IteratorNextSetDone,
+        /// Stack: `next_result` **=>**
+        ///
+        /// Iterator Stack: iterator **=>** iterator
+        IteratorFinishAsyncNext,
 
-        /// Gets the `value` and `done` properties of an iterator result.
+        ///  - Gets the `value` property of the current iterator record.
         ///
-        /// Stack: next_result **=>** done, next_value
-        IteratorUnwrapNext,
+        /// Stack: **=>** `value`
+        ///
+        /// Iterator Stack: `iterator` **=>** `iterator`
+        IteratorValue,
 
-        /// Gets the `value` property of an iterator result.
+        ///  - Gets the last iteration result of the current iterator record.
         ///
-        /// Stack: next_result **=>** next_value
-        IteratorUnwrapValue,
-
-        /// Gets the `value` and `done` properties of an iterator result, or jump to `address` if
-        /// `done` is true.
+        /// Stack: **=>** `result`
         ///
-        /// Operands: address: `u32`
-        ///
-        /// Stack: next_result **=>** done, next_value ( if done != true  )
-        IteratorUnwrapNextOrJump,
+        /// Iterator Stack: `iterator` **=>** `iterator`
+        IteratorResult,
 
         /// Consume the iterator and construct and array with all the values.
         ///
         /// Operands:
         ///
-        /// Stack: iterator, next_method **=>** iterator, next_method, array
+        /// Stack: **=>** array
+        ///
+        /// Iterator Stack: `iterator` **=>** `iterator`
         IteratorToArray,
-
-        /// Push an iterator to the call frame close iterator stack.
-        ///
-        /// Operands:
-        ///
-        /// Stack: iterator, next_method => iterator, next_method
-        IteratorClosePush,
 
         /// Pop an iterator from the call frame close iterator stack.
         ///
-        /// Operands:
+        /// Iterator Stack:
+        /// - `iterator` **=>**
+        IteratorPop,
+
+        /// Pushes `true` to the stack if the iterator stack is empty.
         ///
         /// Stack:
-        IteratorClosePop,
+        /// - **=>** `is_empty`
+        ///
+        /// Iterator Stack:
+        /// - **=>**
+        IteratorStackEmpty,
+
+        /// Calls `return` on the current iterator and returns the result.
+        ///
+        /// Stack: **=>** return_val (if return is a method), is_return_method
+        ///
+        /// Iterator Stack: `iterator` **=>**
+        IteratorReturn,
 
         /// Concat multiple stack objects into a string.
         ///
         /// Operands: value_count: `u32`
         ///
-        /// Stack: value_1,...value_n **=>** string
+        /// Stack: `value_1`,...`value_n` **=>** `string`
         ConcatToString,
 
         /// Call RequireObjectCoercible on the stack value.
@@ -1576,26 +1604,19 @@ generate_impl! {
         /// Stack: **=>**
         GeneratorAsyncResumeYield,
 
-        /// Delegates the current generator function to another iterator.
-        ///
-        /// Operands: done_address: `u32`
-        ///
-        /// Stack: iterator, next_method, received **=>** iterator, next_method
-        GeneratorNextDelegate,
-
         /// Delegates the current async generator function to another iterator.
         ///
         /// Operands: throw_method_undefined: `u32`, return_method_undefined: `u32`
         ///
-        /// Stack: iterator, next_method, received **=>** iterator, next_method, is_return, result
-        GeneratorAsyncDelegateNext,
+        /// Stack: received **=>** result
+        GeneratorDelegateNext,
 
         /// Resume the async generator with yield delegate logic after it awaits a value.
         ///
-        /// Operands: skip_yield: `u32`, normal_completion: `u32`, exit: `u32`
+        /// Operands: return: `u32`, exit: `u32`
         ///
         /// Stack: is_return, received **=>** value
-        GeneratorAsyncDelegateResume,
+        GeneratorDelegateResume,
 
         /// Stops the current async function and schedules it to resume later.
         ///
@@ -1770,8 +1791,6 @@ generate_impl! {
         Reserved54 => Reserved,
         /// Reserved [`Opcode`].
         Reserved55 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved56 => Reserved,
     }
 }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1807,10 +1807,6 @@ generate_impl! {
         Reserved52 => Reserved,
         /// Reserved [`Opcode`].
         Reserved53 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved54 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved55 => Reserved,
     }
 }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1513,6 +1513,16 @@ generate_impl! {
         /// - **=>**
         IteratorStackEmpty,
 
+        /// Creates a new iterator result object.
+        ///
+        /// Operands:
+        /// - done: bool (codified as u8 with `0` -> `false` and `!0` -> `true`)
+        ///
+        /// Stack:
+        /// - value **=>**
+        ///
+        CreateIteratorResult,
+
         /// Calls `return` on the current iterator and returns the result.
         ///
         /// Stack: **=>** return_val (if return is a method), is_return_method
@@ -1569,12 +1579,12 @@ generate_impl! {
         /// Stack: **=>**
         PopOnReturnSub,
 
-        /// Yield from the current execution.
+        /// Yields from the current generator execution.
         ///
         /// Operands:
         ///
-        /// Stack: value **=>**
-        Yield,
+        /// Stack: value **=>** received
+        GeneratorYield,
 
         /// Resumes the current generator function.
         ///
@@ -1590,19 +1600,29 @@ generate_impl! {
         /// Stack: **=>**
         GeneratorResumeReturn,
 
-        /// Resumes the current generator function.
+        /// Yields from the current async generator execution.
         ///
-        /// Operands: skip_yield: u32, skip_yield_await: u32
+        /// Operands:
         ///
-        /// Stack: received **=>** `Option<value>`
-        AsyncGeneratorNext,
+        /// Stack: value **=>** received
+        AsyncGeneratorYield,
 
-        /// Resumes the current async generator function after a yield.
+        /// Jumps to the specified instruction for each resume kind.
         ///
-        /// Operands: normal_completion: u32
+        /// Operands:
+        /// - normal: u32,
+        /// - throw: u32,
+        /// - return: u32,
         ///
-        /// Stack: **=>**
-        GeneratorAsyncResumeYield,
+        /// Stack:
+        GeneratorJumpOnResumeKind,
+
+        /// Sets the current generator resume kind to `Return`.
+        ///
+        /// Operands:
+        ///
+        /// Stack:
+        GeneratorSetReturn,
 
         /// Delegates the current async generator function to another iterator.
         ///
@@ -1622,7 +1642,7 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: promise **=>**
+        /// Stack: promise **=>** received
         Await,
 
         /// Push the current new target to the stack.


### PR DESCRIPTION
This Pull Request fixes a bunch of iterator tests that were failing because we handled async iterators and iterators differently with respect to closes and returns.

- Unifies compilation logic for iterators and async iterators.
- Refactors `IteratorRecord` to be able to use it as iterator state at vm execution.
- Avoids using the values stack for iterator tracking, instead using an `IteratorRecord` stack.