### PR TITLE
Fix prompt on windows

### DIFF
--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -77,7 +77,7 @@ use boa_engine::{
 };
 use boa_runtime::Console;
 use clap::{Parser, ValueEnum, ValueHint};
-use colored::{Color, Colorize};
+use colored::Colorize;
 use debug::init_boa_debug_object;
 use rustyline::{config::Config, error::ReadlineError, EditMode, Editor};
 use std::{
@@ -94,8 +94,6 @@ static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 /// CLI configuration for Boa.
 static CLI_HISTORY: &str = ".boa_history";
-
-const READLINE_COLOR: Color = Color::Cyan;
 
 // Added #[allow(clippy::option_option)] because to StructOpt an Option<Option<T>>
 // is an optional argument that optionally takes a value ([--opt=[val]]).
@@ -419,12 +417,11 @@ fn main() -> Result<(), io::Error> {
             ReadlineError::Io(e) => e,
             e => io::Error::new(io::ErrorKind::Other, e),
         })?;
-        editor.set_helper(Some(helper::RLHelper::new()));
-
-        let readline = ">> ".color(READLINE_COLOR).bold().to_string();
+        let readline = ">> ";
+        editor.set_helper(Some(helper::RLHelper::new(readline)));
 
         loop {
-            match editor.readline(&readline) {
+            match editor.readline(readline) {
                 Ok(line) if line == ".exit" => break,
                 Err(ReadlineError::Interrupted | ReadlineError::Eof) => break,
 

--- a/boa_engine/src/optimizer/mod.rs
+++ b/boa_engine/src/optimizer/mod.rs
@@ -16,7 +16,7 @@ bitflags! {
         /// Print statistics to `stdout`.
         const STATISTICS = 0b0000_0001;
 
-        /// Apply contant folding optimization.
+        /// Apply constant folding optimization.
         const CONSTANT_FOLDING = 0b0000_0010;
 
         /// Apply all optimizations.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->


It changes the following:

- Moves prompt highlighting to the helper class
- Fixes prompt width calculation on windows

### Details
In rustyline, there are two implementations of `calculate_position`, one for [windows](https://github.com/kkawakam/rustyline/blob/master/src/tty/windows.rs#L469) and one for [unix](https://github.com/kkawakam/rustyline/blob/master/src/tty/unix.rs#L1020). The one for unix support ignoring ANSI escape sequences when calculating width, but the one on windows does not, [by design](https://github.com/kkawakam/rustyline/pull/215#issuecomment-491945339).

This caused an issue where the cursor would be placed 12 columns in, instead of 3.

#### Before
![before](https://github.com/boa-dev/boa/assets/47866566/bea503d2-f30d-45a1-bd3b-3d34822ee632)
#### After
![after](https://github.com/boa-dev/boa/assets/47866566/9f158a7b-f498-4ab5-a951-0cbf1ab1d451)
