### PR TITLE
Fix WASM playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,6 +604,7 @@ version = "0.16.0"
 dependencies = [
  "boa_engine",
  "chrono",
+ "console_error_panic_hook",
  "getrandom",
  "wasm-bindgen",
 ]
@@ -934,6 +935,16 @@ dependencies = [
  "lazy_static",
  "libc",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -16,6 +16,7 @@ boa_engine.workspace = true
 wasm-bindgen = "0.2.86"
 getrandom = { version = "0.2.9", features = ["js"] }
 chrono = { version = "0.4.26", features = ["clock", "std", "wasmbind"] }
+console_error_panic_hook = "0.1.7"
 
 [features]
 default = ["boa_engine/annex-b"]

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -63,6 +63,11 @@ use chrono as _;
 use getrandom as _;
 use wasm_bindgen::prelude::*;
 
+#[wasm_bindgen(start)]
+fn main() {
+    console_error_panic_hook::set_once();
+}
+
 /// Evaluate the given ECMAScript code.
 #[wasm_bindgen]
 pub fn evaluate(src: &str) -> Result<String, JsValue> {


### PR DESCRIPTION
This Pull Request fixes #2991.

It changes the following:

- Creates a new `IdleModuleLoader` that rejects all load requests.
- Makes `IdleModuleLoader` the default loader if `SimpleModuleLoader` returns a creation error.
