### PR TITLE
Allow `true`, `false` and `null` in object patterns

### DIFF
--- a/boa_engine/src/tests/mod.rs
+++ b/boa_engine/src/tests/mod.rs
@@ -481,3 +481,21 @@ fn template_literal() {
         "result: 10 and 20",
     )]);
 }
+
+#[test]
+fn null_bool_in_object_pattern() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            let obj = {
+                null: 0,
+                true: 10,
+                false: 100
+            };
+
+            let { null: a, true: b, false: c } = obj;
+        "#}),
+        TestAction::assert_eq("a", 0),
+        TestAction::assert_eq("b", 10),
+        TestAction::assert_eq("c", 100),
+    ]);
+}

--- a/boa_parser/src/parser/statement/mod.rs
+++ b/boa_parser/src/parser/statement/mod.rs
@@ -529,6 +529,8 @@ where
                         | TokenKind::NumericLiteral(_) => true,
                         TokenKind::IdentifierName(_) if next_token_is_colon => true,
                         TokenKind::Keyword(_) if next_token_is_colon => true,
+                        TokenKind::BooleanLiteral(_) if next_token_is_colon => true,
+                        TokenKind::NullLiteral(_) if next_token_is_colon => true,
                         _ => false,
                     };
 


### PR DESCRIPTION
This Pull Request allows using certain valid keywords inside patterns.