### PR TITLE
Fix panic in constructor call

### DIFF
--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1405,10 +1405,11 @@ impl JsObject {
                 );
 
                 if code.has_parameters_env_bindings() {
+                    last_env -= 1;
                     context
                         .vm
                         .environments
-                        .push_lexical(code.compile_environments[0].clone());
+                        .push_lexical(code.compile_environments[last_env].clone());
                 }
 
                 // Taken from: `FunctionDeclarationInstantiation` abstract function.

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -309,3 +309,18 @@ fn recursion_runtime_limit() {
         ),
     ]);
 }
+
+#[test]
+fn arguments_object_constructor_valid_index() {
+    run_test_actions([TestAction::assert_eq(
+        indoc! {r#"
+            let args;
+            function F(a = 1) {
+                args = arguments;
+            }
+            new F();
+            typeof args
+        "#},
+        "object",
+    )]);
+}


### PR DESCRIPTION
This Pull Request changes the following:

- Fix a bug in the constructor execution that leads to a panic when an arguments object is needed. In contrast to the call execution the wrong environment is being pushed.
