### PR TITLE
Correctly parse `yield import(..)` expressions

### DIFF
--- a/boa_parser/src/parser/expression/assignment/yield.rs
+++ b/boa_parser/src/parser/expression/assignment/yield.rs
@@ -99,7 +99,8 @@ where
                 | Keyword::Function
                 | Keyword::Class
                 | Keyword::Async
-                | Keyword::Super,
+                | Keyword::Super
+                | Keyword::Import,
                 _,
             ))
             | TokenKind::BooleanLiteral(_)


### PR DESCRIPTION
Very small change that allows `yield import(..)` expressions.
