### PR TITLE
Add convenience methods to `ModuleLoader`

### DIFF
--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -108,6 +108,26 @@ pub trait ModuleLoader {
         context: &mut Context<'_>,
     );
 
+    /// Registers a new module into the module loader.
+    ///
+    /// This is a convenience method for module loaders caching already parsed modules, since it
+    /// allows registering a new module through the `&dyn ModuleLoader` provided by
+    /// [`Context::module_loader`].
+    ///
+    /// Does nothing by default.
+    fn register_module(&self, _specifier: JsString, _module: Module) {}
+
+    /// Gets the module associated with the provided specifier.
+    ///
+    /// This is a convenience method for module loaders caching already parsed modules, since it
+    /// allows getting a cached module through the `&dyn ModuleLoader` provided by
+    /// [`Context::module_loader`].
+    ///
+    /// Returns `None` by default.
+    fn get_module(&self, _specifier: JsString) -> Option<Module> {
+        None
+    }
+
     /// Host hooks [`HostGetImportMetaProperties ( moduleRecord )`][meta] and
     /// [`HostFinalizeImportMeta ( importMeta, moduleRecord )`][final].
     ///
@@ -232,6 +252,22 @@ impl ModuleLoader for SimpleModuleLoader {
         })();
 
         finish_load(result, context);
+    }
+
+    // TODO: Try to unify `ModuleLoader::register_module` with `SimpleModuleLoader::insert`.
+    fn register_module(&self, _specifier: JsString, _module: Module) {
+        panic!(
+            "`SimpleModuleLoader` uses paths to cache the modules instead of specifiers.
+        To register a module, you need to use the `SimpleModuleLoader::insert` method."
+        )
+    }
+
+    // TODO: Try to unify `ModuleLoader::get_module` with `SimpleModuleLoader::get`.
+    fn get_module(&self, _specifier: JsString) -> Option<Module> {
+        panic!(
+            "`SimpleModuleLoader` uses paths to cache the modules instead of specifiers.
+        To get a module, you need to use the `SimpleModuleLoader::get` method."
+        )
     }
 }
 

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -173,6 +173,12 @@ impl ModuleLoader for IdleModuleLoader {
 }
 
 /// A simple module loader that loads modules relative to a root path.
+///
+/// # Note
+///
+/// This loader only works by using the type methods [`SimpleModuleLoader::insert`] and
+/// [`SimpleModuleLoader::get`]. The utility methods on [`ModuleLoader`] don't work at the moment,
+/// but we'll unify both APIs in the future.
 #[derive(Debug)]
 pub struct SimpleModuleLoader {
     root: PathBuf,
@@ -252,22 +258,6 @@ impl ModuleLoader for SimpleModuleLoader {
         })();
 
         finish_load(result, context);
-    }
-
-    // TODO: Try to unify `ModuleLoader::register_module` with `SimpleModuleLoader::insert`.
-    fn register_module(&self, _specifier: JsString, _module: Module) {
-        panic!(
-            "`SimpleModuleLoader` uses paths to cache the modules instead of specifiers.
-        To register a module, you need to use the `SimpleModuleLoader::insert` method."
-        )
-    }
-
-    // TODO: Try to unify `ModuleLoader::get_module` with `SimpleModuleLoader::get`.
-    fn get_module(&self, _specifier: JsString) -> Option<Module> {
-        panic!(
-            "`SimpleModuleLoader` uses paths to cache the modules instead of specifiers.
-        To get a module, you need to use the `SimpleModuleLoader::get` method."
-        )
     }
 }
 

--- a/boa_examples/src/bin/modules.rs
+++ b/boa_examples/src/bin/modules.rs
@@ -44,8 +44,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         module.clone(),
     );
 
-    // The lifecycle of the module is tracked using promises, which can be a bit cumbersome
-    // for simple uses but that use case is better suited by the `Module::load_link_evaluate` method.
+    // The lifecycle of the module is tracked using promises which can be a bit cumbersome to use.
+    // If you just want to directly execute a module, you can use the `Module::load_link_evaluate`
+    // method to skip all the boilerplate.
     // This does the full version for demonstration purposes.
     //
     // parse -> load -> link -> evaluate


### PR DESCRIPTION
While implementing an example of async module fetching, I realized it would be useful to have a way to insert a module through a `&dyn ModuleLoader`. This PR provides that API.

~~Drafting because I'm still experimenting with the final design of the API.~~