### PR TITLE
Allow awaiting `JsPromise` from Rust code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,7 @@ dependencies = [
  "dashmap",
  "fast-float",
  "float-cmp",
+ "futures-lite",
  "icu_calendar",
  "icu_casemapping",
  "icu_collator",

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -99,6 +99,7 @@ criterion = "0.4.0"
 float-cmp = "0.9.0"
 indoc = "2.0.1"
 textwrap = "0.16.0"
+futures-lite = "1.13.0"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 jemallocator = "0.5.0"

--- a/boa_engine/src/native_function.rs
+++ b/boa_engine/src/native_function.rs
@@ -150,17 +150,13 @@ impl NativeFunction {
     /// fully lazy, which makes `test` equivalent to something like:
     ///
     /// ```
-    /// # use boa_engine::{
-    /// #   JsValue,
-    /// #   Context,
-    /// #   JsResult,
-    /// #   NativeFunction
-    /// # };
-    /// async fn test(
+    /// # use std::future::Future;
+    /// # use boa_engine::{JsValue, Context, JsResult};
+    /// fn test<'a>(
     ///     _this: &JsValue,
-    ///     args: &[JsValue],
+    ///     args: &'a [JsValue],
     ///     _context: &mut Context<'_>,
-    /// ) -> JsResult<JsValue> {
+    /// ) -> impl Future<Output = JsResult<JsValue>> + 'a {
     ///     async move {
     ///         let arg = args.get(0).cloned();
     ///         std::future::ready(()).await;

--- a/boa_engine/src/object/builtins/jspromise.rs
+++ b/boa_engine/src/object/builtins/jspromise.rs
@@ -933,7 +933,7 @@ impl JsPromise {
     /// ```
     pub fn into_js_future(self, context: &mut Context<'_>) -> JsResult<JsFuture> {
         // Mostly based from:
-        // https://rustwasm.github.io/wasm-bindgen/api/src/wasm_bindgen_futures/lib.rs.html#109-168
+        // https://docs.rs/wasm-bindgen-futures/0.4.37/src/wasm_bindgen_futures/lib.rs.html#109-168
 
         fn finish(state: &GcRefCell<Inner>, val: JsResult<JsValue>) {
             let task = {
@@ -1061,7 +1061,7 @@ struct Inner {
 }
 
 // Taken from:
-// https://rustwasm.github.io/wasm-bindgen/api/src/wasm_bindgen_futures/lib.rs.html#171-187
+// https://docs.rs/wasm-bindgen-futures/0.4.37/src/wasm_bindgen_futures/lib.rs.html#171-187
 impl Future for JsFuture {
     type Output = JsResult<JsValue>;
 

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -1,7 +1,7 @@
 //! Boa's **`boa_icu_provider`** exports the default data provider used by its `Intl` implementation.
 //!
 //! # Crate Overview
-//! This crate exports the function [`buffer`], which contains an extensive dataset of locale data to
+//! This crate exports the function `buffer`, which contains an extensive dataset of locale data to
 //! enable `Intl` functionality in the engine. The set of locales included is precisely the ["modern"]
 //! subset of locales in the [Unicode Common Locale Data Repository][cldr].
 //!


### PR DESCRIPTION
Should be mostly useful for consumers of the `JobQueue::enqueue_future_job` API, since they can now await for certain promises inside `async` blocks and functions.

Changes:
- Adds a new `JsFuture` type that implements `Future`.
- Adds a new `JsPromise::into_js_future` method.
- Rewrites the caveats section of `NativeFunction::from_async_fn`, since the old explanation was wrong.
- Adds a new `JsPromise::from_future` constructor.
- Improves some promise code.