### PR TITLE
Make `IntegerIndexed::byte_offset` public

### DIFF
--- a/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
+++ b/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
@@ -66,7 +66,7 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's byte offset.
-    pub(crate) const fn byte_offset(&self) -> u64 {
+    pub const fn byte_offset(&self) -> u64 {
         self.byte_offset
     }
 


### PR DESCRIPTION
This allows querying the full range of the `TypedArray` in the underlying `ArrayBuffer`.