### PR TITLE
Fix panics on empty return values

### DIFF
--- a/boa_ast/src/statement/mod.rs
+++ b/boa_ast/src/statement/mod.rs
@@ -162,17 +162,6 @@ impl Statement {
             _ => false,
         }
     }
-
-    /// Returns `true` if the statement returns a value.
-    #[inline]
-    #[must_use]
-    pub const fn returns_value(&self) -> bool {
-        match self {
-            Self::Block(block) if block.statement_list().statements().is_empty() => false,
-            Self::Empty | Self::Var(_) | Self::Break(_) | Self::Continue(_) => false,
-            _ => true,
-        }
-    }
 }
 
 impl ToIndentedString for Statement {

--- a/boa_engine/src/bytecompiler/statement/if.rs
+++ b/boa_engine/src/bytecompiler/statement/if.rs
@@ -1,12 +1,12 @@
 use crate::{bytecompiler::ByteCompiler, vm::Opcode};
-use boa_ast::statement::If;
+use boa_ast::{operations::returns_value, statement::If};
 
 impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_if(&mut self, node: &If, use_expr: bool) {
         self.compile_expr(node.cond(), true);
         let jelse = self.jump_if_false();
 
-        if !node.body().returns_value() {
+        if !returns_value(node.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(node.body(), true);
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
                 self.emit_opcode(Opcode::PushUndefined);
             }
             Some(else_body) => {
-                if !else_body.returns_value() {
+                if !returns_value(else_body) {
                     self.emit_opcode(Opcode::PushUndefined);
                 }
                 self.compile_stmt(else_body, true);

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -1,6 +1,6 @@
 use boa_ast::{
     declaration::Binding,
-    operations::bound_names,
+    operations::{bound_names, returns_value},
     statement::{
         iteration::{ForLoopInitializer, IterableLoopInitializer},
         DoWhileLoop, ForInLoop, ForLoop, ForOfLoop, WhileLoop,
@@ -95,7 +95,7 @@ impl ByteCompiler<'_, '_> {
         }
         let exit = self.jump_if_false();
 
-        if !for_loop.body().returns_value() {
+        if !returns_value(for_loop.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(for_loop.body(), true);
@@ -229,7 +229,7 @@ impl ByteCompiler<'_, '_> {
             }
         }
 
-        if !for_in_loop.body().returns_value() {
+        if !returns_value(for_in_loop.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(for_in_loop.body(), true);
@@ -375,7 +375,7 @@ impl ByteCompiler<'_, '_> {
             }
         }
 
-        if !for_of_loop.body().returns_value() {
+        if !returns_value(for_of_loop.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(for_of_loop.body(), true);
@@ -416,7 +416,7 @@ impl ByteCompiler<'_, '_> {
         self.compile_expr(while_loop.condition(), true);
         let exit = self.jump_if_false();
 
-        if !while_loop.body().returns_value() {
+        if !returns_value(while_loop.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(while_loop.body(), true);
@@ -454,7 +454,7 @@ impl ByteCompiler<'_, '_> {
 
         self.patch_jump(initial_label);
 
-        if !do_while_loop.body().returns_value() {
+        if !returns_value(do_while_loop.body()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(do_while_loop.body(), true);

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -1,5 +1,5 @@
 use crate::{bytecompiler::ByteCompiler, vm::Opcode};
-use boa_ast::statement::Switch;
+use boa_ast::{operations::returns_value, statement::Switch};
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`Switch`] `boa_ast` node
@@ -44,7 +44,7 @@ impl ByteCompiler<'_, '_> {
             };
             self.patch_jump(label);
             self.compile_statement_list(case.body(), true, true);
-            if !case.body().statements().is_empty() {
+            if returns_value(case) {
                 self.emit_opcode(Opcode::LoopUpdateReturnValue);
             }
         }

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use boa_ast::{
     declaration::Binding,
-    operations::bound_names,
+    operations::{bound_names, returns_value},
     statement::{Catch, Finally, Try},
 };
 
@@ -21,7 +21,7 @@ impl ByteCompiler<'_, '_> {
         self.push_try_control_info(t.finally().is_some(), try_start);
 
         self.compile_block(t.block(), true);
-        if t.block().statement_list().statements().is_empty() {
+        if !returns_value(t.block()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         if !use_expr {
@@ -80,7 +80,7 @@ impl ByteCompiler<'_, '_> {
         }
 
         self.compile_block(catch.block(), true);
-        if catch.block().statement_list().statements().is_empty() {
+        if !returns_value(catch.block()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         if !use_expr {
@@ -103,7 +103,7 @@ impl ByteCompiler<'_, '_> {
 
     pub(crate) fn compile_finally_stmt(&mut self, finally: &Finally, finally_end_label: Label) {
         self.compile_block(finally.block(), true);
-        if !finally.block().statement_list().statements().is_empty() {
+        if returns_value(finally.block()) {
             self.emit_opcode(Opcode::Pop);
         }
 

--- a/boa_engine/src/bytecompiler/statement/with.rs
+++ b/boa_engine/src/bytecompiler/statement/with.rs
@@ -1,5 +1,5 @@
 use crate::{bytecompiler::ByteCompiler, vm::Opcode};
-use boa_ast::statement::With;
+use boa_ast::{operations::returns_value, statement::With};
 
 impl ByteCompiler<'_, '_> {
     /// Compile a [`With`] `boa_ast` node
@@ -8,7 +8,7 @@ impl ByteCompiler<'_, '_> {
         self.push_compile_environment(false);
         self.emit_opcode(Opcode::PushObjectEnvironment);
 
-        if !with.statement().returns_value() {
+        if !returns_value(with.statement()) {
             self.emit_opcode(Opcode::PushUndefined);
         }
         self.compile_stmt(with.statement(), true);

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -324,3 +324,36 @@ fn arguments_object_constructor_valid_index() {
         "object",
     )]);
 }
+
+#[test]
+fn empty_return_values() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"do {{}} while (false);"#}),
+        TestAction::run(indoc! {r#"do try {{}} catch {} while (false);"#}),
+        TestAction::run(indoc! {r#"do {} while (false);"#}),
+        TestAction::run(indoc! {r#"do try {{}{}} catch {} while (false);"#}),
+        TestAction::run(indoc! {r#"do {{}{}} while (false);"#}),
+        TestAction::run(indoc! {r#"do {;{}} while (false);"#}),
+        TestAction::run(indoc! {r#"do {e: {}} while (false);"#}),
+        TestAction::run(indoc! {r#"do {e: ;} while (false);"#}),
+        TestAction::run(indoc! {r#"do { break } while (false);"#}),
+        TestAction::run(indoc! {r#"while (true) a: break"#}),
+        TestAction::run(indoc! {r#"while (true) a: {"a"; break};"#}),
+        TestAction::run(indoc! {r#"do {"a";{}} while (false);"#}),
+        TestAction::run(indoc! {r#"
+            switch (false) {
+                default: {}
+            }
+        "#}),
+        TestAction::run(indoc! {r#"
+            switch (false) {
+                default: {}{}
+            }
+        "#}),
+        TestAction::run(indoc! {r#"
+            switch (false) {
+                default: ;{}{}
+            }
+        "#}),
+    ]);
+}


### PR DESCRIPTION
This adds and fixes some tests that caused panics on `main` and during the development of the fixes. All where found with the fuzzer. After running the fuzzer for some time I did not encounter any similar panics anymore.
