### PR TITLE
Make `Context` a trait

### DIFF
--- a/boa_cli/src/debug/function.rs
+++ b/boa_cli/src/debug/function.rs
@@ -50,7 +50,11 @@ fn flowgraph_parse_direction_option(value: &JsValue) -> JsResult<Direction> {
 }
 
 /// Get functions instruction flowgraph
-fn flowgraph(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn flowgraph(
+    _this: &JsValue,
+    args: &[JsValue],
+    context: &mut dyn Context<'_>,
+) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
         .with_message("expected function argument")
@@ -100,7 +104,7 @@ fn flowgraph(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> Js
     Ok(JsValue::new(result))
 }
 
-fn bytecode(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn bytecode(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
         .with_message("expected function argument")
@@ -140,7 +144,7 @@ fn set_trace_flag_in_function_object(object: &JsObject, value: bool) -> JsResult
 }
 
 /// Trace function.
-fn trace(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn trace(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0);
     let this = args.get_or_undefined(1);
 
@@ -159,7 +163,7 @@ fn trace(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<J
     result
 }
 
-fn traceable(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn traceable(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0);
     let traceable = args.get_or_undefined(1).to_boolean();
 
@@ -174,7 +178,7 @@ fn traceable(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsV
     Ok(value.clone())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(flowgraph), "flowgraph", 1)
         .function(NativeFunction::from_fn_ptr(bytecode), "bytecode", 1)

--- a/boa_cli/src/debug/gc.rs
+++ b/boa_cli/src/debug/gc.rs
@@ -1,12 +1,12 @@
 use boa_engine::{object::ObjectInitializer, Context, JsObject, JsResult, JsValue, NativeFunction};
 
 /// Trigger garbage collection.
-fn collect(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn collect(_: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     boa_gc::force_collect();
     Ok(JsValue::undefined())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(collect), "collect", 0)
         .build()

--- a/boa_cli/src/debug/limits.rs
+++ b/boa_cli/src/debug/limits.rs
@@ -4,23 +4,27 @@ use boa_engine::{
     Context, JsArgs, JsNativeError, JsObject, JsResult, JsValue, NativeFunction,
 };
 
-fn get_loop(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn get_loop(_: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let max = context.runtime_limits().loop_iteration_limit();
     Ok(JsValue::from(max))
 }
 
-fn set_loop(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn set_loop(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
     context.runtime_limits_mut().set_loop_iteration_limit(value);
     Ok(JsValue::undefined())
 }
 
-fn get_recursion(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn get_recursion(_: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let max = context.runtime_limits().recursion_limit();
     Ok(JsValue::from(max))
 }
 
-fn set_recursion(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn set_recursion(
+    _: &JsValue,
+    args: &[JsValue],
+    context: &mut dyn Context<'_>,
+) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
     let Ok(value) = value.try_into() else {
         return Err(
@@ -31,7 +35,7 @@ fn set_recursion(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> Js
     Ok(JsValue::undefined())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     let get_loop = FunctionObjectBuilder::new(context, NativeFunction::from_fn_ptr(get_loop))
         .name("get loop")
         .length(0)

--- a/boa_cli/src/debug/mod.rs
+++ b/boa_cli/src/debug/mod.rs
@@ -11,7 +11,7 @@ mod optimizer;
 mod realm;
 mod shape;
 
-fn create_boa_object(context: &mut Context<'_>) -> JsObject {
+fn create_boa_object(context: &mut dyn Context<'_>) -> JsObject {
     let function_module = function::create_object(context);
     let object_module = object::create_object(context);
     let shape_module = shape::create_object(context);
@@ -59,7 +59,7 @@ fn create_boa_object(context: &mut Context<'_>) -> JsObject {
         .build()
 }
 
-pub(crate) fn init_boa_debug_object(context: &mut Context<'_>) {
+pub(crate) fn init_boa_debug_object(context: &mut dyn Context<'_>) {
     let boa_object = create_boa_object(context);
     context
         .register_global_property(

--- a/boa_cli/src/debug/object.rs
+++ b/boa_cli/src/debug/object.rs
@@ -3,7 +3,7 @@ use boa_engine::{
 };
 
 /// Returns objects pointer in memory.
-fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn id(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
         .with_message("expected object argument")
@@ -20,7 +20,7 @@ fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
     Ok(format!("0x{:X}", ptr as usize).into())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(id), "id", 1)
         .build()

--- a/boa_cli/src/debug/optimizer.rs
+++ b/boa_cli/src/debug/optimizer.rs
@@ -8,7 +8,7 @@ use boa_engine::{
 fn get_constant_folding(
     _: &JsValue,
     _: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     Ok(context
         .optimizer_options()
@@ -19,7 +19,7 @@ fn get_constant_folding(
 fn set_constant_folding(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_boolean();
     let mut options = context.optimizer_options();
@@ -28,14 +28,18 @@ fn set_constant_folding(
     Ok(JsValue::undefined())
 }
 
-fn get_statistics(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn get_statistics(_: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     Ok(context
         .optimizer_options()
         .contains(OptimizerOptions::STATISTICS)
         .into())
 }
 
-fn set_statistics(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn set_statistics(
+    _: &JsValue,
+    args: &[JsValue],
+    context: &mut dyn Context<'_>,
+) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_boolean();
     let mut options = context.optimizer_options();
     options.set(OptimizerOptions::STATISTICS, value);
@@ -43,7 +47,7 @@ fn set_statistics(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> J
     Ok(JsValue::undefined())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     let get_constant_folding =
         FunctionObjectBuilder::new(context, NativeFunction::from_fn_ptr(get_constant_folding))
             .name("get constantFolding")

--- a/boa_cli/src/debug/realm.rs
+++ b/boa_cli/src/debug/realm.rs
@@ -1,13 +1,15 @@
-use boa_engine::{object::ObjectInitializer, Context, JsObject, JsResult, JsValue, NativeFunction};
+use boa_engine::{
+    object::ObjectInitializer, Context, DefaultContext, JsObject, JsResult, JsValue, NativeFunction,
+};
 
 /// Creates a new ECMAScript Realm and returns the global object of the realm.
-fn create(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
-    let context = &mut Context::default();
+fn create(_: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
+    let context: &dyn Context<'_> = &mut DefaultContext::default();
 
     Ok(context.global_object().into())
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(create), "create", 0)
         .build()

--- a/boa_cli/src/debug/shape.rs
+++ b/boa_cli/src/debug/shape.rs
@@ -16,7 +16,7 @@ fn get_object(args: &[JsValue], position: usize) -> JsResult<&JsObject> {
 }
 
 /// Returns object's shape pointer in memory.
-fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn id(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let object = get_object(args, 0)?;
     let object = object.borrow();
     let shape = object.shape();
@@ -24,7 +24,7 @@ fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
 }
 
 /// Returns object's shape type.
-fn r#type(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn r#type(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let object = get_object(args, 0)?;
     let object = object.borrow();
     let shape = object.shape();
@@ -38,7 +38,7 @@ fn r#type(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValu
 }
 
 /// Returns object's shape type.
-fn same(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+fn same(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
     let lhs = get_object(args, 0)?;
     let rhs = get_object(args, 1)?;
 
@@ -57,7 +57,7 @@ fn same(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue>
     Ok(JsValue::new(lhs_shape_ptr == rhs_shape_ptr))
 }
 
-pub(super) fn create_object(context: &mut Context<'_>) -> JsObject {
+pub(super) fn create_object(context: &mut dyn Context<'_>) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(id), "id", 1)
         .function(NativeFunction::from_fn_ptr(r#type), "type", 1)

--- a/boa_engine/benches/full.rs
+++ b/boa_engine/benches/full.rs
@@ -2,7 +2,7 @@
 
 use boa_engine::{
     context::DefaultHooks, object::shape::RootShape, optimizer::OptimizerOptions, realm::Realm,
-    script::Script, Context, Source,
+    script::Script, Context, DefaultContext, Source,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::hint::black_box;
@@ -27,7 +27,7 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let mut context = Context::default();
+                    let context: &mut dyn Context = &mut DefaultContext::default();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());
@@ -37,7 +37,7 @@ macro_rules! full_benchmarks {
                             Script::parse(
                                 black_box(Source::from_bytes(CODE)),
                                 None,
-                                &mut context,
+                                context,
                             ).unwrap()
                         })
                     });
@@ -48,7 +48,7 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let context = &mut Context::default();
+                    let context: &mut dyn Context = &mut DefaultContext::default();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());
@@ -70,7 +70,7 @@ macro_rules! full_benchmarks {
             $(
                 {
                     static CODE: &str = include_str!(concat!("bench_scripts/", stringify!($name), ".js"));
-                    let context = &mut Context::default();
+                    let context: &mut dyn Context = &mut DefaultContext::default();
 
                     // Disable optimizations
                     context.set_optimizer_options(OptimizerOptions::empty());

--- a/boa_engine/src/builtins/array/array_iterator.rs
+++ b/boa_engine/src/builtins/array/array_iterator.rs
@@ -82,11 +82,16 @@ impl ArrayIterator {
     pub(crate) fn create_array_iterator(
         array: JsObject,
         kind: PropertyNameKind,
-        context: &Context<'_>,
+        context: &dyn Context<'_>,
     ) -> JsValue {
         let array_iterator = JsObject::from_proto_and_data_with_shared_shape(
-            context.root_shape(),
-            context.intrinsics().objects().iterator_prototypes().array(),
+            context.as_raw_context().root_shape(),
+            context
+                .as_raw_context()
+                .intrinsics()
+                .objects()
+                .iterator_prototypes()
+                .array(),
             ObjectData::array_iterator(Self::new(array, kind)),
         );
         array_iterator.into()
@@ -103,7 +108,7 @@ impl ArrayIterator {
     pub(crate) fn next(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let mut array_iterator = this.as_object().map(JsObject::borrow_mut);
         let array_iterator = array_iterator
@@ -150,7 +155,10 @@ impl ArrayIterator {
             }
             PropertyNameKind::KeyAndValue => {
                 let element_value = array_iterator.array.get(index, context)?;
-                let result = Array::create_array_from_list([index.into(), element_value], context);
+                let result = Array::create_array_from_list(
+                    [index.into(), element_value],
+                    context.as_raw_context(),
+                );
                 Ok(create_iter_result_object(result.into(), false, context))
             }
         }

--- a/boa_engine/src/builtins/array/tests.rs
+++ b/boa_engine/src/builtins/array/tests.rs
@@ -870,7 +870,7 @@ fn array_spread_non_iterable() {
 #[test]
 fn get_relative_start() {
     #[track_caller]
-    fn assert(context: &mut Context<'_>, arg: Option<&JsValue>, len: u64, expected: u64) {
+    fn assert(context: &mut dyn Context<'_>, arg: Option<&JsValue>, len: u64, expected: u64) {
         assert_eq!(
             Array::get_relative_start(context, arg, len).unwrap(),
             expected
@@ -896,7 +896,7 @@ fn get_relative_start() {
 #[test]
 fn get_relative_end() {
     #[track_caller]
-    fn assert(context: &mut Context<'_>, arg: Option<&JsValue>, len: u64, expected: u64) {
+    fn assert(context: &mut dyn Context<'_>, arg: Option<&JsValue>, len: u64, expected: u64) {
         assert_eq!(
             Array::get_relative_end(context, arg, len).unwrap(),
             expected

--- a/boa_engine/src/builtins/array_buffer/mod.rs
+++ b/boa_engine/src/builtins/array_buffer/mod.rs
@@ -108,7 +108,7 @@ impl BuiltInConstructor for ArrayBuffer {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -133,7 +133,7 @@ impl ArrayBuffer {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-arraybuffer-@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -145,7 +145,7 @@ impl ArrayBuffer {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.isview
     #[allow(clippy::unnecessary_wraps)]
-    fn is_view(_: &JsValue, args: &[JsValue], _context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn is_view(_: &JsValue, args: &[JsValue], _context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. If Type(arg) is not Object, return false.
         // 2. If arg has a [[ViewedArrayBuffer]] internal slot, return true.
         // 3. Return false.
@@ -166,7 +166,7 @@ impl ArrayBuffer {
     pub(crate) fn get_byte_length(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
@@ -197,7 +197,7 @@ impl ArrayBuffer {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
-    fn slice(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn slice(this: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[ArrayBufferData]]).
         let obj = this.as_object().ok_or_else(|| {
@@ -339,7 +339,7 @@ impl ArrayBuffer {
     pub(crate) fn allocate(
         constructor: &JsValue,
         byte_length: u64,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] »).
         let prototype = get_prototype_from_constructor(
@@ -390,7 +390,7 @@ impl ArrayBuffer {
         src_byte_offset: u64,
         src_length: u64,
         clone_constructor: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
         let target_buffer = Self::allocate(clone_constructor, src_length, context)?;
@@ -635,7 +635,7 @@ impl ArrayBuffer {
         t: TypedArrayKind,
         value: &JsValue,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Vec<u8>> {
         Ok(match t {
             TypedArrayKind::Int8 if is_little_endian => {
@@ -730,7 +730,7 @@ impl ArrayBuffer {
         value: &JsValue,
         _order: SharedMemoryOrder,
         is_little_endian: Option<bool>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
         // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.

--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -64,15 +64,20 @@ impl BuiltInConstructor for AsyncFunction {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
-            context
-                .intrinsics()
-                .constructors()
-                .async_function()
-                .constructor()
-        });
+        let active_function = context
+            .as_raw_context()
+            .vm
+            .active_function
+            .clone()
+            .unwrap_or_else(|| {
+                context
+                    .intrinsics()
+                    .constructors()
+                    .async_function()
+                    .constructor()
+            });
         BuiltInFunctionObject::create_dynamic_function(
             active_function,
             new_target,

--- a/boa_engine/src/builtins/async_generator/mod.rs
+++ b/boa_engine/src/builtins/async_generator/mod.rs
@@ -115,7 +115,7 @@ impl AsyncGenerator {
     pub(crate) fn next(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -203,7 +203,7 @@ impl AsyncGenerator {
     pub(crate) fn r#return(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -281,7 +281,7 @@ impl AsyncGenerator {
     pub(crate) fn throw(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let generator be the this value.
         let generator = this;
@@ -401,7 +401,7 @@ impl AsyncGenerator {
         completion: JsResult<JsValue>,
         done: bool,
         realm: Option<Realm>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) {
         // 1. Let queue be generator.[[AsyncGeneratorQueue]].
         // 2. Assert: queue is not empty.
@@ -463,7 +463,7 @@ impl AsyncGenerator {
         state: AsyncGeneratorState,
         mut generator_context: GeneratorContext,
         completion: CompletionRecord,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) {
         // 1. Assert: generator.[[AsyncGeneratorState]] is either suspendedStart or suspendedYield.
         assert!(
@@ -514,7 +514,7 @@ impl AsyncGenerator {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorawaitreturn
-    pub(crate) fn await_return(generator: JsObject, value: JsValue, context: &mut Context<'_>) {
+    pub(crate) fn await_return(generator: JsObject, value: JsValue, context: &mut dyn Context<'_>) {
         // 1. Let queue be generator.[[AsyncGeneratorQueue]].
         // 2. Assert: queue is not empty.
         // 3. Let next be the first element of queue.
@@ -637,7 +637,7 @@ impl AsyncGenerator {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratordrainqueue
-    pub(crate) fn drain_queue(generator: &JsObject, context: &mut Context<'_>) {
+    pub(crate) fn drain_queue(generator: &JsObject, context: &mut dyn Context<'_>) {
         let mut generator_borrow_mut = generator.borrow_mut();
         let gen = generator_borrow_mut
             .as_async_generator_mut()

--- a/boa_engine/src/builtins/async_generator_function/mod.rs
+++ b/boa_engine/src/builtins/async_generator_function/mod.rs
@@ -69,15 +69,20 @@ impl BuiltInConstructor for AsyncGeneratorFunction {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
-            context
-                .intrinsics()
-                .constructors()
-                .generator_function()
-                .constructor()
-        });
+        let active_function = context
+            .as_raw_context()
+            .vm
+            .active_function
+            .clone()
+            .unwrap_or_else(|| {
+                context
+                    .intrinsics()
+                    .constructors()
+                    .generator_function()
+                    .constructor()
+            });
         BuiltInFunctionObject::create_dynamic_function(
             active_function,
             new_target,

--- a/boa_engine/src/builtins/bigint/mod.rs
+++ b/boa_engine/src/builtins/bigint/mod.rs
@@ -80,7 +80,7 @@ impl BuiltInConstructor for BigInt {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is not undefined, throw a TypeError exception.
         if !new_target.is_undefined() {
@@ -168,7 +168,7 @@ impl BigInt {
     pub(crate) fn to_string(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisBigIntValue(this value).
         let x = Self::this_bigint_value(this)?;
@@ -220,7 +220,7 @@ impl BigInt {
     pub(crate) fn value_of(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_bigint_value(this)?))
     }
@@ -235,7 +235,7 @@ impl BigInt {
     pub(crate) fn as_int_n(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let (modulo, bits) = Self::calculate_as_uint_n(args, context)?;
 
@@ -261,7 +261,7 @@ impl BigInt {
     pub(crate) fn as_uint_n(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let (modulo, _) = Self::calculate_as_uint_n(args, context)?;
 
@@ -275,7 +275,7 @@ impl BigInt {
     /// can be reused from the `as_int_n` method.
     fn calculate_as_uint_n(
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<(JsBigInt, u32)> {
         let bits_arg = args.get_or_undefined(0);
         let bigint_arg = args.get_or_undefined(1);

--- a/boa_engine/src/builtins/boolean/mod.rs
+++ b/boa_engine/src/builtins/boolean/mod.rs
@@ -59,7 +59,7 @@ impl BuiltInConstructor for Boolean {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // Get the argument, if any
         let data = args.get(0).map_or(false, JsValue::to_boolean);
@@ -108,7 +108,7 @@ impl Boolean {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let boolean = Self::this_boolean_value(this)?;
         Ok(JsValue::new(boolean.to_string()))
@@ -125,7 +125,7 @@ impl Boolean {
     pub(crate) fn value_of(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_boolean_value(this)?))
     }

--- a/boa_engine/src/builtins/dataview/mod.rs
+++ b/boa_engine/src/builtins/dataview/mod.rs
@@ -118,7 +118,7 @@ impl BuiltInConstructor for DataView {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_length = args.get_or_undefined(2);
 
@@ -224,7 +224,7 @@ impl DataView {
     pub(crate) fn get_buffer(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -253,7 +253,7 @@ impl DataView {
     pub(crate) fn get_byte_length(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -294,7 +294,7 @@ impl DataView {
     pub(crate) fn get_byte_offset(
         this: &JsValue,
         _args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[DataView]]).
@@ -336,7 +336,7 @@ impl DataView {
         request_index: &JsValue,
         is_little_endian: &JsValue,
         t: TypedArrayKind,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -407,7 +407,7 @@ impl DataView {
     pub(crate) fn get_big_int64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -436,7 +436,7 @@ impl DataView {
     pub(crate) fn get_big_uint64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -465,7 +465,7 @@ impl DataView {
     pub(crate) fn get_float32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -494,7 +494,7 @@ impl DataView {
     pub(crate) fn get_float64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -523,7 +523,7 @@ impl DataView {
     pub(crate) fn get_int8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -552,7 +552,7 @@ impl DataView {
     pub(crate) fn get_int16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -581,7 +581,7 @@ impl DataView {
     pub(crate) fn get_int32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -610,7 +610,7 @@ impl DataView {
     pub(crate) fn get_uint8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -639,7 +639,7 @@ impl DataView {
     pub(crate) fn get_uint16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -668,7 +668,7 @@ impl DataView {
     pub(crate) fn get_uint32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let is_little_endian = args.get_or_undefined(1);
@@ -699,7 +699,7 @@ impl DataView {
         is_little_endian: &JsValue,
         t: TypedArrayKind,
         value: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireInternalSlot(view, [[DataView]]).
         // 2. Assert: view has a [[ViewedArrayBuffer]] internal slot.
@@ -779,7 +779,7 @@ impl DataView {
     pub(crate) fn set_big_int64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -810,7 +810,7 @@ impl DataView {
     pub(crate) fn set_big_uint64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -841,7 +841,7 @@ impl DataView {
     pub(crate) fn set_float32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -872,7 +872,7 @@ impl DataView {
     pub(crate) fn set_float64(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -903,7 +903,7 @@ impl DataView {
     pub(crate) fn set_int8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -934,7 +934,7 @@ impl DataView {
     pub(crate) fn set_int16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -965,7 +965,7 @@ impl DataView {
     pub(crate) fn set_int32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -996,7 +996,7 @@ impl DataView {
     pub(crate) fn set_uint8(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -1027,7 +1027,7 @@ impl DataView {
     pub(crate) fn set_uint16(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
@@ -1058,7 +1058,7 @@ impl DataView {
     pub(crate) fn set_uint32(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let byte_offset = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -199,7 +199,7 @@ impl BuiltInConstructor for Date {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, then
         if new_target.is_undefined() {
@@ -294,7 +294,7 @@ impl Date {
     /// Gets the timestamp from a list of component values.
     fn construct_date(
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<NaiveDateTime>> {
         // 1. Let y be ? ToNumber(year).
         let Some(mut year) = values.get_or_undefined(0).to_integer_or_nan(context)?.as_integer() else {
@@ -387,7 +387,11 @@ impl Date {
     /// [spec]: https://tc39.es/ecma262/#sec-date.now
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn now(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn now(
+        _: &JsValue,
+        _: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Ok(JsValue::new(
             context.host_hooks().utc_now().timestamp_millis(),
         ))
@@ -408,7 +412,7 @@ impl Date {
     pub(crate) fn parse(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // This method is implementation-defined and discouraged, so we just require the same format as the string
         // constructor.
@@ -438,7 +442,7 @@ impl Date {
     pub(crate) fn utc(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let t = some_or_nan!(Self::construct_date(args, context)?);
 
@@ -455,7 +459,7 @@ impl Date {
     pub(crate) fn get_date<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -484,7 +488,7 @@ impl Date {
     pub(crate) fn get_day<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -516,7 +520,7 @@ impl Date {
     pub(crate) fn get_year(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -539,7 +543,7 @@ impl Date {
     pub(crate) fn get_full_year<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -567,7 +571,7 @@ impl Date {
     pub(crate) fn get_hours<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -595,7 +599,7 @@ impl Date {
     pub(crate) fn get_milliseconds<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -623,7 +627,7 @@ impl Date {
     pub(crate) fn get_minutes<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -652,7 +656,7 @@ impl Date {
     pub(crate) fn get_month<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -680,7 +684,7 @@ impl Date {
     pub(crate) fn get_seconds<const LOCAL: bool>(
         this: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         let t = this_time_value(this)?;
@@ -711,7 +715,7 @@ impl Date {
     pub(crate) fn get_time(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisTimeValue(this value).
         Ok(this_time_value(this)?.map_or(JsValue::nan(), JsValue::from))
@@ -731,7 +735,7 @@ impl Date {
     pub(crate) fn get_timezone_offset(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 2. If t is NaN, return NaN.
@@ -759,7 +763,7 @@ impl Date {
     pub(crate) fn set_date<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be LocalTime(? thisTimeValue(this value)).
         get_mut_date!(let t = this);
@@ -800,7 +804,7 @@ impl Date {
     pub(crate) fn set_full_year<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -868,7 +872,7 @@ impl Date {
     pub(crate) fn set_hours<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -932,7 +936,7 @@ impl Date {
     pub(crate) fn set_milliseconds<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         // 1. Let t be LocalTime(? thisTimeValue(this value)).
@@ -973,7 +977,7 @@ impl Date {
     pub(crate) fn set_minutes<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1030,7 +1034,7 @@ impl Date {
     pub(crate) fn set_month<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1078,7 +1082,7 @@ impl Date {
     pub(crate) fn set_seconds<const LOCAL: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1133,7 +1137,7 @@ impl Date {
     pub(crate) fn set_year(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let t be ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1200,7 +1204,7 @@ impl Date {
     pub(crate) fn set_time(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? thisTimeValue(this value).
         get_mut_date!(let t = this);
@@ -1232,7 +1236,7 @@ impl Date {
     pub(crate) fn to_date_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         // 2. Let tv be ? thisTimeValue(O).
@@ -1265,7 +1269,7 @@ impl Date {
     pub(crate) fn to_iso_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let t = this_time_value(this)?
             .and_then(NaiveDateTime::from_timestamp_millis)
@@ -1289,7 +1293,7 @@ impl Date {
     pub(crate) fn to_json(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let o = this.to_object(context)?;
@@ -1322,7 +1326,7 @@ impl Date {
     pub(crate) fn to_locale_date_string(
         _this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new("Function Unimplemented")))
     }
@@ -1339,7 +1343,7 @@ impl Date {
     pub(crate) fn to_locale_string(
         _this: &JsValue,
         _: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new(
             "Function Unimplemented]",
@@ -1359,7 +1363,7 @@ impl Date {
     pub(crate) fn to_locale_time_string(
         _this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Err(JsError::from_opaque(JsValue::new(
             "Function Unimplemented]",
@@ -1378,7 +1382,7 @@ impl Date {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let tv be ? thisTimeValue(this value).
         // 2. Return ToDateString(tv).
@@ -1406,7 +1410,7 @@ impl Date {
     pub(crate) fn to_time_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         // 2. Let tv be ? thisTimeValue(O).
@@ -1437,7 +1441,7 @@ impl Date {
     pub(crate) fn to_utc_string(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be this Date object.
         let Some(t) = this_time_value(this)?.and_then(NaiveDateTime::from_timestamp_millis) else {
@@ -1471,7 +1475,7 @@ impl Date {
     pub(crate) fn value_of(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisTimeValue(this value).
         Ok(Self::new(this_time_value(this)?).as_value())
@@ -1489,7 +1493,7 @@ impl Date {
     pub(crate) fn to_primitive(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, throw a TypeError exception.

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -58,11 +58,12 @@ impl BuiltInConstructor for AggregateError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()
@@ -118,7 +119,10 @@ impl BuiltInConstructor for AggregateError {
                 .configurable(true)
                 .enumerable(false)
                 .writable(true)
-                .value(Array::create_array_from_list(errors_list, context))
+                .value(Array::create_array_from_list(
+                    errors_list,
+                    context.as_raw_context(),
+                ))
                 .build(),
             context,
         )

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -60,11 +60,12 @@ impl BuiltInConstructor for EvalError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -160,11 +160,12 @@ impl BuiltInConstructor for Error {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()
@@ -205,7 +206,7 @@ impl Error {
     pub(crate) fn install_error_cause(
         o: &JsObject,
         options: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. If Type(options) is Object and ? HasProperty(options, "cause") is true, then
         if let Some(options) = options.as_object() {
@@ -236,7 +237,7 @@ impl Error {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, throw a TypeError exception.

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -58,11 +58,12 @@ impl BuiltInConstructor for RangeError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -57,11 +57,12 @@ impl BuiltInConstructor for ReferenceError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -60,11 +60,12 @@ impl BuiltInConstructor for SyntaxError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -68,11 +68,12 @@ impl BuiltInConstructor for TypeError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()
@@ -119,7 +120,11 @@ pub(crate) struct ThrowTypeError;
 
 impl IntrinsicObject for ThrowTypeError {
     fn init(realm: &Realm) {
-        fn throw_type_error(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+        fn throw_type_error(
+            _: &JsValue,
+            _: &[JsValue],
+            _: &mut dyn Context<'_>,
+        ) -> JsResult<JsValue> {
             Err(JsNativeError::typ()
                 .with_message(
                     "'caller', 'callee', and 'arguments' properties may not be accessed on strict mode \

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -59,11 +59,12 @@ impl BuiltInConstructor for UriError {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()

--- a/boa_engine/src/builtins/escape/mod.rs
+++ b/boa_engine/src/builtins/escape/mod.rs
@@ -38,7 +38,7 @@ impl BuiltInObject for Escape {
 }
 
 /// Builtin JavaScript `escape ( string )` function.
-fn escape(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn escape(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     /// Returns `true` if the codepoint `cp` is part of the `unescapedSet`.
     fn is_unescaped(cp: u16) -> bool {
         let Ok(cp) = TryInto::<u8>::try_into(cp) else {
@@ -110,7 +110,7 @@ impl BuiltInObject for Unescape {
 }
 
 /// Builtin JavaScript `unescape ( string )` function.
-fn unescape(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn unescape(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     /// Converts a char `cp` to its corresponding hex digit value.
     fn to_hex_digit(cp: u16) -> Option<u16> {
         char::from_u32(u32::from(cp))

--- a/boa_engine/src/builtins/function/arguments.rs
+++ b/boa_engine/src/builtins/function/arguments.rs
@@ -1,7 +1,8 @@
 use crate::{
+    context::RawContext,
     environments::DeclarativeEnvironment,
     object::{JsObject, ObjectData},
-    Context, JsValue,
+    JsValue,
 };
 use boa_ast::{function::FormalParameterList, operations::bound_names};
 use boa_gc::{Finalize, Gc, Trace};
@@ -71,7 +72,7 @@ impl Arguments {
     /// [spec]: https://tc39.es/ecma262/#sec-createunmappedargumentsobject
     pub(crate) fn create_unmapped_arguments_object(
         arguments_list: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut RawContext<'_>,
     ) -> JsObject {
         // 1. Let len be the number of elements in argumentsList.
         let len = arguments_list.len();
@@ -125,7 +126,7 @@ impl Arguments {
         formals: &FormalParameterList,
         arguments_list: &[JsValue],
         env: &Gc<DeclarativeEnvironment>,
-        context: &mut Context<'_>,
+        context: &mut RawContext<'_>,
     ) -> JsObject {
         // 1. Assert: formals does not contain a rest parameter, any binding patterns, or any initializers.
         // It may contain duplicate identifiers.

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -74,15 +74,20 @@ impl BuiltInConstructor for GeneratorFunction {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
-            context
-                .intrinsics()
-                .constructors()
-                .generator_function()
-                .constructor()
-        });
+        let active_function = context
+            .as_raw_context()
+            .vm
+            .active_function
+            .clone()
+            .unwrap_or_else(|| {
+                context
+                    .intrinsics()
+                    .constructors()
+                    .generator_function()
+                    .constructor()
+            });
         BuiltInFunctionObject::create_dynamic_function(
             active_function,
             new_target,

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -25,7 +25,7 @@ use icu_datetime::options::preferences::HourCycle;
 use super::options::OptionType;
 
 impl OptionType for HourCycle {
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "h11" => Ok(Self::H11),
             "h12" => Ok(Self::H12),
@@ -94,11 +94,12 @@ impl BuiltInConstructor for DateTimeFormat {
     fn constructor(
         new_target: &JsValue,
         _args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
+                .as_raw_context()
                 .vm
                 .active_function
                 .clone()
@@ -183,7 +184,7 @@ pub(crate) fn to_date_time_options(
     options: &JsValue,
     required: &DateTimeReqs,
     defaults: &DateTimeReqs,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject> {
     // 1. If options is undefined, let options be null;
     // otherwise let options be ? ToObject(options).

--- a/boa_engine/src/builtins/intl/list_format/mod.rs
+++ b/boa_engine/src/builtins/intl/list_format/mod.rs
@@ -92,7 +92,7 @@ impl BuiltInConstructor for ListFormat {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -126,7 +126,7 @@ impl BuiltInConstructor for ListFormat {
                 matcher,
                 ..Default::default()
             },
-            context.icu(),
+            context.icu_provider(),
         );
 
         // 11. Let type be ? GetOption(options, "type", string, « "conjunction", "disjunction", "unit" », "conjunction").
@@ -152,8 +152,7 @@ impl BuiltInConstructor for ListFormat {
             prototype,
             ObjectData::list_format(Self {
                 formatter: context
-                    .icu()
-                    .provider()
+                    .icu_provider()
                     .try_new_list_formatter(&DataLocale::from(&locale), typ, style)
                     .map_err(|e| JsNativeError::typ().with_message(e.to_string()))?,
                 locale,
@@ -181,7 +180,7 @@ impl ListFormat {
     fn supported_locales_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let locales = args.get_or_undefined(0);
         let options = args.get_or_undefined(1);
@@ -204,7 +203,11 @@ impl ListFormat {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.format
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format
-    fn format(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn format(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
         let lf = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -239,7 +242,7 @@ impl ListFormat {
     fn format_to_parts(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // TODO: maybe try to move this into icu4x?
         use writeable::{PartsWrite, Writeable};
@@ -398,7 +401,7 @@ impl ListFormat {
     fn resolved_options(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let lf be the this value.
         // 2. Perform ? RequireInternalSlot(lf, [[InitializedListFormat]]).
@@ -460,7 +463,7 @@ impl ListFormat {
 /// [spec]: https://tc39.es/ecma402/#sec-createstringlistfromiterable
 fn string_list_from_iterable(
     iterable: &JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<JsString>> {
     // 1. If iterable is undefined, then
     if iterable.is_undefined() {

--- a/boa_engine/src/builtins/intl/list_format/options.rs
+++ b/boa_engine/src/builtins/intl/list_format/options.rs
@@ -40,7 +40,7 @@ impl FromStr for ListFormatType {
 impl OptionTypeParsable for ListFormatType {}
 
 impl OptionType for ListLength {
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "long" => Ok(Self::Wide),
             "short" => Ok(Self::Short),

--- a/boa_engine/src/builtins/intl/locale/mod.rs
+++ b/boa_engine/src/builtins/intl/locale/mod.rs
@@ -174,7 +174,7 @@ impl BuiltInConstructor for Locale {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -256,7 +256,10 @@ impl BuiltInConstructor for Locale {
                 .map_err(|e| JsNativeError::range().with_message(e.to_string()))?;
 
             // 10. Set tag to ! CanonicalizeUnicodeLocaleId(tag).
-            context.icu().locale_canonicalizer().canonicalize(&mut tag);
+            context
+                .icu_provider()
+                .locale_canonicalizer()
+                .canonicalize(&mut tag);
 
             // Skipping some boilerplate since this is easier to do using the `Locale` type, but putting the
             // spec for completion.
@@ -287,7 +290,10 @@ impl BuiltInConstructor for Locale {
             }
 
             // 17. Return ! CanonicalizeUnicodeLocaleId(tag).
-            context.icu().locale_canonicalizer().canonicalize(&mut tag);
+            context
+                .icu_provider()
+                .locale_canonicalizer()
+                .canonicalize(&mut tag);
         }
 
         // 12. Let opt be a new Record.
@@ -376,7 +382,10 @@ impl BuiltInConstructor for Locale {
             tag.extensions.unicode.keywords.set(key!("nu"), nu);
         }
 
-        context.icu().locale_canonicalizer().canonicalize(&mut tag);
+        context
+            .icu_provider()
+            .locale_canonicalizer()
+            .canonicalize(&mut tag);
 
         // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Locale.prototype%", internalSlotsList).
         let prototype =
@@ -403,7 +412,7 @@ impl Locale {
     pub(crate) fn maximize(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -419,7 +428,7 @@ impl Locale {
             .clone();
 
         // 3. Let maximal be the result of the Add Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set maximal to loc.[[Locale]].
-        context.icu().locale_expander().maximize(&mut loc);
+        context.icu_provider().locale_expander().maximize(&mut loc);
 
         // 4. Return ! Construct(%Locale%, maximal).
         let prototype = context.intrinsics().constructors().locale().prototype();
@@ -441,7 +450,7 @@ impl Locale {
     pub(crate) fn minimize(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -457,7 +466,7 @@ impl Locale {
             .clone();
 
         // 3. Let minimal be the result of the Remove Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set minimal to loc.[[Locale]].
-        context.icu().locale_expander().minimize(&mut loc);
+        context.icu_provider().locale_expander().minimize(&mut loc);
 
         // 4. Return ! Construct(%Locale%, minimal).
         let prototype = context.intrinsics().constructors().locale().prototype();
@@ -479,7 +488,7 @@ impl Locale {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -504,7 +513,7 @@ impl Locale {
     pub(crate) fn base_name(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -532,7 +541,7 @@ impl Locale {
     pub(crate) fn calendar(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -565,7 +574,7 @@ impl Locale {
     pub(crate) fn case_first(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -598,7 +607,7 @@ impl Locale {
     pub(crate) fn collation(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -631,7 +640,7 @@ impl Locale {
     pub(crate) fn hour_cycle(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -661,7 +670,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/numeric
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
-    pub(crate) fn numeric(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn numeric(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -697,7 +710,7 @@ impl Locale {
     pub(crate) fn numbering_system(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -730,7 +743,7 @@ impl Locale {
     pub(crate) fn language(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
@@ -756,7 +769,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/script
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.script
-    pub(crate) fn script(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn script(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
@@ -786,7 +803,11 @@ impl Locale {
     ///
     /// [spec]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/region
     /// [mdn]: https://tc39.es/ecma402/#sec-Intl.Locale.prototype.region
-    pub(crate) fn region(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn region(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let loc be the this value.
         // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {

--- a/boa_engine/src/builtins/intl/locale/options.rs
+++ b/boa_engine/src/builtins/intl/locale/options.rs
@@ -3,7 +3,7 @@ use icu_locid::extensions::unicode::Value;
 use crate::{builtins::intl::options::OptionType, Context, JsNativeError};
 
 impl OptionType for Value {
-    fn from_value(value: crate::JsValue, context: &mut Context<'_>) -> crate::JsResult<Self> {
+    fn from_value(value: crate::JsValue, context: &mut dyn Context<'_>) -> crate::JsResult<Self> {
         let val = value
             .to_string(context)?
             .to_std_string_escaped()

--- a/boa_engine/src/builtins/intl/mod.rs
+++ b/boa_engine/src/builtins/intl/mod.rs
@@ -11,7 +11,7 @@
 
 use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInObject, IntrinsicObject},
-    context::{intrinsics::Intrinsics, BoaProvider},
+    context::{intrinsics::Intrinsics, IcuProvider},
     object::JsObject,
     property::Attribute,
     realm::Realm,
@@ -109,7 +109,7 @@ impl Intl {
     pub(crate) fn get_canonical_locales(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let locales = args.get_or_undefined(0);
 
@@ -119,7 +119,7 @@ impl Intl {
         // 2. Return CreateArrayFromList(ll).
         Ok(JsValue::Object(Array::create_array_from_list(
             ll.into_iter().map(|loc| loc.to_string().into()),
-            context,
+            context.as_raw_context(),
         )))
     }
 }
@@ -151,7 +151,7 @@ trait Service {
     fn resolve(
         _locale: &mut icu_locid::Locale,
         _options: &mut Self::LocaleOptions,
-        _provider: BoaProvider<'_>,
+        _provider: &IcuProvider<'_>,
     ) {
     }
 }

--- a/boa_engine/src/builtins/intl/options.rs
+++ b/boa_engine/src/builtins/intl/options.rs
@@ -27,7 +27,7 @@ pub(super) trait OptionType: Sized {
     /// steps instead of returning a pure string, number or boolean.
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-getoption
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self>;
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self>;
 }
 
 pub(super) trait OptionTypeParsable: FromStr {}
@@ -36,7 +36,7 @@ impl<T: OptionTypeParsable> OptionType for T
 where
     T::Err: Display,
 {
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         value
             .to_string(context)?
             .to_std_string_escaped()
@@ -46,7 +46,7 @@ where
 }
 
 impl OptionType for bool {
-    fn from_value(value: JsValue, _: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, _: &mut dyn Context<'_>) -> JsResult<Self> {
         // 5. If type is "boolean", then
         //      a. Set value to ! ToBoolean(value).
         Ok(value.to_boolean())
@@ -54,7 +54,7 @@ impl OptionType for bool {
 }
 
 impl OptionType for JsString {
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         // 6. If type is "string", then
         //      a. Set value to ? ToString(value).
         value.to_string(context)
@@ -92,7 +92,7 @@ impl FromStr for LocaleMatcher {
 impl OptionTypeParsable for LocaleMatcher {}
 
 impl OptionType for CaseFirst {
-    fn from_value(value: JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn from_value(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value.to_string(context)?.to_std_string_escaped().as_str() {
             "upper" => Ok(Self::UpperFirst),
             "lower" => Ok(Self::LowerFirst),
@@ -122,7 +122,7 @@ pub(super) fn get_option<T: OptionType>(
     options: &JsObject,
     property: &[u16],
     required: bool,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<T>> {
     // 1. Let value be ? Get(options, property).
     let value = options.get(property, context)?;
@@ -161,7 +161,7 @@ pub(super) fn get_number_option(
     minimum: f64,
     maximum: f64,
     fallback: Option<f64>,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<f64>> {
     // 1. Assert: Type(options) is Object.
     // 2. Let value be ? Get(options, property).
@@ -183,7 +183,7 @@ pub(super) fn default_number_option(
     minimum: f64,
     maximum: f64,
     fallback: Option<f64>,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<f64>> {
     // 1. If value is undefined, return fallback.
     if value.is_undefined() {
@@ -239,7 +239,7 @@ pub(super) fn get_options_object(options: &JsValue) -> JsResult<JsObject> {
 /// [spec]: https://tc39.es/ecma402/#sec-coerceoptionstoobject
 pub(super) fn coerce_options_to_object(
     options: &JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject> {
     // If options is undefined, then
     if options.is_undefined() {

--- a/boa_engine/src/builtins/intl/segmenter/iterator.rs
+++ b/boa_engine/src/builtins/intl/segmenter/iterator.rs
@@ -79,7 +79,7 @@ impl SegmentIterator {
     pub(crate) fn create(
         segmenter: JsObject,
         string: JsString,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsObject {
         // 1. Let internalSlotsList be « [[IteratingSegmenter]], [[IteratedString]], [[IteratedStringNextSegmentCodeUnitIndex]] ».
         // 2. Let iterator be OrdinaryObjectCreate(%SegmentIteratorPrototype%, internalSlotsList).
@@ -104,7 +104,7 @@ impl SegmentIterator {
     /// [`%SegmentIteratorPrototype%.next ( )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-%segmentiteratorprototype%.next
-    fn next(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn next(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let iterator be the this value.
         // 2. Perform ? RequireInternalSlot(iterator, [[IteratingSegmenter]]).
         let mut iter = this.as_object().map(JsObject::borrow_mut).ok_or_else(|| {

--- a/boa_engine/src/builtins/intl/segmenter/mod.rs
+++ b/boa_engine/src/builtins/intl/segmenter/mod.rs
@@ -104,7 +104,7 @@ impl BuiltInConstructor for Segmenter {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -137,7 +137,7 @@ impl BuiltInConstructor for Segmenter {
                 matcher,
                 ..Default::default()
             },
-            context.icu(),
+            context.icu_provider(),
         );
 
         // 12. Let granularity be ? GetOption(options, "granularity", string, « "grapheme", "word", "sentence" », "grapheme").
@@ -147,8 +147,7 @@ impl BuiltInConstructor for Segmenter {
         // 13. Set segmenter.[[SegmenterGranularity]] to granularity.
 
         let kind = context
-            .icu()
-            .provider()
+            .icu_provider()
             .try_new_segmenter(granularity)
             .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
 
@@ -188,7 +187,7 @@ impl Segmenter {
     fn supported_locales_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let locales = args.get_or_undefined(0);
         let options = args.get_or_undefined(1);
@@ -215,7 +214,7 @@ impl Segmenter {
     fn resolved_options(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
@@ -256,7 +255,11 @@ impl Segmenter {
     /// Segments a string according to the locale and granularity of this `Intl.Segmenter` object.
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-intl.segmenter.prototype.segment
-    fn segment(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn segment(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let segmenter be the this value.
         // 2. Perform ? RequireInternalSlot(segmenter, [[InitializedSegmenter]]).
         let segmenter = this
@@ -283,7 +286,7 @@ fn create_segment_data_object(
     string: JsString,
     range: Range<usize>,
     is_word_like: Option<bool>,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsObject {
     // 1. Let len be the length of string.
     // 2. Assert: startIndex ≥ 0.

--- a/boa_engine/src/builtins/intl/segmenter/segments.rs
+++ b/boa_engine/src/builtins/intl/segmenter/segments.rs
@@ -45,7 +45,7 @@ impl Segments {
     pub(crate) fn create(
         segmenter: JsObject,
         string: JsString,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsObject {
         // 1. Let internalSlotsList be « [[SegmentsSegmenter]], [[SegmentsString]] ».
         // 2. Let segments be OrdinaryObjectCreate(%SegmentsPrototype%, internalSlotsList).
@@ -64,7 +64,7 @@ impl Segments {
     fn containing(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
@@ -119,7 +119,7 @@ impl Segments {
     /// [`%SegmentsPrototype% [ @@iterator ] ( )`][spec]
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-%segmentsprototype%-@@iterator
-    fn iterator(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn iterator(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let segments be the this value.
         // 2. Perform ? RequireInternalSlot(segments, [[SegmentsSegmenter]]).
         let segments = this.as_object().map(JsObject::borrow).ok_or_else(|| {

--- a/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/boa_engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -61,7 +61,7 @@ impl AsyncFromSyncIterator {
     /// [spec]: https://tc39.es/ecma262/#sec-createasyncfromsynciterator
     pub(crate) fn create(
         sync_iterator_record: IteratorRecord,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> IteratorRecord {
         // 1. Let asyncIterator be OrdinaryObjectCreate(%AsyncFromSyncIteratorPrototype%, « [[SyncIteratorRecord]] »).
         // 2. Set asyncIterator.[[SyncIteratorRecord]] to syncIteratorRecord.
@@ -93,7 +93,7 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.next
-    fn next(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn next(this: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
@@ -140,7 +140,11 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.return
-    fn r#return(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn r#return(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -212,7 +216,7 @@ impl AsyncFromSyncIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%asyncfromsynciteratorprototype%.throw
-    fn throw(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn throw(this: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIterator be O.[[SyncIteratorRecord]].[[Iterator]].
@@ -287,7 +291,7 @@ impl AsyncFromSyncIterator {
     fn continuation(
         result: &IteratorResult,
         promise_capability: &PromiseCapability,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. NOTE: Because promiseCapability is derived from the intrinsic %Promise%,
         // the calls to promiseCapability.[[Reject]] entailed by the

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -196,7 +196,11 @@ impl IntrinsicObject for AsyncIterator {
 /// `CreateIterResultObject( value, done )`
 ///
 /// Generates an object supporting the `IteratorResult` interface.
-pub fn create_iter_result_object(value: JsValue, done: bool, context: &mut Context<'_>) -> JsValue {
+pub fn create_iter_result_object(
+    value: JsValue,
+    done: bool,
+    context: &mut dyn Context<'_>,
+) -> JsValue {
     let _timer = Profiler::global().start_event("create_iter_result_object", "init");
 
     // 1. Assert: Type(done) is Boolean.
@@ -232,7 +236,7 @@ impl JsValue {
     /// [spec]: https://tc39.es/ecma262/#sec-getiterator
     pub fn get_iterator(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
         hint: Option<IteratorHint>,
         method: Option<JsObject>,
     ) -> JsResult<IteratorRecord> {
@@ -323,7 +327,7 @@ impl IteratorResult {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorcomplete
     #[inline]
-    pub fn complete(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn complete(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         // 1. Return ToBoolean(? Get(iterResult, "done")).
         Ok(self.object.get(js_string!("done"), context)?.to_boolean())
     }
@@ -339,7 +343,7 @@ impl IteratorResult {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorvalue
     #[inline]
-    pub fn value(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn value(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return ? Get(iterResult, "value").
         self.object.get(js_string!("value"), context)
     }
@@ -418,7 +422,7 @@ impl IteratorRecord {
     }
 
     /// Gets the current value of the `IteratorRecord`.
-    pub(crate) fn value(&mut self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn value(&mut self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         self.set_done_on_err(|iter| iter.last_result.value(context))
     }
 
@@ -431,7 +435,7 @@ impl IteratorRecord {
     pub(crate) fn update_result(
         &mut self,
         result: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         self.set_done_on_err(|iter| {
             // 3. If Type(result) is not Object, throw a TypeError exception.
@@ -466,7 +470,7 @@ impl IteratorRecord {
     pub(crate) fn step_with(
         &mut self,
         value: Option<&JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("IteratorRecord::step_with", "iterator");
 
@@ -498,7 +502,7 @@ impl IteratorRecord {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iteratorstep
-    pub(crate) fn step(&mut self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub(crate) fn step(&mut self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         self.step_with(None, context)
     }
 
@@ -516,7 +520,7 @@ impl IteratorRecord {
     pub(crate) fn close(
         &self,
         completion: JsResult<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("IteratorRecord::close", "iterator");
 
@@ -576,7 +580,7 @@ impl IteratorRecord {
 ///
 ///  [spec]: https://tc39.es/ecma262/#sec-iterabletolist
 pub(crate) fn iterable_to_list(
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
     items: &JsValue,
     method: Option<JsObject>,
 ) -> JsResult<Vec<JsValue>> {

--- a/boa_engine/src/builtins/map/map_iterator.rs
+++ b/boa_engine/src/builtins/map/map_iterator.rs
@@ -74,7 +74,7 @@ impl MapIterator {
     pub(crate) fn create_map_iterator(
         map: &JsValue,
         kind: PropertyNameKind,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         if let Some(map_obj) = map.as_object() {
             if let Some(map) = map_obj.borrow_mut().as_map_mut() {
@@ -109,7 +109,7 @@ impl MapIterator {
     pub(crate) fn next(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let mut map_iterator = this.as_object().map(JsObject::borrow_mut);
         let map_iterator = map_iterator
@@ -139,7 +139,8 @@ impl MapIterator {
                     PropertyNameKind::Key => Ok(create_iter_result_object(key, false, context)),
                     PropertyNameKind::Value => Ok(create_iter_result_object(value, false, context)),
                     PropertyNameKind::KeyAndValue => {
-                        let result = Array::create_array_from_list([key, value], context);
+                        let result =
+                            Array::create_array_from_list([key, value], context.as_raw_context());
                         Ok(create_iter_result_object(result.into(), false, context))
                     }
                 };

--- a/boa_engine/src/builtins/map/mod.rs
+++ b/boa_engine/src/builtins/map/mod.rs
@@ -120,7 +120,7 @@ impl BuiltInConstructor for Map {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -165,7 +165,7 @@ impl Map {
     /// [spec]: https://tc39.es/ecma262/#sec-get-map-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -183,7 +183,7 @@ impl Map {
     pub(crate) fn entries(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, key+value).
@@ -203,7 +203,7 @@ impl Map {
     pub(crate) fn keys(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, key).
@@ -220,7 +220,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.set
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/set
-    pub(crate) fn set(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn set(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         let key = args.get_or_undefined(0);
         let value = args.get_or_undefined(1);
 
@@ -270,7 +274,7 @@ impl Map {
     pub(crate) fn get_size(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         if let Some(object) = this.as_object() {
@@ -303,7 +307,7 @@ impl Map {
     pub(crate) fn delete(
         this: &JsValue,
         args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
         let key = args.get_or_undefined(0);
@@ -340,7 +344,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.get
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/get
-    pub(crate) fn get(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn get(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
         let key = args.get_or_undefined(0);
         let key = match key.as_number() {
@@ -375,7 +383,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/clear
-    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn clear(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
         if let Some(object) = this.as_object() {
@@ -405,7 +417,11 @@ impl Map {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn has(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
         let key = args.get_or_undefined(0);
         let key = match key.as_number() {
@@ -443,7 +459,7 @@ impl Map {
     pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[MapData]]).
@@ -514,7 +530,7 @@ impl Map {
     pub(crate) fn values(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Return ? CreateMapIterator(M, value).
@@ -534,7 +550,7 @@ pub(crate) fn add_entries_from_iterable(
     target: &JsObject,
     iterable: &JsValue,
     adder: &JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. If IsCallable(adder) is false, throw a TypeError exception.
     let adder = adder.as_callable().ok_or_else(|| {

--- a/boa_engine/src/builtins/math/mod.rs
+++ b/boa_engine/src/builtins/math/mod.rs
@@ -109,7 +109,7 @@ impl Math {
     pub(crate) fn abs(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -135,7 +135,7 @@ impl Math {
     pub(crate) fn acos(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -159,7 +159,7 @@ impl Math {
     pub(crate) fn acosh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -184,7 +184,7 @@ impl Math {
     pub(crate) fn asin(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -208,7 +208,7 @@ impl Math {
     pub(crate) fn asinh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -231,7 +231,7 @@ impl Math {
     pub(crate) fn atan(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -256,7 +256,7 @@ impl Math {
     pub(crate) fn atanh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -282,7 +282,7 @@ impl Math {
     pub(crate) fn atan2(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let ny be ? ToNumber(y).
         let y = args.get_or_undefined(0).to_number(context)?;
@@ -329,7 +329,7 @@ impl Math {
     pub(crate) fn cbrt(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -352,7 +352,7 @@ impl Math {
     pub(crate) fn ceil(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -377,7 +377,7 @@ impl Math {
     pub(crate) fn clz32(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -400,7 +400,7 @@ impl Math {
     pub(crate) fn cos(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -424,7 +424,7 @@ impl Math {
     pub(crate) fn cosh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -449,7 +449,7 @@ impl Math {
     pub(crate) fn exp(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -476,7 +476,7 @@ impl Math {
     pub(crate) fn expm1(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -500,7 +500,7 @@ impl Math {
     pub(crate) fn floor(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -525,7 +525,7 @@ impl Math {
     pub(crate) fn fround(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let n be ? ToNumber(x).
         let x = args.get_or_undefined(0).to_number(context)?;
@@ -549,7 +549,7 @@ impl Math {
     pub(crate) fn hypot(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
@@ -583,7 +583,7 @@ impl Math {
     pub(crate) fn imul(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let a be ℝ(? ToUint32(x)).
         let x = args.get_or_undefined(0).to_u32(context)?;
@@ -607,7 +607,7 @@ impl Math {
     pub(crate) fn log(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -633,7 +633,7 @@ impl Math {
     pub(crate) fn log1p(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -658,7 +658,7 @@ impl Math {
     pub(crate) fn log10(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -684,7 +684,7 @@ impl Math {
     pub(crate) fn log2(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -710,7 +710,7 @@ impl Math {
     pub(crate) fn max(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
@@ -752,7 +752,7 @@ impl Math {
     pub(crate) fn min(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let coerced be a new empty List.
         // 2. For each element arg of args, do
@@ -795,7 +795,7 @@ impl Math {
     pub(crate) fn pow(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Set base to ? ToNumber(base).
         let x = args.get_or_undefined(0).to_number(context)?;
@@ -821,7 +821,7 @@ impl Math {
     /// [spec]: https://tc39.es/ecma262/#sec-math.random
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/random
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn random(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn random(_: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // NOTE: Each Math.random function created for distinct realms must produce a distinct sequence of values from successive calls.
         Ok(rand::random::<f64>().into())
     }
@@ -838,7 +838,7 @@ impl Math {
     pub(crate) fn round(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let num = args
             .get_or_undefined(0)
@@ -868,7 +868,7 @@ impl Math {
     pub(crate) fn sign(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let n be ? ToNumber(x).
         let n = args.get_or_undefined(0).to_number(context)?;
@@ -893,7 +893,7 @@ impl Math {
     pub(crate) fn sin(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -917,7 +917,7 @@ impl Math {
     pub(crate) fn sinh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -940,7 +940,7 @@ impl Math {
     pub(crate) fn sqrt(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -964,7 +964,7 @@ impl Math {
     pub(crate) fn tan(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -988,7 +988,7 @@ impl Math {
     pub(crate) fn tanh(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)
@@ -1013,7 +1013,7 @@ impl Math {
     pub(crate) fn trunc(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args
             .get_or_undefined(0)

--- a/boa_engine/src/builtins/mod.rs
+++ b/boa_engine/src/builtins/mod.rs
@@ -158,11 +158,11 @@ pub(crate) trait BuiltInConstructor: BuiltInObject {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue>;
 }
 
-fn global_binding<B: BuiltInObject>(context: &mut Context<'_>) -> JsResult<()> {
+fn global_binding<B: BuiltInObject>(context: &mut dyn Context<'_>) -> JsResult<()> {
     let name = B::NAME;
     let attr = B::ATTRIBUTE;
     let intrinsic = B::get(context.intrinsics());
@@ -276,7 +276,7 @@ impl Realm {
 /// Abstract operation [`SetDefaultGlobalBindings ( realmRec )`][spec].
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-setdefaultglobalbindings
-pub(crate) fn set_default_global_bindings(context: &mut Context<'_>) -> JsResult<()> {
+pub(crate) fn set_default_global_bindings(context: &mut dyn Context<'_>) -> JsResult<()> {
     let global_object = context.global_object();
 
     global_object.define_property_or_throw(

--- a/boa_engine/src/builtins/number/globals.rs
+++ b/boa_engine/src/builtins/number/globals.rs
@@ -25,7 +25,7 @@ use num_traits::Num;
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-isfinite-number
 /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isFinite
-fn is_finite(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+fn is_finite(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
     if let Some(value) = args.get(0) {
         let number = value.to_number(context)?;
         Ok(number.is_finite().into())
@@ -70,7 +70,7 @@ impl BuiltInObject for IsFinite {
 pub(crate) fn is_nan(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     if let Some(value) = args.get(0) {
         let number = value.to_number(context)?;
@@ -116,7 +116,7 @@ impl BuiltInObject for IsNaN {
 pub(crate) fn parse_int(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     if let (Some(val), radix) = (args.get(0), args.get_or_undefined(1)) {
         // 1. Let inputString be ? ToString(string).
@@ -258,7 +258,7 @@ impl BuiltInObject for ParseInt {
 pub(crate) fn parse_float(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     if let Some(val) = args.get(0) {
         // TODO: parse float with optimal utf16 algorithm

--- a/boa_engine/src/builtins/number/mod.rs
+++ b/boa_engine/src/builtins/number/mod.rs
@@ -110,7 +110,7 @@ impl BuiltInConstructor for Number {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let data = match args.get(0) {
             Some(value) => value.to_numeric_number(context)?,
@@ -211,7 +211,7 @@ impl Number {
     pub(crate) fn to_exponential(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisNumberValue(this value).
         let this_num = Self::this_number_value(this)?;
@@ -256,7 +256,7 @@ impl Number {
     pub(crate) fn to_fixed(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let this_num be ? thisNumberValue(this value).
         let this_num = Self::this_number_value(this)?;
@@ -305,7 +305,7 @@ impl Number {
     pub(crate) fn to_locale_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let this_num = Self::this_number_value(this)?;
         let this_str_num = this_num.to_string();
@@ -413,7 +413,7 @@ impl Number {
     pub(crate) fn to_precision(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let precision = args.get_or_undefined(0);
 
@@ -662,7 +662,7 @@ impl Number {
     pub(crate) fn to_string(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let x be ? thisNumberValue(this value).
         let x = Self::this_number_value(this)?;
@@ -724,7 +724,7 @@ impl Number {
     pub(crate) fn value_of(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(Self::this_number_value(this)?))
     }
@@ -747,7 +747,7 @@ impl Number {
     pub(crate) fn number_is_finite(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context<'_>,
+        _ctx: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If number is not a Number, return false.
         // 2. If number is not finite, return false.
@@ -773,7 +773,7 @@ impl Number {
     pub(crate) fn number_is_integer(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context<'_>,
+        _ctx: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(args.get(0).map_or(false, Self::is_integer).into())
     }
@@ -796,7 +796,7 @@ impl Number {
     pub(crate) fn number_is_nan(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context<'_>,
+        _ctx: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(
             if let Some(&JsValue::Rational(number)) = args.get(0) {
@@ -825,7 +825,7 @@ impl Number {
     pub(crate) fn is_safe_integer(
         _: &JsValue,
         args: &[JsValue],
-        _ctx: &mut Context<'_>,
+        _ctx: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Ok(JsValue::new(match args.get(0) {
             Some(JsValue::Integer(_)) => true,

--- a/boa_engine/src/builtins/object/for_in_iterator.rs
+++ b/boa_engine/src/builtins/object/for_in_iterator.rs
@@ -76,7 +76,7 @@ impl ForInIterator {
     ///  - [ECMA reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-createforiniterator
-    pub(crate) fn create_for_in_iterator(object: JsValue, context: &Context<'_>) -> JsObject {
+    pub(crate) fn create_for_in_iterator(object: JsValue, context: &dyn Context<'_>) -> JsObject {
         JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             context
@@ -99,7 +99,7 @@ impl ForInIterator {
     pub(crate) fn next(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -125,12 +125,13 @@ impl BuiltInConstructor for Object {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is neither undefined nor the active function object, then
         if !new_target.is_undefined()
             && new_target
                 != &context
+                    .as_raw_context()
                     .vm
                     .active_function
                     .clone()
@@ -175,7 +176,7 @@ impl Object {
     pub fn legacy_proto_getter(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let obj = this.to_object(context)?;
@@ -200,7 +201,7 @@ impl Object {
     pub fn legacy_proto_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -244,7 +245,7 @@ impl Object {
     pub fn legacy_define_getter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let getter = args.get_or_undefined(1);
 
@@ -287,7 +288,7 @@ impl Object {
     pub fn legacy_define_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let setter = args.get_or_undefined(1);
 
@@ -330,7 +331,7 @@ impl Object {
     pub fn legacy_lookup_getter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let mut obj = this.to_object(context)?;
@@ -374,7 +375,7 @@ impl Object {
     pub fn legacy_lookup_setter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? ToObject(this value).
         let mut obj = this.to_object(context)?;
@@ -416,7 +417,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.create
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
-    pub fn create(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn create(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         let prototype = args.get_or_undefined(0);
         let properties = args.get_or_undefined(1);
 
@@ -457,7 +462,7 @@ impl Object {
     pub fn get_own_property_descriptor(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
@@ -485,7 +490,7 @@ impl Object {
     pub fn get_own_property_descriptors(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
@@ -524,7 +529,7 @@ impl Object {
     /// [spec]: https://tc39.es/ecma262/#sec-frompropertydescriptor
     pub(crate) fn from_property_descriptor(
         desc: Option<PropertyDescriptor>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsValue {
         // 1. If Desc is undefined, return undefined.
         let Some(desc)= desc else {
@@ -582,7 +587,7 @@ impl Object {
     }
 
     /// Uses the `SameValue` algorithm to check equality of objects
-    pub fn is(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn is(_: &JsValue, args: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         let x = args.get_or_undefined(0);
         let y = args.get_or_undefined(1);
 
@@ -597,7 +602,7 @@ impl Object {
     pub fn get_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         if args.is_empty() {
             return Err(JsNativeError::typ()
@@ -624,7 +629,7 @@ impl Object {
     pub fn set_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         if args.len() < 2 {
             return Err(JsNativeError::typ()
@@ -689,7 +694,7 @@ impl Object {
     pub fn is_prototype_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let v = args.get_or_undefined(0);
         if !v.is_object() {
@@ -712,7 +717,7 @@ impl Object {
     pub fn define_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let object = args.get_or_undefined(0);
         if let JsValue::Object(object) = object {
@@ -748,7 +753,7 @@ impl Object {
     pub fn define_properties(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let arg = args.get_or_undefined(0);
         if let JsValue::Object(obj) = arg {
@@ -770,7 +775,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.prototype.valueof
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf
-    pub fn value_of(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn value_of(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Return ? ToObject(this value).
         Ok(this.to_object(context)?.into())
     }
@@ -789,7 +798,7 @@ impl Object {
     pub fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If the this value is undefined, return "[object Undefined]".
         if this.is_undefined() {
@@ -851,7 +860,7 @@ impl Object {
     pub fn to_locale_string(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Return ? Invoke(O, "toString").
@@ -872,7 +881,7 @@ impl Object {
     pub fn has_own_property(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let P be ? ToPropertyKey(V).
         let key = args.get_or_undefined(0).to_property_key(context)?;
@@ -898,7 +907,7 @@ impl Object {
     pub fn property_is_enumerable(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let Some(key) = args.get(0) else {
             return Ok(JsValue::new(false));
@@ -928,7 +937,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.assign
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-    pub fn assign(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn assign(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let to be ? ToObject(target).
         let to = args.get_or_undefined(0).to_object(context)?;
 
@@ -978,7 +991,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.keys
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
-    pub fn keys(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn keys(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -990,7 +1003,7 @@ impl Object {
         let name_list = obj.enumerable_own_property_names(PropertyNameKind::Key, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        let result = Array::create_array_from_list(name_list, context);
+        let result = Array::create_array_from_list(name_list, context.as_raw_context());
 
         Ok(result.into())
     }
@@ -1003,7 +1016,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.values
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values
-    pub fn values(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn values(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -1015,7 +1032,7 @@ impl Object {
         let name_list = obj.enumerable_own_property_names(PropertyNameKind::Value, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        let result = Array::create_array_from_list(name_list, context);
+        let result = Array::create_array_from_list(name_list, context.as_raw_context());
 
         Ok(result.into())
     }
@@ -1032,7 +1049,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.entries
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries
-    pub fn entries(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn entries(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(target).
         let obj = args
             .get(0)
@@ -1045,7 +1066,7 @@ impl Object {
             obj.enumerable_own_property_names(PropertyNameKind::KeyAndValue, context)?;
 
         // 3. Return CreateArrayFromList(nameList).
-        let result = Array::create_array_from_list(name_list, context);
+        let result = Array::create_array_from_list(name_list, context.as_raw_context());
 
         Ok(result.into())
     }
@@ -1058,7 +1079,7 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.seal
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/seal
-    pub fn seal(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn seal(_: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         if let Some(o) = o.as_object() {
@@ -1087,7 +1108,7 @@ impl Object {
     pub fn is_sealed(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
@@ -1109,7 +1130,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.freeze
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze
-    pub fn freeze(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn freeze(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
         if let Some(o) = o.as_object() {
@@ -1138,7 +1163,7 @@ impl Object {
     pub fn is_frozen(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
@@ -1163,7 +1188,7 @@ impl Object {
     pub fn prevent_extensions(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
 
@@ -1193,7 +1218,7 @@ impl Object {
     pub fn is_extensible(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let o = args.get_or_undefined(0);
         // 1. If Type(O) is not Object, return false.
@@ -1216,7 +1241,7 @@ impl Object {
     pub fn get_own_property_names(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? GetOwnPropertyKeys(O, string).
         let o = args.get_or_undefined(0);
@@ -1234,7 +1259,7 @@ impl Object {
     pub fn get_own_property_symbols(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? GetOwnPropertyKeys(O, symbol).
         let o = args.get_or_undefined(0);
@@ -1249,7 +1274,11 @@ impl Object {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object.hasown
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn
-    pub fn has_own(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn has_own(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let obj be ? ToObject(O).
         let obj = args.get_or_undefined(0).to_object(context)?;
 
@@ -1271,7 +1300,7 @@ impl Object {
     pub fn from_entries(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Perform ? RequireObjectCoercible(iterable).
         let iterable = args.get_or_undefined(0).require_object_coercible()?;
@@ -1319,7 +1348,7 @@ impl Object {
 fn object_define_properties(
     object: &JsObject,
     props: &JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<()> {
     // 1. Assert: Type(O) is Object.
     // 2. Let props be ? ToObject(Properties).
@@ -1377,7 +1406,7 @@ enum PropertyKeyType {
 fn get_own_property_keys(
     o: &JsValue,
     r#type: PropertyKeyType,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let obj be ? ToObject(o).
     let obj = o.to_object(context)?;
@@ -1399,5 +1428,5 @@ fn get_own_property_keys(
     });
 
     // 5. Return CreateArrayFromList(nameList).
-    Ok(Array::create_array_from_list(name_list, context).into())
+    Ok(Array::create_array_from_list(name_list, context.as_raw_context()).into())
 }

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -203,7 +203,7 @@ impl PromiseCapability {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-newpromisecapability
-    pub(crate) fn new(c: &JsObject, context: &mut Context<'_>) -> JsResult<Self> {
+    pub(crate) fn new(c: &JsObject, context: &mut dyn Context<'_>) -> JsResult<Self> {
         #[derive(Debug, Clone, Trace, Finalize)]
         struct RejectResolve {
             reject: JsValue,
@@ -373,7 +373,7 @@ impl BuiltInConstructor for Promise {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -456,7 +456,7 @@ impl Promise {
     pub(crate) fn all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this.as_object().ok_or_else(|| {
@@ -517,7 +517,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct ResolveElementCaptures {
@@ -557,7 +557,7 @@ impl Promise {
                     // 1. Let valuesArray be CreateArrayFromList(values).
                     let values_array = crate::builtins::Array::create_array_from_list(
                         values.borrow().iter().cloned(),
-                        context,
+                        context.as_raw_context(),
                     );
 
                     // 2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
@@ -626,7 +626,7 @@ impl Promise {
                             // a. Let valuesArray be CreateArrayFromList(values).
                             let values_array = crate::builtins::Array::create_array_from_list(
                                 captures.values.borrow().as_slice().iter().cloned(),
-                                context,
+                                context.as_raw_context(),
                             );
 
                             // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
@@ -680,7 +680,7 @@ impl Promise {
     pub(crate) fn all_settled(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this.as_object().ok_or_else(|| {
@@ -741,7 +741,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct ResolveRejectElementCaptures {
@@ -781,7 +781,7 @@ impl Promise {
                     // 1. Let valuesArray be CreateArrayFromList(values).
                     let values_array = crate::builtins::Array::create_array_from_list(
                         values.borrow().as_slice().iter().cloned(),
-                        context,
+                        context.as_raw_context(),
                     );
 
                     // 2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
@@ -867,7 +867,7 @@ impl Promise {
                             // a. Let valuesArray be CreateArrayFromList(values).
                             let values_array = Array::create_array_from_list(
                                 captures.values.borrow().as_slice().iter().cloned(),
-                                context,
+                                context.as_raw_context(),
                             );
 
                             // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
@@ -953,7 +953,7 @@ impl Promise {
                             // a. Let valuesArray be CreateArrayFromList(values).
                             let values_array = Array::create_array_from_list(
                                 captures.values.borrow().as_slice().iter().cloned(),
-                                context,
+                                context.as_raw_context(),
                             );
 
                             // b. Return ? Call(promiseCapability.[[Resolve]], undefined, « valuesArray »).
@@ -1007,7 +1007,7 @@ impl Promise {
     pub(crate) fn any(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         let c = this.as_object().ok_or_else(|| {
@@ -1068,7 +1068,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         #[derive(Debug, Trace, Finalize)]
         struct RejectElementCaptures {
@@ -1245,7 +1245,7 @@ impl Promise {
     pub(crate) fn race(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let iterable = args.get_or_undefined(0);
 
@@ -1313,7 +1313,7 @@ impl Promise {
         constructor: &JsObject,
         result_capability: &PromiseCapability,
         promise_resolve: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         let constructor = constructor.clone().into();
         // 1. Repeat,
@@ -1361,7 +1361,7 @@ impl Promise {
     pub(crate) fn reject(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let r = args.get_or_undefined(0).clone();
 
@@ -1377,7 +1377,7 @@ impl Promise {
     pub(crate) fn promise_reject(
         c: &JsObject,
         e: &JsError,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         let e = e.to_opaque(context);
 
@@ -1404,7 +1404,7 @@ impl Promise {
     pub(crate) fn resolve(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let x = args.get_or_undefined(0);
 
@@ -1431,7 +1431,7 @@ impl Promise {
     pub(crate) fn promise_resolve(
         c: &JsObject,
         x: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. If IsPromise(x) is true, then
         if let Some(x) = x.as_promise() {
@@ -1469,7 +1469,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-get-promise-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -1485,7 +1485,7 @@ impl Promise {
     pub(crate) fn catch(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let on_rejected = args.get_or_undefined(0);
 
@@ -1510,7 +1510,7 @@ impl Promise {
     pub(crate) fn finally(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let promise be the this value.
         let promise = this;
@@ -1550,7 +1550,7 @@ impl Promise {
     pub(crate) fn then_catch_finally_closures(
         c: JsObject,
         on_finally: JsFunction,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> (JsFunction, JsFunction) {
         /// Capture object for the `thenFinallyClosure` abstract closure.
         #[derive(Debug, Trace, Finalize)]
@@ -1672,7 +1672,7 @@ impl Promise {
     pub(crate) fn then(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let promise be the this value.
         let promise = this;
@@ -1703,7 +1703,7 @@ impl Promise {
         promise: &JsObject,
         on_fulfilled: Option<JsFunction>,
         on_rejected: Option<JsFunction>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 3. Let C be ? SpeciesConstructor(promise, %Promise%).
         let c = promise.species_constructor(StandardConstructors::promise, context)?;
@@ -1735,7 +1735,7 @@ impl Promise {
         on_fulfilled: Option<JsFunction>,
         on_rejected: Option<JsFunction>,
         result_capability: Option<PromiseCapability>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) {
         // 1. Assert: IsPromise(promise) is true.
 
@@ -1800,9 +1800,7 @@ impl Promise {
                     new_promise_reaction_job(fulfill_reaction, value.clone(), context);
 
                 //   c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
-                context
-                    .job_queue()
-                    .enqueue_promise_job(fulfill_job, context);
+                context.enqueue_promise_job(fulfill_job);
             }
 
             // 11. Else,
@@ -1822,7 +1820,7 @@ impl Promise {
                 let reject_job = new_promise_reaction_job(reject_reaction, reason.clone(), context);
 
                 //   e. Perform HostEnqueuePromiseJob(rejectJob.[[Job]], rejectJob.[[Realm]]).
-                context.job_queue().enqueue_promise_job(reject_job, context);
+                context.enqueue_promise_job(reject_job);
 
                 // 12. Set promise.[[PromiseIsHandled]] to true.
                 promise
@@ -1852,7 +1850,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-getpromiseresolve
     pub(crate) fn get_promise_resolve(
         promise_constructor: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let promiseResolve be ? Get(promiseConstructor, "resolve").
         let promise_resolve = promise_constructor.get(utf16!("resolve"), context)?;
@@ -1873,7 +1871,7 @@ impl Promise {
     /// [spec]: https://tc39.es/ecma262/#sec-createresolvingfunctions
     pub(crate) fn create_resolving_functions(
         promise: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> ResolvingFunctions {
         /// `TriggerPromiseReactions ( reactions, argument )`
         ///
@@ -1891,7 +1889,7 @@ impl Promise {
         fn trigger_promise_reactions(
             reactions: Vec<ReactionRecord>,
             argument: &JsValue,
-            context: &mut Context<'_>,
+            context: &mut dyn Context<'_>,
         ) {
             // 1. For each element reaction of reactions, do
             for reaction in reactions {
@@ -1899,7 +1897,7 @@ impl Promise {
                 let job = new_promise_reaction_job(reaction, argument.clone(), context);
 
                 // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                context.job_queue().enqueue_promise_job(job, context);
+                context.enqueue_promise_job(job);
             }
             // 2. Return unused.
         }
@@ -1917,7 +1915,7 @@ impl Promise {
         /// # Panics
         ///
         /// Panics if `Promise` is not pending.
-        fn fulfill_promise(promise: &JsObject, value: JsValue, context: &mut Context<'_>) {
+        fn fulfill_promise(promise: &JsObject, value: JsValue, context: &mut dyn Context<'_>) {
             let mut promise = promise.borrow_mut();
             let promise = promise
                 .as_promise_mut()
@@ -1961,7 +1959,7 @@ impl Promise {
         /// # Panics
         ///
         /// Panics if `Promise` is not pending.
-        fn reject_promise(promise: &JsObject, reason: JsValue, context: &mut Context<'_>) {
+        fn reject_promise(promise: &JsObject, reason: JsValue, context: &mut dyn Context<'_>) {
             let handled = {
                 let mut promise = promise.borrow_mut();
                 let promise = promise
@@ -2108,7 +2106,7 @@ impl Promise {
                     );
 
                     // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                    context.job_queue().enqueue_promise_job(job, context);
+                    context.enqueue_promise_job(job);
 
                     // 16. Return undefined.
                     Ok(JsValue::Undefined)
@@ -2180,7 +2178,7 @@ impl Promise {
 fn new_promise_reaction_job(
     mut reaction: ReactionRecord,
     argument: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> NativeJob {
     // Inverting order since `job` captures `reaction` by value.
 
@@ -2198,7 +2196,7 @@ fn new_promise_reaction_job(
         .unwrap_or_else(|| context.realm().clone());
 
     // 1. Let job be a new Job Abstract Closure with no parameters that captures reaction and argument and performs the following steps when called:
-    let job = move |context: &mut Context<'_>| {
+    let job = move |context: &mut dyn Context<'_>| {
         //   a. Let promiseCapability be reaction.[[Capability]].
         let promise_capability = reaction.promise_capability.take();
         //   b. Let type be reaction.[[Type]].
@@ -2274,7 +2272,7 @@ fn new_promise_resolve_thenable_job(
     promise_to_resolve: JsObject,
     thenable: JsValue,
     then: JobCallback,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> NativeJob {
     // Inverting order since `job` captures variables by value.
 
@@ -2288,7 +2286,7 @@ fn new_promise_resolve_thenable_job(
         .unwrap_or_else(|_| context.realm().clone());
 
     // 1. Let job be a new Job Abstract Closure with no parameters that captures promiseToResolve, thenable, and then and performs the following steps when called:
-    let job = move |context: &mut Context<'_>| {
+    let job = move |context: &mut dyn Context<'_>| {
         //    a. Let resolvingFunctions be CreateResolvingFunctions(promiseToResolve).
         let resolving_functions = Promise::create_resolving_functions(&promise_to_resolve, context);
 

--- a/boa_engine/src/builtins/proxy/mod.rs
+++ b/boa_engine/src/builtins/proxy/mod.rs
@@ -64,7 +64,7 @@ impl BuiltInConstructor for Proxy {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -105,7 +105,7 @@ impl Proxy {
     pub(crate) fn create(
         target: &JsValue,
         handler: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         let target = target.as_object().ok_or_else(|| {
@@ -139,7 +139,7 @@ impl Proxy {
         Ok(p)
     }
 
-    pub(crate) fn revoker(proxy: JsObject, context: &mut Context<'_>) -> JsFunction {
+    pub(crate) fn revoker(proxy: JsObject, context: &mut dyn Context<'_>) -> JsFunction {
         // 3. Let revoker be ! CreateBuiltinFunction(revokerClosure, 0, "", « [[RevocableProxy]] »).
         // 4. Set revoker.[[RevocableProxy]] to p.
         FunctionObjectBuilder::new(
@@ -175,7 +175,11 @@ impl Proxy {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-proxy.revocable
-    fn revocable(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn revocable(
+        _: &JsValue,
+        args: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let p be ? ProxyCreate(target, handler).
         let p = Self::create(args.get_or_undefined(0), args.get_or_undefined(1), context)?;
 

--- a/boa_engine/src/builtins/reflect/mod.rs
+++ b/boa_engine/src/builtins/reflect/mod.rs
@@ -83,7 +83,7 @@ impl Reflect {
     pub(crate) fn apply(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -112,7 +112,7 @@ impl Reflect {
     pub(crate) fn construct(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If IsConstructor(target) is false, throw a TypeError exception.
         let target = args
@@ -152,7 +152,7 @@ impl Reflect {
     pub(crate) fn define_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -183,7 +183,7 @@ impl Reflect {
     pub(crate) fn delete_property(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -205,7 +205,7 @@ impl Reflect {
     pub(crate) fn get(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         let target = args
@@ -235,7 +235,7 @@ impl Reflect {
     pub(crate) fn get_own_property_descriptor(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         if args.get_or_undefined(0).is_object() {
             // This function is the same as Object.prototype.getOwnPropertyDescriptor, that why
@@ -263,7 +263,7 @@ impl Reflect {
     pub(crate) fn get_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -285,7 +285,7 @@ impl Reflect {
     pub(crate) fn has(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -309,7 +309,7 @@ impl Reflect {
     pub(crate) fn is_extensible(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -329,7 +329,7 @@ impl Reflect {
     pub(crate) fn own_keys(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -342,7 +342,7 @@ impl Reflect {
             .map(Into::into)
             .collect();
 
-        Ok(Array::create_array_from_list(keys, context).into())
+        Ok(Array::create_array_from_list(keys, context.as_raw_context()).into())
     }
 
     /// Prevents new properties from ever being added to an object.
@@ -356,7 +356,7 @@ impl Reflect {
     pub(crate) fn prevent_extensions(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -377,7 +377,7 @@ impl Reflect {
     pub(crate) fn set(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)
@@ -405,7 +405,7 @@ impl Reflect {
     pub(crate) fn set_prototype_of(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let target = args
             .get(0)

--- a/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
+++ b/boa_engine/src/builtins/regexp/regexp_string_iterator.rs
@@ -89,7 +89,7 @@ impl RegExpStringIterator {
         string: JsString,
         global: bool,
         unicode: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsValue {
         // TODO: Implement this with closures and generators.
         //       For now all values of the closure are stored in RegExpStringIterator and the actual closure execution is in `.next()`.
@@ -122,7 +122,7 @@ impl RegExpStringIterator {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%regexpstringiteratorprototype%.next
-    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn next(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         let mut iterator = this.as_object().map(JsObject::borrow_mut);
         let iterator = iterator
             .as_mut()

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -111,7 +111,7 @@ impl BuiltInConstructor for Set {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -170,7 +170,10 @@ impl BuiltInConstructor for Set {
 
 impl Set {
     /// Utility for constructing `Set` objects.
-    pub(crate) fn set_create(prototype: Option<JsObject>, context: &mut Context<'_>) -> JsObject {
+    pub(crate) fn set_create(
+        prototype: Option<JsObject>,
+        context: &mut dyn Context<'_>,
+    ) -> JsObject {
         let prototype =
             prototype.unwrap_or_else(|| context.intrinsics().constructors().set().prototype());
 
@@ -182,7 +185,7 @@ impl Set {
     }
 
     /// Utility for constructing `Set` objects from an iterator of `JsValue`'s.
-    pub(crate) fn create_set_from_list<I>(elements: I, context: &mut Context<'_>) -> JsObject
+    pub(crate) fn create_set_from_list<I>(elements: I, context: &mut dyn Context<'_>) -> JsObject
     where
         I: IntoIterator<Item = JsValue>,
     {
@@ -208,7 +211,7 @@ impl Set {
     /// [spec]: https://tc39.es/ecma262/#sec-get-set-@@species
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -223,7 +226,11 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.add
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/add
-    pub(crate) fn add(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn add(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
 
         // 1. Let S be the this value.
@@ -266,7 +273,11 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set.prototype.clear
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/clear
-    pub(crate) fn clear(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn clear(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         let mut object = this
             .as_object()
             .map(JsObject::borrow_mut)
@@ -295,7 +306,7 @@ impl Set {
     pub(crate) fn delete(
         this: &JsValue,
         args: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
 
@@ -339,7 +350,7 @@ impl Set {
     pub(crate) fn entries(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let Some(lock) = this.as_object().and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone()))) else {
             return Err(JsNativeError::typ()
@@ -368,7 +379,7 @@ impl Set {
     pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
@@ -431,7 +442,11 @@ impl Set {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map.prototype.has
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map/has
-    pub(crate) fn has(this: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn has(
+        this: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         const JS_ZERO: &JsValue = &JsValue::Integer(0);
 
         // 1. Let S be the this value.
@@ -472,7 +487,7 @@ impl Set {
     pub(crate) fn values(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let Some(lock) = this.as_object().and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone()))) else {
             return Err(JsNativeError::typ()
@@ -488,7 +503,7 @@ impl Set {
         ))
     }
 
-    fn size_getter(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn size_getter(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Self::get_size(this).map(JsValue::from)
     }
 

--- a/boa_engine/src/builtins/set/set_iterator.rs
+++ b/boa_engine/src/builtins/set/set_iterator.rs
@@ -85,7 +85,7 @@ impl SetIterator {
         set: JsValue,
         kind: PropertyNameKind,
         lock: SetLock,
-        context: &Context<'_>,
+        context: &dyn Context<'_>,
     ) -> JsValue {
         let set_iterator = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
@@ -106,7 +106,7 @@ impl SetIterator {
     pub(crate) fn next(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let mut set_iterator = this.as_object().map(JsObject::borrow_mut);
 
@@ -146,7 +146,7 @@ impl SetIterator {
                         PropertyNameKind::KeyAndValue => {
                             let result = Array::create_array_from_list(
                                 [value.clone(), value.clone()],
-                                context,
+                                context.as_raw_context(),
                             );
                             return Ok(create_iter_result_object(result.into(), false, context));
                         }

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -199,7 +199,7 @@ impl BuiltInConstructor for String {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // This value is used by console.log and other routines to match Object type
         // to its Javascript Identifier (global constructor method name)
@@ -243,7 +243,11 @@ impl String {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-stringcreate
-    fn string_create(value: JsString, prototype: JsObject, context: &mut Context<'_>) -> JsObject {
+    fn string_create(
+        value: JsString,
+        prototype: JsObject,
+        context: &mut dyn Context<'_>,
+    ) -> JsObject {
         // 7. Let length be the number of code unit elements in value.
         let len = value.len();
 
@@ -312,7 +316,7 @@ impl String {
     pub(crate) fn from_code_point(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let result be the empty String.
         let mut result = Vec::with_capacity(args.len());
@@ -369,7 +373,7 @@ impl String {
     pub(crate) fn raw(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let substitutions = args.get(1..).unwrap_or_default();
 
@@ -444,7 +448,7 @@ impl String {
     pub(crate) fn from_char_code(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let result be the empty String.
         let mut result = Vec::new();
@@ -472,7 +476,7 @@ impl String {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisStringValue(this value).
         Ok(Self::this_string_value(this)?.into())
@@ -497,7 +501,7 @@ impl String {
     pub(crate) fn char_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -534,7 +538,7 @@ impl String {
     pub(crate) fn at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -579,7 +583,7 @@ impl String {
     pub(crate) fn code_point_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -622,7 +626,7 @@ impl String {
     pub(crate) fn char_code_at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -661,7 +665,7 @@ impl String {
     pub(crate) fn concat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -695,7 +699,7 @@ impl String {
     pub(crate) fn repeat(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -748,7 +752,7 @@ impl String {
     pub(crate) fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -813,7 +817,7 @@ impl String {
     pub(crate) fn starts_with(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -882,7 +886,7 @@ impl String {
     pub(crate) fn ends_with(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -948,7 +952,7 @@ impl String {
     pub(crate) fn includes(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1000,7 +1004,7 @@ impl String {
     pub(crate) fn replace(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // Helper enum.
         enum CallableOrString<'a> {
@@ -1109,7 +1113,7 @@ impl String {
     pub(crate) fn replace_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1261,7 +1265,7 @@ impl String {
     pub(crate) fn index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1305,7 +1309,7 @@ impl String {
     pub(crate) fn last_index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1372,7 +1376,7 @@ impl String {
     pub(crate) fn locale_compare(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1435,7 +1439,7 @@ impl String {
     pub(crate) fn r#match(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -1475,7 +1479,7 @@ impl String {
         max_length: &JsValue,
         fill_string: &JsValue,
         placement: Placement,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be ? ToString(O).
         let string = object.to_string(context)?;
@@ -1547,7 +1551,7 @@ impl String {
     pub(crate) fn pad_end(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1574,7 +1578,7 @@ impl String {
     pub(crate) fn pad_start(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1601,7 +1605,7 @@ impl String {
     pub(crate) fn trim(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, start+end).
@@ -1625,7 +1629,7 @@ impl String {
     pub(crate) fn trim_start(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, start).
@@ -1649,7 +1653,7 @@ impl String {
     pub(crate) fn trim_end(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Return ? TrimString(S, end).
@@ -1673,7 +1677,7 @@ impl String {
     pub(crate) fn to_case<const UPPER: bool>(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1705,7 +1709,7 @@ impl String {
     pub(crate) fn to_locale_case<const UPPER: bool>(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         #[cfg(feature = "intl")]
         {
@@ -1734,19 +1738,17 @@ impl String {
                 .next()
                 // 3. Else,
                 //     a. Let requestedLocale be ! DefaultLocale().
-                .unwrap_or_else(|| default_locale(context.icu().locale_canonicalizer()))
+                .unwrap_or_else(|| default_locale(context.icu_provider().locale_canonicalizer()))
                 .id;
             // 4. Let noExtensionsLocale be the String value that is requestedLocale with any Unicode locale extension sequences (6.2.1) removed.
             // 5. Let availableLocales be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
             // 6. Let locale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
             // 7. If locale is undefined, set locale to "und".
-            let lang =
-                best_available_locale::<CaseMappingV1Marker>(lang, &context.icu().provider())
-                    .unwrap_or(LanguageIdentifier::UND);
+            let lang = best_available_locale::<CaseMappingV1Marker>(lang, context.icu_provider())
+                .unwrap_or(LanguageIdentifier::UND);
 
-            let casemapper =
-                CaseMapping::try_new_with_locale(&context.icu().provider(), &lang.into())
-                    .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
+            let casemapper = CaseMapping::try_new_with_locale(context.icu_provider(), &lang.into())
+                .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
 
             // 8. Let codePoints be StringToCodePoints(S).
             let result = string.map_valid_segments(|segment| {
@@ -1785,7 +1787,7 @@ impl String {
     pub(crate) fn substring(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1835,7 +1837,7 @@ impl String {
     pub(crate) fn split(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let this = this.require_object_coercible()?;
@@ -1870,13 +1872,15 @@ impl String {
         // 6. If lim = 0, return A.
         if lim == 0 {
             // a. Return ! CreateArrayFromList(« »).
-            return Ok(Array::create_array_from_list([], context).into());
+            return Ok(Array::create_array_from_list([], context.as_raw_context()).into());
         }
 
         // 7. If separator is undefined, then
         if separator.is_undefined() {
             // a. Return ! CreateArrayFromList(« S »).
-            return Ok(Array::create_array_from_list([this_str.into()], context).into());
+            return Ok(
+                Array::create_array_from_list([this_str.into()], context.as_raw_context()).into(),
+            );
         }
 
         // 8. Let separatorLength be the length of R.
@@ -1892,12 +1896,14 @@ impl String {
                 .iter()
                 .map(|code| js_string!(std::slice::from_ref(code)).into());
             // c. Return ! CreateArrayFromList(codeUnits).
-            return Ok(Array::create_array_from_list(head, context).into());
+            return Ok(Array::create_array_from_list(head, context.as_raw_context()).into());
         }
 
         // 10. If S is the empty String, return ! CreateArrayFromList(« S »).
         if this_str.is_empty() {
-            return Ok(Array::create_array_from_list([this_str.into()], context).into());
+            return Ok(
+                Array::create_array_from_list([this_str.into()], context.as_raw_context()).into(),
+            );
         }
 
         // 11. Let substrings be a new empty List.
@@ -1919,7 +1925,7 @@ impl String {
             if substrings.len() == lim {
                 return Ok(Array::create_array_from_list(
                     substrings.into_iter().map(JsValue::from),
-                    context,
+                    context.as_raw_context(),
                 )
                 .into());
             }
@@ -1935,10 +1941,11 @@ impl String {
         substrings.push(js_string!(&this_str[i..]));
 
         // 17. Return ! CreateArrayFromList(substrings).
-        Ok(
-            Array::create_array_from_list(substrings.into_iter().map(JsValue::from), context)
-                .into(),
+        Ok(Array::create_array_from_list(
+            substrings.into_iter().map(JsValue::from),
+            context.as_raw_context(),
         )
+        .into())
     }
 
     /// String.prototype.valueOf()
@@ -1954,7 +1961,7 @@ impl String {
     pub(crate) fn value_of(
         this: &JsValue,
         _args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisStringValue(this value).
         Self::this_string_value(this).map(JsValue::from)
@@ -1975,7 +1982,7 @@ impl String {
     pub(crate) fn match_all(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2032,7 +2039,7 @@ impl String {
     pub(crate) fn normalize(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         /// Represents the type of normalization applied to a [`JsString`]
         #[derive(Clone, Copy)]
@@ -2098,7 +2105,7 @@ impl String {
             }
             #[cfg(feature = "intl")]
             {
-                context.icu().string_normalizers()
+                context.icu_provider().string_normalizers()
             }
         };
 
@@ -2126,7 +2133,7 @@ impl String {
     pub(crate) fn search(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2156,7 +2163,7 @@ impl String {
     pub(crate) fn iterator(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2183,7 +2190,7 @@ impl String {
     pub(crate) fn substr(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be ? RequireObjectCoercible(this value).
         let o = this.require_object_coercible()?;
@@ -2247,7 +2254,7 @@ impl String {
         string: &JsValue,
         tag: &[u16],
         attribute_and_value: Option<(&[u16], &JsValue)>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let str be ? RequireObjectCoercible(string).
         let str = string.require_object_coercible()?;
@@ -2320,7 +2327,7 @@ impl String {
     pub(crate) fn anchor(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let name = args.get_or_undefined(0);
 
@@ -2341,7 +2348,7 @@ impl String {
     pub(crate) fn big(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2360,7 +2367,7 @@ impl String {
     pub(crate) fn blink(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2379,7 +2386,7 @@ impl String {
     pub(crate) fn bold(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2398,7 +2405,7 @@ impl String {
     pub(crate) fn fixed(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2417,7 +2424,7 @@ impl String {
     pub(crate) fn fontcolor(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let color = args.get_or_undefined(0);
 
@@ -2438,7 +2445,7 @@ impl String {
     pub(crate) fn fontsize(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let size = args.get_or_undefined(0);
 
@@ -2459,7 +2466,7 @@ impl String {
     pub(crate) fn italics(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2478,7 +2485,7 @@ impl String {
     pub(crate) fn link(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let url = args.get_or_undefined(0);
 
@@ -2499,7 +2506,7 @@ impl String {
     pub(crate) fn small(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2518,7 +2525,7 @@ impl String {
     pub(crate) fn strike(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2537,7 +2544,7 @@ impl String {
     pub(crate) fn sub(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2556,7 +2563,7 @@ impl String {
     pub(crate) fn sup(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         let s = this;
@@ -2578,7 +2585,7 @@ pub(crate) fn get_substitution(
     captures: &[JsValue],
     named_captures: &JsValue,
     replacement: &JsString,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsString> {
     let mut buf = [0; 2];
     // 1. Assert: Type(matched) is String.

--- a/boa_engine/src/builtins/string/string_iterator.rs
+++ b/boa_engine/src/builtins/string/string_iterator.rs
@@ -59,7 +59,7 @@ impl IntrinsicObject for StringIterator {
 
 impl StringIterator {
     /// Create a new `StringIterator`.
-    pub fn create_string_iterator(string: JsString, context: &mut Context<'_>) -> JsObject {
+    pub fn create_string_iterator(string: JsString, context: &mut dyn Context<'_>) -> JsObject {
         JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             context
@@ -75,7 +75,7 @@ impl StringIterator {
     }
 
     /// `StringIterator.prototype.next( )`
-    pub fn next(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn next(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         let mut string_iterator = this.as_object().map(JsObject::borrow_mut);
         let string_iterator = string_iterator
             .as_mut()

--- a/boa_engine/src/builtins/symbol/mod.rs
+++ b/boa_engine/src/builtins/symbol/mod.rs
@@ -198,7 +198,7 @@ impl BuiltInConstructor for Symbol {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is not undefined, throw a TypeError exception.
         if !new_target.is_undefined() {
@@ -250,7 +250,7 @@ impl Symbol {
     pub(crate) fn to_string(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let sym be ? thisSymbolValue(this value).
         let symbol = Self::this_symbol_value(this)?;
@@ -272,7 +272,7 @@ impl Symbol {
     pub(crate) fn value_of(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Return ? thisSymbolValue(this value).
         let symbol = Self::this_symbol_value(this)?;
@@ -292,7 +292,7 @@ impl Symbol {
     pub(crate) fn get_description(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let s be the this value.
         // 2. Let sym be ? thisSymbolValue(s).
@@ -315,7 +315,7 @@ impl Symbol {
     pub(crate) fn for_(
         _: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let stringKey be ? ToString(key).
         let string_key = args
@@ -343,7 +343,11 @@ impl Symbol {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol.prototype.keyfor
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/keyFor
-    pub(crate) fn key_for(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn key_for(
+        _: &JsValue,
+        args: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. If Type(sym) is not Symbol, throw a TypeError exception.
         let sym = args.get_or_undefined(0).as_symbol().ok_or_else(|| {
             JsNativeError::typ().with_message("Symbol.keyFor: sym is not a symbol")
@@ -374,7 +378,7 @@ impl Symbol {
     pub(crate) fn to_primitive(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let sym = Self::this_symbol_value(this)?;
         // 1. Return ? thisSymbolValue(this value).

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -109,7 +109,7 @@ macro_rules! typed_array {
             fn constructor(
                 new_target: &JsValue,
                 args: &[JsValue],
-                context: &mut Context<'_>,
+                context: &mut dyn Context<'_>,
             ) -> JsResult<JsValue> {
                 // 1. If NewTarget is undefined, throw a TypeError exception.
                 if new_target.is_undefined() {
@@ -365,7 +365,7 @@ impl BuiltInConstructor for TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%
-    fn constructor(_: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn constructor(_: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
         Err(JsNativeError::typ()
             .with_message("the TypedArray constructor should never be called directly")
@@ -380,7 +380,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.from
-    fn from(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn from(this: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let C be the this value.
         // 2. If IsConstructor(C) is false, throw a TypeError exception.
         let constructor = match this.as_object() {
@@ -490,7 +490,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.of
-    fn of(this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn of(this: &JsValue, args: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let len be the number of elements in items.
 
         // 2. Let C be the this value.
@@ -527,7 +527,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%-@@species
     #[allow(clippy::unnecessary_wraps)]
-    fn get_species(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn get_species(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Return the this value.
         Ok(this.clone())
     }
@@ -541,7 +541,7 @@ impl TypedArray {
     pub(crate) fn at(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -592,7 +592,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
-    fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn buffer(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
@@ -620,7 +620,7 @@ impl TypedArray {
     pub(crate) fn byte_length(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
@@ -653,7 +653,7 @@ impl TypedArray {
     pub(crate) fn byte_offset(
         this: &JsValue,
         _: &[JsValue],
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
@@ -686,7 +686,7 @@ impl TypedArray {
     fn copy_within(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         let obj = this.as_object().ok_or_else(|| {
@@ -860,7 +860,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.entries
-    fn entries(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn entries(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let o = this.as_object().ok_or_else(|| {
@@ -893,7 +893,7 @@ impl TypedArray {
     pub(crate) fn every(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -960,7 +960,7 @@ impl TypedArray {
     pub(crate) fn fill(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1048,7 +1048,7 @@ impl TypedArray {
     pub(crate) fn filter(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1136,7 +1136,7 @@ impl TypedArray {
     pub(crate) fn find(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1202,7 +1202,7 @@ impl TypedArray {
     pub(crate) fn findindex(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1266,7 +1266,7 @@ impl TypedArray {
     pub(crate) fn foreach(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1325,7 +1325,7 @@ impl TypedArray {
     pub(crate) fn includes(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1404,7 +1404,7 @@ impl TypedArray {
     pub(crate) fn index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1492,7 +1492,7 @@ impl TypedArray {
     pub(crate) fn join(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1555,7 +1555,7 @@ impl TypedArray {
     pub(crate) fn keys(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1589,7 +1589,7 @@ impl TypedArray {
     pub(crate) fn last_index_of(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1666,7 +1666,11 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.length
-    pub(crate) fn length(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    pub(crate) fn length(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has [[ViewedArrayBuffer]] and [[ArrayLength]] internal slots.
@@ -1698,7 +1702,7 @@ impl TypedArray {
     pub(crate) fn map(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1764,7 +1768,7 @@ impl TypedArray {
     pub(crate) fn reduce(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1849,7 +1853,7 @@ impl TypedArray {
     pub(crate) fn reduceright(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1937,7 +1941,7 @@ impl TypedArray {
     pub(crate) fn reverse(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -1998,7 +2002,7 @@ impl TypedArray {
     pub(crate) fn set(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let target be the this value.
         // 2. Perform ? RequireInternalSlot(target, [[TypedArrayName]]).
@@ -2058,7 +2062,7 @@ impl TypedArray {
         target: &JsObject,
         target_offset: IntegerOrInfinity,
         source: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         let target_borrow = target.borrow();
         let target_array = target_borrow
@@ -2281,7 +2285,7 @@ impl TypedArray {
         target: &JsObject,
         target_offset: IntegerOrInfinity,
         source: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         let target_borrow = target.borrow();
         let target_array = target_borrow
@@ -2400,7 +2404,7 @@ impl TypedArray {
     pub(crate) fn slice(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -2573,7 +2577,7 @@ impl TypedArray {
     pub(crate) fn some(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
@@ -2639,7 +2643,7 @@ impl TypedArray {
     pub(crate) fn sort(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If comparefn is not undefined and IsCallable(comparefn) is false, throw a TypeError exception.
         let compare_fn = match args.get(0) {
@@ -2706,7 +2710,7 @@ impl TypedArray {
         let sort_compare = |x: &JsValue,
                             y: &JsValue,
                             compare_fn: Option<&JsObject>,
-                            context: &mut Context<'_>|
+                            context: &mut dyn Context<'_>|
          -> JsResult<Ordering> {
             // 1. Assert: Both Type(x) and Type(y) are Number or both are BigInt.
             // 2. If comparefn is not undefined, then
@@ -2853,7 +2857,7 @@ impl TypedArray {
     pub(crate) fn subarray(
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
@@ -2939,7 +2943,7 @@ impl TypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.values
-    fn values(this: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    fn values(this: &JsValue, _: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? ValidateTypedArray(O).
         let o = this.as_object().ok_or_else(|| {
@@ -2970,7 +2974,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
     #[allow(clippy::unnecessary_wraps)]
-    fn to_string_tag(this: &JsValue, _: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
+    fn to_string_tag(this: &JsValue, _: &[JsValue], _: &mut dyn Context<'_>) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, return undefined.
         // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.
@@ -2997,7 +3001,7 @@ impl TypedArray {
         exemplar: &JsObject,
         typed_array_name: TypedArrayKind,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let defaultConstructor be the intrinsic object listed in column one of Table 73 for exemplar.[[TypedArrayName]].
         let default_constructor = match typed_array_name {
@@ -3048,7 +3052,7 @@ impl TypedArray {
     fn create(
         constructor: &JsObject,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject> {
         // 1. Let newTypedArray be ? Construct(constructor, argumentList).
         let new_typed_array = constructor.construct(args, Some(constructor), context)?;
@@ -3084,7 +3088,7 @@ impl TypedArray {
     fn allocate_buffer(
         indexed: &mut IntegerIndexed,
         length: u64,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Assert: O.[[ViewedArrayBuffer]] is undefined.
         assert!(indexed.viewed_array_buffer().is_none());
@@ -3125,7 +3129,7 @@ impl TypedArray {
     pub(crate) fn initialize_from_list(
         o: &JsObject,
         values: Vec<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Let len be the number of elements in values.
         let len = values.len() as u64;
@@ -3167,7 +3171,7 @@ impl TypedArray {
         new_target: &JsValue,
         default_proto: P,
         length: Option<u64>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsObject>
     where
         P: FnOnce(&StandardConstructors) -> &StandardConstructor,
@@ -3211,7 +3215,7 @@ impl TypedArray {
     fn initialize_from_typed_array(
         o: &JsObject,
         src_array: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         let o_obj = o.borrow();
         let src_array_obj = src_array.borrow();
@@ -3362,7 +3366,7 @@ impl TypedArray {
         buffer: JsObject,
         byte_offset: &JsValue,
         length: &JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Let constructorName be the String value of O.[[TypedArrayName]].
         // 2. Let elementSize be the Element Size value specified in Table 73 for constructorName.
@@ -3463,7 +3467,7 @@ impl TypedArray {
     fn initialize_from_array_like(
         o: &JsObject,
         array_like: &JsObject,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Let len be ? LengthOfArrayLike(arrayLike).
         let len = array_like.length_of_array_like(context)?;

--- a/boa_engine/src/builtins/uri/mod.rs
+++ b/boa_engine/src/builtins/uri/mod.rs
@@ -173,7 +173,7 @@ impl BuiltInObject for EncodeUriComponent {
 pub(crate) fn decode_uri(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let encoded_uri = args.get_or_undefined(0);
 
@@ -201,7 +201,7 @@ pub(crate) fn decode_uri(
 pub(crate) fn decode_uri_component(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let encoded_uri_component = args.get_or_undefined(0);
 
@@ -233,7 +233,7 @@ pub(crate) fn decode_uri_component(
 pub(crate) fn encode_uri(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let uri = args.get_or_undefined(0);
 
@@ -262,7 +262,7 @@ pub(crate) fn encode_uri(
 pub(crate) fn encode_uri_component(
     _: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let uri_component = args.get_or_undefined(0);
 

--- a/boa_engine/src/builtins/weak/weak_ref.rs
+++ b/boa_engine/src/builtins/weak/weak_ref.rs
@@ -61,7 +61,7 @@ impl BuiltInConstructor for WeakRef {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -89,7 +89,7 @@ impl BuiltInConstructor for WeakRef {
         );
 
         // 4. Perform AddToKeptObjects(target).
-        context.kept_alive.push(target.clone());
+        context.as_raw_context_mut().kept_alive.push(target.clone());
 
         // 6. Return weakRef.
         Ok(weak_ref.into())
@@ -106,7 +106,7 @@ impl WeakRef {
     pub(crate) fn deref(
         this: &JsValue,
         _: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let weakRef be the this value.
         // 2. Perform ? RequireInternalSlot(weakRef, [[WeakRefTarget]]).
@@ -132,7 +132,7 @@ impl WeakRef {
             let object = JsObject::from(object);
 
             // a. Perform AddToKeptObjects(target).
-            context.kept_alive.push(object.clone());
+            context.as_raw_context_mut().kept_alive.push(object.clone());
 
             // b. Return target.
             Ok(object.into())

--- a/boa_engine/src/builtins/weak_map/mod.rs
+++ b/boa_engine/src/builtins/weak_map/mod.rs
@@ -71,7 +71,7 @@ impl BuiltInConstructor for WeakMap {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -123,7 +123,7 @@ impl WeakMap {
     pub(crate) fn delete(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
@@ -163,7 +163,7 @@ impl WeakMap {
     pub(crate) fn get(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
@@ -200,7 +200,7 @@ impl WeakMap {
     pub(crate) fn has(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).
@@ -237,7 +237,7 @@ impl WeakMap {
     pub(crate) fn set(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let M be the this value.
         // 2. Perform ? RequireInternalSlot(M, [[WeakMapData]]).

--- a/boa_engine/src/builtins/weak_set/mod.rs
+++ b/boa_engine/src/builtins/weak_set/mod.rs
@@ -67,7 +67,7 @@ impl BuiltInConstructor for WeakSet {
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If NewTarget is undefined, throw a TypeError exception.
         if new_target.is_undefined() {
@@ -135,7 +135,7 @@ impl WeakSet {
     pub(crate) fn add(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
@@ -187,7 +187,7 @@ impl WeakSet {
     pub(crate) fn delete(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).
@@ -229,7 +229,7 @@ impl WeakSet {
     pub(crate) fn has(
         this: &JsValue,
         args: &[JsValue],
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[WeakSetData]]).

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -89,7 +89,7 @@ impl FunctionCompiler {
         parameters: &FormalParameterList,
         body: &FunctionBody,
         outer_env: Gc<GcRefCell<CompileTimeEnvironment>>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> Gc<CodeBlock> {
         self.strict = self.strict || body.strict();
 

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -210,9 +210,9 @@ impl Access<'_> {
 }
 
 /// The [`ByteCompiler`] is used to compile ECMAScript AST from [`boa_ast`] to bytecode.
-#[derive(Debug)]
 #[allow(clippy::struct_excessive_bools)]
-pub struct ByteCompiler<'ctx, 'host> {
+#[derive(Debug)]
+pub struct ByteCompiler<'ctx, 'icu> {
     /// Name of this function.
     pub(crate) function_name: Sym,
 
@@ -256,13 +256,13 @@ pub struct ByteCompiler<'ctx, 'host> {
     json_parse: bool,
 
     // TODO: remove when we separate scripts from the context
-    context: &'ctx mut Context<'host>,
+    context: &'ctx mut dyn Context<'icu>,
 
     #[cfg(feature = "annex-b")]
     annex_b_function_names: Vec<Identifier>,
 }
 
-impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
+impl<'ctx, 'icu> ByteCompiler<'ctx, 'icu> {
     /// Represents a placeholder address that will be patched later.
     const DUMMY_ADDRESS: u32 = u32::MAX;
     const DUMMY_LABEL: Label = Label { index: u32::MAX };
@@ -275,8 +275,8 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         json_parse: bool,
         current_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
         // TODO: remove when we separate scripts from the context
-        context: &'ctx mut Context<'host>,
-    ) -> ByteCompiler<'ctx, 'host> {
+        context: &'ctx mut dyn Context<'icu>,
+    ) -> ByteCompiler<'ctx, 'icu> {
         let mut code_block_flags = CodeBlockFlags::empty();
         code_block_flags.set(CodeBlockFlags::STRICT, strict);
         Self {

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -34,7 +34,7 @@ use super::intrinsics::Intrinsics;
 ///     fn ensure_can_compile_strings(
 ///         &self,
 ///         _realm: Realm,
-///         context: &mut Context<'_>,
+///         context: &mut dyn Context<'_>,
 ///     ) -> JsResult<()> {
 ///         Err(JsNativeError::typ().with_message("eval calls not available").into())
 ///     }
@@ -54,7 +54,11 @@ pub trait HostHooks {
     /// - It must return a `JobCallback` Record whose `[[Callback]]` field is `callback`.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hostmakejobcallback
-    fn make_job_callback(&self, callback: JsFunction, _context: &mut Context<'_>) -> JobCallback {
+    fn make_job_callback(
+        &self,
+        callback: JsFunction,
+        _context: &mut dyn Context<'_>,
+    ) -> JobCallback {
         // The default implementation of HostMakeJobCallback performs the following steps when called:
 
         // 1. Return the JobCallback Record { [[Callback]]: callback, [[HostDefined]]: empty }.
@@ -73,7 +77,7 @@ pub trait HostHooks {
         job: JobCallback,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // The default implementation of HostCallJobCallback performs the following steps when called:
 
@@ -95,7 +99,7 @@ pub trait HostHooks {
         &self,
         _promise: &JsObject,
         _operation: OperationType,
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) {
         // The default implementation of HostPromiseRejectionTracker is to return unused.
     }
@@ -112,7 +116,7 @@ pub trait HostHooks {
     fn ensure_can_compile_strings(
         &self,
         _realm: Realm,
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(unused).
         Ok(())
@@ -129,7 +133,7 @@ pub trait HostHooks {
     fn has_source_text_available(
         &self,
         _function: &JsFunction,
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> bool {
         // The default implementation of HostHasSourceTextAvailable is to return true.
         true
@@ -149,7 +153,7 @@ pub trait HostHooks {
     fn ensure_can_add_private_element(
         &self,
         _o: &JsObject,
-        _context: &mut Context<'_>,
+        _context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         Ok(())
     }

--- a/boa_engine/src/context/icu.rs
+++ b/boa_engine/src/context/icu.rs
@@ -24,60 +24,103 @@ use crate::builtins::{
 
 /// ICU4X data provider used in boa.
 ///
-/// Providers can be either [`BufferProvider`]s or [`AnyProvider`]s.
+/// An icu provider can be constructed from either [`BufferProvider`]s or [`AnyProvider`]s.
 ///
 /// The [`icu_provider`] documentation has more information about data providers.
-#[derive(Clone, Copy)]
-pub enum BoaProvider<'a> {
+#[derive(Debug)]
+pub struct IcuProvider<'a> {
+    provider: Inner<'a>,
+    locale_canonicalizer: LocaleCanonicalizer,
+    locale_expander: LocaleExpander,
+    string_normalizers: StringNormalizers,
+}
+
+#[derive(Copy, Clone)]
+enum Inner<'a> {
     /// A [`BufferProvider`] data provider.
     Buffer(&'a dyn BufferProvider),
     /// An [`AnyProvider`] data provider.
     Any(&'a dyn AnyProvider),
 }
 
-impl Debug for BoaProvider<'_> {
+impl Debug for Inner<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Buffer(_) => f.debug_tuple("Buffer").field(&"..").finish(),
-            Self::Any(_) => f.debug_tuple("Any").field(&"..").finish(),
+            Self::Buffer(_) => f.debug_tuple("Buffer").field(&"_").finish(),
+            Self::Any(_) => f.debug_tuple("Any").field(&"_").finish(),
         }
     }
 }
 
-impl<M> DataProvider<M> for BoaProvider<'_>
-where
-    M: KeyedDataMarker + 'static,
-    for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: Deserialize<'de>,
-    for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
-    M::Yokeable: ZeroFrom<'static, M::Yokeable> + MaybeSendSync,
-{
-    fn load(&self, req: DataRequest<'_>) -> Result<DataResponse<M>, DataError> {
-        match self {
-            BoaProvider::Buffer(provider) => provider.as_deserializing().load(req),
-            BoaProvider::Any(provider) => provider.as_downcasting().load(req),
-        }
+impl<'a> IcuProvider<'a> {
+    /// Creates a new [`IcuProvider`] from a [`BufferProvider`].
+    ///
+    /// # Errors
+    ///
+    /// This returns `Err` if the provided provider doesn't have the required locale information
+    /// to construct the tools required by `Intl`. Note that this doesn't
+    /// mean that the provider will successfully construct all `Intl` services; that check is made
+    /// until the creation of an instance of a service.
+    pub fn from_buffer_provider<P: BufferProvider>(
+        provider: &'a P,
+    ) -> Result<IcuProvider<'a>, IcuError> {
+        let locale_canonicalizer = LocaleCanonicalizer::try_new_with_buffer_provider(provider)?;
+        let locale_expander = LocaleExpander::try_new_with_buffer_provider(provider)?;
+        let string_normalizers = StringNormalizers {
+            nfc: ComposingNormalizer::try_new_nfc_with_buffer_provider(provider)?,
+            nfkc: ComposingNormalizer::try_new_nfkc_with_buffer_provider(provider)?,
+            nfd: DecomposingNormalizer::try_new_nfd_with_buffer_provider(provider)?,
+            nfkd: DecomposingNormalizer::try_new_nfkd_with_buffer_provider(provider)?,
+        };
+
+        Ok(Self {
+            provider: Inner::Buffer(provider),
+            locale_canonicalizer,
+            locale_expander,
+            string_normalizers,
+        })
+    }
+
+    /// Creates a new [`IcuProvider`] from an [`AnyProvider`].
+    ///
+    /// # Errors
+    ///
+    /// This returns `Err` if the provided provider doesn't have the required locale information
+    /// to construct the tools required by `Intl`. Note that this doesn't
+    /// mean that the provider will successfully construct all `Intl` services; that check is made
+    /// until the creation of an instance of a service.
+    pub fn from_any_provider<P: AnyProvider>(provider: &'a P) -> Result<IcuProvider<'a>, IcuError> {
+        let locale_canonicalizer = LocaleCanonicalizer::try_new_with_any_provider(provider)?;
+        let locale_expander = LocaleExpander::try_new_with_any_provider(provider)?;
+        let string_normalizers = StringNormalizers {
+            nfc: ComposingNormalizer::try_new_nfc_with_any_provider(provider)?,
+            nfkc: ComposingNormalizer::try_new_nfkc_with_any_provider(provider)?,
+            nfd: DecomposingNormalizer::try_new_nfd_with_any_provider(provider)?,
+            nfkd: DecomposingNormalizer::try_new_nfkd_with_any_provider(provider)?,
+        };
+        Ok(Self {
+            provider: Inner::Any(provider),
+            locale_canonicalizer,
+            locale_expander,
+            string_normalizers,
+        })
     }
 }
 
-impl BoaProvider<'_> {
-    /// Creates a new [`LocaleCanonicalizer`] from the provided [`DataProvider`].
-    pub(crate) fn try_new_locale_canonicalizer(
-        &self,
-    ) -> Result<LocaleCanonicalizer, LocaleTransformError> {
-        match *self {
-            BoaProvider::Buffer(buffer) => {
-                LocaleCanonicalizer::try_new_with_buffer_provider(buffer)
-            }
-            BoaProvider::Any(any) => LocaleCanonicalizer::try_new_with_any_provider(any),
-        }
+impl IcuProvider<'_> {
+    /// Gets the [`LocaleCanonicalizer`] tool.
+    pub(crate) const fn locale_canonicalizer(&self) -> &LocaleCanonicalizer {
+        &self.locale_canonicalizer
     }
 
-    /// Creates a new [`LocaleExpander`] from the provided [`DataProvider`].
-    pub(crate) fn try_new_locale_expander(&self) -> Result<LocaleExpander, LocaleTransformError> {
-        match *self {
-            BoaProvider::Buffer(buffer) => LocaleExpander::try_new_with_buffer_provider(buffer),
-            BoaProvider::Any(any) => LocaleExpander::try_new_with_any_provider(any),
-        }
+    /// Gets the [`LocaleExpander`] tool.
+    pub(crate) const fn locale_expander(&self) -> &LocaleExpander {
+        &self.locale_expander
+    }
+
+    /// Gets the [`StringNormalizers`] tools.
+    pub(crate) const fn string_normalizers(&self) -> &StringNormalizers {
+        &self.string_normalizers
     }
 
     /// Creates a new [`ListFormatter`] from the provided [`DataProvider`] and options.
@@ -87,8 +130,8 @@ impl BoaProvider<'_> {
         typ: ListFormatType,
         style: ListLength,
     ) -> Result<ListFormatter, ListError> {
-        match *self {
-            BoaProvider::Buffer(buf) => match typ {
+        match self.provider {
+            Inner::Buffer(buf) => match typ {
                 ListFormatType::Conjunction => {
                     ListFormatter::try_new_and_with_length_with_buffer_provider(buf, locale, style)
                 }
@@ -99,7 +142,7 @@ impl BoaProvider<'_> {
                     ListFormatter::try_new_unit_with_length_with_buffer_provider(buf, locale, style)
                 }
             },
-            BoaProvider::Any(any) => match typ {
+            Inner::Any(any) => match typ {
                 ListFormatType::Conjunction => {
                     ListFormatter::try_new_and_with_length_with_any_provider(any, locale, style)
                 }
@@ -119,11 +162,9 @@ impl BoaProvider<'_> {
         locale: &DataLocale,
         options: CollatorOptions,
     ) -> Result<Collator, CollatorError> {
-        match *self {
-            BoaProvider::Buffer(buf) => {
-                Collator::try_new_with_buffer_provider(buf, locale, options)
-            }
-            BoaProvider::Any(any) => Collator::try_new_with_any_provider(any, locale, options),
+        match self.provider {
+            Inner::Buffer(buf) => Collator::try_new_with_buffer_provider(buf, locale, options),
+            Inner::Any(any) => Collator::try_new_with_any_provider(any, locale, options),
         }
     }
 
@@ -133,41 +174,37 @@ impl BoaProvider<'_> {
         granularity: Granularity,
     ) -> Result<NativeSegmenter, SegmenterError> {
         match granularity {
-            Granularity::Grapheme => match *self {
-                BoaProvider::Buffer(buf) => {
-                    GraphemeClusterSegmenter::try_new_with_buffer_provider(buf)
-                }
-                BoaProvider::Any(any) => GraphemeClusterSegmenter::try_new_with_any_provider(any),
+            Granularity::Grapheme => match self.provider {
+                Inner::Buffer(buf) => GraphemeClusterSegmenter::try_new_with_buffer_provider(buf),
+                Inner::Any(any) => GraphemeClusterSegmenter::try_new_with_any_provider(any),
             }
             .map(|seg| NativeSegmenter::Grapheme(Box::new(seg))),
-            Granularity::Word => match *self {
-                BoaProvider::Buffer(buf) => WordSegmenter::try_new_auto_with_buffer_provider(buf),
-                BoaProvider::Any(any) => WordSegmenter::try_new_auto_with_any_provider(any),
+            Granularity::Word => match self.provider {
+                Inner::Buffer(buf) => WordSegmenter::try_new_auto_with_buffer_provider(buf),
+                Inner::Any(any) => WordSegmenter::try_new_auto_with_any_provider(any),
             }
             .map(|seg| NativeSegmenter::Word(Box::new(seg))),
-            Granularity::Sentence => match *self {
-                BoaProvider::Buffer(buf) => SentenceSegmenter::try_new_with_buffer_provider(buf),
-                BoaProvider::Any(any) => SentenceSegmenter::try_new_with_any_provider(any),
+            Granularity::Sentence => match self.provider {
+                Inner::Buffer(buf) => SentenceSegmenter::try_new_with_buffer_provider(buf),
+                Inner::Any(any) => SentenceSegmenter::try_new_with_any_provider(any),
             }
             .map(|seg| NativeSegmenter::Sentence(Box::new(seg))),
         }
     }
+}
 
-    pub(crate) fn try_new_string_normalizers(&self) -> Result<StringNormalizers, NormalizerError> {
-        Ok(match *self {
-            BoaProvider::Buffer(buf) => StringNormalizers {
-                nfc: ComposingNormalizer::try_new_nfc_with_buffer_provider(buf)?,
-                nfkc: ComposingNormalizer::try_new_nfkc_with_buffer_provider(buf)?,
-                nfd: DecomposingNormalizer::try_new_nfd_with_buffer_provider(buf)?,
-                nfkd: DecomposingNormalizer::try_new_nfkd_with_buffer_provider(buf)?,
-            },
-            BoaProvider::Any(any) => StringNormalizers {
-                nfc: ComposingNormalizer::try_new_nfc_with_any_provider(any)?,
-                nfkc: ComposingNormalizer::try_new_nfkc_with_any_provider(any)?,
-                nfd: DecomposingNormalizer::try_new_nfd_with_any_provider(any)?,
-                nfkd: DecomposingNormalizer::try_new_nfkd_with_any_provider(any)?,
-            },
-        })
+impl<M> DataProvider<M> for IcuProvider<'_>
+where
+    M: KeyedDataMarker + 'static,
+    for<'de> YokeTraitHack<<M::Yokeable as Yokeable<'de>>::Output>: Deserialize<'de>,
+    for<'a> YokeTraitHack<<M::Yokeable as Yokeable<'a>>::Output>: Clone,
+    M::Yokeable: ZeroFrom<'static, M::Yokeable> + MaybeSendSync,
+{
+    fn load(&self, req: DataRequest<'_>) -> Result<DataResponse<M>, DataError> {
+        match self.provider {
+            Inner::Buffer(provider) => provider.as_deserializing().load(req),
+            Inner::Any(provider) => provider.as_downcasting().load(req),
+        }
     }
 }
 
@@ -180,60 +217,4 @@ pub enum IcuError {
     /// Failed to create the string normalization tools.
     #[error("could not construct the string normalization tools")]
     Normalizer(#[from] NormalizerError),
-}
-
-/// Collection of tools initialized from a [`DataProvider`] that are used for the functionality of
-/// `Intl`.
-pub(crate) struct Icu<'provider> {
-    provider: BoaProvider<'provider>,
-    locale_canonicalizer: LocaleCanonicalizer,
-    locale_expander: LocaleExpander,
-    string_normalizers: StringNormalizers,
-}
-
-impl Debug for Icu<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Icu")
-            .field("provider", &self.provider)
-            .field("locale_canonicalizer", &self.locale_canonicalizer)
-            .field("locale_expander", &self.locale_expander)
-            .field("string_normalizers", &self.string_normalizers)
-            .finish()
-    }
-}
-
-impl<'provider> Icu<'provider> {
-    /// Creates a new [`Icu`] from a valid [`BoaProvider`]
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if any of the tools required cannot be constructed.
-    pub(crate) fn new(provider: BoaProvider<'provider>) -> Result<Icu<'provider>, IcuError> {
-        Ok(Self {
-            locale_canonicalizer: provider.try_new_locale_canonicalizer()?,
-            locale_expander: provider.try_new_locale_expander()?,
-            string_normalizers: provider.try_new_string_normalizers()?,
-            provider,
-        })
-    }
-
-    /// Gets the [`LocaleCanonicalizer`] tool.
-    pub(crate) const fn locale_canonicalizer(&self) -> &LocaleCanonicalizer {
-        &self.locale_canonicalizer
-    }
-
-    /// Gets the [`LocaleExpander`] tool.
-    pub(crate) const fn locale_expander(&self) -> &LocaleExpander {
-        &self.locale_expander
-    }
-
-    /// Gets the [`StringNormalizers`] tools.
-    pub(crate) const fn string_normalizers(&self) -> &StringNormalizers {
-        &self.string_normalizers
-    }
-
-    /// Gets the inner icu data provider
-    pub(crate) const fn provider(&self) -> BoaProvider<'provider> {
-        self.provider
-    }
 }

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -637,6 +637,9 @@ pub struct RawContext<'icu> {
     #[cfg(feature = "intl")]
     icu_provider: IcuProvider<'icu>,
 
+    #[cfg(not(feature = "intl"))]
+    icu_provider: PhantomData<&'icu ()>,
+
     pub(crate) host_hooks: &'static dyn HostHooks,
 
     /// Unique identifier for each parser instance used during the context lifetime.
@@ -669,7 +672,7 @@ impl Default for RawContext<'_> {
     }
 }
 
-impl<'icu> RawContext<'icu> {
+impl RawContext<'_> {
     /// Gets the string interner.
     #[inline]
     pub fn interner(&self) -> &Interner {
@@ -799,9 +802,11 @@ impl<'icu> RawContext<'icu> {
     pub(crate) fn is_strict(&self) -> bool {
         self.strict
     }
+}
 
-    /// Gets the icu provider.
-    #[cfg(feature = "intl")]
+/// Gets the icu provider.
+#[cfg(feature = "intl")]
+impl<'icu> RawContext<'icu> {
     pub(crate) fn icu_provider(&self) -> &IcuProvider<'icu> {
         &self.icu_provider
     }
@@ -985,6 +990,8 @@ impl<'icu> RawContextBuilder<'icu> {
                 IcuProvider::from_buffer_provider(boa_icu_provider::buffer())
                     .expect("Failed to initialize default icu data.")
             }),
+            #[cfg(not(feature = "intl"))]
+            icu_provider: PhantomData,
             #[cfg(feature = "fuzz")]
             instructions_remaining: self.instructions_remaining,
             kept_alive: Vec::new(),

--- a/boa_engine/src/object/builtins/jsarray.rs
+++ b/boa_engine/src/object/builtins/jsarray.rs
@@ -18,7 +18,7 @@ pub struct JsArray {
 impl JsArray {
     /// Create a new empty array.
     #[inline]
-    pub fn new(context: &mut Context<'_>) -> Self {
+    pub fn new(context: &mut dyn Context<'_>) -> Self {
         let inner = Array::array_create(0, None, context)
             .expect("creating an empty array with the default prototype must not fail");
 
@@ -26,12 +26,12 @@ impl JsArray {
     }
 
     /// Create an array from a `IntoIterator<Item = JsValue>` convertible object.
-    pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> Self
+    pub fn from_iter<I>(elements: I, context: &mut dyn Context<'_>) -> Self
     where
         I: IntoIterator<Item = JsValue>,
     {
         Self {
-            inner: Array::create_array_from_list(elements, context),
+            inner: Array::create_array_from_list(elements, context.as_raw_context()),
         }
     }
 
@@ -53,18 +53,18 @@ impl JsArray {
     ///
     /// Same a `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub fn length(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         self.inner.length_of_array_like(context)
     }
 
     /// Check if the array is empty, i.e. the `length` is zero.
     #[inline]
-    pub fn is_empty(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn is_empty(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         self.inner.length_of_array_like(context).map(|len| len == 0)
     }
 
     /// Push an element to the array.
-    pub fn push<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn push<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -73,18 +73,22 @@ impl JsArray {
 
     /// Pushes a slice of elements to the array.
     #[inline]
-    pub fn push_items(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn push_items(
+        &self,
+        items: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Array::push(&self.inner.clone().into(), items, context)
     }
 
     /// Pops an element from the array.
     #[inline]
-    pub fn pop(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn pop(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Array::pop(&self.inner.clone().into(), &[], context)
     }
 
     /// Calls `Array.prototype.at()`.
-    pub fn at<T>(&self, index: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn at<T>(&self, index: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<i64>,
     {
@@ -93,26 +97,26 @@ impl JsArray {
 
     /// Calls `Array.prototype.shift()`.
     #[inline]
-    pub fn shift(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn shift(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Array::shift(&self.inner.clone().into(), &[], context)
     }
 
     /// Calls `Array.prototype.unshift()`.
     #[inline]
-    pub fn unshift(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn unshift(&self, items: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Array::shift(&self.inner.clone().into(), items, context)
     }
 
     /// Calls `Array.prototype.reverse()`.
     #[inline]
-    pub fn reverse(&self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn reverse(&self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Array::reverse(&self.inner.clone().into(), &[], context)?;
         Ok(self.clone())
     }
 
     /// Calls `Array.prototype.concat()`.
     #[inline]
-    pub fn concat(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn concat(&self, items: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<Self> {
         let object = Array::concat(&self.inner.clone().into(), items, context)?
             .as_object()
             .cloned()
@@ -126,7 +130,7 @@ impl JsArray {
     pub fn join(
         &self,
         separator: Option<JsString>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsString> {
         Array::join(
             &self.inner.clone().into(),
@@ -146,7 +150,7 @@ impl JsArray {
         value: T,
         start: Option<u32>,
         end: Option<u32>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self>
     where
         T: Into<JsValue>,
@@ -168,7 +172,7 @@ impl JsArray {
         &self,
         search_element: T,
         from_index: Option<u32>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<u32>>
     where
         T: Into<JsValue>,
@@ -194,7 +198,7 @@ impl JsArray {
         &self,
         search_element: T,
         from_index: Option<u32>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<u32>>
     where
         T: Into<JsValue>,
@@ -221,7 +225,7 @@ impl JsArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Array::find(
             &self.inner.clone().into(),
@@ -236,7 +240,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::filter(
             &self.inner.clone().into(),
@@ -256,7 +260,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::map(
             &self.inner.clone().into(),
@@ -276,7 +280,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let result = Array::every(
             &self.inner.clone().into(),
@@ -295,7 +299,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let result = Array::some(
             &self.inner.clone().into(),
@@ -313,7 +317,7 @@ impl JsArray {
     pub fn sort(
         &self,
         compare_fn: Option<JsFunction>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         Array::sort(
             &self.inner.clone().into(),
@@ -330,7 +334,7 @@ impl JsArray {
         &self,
         start: Option<u32>,
         end: Option<u32>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = Array::slice(
             &self.inner.clone().into(),
@@ -350,7 +354,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Array::reduce(
             &self.inner.clone().into(),
@@ -365,7 +369,7 @@ impl JsArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Array::reduce_right(
             &self.inner.clone().into(),
@@ -401,7 +405,7 @@ impl Deref for JsArray {
 impl JsObjectType for JsArray {}
 
 impl TryFromJs for JsArray {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsarraybuffer.rs
+++ b/boa_engine/src/object/builtins/jsarraybuffer.rs
@@ -38,7 +38,7 @@ impl JsArrayBuffer {
     /// # }
     /// ```
     #[inline]
-    pub fn new(byte_length: usize, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn new(byte_length: usize, context: &mut dyn Context<'_>) -> JsResult<Self> {
         let inner = ArrayBuffer::allocate(
             &context
                 .intrinsics()
@@ -76,7 +76,7 @@ impl JsArrayBuffer {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_byte_block(byte_block: Vec<u8>, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn from_byte_block(byte_block: Vec<u8>, context: &mut dyn Context<'_>) -> JsResult<Self> {
         let byte_length = byte_block.len();
 
         let constructor = context
@@ -150,7 +150,7 @@ impl JsArrayBuffer {
     /// # }
     ///  ```
     #[inline]
-    pub fn byte_length(&self, context: &mut Context<'_>) -> usize {
+    pub fn byte_length(&self, context: &mut dyn Context<'_>) -> usize {
         ArrayBuffer::get_byte_length(&self.inner.clone().into(), &[], context)
             .expect("it should not throw")
             .as_number()
@@ -226,7 +226,7 @@ impl Deref for JsArrayBuffer {
 impl JsObjectType for JsArrayBuffer {}
 
 impl TryFromJs for JsArrayBuffer {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -43,7 +43,7 @@ impl JsDataView {
         array_buffer: &JsArrayBuffer,
         offset: Option<u64>,
         byte_length: Option<u64>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let (byte_offset, byte_length) = {
             let borrowed_buffer = array_buffer.borrow();
@@ -124,20 +124,20 @@ impl JsDataView {
 
     /// Returns the `viewed_array_buffer` field for [`JsDataView`]
     #[inline]
-    pub fn buffer(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn buffer(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         DataView::get_buffer(&self.inner.clone().into(), &[], context)
     }
 
     /// Returns the `byte_length` property of [`JsDataView`] as a u64 integer
     #[inline]
-    pub fn byte_length(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub fn byte_length(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         DataView::get_byte_length(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_number().expect("value should be a number") as u64)
     }
 
     /// Returns the `byte_offset` field property of [`JsDataView`] as a u64 integer
     #[inline]
-    pub fn byte_offset(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub fn byte_offset(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         DataView::get_byte_offset(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_number().expect("byte_offset value must be a number") as u64)
     }
@@ -148,7 +148,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<i64> {
         DataView::get_big_int64(
             &self.inner.clone().into(),
@@ -164,7 +164,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<u64> {
         DataView::get_big_uint64(
             &self.inner.clone().into(),
@@ -180,7 +180,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<f32> {
         DataView::get_float32(
             &self.inner.clone().into(),
@@ -196,7 +196,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<f64> {
         DataView::get_float64(
             &self.inner.clone().into(),
@@ -212,7 +212,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<i8> {
         DataView::get_int8(
             &self.inner.clone().into(),
@@ -228,7 +228,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<i16> {
         DataView::get_int16(
             &self.inner.clone().into(),
@@ -244,7 +244,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<i32> {
         DataView::get_int32(
             &self.inner.clone().into(),
@@ -260,7 +260,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<u8> {
         DataView::get_uint8(
             &self.inner.clone().into(),
@@ -276,7 +276,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<u16> {
         DataView::get_uint16(
             &self.inner.clone().into(),
@@ -292,7 +292,7 @@ impl JsDataView {
         &self,
         byte_offset: usize,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<u32> {
         DataView::get_uint32(
             &self.inner.clone().into(),
@@ -309,7 +309,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i64,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_big_int64(
             &self.inner.clone().into(),
@@ -325,7 +325,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u64,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_big_uint64(
             &self.inner.clone().into(),
@@ -341,7 +341,7 @@ impl JsDataView {
         byte_offset: usize,
         value: f32,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_float32(
             &self.inner.clone().into(),
@@ -357,7 +357,7 @@ impl JsDataView {
         byte_offset: usize,
         value: f64,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_float64(
             &self.inner.clone().into(),
@@ -373,7 +373,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i8,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int8(
             &self.inner.clone().into(),
@@ -389,7 +389,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i16,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int16(
             &self.inner.clone().into(),
@@ -405,7 +405,7 @@ impl JsDataView {
         byte_offset: usize,
         value: i32,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_int32(
             &self.inner.clone().into(),
@@ -421,7 +421,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u8,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint8(
             &self.inner.clone().into(),
@@ -437,7 +437,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u16,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint16(
             &self.inner.clone().into(),
@@ -453,7 +453,7 @@ impl JsDataView {
         byte_offset: usize,
         value: u32,
         is_little_endian: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         DataView::set_uint32(
             &self.inner.clone().into(),
@@ -489,7 +489,7 @@ impl Deref for JsDataView {
 impl JsObjectType for JsDataView {}
 
 impl TryFromJs for JsDataView {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -41,7 +41,7 @@ pub struct JsDate {
 impl JsDate {
     /// Create a new `Date` object with universal time.
     #[inline]
-    pub fn new(context: &mut Context<'_>) -> Self {
+    pub fn new(context: &mut dyn Context<'_>) -> Self {
         let prototype = context.intrinsics().constructors().date().prototype();
         let inner = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
@@ -68,7 +68,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.now()`
     #[inline]
-    pub fn now(context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn now(context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::now(&JsValue::Null, &[JsValue::Null], context)
     }
 
@@ -80,7 +80,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.parse(value)`.
     #[inline]
-    pub fn parse(value: JsValue, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn parse(value: JsValue, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::parse(&JsValue::Null, &[value], context)
     }
 
@@ -89,7 +89,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.UTC()`
     #[inline]
-    pub fn utc(values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn utc(values: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::utc(&JsValue::Null, values, context)
     }
 
@@ -98,7 +98,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getDate()`.
     #[inline]
-    pub fn get_date(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_date(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_date::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -107,7 +107,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getDay()`.
     #[inline]
-    pub fn get_day(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_day(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_day::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -116,7 +116,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getFullYear()`.
     #[inline]
-    pub fn get_full_year(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_full_year(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_full_year::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -124,7 +124,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getHours()`.
     #[inline]
-    pub fn get_hours(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_hours(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_hours::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -133,7 +133,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMilliseconds()`.
     #[inline]
-    pub fn get_milliseconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_milliseconds(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_milliseconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -141,7 +141,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMinutes()`.
     #[inline]
-    pub fn get_minutes(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_minutes(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_minutes::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -149,7 +149,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getMonth()`.
     #[inline]
-    pub fn get_month(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_month(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_month::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -157,7 +157,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getSeconds()`.
     #[inline]
-    pub fn get_seconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_seconds(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_seconds::<true>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -167,7 +167,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getTime()`.
     #[inline]
-    pub fn get_time(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_time(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_time(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -175,7 +175,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getTimezoneOffset()`.
     #[inline]
-    pub fn get_timezone_offset(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_timezone_offset(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_timezone_offset(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -184,7 +184,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCDate()`.
     #[inline]
-    pub fn get_utc_date(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_date(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_date::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -193,7 +193,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCDay()`.
     #[inline]
-    pub fn get_utc_day(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_day(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_day::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -202,7 +202,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCFullYear()`.
     #[inline]
-    pub fn get_utc_full_year(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_full_year(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_full_year::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -211,7 +211,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCHours()`.
     #[inline]
-    pub fn get_utc_hours(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_hours(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_hours::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -220,7 +220,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMilliseconds()`.
     #[inline]
-    pub fn get_utc_milliseconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_milliseconds(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_milliseconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -229,7 +229,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMinutes()`.
     #[inline]
-    pub fn get_utc_minutes(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_minutes(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_minutes::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -238,7 +238,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCMonth()`.
     #[inline]
-    pub fn get_utc_month(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_month(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_month::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -247,7 +247,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.getUTCSeconds()`.
     #[inline]
-    pub fn get_utc_seconds(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_utc_seconds(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::get_seconds::<false>(&self.inner.clone().into(), &[JsValue::null()], context)
     }
 
@@ -258,7 +258,7 @@ impl JsDate {
     /// the UNIX epoch and the given date.
     ///
     /// Same as JavaScript's `Date.prototype.setDate()`.
-    pub fn set_date<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set_date<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -276,7 +276,7 @@ impl JsDate {
     pub fn set_full_year(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_full_year::<true>(&self.inner.clone().into(), values, context)
     }
@@ -288,7 +288,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setHours()`.
     #[inline]
-    pub fn set_hours(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn set_hours(
+        &self,
+        values: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_hours::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -298,7 +302,7 @@ impl JsDate {
     /// the UNIX epoch and updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setMilliseconds()`.
-    pub fn set_milliseconds<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set_milliseconds<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -312,7 +316,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setMinutes()`.
     #[inline]
-    pub fn set_minutes(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn set_minutes(
+        &self,
+        values: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_minutes::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -323,7 +331,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setMonth()`.
     #[inline]
-    pub fn set_month(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn set_month(
+        &self,
+        values: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_month::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -334,7 +346,11 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.setSeconds()`.
     #[inline]
-    pub fn set_seconds(&self, values: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn set_seconds(
+        &self,
+        values: &[JsValue],
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue> {
         Date::set_seconds::<true>(&self.inner.clone().into(), values, context)
     }
 
@@ -346,7 +362,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setTime()`.
-    pub fn set_time<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set_time<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -360,7 +376,7 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCDate()`.
-    pub fn set_utc_date<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set_utc_date<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -378,7 +394,7 @@ impl JsDate {
     pub fn set_utc_full_year(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_full_year::<false>(&self.inner.clone().into(), values, context)
     }
@@ -393,7 +409,7 @@ impl JsDate {
     pub fn set_utc_hours(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_hours::<false>(&self.inner.clone().into(), values, context)
     }
@@ -404,7 +420,11 @@ impl JsDate {
     /// the UNIX epoch and the updated date.
     ///
     /// Same as JavaScript's `Date.prototype.setUTCMilliseconds()`.
-    pub fn set_utc_milliseconds<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set_utc_milliseconds<T>(
+        &self,
+        value: T,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -421,7 +441,7 @@ impl JsDate {
     pub fn set_utc_minutes(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_minutes::<false>(&self.inner.clone().into(), values, context)
     }
@@ -436,7 +456,7 @@ impl JsDate {
     pub fn set_utc_month(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_month::<false>(&self.inner.clone().into(), values, context)
     }
@@ -451,7 +471,7 @@ impl JsDate {
     pub fn set_utc_seconds(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::set_seconds::<false>(&self.inner.clone().into(), values, context)
     }
@@ -460,7 +480,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toDateString()`.
     #[inline]
-    pub fn to_date_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_date_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_date_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -471,7 +491,7 @@ impl JsDate {
     /// Same as JavaScript's legacy `Date.prototype.toGMTString()`
     #[deprecated]
     #[inline]
-    pub fn to_gmt_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_gmt_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_utc_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -480,7 +500,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toISOString()`.
     #[inline]
-    pub fn to_iso_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_iso_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_iso_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -488,7 +508,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toJSON()`.
     #[inline]
-    pub fn to_json(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_json(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_json(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -501,7 +521,7 @@ impl JsDate {
     pub fn to_local_date_string(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::to_locale_date_string(&self.inner.clone().into(), values, context)
     }
@@ -514,7 +534,7 @@ impl JsDate {
     pub fn to_locale_string(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::to_locale_string(&self.inner.clone().into(), values, context)
     }
@@ -526,7 +546,7 @@ impl JsDate {
     pub fn to_locale_time_string(
         &self,
         values: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Date::to_locale_time_string(&self.inner.clone().into(), values, context)
     }
@@ -535,7 +555,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toString()`.
     #[inline]
-    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -543,7 +563,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toTimeString()`.
     #[inline]
-    pub fn to_time_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_time_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_time_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -551,7 +571,7 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.toUTCString()`.
     #[inline]
-    pub fn to_utc_string(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn to_utc_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::to_utc_string(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -559,12 +579,12 @@ impl JsDate {
     ///
     /// Same as JavaScript's `Date.prototype.valueOf()`.
     #[inline]
-    pub fn value_of(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn value_of(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Date::value_of(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
     /// Utility create a `Date` object from RFC3339 string
-    pub fn new_from_parse(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn new_from_parse(value: &JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         let prototype = context.intrinsics().constructors().date().prototype();
         let string = value
             .to_string(context)?
@@ -610,7 +630,7 @@ impl Deref for JsDate {
 impl JsObjectType for JsDate {}
 
 impl TryFromJs for JsDate {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -77,7 +77,7 @@ impl Deref for JsFunction {
 impl JsObjectType for JsFunction {}
 
 impl TryFromJs for JsFunction {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()).ok_or_else(|| {
                 JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsgenerator.rs
+++ b/boa_engine/src/object/builtins/jsgenerator.rs
@@ -31,7 +31,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.next()`
     ///
     /// This method returns an object with the properties `done` and `value`
-    pub fn next<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn next<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -41,7 +41,7 @@ impl JsGenerator {
     /// Calls `Generator.prototype.return()`
     ///
     /// This method returns the given value and finishes the generator
-    pub fn r#return<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn r#return<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -52,7 +52,7 @@ impl JsGenerator {
     ///
     /// This method resumes the execution of a generator by throwing an error and returning an
     /// an object with the properties `done` and `value`
-    pub fn throw<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn throw<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -86,7 +86,7 @@ impl Deref for JsGenerator {
 impl JsObjectType for JsGenerator {}
 
 impl TryFromJs for JsGenerator {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsmap.rs
+++ b/boa_engine/src/object/builtins/jsmap.rs
@@ -88,7 +88,7 @@ impl JsMap {
     /// let map = JsMap::new(context);
     /// ```
     #[inline]
-    pub fn new(context: &mut Context<'_>) -> Self {
+    pub fn new(context: &mut dyn Context<'_>) -> Self {
         let map = Self::create_map(context);
         Self { inner: map }
     }
@@ -117,7 +117,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_js_iterable(iterable: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn from_js_iterable(iterable: &JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         // Create a new map object.
         let map = Self::create_map(context);
 
@@ -180,7 +180,7 @@ impl JsMap {
     }
 
     // Utility function to generate the default `Map` object.
-    fn create_map(context: &mut Context<'_>) -> JsObject {
+    fn create_map(context: &mut dyn Context<'_>) -> JsObject {
         // Get default Map prototype
         let prototype = context.intrinsics().constructors().map().prototype();
 
@@ -194,7 +194,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `[key, value]` pairs within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn entries(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
+    pub fn entries(&self, context: &mut dyn Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::entries(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
@@ -203,7 +203,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `key` for each element within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn keys(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
+    pub fn keys(&self, context: &mut dyn Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::keys(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
@@ -231,7 +231,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn set<K, V>(&self, key: K, value: V, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn set<K, V>(&self, key: K, value: V, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         K: Into<JsValue>,
         V: Into<JsValue>,
@@ -265,7 +265,7 @@ impl JsMap {
     /// # }
     /// ```
     #[inline]
-    pub fn get_size(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn get_size(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Map::get_size(&self.inner.clone().into(), &[], context)
     }
 
@@ -291,7 +291,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn delete<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn delete<T>(&self, key: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -318,7 +318,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn get<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn get<T>(&self, key: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -347,7 +347,7 @@ impl JsMap {
     /// # }
     /// ```
     #[inline]
-    pub fn clear(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn clear(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Map::clear(&self.inner.clone().into(), &[], context)
     }
 
@@ -371,7 +371,7 @@ impl JsMap {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn has<T>(&self, key: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn has<T>(&self, key: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -384,7 +384,7 @@ impl JsMap {
         &self,
         callback: JsFunction,
         this_arg: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Map::for_each(
             &self.inner.clone().into(),
@@ -395,7 +395,7 @@ impl JsMap {
 
     /// Returns a new [`JsMapIterator`] object that yields the `value` for each element within the [`JsMap`] in insertion order.
     #[inline]
-    pub fn values(&self, context: &mut Context<'_>) -> JsResult<JsMapIterator> {
+    pub fn values(&self, context: &mut dyn Context<'_>) -> JsResult<JsMapIterator> {
         let iterator_record = Map::values(&self.inner.clone().into(), &[], context)?
             .get_iterator(context, None, None)?;
         let map_iterator_object = iterator_record.iterator();
@@ -429,7 +429,7 @@ impl Deref for JsMap {
 impl JsObjectType for JsMap {}
 
 impl TryFromJs for JsMap {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsmap_iterator.rs
+++ b/boa_engine/src/object/builtins/jsmap_iterator.rs
@@ -30,7 +30,7 @@ impl JsMapIterator {
     }
 
     /// Advances the `JsMapIterator` and gets the next result in the `JsMap`
-    pub fn next(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn next(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         MapIterator::next(&self.inner.clone().into(), &[], context)
     }
 }
@@ -61,7 +61,7 @@ impl Deref for JsMapIterator {
 impl JsObjectType for JsMapIterator {}
 
 impl TryFromJs for JsMapIterator {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsproxy.rs
+++ b/boa_engine/src/object/builtins/jsproxy.rs
@@ -75,7 +75,7 @@ impl std::ops::Deref for JsProxy {
 impl JsObjectType for JsProxy {}
 
 impl TryFromJs for JsProxy {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()
@@ -107,7 +107,7 @@ impl JsRevocableProxy {
     /// Disables the traps of the internal `proxy` object, essentially
     /// making it unusable and throwing `TypeError`s for all the traps.
     #[inline]
-    pub fn revoke(self, context: &mut Context<'_>) -> JsResult<()> {
+    pub fn revoke(self, context: &mut dyn Context<'_>) -> JsResult<()> {
         self.revoker.call(&JsValue::undefined(), &[], context)?;
         Ok(())
     }
@@ -397,7 +397,7 @@ impl JsProxyBuilder {
     /// [`JsObject`] in case there's a need to manipulate the returned object
     /// inside Rust code.
     #[must_use]
-    pub fn build(self, context: &mut Context<'_>) -> JsProxy {
+    pub fn build(self, context: &mut dyn Context<'_>) -> JsProxy {
         let handler = JsObject::with_object_proto(context.intrinsics());
 
         if let Some(apply) = self.apply {
@@ -535,7 +535,7 @@ impl JsProxyBuilder {
     /// revoker in case there's a need to manipulate the returned objects
     /// inside Rust code.
     #[must_use]
-    pub fn build_revocable(self, context: &mut Context<'_>) -> JsRevocableProxy {
+    pub fn build_revocable(self, context: &mut dyn Context<'_>) -> JsRevocableProxy {
         let proxy = self.build(context);
         let revoker = Proxy::revoker(proxy.inner.clone(), context);
 

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -57,7 +57,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new<S>(pattern: S, flags: S, context: &mut Context<'_>) -> JsResult<Self>
+    pub fn new<S>(pattern: S, flags: S, context: &mut dyn Context<'_>) -> JsResult<Self>
     where
         S: Into<JsValue>,
     {
@@ -91,49 +91,49 @@ impl JsRegExp {
 
     /// Returns a boolean value for whether the `d` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn has_indices(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn has_indices(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_has_indices(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `g` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn global(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn global(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_global(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `i` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn ignore_case(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn ignore_case(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_ignore_case(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `m` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn multiline(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn multiline(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_multiline(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `s` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn dot_all(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn dot_all(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_dot_all(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `u` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn unicode(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn unicode(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_unicode(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
 
     /// Returns a boolean value for whether the `y` flag is present in `JsRegExp` flags
     #[inline]
-    pub fn sticky(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn sticky(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         RegExp::get_sticky(&self.inner.clone().into(), &[], context)
             .map(|v| v.as_boolean().expect("value must be a bool"))
     }
@@ -154,7 +154,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn flags(&self, context: &mut Context<'_>) -> JsResult<String> {
+    pub fn flags(&self, context: &mut dyn Context<'_>) -> JsResult<String> {
         RegExp::get_flags(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be string")
@@ -179,7 +179,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn source(&self, context: &mut Context<'_>) -> JsResult<String> {
+    pub fn source(&self, context: &mut dyn Context<'_>) -> JsResult<String> {
         RegExp::get_source(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be string")
@@ -203,7 +203,7 @@ impl JsRegExp {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn test<S>(&self, search_string: S, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn test<S>(&self, search_string: S, context: &mut dyn Context<'_>) -> JsResult<bool>
     where
         S: Into<JsValue>,
     {
@@ -214,7 +214,11 @@ impl JsRegExp {
     /// Executes a search for a match in a specified string
     ///
     /// Returns a `JsArray` containing matched value and updates the `lastIndex` property, or `None`
-    pub fn exec<S>(&self, search_string: S, context: &mut Context<'_>) -> JsResult<Option<JsArray>>
+    pub fn exec<S>(
+        &self,
+        search_string: S,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<Option<JsArray>>
     where
         S: Into<JsValue>,
     {
@@ -246,7 +250,7 @@ impl JsRegExp {
     /// # }
     /// ```
     #[inline]
-    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<String> {
+    pub fn to_string(&self, context: &mut dyn Context<'_>) -> JsResult<String> {
         RegExp::to_string(&self.inner.clone().into(), &[], context).map(|v| {
             v.as_string()
                 .expect("value must be a string")
@@ -282,7 +286,7 @@ impl Deref for JsRegExp {
 impl JsObjectType for JsRegExp {}
 
 impl TryFromJs for JsRegExp {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -23,7 +23,7 @@ impl JsSet {
     /// Doesn't matches JavaScript `new Set()` as it doesn't takes an iterator
     /// similar to Rust initialization.
     #[inline]
-    pub fn new(context: &mut Context<'_>) -> Self {
+    pub fn new(context: &mut dyn Context<'_>) -> Self {
         let inner = Set::set_create(None, context);
 
         Self { inner }
@@ -41,7 +41,7 @@ impl JsSet {
     /// Returns the Set object with added value.
     ///
     /// Same as JavaScript's `set.add(value)`.
-    pub fn add<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn add<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<JsValue>,
     {
@@ -53,7 +53,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.add(["one", "two", "three"])`
     #[inline]
-    pub fn add_items(&self, items: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn add_items(&self, items: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Set::add(&self.inner.clone().into(), items, context)
     }
 
@@ -62,7 +62,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.clear()`.
     #[inline]
-    pub fn clear(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn clear(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         Set::clear(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 
@@ -71,7 +71,7 @@ impl JsSet {
     /// successfully removed or not.
     ///
     /// Same as JavaScript's `set.delete(value)`.
-    pub fn delete<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn delete<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<bool>
     where
         T: Into<JsValue>,
     {
@@ -86,7 +86,7 @@ impl JsSet {
     /// with the given value in the Set object or not.
     ///
     /// Same as JavaScript's `set.has(value)`.
-    pub fn has<T>(&self, value: T, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn has<T>(&self, value: T, context: &mut dyn Context<'_>) -> JsResult<bool>
     where
         T: Into<JsValue>,
     {
@@ -102,7 +102,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.values()`.
     #[inline]
-    pub fn values(&self, context: &mut Context<'_>) -> JsResult<JsSetIterator> {
+    pub fn values(&self, context: &mut dyn Context<'_>) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
@@ -115,7 +115,7 @@ impl JsSet {
     ///
     /// Same as JavaScript's `set.keys()`.
     #[inline]
-    pub fn keys(&self, context: &mut Context<'_>) -> JsResult<JsSetIterator> {
+    pub fn keys(&self, context: &mut dyn Context<'_>) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
             .get_iterator(context, None, None)?;
 
@@ -132,7 +132,7 @@ impl JsSet {
         &self,
         callback: JsFunction,
         this_arg: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         Set::for_each(
             &self.inner.clone().into(),
@@ -154,7 +154,7 @@ impl JsSet {
     }
 
     /// Utility: Creates a `JsSet` from a `<IntoIterator<Item = JsValue>` convertible object.
-    pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> Self
+    pub fn from_iter<I>(elements: I, context: &mut dyn Context<'_>) -> Self
     where
         I: IntoIterator<Item = JsValue>,
     {
@@ -188,7 +188,7 @@ impl Deref for JsSet {
 impl JsObjectType for JsSet {}
 
 impl TryFromJs for JsSet {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jsset_iterator.rs
+++ b/boa_engine/src/object/builtins/jsset_iterator.rs
@@ -30,7 +30,7 @@ impl JsSetIterator {
         }
     }
     /// Advances the `JsSetIterator` and gets the next result in the `JsSet`.
-    pub fn next(&self, context: &mut Context<'_>) -> JsResult<JsValue> {
+    pub fn next(&self, context: &mut dyn Context<'_>) -> JsResult<JsValue> {
         SetIterator::next(&self.inner.clone().into(), &[JsValue::Null], context)
     }
 }
@@ -61,7 +61,7 @@ impl Deref for JsSetIterator {
 impl JsObjectType for JsSetIterator {}
 
 impl TryFromJs for JsSetIterator {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/builtins/jstypedarray.rs
+++ b/boa_engine/src/object/builtins/jstypedarray.rs
@@ -40,7 +40,7 @@ impl JsTypedArray {
     ///
     /// Same a `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context<'_>) -> JsResult<usize> {
+    pub fn length(&self, context: &mut dyn Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::length(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -49,12 +49,12 @@ impl JsTypedArray {
 
     /// Check if the array is empty, i.e. the `length` is zero.
     #[inline]
-    pub fn is_empty(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn is_empty(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         Ok(self.length(context)? == 0)
     }
 
     /// Calls `TypedArray.prototype.at()`.
-    pub fn at<T>(&self, index: T, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn at<T>(&self, index: T, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         T: Into<i64>,
     {
@@ -63,7 +63,7 @@ impl JsTypedArray {
 
     /// Returns `TypedArray.prototype.byteLength`.
     #[inline]
-    pub fn byte_length(&self, context: &mut Context<'_>) -> JsResult<usize> {
+    pub fn byte_length(&self, context: &mut dyn Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::byte_length(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -72,7 +72,7 @@ impl JsTypedArray {
 
     /// Returns `TypedArray.prototype.byteOffset`.
     #[inline]
-    pub fn byte_offset(&self, context: &mut Context<'_>) -> JsResult<usize> {
+    pub fn byte_offset(&self, context: &mut dyn Context<'_>) -> JsResult<usize> {
         Ok(TypedArray::byte_offset(&self.inner, &[], context)?
             .as_number()
             .map(|x| x as usize)
@@ -85,7 +85,7 @@ impl JsTypedArray {
         value: T,
         start: Option<usize>,
         end: Option<usize>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self>
     where
         T: Into<JsValue>,
@@ -107,7 +107,7 @@ impl JsTypedArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let result = TypedArray::every(
             &self.inner,
@@ -126,7 +126,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let result = TypedArray::some(
             &self.inner,
@@ -144,7 +144,7 @@ impl JsTypedArray {
     pub fn sort(
         &self,
         compare_fn: Option<JsFunction>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         TypedArray::sort(&self.inner, &[compare_fn.into_or_undefined()], context)?;
 
@@ -157,7 +157,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::filter(
             &self.inner,
@@ -174,7 +174,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::map(
             &self.inner,
@@ -191,7 +191,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::reduce(
             &self.inner,
@@ -206,7 +206,7 @@ impl JsTypedArray {
         &self,
         callback: JsFunction,
         initial_value: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::reduceright(
             &self.inner,
@@ -217,7 +217,7 @@ impl JsTypedArray {
 
     /// Calls `TypedArray.prototype.reverse()`.
     #[inline]
-    pub fn reverse(&self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn reverse(&self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         TypedArray::reverse(&self.inner, &[], context)?;
         Ok(self.clone())
     }
@@ -228,7 +228,7 @@ impl JsTypedArray {
         &self,
         start: Option<usize>,
         end: Option<usize>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let object = TypedArray::slice(
             &self.inner,
@@ -245,7 +245,7 @@ impl JsTypedArray {
         &self,
         predicate: JsFunction,
         this_arg: Option<JsValue>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         TypedArray::find(
             &self.inner,
@@ -259,7 +259,7 @@ impl JsTypedArray {
         &self,
         search_element: T,
         from_index: Option<usize>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<usize>>
     where
         T: Into<JsValue>,
@@ -285,7 +285,7 @@ impl JsTypedArray {
         &self,
         search_element: T,
         from_index: Option<usize>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<usize>>
     where
         T: Into<JsValue>,
@@ -311,7 +311,7 @@ impl JsTypedArray {
     pub fn join(
         &self,
         separator: Option<JsString>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsString> {
         TypedArray::join(&self.inner, &[separator.into_or_undefined()], context).map(|x| {
             x.as_string()
@@ -350,7 +350,7 @@ impl Deref for JsTypedArray {
 impl JsObjectType for JsTypedArray {}
 
 impl TryFromJs for JsTypedArray {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Object(o) => Self::from_object(o.clone()),
             _ => Err(JsNativeError::typ()
@@ -401,7 +401,7 @@ macro_rules! JsTypedArrayType {
             /// Create the typed array from a [`JsArrayBuffer`].
             pub fn from_array_buffer(
                 array_buffer: JsArrayBuffer,
-                context: &mut Context<'_>,
+                context: &mut dyn Context<'_>,
             ) -> JsResult<Self> {
                 let new_target = context
                     .intrinsics()
@@ -426,7 +426,7 @@ macro_rules! JsTypedArrayType {
             }
 
             /// Create the typed array from an iterator.
-            pub fn from_iter<I>(elements: I, context: &mut Context<'_>) -> JsResult<Self>
+            pub fn from_iter<I>(elements: I, context: &mut dyn Context<'_>) -> JsResult<Self>
             where
                 I: IntoIterator<Item = $element>,
             {
@@ -486,7 +486,7 @@ macro_rules! JsTypedArrayType {
         }
 
         impl TryFromJs for $name {
-            fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+            fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
                 match value {
                     JsValue::Object(o) => Self::from_object(o.clone()),
                     _ => Err(JsNativeError::typ()

--- a/boa_engine/src/object/internal_methods/arguments.rs
+++ b/boa_engine/src/object/internal_methods/arguments.rs
@@ -25,7 +25,7 @@ pub(crate) static ARGUMENTS_EXOTIC_INTERNAL_METHODS: InternalObjectMethods =
 pub(crate) fn arguments_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let desc be OrdinaryGetOwnProperty(args, P).
     // 2. If desc is undefined, return desc.
@@ -70,7 +70,7 @@ pub(crate) fn arguments_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 2. Let isMapped be HasOwnProperty(map, P).
     let mapped = if let &PropertyKey::Index(index) = key {
@@ -161,7 +161,7 @@ pub(crate) fn arguments_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     if let PropertyKey::Index(index) = key {
         // 1. Let map be args.[[ParameterMap]].
@@ -194,7 +194,7 @@ pub(crate) fn arguments_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If SameValue(args, Receiver) is false, then
     // a. Let isMapped be false.
@@ -226,7 +226,7 @@ pub(crate) fn arguments_exotic_set(
 pub(crate) fn arguments_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 3. Let result be ? OrdinaryDelete(args, P).
     let result = super::ordinary_delete(obj, key, context)?;

--- a/boa_engine/src/object/internal_methods/array.rs
+++ b/boa_engine/src/object/internal_methods/array.rs
@@ -29,7 +29,7 @@ pub(crate) fn array_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     match *key {
@@ -109,7 +109,7 @@ pub(crate) fn array_exotic_define_own_property(
 fn array_set_length(
     obj: &JsObject,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Desc.[[Value]] is absent, then
     let Some(new_len_val) = desc.value() else {

--- a/boa_engine/src/object/internal_methods/bound_function.rs
+++ b/boa_engine/src/object/internal_methods/bound_function.rs
@@ -32,7 +32,7 @@ fn bound_function_exotic_call(
     obj: &JsObject,
     _: &JsValue,
     arguments_list: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let obj = obj.borrow();
     let bound_function = obj
@@ -67,7 +67,7 @@ fn bound_function_exotic_construct(
     obj: &JsObject,
     arguments_list: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject> {
     let object = obj.borrow();
     let bound_function = object

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -36,7 +36,7 @@ fn function_call(
     obj: &JsObject,
     this: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     obj.call_internal(this, args, context)
 }
@@ -52,7 +52,7 @@ fn function_construct(
     obj: &JsObject,
     args: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject> {
     obj.construct_internal(args, &new_target.clone().into(), context)
 }

--- a/boa_engine/src/object/internal_methods/immutable_prototype.rs
+++ b/boa_engine/src/object/internal_methods/immutable_prototype.rs
@@ -21,7 +21,7 @@ pub(crate) static IMMUTABLE_PROTOTYPE_EXOTIC_INTERNAL_METHODS: InternalObjectMet
 pub(crate) fn immutable_prototype_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Return ? SetImmutablePrototype(O, V).
 

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -36,7 +36,7 @@ pub(crate) static INTEGER_INDEXED_EXOTIC_INTERNAL_METHODS: InternalObjectMethods
 pub(crate) fn integer_indexed_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -76,7 +76,7 @@ pub(crate) fn integer_indexed_exotic_get_own_property(
 pub(crate) fn integer_indexed_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -105,7 +105,7 @@ pub(crate) fn integer_indexed_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -154,7 +154,7 @@ pub(crate) fn integer_indexed_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -185,7 +185,7 @@ pub(crate) fn integer_indexed_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -217,7 +217,7 @@ pub(crate) fn integer_indexed_exotic_set(
 pub(crate) fn integer_indexed_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If Type(P) is String, then
     // a. Let numericIndex be ! CanonicalNumericIndexString(P).
@@ -261,7 +261,7 @@ pub(crate) fn integer_indexed_exotic_delete(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn integer_indexed_exotic_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let obj = obj.borrow();
     let inner = obj.as_typed_array().expect(
@@ -375,7 +375,7 @@ fn integer_indexed_element_set(
     obj: &JsObject,
     index: usize,
     value: &JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<()> {
     let obj_borrow = obj.borrow();
     let inner = obj_borrow.as_typed_array().expect(

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -37,7 +37,10 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-getprototypeof
     #[track_caller]
-    pub(crate) fn __get_prototype_of__(&self, context: &mut Context<'_>) -> JsResult<JsPrototype> {
+    pub(crate) fn __get_prototype_of__(
+        &self,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<JsPrototype> {
         let _timer = Profiler::global().start_event("Object::__get_prototype_of__", "object");
         (self.vtable().__get_prototype_of__)(self, context)
     }
@@ -53,7 +56,7 @@ impl JsObject {
     pub(crate) fn __set_prototype_of__(
         &self,
         val: JsPrototype,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set_prototype_of__", "object");
         (self.vtable().__set_prototype_of__)(self, val, context)
@@ -67,7 +70,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-isextensible
-    pub(crate) fn __is_extensible__(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub(crate) fn __is_extensible__(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__is_extensible__", "object");
         (self.vtable().__is_extensible__)(self, context)
     }
@@ -80,7 +83,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-preventextensions
-    pub(crate) fn __prevent_extensions__(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub(crate) fn __prevent_extensions__(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__prevent_extensions__", "object");
         (self.vtable().__prevent_extensions__)(self, context)
     }
@@ -96,7 +99,7 @@ impl JsObject {
     pub(crate) fn __get_own_property__(
         &self,
         key: &PropertyKey,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<PropertyDescriptor>> {
         let _timer = Profiler::global().start_event("Object::__get_own_property__", "object");
         (self.vtable().__get_own_property__)(self, key, context)
@@ -114,7 +117,7 @@ impl JsObject {
         &self,
         key: &PropertyKey,
         desc: PropertyDescriptor,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__define_own_property__", "object");
         (self.vtable().__define_own_property__)(self, key, desc, context)
@@ -131,7 +134,7 @@ impl JsObject {
     pub(crate) fn __has_property__(
         &self,
         key: &PropertyKey,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__has_property__", "object");
         (self.vtable().__has_property__)(self, key, context)
@@ -149,7 +152,7 @@ impl JsObject {
         &self,
         key: &PropertyKey,
         receiver: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__get__", "object");
         (self.vtable().__get__)(self, key, receiver, context)
@@ -168,7 +171,7 @@ impl JsObject {
         key: PropertyKey,
         value: JsValue,
         receiver: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__set__", "object");
         (self.vtable().__set__)(self, key, value, receiver, context)
@@ -185,7 +188,7 @@ impl JsObject {
     pub(crate) fn __delete__(
         &self,
         key: &PropertyKey,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         let _timer = Profiler::global().start_event("Object::__delete__", "object");
         (self.vtable().__delete__)(self, key, context)
@@ -202,7 +205,7 @@ impl JsObject {
     #[track_caller]
     pub(crate) fn __own_property_keys__(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Vec<PropertyKey>> {
         let _timer = Profiler::global().start_event("Object::__own_property_keys__", "object");
         (self.vtable().__own_property_keys__)(self, context)
@@ -221,7 +224,7 @@ impl JsObject {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Object::__call__", "object");
         self.vtable()
@@ -244,7 +247,7 @@ impl JsObject {
         &self,
         args: &[JsValue],
         new_target: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         let _timer = Profiler::global().start_event("Object::__construct__", "object");
         self.vtable()
@@ -292,24 +295,28 @@ pub(crate) static ORDINARY_INTERNAL_METHODS: InternalObjectMethods = InternalObj
 #[derive(Clone, Copy)]
 #[allow(clippy::type_complexity)]
 pub(crate) struct InternalObjectMethods {
-    pub(crate) __get_prototype_of__: fn(&JsObject, &mut Context<'_>) -> JsResult<JsPrototype>,
-    pub(crate) __set_prototype_of__: fn(&JsObject, JsPrototype, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __is_extensible__: fn(&JsObject, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __prevent_extensions__: fn(&JsObject, &mut Context<'_>) -> JsResult<bool>,
+    pub(crate) __get_prototype_of__: fn(&JsObject, &mut dyn Context<'_>) -> JsResult<JsPrototype>,
+    pub(crate) __set_prototype_of__:
+        fn(&JsObject, JsPrototype, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __is_extensible__: fn(&JsObject, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __prevent_extensions__: fn(&JsObject, &mut dyn Context<'_>) -> JsResult<bool>,
     pub(crate) __get_own_property__:
-        fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<Option<PropertyDescriptor>>,
+        fn(&JsObject, &PropertyKey, &mut dyn Context<'_>) -> JsResult<Option<PropertyDescriptor>>,
     pub(crate) __define_own_property__:
-        fn(&JsObject, &PropertyKey, PropertyDescriptor, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __has_property__: fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __get__: fn(&JsObject, &PropertyKey, JsValue, &mut Context<'_>) -> JsResult<JsValue>,
+        fn(&JsObject, &PropertyKey, PropertyDescriptor, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __has_property__:
+        fn(&JsObject, &PropertyKey, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __get__:
+        fn(&JsObject, &PropertyKey, JsValue, &mut dyn Context<'_>) -> JsResult<JsValue>,
     pub(crate) __set__:
-        fn(&JsObject, PropertyKey, JsValue, JsValue, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __delete__: fn(&JsObject, &PropertyKey, &mut Context<'_>) -> JsResult<bool>,
-    pub(crate) __own_property_keys__: fn(&JsObject, &mut Context<'_>) -> JsResult<Vec<PropertyKey>>,
+        fn(&JsObject, PropertyKey, JsValue, JsValue, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __delete__: fn(&JsObject, &PropertyKey, &mut dyn Context<'_>) -> JsResult<bool>,
+    pub(crate) __own_property_keys__:
+        fn(&JsObject, &mut dyn Context<'_>) -> JsResult<Vec<PropertyKey>>,
     pub(crate) __call__:
-        Option<fn(&JsObject, &JsValue, &[JsValue], &mut Context<'_>) -> JsResult<JsValue>>,
+        Option<fn(&JsObject, &JsValue, &[JsValue], &mut dyn Context<'_>) -> JsResult<JsValue>>,
     pub(crate) __construct__:
-        Option<fn(&JsObject, &[JsValue], &JsObject, &mut Context<'_>) -> JsResult<JsObject>>,
+        Option<fn(&JsObject, &[JsValue], &JsObject, &mut dyn Context<'_>) -> JsResult<JsObject>>,
 }
 
 /// Abstract operation `OrdinaryGetPrototypeOf`.
@@ -321,7 +328,7 @@ pub(crate) struct InternalObjectMethods {
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_get_prototype_of(
     obj: &JsObject,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<JsPrototype> {
     let _timer = Profiler::global().start_event("Object::ordinary_get_prototype_of", "object");
 
@@ -339,7 +346,7 @@ pub(crate) fn ordinary_get_prototype_of(
 pub(crate) fn ordinary_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    _: &mut Context<'_>,
+    _: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: Either Type(V) is Object or Type(V) is Null.
     // 2. Let current be O.[[Prototype]].
@@ -392,7 +399,10 @@ pub(crate) fn ordinary_set_prototype_of(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-ordinaryisextensible
 #[allow(clippy::unnecessary_wraps)]
-pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context<'_>) -> JsResult<bool> {
+pub(crate) fn ordinary_is_extensible(
+    obj: &JsObject,
+    _context: &mut dyn Context<'_>,
+) -> JsResult<bool> {
     // 1. Return O.[[Extensible]].
     Ok(obj.borrow().extensible)
 }
@@ -406,7 +416,7 @@ pub(crate) fn ordinary_is_extensible(obj: &JsObject, _context: &mut Context<'_>)
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_prevent_extensions(
     obj: &JsObject,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Set O.[[Extensible]] to false.
     obj.borrow_mut().extensible = false;
@@ -425,7 +435,7 @@ pub(crate) fn ordinary_prevent_extensions(
 pub(crate) fn ordinary_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     let _timer = Profiler::global().start_event("Object::ordinary_get_own_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -455,7 +465,7 @@ pub(crate) fn ordinary_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_define_own_property", "object");
     // 1. Let current be ? O.[[GetOwnProperty]](P).
@@ -482,7 +492,7 @@ pub(crate) fn ordinary_define_own_property(
 pub(crate) fn ordinary_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_has_property", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -512,7 +522,7 @@ pub(crate) fn ordinary_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     let _timer = Profiler::global().start_event("Object::ordinary_get", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -558,7 +568,7 @@ pub(crate) fn ordinary_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_set", "object");
 
@@ -657,7 +667,7 @@ pub(crate) fn ordinary_set(
 pub(crate) fn ordinary_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     let _timer = Profiler::global().start_event("Object::ordinary_delete", "object");
     // 1. Assert: IsPropertyKey(P) is true.
@@ -688,7 +698,7 @@ pub(crate) fn ordinary_delete(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn ordinary_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let _timer = Profiler::global().start_event("Object::ordinary_own_property_keys", "object");
     // 1. Let keys be a new empty List.
@@ -894,7 +904,7 @@ pub(crate) fn validate_and_apply_property_descriptor(
 pub(crate) fn get_prototype_from_constructor<F>(
     constructor: &JsValue,
     default: F,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject>
 where
     F: FnOnce(&StandardConstructors) -> &StandardConstructor,

--- a/boa_engine/src/object/internal_methods/module_namespace.rs
+++ b/boa_engine/src/object/internal_methods/module_namespace.rs
@@ -39,7 +39,7 @@ pub(crate) static MODULE_NAMESPACE_EXOTIC_INTERNAL_METHODS: InternalObjectMethod
 #[allow(clippy::unnecessary_wraps)]
 fn module_namespace_exotic_get_prototype_of(
     _: &JsObject,
-    _: &mut Context<'_>,
+    _: &mut dyn Context<'_>,
 ) -> JsResult<JsPrototype> {
     // 1. Return null.
     Ok(None)
@@ -52,7 +52,7 @@ fn module_namespace_exotic_get_prototype_of(
 fn module_namespace_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Return ! SetImmutablePrototype(O, V).
     Ok(
@@ -65,7 +65,7 @@ fn module_namespace_exotic_set_prototype_of(
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-isextensible
 #[allow(clippy::unnecessary_wraps)]
-fn module_namespace_exotic_is_extensible(_: &JsObject, _: &mut Context<'_>) -> JsResult<bool> {
+fn module_namespace_exotic_is_extensible(_: &JsObject, _: &mut dyn Context<'_>) -> JsResult<bool> {
     // 1. Return false.
     Ok(false)
 }
@@ -74,7 +74,10 @@ fn module_namespace_exotic_is_extensible(_: &JsObject, _: &mut Context<'_>) -> J
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-preventextensions
 #[allow(clippy::unnecessary_wraps)]
-fn module_namespace_exotic_prevent_extensions(_: &JsObject, _: &mut Context<'_>) -> JsResult<bool> {
+fn module_namespace_exotic_prevent_extensions(
+    _: &JsObject,
+    _: &mut dyn Context<'_>,
+) -> JsResult<bool> {
     Ok(true)
 }
 
@@ -84,7 +87,7 @@ fn module_namespace_exotic_prevent_extensions(_: &JsObject, _: &mut Context<'_>)
 fn module_namespace_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. If P is a Symbol, return OrdinaryGetOwnProperty(O, P).
     let key = match key {
@@ -128,7 +131,7 @@ fn module_namespace_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryDefineOwnProperty(O, P, Desc).
     if let PropertyKey::Symbol(_) = key {
@@ -164,7 +167,7 @@ fn module_namespace_exotic_define_own_property(
 fn module_namespace_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, return ! OrdinaryHasProperty(O, P).
     let key = match key {
@@ -193,7 +196,7 @@ fn module_namespace_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryGet(O, P, Receiver).
@@ -255,7 +258,7 @@ fn module_namespace_exotic_get(
     } else {
         // 9. If binding.[[BindingName]] is namespace, then
         //     a. Return GetModuleNamespace(targetModule).
-        Ok(target_module.namespace(context).into())
+        Ok(target_module.namespace(context.as_raw_context()).into())
     }
 }
 
@@ -268,7 +271,7 @@ fn module_namespace_exotic_set(
     _key: PropertyKey,
     _value: JsValue,
     _receiver: JsValue,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Return false.
     Ok(false)
@@ -280,7 +283,7 @@ fn module_namespace_exotic_set(
 fn module_namespace_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. If P is a Symbol, then
     //     a. Return ! OrdinaryDelete(O, P).
@@ -308,7 +311,7 @@ fn module_namespace_exotic_delete(
 /// [spec]: https://tc39.es/ecma262/#sec-module-namespace-exotic-objects-ownpropertykeys
 fn module_namespace_exotic_own_property_keys(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     // 2. Let symbolKeys be OrdinaryOwnPropertyKeys(O).
     let symbol_keys = ordinary_own_property_keys(obj, context)?;

--- a/boa_engine/src/object/internal_methods/proxy.rs
+++ b/boa_engine/src/object/internal_methods/proxy.rs
@@ -53,7 +53,7 @@ pub(crate) static PROXY_EXOTIC_INTERNAL_METHODS_ALL: InternalObjectMethods =
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-getprototypeof
 pub(crate) fn proxy_exotic_get_prototype_of(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsPrototype> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -115,7 +115,7 @@ pub(crate) fn proxy_exotic_get_prototype_of(
 pub(crate) fn proxy_exotic_set_prototype_of(
     obj: &JsObject,
     val: JsPrototype,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -178,7 +178,7 @@ pub(crate) fn proxy_exotic_set_prototype_of(
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-isextensible
 pub(crate) fn proxy_exotic_is_extensible(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -224,7 +224,7 @@ pub(crate) fn proxy_exotic_is_extensible(
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-preventextensions
 pub(crate) fn proxy_exotic_prevent_extensions(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -270,7 +270,7 @@ pub(crate) fn proxy_exotic_prevent_extensions(
 pub(crate) fn proxy_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -394,7 +394,7 @@ pub(crate) fn proxy_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -505,7 +505,7 @@ pub(crate) fn proxy_exotic_define_own_property(
 pub(crate) fn proxy_exotic_has_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -571,7 +571,7 @@ pub(crate) fn proxy_exotic_get(
     obj: &JsObject,
     key: &PropertyKey,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -640,7 +640,7 @@ pub(crate) fn proxy_exotic_set(
     key: PropertyKey,
     value: JsValue,
     receiver: JsValue,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -721,7 +721,7 @@ pub(crate) fn proxy_exotic_set(
 pub(crate) fn proxy_exotic_delete(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -787,7 +787,7 @@ pub(crate) fn proxy_exotic_delete(
 /// [spec]: https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys
 pub(crate) fn proxy_exotic_own_property_keys(
     obj: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -923,7 +923,7 @@ fn proxy_exotic_call(
     obj: &JsObject,
     this: &JsValue,
     args: &[JsValue],
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsValue> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -943,7 +943,7 @@ fn proxy_exotic_call(
     };
 
     // 7. Let argArray be ! CreateArrayFromList(argumentsList).
-    let arg_array = array::Array::create_array_from_list(args.to_vec(), context);
+    let arg_array = array::Array::create_array_from_list(args.to_vec(), context.as_raw_context());
 
     // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
     trap.call(
@@ -963,7 +963,7 @@ fn proxy_exotic_construct(
     obj: &JsObject,
     args: &[JsValue],
     new_target: &JsObject,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<JsObject> {
     // 1. Let handler be O.[[ProxyHandler]].
     // 2. If handler is null, throw a TypeError exception.
@@ -986,7 +986,7 @@ fn proxy_exotic_construct(
     };
 
     // 8. Let argArray be ! CreateArrayFromList(argumentsList).
-    let arg_array = array::Array::create_array_from_list(args.to_vec(), context);
+    let arg_array = array::Array::create_array_from_list(args.to_vec(), context.as_raw_context());
 
     // 9. Let newObj be ? Call(trap, handler, « target, argArray, newTarget »).
     let new_obj = trap.call(

--- a/boa_engine/src/object/internal_methods/string.rs
+++ b/boa_engine/src/object/internal_methods/string.rs
@@ -29,7 +29,7 @@ pub(crate) static STRING_EXOTIC_INTERNAL_METHODS: InternalObjectMethods = Intern
 pub(crate) fn string_exotic_get_own_property(
     obj: &JsObject,
     key: &PropertyKey,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<Option<PropertyDescriptor>> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let desc be OrdinaryGetOwnProperty(S, P).
@@ -54,7 +54,7 @@ pub(crate) fn string_exotic_define_own_property(
     obj: &JsObject,
     key: &PropertyKey,
     desc: PropertyDescriptor,
-    context: &mut Context<'_>,
+    context: &mut dyn Context<'_>,
 ) -> JsResult<bool> {
     // 1. Assert: IsPropertyKey(P) is true.
     // 2. Let stringDesc be ! StringGetOwnProperty(S, P).
@@ -85,7 +85,7 @@ pub(crate) fn string_exotic_define_own_property(
 #[allow(clippy::unnecessary_wraps)]
 pub(crate) fn string_exotic_own_property_keys(
     obj: &JsObject,
-    _context: &mut Context<'_>,
+    _context: &mut dyn Context<'_>,
 ) -> JsResult<Vec<PropertyKey>> {
     let obj = obj.borrow();
 

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -225,7 +225,7 @@ impl JsObject {
     /// [spec]: https://tc39.es/ecma262/#sec-ordinarytoprimitive
     pub(crate) fn ordinary_to_primitive(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
         hint: PreferredType,
     ) -> JsResult<JsValue> {
         // 1. Assert: Type(O) is Object.
@@ -712,7 +712,7 @@ impl JsObject {
     /// [spec]: https://tc39.es/ecma262/#sec-topropertydescriptor
     pub fn to_property_descriptor(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<PropertyDescriptor> {
         // 1 is implemented on the method `to_property_descriptor` of value
 
@@ -814,7 +814,7 @@ Cannot both specify accessors and a value or writable attribute",
         &self,
         source: &JsValue,
         excluded_keys: Vec<K>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()>
     where
         K: Into<PropertyKey>,

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -1856,18 +1856,18 @@ where
 
 /// Builder for creating native function objects
 #[derive(Debug)]
-pub struct FunctionObjectBuilder<'ctx, 'host> {
-    context: &'ctx mut Context<'host>,
+pub struct FunctionObjectBuilder<'ctx, 'icu> {
+    context: &'ctx mut dyn Context<'icu>,
     function: NativeFunction,
     constructor: Option<ConstructorKind>,
     name: JsString,
     length: usize,
 }
 
-impl<'ctx, 'host> FunctionObjectBuilder<'ctx, 'host> {
+impl<'ctx, 'icu> FunctionObjectBuilder<'ctx, 'icu> {
     /// Create a new `FunctionBuilder` for creating a native function.
     #[inline]
-    pub fn new(context: &'ctx mut Context<'host>, function: NativeFunction) -> Self {
+    pub fn new(context: &'ctx mut dyn Context<'icu>, function: NativeFunction) -> Self {
         Self {
             context,
             function,
@@ -1957,21 +1957,21 @@ impl<'ctx, 'host> FunctionObjectBuilder<'ctx, 'host> {
 /// }
 /// ```
 #[derive(Debug)]
-pub struct ObjectInitializer<'ctx, 'host> {
-    context: &'ctx mut Context<'host>,
+pub struct ObjectInitializer<'ctx, 'icu> {
+    context: &'ctx mut dyn Context<'icu>,
     object: JsObject,
 }
 
-impl<'ctx, 'host> ObjectInitializer<'ctx, 'host> {
+impl<'ctx, 'icu> ObjectInitializer<'ctx, 'icu> {
     /// Create a new `ObjectBuilder`.
     #[inline]
-    pub fn new(context: &'ctx mut Context<'host>) -> Self {
+    pub fn new(context: &'ctx mut dyn Context<'icu>) -> Self {
         let object = JsObject::with_object_proto(context.intrinsics());
         Self { context, object }
     }
 
     /// Create a new `ObjectBuilder` with custom [`NativeObject`] data.
-    pub fn with_native<T: NativeObject>(data: T, context: &'ctx mut Context<'host>) -> Self {
+    pub fn with_native<T: NativeObject>(data: T, context: &'ctx mut dyn Context<'icu>) -> Self {
         let object = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             context.intrinsics().constructors().object().prototype(),
@@ -2054,8 +2054,8 @@ impl<'ctx, 'host> ObjectInitializer<'ctx, 'host> {
 
 /// Builder for creating constructors objects, like `Array`.
 #[derive(Debug)]
-pub struct ConstructorBuilder<'ctx, 'host> {
-    context: &'ctx mut Context<'host>,
+pub struct ConstructorBuilder<'ctx, 'icu> {
+    context: &'ctx mut dyn Context<'icu>,
     function: NativeFunction,
     constructor_object: Object,
     has_prototype_property: bool,
@@ -2068,13 +2068,13 @@ pub struct ConstructorBuilder<'ctx, 'host> {
     custom_prototype: Option<JsPrototype>,
 }
 
-impl<'ctx, 'host> ConstructorBuilder<'ctx, 'host> {
+impl<'ctx, 'icu> ConstructorBuilder<'ctx, 'icu> {
     /// Create a new `ConstructorBuilder`.
     #[inline]
     pub fn new(
-        context: &'ctx mut Context<'host>,
+        context: &'ctx mut dyn Context<'icu>,
         function: NativeFunction,
-    ) -> ConstructorBuilder<'ctx, 'host> {
+    ) -> ConstructorBuilder<'ctx, 'icu> {
         Self {
             context,
             function,
@@ -2309,7 +2309,7 @@ impl<'ctx, 'host> ConstructorBuilder<'ctx, 'host> {
 
     /// Return the current context.
     #[inline]
-    pub fn context(&mut self) -> &mut Context<'host> {
+    pub fn context(&mut self) -> &mut dyn Context<'icu> {
         self.context
     }
 

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -53,7 +53,7 @@ impl JsObject {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isextensible-o
     #[inline]
-    pub fn is_extensible(&self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn is_extensible(&self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         // 1. Return ? O.[[IsExtensible]]().
         self.__is_extensible__(context)
     }
@@ -64,7 +64,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-o-p
-    pub fn get<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<JsValue>
+    pub fn get<K>(&self, key: K, context: &mut dyn Context<'_>) -> JsResult<JsValue>
     where
         K: Into<PropertyKey>,
     {
@@ -85,7 +85,7 @@ impl JsObject {
         key: K,
         value: V,
         throw: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -117,7 +117,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -147,7 +147,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -178,7 +178,7 @@ impl JsObject {
         &self,
         key: K,
         value: V,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) where
         K: Into<PropertyKey>,
         V: Into<JsValue>,
@@ -215,7 +215,7 @@ impl JsObject {
         &self,
         key: K,
         desc: P,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
@@ -242,7 +242,11 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-deletepropertyorthrow
-    pub fn delete_property_or_throw<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn delete_property_or_throw<K>(
+        &self,
+        key: K,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -267,7 +271,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasproperty
-    pub fn has_property<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn has_property<K>(&self, key: K, context: &mut dyn Context<'_>) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -283,7 +287,7 @@ impl JsObject {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hasownproperty
-    pub fn has_own_property<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<bool>
+    pub fn has_own_property<K>(&self, key: K, context: &mut dyn Context<'_>) -> JsResult<bool>
     where
         K: Into<PropertyKey>,
     {
@@ -313,7 +317,7 @@ impl JsObject {
         &self,
         this: &JsValue,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. If argumentsList is not present, set argumentsList to a new empty List.
         // 2. If IsCallable(F) is false, throw a TypeError exception.
@@ -343,7 +347,7 @@ impl JsObject {
         &self,
         args: &[JsValue],
         new_target: Option<&Self>,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         // 1. If newTarget is not present, set newTarget to F.
         let new_target = new_target.unwrap_or(self);
@@ -361,7 +365,7 @@ impl JsObject {
     pub fn set_integrity_level(
         &self,
         level: IntegrityLevel,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: level is either sealed or frozen.
@@ -430,7 +434,7 @@ impl JsObject {
     pub fn test_integrity_level(
         &self,
         level: IntegrityLevel,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         // 1. Assert: Type(O) is Object.
         // 2. Assert: level is either sealed or frozen.
@@ -475,7 +479,7 @@ impl JsObject {
     /// Returns the value of the "length" property of an array-like object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-lengthofarraylike
-    pub(crate) fn length_of_array_like(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub(crate) fn length_of_array_like(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         // 1. Assert: Type(obj) is Object.
 
         // NOTE: This is an optimization, most of the cases that `LengthOfArrayLike` will be called
@@ -507,7 +511,7 @@ impl JsObject {
     pub(crate) fn species_constructor<F>(
         &self,
         default_constructor: F,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self>
     where
         F: FnOnce(&StandardConstructors) -> &StandardConstructor,
@@ -555,7 +559,7 @@ impl JsObject {
     pub(crate) fn enumerable_own_property_names(
         &self,
         kind: PropertyNameKind,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Vec<JsValue>> {
         // 1. Assert: Type(O) is Object.
         // 2. Let ownKeys be ? O.[[OwnPropertyKeys]]().
@@ -594,7 +598,7 @@ impl JsObject {
                             PropertyNameKind::KeyAndValue => properties.push(
                                 Array::create_array_from_list(
                                     [key_str.into(), self.get(key.clone(), context)?],
-                                    context,
+                                    context.as_raw_context(),
                                 )
                                 .into(),
                             ),
@@ -616,7 +620,11 @@ impl JsObject {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getmethod
-    pub(crate) fn get_method<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<Option<Self>>
+    pub(crate) fn get_method<K>(
+        &self,
+        key: K,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<Option<Self>>
     where
         K: Into<PropertyKey>,
     {
@@ -672,7 +680,7 @@ impl JsObject {
     /// Abstract operation [`GetFunctionRealm`][spec].
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getfunctionrealm
-    pub(crate) fn get_function_realm(&self, context: &mut Context<'_>) -> JsResult<Realm> {
+    pub(crate) fn get_function_realm(&self, context: &mut dyn Context<'_>) -> JsResult<Realm> {
         let constructor = self.borrow();
         if let Some(fun) = constructor.as_function() {
             return Ok(fun.realm().clone());
@@ -741,7 +749,7 @@ impl JsObject {
         &self,
         name: &PrivateName,
         value: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. If the host is a web browser, then
         // a. Perform ? HostEnsureCanAddPrivateElement(O).
@@ -780,7 +788,7 @@ impl JsObject {
         &self,
         name: &PrivateName,
         method: &PrivateElement,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Assert: method.[[Kind]] is either method or accessor.
         assert!(matches!(
@@ -828,7 +836,7 @@ impl JsObject {
     pub(crate) fn private_get(
         &self,
         name: &PrivateName,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         // 1. Let entry be PrivateElementFind(O, P).
         let entry = self.private_element_find(name, true, true);
@@ -871,7 +879,7 @@ impl JsObject {
         &self,
         name: &PrivateName,
         value: JsValue,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 1. Let entry be PrivateElementFind(O, P).
         // Note: This function is inlined here for mutable access.
@@ -934,7 +942,7 @@ impl JsObject {
     pub(crate) fn define_field(
         &self,
         field_record: &ClassFieldDefinition,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         // 2. Let initializer be fieldRecord.[[Initializer]].
         let initializer = match field_record {
@@ -978,7 +986,7 @@ impl JsObject {
     pub(crate) fn initialize_instance_elements(
         &self,
         constructor: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<()> {
         let constructor_borrow = constructor.borrow();
         let constructor_function = constructor_borrow
@@ -1017,7 +1025,7 @@ impl JsObject {
         &self,
         key: K,
         args: &[JsValue],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue>
     where
         K: Into<PropertyKey>,
@@ -1044,7 +1052,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-getv
-    pub(crate) fn get_v<K>(&self, key: K, context: &mut Context<'_>) -> JsResult<Self>
+    pub(crate) fn get_v<K>(&self, key: K, context: &mut dyn Context<'_>) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
     {
@@ -1066,7 +1074,7 @@ impl JsValue {
     pub(crate) fn get_method<K>(
         &self,
         key: K,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Option<JsObject>>
     where
         K: Into<PropertyKey>,
@@ -1086,7 +1094,7 @@ impl JsValue {
     pub(crate) fn create_list_from_array_like(
         &self,
         element_types: &[Type],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Vec<Self>> {
         // 1. If elementTypes is not present, set elementTypes to « Undefined, Null, Boolean, String, Symbol, Number, BigInt, Object ».
         let types = if element_types.is_empty() {
@@ -1151,7 +1159,7 @@ impl JsValue {
         &self,
         this: &Self,
         args: &[Self],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self> {
         self.as_callable()
             .ok_or_else(|| {
@@ -1175,7 +1183,7 @@ impl JsValue {
         &self,
         key: K,
         args: &[Self],
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<Self>
     where
         K: Into<PropertyKey>,
@@ -1197,7 +1205,7 @@ impl JsValue {
     pub fn ordinary_has_instance(
         function: &Self,
         object: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<bool> {
         // 1. If IsCallable(C) is false, return false.
         let Some(function) = function.as_callable() else {

--- a/boa_engine/src/optimizer/mod.rs
+++ b/boa_engine/src/optimizer/mod.rs
@@ -65,15 +65,14 @@ impl fmt::Display for OptimizerStatistics {
 }
 
 /// This represents an AST optimizer.
-#[derive(Debug)]
-pub(crate) struct Optimizer<'context, 'host> {
+pub(crate) struct Optimizer<'context, 'icu> {
     statistics: OptimizerStatistics,
-    context: &'context mut Context<'host>,
+    context: &'context mut dyn Context<'icu>,
 }
 
-impl<'context, 'host> Optimizer<'context, 'host> {
+impl<'context, 'icu> Optimizer<'context, 'icu> {
     /// Create a optimizer.
-    pub(crate) fn new(context: &'context mut Context<'host>) -> Self {
+    pub(crate) fn new(context: &'context mut dyn Context<'icu>) -> Self {
         Self {
             statistics: OptimizerStatistics::default(),
             context,

--- a/boa_engine/src/optimizer/pass/constant_folding.rs
+++ b/boa_engine/src/optimizer/pass/constant_folding.rs
@@ -13,7 +13,7 @@ use boa_ast::{
     Expression,
 };
 
-fn literal_to_js_value(literal: &Literal, context: &mut Context<'_>) -> JsValue {
+fn literal_to_js_value(literal: &Literal, context: &mut dyn Context<'_>) -> JsValue {
     match literal {
         Literal::String(v) => JsValue::new(JsString::from(
             context.interner().resolve_expect(*v).utf16(),
@@ -27,7 +27,7 @@ fn literal_to_js_value(literal: &Literal, context: &mut Context<'_>) -> JsValue 
     }
 }
 
-fn js_value_to_literal(value: JsValue, context: &mut Context<'_>) -> Literal {
+fn js_value_to_literal(value: JsValue, context: &mut dyn Context<'_>) -> Literal {
     match value {
         JsValue::Null => Literal::Null,
         JsValue::Undefined => Literal::Undefined,
@@ -48,7 +48,7 @@ pub(crate) struct ConstantFolding {}
 impl ConstantFolding {
     pub(crate) fn fold_expression(
         expr: &mut Expression,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> PassAction<Expression> {
         match expr {
             Expression::Unary(unary) => Self::constant_fold_unary_expr(unary, context),
@@ -59,7 +59,7 @@ impl ConstantFolding {
 
     fn constant_fold_unary_expr(
         unary: &mut Unary,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> PassAction<Expression> {
         let Expression::Literal(literal) = unary.target() else {
             return PassAction::Keep;
@@ -102,7 +102,7 @@ impl ConstantFolding {
 
     fn constant_fold_binary_expr(
         binary: &mut Binary,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> PassAction<Expression> {
         let Expression::Literal(lhs) = binary.lhs() else {
             return PassAction::Keep;

--- a/boa_engine/src/value/conversions/serde_json.rs
+++ b/boa_engine/src/value/conversions/serde_json.rs
@@ -35,7 +35,7 @@ impl JsValue {
     /// #
     /// # assert_eq!(json, value.to_json(&mut context).unwrap());
     /// ```
-    pub fn from_json(json: &Value, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn from_json(json: &Value, context: &mut dyn Context<'_>) -> JsResult<Self> {
         /// Biggest possible integer, as i64.
         const MAX_INT: i64 = i32::MAX as i64;
 
@@ -61,7 +61,7 @@ impl JsValue {
                 for val in vec {
                     arr.push(Self::from_json(val, context)?);
                 }
-                Ok(Array::create_array_from_list(arr, context).into())
+                Ok(Array::create_array_from_list(arr, context.as_raw_context()).into())
             }
             Value::Object(obj) => {
                 let js_obj = JsObject::with_object_proto(context.intrinsics());
@@ -109,7 +109,7 @@ impl JsValue {
     /// # Panics
     ///
     /// Panics if the `JsValue` is `Undefined`.
-    pub fn to_json(&self, context: &mut Context<'_>) -> JsResult<Value> {
+    pub fn to_json(&self, context: &mut dyn Context<'_>) -> JsResult<Value> {
         match self {
             Self::Null => Ok(Value::Null),
             Self::Undefined => todo!("undefined to JSON"),

--- a/boa_engine/src/value/conversions/try_from_js.rs
+++ b/boa_engine/src/value/conversions/try_from_js.rs
@@ -6,13 +6,13 @@ use num_bigint::BigInt;
 /// This trait adds a fallible and efficient conversions from a [`JsValue`] to Rust types.
 pub trait TryFromJs: Sized {
     /// This function tries to convert a JavaScript value into `Self`.
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self>;
+    fn try_from_js(value: &JsValue, context: &mut dyn Context<'_>) -> JsResult<Self>;
 }
 
 impl JsValue {
     /// This function is the inverse of [`TryFromJs`]. It tries to convert a [`JsValue`] to a given
     /// Rust type.
-    pub fn try_js_into<T>(&self, context: &mut Context<'_>) -> JsResult<T>
+    pub fn try_js_into<T>(&self, context: &mut dyn Context<'_>) -> JsResult<T>
     where
         T: TryFromJs,
     {
@@ -21,7 +21,7 @@ impl JsValue {
 }
 
 impl TryFromJs for bool {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Boolean(b) => Ok(*b),
             _ => Err(JsNativeError::typ()
@@ -32,7 +32,7 @@ impl TryFromJs for bool {
 }
 
 impl TryFromJs for String {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::String(s) => s.to_std_string().map_err(|e| {
                 JsNativeError::typ()
@@ -50,7 +50,7 @@ impl<T> TryFromJs for Option<T>
 where
     T: TryFromJs,
 {
-    fn try_from_js(value: &JsValue, context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Null | JsValue::Undefined => Ok(None),
             value => Ok(Some(T::try_from_js(value, context)?)),
@@ -59,7 +59,7 @@ where
 }
 
 impl TryFromJs for JsBigInt {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::BigInt(b) => Ok(b.clone()),
             _ => Err(JsNativeError::typ()
@@ -70,7 +70,7 @@ impl TryFromJs for JsBigInt {
 }
 
 impl TryFromJs for BigInt {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::BigInt(b) => Ok(b.as_inner().clone()),
             _ => Err(JsNativeError::typ()
@@ -81,13 +81,13 @@ impl TryFromJs for BigInt {
 }
 
 impl TryFromJs for JsValue {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(value.clone())
     }
 }
 
 impl TryFromJs for f64 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => Ok((*i).into()),
             JsValue::Rational(r) => Ok(*r),
@@ -99,7 +99,7 @@ impl TryFromJs for f64 {
 }
 
 impl TryFromJs for i8 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -114,7 +114,7 @@ impl TryFromJs for i8 {
 }
 
 impl TryFromJs for u8 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -129,7 +129,7 @@ impl TryFromJs for u8 {
 }
 
 impl TryFromJs for i16 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -144,7 +144,7 @@ impl TryFromJs for i16 {
 }
 
 impl TryFromJs for u16 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -159,7 +159,7 @@ impl TryFromJs for u16 {
 }
 
 impl TryFromJs for i32 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => Ok(*i),
             _ => Err(JsNativeError::typ()
@@ -170,7 +170,7 @@ impl TryFromJs for i32 {
 }
 
 impl TryFromJs for u32 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -185,7 +185,7 @@ impl TryFromJs for u32 {
 }
 
 impl TryFromJs for i64 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => Ok((*i).into()),
             _ => Err(JsNativeError::typ()
@@ -196,7 +196,7 @@ impl TryFromJs for i64 {
 }
 
 impl TryFromJs for u64 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()
@@ -211,7 +211,7 @@ impl TryFromJs for u64 {
 }
 
 impl TryFromJs for i128 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => Ok((*i).into()),
             _ => Err(JsNativeError::typ()
@@ -222,7 +222,7 @@ impl TryFromJs for i128 {
 }
 
 impl TryFromJs for u128 {
-    fn try_from_js(value: &JsValue, _context: &mut Context<'_>) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut dyn Context<'_>) -> JsResult<Self> {
         match value {
             JsValue::Integer(i) => (*i).try_into().map_err(|e| {
                 JsNativeError::typ()

--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -37,7 +37,7 @@ impl JsValue {
     /// This method is executed when doing abstract equality comparisons with the `==` operator.
     ///  For more information, check <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
     #[allow(clippy::float_cmp)]
-    pub fn equals(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn equals(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         // 1. If Type(x) is the same as Type(y), then
         //     a. Return the result of performing Strict Equality Comparison x === y.
         if self.get_type() == other.get_type() {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -325,7 +325,7 @@ impl JsValue {
     /// <https://tc39.es/ecma262/#sec-toprimitive>
     pub fn to_primitive(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
         preferred_type: PreferredType,
     ) -> JsResult<Self> {
         // 1. Assert: input is an ECMAScript language value. (always a value not need to check)
@@ -381,7 +381,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobigint
-    pub fn to_bigint(&self, context: &mut Context<'_>) -> JsResult<JsBigInt> {
+    pub fn to_bigint(&self, context: &mut dyn Context<'_>) -> JsResult<JsBigInt> {
         match self {
             Self::Null => Err(JsNativeError::typ()
                 .with_message("cannot convert null to a BigInt")
@@ -441,7 +441,7 @@ impl JsValue {
     /// Converts the value to a string.
     ///
     /// This function is equivalent to `String(value)` in JavaScript.
-    pub fn to_string(&self, context: &mut Context<'_>) -> JsResult<JsString> {
+    pub fn to_string(&self, context: &mut dyn Context<'_>) -> JsResult<JsString> {
         match self {
             Self::Null => Ok("null".into()),
             Self::Undefined => Ok("undefined".into()),
@@ -465,7 +465,7 @@ impl JsValue {
     /// This function is equivalent to `Object(value)` in JavaScript.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toobject>
-    pub fn to_object(&self, context: &mut Context<'_>) -> JsResult<JsObject> {
+    pub fn to_object(&self, context: &mut dyn Context<'_>) -> JsResult<JsObject> {
         // TODO: add fast paths with object template
         match self {
             Self::Undefined | Self::Null => Err(JsNativeError::typ()
@@ -507,7 +507,7 @@ impl JsValue {
     /// Converts the value to a `PropertyKey`, that can be used as a key for properties.
     ///
     /// See <https://tc39.es/ecma262/#sec-topropertykey>
-    pub fn to_property_key(&self, context: &mut Context<'_>) -> JsResult<PropertyKey> {
+    pub fn to_property_key(&self, context: &mut dyn Context<'_>) -> JsResult<PropertyKey> {
         Ok(match self {
             // Fast path:
             Self::String(string) => string.clone().into(),
@@ -527,7 +527,7 @@ impl JsValue {
     /// It returns value converted to a numeric value of type `Number` or `BigInt`.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumeric>
-    pub fn to_numeric(&self, context: &mut Context<'_>) -> JsResult<Numeric> {
+    pub fn to_numeric(&self, context: &mut dyn Context<'_>) -> JsResult<Numeric> {
         // 1. Let primValue be ? ToPrimitive(value, number).
         let primitive = self.to_primitive(context, PreferredType::Number)?;
 
@@ -545,7 +545,7 @@ impl JsValue {
     /// This function is equivalent to `value | 0` in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-touint32>
-    pub fn to_u32(&self, context: &mut Context<'_>) -> JsResult<u32> {
+    pub fn to_u32(&self, context: &mut dyn Context<'_>) -> JsResult<u32> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Self::Integer(number) = *self {
             if let Ok(number) = u32::try_from(number) {
@@ -560,7 +560,7 @@ impl JsValue {
     /// Converts a value to an integral 32 bit signed integer.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toint32>
-    pub fn to_i32(&self, context: &mut Context<'_>) -> JsResult<i32> {
+    pub fn to_i32(&self, context: &mut dyn Context<'_>) -> JsResult<i32> {
         // This is the fast path, if the value is Integer we can just return it.
         if let Self::Integer(number) = *self {
             return Ok(number);
@@ -576,7 +576,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-toint8
-    pub fn to_int8(&self, context: &mut Context<'_>) -> JsResult<i8> {
+    pub fn to_int8(&self, context: &mut dyn Context<'_>) -> JsResult<i8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -605,7 +605,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint8
-    pub fn to_uint8(&self, context: &mut Context<'_>) -> JsResult<u8> {
+    pub fn to_uint8(&self, context: &mut dyn Context<'_>) -> JsResult<u8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -630,7 +630,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint8clamp
-    pub fn to_uint8_clamp(&self, context: &mut Context<'_>) -> JsResult<u8> {
+    pub fn to_uint8_clamp(&self, context: &mut dyn Context<'_>) -> JsResult<u8> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -677,7 +677,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-toint16
-    pub fn to_int16(&self, context: &mut Context<'_>) -> JsResult<i16> {
+    pub fn to_int16(&self, context: &mut dyn Context<'_>) -> JsResult<i16> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -706,7 +706,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-touint16
-    pub fn to_uint16(&self, context: &mut Context<'_>) -> JsResult<u16> {
+    pub fn to_uint16(&self, context: &mut dyn Context<'_>) -> JsResult<u16> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -731,7 +731,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobigint64
-    pub fn to_big_int64(&self, context: &mut Context<'_>) -> JsResult<BigInt> {
+    pub fn to_big_int64(&self, context: &mut dyn Context<'_>) -> JsResult<BigInt> {
         // 1. Let n be ? ToBigInt(argument).
         let n = self.to_bigint(context)?;
 
@@ -752,7 +752,7 @@ impl JsValue {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tobiguint64
-    pub fn to_big_uint64(&self, context: &mut Context<'_>) -> JsResult<BigInt> {
+    pub fn to_big_uint64(&self, context: &mut dyn Context<'_>) -> JsResult<BigInt> {
         let two_e_64: u128 = 0x1_0000_0000_0000_0000;
         let two_e_64 = BigInt::from(two_e_64);
 
@@ -767,7 +767,7 @@ impl JsValue {
     /// Converts a value to a non-negative integer if it is a valid integer index value.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toindex>
-    pub fn to_index(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub fn to_index(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         // 1. If value is undefined, then
         if self.is_undefined() {
             // a. Return 0.
@@ -798,7 +798,7 @@ impl JsValue {
     /// Converts argument to an integer suitable for use as the length of an array-like object.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tolength>
-    pub fn to_length(&self, context: &mut Context<'_>) -> JsResult<u64> {
+    pub fn to_length(&self, context: &mut dyn Context<'_>) -> JsResult<u64> {
         // 1. Let len be ? ToInteger(argument).
         // 2. If len ≤ +0, return +0.
         // 3. Return min(len, 2^53 - 1).
@@ -816,7 +816,10 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-tointegerorinfinity
-    pub fn to_integer_or_infinity(&self, context: &mut Context<'_>) -> JsResult<IntegerOrInfinity> {
+    pub fn to_integer_or_infinity(
+        &self,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<IntegerOrInfinity> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -828,7 +831,10 @@ impl JsValue {
     ///
     /// This function is almost the same as [`Self::to_integer_or_infinity`], but with the exception
     /// that this will return `Nan` if [`Self::to_number`] returns a non-finite number.
-    pub(crate) fn to_integer_or_nan(&self, context: &mut Context<'_>) -> JsResult<IntegerOrNan> {
+    pub(crate) fn to_integer_or_nan(
+        &self,
+        context: &mut dyn Context<'_>,
+    ) -> JsResult<IntegerOrNan> {
         // 1. Let number be ? ToNumber(argument).
         let number = self.to_number(context)?;
 
@@ -845,7 +851,7 @@ impl JsValue {
     /// This function is equivalent to the unary `+` operator (`+value`) in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumber>
-    pub fn to_number(&self, context: &mut Context<'_>) -> JsResult<f64> {
+    pub fn to_number(&self, context: &mut dyn Context<'_>) -> JsResult<f64> {
         match *self {
             Self::Null => Ok(0.0),
             Self::Undefined => Ok(f64::NAN),
@@ -871,7 +877,7 @@ impl JsValue {
     /// This function is equivalent to `Number(value)` in JavaScript
     ///
     /// See: <https://tc39.es/ecma262/#sec-tonumeric>
-    pub fn to_numeric_number(&self, context: &mut Context<'_>) -> JsResult<f64> {
+    pub fn to_numeric_number(&self, context: &mut dyn Context<'_>) -> JsResult<f64> {
         let primitive = self.to_primitive(context, PreferredType::Number)?;
         if let Some(bigint) = primitive.as_bigint() {
             return Ok(bigint.to_f64());
@@ -910,7 +916,7 @@ impl JsValue {
     #[inline]
     pub fn to_property_descriptor(
         &self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<PropertyDescriptor> {
         // 1. If Type(Obj) is not Object, throw a TypeError exception.
         self.as_object()

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -11,7 +11,7 @@ use crate::{
 
 impl JsValue {
     /// Perform the binary `+` operator on the value and return the result.
-    pub fn add(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn add(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             // Numeric add
@@ -51,7 +51,7 @@ impl JsValue {
     }
 
     /// Perform the binary `-` operator on the value and return the result.
-    pub fn sub(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn sub(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -77,7 +77,7 @@ impl JsValue {
     }
 
     /// Perform the binary `*` operator on the value and return the result.
-    pub fn mul(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn mul(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -103,7 +103,7 @@ impl JsValue {
     }
 
     /// Perform the binary `/` operator on the value and return the result.
-    pub fn div(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn div(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => x
@@ -144,7 +144,7 @@ impl JsValue {
     }
 
     /// Perform the binary `%` operator on the value and return the result.
-    pub fn rem(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn rem(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => {
@@ -197,7 +197,7 @@ impl JsValue {
     /// Perform the binary `**` operator on the value and return the result.
     // NOTE: There are some cases in the spec where we have to compare floats
     #[allow(clippy::float_cmp)]
-    pub fn pow(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn pow(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => u32::try_from(*y)
@@ -241,7 +241,7 @@ impl JsValue {
     }
 
     /// Perform the binary `&` operator on the value and return the result.
-    pub fn bitand(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn bitand(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x & y),
@@ -271,7 +271,7 @@ impl JsValue {
     }
 
     /// Perform the binary `|` operator on the value and return the result.
-    pub fn bitor(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn bitor(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x | y),
@@ -301,7 +301,7 @@ impl JsValue {
     }
 
     /// Perform the binary `^` operator on the value and return the result.
-    pub fn bitxor(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn bitxor(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x ^ y),
@@ -331,7 +331,7 @@ impl JsValue {
     }
 
     /// Perform the binary `<<` operator on the value and return the result.
-    pub fn shl(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn shl(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x.wrapping_shl(*y as u32)),
@@ -363,7 +363,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>` operator on the value and return the result.
-    pub fn shr(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn shr(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new(x.wrapping_shr(*y as u32)),
@@ -395,7 +395,7 @@ impl JsValue {
     }
 
     /// Perform the binary `>>>` operator on the value and return the result.
-    pub fn ushr(&self, other: &Self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn ushr(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match (self, other) {
             // Fast path:
             (Self::Integer(x), Self::Integer(y)) => Self::new((*x as u32).wrapping_shr(*y as u32)),
@@ -434,7 +434,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-instanceofoperator
-    pub fn instance_of(&self, target: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn instance_of(&self, target: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         // 1. If Type(target) is not Object, throw a TypeError exception.
         if !target.is_object() {
             return Err(JsNativeError::typ()
@@ -468,7 +468,7 @@ impl JsValue {
     }
 
     /// Returns the negated value.
-    pub fn neg(&self, context: &mut Context<'_>) -> JsResult<Self> {
+    pub fn neg(&self, context: &mut dyn Context<'_>) -> JsResult<Self> {
         Ok(match *self {
             Self::Symbol(_) | Self::Undefined => Self::new(f64::NAN),
             Self::Object(_) => Self::new(
@@ -512,7 +512,7 @@ impl JsValue {
         &self,
         other: &Self,
         left_first: bool,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<AbstractRelation> {
         Ok(match (self, other) {
             // Fast path (for some common operations):
@@ -590,7 +590,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn lt(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn lt(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -607,7 +607,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Less_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn le(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn le(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),
@@ -624,7 +624,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn gt(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn gt(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         match other.abstract_relation(self, false, context)? {
             AbstractRelation::True => Ok(true),
             AbstractRelation::False | AbstractRelation::Undefined => Ok(false),
@@ -641,7 +641,7 @@ impl JsValue {
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal
     /// [spec]: https://tc39.es/ecma262/#sec-relational-operators-runtime-semantics-evaluation
     #[inline]
-    pub fn ge(&self, other: &Self, context: &mut Context<'_>) -> JsResult<bool> {
+    pub fn ge(&self, other: &Self, context: &mut dyn Context<'_>) -> JsResult<bool> {
         match self.abstract_relation(other, true, context)? {
             AbstractRelation::False => Ok(true),
             AbstractRelation::True | AbstractRelation::Undefined => Ok(false),

--- a/boa_engine/src/vm/opcode/binary_ops/logical.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/logical.rs
@@ -14,7 +14,8 @@ impl Operation for LogicalAnd {
     const NAME: &'static str = "LogicalAnd";
     const INSTRUCTION: &'static str = "INST - LogicalAnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if !lhs.to_boolean() {
@@ -36,7 +37,8 @@ impl Operation for LogicalOr {
     const NAME: &'static str = "LogicalOr";
     const INSTRUCTION: &'static str = "INST - LogicalOr";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if lhs.to_boolean() {
@@ -58,7 +60,8 @@ impl Operation for Coalesce {
     const NAME: &'static str = "Coalesce";
     const INSTRUCTION: &'static str = "INST - Coalesce";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let exit = context.vm.read::<u32>();
         let lhs = context.vm.pop();
         if !lhs.is_null_or_undefined() {

--- a/boa_engine/src/vm/opcode/binary_ops/macro_defined.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/macro_defined.rs
@@ -16,11 +16,12 @@ macro_rules! implement_bin_ops {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-                let rhs = context.vm.pop();
-                let lhs = context.vm.pop();
+            fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+                let raw_context = context.as_raw_context_mut();
+                let rhs = raw_context.vm.pop();
+                let lhs = raw_context.vm.pop();
                 let value = lhs.$op(&rhs, context)?;
-                context.vm.push(value);
+                context.as_raw_context_mut().vm.push(value);
                 Ok(CompletionType::Normal)
             }
         }

--- a/boa_engine/src/vm/opcode/binary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/mod.rs
@@ -21,11 +21,12 @@ impl Operation for NotEq {
     const NAME: &'static str = "NotEq";
     const INSTRUCTION: &'static str = "INST - NotEq";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let rhs = context.vm.pop();
-        let lhs = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let rhs = raw_context.vm.pop();
+        let lhs = raw_context.vm.pop();
         let value = !lhs.equals(&rhs, context)?;
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }
@@ -41,10 +42,11 @@ impl Operation for StrictEq {
     const NAME: &'static str = "StrictEq";
     const INSTRUCTION: &'static str = "INST - StrictEq";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let rhs = context.vm.pop();
-        let lhs = context.vm.pop();
-        context.vm.push(lhs.strict_equals(&rhs));
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let rhs = raw_context.vm.pop();
+        let lhs = raw_context.vm.pop();
+        raw_context.vm.push(lhs.strict_equals(&rhs));
         Ok(CompletionType::Normal)
     }
 }
@@ -60,10 +62,11 @@ impl Operation for StrictNotEq {
     const NAME: &'static str = "StrictNotEq";
     const INSTRUCTION: &'static str = "INST - StrictNotEq";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let rhs = context.vm.pop();
-        let lhs = context.vm.pop();
-        context.vm.push(!lhs.strict_equals(&rhs));
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let rhs = raw_context.vm.pop();
+        let lhs = raw_context.vm.pop();
+        raw_context.vm.push(!lhs.strict_equals(&rhs));
         Ok(CompletionType::Normal)
     }
 }
@@ -79,9 +82,10 @@ impl Operation for In {
     const NAME: &'static str = "In";
     const INSTRUCTION: &'static str = "INST - In";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let rhs = context.vm.pop();
-        let lhs = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let rhs = raw_context.vm.pop();
+        let lhs = raw_context.vm.pop();
 
         let Some(rhs) = rhs.as_object() else {
             return Err(JsNativeError::typ()
@@ -93,7 +97,7 @@ impl Operation for In {
         };
         let key = lhs.to_property_key(context)?;
         let value = rhs.has_property(key, context)?;
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }
@@ -109,7 +113,8 @@ impl Operation for InPrivate {
     const NAME: &'static str = "InPrivate";
     const INSTRUCTION: &'static str = "INST - InPrivate";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code_block.names[index as usize].clone();
         let rhs = context.vm.pop();
@@ -149,12 +154,13 @@ impl Operation for InstanceOf {
     const NAME: &'static str = "InstanceOf";
     const INSTRUCTION: &'static str = "INST - InstanceOf";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let target = context.vm.pop();
-        let v = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let target = raw_context.vm.pop();
+        let v = raw_context.vm.pop();
         let value = v.instance_of(&target, context)?;
 
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/concat/mod.rs
+++ b/boa_engine/src/vm/opcode/concat/mod.rs
@@ -14,7 +14,8 @@ impl Operation for ConcatToString {
     const NAME: &'static str = "ConcatToString";
     const INSTRUCTION: &'static str = "INST - ConcatToString";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value_count = context.vm.read::<u32>();
         let mut strings = Vec::with_capacity(value_count as usize);
         for _ in 0..value_count {

--- a/boa_engine/src/vm/opcode/control_flow/break.rs
+++ b/boa_engine/src/vm/opcode/control_flow/break.rs
@@ -13,7 +13,8 @@ impl Operation for Break {
     const NAME: &'static str = "Break";
     const INSTRUCTION: &'static str = "INST - Break";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let jump_address = context.vm.read::<u32>();
         let target_address = context.vm.read::<u32>();
 
@@ -72,7 +73,8 @@ impl Operation for BreakLabel {
     const NAME: &'static str = "BreakLabel";
     const INSTRUCTION: &'static str = "INST - BreakLabel";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let jump_address = context.vm.read::<u32>();
         let target_address = context.vm.read::<u32>();
 

--- a/boa_engine/src/vm/opcode/control_flow/catch.rs
+++ b/boa_engine/src/vm/opcode/control_flow/catch.rs
@@ -14,7 +14,8 @@ impl Operation for CatchStart {
     const NAME: &'static str = "CatchStart";
     const INSTRUCTION: &'static str = "INST - CatchStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let start = context.vm.frame().pc - 1;
         let finally = context.vm.read::<u32>();
 
@@ -40,7 +41,8 @@ impl Operation for CatchEnd {
     const NAME: &'static str = "CatchEnd";
     const INSTRUCTION: &'static str = "INST - CatchEnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let mut envs_to_pop = 0_usize;
         while let Some(env_entry) = context.vm.frame_mut().env_stack.pop() {
             envs_to_pop += env_entry.env_num();
@@ -68,7 +70,8 @@ impl Operation for CatchEnd2 {
     const NAME: &'static str = "CatchEnd2";
     const INSTRUCTION: &'static str = "INST - CatchEnd2";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         if let Some(catch_entry) = context
             .vm
             .frame()

--- a/boa_engine/src/vm/opcode/control_flow/continue.rs
+++ b/boa_engine/src/vm/opcode/control_flow/continue.rs
@@ -17,7 +17,8 @@ impl Operation for Continue {
     const NAME: &'static str = "Continue";
     const INSTRUCTION: &'static str = "INST - Continue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let jump_address = context.vm.read::<u32>();
         let target_address = context.vm.read::<u32>();
 

--- a/boa_engine/src/vm/opcode/control_flow/finally.rs
+++ b/boa_engine/src/vm/opcode/control_flow/finally.rs
@@ -14,7 +14,8 @@ impl Operation for FinallyStart {
     const NAME: &'static str = "FinallyStart";
     const INSTRUCTION: &'static str = "INST - FinallyStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let exit = context.vm.read::<u32>();
 
         let finally_env = context
@@ -40,7 +41,8 @@ impl Operation for FinallyEnd {
     const NAME: &'static str = "FinallyEnd";
     const INSTRUCTION: &'static str = "INST - FinallyEnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let finally_candidates = context
             .vm
             .frame()

--- a/boa_engine/src/vm/opcode/control_flow/labelled.rs
+++ b/boa_engine/src/vm/opcode/control_flow/labelled.rs
@@ -14,7 +14,8 @@ impl Operation for LabelledStart {
     const NAME: &'static str = "LabelledStart";
     const INSTRUCTION: &'static str = "INST - LabelledStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let start = context.vm.frame().pc - 1;
         let end = context.vm.read::<u32>();
         context
@@ -37,7 +38,8 @@ impl Operation for LabelledEnd {
     const NAME: &'static str = "LabelledEnd";
     const INSTRUCTION: &'static str = "INST - LabelledEnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let mut envs_to_pop = 0_usize;
         while let Some(env_entry) = context.vm.frame_mut().env_stack.pop() {
             envs_to_pop += env_entry.env_num();

--- a/boa_engine/src/vm/opcode/control_flow/return.rs
+++ b/boa_engine/src/vm/opcode/control_flow/return.rs
@@ -14,7 +14,8 @@ impl Operation for Return {
     const NAME: &'static str = "Return";
     const INSTRUCTION: &'static str = "INST - Return";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let current_address = context.vm.frame().pc;
         let mut env_to_pop = 0;
         let mut finally_address = None;

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -18,7 +18,8 @@ impl Operation for Throw {
     const NAME: &'static str = "Throw";
     const INSTRUCTION: &'static str = "INST - Throw";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let error = if let Some(err) = context.vm.err.take() {
             err
         } else {
@@ -196,7 +197,8 @@ impl Operation for ThrowNewTypeError {
     const NAME: &'static str = "ThrowNewTypeError";
     const INSTRUCTION: &'static str = "INST - ThrowNewTypeError";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let index = context.vm.read::<u32>();
         let msg = context.vm.frame().code_block.literals[index as usize]
             .as_string()

--- a/boa_engine/src/vm/opcode/control_flow/try.rs
+++ b/boa_engine/src/vm/opcode/control_flow/try.rs
@@ -14,7 +14,8 @@ impl Operation for TryStart {
     const NAME: &'static str = "TryStart";
     const INSTRUCTION: &'static str = "INST - TryStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let catch = context.vm.read::<u32>();
         let finally = context.vm.read::<u32>();
 
@@ -48,7 +49,8 @@ impl Operation for TryEnd {
     const NAME: &'static str = "TryEnd";
     const INSTRUCTION: &'static str = "INST - TryEnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let mut envs_to_pop = 0_usize;
         while let Some(env_entry) = context.vm.frame_mut().env_stack.pop() {
             envs_to_pop += env_entry.env_num();

--- a/boa_engine/src/vm/opcode/copy/mod.rs
+++ b/boa_engine/src/vm/opcode/copy/mod.rs
@@ -14,29 +14,31 @@ impl Operation for CopyDataProperties {
     const NAME: &'static str = "CopyDataProperties";
     const INSTRUCTION: &'static str = "INST - CopyDataProperties";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let excluded_key_count = context.vm.read::<u32>();
-        let excluded_key_count_computed = context.vm.read::<u32>();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let excluded_key_count = raw_context.vm.read::<u32>();
+        let excluded_key_count_computed = raw_context.vm.read::<u32>();
         let mut excluded_keys = Vec::with_capacity(excluded_key_count as usize);
         for _ in 0..excluded_key_count {
-            let key = context.vm.pop();
+            let key = context.as_raw_context_mut().vm.pop();
             excluded_keys.push(
                 key.to_property_key(context)
                     .expect("key must be property key"),
             );
         }
-        let value = context.vm.pop();
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
         let object = value.as_object().expect("not an object");
-        let source = context.vm.pop();
+        let source = raw_context.vm.pop();
         for _ in 0..excluded_key_count_computed {
-            let key = context.vm.pop();
+            let key = context.as_raw_context_mut().vm.pop();
             excluded_keys.push(
                 key.to_property_key(context)
                     .expect("key must be property key"),
             );
         }
         object.copy_data_properties(&source, excluded_keys, context)?;
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -17,12 +17,13 @@ impl Operation for DefineClassStaticGetterByName {
     const NAME: &'static str = "DefineClassStaticGetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -67,12 +68,13 @@ impl Operation for DefineClassGetterByName {
     const NAME: &'static str = "DefineClassGetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassGetterByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -123,10 +125,11 @@ impl Operation for DefineClassStaticGetterByValue {
     const NAME: &'static str = "DefineClassStaticGetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -173,10 +176,11 @@ impl Operation for DefineClassGetterByValue {
     const NAME: &'static str = "DefineClassGetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassGetterByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -17,12 +17,13 @@ impl Operation for DefineClassStaticMethodByName {
     const NAME: &'static str = "DefineClassStaticMethodByName";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticMethodByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -63,12 +64,13 @@ impl Operation for DefineClassMethodByName {
     const NAME: &'static str = "DefineClassMethodByName";
     const INSTRUCTION: &'static str = "INST - DefineClassMethodByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -115,10 +117,11 @@ impl Operation for DefineClassStaticMethodByValue {
     const NAME: &'static str = "DefineClassStaticMethodByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticMethodByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -161,10 +164,11 @@ impl Operation for DefineClassMethodByValue {
     const NAME: &'static str = "DefineClassMethodByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassMethodByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -17,12 +17,13 @@ impl Operation for DefineClassStaticSetterByName {
     const NAME: &'static str = "DefineClassStaticSetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -68,12 +69,13 @@ impl Operation for DefineClassSetterByName {
     const NAME: &'static str = "DefineClassSetterByName";
     const INSTRUCTION: &'static str = "INST - DefineClassSetterByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let function = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let function = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
+        let key = raw_context.vm.frame().code_block.names[index as usize]
             .clone()
             .into();
         {
@@ -126,10 +128,11 @@ impl Operation for DefineClassStaticSetterByValue {
     const NAME: &'static str = "DefineClassStaticSetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class = raw_context.vm.pop();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -178,10 +181,11 @@ impl Operation for DefineClassSetterByValue {
     const NAME: &'static str = "DefineClassSetterByValue";
     const INSTRUCTION: &'static str = "INST - DefineClassSetterByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let key = context.vm.pop();
-        let class_proto = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let function = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let class_proto = raw_context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -15,16 +15,17 @@ impl Operation for DefineOwnPropertyByName {
     const NAME: &'static str = "DefineOwnPropertyByName";
     const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let value = context.vm.pop();
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let value = raw_context.vm.pop();
+        let object = raw_context.vm.pop();
+        let name = raw_context.vm.frame().code_block.names[index as usize].clone();
         let object = if let Some(object) = object.as_object() {
             object.clone()
         } else {
             object.to_object(context)?
         };
-        let name = context.vm.frame().code_block.names[index as usize].clone();
         object.__define_own_property__(
             &name.into(),
             PropertyDescriptor::builder()
@@ -50,10 +51,11 @@ impl Operation for DefineOwnPropertyByValue {
     const NAME: &'static str = "DefineOwnPropertyByValue";
     const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
-        let key = context.vm.pop();
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
+        let key = raw_context.vm.pop();
+        let object = raw_context.vm.pop();
         let object = if let Some(object) = object.as_object() {
             object.clone()
         } else {

--- a/boa_engine/src/vm/opcode/dup/mod.rs
+++ b/boa_engine/src/vm/opcode/dup/mod.rs
@@ -14,7 +14,8 @@ impl Operation for Dup {
     const NAME: &'static str = "Dup";
     const INSTRUCTION: &'static str = "INST - Dup";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context.vm.push(value.clone());
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/generator/yield_stm.rs
+++ b/boa_engine/src/vm/opcode/generator/yield_stm.rs
@@ -15,7 +15,8 @@ impl Operation for GeneratorYield {
     const NAME: &'static str = "GeneratorYield";
     const INSTRUCTION: &'static str = "INST - GeneratorYield";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         context.vm.frame_mut().r#yield = true;
         Ok(CompletionType::Return)
     }
@@ -32,10 +33,11 @@ impl Operation for AsyncGeneratorYield {
     const NAME: &'static str = "AsyncGeneratorYield";
     const INSTRUCTION: &'static str = "INST - AsyncGeneratorYield";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
 
-        let async_gen = context
+        let async_gen = raw_context
             .vm
             .frame()
             .async_generator
@@ -57,6 +59,8 @@ impl Operation for AsyncGeneratorYield {
         let gen = generator_object_mut
             .as_async_generator_mut()
             .expect("must be async generator object");
+
+        let context = context.as_raw_context_mut();
 
         if let Some(next) = gen.queue.front() {
             let resume_kind = match next.completion.clone() {

--- a/boa_engine/src/vm/opcode/get/function.rs
+++ b/boa_engine/src/vm/opcode/get/function.rs
@@ -14,12 +14,13 @@ impl Operation for GetArrowFunction {
     const NAME: &'static str = "GetArrowFunction";
     const INSTRUCTION: &'static str = "INST - GetArrowFunction";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        context.vm.read::<u8>();
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        raw_context.vm.read::<u8>();
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_function_object_fast(code, false, true, false, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }
@@ -35,12 +36,13 @@ impl Operation for GetAsyncArrowFunction {
     const NAME: &'static str = "GetAsyncArrowFunction";
     const INSTRUCTION: &'static str = "INST - GetAsyncArrowFunction";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        context.vm.read::<u8>();
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        raw_context.vm.read::<u8>();
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_function_object_fast(code, true, true, false, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }
@@ -56,12 +58,13 @@ impl Operation for GetFunction {
     const NAME: &'static str = "GetFunction";
     const INSTRUCTION: &'static str = "INST - GetFunction";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let method = context.vm.read::<u8>() != 0;
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let method = raw_context.vm.read::<u8>() != 0;
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_function_object_fast(code, false, false, method, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }
@@ -77,12 +80,13 @@ impl Operation for GetFunctionAsync {
     const NAME: &'static str = "GetFunctionAsync";
     const INSTRUCTION: &'static str = "INST - GetFunctionAsync";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let method = context.vm.read::<u8>() != 0;
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let method = raw_context.vm.read::<u8>() != 0;
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_function_object_fast(code, true, false, method, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/get/generator.rs
+++ b/boa_engine/src/vm/opcode/get/generator.rs
@@ -14,11 +14,12 @@ impl Operation for GetGenerator {
     const NAME: &'static str = "GetGenerator";
     const INSTRUCTION: &'static str = "INST - GetGenerator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_generator_function_object(code, false, None, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }
@@ -34,11 +35,12 @@ impl Operation for GetGeneratorAsync {
     const NAME: &'static str = "GetGeneratorAsync";
     const INSTRUCTION: &'static str = "INST - GetGeneratorAsync";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let code = context.vm.frame().code_block.functions[index as usize].clone();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let code = raw_context.vm.frame().code_block.functions[index as usize].clone();
         let function = create_generator_function_object(code, true, None, context);
-        context.vm.push(function);
+        context.as_raw_context_mut().vm.push(function);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -15,9 +15,10 @@ impl Operation for GetName {
     const NAME: &'static str = "GetName";
     const INSTRUCTION: &'static str = "INST - GetName";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let mut binding_locator = raw_context.vm.frame().code_block.bindings[index as usize];
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -27,7 +28,7 @@ impl Operation for GetName {
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }
@@ -43,12 +44,18 @@ impl Operation for GetLocator {
     const NAME: &'static str = "GetLocator";
     const INSTRUCTION: &'static str = "INST - GetLocator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let mut binding_locator = raw_context.vm.frame().code_block.bindings[index as usize];
         context.find_runtime_binding(&mut binding_locator)?;
 
-        context.vm.frame_mut().binding_stack.push(binding_locator);
+        context
+            .as_raw_context_mut()
+            .vm
+            .frame_mut()
+            .binding_stack
+            .push(binding_locator);
 
         Ok(CompletionType::Normal)
     }
@@ -66,9 +73,10 @@ impl Operation for GetNameAndLocator {
     const NAME: &'static str = "GetNameAndLocator";
     const INSTRUCTION: &'static str = "INST - GetNameAndLocator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let mut binding_locator = raw_context.vm.frame().code_block.bindings[index as usize];
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -77,9 +85,11 @@ impl Operation for GetNameAndLocator {
                 .to_string();
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
-
-        context.vm.frame_mut().binding_stack.push(binding_locator);
-        context.vm.push(value);
+        {
+            let context = context.as_raw_context_mut();
+            context.vm.frame_mut().binding_stack.push(binding_locator);
+            context.vm.push(value);
+        }
         Ok(CompletionType::Normal)
     }
 }
@@ -95,9 +105,10 @@ impl Operation for GetNameOrUndefined {
     const NAME: &'static str = "GetNameOrUndefined";
     const INSTRUCTION: &'static str = "INST - GetNameOrUndefined";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let mut binding_locator = raw_context.vm.frame().code_block.bindings[index as usize];
 
         let is_global = binding_locator.is_global();
 
@@ -117,7 +128,7 @@ impl Operation for GetNameOrUndefined {
                 .into());
         };
 
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -14,20 +14,22 @@ impl Operation for GetPrivateField {
     const NAME: &'static str = "GetPrivateField";
     const INSTRUCTION: &'static str = "INST - GetPrivateField";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let name = raw_context.vm.frame().code_block.names[index as usize].clone();
+        let value = raw_context.vm.pop();
         let base_obj = value.to_object(context)?;
 
         let name = context
+            .as_raw_context()
             .vm
             .environments
             .resolve_private_identifier(name)
             .expect("private name must be in environment");
 
         let result = base_obj.private_get(&name, context)?;
-        context.vm.push(result);
+        context.as_raw_context_mut().vm.push(result);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/for_in.rs
+++ b/boa_engine/src/vm/opcode/iteration/for_in.rs
@@ -15,8 +15,8 @@ impl Operation for CreateForInIterator {
     const NAME: &'static str = "CreateForInIterator";
     const INSTRUCTION: &'static str = "INST - CreateForInIterator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let object = context.as_raw_context_mut().vm.pop();
 
         let object = object.to_object(context)?;
         let iterator = ForInIterator::create_for_in_iterator(JsValue::new(object), context);
@@ -25,6 +25,7 @@ impl Operation for CreateForInIterator {
             .expect("ForInIterator must have a `next` method");
 
         context
+            .as_raw_context_mut()
             .vm
             .frame_mut()
             .iterators

--- a/boa_engine/src/vm/opcode/iteration/get.rs
+++ b/boa_engine/src/vm/opcode/iteration/get.rs
@@ -15,10 +15,15 @@ impl Operation for GetIterator {
     const NAME: &'static str = "GetIterator";
     const INSTRUCTION: &'static str = "INST - GetIterator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let object = context.as_raw_context_mut().vm.pop();
         let iterator = object.get_iterator(context, None, None)?;
-        context.vm.frame_mut().iterators.push(iterator);
+        context
+            .as_raw_context_mut()
+            .vm
+            .frame_mut()
+            .iterators
+            .push(iterator);
         Ok(CompletionType::Normal)
     }
 }
@@ -34,10 +39,15 @@ impl Operation for GetAsyncIterator {
     const NAME: &'static str = "GetAsyncIterator";
     const INSTRUCTION: &'static str = "INST - GetAsyncIterator";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let object = context.as_raw_context_mut().vm.pop();
         let iterator = object.get_iterator(context, Some(IteratorHint::Async), None)?;
-        context.vm.frame_mut().iterators.push(iterator);
+        context
+            .as_raw_context_mut()
+            .vm
+            .frame_mut()
+            .iterators
+            .push(iterator);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/boa_engine/src/vm/opcode/iteration/loop_ops.rs
@@ -15,7 +15,8 @@ impl Operation for IteratorLoopStart {
     const NAME: &'static str = "IteratorLoopStart";
     const INSTRUCTION: &'static str = "INST - IteratorLoopStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let start = context.vm.read::<u32>();
         let exit = context.vm.read::<u32>();
 
@@ -38,7 +39,8 @@ impl Operation for LoopStart {
     const NAME: &'static str = "LoopStart";
     const INSTRUCTION: &'static str = "INST - LoopStart";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let start = context.vm.read::<u32>();
         let exit = context.vm.read::<u32>();
 
@@ -60,7 +62,8 @@ impl Operation for LoopContinue {
     const NAME: &'static str = "LoopContinue";
     const INSTRUCTION: &'static str = "INST - LoopContinue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         // 1. Clean up the previous environment.
         let env = context
             .vm
@@ -102,7 +105,8 @@ impl Operation for LoopEnd {
     const NAME: &'static str = "LoopEnd";
     const INSTRUCTION: &'static str = "INST - LoopEnd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let mut envs_to_pop = 0_usize;
         while let Some(env_entry) = context.vm.frame_mut().env_stack.pop() {
             envs_to_pop += env_entry.env_num();
@@ -132,7 +136,8 @@ impl Operation for LoopUpdateReturnValue {
     const NAME: &'static str = "LoopUpdateReturnValue";
     const INSTRUCTION: &'static str = "INST - LoopUpdateReturnValue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context
             .vm

--- a/boa_engine/src/vm/opcode/jump/mod.rs
+++ b/boa_engine/src/vm/opcode/jump/mod.rs
@@ -14,7 +14,8 @@ impl Operation for Jump {
     const NAME: &'static str = "Jump";
     const INSTRUCTION: &'static str = "INST - Jump";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         context.vm.frame_mut().pc = address;
         Ok(CompletionType::Normal)
@@ -32,7 +33,8 @@ impl Operation for JumpIfTrue {
     const NAME: &'static str = "JumpIfTrue";
     const INSTRUCTION: &'static str = "INST - JumpIfTrue";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         if context.vm.pop().to_boolean() {
             context.vm.frame_mut().pc = address;
@@ -52,7 +54,8 @@ impl Operation for JumpIfFalse {
     const NAME: &'static str = "JumpIfFalse";
     const INSTRUCTION: &'static str = "INST - JumpIfFalse";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         if !context.vm.pop().to_boolean() {
             context.vm.frame_mut().pc = address;
@@ -72,7 +75,8 @@ impl Operation for JumpIfNotUndefined {
     const NAME: &'static str = "JumpIfNotUndefined";
     const INSTRUCTION: &'static str = "INST - JumpIfNotUndefined";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         let value = context.vm.pop();
         if !value.is_undefined() {
@@ -94,7 +98,8 @@ impl Operation for JumpIfNullOrUndefined {
     const NAME: &'static str = "JumpIfNullOrUndefined";
     const INSTRUCTION: &'static str = "INST - JumpIfNullOrUndefined";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         let value = context.vm.pop();
         if value.is_null_or_undefined() {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -148,11 +148,11 @@ macro_rules! generate_impl {
                 Self::INSTRUCTIONS[self as usize]
             }
 
-            const EXECUTE_FNS: [fn(&mut Context<'_>) -> JsResult<CompletionType>; Self::MAX] = [
+            const EXECUTE_FNS: [fn(&mut dyn Context<'_>) -> JsResult<CompletionType>; Self::MAX] = [
                 $(<generate_impl!(name $Variant $(=> $mapping)?)>::execute),*
             ];
 
-            pub(super) fn execute(self, context: &mut Context<'_>) -> JsResult<CompletionType> {
+            pub(super) fn execute(self, context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
                 Self::EXECUTE_FNS[self as usize](context)
             }
         }
@@ -169,7 +169,7 @@ pub(crate) trait Operation {
     const NAME: &'static str;
     const INSTRUCTION: &'static str;
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType>;
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType>;
 }
 
 generate_impl! {

--- a/boa_engine/src/vm/opcode/new/mod.rs
+++ b/boa_engine/src/vm/opcode/new/mod.rs
@@ -15,27 +15,28 @@ impl Operation for New {
     const NAME: &'static str = "New";
     const INSTRUCTION: &'static str = "INST - New";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        if raw_context.vm.runtime_limits.recursion_limit() <= raw_context.vm.frames.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message(format!(
                     "Maximum recursion limit {} exceeded",
-                    context.vm.runtime_limits.recursion_limit()
+                    raw_context.vm.runtime_limits.recursion_limit()
                 ))
                 .into());
         }
-        if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
+        if raw_context.vm.runtime_limits.stack_size_limit() <= raw_context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
                 .into());
         }
-        let argument_count = context.vm.read::<u32>();
+        let argument_count = raw_context.vm.read::<u32>();
         let mut arguments = Vec::with_capacity(argument_count as usize);
         for _ in 0..argument_count {
-            arguments.push(context.vm.pop());
+            arguments.push(raw_context.vm.pop());
         }
         arguments.reverse();
-        let func = context.vm.pop();
+        let func = raw_context.vm.pop();
 
         let result = func
             .as_constructor()
@@ -46,7 +47,7 @@ impl Operation for New {
             })
             .and_then(|cons| cons.__construct__(&arguments, cons, context))?;
 
-        context.vm.push(result);
+        context.as_raw_context_mut().vm.push(result);
         Ok(CompletionType::Normal)
     }
 }
@@ -62,22 +63,23 @@ impl Operation for NewSpread {
     const NAME: &'static str = "NewSpread";
     const INSTRUCTION: &'static str = "INST - NewSpread";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        if context.vm.runtime_limits.recursion_limit() <= context.vm.frames.len() {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        if raw_context.vm.runtime_limits.recursion_limit() <= raw_context.vm.frames.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message(format!(
                     "Maximum recursion limit {} exceeded",
-                    context.vm.runtime_limits.recursion_limit()
+                    raw_context.vm.runtime_limits.recursion_limit()
                 ))
                 .into());
         }
-        if context.vm.runtime_limits.stack_size_limit() <= context.vm.stack.len() {
+        if raw_context.vm.runtime_limits.stack_size_limit() <= raw_context.vm.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("Maximum call stack size exceeded")
                 .into());
         }
         // Get the arguments that are stored as an array object on the stack.
-        let arguments_array = context.vm.pop();
+        let arguments_array = raw_context.vm.pop();
         let arguments_array_object = arguments_array
             .as_object()
             .expect("arguments array in call spread function must be an object");
@@ -88,7 +90,7 @@ impl Operation for NewSpread {
             .expect("arguments array in call spread function must be dense")
             .clone();
 
-        let func = context.vm.pop();
+        let func = raw_context.vm.pop();
 
         let result = func
             .as_constructor()
@@ -99,7 +101,7 @@ impl Operation for NewSpread {
             })
             .and_then(|cons| cons.__construct__(&arguments, cons, context))?;
 
-        context.vm.push(result);
+        context.as_raw_context_mut().vm.push(result);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/nop/mod.rs
+++ b/boa_engine/src/vm/opcode/nop/mod.rs
@@ -14,7 +14,7 @@ impl Operation for Nop {
     const NAME: &'static str = "Nop";
     const INSTRUCTION: &'static str = "INST - Nop";
 
-    fn execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(_: &mut dyn Context<'_>) -> JsResult<CompletionType> {
         Ok(CompletionType::Normal)
     }
 }
@@ -30,7 +30,7 @@ impl Operation for Reserved {
     const NAME: &'static str = "Reserved";
     const INSTRUCTION: &'static str = "INST - Reserved";
 
-    fn execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(_: &mut dyn Context<'_>) -> JsResult<CompletionType> {
         unreachable!("Reserved opcodes are unreachable!")
     }
 }

--- a/boa_engine/src/vm/opcode/pop/mod.rs
+++ b/boa_engine/src/vm/opcode/pop/mod.rs
@@ -14,7 +14,8 @@ impl Operation for Pop {
     const NAME: &'static str = "Pop";
     const INSTRUCTION: &'static str = "INST - Pop";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let _val = context.vm.pop();
         Ok(CompletionType::Normal)
     }
@@ -31,7 +32,8 @@ impl Operation for PopIfThrown {
     const NAME: &'static str = "PopIfThrown";
     const INSTRUCTION: &'static str = "INST - PopIfThrown";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let frame = context.vm.frame();
         match frame.abrupt_completion {
             Some(record) if record.is_throw() => {
@@ -54,7 +56,8 @@ impl Operation for PopEnvironment {
     const NAME: &'static str = "PopEnvironment";
     const INSTRUCTION: &'static str = "INST - PopEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         context.vm.environments.pop();
         context.vm.frame_mut().dec_frame_env_stack();
         Ok(CompletionType::Normal)
@@ -72,7 +75,8 @@ impl Operation for PopOnReturnAdd {
     const NAME: &'static str = "PopOnReturnAdd";
     const INSTRUCTION: &'static str = "INST - PopOnReturnAdd";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         context.vm.frame_mut().pop_on_return += 1;
         Ok(CompletionType::Normal)
     }
@@ -89,7 +93,8 @@ impl Operation for PopOnReturnSub {
     const NAME: &'static str = "PopOnReturnSub";
     const INSTRUCTION: &'static str = "INST - PopOnReturnSub";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         context.vm.frame_mut().pop_on_return -= 1;
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/array.rs
+++ b/boa_engine/src/vm/opcode/push/array.rs
@@ -17,7 +17,8 @@ impl Operation for PushNewArray {
     const NAME: &'static str = "PushNewArray";
     const INSTRUCTION: &'static str = "INST - PushNewArray";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let array = context
             .intrinsics()
             .templates()
@@ -39,16 +40,17 @@ impl Operation for PushValueToArray {
     const NAME: &'static str = "PushValueToArray";
     const INSTRUCTION: &'static str = "INST - PushValueToArray";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
-        let array = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
+        let array = raw_context.vm.pop();
         let o = array.as_object().expect("should be an object");
         let len = o
             .length_of_array_like(context)
             .expect("should have 'length' property");
         o.create_data_property_or_throw(len, value, context)
             .expect("should be able to create new data property");
-        context.vm.push(array);
+        context.as_raw_context_mut().vm.push(array);
         Ok(CompletionType::Normal)
     }
 }
@@ -64,8 +66,8 @@ impl Operation for PushElisionToArray {
     const NAME: &'static str = "PushElisionToArray";
     const INSTRUCTION: &'static str = "INST - PushElisionToArray";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let array = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let array = context.as_raw_context_mut().vm.pop();
         let o = array.as_object().expect("should always be an object");
 
         let len = o
@@ -73,7 +75,7 @@ impl Operation for PushElisionToArray {
             .expect("arrays should always have a 'length' property");
 
         o.set(utf16!("length"), len + 1, true, context)?;
-        context.vm.push(array);
+        context.as_raw_context_mut().vm.push(array);
         Ok(CompletionType::Normal)
     }
 }
@@ -89,21 +91,22 @@ impl Operation for PushIteratorToArray {
     const NAME: &'static str = "PushIteratorToArray";
     const INSTRUCTION: &'static str = "INST - PushIteratorToArray";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let mut iterator = context
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let mut iterator = raw_context
             .vm
             .frame_mut()
             .iterators
             .pop()
             .expect("iterator stack should have at least an iterator");
-        let array = context.vm.pop();
+        let array = raw_context.vm.pop();
 
         while !iterator.step(context)? {
             let next = iterator.value(context)?;
             Array::push(&array, &[next], context)?;
         }
 
-        context.vm.push(array);
+        context.as_raw_context_mut().vm.push(array);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -57,8 +57,8 @@ impl Operation for PushClassFieldPrivate {
     const NAME: &'static str = "PushClassFieldPrivate";
     const INSTRUCTION: &'static str = "INST - PushClassFieldPrivate";
 
-fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
-    let raw_context = context.as_raw_context_mut();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
         let index = raw_context.vm.read::<u32>();
         let name = raw_context.vm.frame().code_block.names[index as usize].clone();
         let field_function_value = raw_context.vm.pop();

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -15,10 +15,11 @@ impl Operation for PushClassField {
     const NAME: &'static str = "PushClassField";
     const INSTRUCTION: &'static str = "INST - PushClassField";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let field_function_value = context.vm.pop();
-        let field_name_value = context.vm.pop();
-        let class_value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let field_function_value = raw_context.vm.pop();
+        let field_name_value = raw_context.vm.pop();
+        let class_value = raw_context.vm.pop();
 
         let field_name_key = field_name_value.to_property_key(context)?;
         let field_function_object = field_function_value
@@ -56,11 +57,12 @@ impl Operation for PushClassFieldPrivate {
     const NAME: &'static str = "PushClassFieldPrivate";
     const INSTRUCTION: &'static str = "INST - PushClassFieldPrivate";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
-        let field_function_value = context.vm.pop();
-        let class_value = context.vm.pop();
+fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+    let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let name = raw_context.vm.frame().code_block.names[index as usize].clone();
+        let field_function_value = raw_context.vm.pop();
+        let class_value = raw_context.vm.pop();
 
         let field_function_object = field_function_value
             .as_object()

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -17,10 +17,11 @@ impl Operation for PushClassPrivateMethod {
     const NAME: &'static str = "PushClassPrivateMethod";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateMethod";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
-        let method = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let index = raw_context.vm.read::<u32>();
+        let name = raw_context.vm.frame().code_block.names[index as usize].clone();
+        let method = raw_context.vm.pop();
         let method_object = method.as_callable().expect("method must be callable");
 
         let name_string = format!("#{}", name.to_std_string_escaped());
@@ -34,7 +35,7 @@ impl Operation for PushClassPrivateMethod {
             .__define_own_property__(&utf16!("name").into(), desc, context)
             .expect("failed to set name property on private method");
 
-        let class = context.vm.pop();
+        let class = context.as_raw_context_mut().vm.pop();
         let class_object = class.as_object().expect("class must be function object");
 
         class_object
@@ -66,7 +67,8 @@ impl Operation for PushClassPrivateGetter {
     const NAME: &'static str = "PushClassPrivateGetter";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateGetter";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code_block.names[index as usize].clone();
         let getter = context.vm.pop();
@@ -105,7 +107,8 @@ impl Operation for PushClassPrivateSetter {
     const NAME: &'static str = "PushClassPrivateSetter";
     const INSTRUCTION: &'static str = "INST - PushClassPrivateSetter";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let index = context.vm.read::<u32>();
         let name = context.vm.frame().code_block.names[index as usize].clone();
         let setter = context.vm.pop();

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -16,7 +16,8 @@ impl Operation for PushDeclarativeEnvironment {
     const NAME: &'static str = "PushDeclarativeEnvironment";
     const INSTRUCTION: &'static str = "INST - PushDeclarativeEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]
@@ -38,7 +39,8 @@ impl Operation for PushFunctionEnvironment {
     const NAME: &'static str = "PushFunctionEnvironment";
     const INSTRUCTION: &'static str = "INST - PushFunctionEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let compile_environments_index = context.vm.read::<u32>();
         let compile_environment = context.vm.frame().code_block.compile_environments
             [compile_environments_index as usize]
@@ -62,10 +64,11 @@ impl Operation for PushObjectEnvironment {
     const NAME: &'static str = "PushObjectEnvironment";
     const INSTRUCTION: &'static str = "INST - PushObjectEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let object = context.as_raw_context_mut().vm.pop();
         let object = object.to_object(context)?;
 
+        let context = context.as_raw_context_mut();
         context.vm.environments.push_object(object);
         context.vm.frame_mut().inc_frame_env_stack();
         Ok(CompletionType::Normal)
@@ -83,10 +86,11 @@ impl Operation for PushPrivateEnvironment {
     const NAME: &'static str = "PushPrivateEnvironment";
     const INSTRUCTION: &'static str = "INST - PushPrivateEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let class_value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let class_value = context.as_raw_context_mut().vm.pop();
         let class = class_value.to_object(context)?;
 
+        let context = context.as_raw_context_mut();
         let count = context.vm.read::<u32>();
         let mut names = Vec::with_capacity(count as usize);
         for _ in 0..count {
@@ -122,8 +126,8 @@ impl Operation for PopPrivateEnvironment {
     const NAME: &'static str = "PopPrivateEnvironment";
     const INSTRUCTION: &'static str = "INST - PopPrivateEnvironment";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        context.vm.environments.pop_private();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        context.as_raw_context_mut().vm.environments.pop_private();
 
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/push/literal.rs
+++ b/boa_engine/src/vm/opcode/push/literal.rs
@@ -14,7 +14,8 @@ impl Operation for PushLiteral {
     const NAME: &'static str = "PushLiteral";
     const INSTRUCTION: &'static str = "INST - PushLiteral";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let index = context.vm.read::<u32>() as usize;
         let value = context.vm.frame().code_block.literals[index].clone();
         context.vm.push(value);

--- a/boa_engine/src/vm/opcode/push/mod.rs
+++ b/boa_engine/src/vm/opcode/push/mod.rs
@@ -30,7 +30,8 @@ macro_rules! implement_push_generics {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+            fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+                let context = context.as_raw_context_mut();
                 context.vm.push($push_value);
                 Ok(CompletionType::Normal)
             }

--- a/boa_engine/src/vm/opcode/push/numbers.rs
+++ b/boa_engine/src/vm/opcode/push/numbers.rs
@@ -16,7 +16,8 @@ macro_rules! implement_push_numbers_with_conversion {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+            fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+                let context = context.as_raw_context_mut();
                 let value = context.vm.read::<$num_type>();
                 context.vm.push(i32::from(value));
                 Ok(CompletionType::Normal)
@@ -38,7 +39,8 @@ macro_rules! implement_push_numbers_no_conversion {
             const NAME: &'static str = stringify!($name);
             const INSTRUCTION: &'static str = stringify!("INST - " + $name);
 
-            fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+            fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+                let context = context.as_raw_context_mut();
                 let value = context.vm.read::<$num_type>();
                 context.vm.push(value);
                 Ok(CompletionType::Normal)

--- a/boa_engine/src/vm/opcode/push/object.rs
+++ b/boa_engine/src/vm/opcode/push/object.rs
@@ -15,7 +15,8 @@ impl Operation for PushEmptyObject {
     const NAME: &'static str = "PushEmptyObject";
     const INSTRUCTION: &'static str = "INST - PushEmptyObject";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let o = context
             .intrinsics()
             .templates()

--- a/boa_engine/src/vm/opcode/require/mod.rs
+++ b/boa_engine/src/vm/opcode/require/mod.rs
@@ -14,7 +14,8 @@ impl Operation for RequireObjectCoercible {
     const NAME: &'static str = "RequireObjectCoercible";
     const INSTRUCTION: &'static str = "INST - RequireObjectCoercible";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         let value = value.require_object_coercible()?;
         context.vm.push(value.clone());

--- a/boa_engine/src/vm/opcode/rest_parameter/mod.rs
+++ b/boa_engine/src/vm/opcode/rest_parameter/mod.rs
@@ -15,24 +15,25 @@ impl Operation for RestParameterInit {
     const NAME: &'static str = "RestParameterInit";
     const INSTRUCTION: &'static str = "INST - RestParameterInit";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let arg_count = context.vm.frame().argument_count as usize;
-        let param_count = context.vm.frame().code_block().params.as_ref().len();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let arg_count = raw_context.vm.frame().argument_count as usize;
+        let param_count = raw_context.vm.frame().code_block().params.as_ref().len();
         if arg_count >= param_count {
             let rest_count = arg_count - param_count + 1;
             let mut args = Vec::with_capacity(rest_count);
             for _ in 0..rest_count {
-                args.push(context.vm.pop());
+                args.push(raw_context.vm.pop());
             }
-            let array = Array::create_array_from_list(args, context);
+            let array = Array::create_array_from_list(args, raw_context);
 
-            context.vm.push(array);
+            raw_context.vm.push(array);
         } else {
-            context.vm.pop();
+            raw_context.vm.pop();
 
             let array =
                 Array::array_create(0, None, context).expect("could not create an empty array");
-            context.vm.push(array);
+            context.as_raw_context_mut().vm.push(array);
         }
         Ok(CompletionType::Normal)
     }
@@ -49,7 +50,8 @@ impl Operation for RestParameterPop {
     const NAME: &'static str = "RestParameterPop";
     const INSTRUCTION: &'static str = "INST - RestParameterPop";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let arg_count = context.vm.frame().argument_count;
         let param_count = context.vm.frame().code_block().params.as_ref().len() as u32;
         if arg_count > param_count {

--- a/boa_engine/src/vm/opcode/set/home_object.rs
+++ b/boa_engine/src/vm/opcode/set/home_object.rs
@@ -14,7 +14,8 @@ impl Operation for SetHomeObject {
     const NAME: &'static str = "SetHomeObject";
     const INSTRUCTION: &'static str = "INST - SetHomeObject";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let function = context.vm.pop();
         let home = context.vm.pop();
 

--- a/boa_engine/src/vm/opcode/set/prototype.rs
+++ b/boa_engine/src/vm/opcode/set/prototype.rs
@@ -14,9 +14,10 @@ impl Operation for SetPrototype {
     const NAME: &'static str = "SetPrototype";
     const INSTRUCTION: &'static str = "INST - SetPrototype";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
-        let object = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
+        let object = raw_context.vm.pop();
 
         let prototype = if let Some(prototype) = value.as_object() {
             Some(prototype.clone())

--- a/boa_engine/src/vm/opcode/swap/mod.rs
+++ b/boa_engine/src/vm/opcode/swap/mod.rs
@@ -14,7 +14,8 @@ impl Operation for Swap {
     const NAME: &'static str = "Swap";
     const INSTRUCTION: &'static str = "INST - Swap";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let len = context.vm.stack.len();
         assert!(len > 1);
         context.vm.stack.swap(len - 1, len - 2);
@@ -33,7 +34,8 @@ impl Operation for RotateLeft {
     const NAME: &'static str = "RotateLeft";
     const INSTRUCTION: &'static str = "INST - RotateLeft";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let n = context.vm.read::<u8>() as usize;
         let len = context.vm.stack.len();
         context.vm.stack[(len - n)..].rotate_left(1);
@@ -52,7 +54,8 @@ impl Operation for RotateRight {
     const NAME: &'static str = "RotateRight";
     const INSTRUCTION: &'static str = "INST - RotateRight";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let n = context.vm.read::<u8>() as usize;
         let len = context.vm.stack.len();
         context.vm.stack[(len - n)..].rotate_right(1);

--- a/boa_engine/src/vm/opcode/switch/mod.rs
+++ b/boa_engine/src/vm/opcode/switch/mod.rs
@@ -15,7 +15,8 @@ impl Operation for Case {
     const NAME: &'static str = "Case";
     const INSTRUCTION: &'static str = "INST - Case";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let address = context.vm.read::<u32>();
         let cond = context.vm.pop();
         let value = context.vm.pop();
@@ -40,7 +41,8 @@ impl Operation for Default {
     const NAME: &'static str = "Default";
     const INSTRUCTION: &'static str = "INST - Default";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let exit = context.vm.read::<u32>();
         let _val = context.vm.pop();
         context.vm.frame_mut().pc = exit;

--- a/boa_engine/src/vm/opcode/to/mod.rs
+++ b/boa_engine/src/vm/opcode/to/mod.rs
@@ -14,7 +14,8 @@ impl Operation for ToBoolean {
     const NAME: &'static str = "ToBoolean";
     const INSTRUCTION: &'static str = "INST - ToBoolean";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context.vm.push(value.to_boolean());
         Ok(CompletionType::Normal)
@@ -32,10 +33,10 @@ impl Operation for ToPropertyKey {
     const NAME: &'static str = "ToPropertyKey";
     const INSTRUCTION: &'static str = "INST - ToPropertyKey";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let value = context.as_raw_context_mut().vm.pop();
         let key = value.to_property_key(context)?;
-        context.vm.push(key);
+        context.as_raw_context_mut().vm.push(key);
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/unary_ops/decrement.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/decrement.rs
@@ -15,16 +15,20 @@ impl Operation for Dec {
     const NAME: &'static str = "Dec";
     const INSTRUCTION: &'static str = "INST - Dec";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
         match value {
             JsValue::Integer(number) if number > i32::MIN => {
-                context.vm.push(number - 1);
+                raw_context.vm.push(number - 1);
             }
             _ => match value.to_numeric(context)? {
-                Numeric::Number(number) => context.vm.push(number - 1f64),
+                Numeric::Number(number) => context.as_raw_context_mut().vm.push(number - 1f64),
                 Numeric::BigInt(bigint) => {
-                    context.vm.push(JsBigInt::sub(&bigint, &JsBigInt::one()));
+                    context
+                        .as_raw_context_mut()
+                        .vm
+                        .push(JsBigInt::sub(&bigint, &JsBigInt::one()));
                 }
             },
         }
@@ -43,15 +47,17 @@ impl Operation for DecPost {
     const NAME: &'static str = "DecPost";
     const INSTRUCTION: &'static str = "INST - DecPost";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
         match value {
             JsValue::Integer(number) if number > i32::MIN => {
-                context.vm.push(number - 1);
-                context.vm.push(value);
+                raw_context.vm.push(number - 1);
+                raw_context.vm.push(value);
             }
             _ => {
                 let value = value.to_numeric(context)?;
+                let context = context.as_raw_context_mut();
                 match value {
                     Numeric::Number(number) => context.vm.push(number - 1f64),
                     Numeric::BigInt(ref bigint) => {

--- a/boa_engine/src/vm/opcode/unary_ops/increment.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/increment.rs
@@ -15,16 +15,20 @@ impl Operation for Inc {
     const NAME: &'static str = "Inc";
     const INSTRUCTION: &'static str = "INST - Inc";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
         match value {
             JsValue::Integer(number) if number < i32::MAX => {
-                context.vm.push(number + 1);
+                raw_context.vm.push(number + 1);
             }
             _ => match value.to_numeric(context)? {
-                Numeric::Number(number) => context.vm.push(number + 1f64),
+                Numeric::Number(number) => context.as_raw_context_mut().vm.push(number + 1f64),
                 Numeric::BigInt(bigint) => {
-                    context.vm.push(JsBigInt::add(&bigint, &JsBigInt::one()));
+                    context
+                        .as_raw_context_mut()
+                        .vm
+                        .push(JsBigInt::add(&bigint, &JsBigInt::one()));
                 }
             },
         }
@@ -43,15 +47,17 @@ impl Operation for IncPost {
     const NAME: &'static str = "IncPost";
     const INSTRUCTION: &'static str = "INST - IncPost";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let raw_context = context.as_raw_context_mut();
+        let value = raw_context.vm.pop();
         match value {
             JsValue::Integer(number) if number < i32::MAX => {
-                context.vm.push(number + 1);
-                context.vm.push(value);
+                raw_context.vm.push(number + 1);
+                raw_context.vm.push(value);
             }
             _ => {
                 let value = value.to_numeric(context)?;
+                let context = context.as_raw_context_mut();
                 match value {
                     Numeric::Number(number) => context.vm.push(number + 1f64),
                     Numeric::BigInt(ref bigint) => {

--- a/boa_engine/src/vm/opcode/unary_ops/logical.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/logical.rs
@@ -14,7 +14,8 @@ impl Operation for LogicalNot {
     const NAME: &'static str = "LogicalNot";
     const INSTRUCTION: &'static str = "INST - LogicalNot";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context.vm.push(!value.to_boolean());
         Ok(CompletionType::Normal)

--- a/boa_engine/src/vm/opcode/unary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/mod.rs
@@ -27,7 +27,8 @@ impl Operation for TypeOf {
     const NAME: &'static str = "TypeOf";
     const INSTRUCTION: &'static str = "INST - TypeOf";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context.vm.push(value.type_of());
         Ok(CompletionType::Normal)
@@ -45,10 +46,10 @@ impl Operation for Pos {
     const NAME: &'static str = "Pos";
     const INSTRUCTION: &'static str = "INST - Pos";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let value = context.as_raw_context_mut().vm.pop();
         let value = value.to_number(context)?;
-        context.vm.push(value);
+        context.as_raw_context_mut().vm.push(value);
         Ok(CompletionType::Normal)
     }
 }
@@ -64,11 +65,11 @@ impl Operation for Neg {
     const NAME: &'static str = "Neg";
     const INSTRUCTION: &'static str = "INST - Neg";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let value = context.as_raw_context_mut().vm.pop();
         match value.to_numeric(context)? {
-            Numeric::Number(number) => context.vm.push(number.neg()),
-            Numeric::BigInt(bigint) => context.vm.push(JsBigInt::neg(&bigint)),
+            Numeric::Number(number) => context.as_raw_context_mut().vm.push(number.neg()),
+            Numeric::BigInt(bigint) => context.as_raw_context_mut().vm.push(JsBigInt::neg(&bigint)),
         }
         Ok(CompletionType::Normal)
     }
@@ -85,11 +86,11 @@ impl Operation for BitNot {
     const NAME: &'static str = "BitNot";
     const INSTRUCTION: &'static str = "INST - BitNot";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let value = context.vm.pop();
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let value = context.as_raw_context_mut().vm.pop();
         match value.to_numeric(context)? {
-            Numeric::Number(number) => context.vm.push(Number::not(number)),
-            Numeric::BigInt(bigint) => context.vm.push(JsBigInt::not(&bigint)),
+            Numeric::Number(number) => context.as_raw_context_mut().vm.push(Number::not(number)),
+            Numeric::BigInt(bigint) => context.as_raw_context_mut().vm.push(JsBigInt::not(&bigint)),
         }
         Ok(CompletionType::Normal)
     }

--- a/boa_engine/src/vm/opcode/unary_ops/void.rs
+++ b/boa_engine/src/vm/opcode/unary_ops/void.rs
@@ -14,7 +14,8 @@ impl Operation for Void {
     const NAME: &'static str = "Void";
     const INSTRUCTION: &'static str = "INST - Void";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let _old = context.vm.pop();
         context.vm.push(JsValue::undefined());
         Ok(CompletionType::Normal)

--- a/boa_engine/src/vm/opcode/value/mod.rs
+++ b/boa_engine/src/vm/opcode/value/mod.rs
@@ -15,7 +15,8 @@ impl Operation for ValueNotNullOrUndefined {
     const NAME: &'static str = "ValueNotNullOrUndefined";
     const INSTRUCTION: &'static str = "INST - ValueNotNullOrUndefined";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         if value.is_null() {
             return Err(JsNativeError::typ()
@@ -43,7 +44,8 @@ impl Operation for IsObject {
     const NAME: &'static str = "IsObject";
     const INSTRUCTION: &'static str = "INST - IsObject";
 
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+    fn execute(context: &mut dyn Context<'_>) -> JsResult<CompletionType> {
+        let context = context.as_raw_context_mut();
         let value = context.vm.pop();
         context.vm.push(value.is_object());
         Ok(CompletionType::Normal)

--- a/boa_runtime/src/console/mod.rs
+++ b/boa_runtime/src/console/mod.rs
@@ -49,7 +49,7 @@ fn logger(msg: LogMessage, console_state: &Console) {
 }
 
 /// This represents the `console` formatter.
-fn formatter(data: &[JsValue], context: &mut Context<'_>) -> JsResult<String> {
+fn formatter(data: &[JsValue], context: &mut dyn Context<'_>) -> JsResult<String> {
     match data {
         [] => Ok(String::new()),
         [val] => Ok(val.to_string(context)?.to_std_string_escaped()),
@@ -133,9 +133,9 @@ impl Console {
     pub const NAME: &'static str = "console";
 
     /// Initializes the `console` built-in object.
-    pub fn init(context: &mut Context<'_>) -> JsObject {
+    pub fn init(context: &mut dyn Context<'_>) -> JsObject {
         fn console_method(
-            f: fn(&JsValue, &[JsValue], &Console, &mut Context<'_>) -> JsResult<JsValue>,
+            f: fn(&JsValue, &[JsValue], &Console, &mut dyn Context<'_>) -> JsResult<JsValue>,
             state: Rc<RefCell<Console>>,
         ) -> NativeFunction {
             // SAFETY: `Console` doesn't contain types that need tracing.
@@ -146,7 +146,7 @@ impl Console {
             }
         }
         fn console_method_mut(
-            f: fn(&JsValue, &[JsValue], &mut Console, &mut Context<'_>) -> JsResult<JsValue>,
+            f: fn(&JsValue, &[JsValue], &mut Console, &mut dyn Context<'_>) -> JsResult<JsValue>,
             state: Rc<RefCell<Console>>,
         ) -> NativeFunction {
             // SAFETY: `Console` doesn't contain types that need tracing.
@@ -213,7 +213,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let assertion = args.get(0).map_or(false, JsValue::to_boolean);
 
@@ -250,7 +250,7 @@ impl Console {
         _: &JsValue,
         _: &[JsValue],
         console: &mut Self,
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         console.groups.clear();
         Ok(JsValue::undefined())
@@ -270,7 +270,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(LogMessage::Log(formatter(args, context)?), console);
         Ok(JsValue::undefined())
@@ -290,7 +290,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(LogMessage::Error(formatter(args, context)?), console);
         Ok(JsValue::undefined())
@@ -310,7 +310,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(LogMessage::Info(formatter(args, context)?), console);
         Ok(JsValue::undefined())
@@ -330,7 +330,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(LogMessage::Log(formatter(args, context)?), console);
         Ok(JsValue::undefined())
@@ -350,12 +350,13 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         if !args.is_empty() {
             logger(LogMessage::Log(formatter(args, context)?), console);
 
             let stack_trace_dump = context
+                .as_raw_context()
                 .stack_trace()
                 .map(|frame| frame.code_block().name())
                 .collect::<Vec<_>>()
@@ -383,7 +384,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(LogMessage::Warn(formatter(args, context)?), console);
         Ok(JsValue::undefined())
@@ -403,7 +404,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &mut Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -432,7 +433,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &mut Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -471,7 +472,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &mut Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -508,7 +509,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -552,7 +553,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &mut Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let label = match args.get(0) {
             Some(value) => value.to_string(context)?,
@@ -599,7 +600,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &mut Self,
-        context: &mut Context<'_>,
+        context: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         let group_label = formatter(args, context)?;
 
@@ -624,7 +625,7 @@ impl Console {
         _: &JsValue,
         _: &[JsValue],
         console: &mut Self,
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         console.groups.pop();
 
@@ -646,7 +647,7 @@ impl Console {
         _: &JsValue,
         args: &[JsValue],
         console: &Self,
-        _: &mut Context<'_>,
+        _: &mut dyn Context<'_>,
     ) -> JsResult<JsValue> {
         logger(
             LogMessage::Info(args.get_or_undefined(0).display_obj(true)),

--- a/boa_runtime/src/console/tests.rs
+++ b/boa_runtime/src/console/tests.rs
@@ -1,6 +1,6 @@
 use super::{formatter, Console};
 use crate::test::{run_test_actions, run_test_actions_with, TestAction};
-use boa_engine::{property::Attribute, Context, JsValue};
+use boa_engine::{property::Attribute, Context, DefaultContext, JsValue};
 use indoc::indoc;
 
 #[test]
@@ -87,8 +87,8 @@ fn formatter_float_format_works() {
 
 #[test]
 fn console_log_cyclic() {
-    let mut context = Context::default();
-    let console = Console::init(&mut context);
+    let context: &mut dyn Context<'_> = &mut DefaultContext::default();
+    let console = Console::init(context);
     context
         .register_global_property(Console::NAME, console, Attribute::all())
         .unwrap();
@@ -99,7 +99,7 @@ fn console_log_cyclic() {
                 a[1] = a;
                 console.log(a);
             "#})],
-        &mut context,
+        context,
     );
     // Should not stack overflow
 }


### PR DESCRIPTION
One of the most painful problems for our users right now is that any `JobQueue` and `ModuleLoader` can only be immutable by the nature of our current Context API. However, there's an alternative: to make `Context` a trait and make `JobQueue` and `ModuleLoader` a supertrait of `Context`. This gives us several advantages:
- Allows us to have mutable module loader data and job queue data, avoiding the need to wrap everything in a `RefCell`.
- Unblocks the possibility of adding `Provider` as a supertrait in the future, which is useful for users that want to append additional data onto a context and recover it inside JS calls.
- Gives freedom to the user about how to store the context itself, which could be useful if some user wants to e.g. wrap a `Context` in a `RefCell` to share it between async future jobs.
- By design, disallows using a job queue or a module loader with a different context than the one provided on initialization.

This comes with certain disadvantages however:
- Now every access to the `vm` needs to pass through a virtual method call. This could impact performance but the cache could also store the `vm` after some calls and completely remove the overhead. This would need to be tested with benchmarks.
- It makes our API more complex. I couldn't find a way to override only the `JobQueue` or only the `ModuleLoader` without having to copy the whole `DefaultContext` implementation. Though, this could be alleviated with a new `DefaultContext` API with interchangeable modules, but I'm still not sure about what the design would be.

I'm opening this PR to seek comments and suggestions to know if we should commit to this. I'll finish the implementation this weekend to be able to benchmark it against the current implementation and see if there's a performance regression.
