### PR TITLE
Remove `[[ClassFieldInitializerName]]` from `CodeBlock`

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -155,7 +155,7 @@ impl Eval {
 
                 // v. Let classFieldInitializerName be F.[[ClassFieldInitializerName]].
                 // vi. If classFieldInitializerName is not empty, set inClassFieldInitializer to true.
-                if function_object.class_field_initializer_name().is_some() {
+                if function_object.in_class_field_initializer() {
                     flags |= Flags::IN_CLASS_FIELD_INITIALIZER;
                 }
 

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -350,12 +350,12 @@ impl Function {
         }
     }
 
-    /// Returns the `[[ClassFieldInitializerName]]` internal slot of the function.
-    pub(crate) fn class_field_initializer_name(&self) -> Option<Sym> {
+    /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.
+    pub(crate) fn in_class_field_initializer(&self) -> bool {
         if let FunctionKind::Ordinary { code, .. } = &self.kind {
-            code.class_field_initializer_name
+            code.in_class_field_initializer()
         } else {
-            None
+            false
         }
     }
 

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -267,8 +267,9 @@ impl ByteCompiler<'_, '_> {
                     field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
-                    let mut code = field_compiler.finish();
-                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    field_compiler.code_block_flags |= CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER;
+
+                    let code = field_compiler.finish();
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
@@ -298,8 +299,9 @@ impl ByteCompiler<'_, '_> {
                     field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
-                    let mut code = field_compiler.finish();
-                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    field_compiler.code_block_flags |= CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER;
+
+                    let code = field_compiler.finish();
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
@@ -339,8 +341,9 @@ impl ByteCompiler<'_, '_> {
                     field_compiler.pop_compile_environment();
                     field_compiler.emit_opcode(Opcode::Return);
 
-                    let mut code = field_compiler.finish();
-                    code.class_field_initializer_name = Some(Sym::EMPTY_STRING);
+                    field_compiler.code_block_flags |= CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER;
+
+                    let code = field_compiler.finish();
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -246,9 +246,6 @@ pub struct ByteCompiler<'ctx, 'host> {
     /// Compile time environments in this function.
     pub(crate) compile_environments: Vec<Gc<GcRefCell<CompileTimeEnvironment>>>,
 
-    /// The `[[ClassFieldInitializerName]]` internal slot.
-    pub(crate) class_field_initializer_name: Option<Sym>,
-
     /// The environment that is currently active.
     pub(crate) current_environment: Gc<GcRefCell<CompileTimeEnvironment>>,
 
@@ -298,7 +295,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
             compile_environments: Vec::default(),
-            class_field_initializer_name: None,
             code_block_flags,
 
             literals_map: FxHashMap::default(),
@@ -1365,7 +1361,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             bindings: self.bindings.into_boxed_slice(),
             functions: self.functions.into_boxed_slice(),
             compile_environments: self.compile_environments.into_boxed_slice(),
-            class_field_initializer_name: self.class_field_initializer_name,
             flags: Cell::new(self.code_block_flags),
         }
     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -74,6 +74,9 @@ bitflags! {
         /// The `"arguments"` binding is the first binding.
         const NEEDS_ARGUMENTS_OBJECT = 0b0001_0000;
 
+        /// The `[[ClassFieldInitializerName]]` internal slot.
+        const IN_CLASS_FIELD_INITIALIZER = 0b0010_0000;
+
         /// Trace instruction execution to `stdout`.
         #[cfg(feature = "trace")]
         const TRACEABLE = 0b1000_0000;
@@ -131,10 +134,6 @@ pub struct CodeBlock {
 
     /// Compile time environments in this function.
     pub(crate) compile_environments: Box<[Gc<GcRefCell<CompileTimeEnvironment>>]>,
-
-    /// The `[[ClassFieldInitializerName]]` internal slot.
-    #[unsafe_ignore_trace]
-    pub(crate) class_field_initializer_name: Option<Sym>,
 }
 
 /// ---- `CodeBlock` public API ----
@@ -157,7 +156,6 @@ impl CodeBlock {
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
             compile_environments: Box::default(),
-            class_field_initializer_name: None,
         }
     }
 
@@ -212,6 +210,13 @@ impl CodeBlock {
         self.flags
             .get()
             .contains(CodeBlockFlags::NEEDS_ARGUMENTS_OBJECT)
+    }
+
+    /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.
+    pub(crate) fn in_class_field_initializer(&self) -> bool {
+        self.flags
+            .get()
+            .contains(CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER)
     }
 }
 


### PR DESCRIPTION
In the entire spec the `[[ClassFieldInitializerName]]` field is only used to check that it's not empty (in `PerformEval`), so removed it and added a bitflag for it.

It changes the following:

- Remove `[[ClassFieldInitializerName]]` from `CodeBlock`
- Add `IN_CLASS_FIELD_INITIALIZER` bitflag
