### PR TITLE
Remove `mutate_immutable` and `silent` checks from Opcodes 

### DIFF
--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -1,5 +1,6 @@
 use crate::{
     bytecompiler::{ByteCompiler, FunctionCompiler, FunctionSpec, Label, NodeKind},
+    environments::BindingLocatorError,
     vm::{
         create_function_object_fast, create_generator_function_object, BindingOpcode,
         CodeBlockFlags, Opcode,
@@ -742,9 +743,12 @@ impl ByteCompiler<'_, '_> {
                             let index = self.get_or_insert_binding(binding);
                             self.emit(Opcode::SetName, &[index]);
                         }
-                        Err(()) => {
+                        Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
                             self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                        Err(BindingLocatorError::Silent) => {
+                            self.emit(Opcode::Pop, &[]);
                         }
                     }
                 } else {

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -737,9 +737,16 @@ impl ByteCompiler<'_, '_> {
                 // iii. Else,
                 if binding_exists {
                     // 1. Perform ! varEnv.SetMutableBinding(fn, fo, false).
-                    let binding = self.set_mutable_binding(name);
-                    let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::SetName, &[index]);
+                    match self.set_mutable_binding(name) {
+                        Ok(binding) => {
+                            let index = self.get_or_insert_binding(binding);
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Err(()) => {
+                            let index = self.get_or_insert_name(name);
+                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                    }
                 } else {
                     // 1. NOTE: The following invocation cannot return an abrupt completion because of the validation preceding step 14.
                     // 2. Perform ! varEnv.CreateMutableBinding(fn, true).

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -1,5 +1,5 @@
 use super::ByteCompiler;
-use crate::environments::{BindingLocator, CompileTimeEnvironment};
+use crate::environments::{BindingLocator, BindingLocatorError, CompileTimeEnvironment};
 use boa_ast::expression::Identifier;
 use boa_gc::{Gc, GcRefCell};
 
@@ -108,7 +108,10 @@ impl ByteCompiler<'_, '_> {
     }
 
     /// Return the binding locator for a set operation on an existing binding.
-    pub(crate) fn set_mutable_binding(&self, name: Identifier) -> Result<BindingLocator, ()> {
+    pub(crate) fn set_mutable_binding(
+        &self,
+        name: Identifier,
+    ) -> Result<BindingLocator, BindingLocatorError> {
         self.current_environment
             .borrow()
             .set_mutable_binding_recursive(name)
@@ -116,7 +119,10 @@ impl ByteCompiler<'_, '_> {
 
     #[cfg(feature = "annex-b")]
     /// Return the binding locator for a set operation on an existing var binding.
-    pub(crate) fn set_mutable_binding_var(&self, name: Identifier) -> Result<BindingLocator, ()> {
+    pub(crate) fn set_mutable_binding_var(
+        &self,
+        name: Identifier,
+    ) -> Result<BindingLocator, BindingLocatorError> {
         self.current_environment
             .borrow()
             .set_mutable_binding_var_recursive(name)

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -108,7 +108,7 @@ impl ByteCompiler<'_, '_> {
     }
 
     /// Return the binding locator for a set operation on an existing binding.
-    pub(crate) fn set_mutable_binding(&self, name: Identifier) -> BindingLocator {
+    pub(crate) fn set_mutable_binding(&self, name: Identifier) -> Result<BindingLocator, ()> {
         self.current_environment
             .borrow()
             .set_mutable_binding_recursive(name)
@@ -116,7 +116,7 @@ impl ByteCompiler<'_, '_> {
 
     #[cfg(feature = "annex-b")]
     /// Return the binding locator for a set operation on an existing var binding.
-    pub(crate) fn set_mutable_binding_var(&self, name: Identifier) -> BindingLocator {
+    pub(crate) fn set_mutable_binding_var(&self, name: Identifier) -> Result<BindingLocator, ()> {
         self.current_environment
             .borrow()
             .set_mutable_binding_var_recursive(name)

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -1,5 +1,6 @@
 use crate::{
     bytecompiler::{Access, ByteCompiler},
+    environments::BindingLocatorError,
     vm::{BindingOpcode, Opcode},
 };
 use boa_ast::expression::{
@@ -80,9 +81,12 @@ impl ByteCompiler<'_, '_> {
                                 let index = self.get_or_insert_binding(binding);
                                 self.emit(Opcode::SetName, &[index]);
                             }
-                            Err(()) => {
+                            Err(BindingLocatorError::MutateImmutable) => {
                                 let index = self.get_or_insert_name(name);
                                 self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                            }
+                            Err(BindingLocatorError::Silent) => {
+                                self.emit(Opcode::Pop, &[]);
                             }
                         }
                     } else {

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -75,9 +75,16 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Dup);
                     }
                     if lex {
-                        let binding = self.set_mutable_binding(name);
-                        let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::SetName, &[index]);
+                        match self.set_mutable_binding(name) {
+                            Ok(binding) => {
+                                let index = self.get_or_insert_binding(binding);
+                                self.emit(Opcode::SetName, &[index]);
+                            }
+                            Err(()) => {
+                                let index = self.get_or_insert_name(name);
+                                self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                            }
+                        }
                     } else {
                         self.emit_opcode(Opcode::SetNameByLocator);
                     }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -1,5 +1,6 @@
 use crate::{
     bytecompiler::{Access, ByteCompiler},
+    environments::BindingLocatorError,
     vm::Opcode,
 };
 use boa_ast::expression::{
@@ -45,9 +46,12 @@ impl ByteCompiler<'_, '_> {
                             let index = self.get_or_insert_binding(binding);
                             self.emit(Opcode::SetName, &[index]);
                         }
-                        Err(()) => {
+                        Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
                             self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                        Err(BindingLocatorError::Silent) => {
+                            self.emit(Opcode::Pop, &[]);
                         }
                     }
                 } else {

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -40,9 +40,16 @@ impl ByteCompiler<'_, '_> {
                 }
 
                 if lex {
-                    let binding = self.set_mutable_binding(name);
-                    let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::SetName, &[index]);
+                    match self.set_mutable_binding(name) {
+                        Ok(binding) => {
+                            let index = self.get_or_insert_binding(binding);
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Err(()) => {
+                            let index = self.get_or_insert_name(name);
+                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                    }
                 } else {
                     self.emit_opcode(Opcode::SetNameByLocator);
                 }

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -367,13 +367,22 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                 self.emit(Opcode::DefVar, &[index]);
             }
             BindingOpcode::InitVar => {
-                let binding = if self.has_binding(name) {
-                    self.set_mutable_binding(name)
+                if self.has_binding(name) {
+                    match self.set_mutable_binding(name) {
+                        Ok(binding) => {
+                            let index = self.get_or_insert_binding(binding);
+                            self.emit(Opcode::DefInitVar, &[index]);
+                        }
+                        Err(()) => {
+                            let index = self.get_or_insert_name(name);
+                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                    }
                 } else {
-                    self.initialize_mutable_binding(name, true)
+                    let binding = self.initialize_mutable_binding(name, true);
+                    let index = self.get_or_insert_binding(binding);
+                    self.emit(Opcode::DefInitVar, &[index]);
                 };
-                let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::DefInitVar, &[index]);
             }
             BindingOpcode::InitLet => {
                 let binding = self.initialize_mutable_binding(name, false);
@@ -385,11 +394,16 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                 let index = self.get_or_insert_binding(binding);
                 self.emit(Opcode::PutLexicalValue, &[index]);
             }
-            BindingOpcode::SetName => {
-                let binding = self.set_mutable_binding(name);
-                let index = self.get_or_insert_binding(binding);
-                self.emit(Opcode::SetName, &[index]);
-            }
+            BindingOpcode::SetName => match self.set_mutable_binding(name) {
+                Ok(binding) => {
+                    let index = self.get_or_insert_binding(binding);
+                    self.emit(Opcode::SetName, &[index]);
+                }
+                Err(()) => {
+                    let index = self.get_or_insert_name(name);
+                    self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                }
+            },
         }
     }
 
@@ -618,9 +632,16 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                 }
 
                 if lex {
-                    let binding = self.set_mutable_binding(name);
-                    let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::SetName, &[index]);
+                    match self.set_mutable_binding(name) {
+                        Ok(binding) => {
+                            let index = self.get_or_insert_binding(binding);
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Err(()) => {
+                            let index = self.get_or_insert_name(name);
+                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                    }
                 } else {
                     self.emit_opcode(Opcode::SetNameByLocator);
                 }
@@ -1032,9 +1053,17 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                     let binding = self.get_binding_value(name);
                     let index = self.get_or_insert_binding(binding);
                     self.emit(Opcode::GetName, &[index]);
-                    let binding = self.set_mutable_binding_var(name);
-                    let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::SetName, &[index]);
+
+                    match self.set_mutable_binding_var(name) {
+                        Ok(binding) => {
+                            let index = self.get_or_insert_binding(binding);
+                            self.emit(Opcode::SetName, &[index]);
+                        }
+                        Err(()) => {
+                            let index = self.get_or_insert_name(name);
+                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                    }
                 }
             }
             Declaration::Class(class) => self.class(class, false),

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -15,7 +15,7 @@ use std::cell::Cell;
 
 use crate::{
     builtins::function::ThisMode,
-    environments::{BindingLocator, CompileTimeEnvironment},
+    environments::{BindingLocator, BindingLocatorError, CompileTimeEnvironment},
     js_string,
     vm::{BindingOpcode, CodeBlock, CodeBlockFlags, Opcode},
     Context, JsBigInt, JsString, JsValue,
@@ -373,9 +373,12 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                             let index = self.get_or_insert_binding(binding);
                             self.emit(Opcode::DefInitVar, &[index]);
                         }
-                        Err(()) => {
+                        Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
                             self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                        Err(BindingLocatorError::Silent) => {
+                            self.emit(Opcode::Pop, &[]);
                         }
                     }
                 } else {
@@ -399,9 +402,12 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                     let index = self.get_or_insert_binding(binding);
                     self.emit(Opcode::SetName, &[index]);
                 }
-                Err(()) => {
+                Err(BindingLocatorError::MutateImmutable) => {
                     let index = self.get_or_insert_name(name);
                     self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                }
+                Err(BindingLocatorError::Silent) => {
+                    self.emit(Opcode::Pop, &[]);
                 }
             },
         }
@@ -637,9 +643,12 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                             let index = self.get_or_insert_binding(binding);
                             self.emit(Opcode::SetName, &[index]);
                         }
-                        Err(()) => {
+                        Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
                             self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                        Err(BindingLocatorError::Silent) => {
+                            self.emit(Opcode::Pop, &[]);
                         }
                     }
                 } else {
@@ -1059,9 +1068,12 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                             let index = self.get_or_insert_binding(binding);
                             self.emit(Opcode::SetName, &[index]);
                         }
-                        Err(()) => {
+                        Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
                             self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        }
+                        Err(BindingLocatorError::Silent) => {
+                            self.emit(Opcode::Pop, &[]);
                         }
                     }
                 }

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -10,6 +10,7 @@ use boa_interner::Sym;
 
 use crate::{
     bytecompiler::{Access, ByteCompiler},
+    environments::BindingLocatorError,
     vm::{BindingOpcode, Opcode},
 };
 
@@ -328,9 +329,12 @@ impl ByteCompiler<'_, '_> {
                         let index = self.get_or_insert_binding(binding);
                         self.emit(Opcode::DefInitVar, &[index]);
                     }
-                    Err(()) => {
+                    Err(BindingLocatorError::MutateImmutable) => {
                         let index = self.get_or_insert_name(*ident);
                         self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                    }
+                    Err(BindingLocatorError::Silent) => {
+                        self.emit(Opcode::Pop, &[]);
                     }
                 }
             }

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -255,9 +255,7 @@ impl CompileTimeEnvironment {
             Some(binding) if binding.mutable => {
                 BindingLocator::declarative(name, self.environment_index, binding.index)
             }
-            Some(binding) if binding.strict => {
-                return Err(BindingLocatorError::MutateImmutable)
-            }
+            Some(binding) if binding.strict => return Err(BindingLocatorError::MutateImmutable),
             Some(_) => return Err(BindingLocatorError::Silent),
             None => self.outer.as_ref().map_or_else(
                 || Ok(BindingLocator::global(name)),
@@ -283,9 +281,7 @@ impl CompileTimeEnvironment {
             Some(binding) if binding.mutable => {
                 BindingLocator::declarative(name, self.environment_index, binding.index)
             }
-            Some(binding) if binding.strict => {
-                return Err(BindingLocatorError::MutateImmutable)
-            }
+            Some(binding) if binding.strict => return Err(BindingLocatorError::MutateImmutable),
             Some(_) => return Err(BindingLocatorError::Silent),
             None => self.outer.as_ref().map_or_else(
                 || Ok(BindingLocator::global(name)),

--- a/boa_engine/src/environments/mod.rs
+++ b/boa_engine/src/environments/mod.rs
@@ -30,8 +30,8 @@ mod runtime;
 pub(crate) use {
     compile::CompileTimeEnvironment,
     runtime::{
-        BindingLocator, DeclarativeEnvironment, Environment, EnvironmentStack, FunctionSlots,
-        PrivateEnvironment, ThisBindingStatus,
+        BindingLocator, BindingLocatorError, DeclarativeEnvironment, Environment, EnvironmentStack,
+        FunctionSlots, PrivateEnvironment, ThisBindingStatus,
     },
 };
 

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -523,7 +523,6 @@ pub(crate) struct BindingLocator {
     environment_index: u32,
     binding_index: u32,
     global: bool,
-    silent: bool,
 }
 
 unsafe impl Trace for BindingLocator {
@@ -542,7 +541,6 @@ impl BindingLocator {
             environment_index,
             binding_index,
             global: false,
-            silent: false,
         }
     }
 
@@ -553,18 +551,6 @@ impl BindingLocator {
             environment_index: 0,
             binding_index: 0,
             global: true,
-            silent: false,
-        }
-    }
-
-    /// Creates a binding locator that indicates that any action is silently ignored.
-    pub(in crate::environments) const fn silent(name: Identifier) -> Self {
-        Self {
-            name,
-            environment_index: 0,
-            binding_index: 0,
-            global: false,
-            silent: true,
         }
     }
 
@@ -587,11 +573,15 @@ impl BindingLocator {
     pub(crate) const fn binding_index(&self) -> u32 {
         self.binding_index
     }
+}
 
-    /// Returns if the binding is a silent operation.
-    pub(crate) const fn is_silent(&self) -> bool {
-        self.silent
-    }
+/// Action that is returned when a fallible binding operation.
+pub(crate) enum BindingLocatorError {
+    /// Trying to mutate immutable binding,
+    MutateImmutable,
+
+    /// Indicates that any action is silently ignored.
+    Silent,
 }
 
 impl Context<'_> {

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -410,7 +410,8 @@ impl CodeBlock {
             | Opcode::PushClassPrivateGetter
             | Opcode::PushClassPrivateSetter
             | Opcode::PushClassPrivateMethod
-            | Opcode::InPrivate => {
+            | Opcode::InPrivate
+            | Opcode::ThrowMutateImmutable => {
                 let operand = self.read::<u32>(*pc);
                 *pc += size_of::<u32>();
                 format!(
@@ -609,8 +610,7 @@ impl CodeBlock {
             | Opcode::Reserved48
             | Opcode::Reserved49
             | Opcode::Reserved50
-            | Opcode::Reserved51
-            | Opcode::Reserved52 => unreachable!("Reserved opcodes are unrechable"),
+            | Opcode::Reserved51 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -471,7 +471,8 @@ impl CodeBlock {
                 | Opcode::PushClassPrivateGetter
                 | Opcode::PushClassPrivateSetter
                 | Opcode::PushClassPrivateMethod
-                | Opcode::InPrivate => {
+                | Opcode::InPrivate
+                | Opcode::ThrowMutateImmutable => {
                     let operand = self.read::<u32>(pc);
                     pc += size_of::<u32>();
                     let label = format!(
@@ -708,8 +709,7 @@ impl CodeBlock {
                 | Opcode::Reserved48
                 | Opcode::Reserved49
                 | Opcode::Reserved50
-                | Opcode::Reserved51
-                | Opcode::Reserved52 => unreachable!("Reserved opcodes are unrechable"),
+                | Opcode::Reserved51 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -56,7 +56,6 @@ impl Operation for DefInitVar {
         if binding_locator.is_silent() {
             return Ok(CompletionType::Normal);
         }
-        binding_locator.throw_mutate_immutable(context)?;
 
         context.find_runtime_binding(&mut binding_locator)?;
 

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -53,9 +53,6 @@ impl Operation for DefInitVar {
         let index = context.vm.read::<u32>();
         let value = context.vm.pop();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        if binding_locator.is_silent() {
-            return Ok(CompletionType::Normal);
-        }
 
         context.find_runtime_binding(&mut binding_locator)?;
 

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -74,7 +74,6 @@ impl Operation for DeleteName {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        binding_locator.throw_mutate_immutable(context)?;
 
         context.find_runtime_binding(&mut binding_locator)?;
 

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -18,7 +18,6 @@ impl Operation for GetName {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        binding_locator.throw_mutate_immutable(context)?;
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -70,7 +69,6 @@ impl Operation for GetNameAndLocator {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        binding_locator.throw_mutate_immutable(context)?;
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -100,7 +98,6 @@ impl Operation for GetNameOrUndefined {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
-        binding_locator.throw_mutate_immutable(context)?;
 
         let is_global = binding_locator.is_global();
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -668,6 +668,13 @@ generate_impl! {
         /// Stack: value **=>**
         PutLexicalValue,
 
+        /// Throws an error because the binding access is illegal.
+        ///
+        /// Operands: binding_index: `u32`
+        ///
+        /// Stack: **=>**
+        ThrowMutateImmutable,
+
         /// Find a binding on the environment chain and push its value.
         ///
         /// Operands: name_index: `u32`
@@ -1814,8 +1821,6 @@ generate_impl! {
         Reserved50 => Reserved,
         /// Reserved [`Opcode`].
         Reserved51 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved52 => Reserved,
     }
 }
 

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -43,9 +43,6 @@ impl Operation for SetName {
         let index = context.vm.read::<u32>();
         let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
         let value = context.vm.pop();
-        if binding_locator.is_silent() {
-            return Ok(CompletionType::Normal);
-        }
 
         context.find_runtime_binding(&mut binding_locator)?;
 
@@ -80,9 +77,6 @@ impl Operation for SetNameByLocator {
             .pop()
             .expect("locator should have been popped before");
         let value = context.vm.pop();
-        if binding_locator.is_silent() {
-            return Ok(CompletionType::Normal);
-        }
 
         verify_initialized(binding_locator, context)?;
 


### PR DESCRIPTION
The `mutate_immutable` and `silent` checks are known at compile time and we can generate more specialized opcodes for them.

It changes the following:

- Add `ThrowMutateImmutable` opcode.
- Generate more optimized opcode.
