### PR TITLE
Mark header of rooted ephemerons when tracing

### DIFF
--- a/boa_gc/src/internals/ephemeron_box.rs
+++ b/boa_gc/src/internals/ephemeron_box.rs
@@ -204,7 +204,7 @@ impl<K: Trace + ?Sized, V: Trace> ErasedEphemeronBox for EphemeronBox<K, V> {
             // SAFETY: `data` comes from an `into_raw` call, so this pointer is safe to pass to
             // `from_raw`.
             let contents = unsafe { Box::from_raw(data.as_ptr()) };
-            contents.value.finalize();
+            Trace::run_finalizer(&contents.value);
         }
     }
 }

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -341,7 +341,7 @@ impl Collector {
         while let Some(node) = strong.get() {
             // SAFETY: node must be valid as this phase cannot drop any node.
             let node_ref = unsafe { node.as_ref() };
-            if node_ref.header.roots() > 0 {
+            if node_ref.header.roots() != 0 {
                 // SAFETY: the reference to node must be valid as it is rooted. Passing
                 // invalid references can result in Undefined Behavior
                 unsafe {
@@ -375,14 +375,14 @@ impl Collector {
             // SAFETY: node must be valid as this phase cannot drop any node.
             let eph_ref = unsafe { eph.as_ref() };
             let header = eph_ref.header();
-            if header.roots() > 0 {
+            if header.roots() != 0 {
                 header.mark();
             }
             // SAFETY: the garbage collector ensures `eph_ref` always points to valid data.
             if unsafe { !eph_ref.trace() } {
                 pending_ephemerons.push(eph);
             }
-            weak = &eph_ref.header().next;
+            weak = &header.next;
         }
 
         // 2. Trace all the weak pointers in the live weak maps to make sure they do not get swept.

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -437,7 +437,7 @@ impl Collector {
         for node in unreachables.strong {
             // SAFETY: The caller must ensure all pointers inside `unreachables.strong` are valid.
             let node = unsafe { node.as_ref() };
-            Trace::run_finalizer(&node.value());
+            Trace::run_finalizer(node.value());
         }
         for node in unreachables.weak {
             // SAFETY: The caller must ensure all pointers inside `unreachables.weak` are valid.

--- a/boa_gc/src/test/weak.rs
+++ b/boa_gc/src/test/weak.rs
@@ -65,19 +65,19 @@ fn eph_allocation_chains() {
             let weak = WeakGc::new(&cloned_gc);
             let wrap = Gc::new(weak);
 
-            assert_eq!(*wrap.upgrade().expect("weak is live"), "foo");
+            assert_eq!(wrap.upgrade().as_deref().map(String::as_str), Some("foo"));
 
             let eph = Ephemeron::new(&wrap, 3);
 
             drop(cloned_gc);
             force_collect();
-            assert!(wrap.upgrade().is_some());
-            assert_eq!(eph.value().expect("weak is still live"), 3);
+            assert_eq!(wrap.upgrade().as_deref().map(String::as_str), Some("foo"));
+            assert_eq!(eph.value(), Some(3));
 
             drop(gc_value);
             force_collect();
             assert!(wrap.upgrade().is_none());
-            assert!(eph.value().is_some());
+            assert_eq!(eph.value(), Some(3));
 
             drop(wrap);
             force_collect();
@@ -95,7 +95,7 @@ fn eph_basic_alloc_dump_test() {
         let eph = Ephemeron::new(&gc_value, 4);
         let _fourth = Gc::new("tail");
 
-        assert_eq!(eph.value().expect("must be live"), 4);
+        assert_eq!(eph.value(), Some(4));
     });
 }
 

--- a/boa_gc/src/test/weak.rs
+++ b/boa_gc/src/test/weak.rs
@@ -71,12 +71,14 @@ fn eph_allocation_chains() {
 
             drop(cloned_gc);
             force_collect();
-
             assert_eq!(eph.value().expect("weak is still live"), 3);
 
             drop(gc_value);
             force_collect();
+            assert!(wrap.upgrade().is_none());
 
+            drop(wrap);
+            force_collect();
             assert!(eph.value().is_none());
         }
     });

--- a/boa_gc/src/test/weak.rs
+++ b/boa_gc/src/test/weak.rs
@@ -71,11 +71,13 @@ fn eph_allocation_chains() {
 
             drop(cloned_gc);
             force_collect();
+            assert!(wrap.upgrade().is_some());
             assert_eq!(eph.value().expect("weak is still live"), 3);
 
             drop(gc_value);
             force_collect();
             assert!(wrap.upgrade().is_none());
+            assert!(eph.value().is_some());
 
             drop(wrap);
             force_collect();


### PR DESCRIPTION
A very subtle bug that was discovered by @tunz. Also added additional checks on the test to make sure the ephemerons are correctly cleaned up.