### PR TITLE
Skip reversing arguments in SuperCallDerived

### DIFF
--- a/boa_engine/src/vm/opcode/environment/mod.rs
+++ b/boa_engine/src/vm/opcode/environment/mod.rs
@@ -225,7 +225,6 @@ impl Operation for SuperCallDerived {
         for _ in 0..argument_count {
             arguments.push(context.vm.pop());
         }
-        arguments.reverse();
 
         let this_env = context
             .vm

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1254,7 +1254,7 @@ generate_impl! {
         ///
         /// Operands:
         ///
-        /// Stack: argument_1, ... argument_n **=>**
+        /// Stack: argument_n, ... argument_1 **=>**
         SuperCallDerived,
 
         /// Dynamically import a module.


### PR DESCRIPTION
This Pull Request fixes some failing test262 tests depending on a derived super call.

It changes the following:

- It removes reversing arguments passed to the derived super call. `code_block::construct_internal` already reverses the arguments into `argument_n ... argument_1` on to the stack, since normal constructor parameters are resolved in order.
