### PR TITLE
Cache `cargo-tarpaulin` binary

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,10 +22,10 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-      - uses: actions-rs/install@v0.1
+      - name: Install cargo-tarpaulin
+        uses: baptiste0928/cargo-install@v2.1.0
         with:
           crate: cargo-tarpaulin
-          version: latest
       - uses: Swatinem/rust-cache@v2
         with:
           key: tarpaulin

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -71,7 +71,7 @@ fn main() {
 /// Evaluate the given ECMAScript code.
 #[wasm_bindgen]
 pub fn evaluate(src: &str) -> Result<String, JsValue> {
-    // Setup executor
+    // Setup the executor
     Context::default()
         .eval(Source::from_bytes(src))
         .map_err(|e| JsValue::from(format!("Uncaught {e}")))


### PR DESCRIPTION
Testing if this change improves CI times for the codecov check.

Had to use another `cargo-install` action because the original `actions-rs/cargo-install` is apparently unmaintained, and users were reporting problems with the cache (https://github.com/actions-rs/install/issues/12)
