### PR TITLE
Correctly handle finally..loop..break

### DIFF
--- a/boa_engine/src/tests/control_flow/mod.rs
+++ b/boa_engine/src/tests/control_flow/mod.rs
@@ -195,6 +195,24 @@ fn catch_binding_finally() {
 }
 
 #[test]
+fn finally_with_loop_break() {
+    run_test_actions([TestAction::assert_eq(
+        indoc! {r#"
+            try {
+              30;
+            }
+            catch {
+            } finally {
+              while(true) {
+                break;
+              }
+            }
+        "#},
+        30,
+    )]);
+}
+
+#[test]
 fn single_case_switch() {
     run_test_actions([TestAction::assert_eq(
         indoc! {r#"

--- a/boa_engine/src/vm/opcode/control_flow/finally.rs
+++ b/boa_engine/src/vm/opcode/control_flow/finally.rs
@@ -119,7 +119,7 @@ impl Operation for FinallyEnd {
                 let env_truncation_len = context.vm.environments.len().saturating_sub(envs_to_pop);
                 context.vm.environments.truncate(env_truncation_len);
             }
-            Some(record) if !record.is_throw_with_target() => {
+            Some(record) if record.is_throw() && !record.is_throw_with_target() => {
                 let current_stack = context
                     .vm
                     .frame_mut()


### PR DESCRIPTION
The match was too greedy, being executed for 'break' abrupt completions as well.

Closes #3054
