### PR TITLE
Copy `ABOUT.md` file to all published crates

### DIFF
--- a/boa_ast/ABOUT.md
+++ b/boa_ast/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! [grammar]: https://tc39.es/ecma262/#sec-syntactic-grammar
 //! [early]: https://tc39.es/ecma262/#sec-static-semantic-rules
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_cli/ABOUT.md
+++ b/boa_cli/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -1,6 +1,6 @@
 //! A ECMAScript REPL implementation based on boa_engine.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_engine/ABOUT.md
+++ b/boa_engine/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -46,7 +46,7 @@
 //! [ecma-402]: https://tc39.es/ecma402
 //! [examples]: https://github.com/boa-dev/boa/tree/main/boa_examples
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_gc/ABOUT.md
+++ b/boa_gc/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -4,7 +4,7 @@
 //! **`boa_gc`** is a mark-sweep garbage collector that implements a [`Trace`] and [`Finalize`] trait
 //! for garbage collected values.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_icu_provider/ABOUT.md
+++ b/boa_icu_provider/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -14,7 +14,7 @@
 //! [ICU4X guide]: https://github.com/unicode-org/icu4x/blob/main/docs/tutorials/data_management.md
 //! [`BufferProvider`]: icu_provider::BufferProvider
 //! [`AnyProvider`]: icu_provider::AnyProvider
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_interner/ABOUT.md
+++ b/boa_interner/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -10,7 +10,7 @@
 //! need to store a `usize`. This reduces memory consumption and improves performance in the
 //! compiler.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_macros/ABOUT.md
+++ b/boa_macros/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! Macros for the Boa JavaScript engine.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_parser/ABOUT.md
+++ b/boa_parser/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -10,7 +10,7 @@
 //! [lex]: https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar
 //! [grammar]: https://tc39.es/ecma262/#sec-ecmascript-language-expressions
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_profiler/ABOUT.md
+++ b/boa_profiler/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! [profiler-md]: https://github.com/boa-dev/boa/blob/main/docs/profiling.md
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_runtime/ABOUT.md
+++ b/boa_runtime/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_runtime/src/lib.rs
+++ b/boa_runtime/src/lib.rs
@@ -40,7 +40,7 @@
 //!
 //! ```
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_tester/ABOUT.md
+++ b/boa_tester/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -3,7 +3,7 @@
 //! This crate will run the full ECMAScript test suite (Test262) and report compliance of the
 //! `boa` engine.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"

--- a/boa_wasm/ABOUT.md
+++ b/boa_wasm/ABOUT.md
@@ -1,0 +1,33 @@
+# About Boa
+
+Boa is an open-source, experimental ECMAScript Engine written in Rust for
+lexing, parsing and executing ECMAScript/JavaScript. Currently, Boa supports some
+of the [language][boa-conformance]. More information can be viewed at [Boa's
+website][boa-web].
+
+Try out the most recent release with Boa's live demo
+[playground][boa-playground].
+
+# Boa Crates
+
+- [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
+- [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and
+  execution.
+- [**`boa_gc`**][gc] - Boa's garbage collector.
+- [**`boa_interner`**][interner] - Boa's string interner.
+- [**`boa_parser`**][parser] - Boa's lexer and parser.
+- [**`boa_profiler`**][profiler] - Boa's code profiler.
+- [**`boa_icu_provider`**][icu] - Boa's ICU4X data provider.
+- [**`boa_runtime`**][runtime] - Boa's WebAPI features.
+
+[boa-conformance]: https://boajs.dev/boa/test262/
+[boa-web]: https://boajs.dev/
+[boa-playground]: https://boajs.dev/boa/playground/
+[ast]: https://boajs.dev/boa/doc/boa_ast/index.html
+[engine]: https://boajs.dev/boa/doc/boa_engine/index.html
+[gc]: https://boajs.dev/boa/doc/boa_gc/index.html
+[interner]: https://boajs.dev/boa/doc/boa_interner/index.html
+[parser]: https://boajs.dev/boa/doc/boa_parser/index.html
+[profiler]: https://boajs.dev/boa/doc/boa_profiler/index.html
+[icu]: https://boajs.dev/boa/doc/boa_icu_provider/index.html
+[runtime]: https://boajs.dev/boa/doc/boa_runtime/index.html

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -1,6 +1,6 @@
 //! An ECMAScript WASM implementation based on boa_engine.
 //!
-#![doc = include_str!("../../ABOUT.md")]
+#![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"


### PR DESCRIPTION
Unfortunately, `cargo publish` cannot handle having relative paths to files outside of the published crate, which is why we need to undo the change. Left the individual files though, since it makes it easier to check for diffs at least.

Thought about using symlinks instead, but it seems that support for symlinks in git on windows [is still suboptimal](https://stackoverflow.com/a/59761201).