### PR TITLE
Implement virtual callstack for functions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,7 @@ dependencies = [
  "indoc",
  "itertools",
  "jemallocator",
+ "next-gen",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2727,6 +2728,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "next-gen"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1962f0b64c859f27f9551c74afbdbec7090fa83518daf6c5eb5b31d153455beb"
+dependencies = [
+ "next-gen-proc_macros",
+ "unwind_safe",
+]
+
+[[package]]
+name = "next-gen-proc_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a59395d2ffdd03894479cdd1ce4b7e0700d379d517f2d396cee2a4828707c5a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,6 +4500,12 @@ name = "unsafe-libyaml"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
+
+[[package]]
+name = "unwind_safe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0976c77def3f1f75c4ef892a292c31c0bbe9e3d0702c63044d7c76db298171a3"
 
 [[package]]
 name = "url"

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -77,6 +77,7 @@ pollster = "0.3.0"
 thin-vec = "0.2.12"
 itertools = { version = "0.10.5", default-features = false }
 icu_normalizer = "1.2.0"
+next-gen = "0.1.1"
 
 # intl deps
 icu_locid_transform = { version = "1.2.1", features = ["std", "serde"], optional = true }

--- a/boa_engine/src/object/builtins/jsset.rs
+++ b/boa_engine/src/object/builtins/jsset.rs
@@ -8,7 +8,7 @@ use crate::{
     error::JsNativeError,
     object::{JsFunction, JsObject, JsObjectType, JsSetIterator},
     value::TryFromJs,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsValue, NativeFunction,
 };
 
 /// `JsSet` provides a wrapper for Boa's implementation of the ECMAScript `Set` object.
@@ -134,7 +134,7 @@ impl JsSet {
         this_arg: JsValue,
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        Set::for_each(
+        NativeFunction::from_fn_ptr_2(Set::for_each).call(
             &self.inner.clone().into(),
             &[callback.into(), this_arg],
             context,

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -148,8 +148,7 @@ impl Script {
         // TODO: Here should be https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
 
         self.realm().resize_global_env();
-        let record = context.run();
-        context.vm.pop_frame();
+        let record = context.run2();
 
         context.vm.stack = stack;
         context.vm.active_function = active_function;
@@ -158,6 +157,6 @@ impl Script {
 
         context.clear_kept_objects();
 
-        record.consume()
+        record
     }
 }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -7,15 +7,21 @@
 #[cfg(feature = "fuzz")]
 use crate::JsNativeError;
 use crate::{
-    builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
-    environments::{DeclarativeEnvironment, EnvironmentStack},
+    builtins::{
+        async_generator::{AsyncGenerator, AsyncGeneratorState},
+        function::{arguments::Arguments, FunctionKind, ThisMode},
+    },
+    environments::{DeclarativeEnvironment, EnvironmentStack, FunctionSlots, ThisBindingStatus},
+    native_function::{CallContext, CallResult, JsCoroutine},
+    realm::Realm,
     script::Script,
     vm::code_block::Readable,
-    Context, JsError, JsObject, JsResult, JsValue, Module,
+    Context, JsError, JsNativeError, JsObject, JsResult, JsValue, Module,
 };
 
 use boa_gc::{custom_trace, Finalize, Gc, Trace};
 use boa_profiler::Profiler;
+use next_gen::prelude::GeneratorState;
 use std::mem::size_of;
 
 #[cfg(feature = "trace")]
@@ -48,6 +54,34 @@ pub(crate) use {
 
 #[cfg(test)]
 mod tests;
+
+struct CallerState {
+    realm: Realm,
+    active_function: Option<JsObject>,
+    environments: EnvironmentStack,
+    stack: Vec<JsValue>,
+    active_runnable: Option<ActiveRunnable>,
+}
+enum Caller {
+    Coroutine(JsCoroutine),
+    Caller(CallerState),
+}
+
+impl Caller {
+    fn as_coroutine_mut(&mut self) -> Option<&mut JsCoroutine> {
+        match self {
+            Caller::Coroutine(co) => Some(co),
+            Caller::Caller(_) => None,
+        }
+    }
+
+    fn into_state(self) -> Option<CallerState> {
+        match self {
+            Caller::Coroutine(_) => None,
+            Caller::Caller(caller) => Some(caller),
+        }
+    }
+}
 
 /// Virtual Machine.
 #[derive(Debug)]
@@ -140,6 +174,11 @@ impl Vm {
         self.frames.last_mut().expect("no frame found")
     }
 
+    // TODO: Rename `frame` to `frame_expect` and make this `frame`.
+    pub(crate) fn frame_opt(&self) -> Option<&CallFrame> {
+        self.frames.last()
+    }
+
     pub(crate) fn push_frame(&mut self, frame: CallFrame) {
         self.frames.push(frame);
     }
@@ -172,6 +211,23 @@ impl Context<'_> {
         let _timer = Profiler::global().start_event(opcode.as_instruction_str(), "vm");
 
         opcode.execute(self)
+    }
+
+    fn execute_instruction2(&mut self) -> JsResult<CallResult<CompletionType>> {
+        let opcode: Opcode = {
+            let _timer = Profiler::global().start_event("Opcode retrieval", "vm");
+
+            let frame = self.vm.frame_mut();
+
+            let pc = frame.pc;
+            let opcode = Opcode::from(frame.code_block.bytecode[pc as usize]);
+            frame.pc += 1;
+            opcode
+        };
+
+        let _timer = Profiler::global().start_event(opcode.as_instruction_str(), "vm");
+
+        opcode.execute2(self)
     }
 
     pub(crate) fn run(&mut self) -> CompletionRecord {
@@ -447,4 +503,398 @@ impl Context<'_> {
         }
         CompletionRecord::Normal(execution_result)
     }
+
+    pub(crate) fn run2(&mut self) -> JsResult<JsValue> {
+        #[cfg(feature = "trace")]
+        const COLUMN_WIDTH: usize = 26;
+        #[cfg(feature = "trace")]
+        const TIME_COLUMN_WIDTH: usize = COLUMN_WIDTH / 2;
+        #[cfg(feature = "trace")]
+        const OPCODE_COLUMN_WIDTH: usize = COLUMN_WIDTH;
+        #[cfg(feature = "trace")]
+        const OPERAND_COLUMN_WIDTH: usize = COLUMN_WIDTH;
+        #[cfg(feature = "trace")]
+        const NUMBER_OF_COLUMNS: usize = 4;
+
+        let _timer = Profiler::global().start_event("run2", "vm");
+
+        #[cfg(feature = "trace")]
+        if self.vm.trace {
+            let msg = if self.vm.frames.last().is_some() {
+                " Call Frame "
+            } else {
+                " VM Start "
+            };
+
+            println!(
+                "{}\n",
+                self.vm
+                    .frame()
+                    .code_block
+                    .to_interned_string(self.interner())
+            );
+            println!(
+                "{msg:-^width$}",
+                width = COLUMN_WIDTH * NUMBER_OF_COLUMNS - 10
+            );
+            println!(
+                "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {:<OPERAND_COLUMN_WIDTH$} Top Of Stack\n",
+                "Time",
+                "Opcode",
+                "Operands",
+            );
+        }
+
+        assert_eq!(
+            self.vm.stack.len(),
+            0,
+            "run2 can only run top-level scripts."
+        );
+
+        let mut caller_stack: Vec<Caller> = Vec::new();
+
+        let result = loop {
+            if let Some(co) = caller_stack.last_mut().and_then(Caller::as_coroutine_mut) {
+                let last_result = self
+                    .vm
+                    .err
+                    .take()
+                    .map_or_else(|| Ok(self.vm.pop()), |err| Err(err));
+                match co.as_mut().resume(last_result) {
+                    GeneratorState::Yielded(call) => {
+                        prepare_call(call, &mut caller_stack, self);
+                    }
+                    GeneratorState::Returned(res) => {
+                        caller_stack.pop();
+                        match res {
+                            Ok(val) => self.vm.push(val),
+                            Err(err) => self.vm.err = Some(err),
+                        }
+                    }
+                }
+                continue;
+            }
+
+            // Exit the execution loop if there aren't any more callers.
+            let Some(frame) = self.vm.frame_opt() else {
+                break self
+                        .vm
+                        .err
+                        .take()
+                        .map_or_else(|| Ok(self.vm.pop()), Err);
+            };
+
+            if frame.code_block.bytecode.len() <= frame.pc as usize {
+                let push_undef = self.vm.stack.len() <= self.vm.frame().fp as usize;
+
+                // TODO: cleanup this hack.
+                if !caller_stack.is_empty() {
+                    self.restore_caller(
+                        caller_stack
+                            .pop()
+                            .and_then(Caller::into_state)
+                            .expect("already checked that the stack is not empty"),
+                    );
+                }
+
+                if push_undef {
+                    self.vm.push(JsValue::undefined());
+                }
+
+                self.vm.pop_frame();
+                continue;
+            }
+
+            let result = if let Some(err) = self.vm.err.take() {
+                Err(err)
+            } else {
+                #[cfg(feature = "trace")]
+                if self.vm.trace || self.vm.frame().code_block.traceable() {
+                    let mut pc = self.vm.frame().pc as usize;
+                    let opcode: Opcode = self
+                        .vm
+                        .frame()
+                        .code_block
+                        .read::<u8>(pc)
+                        .try_into()
+                        .expect("invalid opcode");
+                    let operands = self
+                        .vm
+                        .frame()
+                        .code_block
+                        .instruction_operands(&mut pc, self.interner());
+
+                    let instant = Instant::now();
+                    let result = self.execute_instruction2();
+
+                    let duration = instant.elapsed();
+                    println!(
+                        "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {}",
+                        format!("{}μs", duration.as_micros()),
+                        opcode.as_str(),
+                        match self.vm.stack.last() {
+                            Some(value) if value.is_callable() => "[function]".to_string(),
+                            Some(value) if value.is_object() => "[object]".to_string(),
+                            Some(value) => value.display().to_string(),
+                            None => "<empty>".to_string(),
+                        },
+                    );
+
+                    result
+                } else {
+                    self.execute_instruction2()
+                }
+
+                #[cfg(not(feature = "trace"))]
+                self.execute_instruction2()
+            };
+
+            let completion = match result {
+                Ok(CallResult::Coroutine(mut co)) => {
+                    // first resume value is ignored.
+                    match co.as_mut().resume(Ok(JsValue::undefined())) {
+                        GeneratorState::Yielded(call) => {
+                            caller_stack.push(Caller::Coroutine(co));
+                            prepare_call(call, &mut caller_stack, self);
+                        }
+                        GeneratorState::Returned(res) => match res {
+                            Ok(val) => self.vm.push(val),
+                            Err(err) => self.vm.err = Some(err),
+                        },
+                    };
+                    continue;
+                }
+                Ok(CallResult::DirectCall(call)) => {
+                    prepare_call(call, &mut caller_stack, self);
+                    continue;
+                }
+                Ok(CallResult::Value(completion)) => completion,
+                Err(err) => {
+                    self.vm.err = Some(err);
+
+                    // If this frame has not evaluated the throw as an AbruptCompletion, then evaluate it
+                    let evaluation = Opcode::Throw
+                        .execute(self)
+                        .expect("Opcode::Throw cannot return Err");
+
+                    if evaluation == CompletionType::Normal {
+                        continue;
+                    }
+
+                    CompletionType::Throw
+                }
+            };
+
+            if completion == CompletionType::Throw {
+                // TODO: cleanup this hack.
+                if !caller_stack.is_empty() {
+                    self.restore_caller(
+                        caller_stack
+                            .pop()
+                            .and_then(Caller::into_state)
+                            .expect("already checked that the stack is not empty"),
+                    );
+                }
+                self.vm.pop_frame();
+            } else if completion == CompletionType::Return {
+                let result = self.vm.pop();
+                // TODO: cleanup this hack.
+                if !caller_stack.is_empty() {
+                    self.restore_caller(
+                        caller_stack
+                            .pop()
+                            .and_then(Caller::into_state)
+                            .expect("already checked that the stack is not empty"),
+                    );
+                }
+                self.vm.push(result);
+                self.vm.pop_frame();
+            }
+        };
+
+        result
+    }
+
+    fn restore_caller(&mut self, state: CallerState) {
+        self.vm.environments = state.environments;
+        self.vm.stack = state.stack;
+        self.vm.active_function = state.active_function;
+        self.vm.active_runnable = state.active_runnable;
+        self.enter_realm(state.realm);
+    }
+}
+
+fn prepare_call(call: CallContext, caller_stack: &mut Vec<Caller>, context: &mut Context<'_>) {
+    let CallContext { f, this, args } = call;
+
+    let object = f.borrow();
+    let function_object = object.as_function().expect("not a function");
+    let realm = function_object.realm().clone();
+
+    let old_realm = context.enter_realm(realm);
+
+    let old_active_function = context.vm.active_function.replace(f.clone());
+
+    let (code, mut environments, class_object, mut script_or_module) = match function_object.kind()
+    {
+        FunctionKind::Ordinary {
+            code,
+            environments,
+            class_object,
+            script_or_module,
+            ..
+        } => {
+            let code = code.clone();
+            if code.is_class_constructor() {
+                context.vm.err = Some(
+                    JsNativeError::typ()
+                        .with_message("class constructor cannot be invoked without 'new'")
+                        .with_realm(context.realm().clone())
+                        .into(),
+                );
+                return;
+            }
+            (
+                code,
+                environments.clone(),
+                class_object.clone(),
+                script_or_module.clone(),
+            )
+        }
+        _ => {
+            drop(object);
+            match f.call_internal(&this, &args, context) {
+                Ok(val) => context.vm.push(val),
+                Err(err) => {
+                    context.vm.err = Some(err);
+                }
+            }
+            context.enter_realm(old_realm);
+            context.vm.active_function = old_active_function;
+            return;
+        }
+    };
+
+    drop(object);
+
+    std::mem::swap(&mut environments, &mut context.vm.environments);
+
+    let lexical_this_mode = code.this_mode == ThisMode::Lexical;
+
+    let this = if lexical_this_mode {
+        ThisBindingStatus::Lexical
+    } else if code.strict() {
+        ThisBindingStatus::Initialized(this.clone())
+    } else if this.is_null_or_undefined() {
+        ThisBindingStatus::Initialized(context.realm().global_this().clone().into())
+    } else {
+        ThisBindingStatus::Initialized(
+            this.to_object(context)
+                .expect("conversion cannot fail")
+                .into(),
+        )
+    };
+
+    let mut last_env = code.compile_environments.len() - 1;
+
+    if let Some(class_object) = class_object {
+        let index = context
+            .vm
+            .environments
+            .push_lexical(code.compile_environments[last_env].clone());
+        context
+            .vm
+            .environments
+            .put_lexical_value(index, 0, class_object.into());
+        last_env -= 1;
+    }
+
+    if code.has_binding_identifier() {
+        let index = context
+            .vm
+            .environments
+            .push_lexical(code.compile_environments[last_env].clone());
+        context
+            .vm
+            .environments
+            .put_lexical_value(index, 0, f.clone().into());
+        last_env -= 1;
+    }
+
+    context.vm.environments.push_function(
+        code.compile_environments[last_env].clone(),
+        FunctionSlots::new(this, f.clone(), None),
+    );
+
+    if code.has_parameters_env_bindings() {
+        last_env -= 1;
+        context
+            .vm
+            .environments
+            .push_lexical(code.compile_environments[last_env].clone());
+    }
+
+    // Taken from: `FunctionDeclarationInstantiation` abstract function.
+    //
+    // Spec: https://tc39.es/ecma262/#sec-functiondeclarationinstantiation
+    //
+    // 22. If argumentsObjectNeeded is true, then
+    if code.needs_arguments_object() {
+        // a. If strict is true or simpleParameterList is false, then
+        //     i. Let ao be CreateUnmappedArgumentsObject(argumentsList).
+        // b. Else,
+        //     i. NOTE: A mapped argument object is only provided for non-strict functions
+        //              that don't have a rest parameter, any parameter
+        //              default value initializers, or any destructured parameters.
+        //     ii. Let ao be CreateMappedArgumentsObject(func, formals, argumentsList, env).
+        let arguments_obj = if code.strict() || !code.params.is_simple() {
+            Arguments::create_unmapped_arguments_object(&args, context)
+        } else {
+            let env = context.vm.environments.current();
+            Arguments::create_mapped_arguments_object(
+                &f,
+                &code.params,
+                &args,
+                env.declarative_expect(),
+                context,
+            )
+        };
+        let env_index = context.vm.environments.len() as u32 - 1;
+        context
+            .vm
+            .environments
+            .put_lexical_value(env_index, 0, arguments_obj.into());
+    }
+
+    let argument_count = args.len();
+
+    // Push function arguments to the stack.
+    let mut args = if code.params.as_ref().len() > args.len() {
+        let mut v = args.to_vec();
+        v.extend(vec![
+            JsValue::Undefined;
+            code.params.as_ref().len() - args.len()
+        ]);
+        v
+    } else {
+        args.to_vec()
+    };
+    args.reverse();
+    let mut stack = args;
+
+    std::mem::swap(&mut context.vm.stack, &mut stack);
+
+    let frame = CallFrame::new(code).with_argument_count(argument_count as u32);
+
+    std::mem::swap(&mut context.vm.active_runnable, &mut script_or_module);
+
+    context.vm.push_frame(frame);
+
+    caller_stack.push(Caller::Caller(CallerState {
+        realm: old_realm,
+        active_function: old_active_function,
+        environments,
+        stack,
+        active_runnable: script_or_module,
+    }));
 }

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1,5 +1,5 @@
 /// The opcodes of the vm.
-use crate::{vm::CompletionType, Context, JsResult};
+use crate::{native_function::CallResult, vm::CompletionType, Context, JsResult};
 
 // Operation modules
 mod await_stm;
@@ -155,6 +155,14 @@ macro_rules! generate_impl {
             pub(super) fn execute(self, context: &mut Context<'_>) -> JsResult<CompletionType> {
                 Self::EXECUTE_FNS[self as usize](context)
             }
+
+            const EXECUTE2_FNS: [fn(&mut Context<'_>) -> JsResult<CallResult<CompletionType>>; Self::MAX] = [
+                $(<generate_impl!(name $Variant $(=> $mapping)?)>::execute2),*
+            ];
+
+            pub(super) fn execute2(self, context: &mut Context<'_>) -> JsResult<CallResult<CompletionType>> {
+                Self::EXECUTE2_FNS[self as usize](context)
+            }
         }
     };
 }
@@ -170,6 +178,10 @@ pub(crate) trait Operation {
     const INSTRUCTION: &'static str;
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType>;
+
+    fn execute2(context: &mut Context<'_>) -> JsResult<CallResult<CompletionType>> {
+        Self::execute(context).map(CallResult::Value)
+    }
 }
 
 generate_impl! {


### PR DESCRIPTION
This is the first prototype of a vm design that uses a virtual callstack for JS functions and Rust functions.

Right now it's full of hacks and compatibility patches in order to be able to progressively experiment and bugfix, but that can be left for later.

It currently uses the `next-gen` crate to emulate generators in stable, which is the way this design unifies JS calls with Rust calls.

## Design notes

All functions now return a `JsResult<CallResult>` struct, defined as:
```rust
pub enum CallResult<T> {
    ///
    Value(T),
    ///
    Coroutine(JsCoroutine),
    ///
    DirectCall(CallContext),
}

pub type JsCoroutine =
    Pin<Box<dyn Generator<JsResult<JsValue>, Yield = CallContext, Return = JsResult<JsValue>>>>;

pub struct CallContext {
    pub(crate) f: JsObject,
    pub(crate) this: JsValue,
    pub(crate) args: ThinVec<JsValue>,
}
```

This new return value can signal the VM about what to do on several cases:
- If a function doesn't need to call any JS functions, it can directly return `Value`, which indicates to the VM that the function finished executing and doesn't need to be pushed to the virtual callstack.
- If a function returns `DirectCall(CallContext)`, it's a tail call, meaning the VM can directly call the inner function without storing the current context of the caller.
- If a function returns `Coroutine (JsCoroutine)`, it signals the VM that the callee has inner calls to other JS functions.

The coroutine design looks a bit daunting, but it's essentially divided in steps:
1. The native Rust function returns a generator with inner yields instead of direct calls to JS functions. Each yield corresponds to a JS call that needs to be resolved by the VM.
2. The VM receives the coroutine and pushes it forward until it yields, receiving the JS function that needs to be called in order for the coroutine to progress.
3. The VM prepares the JS call and stores the coroutine in a coroutine stack for future resumption.
4. The JS function is called, returning a result.
5. The VM resumes the coroutine with the result of the JS call.
6. The VM repeats steps 2 to 5 if the coroutine yields again.
7. The coroutine returns its final result.

This bridges the gap between Rust functions and JS functions, making it possible to track both of them with a single callstack :D

cc @HalidOdat 