### PR TITLE
Add regexp indices (`d` flag) support

### DIFF
--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1045,7 +1045,6 @@ impl RegExp {
             let groups = JsObject::with_null_proto();
             let group_names = JsObject::with_null_proto();
 
-
             // e. If the ith capture of R was defined with a GroupName, then
             // i. Let s be the CapturingGroupName of that GroupName.
             // ii. Perform ! CreateDataPropertyOrThrow(groups, s, capturedValue).
@@ -1121,7 +1120,6 @@ impl RegExp {
             // e. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).
             a.create_data_property_or_throw(i, captured_value.clone(), context)
                 .expect("this CreateDataPropertyOrThrow call must not fail");
-
 
             // 22.2.7.8 MakeMatchIndicesIndexPairArray ( S, indices, groupNames, hasGroups )
             if has_indices {

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1040,7 +1040,8 @@ impl RegExp {
         // 30. If R contains any GroupName, then
         // 31. Else,
         // 33. For each integer i such that 1 ≤ i ≤ n, in ascending order, do
-        let (groups, group_names) = if named_groups.clone().len() > 0 {
+        #[allow(clippy::if_not_else)]
+        let (groups, group_names) = if !named_groups.clone().is_empty() {
             // a. Let groups be OrdinaryObjectCreate(null).
             let groups = JsObject::with_null_proto();
             let group_names = JsObject::with_null_proto();


### PR DESCRIPTION
This Pull Request closes #3086

It changes the following:

- Implements `re.exec().indices` & `re.exec().indices.groups`
- Fixes ordering of `re.exec().groups` to pass strict test262 tests
- Updates related comments to be inline with the [spec](https://tc39.es/ecma262/multipage/text-processing.html#sec-regexpbuiltinexec)
- Skipped the two unicode related tests in the `test/built-ins/RegExp/match-indices` suite. Which seems to be a separate task in itself across the Regex implementation.

I'm a bit unsure about the following:

- [`GetMatchIndexPair`](https://tc39.es/ecma262/multipage/text-processing.html#sec-getmatchindexpair) and [`MakeMatchIndicesIndexPairArray`](https://tc39.es/ecma262/multipage/text-processing.html#sec-makematchindicesindexpairarray) are currently done inline. This complicates the comments quite a bit, but not sure if it's worth it to extract them (partially).
- ~The fixed `Date` and failing `Intl402` test262 tests seem to be unrelated and just not yet updated in the gh-pages branch.~ See https://github.com/boa-dev/boa/pull/3094#issuecomment-1627651313
