### PR TITLE
Format let-else expressions

### DIFF
--- a/boa_cli/src/debug/function.rs
+++ b/boa_cli/src/debug/function.rs
@@ -53,14 +53,14 @@ fn flowgraph_parse_direction_option(value: &JsValue) -> JsResult<Direction> {
 fn flowgraph(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
-        .with_message("expected function argument")
-        .into());
+            .with_message("expected function argument")
+            .into());
     };
 
     let Some(object) = value.as_object() else {
         return Err(JsNativeError::typ()
-        .with_message(format!("expected object, got {}", value.type_of()))
-        .into());
+            .with_message(format!("expected object, got {}", value.type_of()))
+            .into());
     };
 
     let mut format = FlowgraphFormat::Mermaid;
@@ -82,8 +82,8 @@ fn flowgraph(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> Js
 
     let Some(function) = object.as_function() else {
         return Err(JsNativeError::typ()
-        .with_message("expected function object")
-        .into());
+            .with_message("expected function object")
+            .into());
     };
 
     let code = function.codeblock().ok_or_else(|| {
@@ -103,20 +103,20 @@ fn flowgraph(_this: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> Js
 fn bytecode(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
-        .with_message("expected function argument")
-        .into());
+            .with_message("expected function argument")
+            .into());
     };
 
     let Some(object) = value.as_object() else {
         return Err(JsNativeError::typ()
-        .with_message(format!("expected object, got {}", value.type_of()))
-        .into());
+            .with_message(format!("expected object, got {}", value.type_of()))
+            .into());
     };
     let object = object.borrow();
     let Some(function) = object.as_function() else {
         return Err(JsNativeError::typ()
-        .with_message("expected function object")
-        .into());
+            .with_message("expected function object")
+            .into());
     };
     let code = function.codeblock().ok_or_else(|| {
         JsNativeError::typ().with_message("native functions do not have bytecode")
@@ -129,8 +129,8 @@ fn set_trace_flag_in_function_object(object: &JsObject, value: bool) -> JsResult
     let object = object.borrow();
     let Some(function) = object.as_function() else {
         return Err(JsNativeError::typ()
-        .with_message("expected function object")
-        .into());
+            .with_message("expected function object")
+            .into());
     };
     let code = function.codeblock().ok_or_else(|| {
         JsNativeError::typ().with_message("native functions do not have bytecode")
@@ -146,8 +146,8 @@ fn trace(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<J
 
     let Some(callable) = value.as_callable() else {
         return Err(JsNativeError::typ()
-        .with_message("expected callable object")
-        .into());
+            .with_message("expected callable object")
+            .into());
     };
 
     let arguments = args.get(2..).unwrap_or(&[]);
@@ -165,8 +165,8 @@ fn traceable(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsV
 
     let Some(callable) = value.as_callable() else {
         return Err(JsNativeError::typ()
-        .with_message("expected callable object")
-        .into());
+            .with_message("expected callable object")
+            .into());
     };
 
     set_trace_flag_in_function_object(callable, traceable)?;

--- a/boa_cli/src/debug/limits.rs
+++ b/boa_cli/src/debug/limits.rs
@@ -23,9 +23,9 @@ fn get_recursion(_: &JsValue, _: &[JsValue], context: &mut Context<'_>) -> JsRes
 fn set_recursion(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
     let Ok(value) = value.try_into() else {
-        return Err(
-            JsNativeError::range().with_message(format!("Argument {value} greater than usize::MAX")).into()
-        );
+        return Err(JsNativeError::range()
+            .with_message(format!("Argument {value} greater than usize::MAX"))
+            .into());
     };
     context.runtime_limits_mut().set_recursion_limit(value);
     Ok(JsValue::undefined())

--- a/boa_cli/src/debug/object.rs
+++ b/boa_cli/src/debug/object.rs
@@ -6,14 +6,14 @@ use boa_engine::{
 fn id(_: &JsValue, args: &[JsValue], _: &mut Context<'_>) -> JsResult<JsValue> {
     let Some(value) = args.get(0) else {
         return Err(JsNativeError::typ()
-        .with_message("expected object argument")
-        .into());
+            .with_message("expected object argument")
+            .into());
     };
 
     let Some(object) = value.as_object() else {
         return Err(JsNativeError::typ()
-        .with_message(format!("expected object, got {}", value.type_of()))
-        .into());
+            .with_message(format!("expected object, got {}", value.type_of()))
+            .into());
     };
 
     let ptr: *const _ = object.as_ref();

--- a/boa_cli/src/debug/shape.rs
+++ b/boa_cli/src/debug/shape.rs
@@ -8,8 +8,11 @@ fn get_object(args: &[JsValue], position: usize) -> JsResult<&JsObject> {
 
     let Some(object) = value.as_object() else {
         return Err(JsNativeError::typ()
-        .with_message(format!("expected object in argument position {position}, got {}", value.type_of()))
-        .into());
+            .with_message(format!(
+                "expected object in argument position {position}, got {}",
+                value.type_of()
+            ))
+            .into());
     };
 
     Ok(object)

--- a/boa_engine/src/builtins/date/mod.rs
+++ b/boa_engine/src/builtins/date/mod.rs
@@ -297,61 +297,71 @@ impl Date {
         context: &mut Context<'_>,
     ) -> JsResult<Option<NaiveDateTime>> {
         // 1. Let y be ? ToNumber(year).
-        let Some(mut year) = values.get_or_undefined(0).to_integer_or_nan(context)?.as_integer() else {
+        let Some(mut year) = values
+            .get_or_undefined(0)
+            .to_integer_or_nan(context)?
+            .as_integer()
+        else {
             return Ok(None);
         };
 
         // 2. If month is present, let m be ? ToNumber(month); else let m be +0𝔽.
         let Some(month) = values.get(1).map_or(Ok(Some(0)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
         // 3. If date is present, let dt be ? ToNumber(date); else let dt be 1𝔽.
         let Some(date) = values.get(2).map_or(Ok(Some(1)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
         // 4. If hours is present, let h be ? ToNumber(hours); else let h be +0𝔽.
         let Some(hour) = values.get(3).map_or(Ok(Some(0)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
         // 5. If minutes is present, let min be ? ToNumber(minutes); else let min be +0𝔽.
         let Some(min) = values.get(4).map_or(Ok(Some(0)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
         // 6. If seconds is present, let s be ? ToNumber(seconds); else let s be +0𝔽.
         let Some(sec) = values.get(5).map_or(Ok(Some(0)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
         // 7. If ms is present, let milli be ? ToNumber(ms); else let milli be +0𝔽.
         let Some(ms) = values.get(6).map_or(Ok(Some(0)), |value| {
             value
-            .to_integer_or_nan(context)
-            .map(IntegerOrNan::as_integer)
-        })? else {
+                .to_integer_or_nan(context)
+                .map(IntegerOrNan::as_integer)
+        })?
+        else {
             return Ok(None);
         };
 
@@ -1442,7 +1452,7 @@ impl Date {
         // 1. Let O be this Date object.
         let Some(t) = this_time_value(this)?.and_then(NaiveDateTime::from_timestamp_millis) else {
             // 3. If tv is NaN, return "Invalid Date".
-            return Ok(js_string!("Invalid Date").into())
+            return Ok(js_string!("Invalid Date").into());
         };
 
         // 2. Let tv be ? thisTimeValue(O).

--- a/boa_engine/src/builtins/escape/mod.rs
+++ b/boa_engine/src/builtins/escape/mod.rs
@@ -176,7 +176,7 @@ fn unescape(_: &JsValue, args: &[JsValue], context: &mut Context<'_>) -> JsResul
 
                 Some((n1 << 4) + n2)
             }
-            _ => None
+            _ => None,
         })() else {
             vec.push(u16::from(b'%'));
             continue;

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -252,19 +252,15 @@ impl Generator {
     ) -> JsResult<JsValue> {
         // 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let Some(generator_obj) = gen.as_object() else {
-            return Err(
-                JsNativeError::typ()
-                    .with_message("Generator method called on non generator")
-                    .into()
-            );
+            return Err(JsNativeError::typ()
+                .with_message("Generator method called on non generator")
+                .into());
         };
         let mut generator_obj_mut = generator_obj.borrow_mut();
         let Some(generator) = generator_obj_mut.as_generator_mut() else {
-            return Err(
-                JsNativeError::typ()
-                    .with_message("generator resumed on non generator object")
-                    .into()
-            );
+            return Err(JsNativeError::typ()
+                .with_message("generator resumed on non generator object")
+                .into());
         };
 
         // 4. Let genContext be generator.[[GeneratorContext]].
@@ -340,19 +336,15 @@ impl Generator {
     ) -> JsResult<JsValue> {
         // 1. Let state be ? GeneratorValidate(generator, generatorBrand).
         let Some(generator_obj) = gen.as_object() else {
-            return Err(
-                JsNativeError::typ()
-                    .with_message("Generator method called on non generator")
-                    .into()
-            );
+            return Err(JsNativeError::typ()
+                .with_message("Generator method called on non generator")
+                .into());
         };
         let mut generator_obj_mut = generator_obj.borrow_mut();
         let Some(generator) = generator_obj_mut.as_generator_mut() else {
-            return Err(
-                JsNativeError::typ()
-                    .with_message("generator resumed on non generator object")
-                    .into()
-            );
+            return Err(JsNativeError::typ()
+                .with_message("generator resumed on non generator object")
+                .into());
         };
 
         // 4. Assert: state is suspendedYield.

--- a/boa_engine/src/builtins/intl/list_format/mod.rs
+++ b/boa_engine/src/builtins/intl/list_format/mod.rs
@@ -488,8 +488,8 @@ fn string_list_from_iterable(
             return Err(iterator
                 .close(
                     Err(JsNativeError::typ()
-                    .with_message("StringListFromIterable: can only format strings into a list")
-                    .into()),
+                        .with_message("StringListFromIterable: can only format strings into a list")
+                        .into()),
                     context,
                 )
                 .expect_err("Should return the provided error"));

--- a/boa_engine/src/builtins/intl/segmenter/iterator.rs
+++ b/boa_engine/src/builtins/intl/segmenter/iterator.rs
@@ -130,11 +130,17 @@ impl SegmentIterator {
             let mut segments = segmenter.native.segment(string);
             // the first elem is always 0.
             segments.next();
-            segments.next().map(|end| (start + end, segments.is_word_like()))
+            segments
+                .next()
+                .map(|end| (start + end, segments.is_word_like()))
         }) else {
             // 7. If endIndex is not finite, then
             //     a. Return CreateIterResultObject(undefined, true).
-            return Ok(create_iter_result_object(JsValue::undefined(), true, context));
+            return Ok(create_iter_result_object(
+                JsValue::undefined(),
+                true,
+                context,
+            ));
         };
         // 8. Set iterator.[[IteratedStringNextSegmentCodeUnitIndex]] to endIndex.
         iter.next_segment_index = end;

--- a/boa_engine/src/builtins/intl/segmenter/segments.rs
+++ b/boa_engine/src/builtins/intl/segmenter/segments.rs
@@ -94,7 +94,8 @@ impl Segments {
             .as_integer()
             // 7. If n < 0 or n ≥ len, return undefined.
             .filter(|i| (0..len).contains(i))
-            .map(|n| n as usize) else {
+            .map(|n| n as usize)
+        else {
             return Ok(JsValue::undefined());
         };
 

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -527,7 +527,7 @@ impl Object {
         context: &mut Context<'_>,
     ) -> JsValue {
         // 1. If Desc is undefined, return undefined.
-        let Some(desc)= desc else {
+        let Some(desc) = desc else {
             return JsValue::undefined();
         };
 

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -1530,7 +1530,11 @@ impl Promise {
 
         let on_finally = args.get_or_undefined(0);
 
-        let Some(on_finally) = on_finally.as_object().cloned().and_then(JsFunction::from_object) else {
+        let Some(on_finally) = on_finally
+            .as_object()
+            .cloned()
+            .and_then(JsFunction::from_object)
+        else {
             // 5. If IsCallable(onFinally) is false, then
             //    a. Let thenFinally be onFinally.
             //    b. Let catchFinally be onFinally.
@@ -2026,7 +2030,7 @@ impl Promise {
                     // 5. If alreadyResolved.[[Value]] is true, return undefined.
                     // 6. Set alreadyResolved.[[Value]] to true.
                     let Some(promise) = captures.take() else {
-                        return Ok(JsValue::undefined())
+                        return Ok(JsValue::undefined());
                     };
 
                     let resolution = args.get_or_undefined(0);
@@ -2069,7 +2073,11 @@ impl Promise {
                     };
 
                     // 12. If IsCallable(thenAction) is false, then
-                    let Some(then_action) = then_action.as_object().cloned().and_then(JsFunction::from_object) else {
+                    let Some(then_action) = then_action
+                        .as_object()
+                        .cloned()
+                        .and_then(JsFunction::from_object)
+                    else {
                         // a. Perform FulfillPromise(promise, resolution).
                         fulfill_promise(&promise, resolution.clone(), context);
 
@@ -2078,14 +2086,15 @@ impl Promise {
                     };
 
                     // 13. Let thenJobCallback be HostMakeJobCallback(thenAction).
-                    let then_job_callback = context.host_hooks().make_job_callback(then_action, context);
+                    let then_job_callback =
+                        context.host_hooks().make_job_callback(then_action, context);
 
                     // 14. Let job be NewPromiseResolveThenableJob(promise, resolution, thenJobCallback).
                     let job = new_promise_resolve_thenable_job(
                         promise.clone(),
                         resolution.clone(),
                         then_job_callback,
-                        context
+                        context,
                     );
 
                     // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).

--- a/boa_engine/src/builtins/set/mod.rs
+++ b/boa_engine/src/builtins/set/mod.rs
@@ -341,7 +341,10 @@ impl Set {
         _: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        let Some(lock) = this.as_object().and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone()))) else {
+        let Some(lock) = this
+            .as_object()
+            .and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone())))
+        else {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.entries called on incompatible receiver")
                 .into());
@@ -372,7 +375,10 @@ impl Set {
     ) -> JsResult<JsValue> {
         // 1. Let S be the this value.
         // 2. Perform ? RequireInternalSlot(S, [[SetData]]).
-        let Some(lock) = this.as_object().and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone()))) else {
+        let Some(lock) = this
+            .as_object()
+            .and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone())))
+        else {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.forEach called on incompatible receiver")
                 .into());
@@ -381,7 +387,9 @@ impl Set {
         // 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
         let Some(callback_fn) = args.get_or_undefined(0).as_callable() else {
             return Err(JsNativeError::typ()
-                .with_message("Method Set.prototype.forEach called with non-callable callback function")
+                .with_message(
+                    "Method Set.prototype.forEach called with non-callable callback function",
+                )
                 .into());
         };
 
@@ -393,7 +401,10 @@ impl Set {
         // 7. Repeat, while index < numEntries,
         while index < Self::get_size_full(this)? {
             // a. Let e be entries[index].
-            let Some(e) = this.as_object().and_then(|o| o.borrow().as_set().map(|s| s.get_index(index).cloned())) else {
+            let Some(e) = this
+                .as_object()
+                .and_then(|o| o.borrow().as_set().map(|s| s.get_index(index).cloned()))
+            else {
                 return Err(JsNativeError::typ()
                     .with_message("Method Set.prototype.forEach called on incompatible receiver")
                     .into());
@@ -474,7 +485,10 @@ impl Set {
         _: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        let Some(lock) = this.as_object().and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone()))) else {
+        let Some(lock) = this
+            .as_object()
+            .and_then(|o| o.borrow_mut().as_set_mut().map(|set| set.lock(o.clone())))
+        else {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.values called on incompatible receiver")
                 .into());

--- a/boa_engine/src/class.rs
+++ b/boa_engine/src/class.rs
@@ -131,7 +131,8 @@ impl<T: Class> ClassConstructor for T {
                 .into());
         };
 
-        let JsValue::Object(ref class_prototype) = class_constructor.get(PROTOTYPE, context)? else {
+        let JsValue::Object(ref class_prototype) = class_constructor.get(PROTOTYPE, context)?
+        else {
             return Err(JsNativeError::typ()
                 .with_message(format!(
                     "invalid default prototype for native class `{}`",

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -426,7 +426,11 @@ fn run_test_actions_with(actions: impl IntoIterator<Item = TestAction>, context:
                     Err(e) => e,
                 };
                 let Some(err) = err.as_opaque() else {
-                    panic!("{}\nExpected opaque error, got native error `{}`", fmt_test(&source, i), err)
+                    panic!(
+                        "{}\nExpected opaque error, got native error `{}`",
+                        fmt_test(&source, i),
+                        err
+                    )
                 };
 
                 assert_eq!(err, &expected, "{}", fmt_test(&source, i));

--- a/boa_engine/src/module/source.rs
+++ b/boa_engine/src/module/source.rs
@@ -1151,7 +1151,10 @@ impl SourceTextModule {
         if pending_async_dependencies > 0 || self.inner.code.has_tla {
             // a. Assert: module.[[AsyncEvaluation]] is false and was never previously set to true.
             {
-                let Status::Evaluating { async_eval_index, .. } = &mut *self.inner.status.borrow_mut() else {
+                let Status::Evaluating {
+                    async_eval_index, ..
+                } = &mut *self.inner.status.borrow_mut()
+                else {
                     unreachable!("self should still be in the evaluating state")
                 };
 
@@ -1326,7 +1329,11 @@ impl SourceTextModule {
                     // i. Assert: m.[[Status]] is evaluating-async.
                     // ii. Assert: m.[[EvaluationError]] is empty.
                     // iii. Assert: m.[[AsyncEvaluation]] is true.
-                    let Status::EvaluatingAsync { pending_async_dependencies, .. } = &mut *m.inner.status.borrow_mut() else {
+                    let Status::EvaluatingAsync {
+                        pending_async_dependencies,
+                        ..
+                    } = &mut *m.inner.status.borrow_mut()
+                    else {
                         unreachable!("i. Assert: m.[[Status]] is evaluating-async.");
                     };
                     // iv. Assert: m.[[PendingAsyncDependencies]] > 0.
@@ -1842,7 +1849,10 @@ fn async_module_execution_fulfilled(module: &SourceTextModule, context: &mut Con
 
     // 10. Let sortedExecList be a List whose elements are the elements of execList, in the order in which they had their [[AsyncEvaluation]] fields set to true in InnerModuleEvaluation.
     ancestors.sort_by_cached_key(|m| {
-        let Status::EvaluatingAsync { async_eval_index, .. } = &*m.inner.status.borrow() else {
+        let Status::EvaluatingAsync {
+            async_eval_index, ..
+        } = &*m.inner.status.borrow()
+        else {
             unreachable!("GatherAvailableAncestors: i. Assert: m.[[Status]] is evaluating-async.");
         };
 

--- a/boa_engine/src/object/internal_methods/module_namespace.rs
+++ b/boa_engine/src/object/internal_methods/module_namespace.rs
@@ -233,9 +233,11 @@ fn module_namespace_exotic_get(
         let Some(env) = target_module.environment() else {
             // 11. If targetEnv is empty, throw a ReferenceError exception.
             let import = context.interner().resolve_expect(export_name);
-            return Err(JsNativeError::reference().with_message(
-                format!("cannot get import `{import}` from an uninitialized module")
-            ).into());
+            return Err(JsNativeError::reference()
+                .with_message(format!(
+                    "cannot get import `{import}` from an uninitialized module"
+                ))
+                .into());
         };
 
         let locator = env

--- a/boa_engine/src/object/shape/slot.rs
+++ b/boa_engine/src/object/shape/slot.rs
@@ -66,7 +66,7 @@ impl Slot {
             return Self {
                 index: 0,
                 attributes: new_attributes,
-            }
+            };
         };
 
         Self {

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -320,7 +320,9 @@ impl JsString {
                     let Some(cp) = self.codepoints.peek().and_then(|cp| match cp {
                         CodePoint::Unicode(c) => Some(*c),
                         CodePoint::UnpairedSurrogate(_) => None,
-                    }) else { break; };
+                    }) else {
+                        break;
+                    };
 
                     string.push(cp);
 

--- a/boa_engine/src/vm/opcode/iteration/iterator.rs
+++ b/boa_engine/src/vm/opcode/iteration/iterator.rs
@@ -174,7 +174,10 @@ impl Operation for IteratorReturn {
             .pop()
             .expect("iterator on the call frame must exist");
 
-        let Some(ret) = record.iterator().get_method(js_string!("return"), context)? else {
+        let Some(ret) = record
+            .iterator()
+            .get_method(js_string!("return"), context)?
+        else {
             context.vm.push(false);
             return Ok(CompletionType::Normal);
         };

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -90,8 +90,10 @@ impl Parse for Static {
                     ));
                 }
                 let Expr::Lit(ExprLit {
-                    lit: Lit::Str(literal), ..
-                }) = literal else {
+                    lit: Lit::Str(literal),
+                    ..
+                }) = literal
+                else {
                     return Err(syn::Error::new_spanned(
                         literal,
                         "expected an UTF-8 string literal",

--- a/boa_parser/src/lexer/mod.rs
+++ b/boa_parser/src/lexer/mod.rs
@@ -344,7 +344,7 @@ impl<R> Lexer<R> {
     {
         loop {
             let Some(next) = self.next_no_skip(interner)? else {
-                return Ok(None)
+                return Ok(None);
             };
 
             if next.kind() != &TokenKind::Comment {

--- a/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
+++ b/boa_parser/src/parser/expression/primary/object_initializer/mod.rs
@@ -227,7 +227,9 @@ where
                         return Err(Error::general("invalid super usage", position));
                     }
 
-                    let property::ClassElementName::PropertyName(property_name) = class_element_name else {
+                    let property::ClassElementName::PropertyName(property_name) =
+                        class_element_name
+                    else {
                         return Err(Error::general(
                             "private identifiers not allowed in object literal",
                             position,
@@ -242,7 +244,8 @@ where
                 let (class_element_name, method) =
                     AsyncMethod::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
 
-                let property::ClassElementName::PropertyName(property_name) = class_element_name else {
+                let property::ClassElementName::PropertyName(property_name) = class_element_name
+                else {
                     return Err(Error::general(
                         "private identifiers not allowed in object literal",
                         position,

--- a/boa_parser/src/parser/function/mod.rs
+++ b/boa_parser/src/parser/function/mod.rs
@@ -75,8 +75,9 @@ where
         let Some(start_position) = cursor
             .peek(0, interner)?
             .filter(|&tok| tok.kind() != &TokenKind::Punctuator(Punctuator::CloseParen))
-            .map(|tok| tok.span().start()) else {
-            return Ok( FormalParameterList::default());
+            .map(|tok| tok.span().start())
+        else {
+            return Ok(FormalParameterList::default());
         };
 
         let mut params = Vec::new();

--- a/boa_parser/src/parser/statement/declaration/mod.rs
+++ b/boa_parser/src/parser/statement/declaration/mod.rs
@@ -133,7 +133,7 @@ where
                 tok.to_string(interner),
                 tok.span(),
                 self.context,
-            ))
+            ));
         };
 
         Ok((*from).into())

--- a/boa_runtime/src/lib.rs
+++ b/boa_runtime/src/lib.rs
@@ -238,12 +238,12 @@ pub(crate) mod test {
                         Ok(v) => v,
                     };
                     let Some(val) = val.as_boolean() else {
-                    panic!(
-                        "{}\nTried to assert with the non-boolean value `{}`",
-                        fmt_test(&source, i),
-                        val.display()
-                    )
-                };
+                        panic!(
+                            "{}\nTried to assert with the non-boolean value `{}`",
+                            fmt_test(&source, i),
+                            val.display()
+                        )
+                    };
                     assert!(val, "{}", fmt_test(&source, i));
                     i += 1;
                 }
@@ -273,8 +273,12 @@ pub(crate) mod test {
                         Err(e) => e,
                     };
                     let Some(err) = err.as_opaque() else {
-                    panic!("{}\nExpected opaque error, got native error `{}`", fmt_test(&source, i), err)
-                };
+                        panic!(
+                            "{}\nExpected opaque error, got native error `{}`",
+                            fmt_test(&source, i),
+                            err
+                        )
+                    };
 
                     assert_eq!(err, &expected, "{}", fmt_test(&source, i));
                     i += 1;

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -186,8 +186,8 @@ impl Test {
                 edition: self.edition,
                 strict,
                 result: TestOutcomeResult::Failed,
-                result_text: Box::from("Could not read test file.")
-            }
+                result_text: Box::from("Could not read test file."),
+            };
         };
         if self.ignored {
             if verbose > 1 {


### PR DESCRIPTION
This PR runs `cargo +nightly fmt` to format all our let-else expressions with the newest rustfmt binary, which now supports let-else.
