### PR TITLE
Add new CLI options to usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Options:
   -a, --dump-ast [<FORMAT>]           Dump the AST to stdout with the given format [possible values: debug, json, json-pretty]
   -t, --trace                         Dump the AST to stdout with the given format
       --vi                            Use vi mode in the REPL
-  -O, --optimize                      
-      --optimizer-statistics          
+  -O, --optimize
+      --optimizer-statistics
       --flowgraph [<FORMAT>]          Generate instruction flowgraph. Default is Graphviz [possible values: graphviz, mermaid]
       --flowgraph-direction <FORMAT>  Specifies the direction of the flowgraph. Default is top-top-bottom [possible values: top-to-bottom, bottom-to-top, left-to-right, right-to-left]
       --debug-object                  Inject debugging object `$boa`

--- a/README.md
+++ b/README.md
@@ -84,11 +84,13 @@ Options:
   -a, --dump-ast [<FORMAT>]           Dump the AST to stdout with the given format [possible values: debug, json, json-pretty]
   -t, --trace                         Dump the AST to stdout with the given format
       --vi                            Use vi mode in the REPL
-  -O, --optimize
-      --optimizer-statistics
+  -O, --optimize                      
+      --optimizer-statistics          
       --flowgraph [<FORMAT>]          Generate instruction flowgraph. Default is Graphviz [possible values: graphviz, mermaid]
       --flowgraph-direction <FORMAT>  Specifies the direction of the flowgraph. Default is top-top-bottom [possible values: top-to-bottom, bottom-to-top, left-to-right, right-to-left]
       --debug-object                  Inject debugging object `$boa`
+  -m, --module                        Treats the input files as modules
+  -r, --root <ROOT>                   Root path from where the module resolver will try to load the modules [default: .]
   -h, --help                          Print help (see more with '--help')
   -V, --version                       Print version
 ```


### PR DESCRIPTION
This PR adds the new CLI options included in Boa 0.17 in the README.

I guess we can leave it for 0.18, but we could in theory release a 0.17.1 version, which would also include the removal of time 0.1 from the dependency tree.