### PR TITLE
Implement i128/u128 to JsBigInt conversions

### DIFF
--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -389,6 +389,7 @@ impl From<u64> for JsBigInt {
         }
     }
 }
+
 impl From<i128> for JsBigInt {
     #[inline]
     fn from(value: i128) -> Self {
@@ -406,6 +407,7 @@ impl From<u128> for JsBigInt {
         }
     }
 }
+
 impl From<isize> for JsBigInt {
     #[inline]
     fn from(value: isize) -> Self {
@@ -423,6 +425,7 @@ impl From<usize> for JsBigInt {
         }
     }
 }
+
 /// The error indicates that the conversion from [`f64`] to [`JsBigInt`] failed.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TryFromF64Error;

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -407,22 +407,6 @@ impl From<usize> for JsBigInt {
         }
     }
 }
-impl From<i128> for JsBigInt {
-    #[inline]
-    fn from(value: i128) -> Self {
-        Self {
-            inner: Rc::new(RawBigInt::from(value)),
-        }
-    }
-}
-impl From<u128> for JsBigInt {
-    #[inline]
-    fn from(value: u128) -> Self {
-        Self {
-            inner: Rc::new(RawBigInt::from(value)),
-        }
-    }
-}
 /// The error indicates that the conversion from [`f64`] to [`JsBigInt`] failed.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TryFromF64Error;

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -389,7 +389,22 @@ impl From<u64> for JsBigInt {
         }
     }
 }
-
+impl From<i128> for JsBigInt {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
+impl From<u128> for JsBigInt {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
 impl From<isize> for JsBigInt {
     #[inline]
     fn from(value: isize) -> Self {

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -407,7 +407,22 @@ impl From<usize> for JsBigInt {
         }
     }
 }
-
+impl From<i128> for JsBigInt {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
+impl From<u128> for JsBigInt {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self {
+            inner: Rc::new(RawBigInt::from(value)),
+        }
+    }
+}
 /// The error indicates that the conversion from [`f64`] to [`JsBigInt`] failed.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct TryFromF64Error;

--- a/boa_engine/src/bigint.rs
+++ b/boa_engine/src/bigint.rs
@@ -397,6 +397,7 @@ impl From<i128> for JsBigInt {
         }
     }
 }
+
 impl From<u128> for JsBigInt {
     #[inline]
     fn from(value: u128) -> Self {

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -1014,18 +1014,6 @@ impl From<i64> for Numeric {
         Self::BigInt(value.into())
     }
 }
-impl From<i128> for Numeric {
-    #[inline]
-    fn from(value: i128) -> Self {
-        Self::BigInt(value.into())
-    }
-}
-impl From<u128> for Numeric {
-    #[inline]
-    fn from(value: u128) -> Self {
-        Self::BigInt(value.into())
-    }
-}
 
 impl From<i32> for Numeric {
     #[inline]

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -1014,6 +1014,18 @@ impl From<i64> for Numeric {
         Self::BigInt(value.into())
     }
 }
+impl From<i128> for Numeric {
+    #[inline]
+    fn from(value: i128) -> Self {
+        Self::BigInt(value.into())
+    }
+}
+impl From<u128> for Numeric {
+    #[inline]
+    fn from(value: u128) -> Self {
+        Self::BigInt(value.into())
+    }
+}
 
 impl From<i32> for Numeric {
     #[inline]


### PR DESCRIPTION
This commit implements trait conversions to JsValue for i128/u128. This addresses #1970

<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{1970}.

It changes the following:

- Adds trait conversions for the missing i128 and u128 rust types to JsValue
-
-
