### PR TITLE
Refactor `Array.prototype.find*` and TypedArray variants to use `FindViaPredicate`

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -3042,7 +3042,9 @@ pub(crate) fn find_via_predicate(
 ) -> JsResult<(JsValue, JsValue)> {
     // 1. If IsCallable(predicate) is false, throw a TypeError exception.
     if !predicate.is_callable() {
-        return Err(JsNativeError::typ().with_message("predicate is not callable" ).into());
+        return Err(JsNativeError::typ()
+            .with_message("predicate is not callable")
+            .into());
     }
 
     let indices = match direction {
@@ -3074,7 +3076,7 @@ pub(crate) fn find_via_predicate(
 
         if test_result {
             // e. If ToBoolean(testResult) is true, return the Record { [[Index]]: 𝔽(k), [[Value]]: kValue }.
-            return Ok((JsValue::new(k), k_value))
+            return Ok((JsValue::new(k), k_value));
         }
     }
 

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -1160,21 +1160,22 @@ impl TypedArray {
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
-        let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("TypedArray.prototype.find: predicate is not callable")
-        })?;
+        let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
 
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec =
-            find_via_predicate(obj, len, Direction::Ascending, predicate, this_arg, context);
+        let (_, value) = find_via_predicate(
+            obj,
+            len,
+            Direction::Ascending,
+            predicate,
+            this_arg,
+            context,
+            "TypedArray.prototype.find",
+        )?;
 
         // 5. Return findRec.[[Value]].
-        match find_rec {
-            Ok((_, value)) => Ok(value),
-            Err(err) => Err(err),
-        }
+        Ok(value)
     }
 
     /// `23.2.3.12 %TypedArray%.prototype.findIndex ( predicate [ , thisArg ] )`
@@ -1206,21 +1207,22 @@ impl TypedArray {
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
-        let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("TypedArray.prototype.findIndex: predicate is not callable")
-        })?;
+        let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
 
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec =
-            find_via_predicate(obj, len, Direction::Ascending, predicate, this_arg, context);
+        let (index, _) = find_via_predicate(
+            obj,
+            len,
+            Direction::Ascending,
+            predicate,
+            this_arg,
+            context,
+            "TypedArray.prototype.findIndex",
+        )?;
 
         // 5. Return findRec.[[Index]].
-        match find_rec {
-            Ok((index, _)) => Ok(index),
-            Err(err) => Err(err),
-        }
+        Ok(index)
     }
 
     /// `23.2.3.13 %TypedArray%.prototype.forEach ( callbackfn [ , thisArg ] )`

--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -14,7 +14,7 @@
 
 use crate::{
     builtins::{
-        array::ArrayIterator,
+        array::{find_via_predicate, ArrayIterator, Direction},
         array_buffer::{ArrayBuffer, SharedMemoryOrder},
         iterable::iterable_to_list,
         typed_array::integer_indexed_object::{ContentType, IntegerIndexed},
@@ -34,7 +34,6 @@ use crate::{
 use boa_profiler::Profiler;
 use num_traits::{Signed, Zero};
 use std::cmp::Ordering;
-use crate::builtins::array;
 
 pub mod integer_indexed_object;
 
@@ -1162,13 +1161,14 @@ impl TypedArray {
         let len = o.array_length();
 
         let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ().with_message("TypedArray.prototype.find: predicate is not callable")
+            JsNativeError::typ()
+                .with_message("TypedArray.prototype.find: predicate is not callable")
         })?;
         let this_arg = args.get_or_undefined(1);
 
-
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec = array::find_via_predicate(obj, len, array::Direction::Ascending, predicate, this_arg, context);
+        let find_rec =
+            find_via_predicate(obj, len, Direction::Ascending, predicate, this_arg, context);
 
         // 5. Return findRec.[[Value]].
         match find_rec {
@@ -1207,12 +1207,14 @@ impl TypedArray {
         let len = o.array_length();
 
         let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ().with_message("TypedArray.prototype.findIndex: predicate is not callable")
+            JsNativeError::typ()
+                .with_message("TypedArray.prototype.findIndex: predicate is not callable")
         })?;
         let this_arg = args.get_or_undefined(1);
 
         // 4. Let findRec be ? FindViaPredicate(O, len, ascending, predicate, thisArg).
-        let find_rec = array::find_via_predicate(obj, len, array::Direction::Ascending, predicate, this_arg, context);
+        let find_rec =
+            find_via_predicate(obj, len, Direction::Ascending, predicate, this_arg, context);
 
         // 5. Return findRec.[[Index]].
         match find_rec {


### PR DESCRIPTION
This Pull Request references #3100 

It changes the following:

- It aligns the implementations of `Array.prototype.find{Index,Last,LastIndex}` and the existing TypedArray variants to use [`FindViaPredicate ( O, len, direction, predicate, thisArg )`](https://tc39.es/ecma262/#sec-findviapredicate)
