### PR TITLE
Implement `findLast` and `findLastIndex` on TypedArray

### DIFF
--- a/boa_engine/src/builtins/typed_array/mod.rs
+++ b/boa_engine/src/builtins/typed_array/mod.rs
@@ -1256,27 +1256,22 @@ impl TypedArray {
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
-        let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("TypedArray.prototype.findLast: predicate is not callable")
-        })?;
+        let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
 
         // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
-        let find_rec = find_via_predicate(
+        let (_, value) = find_via_predicate(
             obj,
             len,
             Direction::Descending,
             predicate,
             this_arg,
             context,
-        );
+            "TypedArray.prototype.findLast",
+        )?;
 
         // 5. Return findRec.[[Value]].
-        match find_rec {
-            Ok((_, value)) => Ok(value),
-            Err(err) => Err(err),
-        }
+        Ok(value)
     }
 
     /// `23.2.3.14 %TypedArray%.prototype.findLastIndex ( predicate [ , thisArg ] )`
@@ -1308,27 +1303,22 @@ impl TypedArray {
         // 3. Let len be O.[[ArrayLength]].
         let len = o.array_length();
 
-        let predicate = args.get_or_undefined(0).as_callable().ok_or_else(|| {
-            JsNativeError::typ()
-                .with_message("TypedArray.prototype.findLastIndex: predicate is not callable")
-        })?;
+        let predicate = args.get_or_undefined(0);
         let this_arg = args.get_or_undefined(1);
 
         // 4. Let findRec be ? FindViaPredicate(O, len, descending, predicate, thisArg).
-        let find_rec = find_via_predicate(
+        let (index, _) = find_via_predicate(
             obj,
             len,
             Direction::Descending,
             predicate,
             this_arg,
             context,
-        );
+            "TypedArray.prototype.findLastIndex",
+        )?;
 
         // 5. Return findRec.[[Index]].
-        match find_rec {
-            Ok((index, _)) => Ok(index),
-            Err(err) => Err(err),
-        }
+        Ok(index)
     }
 
     /// `23.2.3.15 %TypedArray%.prototype.forEach ( callbackfn [ , thisArg ] )`


### PR DESCRIPTION
This Pull Request closes #3100 

Depends on #3134 (iirc putting my fork as the base would not automatically switch the base of this PR to `main` once the other one is merged..)

It changes the following:

- Implements [`%TypedArray%.prototype.findLast ( predicate [ , thisArg ] )`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlast) and [`%TypedArray%.prototype.findLastIndex ( predicate [ , thisArg ] )`](https://tc39.es/ecma262/#sec-%typedarray%.prototype.findlastindex)
