### PR TITLE
Re-enable must_use clippy rule

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -316,6 +316,7 @@ pub struct Function {
 
 impl Function {
     /// Returns the codeblock of the function, or `None` if the function is a [`NativeFunction`].
+    #[must_use]
     pub fn codeblock(&self) -> Option<&CodeBlock> {
         match &self.kind {
             FunctionKind::Native { .. } => None,
@@ -438,6 +439,7 @@ impl Function {
     }
 
     /// Gets the `Realm` from where this function originates.
+    #[must_use]
     pub const fn realm(&self) -> &Realm {
         &self.realm
     }
@@ -1128,16 +1130,19 @@ impl BoundFunction {
     }
 
     /// Get a reference to the bound function's this.
+    #[must_use]
     pub const fn this(&self) -> &JsValue {
         &self.this
     }
 
     /// Get a reference to the bound function's target function.
+    #[must_use]
     pub const fn target_function(&self) -> &JsObject {
         &self.target_function
     }
 
     /// Get a reference to the bound function's args.
+    #[must_use]
     pub fn args(&self) -> &[JsValue] {
         self.args.as_slice()
     }

--- a/boa_engine/src/builtins/iterable/mod.rs
+++ b/boa_engine/src/builtins/iterable/mod.rs
@@ -77,60 +77,70 @@ pub struct IteratorPrototypes {
 impl IteratorPrototypes {
     /// Returns the `ArrayIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn array(&self) -> JsObject {
         self.array.clone()
     }
 
     /// Returns the `IteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn iterator(&self) -> JsObject {
         self.iterator.clone()
     }
 
     /// Returns the `AsyncIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn async_iterator(&self) -> JsObject {
         self.async_iterator.clone()
     }
 
     /// Returns the `AsyncFromSyncIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn async_from_sync_iterator(&self) -> JsObject {
         self.async_from_sync_iterator.clone()
     }
 
     /// Returns the `SetIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn set(&self) -> JsObject {
         self.set.clone()
     }
 
     /// Returns the `StringIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn string(&self) -> JsObject {
         self.string.clone()
     }
 
     /// Returns the `RegExpStringIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn regexp_string(&self) -> JsObject {
         self.regexp_string.clone()
     }
 
     /// Returns the `MapIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn map(&self) -> JsObject {
         self.map.clone()
     }
 
     /// Returns the `ForInIteratorPrototype` object.
     #[inline]
+    #[must_use]
     pub fn for_in(&self) -> JsObject {
         self.for_in.clone()
     }
 
     /// Returns the `%SegmentIteratorPrototype%` object.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub fn segment(&self) -> JsObject {
         self.segment.clone()
@@ -378,6 +388,7 @@ pub struct IteratorRecord {
 impl IteratorRecord {
     /// Creates a new `IteratorRecord` with the given iterator object, next method and `done` flag.
     #[inline]
+    #[must_use]
     pub fn new(iterator: JsObject, next_method: JsValue) -> Self {
         Self {
             iterator,

--- a/boa_engine/src/builtins/map/ordered_map.rs
+++ b/boa_engine/src/builtins/map/ordered_map.rs
@@ -191,6 +191,7 @@ impl<V> OrderedMap<V> {
     /// Return `true` if an equivalent to `key` exists in the map.
     ///
     /// Computes in **O(1)** time (average).
+    #[must_use]
     pub fn contains_key(&self, key: &JsValue) -> bool {
         self.map.contains_key(key)
     }

--- a/boa_engine/src/builtins/promise/mod.rs
+++ b/boa_engine/src/builtins/promise/mod.rs
@@ -51,6 +51,7 @@ unsafe impl Trace for PromiseState {
 impl PromiseState {
     /// Gets the inner `JsValue` of a fulfilled promise state, or returns `None` if
     /// the state is not `Fulfilled`.
+    #[must_use]
     pub const fn as_fulfilled(&self) -> Option<&JsValue> {
         match self {
             Self::Fulfilled(v) => Some(v),
@@ -60,6 +61,7 @@ impl PromiseState {
 
     /// Gets the inner `JsValue` of a rejected promise state, or returns `None` if
     /// the state is not `Rejected`.
+    #[must_use]
     pub const fn as_rejected(&self) -> Option<&JsValue> {
         match self {
             Self::Rejected(v) => Some(v),

--- a/boa_engine/src/builtins/set/ordered_set.rs
+++ b/boa_engine/src/builtins/set/ordered_set.rs
@@ -122,6 +122,7 @@ impl OrderedSet {
     /// Return `true` if `value` is present in set, false otherwise.
     ///
     /// Computes in **O(n)** time (average).
+    #[must_use]
     pub fn contains(&self, value: &JsValue) -> bool {
         self.inner.contains(value)
     }

--- a/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
+++ b/boa_engine/src/builtins/typed_array/integer_indexed_object.rs
@@ -66,6 +66,7 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's byte offset.
+    #[must_use]
     pub const fn byte_offset(&self) -> u64 {
         self.byte_offset
     }
@@ -81,6 +82,7 @@ impl IntegerIndexed {
     }
 
     /// Get a reference to the integer indexed object's viewed array buffer.
+    #[must_use]
     pub const fn viewed_array_buffer(&self) -> Option<&JsObject> {
         self.viewed_array_buffer.as_ref()
     }
@@ -91,6 +93,7 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's byte length.
+    #[must_use]
     pub const fn byte_length(&self) -> u64 {
         self.byte_length
     }
@@ -101,6 +104,7 @@ impl IntegerIndexed {
     }
 
     /// Get the integer indexed object's array length.
+    #[must_use]
     pub const fn array_length(&self) -> u64 {
         self.array_length
     }

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -40,12 +40,14 @@ impl Intrinsics {
 
     /// Return the cached intrinsic objects.
     #[inline]
+    #[must_use]
     pub const fn objects(&self) -> &IntrinsicObjects {
         &self.objects
     }
 
     /// Return the cached standard constructors.
     #[inline]
+    #[must_use]
     pub const fn constructors(&self) -> &StandardConstructors {
         &self.constructors
     }
@@ -84,6 +86,7 @@ impl StandardConstructor {
     ///
     /// This is the same as `Object.prototype`, `Array.prototype`, etc
     #[inline]
+    #[must_use]
     pub fn prototype(&self) -> JsObject {
         self.prototype.clone()
     }
@@ -92,6 +95,7 @@ impl StandardConstructor {
     ///
     /// This is the same as `Object`, `Array`, etc.
     #[inline]
+    #[must_use]
     pub fn constructor(&self) -> JsObject {
         self.constructor.clone().into()
     }
@@ -237,6 +241,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgeneratorfunction-constructor
     #[inline]
+    #[must_use]
     pub const fn async_generator_function(&self) -> &StandardConstructor {
         &self.async_generator_function
     }
@@ -248,6 +253,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-object-constructor
     #[inline]
+    #[must_use]
     pub const fn object(&self) -> &StandardConstructor {
         &self.object
     }
@@ -259,6 +265,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-proxy-constructor
     #[inline]
+    #[must_use]
     pub const fn proxy(&self) -> &StandardConstructor {
         &self.proxy
     }
@@ -270,6 +277,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-date-constructor
     #[inline]
+    #[must_use]
     pub const fn date(&self) -> &StandardConstructor {
         &self.date
     }
@@ -281,6 +289,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-function-constructor
     #[inline]
+    #[must_use]
     pub const fn function(&self) -> &StandardConstructor {
         &self.function
     }
@@ -292,6 +301,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-async-function-constructor
     #[inline]
+    #[must_use]
     pub const fn async_function(&self) -> &StandardConstructor {
         &self.async_function
     }
@@ -303,6 +313,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-generatorfunction-constructor
     #[inline]
+    #[must_use]
     pub const fn generator_function(&self) -> &StandardConstructor {
         &self.generator_function
     }
@@ -314,6 +325,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array-constructor
     #[inline]
+    #[must_use]
     pub const fn array(&self) -> &StandardConstructor {
         &self.array
     }
@@ -325,6 +337,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-bigint-constructor
     #[inline]
+    #[must_use]
     pub const fn bigint(&self) -> &StandardConstructor {
         &self.bigint
     }
@@ -336,6 +349,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-number-constructor
     #[inline]
+    #[must_use]
     pub const fn number(&self) -> &StandardConstructor {
         &self.number
     }
@@ -347,6 +361,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-boolean-constructor
     #[inline]
+    #[must_use]
     pub const fn boolean(&self) -> &StandardConstructor {
         &self.boolean
     }
@@ -358,6 +373,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-string-constructor
     #[inline]
+    #[must_use]
     pub const fn string(&self) -> &StandardConstructor {
         &self.string
     }
@@ -369,6 +385,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-regexp-constructor
     #[inline]
+    #[must_use]
     pub const fn regexp(&self) -> &StandardConstructor {
         &self.regexp
     }
@@ -380,6 +397,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-symbol-constructor
     #[inline]
+    #[must_use]
     pub const fn symbol(&self) -> &StandardConstructor {
         &self.symbol
     }
@@ -391,6 +409,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-error-constructor
     #[inline]
+    #[must_use]
     pub const fn error(&self) -> &StandardConstructor {
         &self.error
     }
@@ -402,6 +421,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-referenceerror
     #[inline]
+    #[must_use]
     pub const fn reference_error(&self) -> &StandardConstructor {
         &self.reference_error
     }
@@ -413,6 +433,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-typeerror
     #[inline]
+    #[must_use]
     pub const fn type_error(&self) -> &StandardConstructor {
         &self.type_error
     }
@@ -424,6 +445,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-rangeerror
     #[inline]
+    #[must_use]
     pub const fn range_error(&self) -> &StandardConstructor {
         &self.range_error
     }
@@ -435,6 +457,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-syntaxerror
     #[inline]
+    #[must_use]
     pub const fn syntax_error(&self) -> &StandardConstructor {
         &self.syntax_error
     }
@@ -446,6 +469,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-evalerror
     #[inline]
+    #[must_use]
     pub const fn eval_error(&self) -> &StandardConstructor {
         &self.eval_error
     }
@@ -457,6 +481,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-native-error-types-used-in-this-standard-urierror
     #[inline]
+    #[must_use]
     pub const fn uri_error(&self) -> &StandardConstructor {
         &self.uri_error
     }
@@ -468,6 +493,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-aggregate-error-constructor
     #[inline]
+    #[must_use]
     pub const fn aggregate_error(&self) -> &StandardConstructor {
         &self.aggregate_error
     }
@@ -479,6 +505,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-map-constructor
     #[inline]
+    #[must_use]
     pub const fn map(&self) -> &StandardConstructor {
         &self.map
     }
@@ -490,6 +517,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-set-constructor
     #[inline]
+    #[must_use]
     pub const fn set(&self) -> &StandardConstructor {
         &self.set
     }
@@ -501,6 +529,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_array(&self) -> &StandardConstructor {
         &self.typed_array
     }
@@ -512,6 +541,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_int8_array(&self) -> &StandardConstructor {
         &self.typed_int8_array
     }
@@ -523,6 +553,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_uint8_array(&self) -> &StandardConstructor {
         &self.typed_uint8_array
     }
@@ -534,6 +565,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_uint8clamped_array(&self) -> &StandardConstructor {
         &self.typed_uint8clamped_array
     }
@@ -545,6 +577,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_int16_array(&self) -> &StandardConstructor {
         &self.typed_int16_array
     }
@@ -556,6 +589,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_uint16_array(&self) -> &StandardConstructor {
         &self.typed_uint16_array
     }
@@ -567,6 +601,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_uint32_array(&self) -> &StandardConstructor {
         &self.typed_uint32_array
     }
@@ -578,6 +613,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_int32_array(&self) -> &StandardConstructor {
         &self.typed_int32_array
     }
@@ -589,6 +625,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_bigint64_array(&self) -> &StandardConstructor {
         &self.typed_bigint64_array
     }
@@ -600,6 +637,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_biguint64_array(&self) -> &StandardConstructor {
         &self.typed_biguint64_array
     }
@@ -611,6 +649,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_float32_array(&self) -> &StandardConstructor {
         &self.typed_float32_array
     }
@@ -622,6 +661,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-constructors
     #[inline]
+    #[must_use]
     pub const fn typed_float64_array(&self) -> &StandardConstructor {
         &self.typed_float64_array
     }
@@ -633,6 +673,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-arraybuffer-constructor
     #[inline]
+    #[must_use]
     pub const fn array_buffer(&self) -> &StandardConstructor {
         &self.array_buffer
     }
@@ -644,6 +685,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-dataview-constructor
     #[inline]
+    #[must_use]
     pub const fn data_view(&self) -> &StandardConstructor {
         &self.data_view
     }
@@ -655,6 +697,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
     #[inline]
+    #[must_use]
     pub const fn date_time_format(&self) -> &StandardConstructor {
         &self.date_time_format
     }
@@ -666,6 +709,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-promise-constructor
     #[inline]
+    #[must_use]
     pub const fn promise(&self) -> &StandardConstructor {
         &self.promise
     }
@@ -677,6 +721,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-weak-ref-constructor
     #[inline]
+    #[must_use]
     pub const fn weak_ref(&self) -> &StandardConstructor {
         &self.weak_ref
     }
@@ -688,6 +733,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-weakmap-constructor
     #[inline]
+    #[must_use]
     pub const fn weak_map(&self) -> &StandardConstructor {
         &self.weak_map
     }
@@ -699,6 +745,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-weakset-constructor
     #[inline]
+    #[must_use]
     pub const fn weak_set(&self) -> &StandardConstructor {
         &self.weak_set
     }
@@ -710,6 +757,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-intl.collator
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn collator(&self) -> &StandardConstructor {
         &self.collator
@@ -722,6 +770,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-Intl.ListFormat
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn list_format(&self) -> &StandardConstructor {
         &self.list_format
@@ -734,6 +783,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-Intl.Locale
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn locale(&self) -> &StandardConstructor {
         &self.locale
@@ -746,6 +796,7 @@ impl StandardConstructors {
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-intl.segmenter
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn segmenter(&self) -> &StandardConstructor {
         &self.segmenter
@@ -848,6 +899,7 @@ impl IntrinsicObjects {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%throwtypeerror%
     #[inline]
+    #[must_use]
     pub fn throw_type_error(&self) -> JsFunction {
         self.throw_type_error.clone()
     }
@@ -856,12 +908,14 @@ impl IntrinsicObjects {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.values
     #[inline]
+    #[must_use]
     pub fn array_prototype_values(&self) -> JsFunction {
         self.array_prototype_values.clone()
     }
 
     /// Gets the cached iterator prototypes.
     #[inline]
+    #[must_use]
     pub const fn iterator_prototypes(&self) -> &IteratorPrototypes {
         &self.iterator_prototypes
     }
@@ -870,6 +924,7 @@ impl IntrinsicObjects {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-generator-objects
     #[inline]
+    #[must_use]
     pub fn generator(&self) -> JsObject {
         self.generator.clone()
     }
@@ -878,6 +933,7 @@ impl IntrinsicObjects {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-asyncgenerator-objects
     #[inline]
+    #[must_use]
     pub fn async_generator(&self) -> JsObject {
         self.async_generator.clone()
     }
@@ -885,11 +941,13 @@ impl IntrinsicObjects {
     /// Gets the [`%eval%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-eval-x
+    #[must_use]
     pub fn eval(&self) -> JsFunction {
         self.eval.clone()
     }
 
     /// Gets the URI intrinsic functions.
+    #[must_use]
     pub const fn uri_functions(&self) -> &UriFunctions {
         &self.uri_functions
     }
@@ -897,6 +955,7 @@ impl IntrinsicObjects {
     /// Gets the [`%Reflect%`][spec] intrinsic object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-reflect
+    #[must_use]
     pub fn reflect(&self) -> JsObject {
         self.reflect.clone()
     }
@@ -904,6 +963,7 @@ impl IntrinsicObjects {
     /// Gets the [`%Math%`][spec] intrinsic object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-math
+    #[must_use]
     pub fn math(&self) -> JsObject {
         self.math.clone()
     }
@@ -911,6 +971,7 @@ impl IntrinsicObjects {
     /// Gets the [`%JSON%`][spec] intrinsic object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-json
+    #[must_use]
     pub fn json(&self) -> JsObject {
         self.json.clone()
     }
@@ -918,6 +979,7 @@ impl IntrinsicObjects {
     /// Gets the [`%isFinite%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isfinite-number
+    #[must_use]
     pub fn is_finite(&self) -> JsFunction {
         self.is_finite.clone()
     }
@@ -925,6 +987,7 @@ impl IntrinsicObjects {
     /// Gets the [`%isNaN%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isnan-number
+    #[must_use]
     pub fn is_nan(&self) -> JsFunction {
         self.is_nan.clone()
     }
@@ -932,6 +995,7 @@ impl IntrinsicObjects {
     /// Gets the [`%parseFloat%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parsefloat-string
+    #[must_use]
     pub fn parse_float(&self) -> JsFunction {
         self.parse_float.clone()
     }
@@ -939,6 +1003,7 @@ impl IntrinsicObjects {
     /// Gets the [`%parseInt%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parseint-string-radix
+    #[must_use]
     pub fn parse_int(&self) -> JsFunction {
         self.parse_int.clone()
     }
@@ -946,6 +1011,7 @@ impl IntrinsicObjects {
     /// Gets the [`%escape%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-escape-string
+    #[must_use]
     #[cfg(feature = "annex-b")]
     pub fn escape(&self) -> JsFunction {
         self.escape.clone()
@@ -954,6 +1020,7 @@ impl IntrinsicObjects {
     /// Gets the [`%unescape%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-unescape-string
+    #[must_use]
     #[cfg(feature = "annex-b")]
     pub fn unescape(&self) -> JsFunction {
         self.unescape.clone()
@@ -962,6 +1029,7 @@ impl IntrinsicObjects {
     /// Gets the [`%Intl%`][spec] intrinsic object.
     ///
     /// [spec]: https://tc39.es/ecma402/#intl-object
+    #[must_use]
     #[cfg(feature = "intl")]
     pub fn intl(&self) -> JsObject {
         self.intl.clone()
@@ -970,6 +1038,7 @@ impl IntrinsicObjects {
     /// Gets the [`%SegmentsPrototype%`][spec] intrinsic object.
     ///
     /// [spec]: https://tc39.es/ecma402/#sec-%segmentsprototype%-object
+    #[must_use]
     #[cfg(feature = "intl")]
     pub fn segments_prototype(&self) -> JsObject {
         self.segments_prototype.clone()

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -344,6 +344,7 @@ impl<'host> Context<'host> {
 
     /// Gets the string interner.
     #[inline]
+    #[must_use]
     pub const fn interner(&self) -> &Interner {
         &self.interner
     }
@@ -356,18 +357,21 @@ impl<'host> Context<'host> {
 
     /// Returns the global object.
     #[inline]
+    #[must_use]
     pub fn global_object(&self) -> JsObject {
         self.realm.global_object().clone()
     }
 
     /// Returns the currently active intrinsic constructors and objects.
     #[inline]
+    #[must_use]
     pub fn intrinsics(&self) -> &Intrinsics {
         self.realm.intrinsics()
     }
 
     /// Returns the currently active realm.
     #[inline]
+    #[must_use]
     pub const fn realm(&self) -> &Realm {
         &self.realm
     }
@@ -381,6 +385,7 @@ impl<'host> Context<'host> {
 
     /// Get optimizer options.
     #[inline]
+    #[must_use]
     pub const fn optimizer_options(&self) -> OptimizerOptions {
         self.optimizer_options
     }
@@ -452,29 +457,34 @@ impl<'host> Context<'host> {
 
     /// Get the [`RootShape`].
     #[inline]
+    #[must_use]
     pub const fn root_shape(&self) -> &RootShape {
         &self.root_shape
     }
 
     /// Gets the host hooks.
     #[inline]
+    #[must_use]
     pub fn host_hooks(&self) -> MaybeShared<'host, dyn HostHooks> {
         self.host_hooks.clone()
     }
 
     /// Gets the job queue.
     #[inline]
+    #[must_use]
     pub fn job_queue(&self) -> MaybeShared<'host, dyn JobQueue> {
         self.job_queue.clone()
     }
 
     /// Gets the module loader.
+    #[must_use]
     pub fn module_loader(&self) -> MaybeShared<'host, dyn ModuleLoader> {
         self.module_loader.clone()
     }
 
     /// Get the [`RuntimeLimits`].
     #[inline]
+    #[must_use]
     pub const fn runtime_limits(&self) -> RuntimeLimits {
         self.vm.runtime_limits
     }

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -149,6 +149,7 @@ impl JsError {
     ///
     /// assert!(error.as_opaque().is_some());
     /// ```
+    #[must_use]
     pub const fn from_opaque(value: JsValue) -> Self {
         Self {
             inner: Repr::Opaque(value),
@@ -329,6 +330,7 @@ impl JsError {
     ///
     /// assert!(error.as_opaque().is_some());
     /// ```
+    #[must_use]
     pub const fn as_opaque(&self) -> Option<&JsValue> {
         match self.inner {
             Repr::Native(_) => None,
@@ -351,6 +353,7 @@ impl JsError {
     ///
     /// assert!(error.as_native().is_none());
     /// ```
+    #[must_use]
     pub const fn as_native(&self) -> Option<&JsNativeError> {
         match &self.inner {
             Repr::Native(e) => Some(e),
@@ -474,6 +477,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Aggregate`].
+    #[must_use]
     #[inline]
     pub const fn is_aggregate(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Aggregate(_))
@@ -496,6 +500,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Error`].
+    #[must_use]
     #[inline]
     pub const fn is_error(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Error)
@@ -518,6 +523,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Eval`].
+    #[must_use]
     #[inline]
     pub const fn is_eval(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Eval)
@@ -540,6 +546,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Range`].
+    #[must_use]
     #[inline]
     pub const fn is_range(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Range)
@@ -562,6 +569,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Reference`].
+    #[must_use]
     #[inline]
     pub const fn is_reference(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Reference)
@@ -584,6 +592,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Syntax`].
+    #[must_use]
     #[inline]
     pub const fn is_syntax(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Syntax)
@@ -606,6 +615,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Type`].
+    #[must_use]
     #[inline]
     pub const fn is_type(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Type)
@@ -628,6 +638,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::Uri`].
+    #[must_use]
     #[inline]
     pub const fn is_uri(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::Uri)
@@ -646,6 +657,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::NoInstructionsRemain`].
+    #[must_use]
     #[inline]
     #[cfg(feature = "fuzz")]
     pub const fn is_no_instructions_remain(&self) -> bool {
@@ -660,6 +672,7 @@ impl JsNativeError {
     }
 
     /// Check if it's a [`JsNativeErrorKind::RuntimeLimit`].
+    #[must_use]
     #[inline]
     pub const fn is_runtime_limit(&self) -> bool {
         matches!(self.kind, JsNativeErrorKind::RuntimeLimit)

--- a/boa_engine/src/job.rs
+++ b/boa_engine/src/job.rs
@@ -104,6 +104,7 @@ impl NativeJob {
     }
 
     /// Gets a reference to the execution realm of the job.
+    #[must_use]
     pub const fn realm(&self) -> Option<&Realm> {
         self.realm.as_ref()
     }
@@ -167,11 +168,13 @@ impl JobCallback {
     }
 
     /// Gets the inner callback of the job.
+    #[must_use]
     pub const fn callback(&self) -> &JsFunction {
         &self.callback
     }
 
     /// Gets a reference to the host defined additional field as an `Any` trait object.
+    #[must_use]
     pub fn host_defined(&self) -> &dyn Any {
         self.host_defined.as_any()
     }

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -119,7 +119,6 @@
     clippy::cast_sign_loss,
     clippy::cast_precision_loss,
     clippy::cast_possible_wrap,
-    clippy::must_use_candidate,
 )]
 
 extern crate static_assertions as sa;

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -383,6 +383,7 @@ impl Module {
 
     /// Gets the realm of this `Module`.
     #[inline]
+    #[must_use]
     pub fn realm(&self) -> &Realm {
         &self.inner.realm
     }

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -44,6 +44,7 @@ impl JsFunction {
     ///
     /// This does not clone the fields of the function, it only does a shallow clone of the object.
     #[inline]
+    #[must_use]
     pub fn from_object(object: JsObject) -> Option<Self> {
         object
             .is_callable()

--- a/boa_engine/src/object/jsobject.rs
+++ b/boa_engine/src/object/jsobject.rs
@@ -156,6 +156,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn borrow(&self) -> Ref<'_, Object> {
         self.try_borrow().expect("Object already mutably borrowed")
@@ -169,6 +170,7 @@ impl JsObject {
     /// # Panics
     /// Panics if the object is currently borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn borrow_mut(&self) -> RefMut<'_, Object, Object> {
         self.try_borrow_mut().expect("Object already borrowed")
@@ -200,6 +202,7 @@ impl JsObject {
     }
 
     /// Checks if the garbage collected memory is the same.
+    #[must_use]
     #[inline]
     pub fn equals(lhs: &Self, rhs: &Self) -> bool {
         std::ptr::eq(lhs.as_ref(), rhs.as_ref())
@@ -285,6 +288,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
+    #[must_use]
     #[track_caller]
     pub fn is<T>(&self) -> bool
     where
@@ -299,6 +303,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
+    #[must_use]
     #[track_caller]
     pub fn downcast_ref<T>(&self) -> Option<Ref<'_, T>>
     where
@@ -320,6 +325,7 @@ impl JsObject {
     /// # Panics
     ///
     /// Panics if the object is currently borrowed.
+    #[must_use]
     #[track_caller]
     pub fn downcast_mut<T>(&self) -> Option<RefMut<'_, Object, T>>
     where
@@ -342,6 +348,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn prototype(&self) -> JsPrototype {
         self.borrow().prototype()
@@ -363,12 +370,14 @@ impl JsObject {
     /// Panics if the object is currently mutably borrowed
     #[inline]
     #[track_caller]
+    #[allow(clippy::must_use_candidate)]
     pub fn set_prototype(&self, prototype: JsPrototype) -> bool {
         self.borrow_mut().set_prototype(prototype)
     }
 
     /// Checks if it's an `Array` object.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_array(&self) -> bool {
         std::ptr::eq(self.vtable(), &ARRAY_EXOTIC_INTERNAL_METHODS)
@@ -380,6 +389,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_data_view(&self) -> bool {
         self.borrow().is_data_view()
@@ -391,6 +401,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_array_iterator(&self) -> bool {
         self.borrow().is_array_iterator()
@@ -402,6 +413,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_array_buffer(&self) -> bool {
         self.borrow().is_array_buffer()
@@ -413,6 +425,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_map(&self) -> bool {
         self.borrow().is_map()
@@ -424,6 +437,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_map_iterator(&self) -> bool {
         self.borrow().is_map_iterator()
@@ -435,6 +449,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_set(&self) -> bool {
         self.borrow().is_set()
@@ -446,6 +461,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_set_iterator(&self) -> bool {
         self.borrow().is_set_iterator()
@@ -457,6 +473,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_string(&self) -> bool {
         self.borrow().is_string()
@@ -468,6 +485,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_function(&self) -> bool {
         self.borrow().is_function()
@@ -479,6 +497,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_generator(&self) -> bool {
         self.borrow().is_generator()
@@ -490,6 +509,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_symbol(&self) -> bool {
         self.borrow().is_symbol()
@@ -501,6 +521,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_error(&self) -> bool {
         self.borrow().is_error()
@@ -512,6 +533,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_boolean(&self) -> bool {
         self.borrow().is_boolean()
@@ -523,6 +545,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_number(&self) -> bool {
         self.borrow().is_number()
@@ -534,6 +557,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_bigint(&self) -> bool {
         self.borrow().is_bigint()
@@ -545,6 +569,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_date(&self) -> bool {
         self.borrow().is_date()
@@ -556,6 +581,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_regexp(&self) -> bool {
         self.borrow().is_regexp()
@@ -567,6 +593,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_array(&self) -> bool {
         self.borrow().is_typed_array()
@@ -578,6 +605,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_uint8_array(&self) -> bool {
         self.borrow().is_typed_uint8_array()
@@ -589,6 +617,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_int8_array(&self) -> bool {
         self.borrow().is_typed_int8_array()
@@ -600,6 +629,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_uint16_array(&self) -> bool {
         self.borrow().is_typed_uint16_array()
@@ -611,6 +641,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_int16_array(&self) -> bool {
         self.borrow().is_typed_int16_array()
@@ -622,6 +653,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_uint32_array(&self) -> bool {
         self.borrow().is_typed_uint32_array()
@@ -633,6 +665,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_int32_array(&self) -> bool {
         self.borrow().is_typed_int32_array()
@@ -644,6 +677,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_float32_array(&self) -> bool {
         self.borrow().is_typed_float32_array()
@@ -655,6 +689,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_typed_float64_array(&self) -> bool {
         self.borrow().is_typed_float64_array()
@@ -666,6 +701,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_promise(&self) -> bool {
         self.borrow().is_promise()
@@ -677,6 +713,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_ordinary(&self) -> bool {
         self.borrow().is_ordinary()
@@ -688,6 +725,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_proxy(&self) -> bool {
         self.borrow().is_proxy()
@@ -699,6 +737,7 @@ impl JsObject {
     ///
     /// Panics if the object is currently mutably borrowed.
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_native_object(&self) -> bool {
         self.borrow().is_native_object()
@@ -915,6 +954,7 @@ Cannot both specify accessors and a value or writable attribute",
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iscallable
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_callable(&self) -> bool {
         self.inner.vtable.__call__.is_some()
@@ -927,12 +967,14 @@ Cannot both specify accessors and a value or writable attribute",
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isconstructor
     #[inline]
+    #[must_use]
     #[track_caller]
     pub fn is_constructor(&self) -> bool {
         self.inner.vtable.__construct__.is_some()
     }
 
     /// Returns true if the `JsObject` is the global for a Realm
+    #[must_use]
     pub fn is_global(&self) -> bool {
         matches!(self.inner.object.borrow().kind, ObjectKind::Global)
     }

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -420,6 +420,7 @@ impl ObjectData {
     }
 
     /// Create the `AsyncFromSyncIterator` object data
+    #[must_use]
     pub fn async_from_sync_iterator(async_from_sync_iterator: AsyncFromSyncIterator) -> Self {
         Self {
             kind: ObjectKind::AsyncFromSyncIterator(async_from_sync_iterator),
@@ -428,6 +429,7 @@ impl ObjectData {
     }
 
     /// Create the `AsyncGenerator` object data
+    #[must_use]
     pub fn async_generator(async_generator: AsyncGenerator) -> Self {
         Self {
             kind: ObjectKind::AsyncGenerator(async_generator),
@@ -436,6 +438,7 @@ impl ObjectData {
     }
 
     /// Create the `AsyncGeneratorFunction` object data
+    #[must_use]
     pub fn async_generator_function(function: Function) -> Self {
         Self {
             internal_methods: &FUNCTION_INTERNAL_METHODS,
@@ -453,6 +456,7 @@ impl ObjectData {
     }
 
     /// Create the `ArrayIterator` object data
+    #[must_use]
     pub fn array_iterator(array_iterator: ArrayIterator) -> Self {
         Self {
             kind: ObjectKind::ArrayIterator(array_iterator),
@@ -461,6 +465,7 @@ impl ObjectData {
     }
 
     /// Create the `ArrayBuffer` object data
+    #[must_use]
     pub fn array_buffer(array_buffer: ArrayBuffer) -> Self {
         Self {
             kind: ObjectKind::ArrayBuffer(array_buffer),
@@ -478,6 +483,7 @@ impl ObjectData {
     }
 
     /// Create the `MapIterator` object data
+    #[must_use]
     pub fn map_iterator(map_iterator: MapIterator) -> Self {
         Self {
             kind: ObjectKind::MapIterator(map_iterator),
@@ -495,6 +501,7 @@ impl ObjectData {
     }
 
     /// Create the `RegExpStringIterator` object data
+    #[must_use]
     pub fn reg_exp_string_iterator(reg_exp_string_iterator: RegExpStringIterator) -> Self {
         Self {
             kind: ObjectKind::RegExpStringIterator(reg_exp_string_iterator),
@@ -521,6 +528,7 @@ impl ObjectData {
     }
 
     /// Create the `DataView` object data
+    #[must_use]
     pub fn data_view(data_view: DataView) -> Self {
         Self {
             kind: ObjectKind::DataView(data_view),
@@ -529,6 +537,7 @@ impl ObjectData {
     }
 
     /// Create the `Promise` object data
+    #[must_use]
     pub fn promise(promise: Promise) -> Self {
         Self {
             kind: ObjectKind::Promise(promise),
@@ -537,6 +546,7 @@ impl ObjectData {
     }
 
     /// Create the `ForInIterator` object data
+    #[must_use]
     pub fn for_in_iterator(for_in_iterator: ForInIterator) -> Self {
         Self {
             kind: ObjectKind::ForInIterator(for_in_iterator),
@@ -545,6 +555,7 @@ impl ObjectData {
     }
 
     /// Create the `Function` object data
+    #[must_use]
     pub fn function(function: Function, constructor: bool) -> Self {
         Self {
             internal_methods: if constructor {
@@ -557,6 +568,7 @@ impl ObjectData {
     }
 
     /// Create the `BoundFunction` object data
+    #[must_use]
     pub fn bound_function(bound_function: BoundFunction, constructor: bool) -> Self {
         Self {
             kind: ObjectKind::BoundFunction(bound_function),
@@ -569,6 +581,7 @@ impl ObjectData {
     }
 
     /// Create the `Generator` object data
+    #[must_use]
     pub fn generator(generator: Generator) -> Self {
         Self {
             kind: ObjectKind::Generator(generator),
@@ -577,6 +590,7 @@ impl ObjectData {
     }
 
     /// Create the `GeneratorFunction` object data
+    #[must_use]
     pub fn generator_function(function: Function) -> Self {
         Self {
             internal_methods: &FUNCTION_INTERNAL_METHODS,
@@ -594,6 +608,7 @@ impl ObjectData {
     }
 
     /// Create the `SetIterator` object data
+    #[must_use]
     pub fn set_iterator(set_iterator: SetIterator) -> Self {
         Self {
             kind: ObjectKind::SetIterator(set_iterator),
@@ -655,6 +670,7 @@ impl ObjectData {
     }
 
     /// Create the `Proxy` object data
+    #[must_use]
     pub fn proxy(proxy: Proxy, call: bool, construct: bool) -> Self {
         Self {
             kind: ObjectKind::Proxy(proxy),
@@ -678,6 +694,7 @@ impl ObjectData {
     }
 
     /// Create the `Arguments` object data
+    #[must_use]
     pub fn arguments(arguments: Arguments) -> Self {
         Self {
             internal_methods: if matches!(arguments, Arguments::Unmapped) {
@@ -690,6 +707,7 @@ impl ObjectData {
     }
 
     /// Creates the `WeakRef` object data
+    #[must_use]
     pub fn weak_ref(weak_ref: WeakGc<VTableObject>) -> Self {
         Self {
             kind: ObjectKind::WeakRef(weak_ref),
@@ -878,24 +896,28 @@ impl Object {
     }
 
     /// Returns the shape of the object.
+    #[must_use]
     pub const fn shape(&self) -> &Shape {
         &self.properties.shape
     }
 
     /// Returns the kind of the object.
     #[inline]
+    #[must_use]
     pub const fn kind(&self) -> &ObjectKind {
         &self.kind
     }
 
     /// Checks if it's an `AsyncFromSyncIterator` object.
     #[inline]
+    #[must_use]
     pub const fn is_async_from_sync_iterator(&self) -> bool {
         matches!(self.kind, ObjectKind::AsyncFromSyncIterator(_))
     }
 
     /// Returns a reference to the `AsyncFromSyncIterator` data on the object.
     #[inline]
+    #[must_use]
     pub const fn as_async_from_sync_iterator(&self) -> Option<&AsyncFromSyncIterator> {
         match self.kind {
             ObjectKind::AsyncFromSyncIterator(ref async_from_sync_iterator) => {
@@ -907,12 +929,14 @@ impl Object {
 
     /// Checks if it's an `AsyncGenerator` object.
     #[inline]
+    #[must_use]
     pub const fn is_async_generator(&self) -> bool {
         matches!(self.kind, ObjectKind::AsyncGenerator(_))
     }
 
     /// Returns a reference to the async generator data on the object.
     #[inline]
+    #[must_use]
     pub const fn as_async_generator(&self) -> Option<&AsyncGenerator> {
         match self.kind {
             ObjectKind::AsyncGenerator(ref async_generator) => Some(async_generator),
@@ -931,29 +955,34 @@ impl Object {
 
     /// Checks if the object is a `Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_array(&self) -> bool {
         matches!(self.kind, ObjectKind::Array)
     }
 
     #[inline]
+    #[must_use]
     pub(crate) const fn has_viewed_array_buffer(&self) -> bool {
         self.is_typed_array() || self.is_data_view()
     }
 
     /// Checks if the object is a `DataView` object.
     #[inline]
+    #[must_use]
     pub const fn is_data_view(&self) -> bool {
         matches!(self.kind, ObjectKind::DataView(_))
     }
 
     /// Checks if the object is a `ArrayBuffer` object.
     #[inline]
+    #[must_use]
     pub const fn is_array_buffer(&self) -> bool {
         matches!(self.kind, ObjectKind::ArrayBuffer(_))
     }
 
     /// Gets the array buffer data if the object is a `ArrayBuffer`.
     #[inline]
+    #[must_use]
     pub const fn as_array_buffer(&self) -> Option<&ArrayBuffer> {
         match &self.kind {
             ObjectKind::ArrayBuffer(buffer) => Some(buffer),
@@ -972,12 +1001,14 @@ impl Object {
 
     /// Checks if the object is a `ArrayIterator` object.
     #[inline]
+    #[must_use]
     pub const fn is_array_iterator(&self) -> bool {
         matches!(self.kind, ObjectKind::ArrayIterator(_))
     }
 
     /// Gets the array-iterator data if the object is a `ArrayIterator`.
     #[inline]
+    #[must_use]
     pub const fn as_array_iterator(&self) -> Option<&ArrayIterator> {
         match self.kind {
             ObjectKind::ArrayIterator(ref iter) => Some(iter),
@@ -1014,6 +1045,7 @@ impl Object {
 
     /// Gets the for-in-iterator data if the object is a `ForInIterator`.
     #[inline]
+    #[must_use]
     pub const fn as_for_in_iterator(&self) -> Option<&ForInIterator> {
         match &self.kind {
             ObjectKind::ForInIterator(iter) => Some(iter),
@@ -1032,12 +1064,14 @@ impl Object {
 
     /// Checks if the object is a `Map` object.
     #[inline]
+    #[must_use]
     pub const fn is_map(&self) -> bool {
         matches!(self.kind, ObjectKind::Map(_))
     }
 
     /// Gets the map data if the object is a `Map`.
     #[inline]
+    #[must_use]
     pub const fn as_map(&self) -> Option<&OrderedMap<JsValue>> {
         match self.kind {
             ObjectKind::Map(ref map) => Some(map),
@@ -1056,12 +1090,14 @@ impl Object {
 
     /// Checks if the object is a `MapIterator` object.
     #[inline]
+    #[must_use]
     pub const fn is_map_iterator(&self) -> bool {
         matches!(self.kind, ObjectKind::MapIterator(_))
     }
 
     /// Gets the map iterator data if the object is a `MapIterator`.
     #[inline]
+    #[must_use]
     pub const fn as_map_iterator_ref(&self) -> Option<&MapIterator> {
         match &self.kind {
             ObjectKind::MapIterator(iter) => Some(iter),
@@ -1080,12 +1116,14 @@ impl Object {
 
     /// Checks if the object is a `Set` object.
     #[inline]
+    #[must_use]
     pub const fn is_set(&self) -> bool {
         matches!(self.kind, ObjectKind::Set(_))
     }
 
     /// Gets the set data if the object is a `Set`.
     #[inline]
+    #[must_use]
     pub const fn as_set(&self) -> Option<&OrderedSet> {
         match self.kind {
             ObjectKind::Set(ref set) => Some(set),
@@ -1104,6 +1142,7 @@ impl Object {
 
     /// Checks if the object is a `SetIterator` object.
     #[inline]
+    #[must_use]
     pub const fn is_set_iterator(&self) -> bool {
         matches!(self.kind, ObjectKind::SetIterator(_))
     }
@@ -1119,12 +1158,14 @@ impl Object {
 
     /// Checks if the object is a `String` object.
     #[inline]
+    #[must_use]
     pub const fn is_string(&self) -> bool {
         matches!(self.kind, ObjectKind::String(_))
     }
 
     /// Gets the string data if the object is a `String`.
     #[inline]
+    #[must_use]
     pub fn as_string(&self) -> Option<JsString> {
         match self.kind {
             ObjectKind::String(ref string) => Some(string.clone()),
@@ -1134,12 +1175,14 @@ impl Object {
 
     /// Checks if the object is a `Function` object.
     #[inline]
+    #[must_use]
     pub const fn is_function(&self) -> bool {
         matches!(self.kind, ObjectKind::Function(_))
     }
 
     /// Gets the function data if the object is a `Function`.
     #[inline]
+    #[must_use]
     pub const fn as_function(&self) -> Option<&Function> {
         match self.kind {
             ObjectKind::Function(ref function) | ObjectKind::GeneratorFunction(ref function) => {
@@ -1161,6 +1204,7 @@ impl Object {
 
     /// Gets the bound function data if the object is a `BoundFunction`.
     #[inline]
+    #[must_use]
     pub const fn as_bound_function(&self) -> Option<&BoundFunction> {
         match self.kind {
             ObjectKind::BoundFunction(ref bound_function) => Some(bound_function),
@@ -1170,12 +1214,14 @@ impl Object {
 
     /// Checks if the object is a `Generator` object.
     #[inline]
+    #[must_use]
     pub const fn is_generator(&self) -> bool {
         matches!(self.kind, ObjectKind::Generator(_))
     }
 
     /// Gets the generator data if the object is a `Generator`.
     #[inline]
+    #[must_use]
     pub const fn as_generator(&self) -> Option<&Generator> {
         match self.kind {
             ObjectKind::Generator(ref generator) => Some(generator),
@@ -1194,12 +1240,14 @@ impl Object {
 
     /// Checks if the object is a `Symbol` object.
     #[inline]
+    #[must_use]
     pub const fn is_symbol(&self) -> bool {
         matches!(self.kind, ObjectKind::Symbol(_))
     }
 
     /// Gets the error data if the object is a `Symbol`.
     #[inline]
+    #[must_use]
     pub fn as_symbol(&self) -> Option<JsSymbol> {
         match self.kind {
             ObjectKind::Symbol(ref symbol) => Some(symbol.clone()),
@@ -1209,12 +1257,14 @@ impl Object {
 
     /// Checks if the object is a `Error` object.
     #[inline]
+    #[must_use]
     pub const fn is_error(&self) -> bool {
         matches!(self.kind, ObjectKind::Error(_))
     }
 
     /// Gets the error data if the object is a `Error`.
     #[inline]
+    #[must_use]
     pub const fn as_error(&self) -> Option<ErrorKind> {
         match self.kind {
             ObjectKind::Error(e) => Some(e),
@@ -1224,12 +1274,14 @@ impl Object {
 
     /// Checks if the object is a `Boolean` object.
     #[inline]
+    #[must_use]
     pub const fn is_boolean(&self) -> bool {
         matches!(self.kind, ObjectKind::Boolean(_))
     }
 
     /// Gets the boolean data if the object is a `Boolean`.
     #[inline]
+    #[must_use]
     pub const fn as_boolean(&self) -> Option<bool> {
         match self.kind {
             ObjectKind::Boolean(boolean) => Some(boolean),
@@ -1239,12 +1291,14 @@ impl Object {
 
     /// Checks if the object is a `Number` object.
     #[inline]
+    #[must_use]
     pub const fn is_number(&self) -> bool {
         matches!(self.kind, ObjectKind::Number(_))
     }
 
     /// Gets the number data if the object is a `Number`.
     #[inline]
+    #[must_use]
     pub const fn as_number(&self) -> Option<f64> {
         match self.kind {
             ObjectKind::Number(number) => Some(number),
@@ -1254,12 +1308,14 @@ impl Object {
 
     /// Checks if the object is a `BigInt` object.
     #[inline]
+    #[must_use]
     pub const fn is_bigint(&self) -> bool {
         matches!(self.kind, ObjectKind::BigInt(_))
     }
 
     /// Gets the bigint data if the object is a `BigInt`.
     #[inline]
+    #[must_use]
     pub const fn as_bigint(&self) -> Option<&JsBigInt> {
         match self.kind {
             ObjectKind::BigInt(ref bigint) => Some(bigint),
@@ -1269,12 +1325,14 @@ impl Object {
 
     /// Checks if the object is a `Date` object.
     #[inline]
+    #[must_use]
     pub const fn is_date(&self) -> bool {
         matches!(self.kind, ObjectKind::Date(_))
     }
 
     /// Gets the date data if the object is a `Date`.
     #[inline]
+    #[must_use]
     pub const fn as_date(&self) -> Option<&Date> {
         match self.kind {
             ObjectKind::Date(ref date) => Some(date),
@@ -1293,12 +1351,14 @@ impl Object {
 
     /// Checks if it a `RegExp` object.
     #[inline]
+    #[must_use]
     pub const fn is_regexp(&self) -> bool {
         matches!(self.kind, ObjectKind::RegExp(_))
     }
 
     /// Gets the regexp data if the object is a regexp.
     #[inline]
+    #[must_use]
     pub const fn as_regexp(&self) -> Option<&RegExp> {
         match self.kind {
             ObjectKind::RegExp(ref regexp) => Some(regexp),
@@ -1308,12 +1368,14 @@ impl Object {
 
     /// Checks if it a `TypedArray` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_array(&self) -> bool {
         matches!(self.kind, ObjectKind::IntegerIndexed(_))
     }
 
     /// Checks if it a `Uint8Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_uint8_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Uint8)
@@ -1324,6 +1386,7 @@ impl Object {
 
     /// Checks if it a `Int8Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_int8_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Int8)
@@ -1334,6 +1397,7 @@ impl Object {
 
     /// Checks if it a `Uint16Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_uint16_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Uint16)
@@ -1344,6 +1408,7 @@ impl Object {
 
     /// Checks if it a `Int16Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_int16_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Int16)
@@ -1354,6 +1419,7 @@ impl Object {
 
     /// Checks if it a `Uint32Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_uint32_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Uint32)
@@ -1364,6 +1430,7 @@ impl Object {
 
     /// Checks if it a `Int32Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_int32_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Int32)
@@ -1374,6 +1441,7 @@ impl Object {
 
     /// Checks if it a `Float32Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_float32_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Float32)
@@ -1384,6 +1452,7 @@ impl Object {
 
     /// Checks if it a `Float64Array` object.
     #[inline]
+    #[must_use]
     pub const fn is_typed_float64_array(&self) -> bool {
         if let ObjectKind::IntegerIndexed(ref int) = self.kind {
             matches!(int.typed_array_name(), TypedArrayKind::Float64)
@@ -1394,6 +1463,7 @@ impl Object {
 
     /// Gets the data view data if the object is a `DataView`.
     #[inline]
+    #[must_use]
     pub const fn as_data_view(&self) -> Option<&DataView> {
         match &self.kind {
             ObjectKind::DataView(data_view) => Some(data_view),
@@ -1412,12 +1482,14 @@ impl Object {
 
     /// Checks if it is an `Arguments` object.
     #[inline]
+    #[must_use]
     pub const fn is_arguments(&self) -> bool {
         matches!(self.kind, ObjectKind::Arguments(_))
     }
 
     /// Gets the mapped arguments data if this is a mapped arguments object.
     #[inline]
+    #[must_use]
     pub const fn as_mapped_arguments(&self) -> Option<&ParameterMap> {
         match self.kind {
             ObjectKind::Arguments(Arguments::Mapped(ref args)) => Some(args),
@@ -1436,6 +1508,7 @@ impl Object {
 
     /// Gets the typed array data (integer indexed object) if this is a typed array.
     #[inline]
+    #[must_use]
     pub const fn as_typed_array(&self) -> Option<&IntegerIndexed> {
         match self.kind {
             ObjectKind::IntegerIndexed(ref integer_indexed_object) => Some(integer_indexed_object),
@@ -1456,18 +1529,21 @@ impl Object {
 
     /// Checks if it an ordinary object.
     #[inline]
+    #[must_use]
     pub const fn is_ordinary(&self) -> bool {
         matches!(self.kind, ObjectKind::Ordinary)
     }
 
     /// Checks if it's an proxy object.
     #[inline]
+    #[must_use]
     pub const fn is_proxy(&self) -> bool {
         matches!(self.kind, ObjectKind::Proxy(_))
     }
 
     /// Gets the proxy data if the object is a `Proxy`.
     #[inline]
+    #[must_use]
     pub const fn as_proxy(&self) -> Option<&Proxy> {
         match self.kind {
             ObjectKind::Proxy(ref proxy) => Some(proxy),
@@ -1486,6 +1562,7 @@ impl Object {
 
     /// Gets the weak map data if the object is a `WeakMap`.
     #[inline]
+    #[must_use]
     pub const fn as_weak_map(&self) -> Option<&boa_gc::WeakMap<VTableObject, JsValue>> {
         match self.kind {
             ObjectKind::WeakMap(ref weak_map) => Some(weak_map),
@@ -1504,6 +1581,7 @@ impl Object {
 
     /// Gets the weak set data if the object is a `WeakSet`.
     #[inline]
+    #[must_use]
     pub const fn as_weak_set(&self) -> Option<&boa_gc::WeakMap<VTableObject, ()>> {
         match self.kind {
             ObjectKind::WeakSet(ref weak_set) => Some(weak_set),
@@ -1522,6 +1600,7 @@ impl Object {
 
     /// Gets the prototype instance of this object.
     #[inline]
+    #[must_use]
     pub fn prototype(&self) -> JsPrototype {
         self.properties.shape.prototype()
     }
@@ -1546,12 +1625,14 @@ impl Object {
 
     /// Returns `true` if it holds an Rust type that implements `NativeObject`.
     #[inline]
+    #[must_use]
     pub const fn is_native_object(&self) -> bool {
         matches!(self.kind, ObjectKind::NativeObject(_))
     }
 
     /// Gets the native object data if the object is a `NativeObject`.
     #[inline]
+    #[must_use]
     pub fn as_native_object(&self) -> Option<&dyn NativeObject> {
         match self.kind {
             ObjectKind::NativeObject(ref object) => Some(object.as_ref()),
@@ -1561,12 +1642,14 @@ impl Object {
 
     /// Checks if it is a `Promise` object.
     #[inline]
+    #[must_use]
     pub const fn is_promise(&self) -> bool {
         matches!(self.kind, ObjectKind::Promise(_))
     }
 
     /// Gets the promise data if the object is a `Promise`.
     #[inline]
+    #[must_use]
     pub const fn as_promise(&self) -> Option<&Promise> {
         match self.kind {
             ObjectKind::Promise(ref promise) => Some(promise),
@@ -1585,6 +1668,7 @@ impl Object {
 
     /// Gets the `WeakRef` data if the object is a `WeakRef`.
     #[inline]
+    #[must_use]
     pub const fn as_weak_ref(&self) -> Option<&WeakGc<VTableObject>> {
         match self.kind {
             ObjectKind::WeakRef(ref weak_ref) => Some(weak_ref),
@@ -1594,6 +1678,7 @@ impl Object {
 
     /// Gets a reference to the module namespace if the object is a `ModuleNamespace`.
     #[inline]
+    #[must_use]
     pub const fn as_module_namespace(&self) -> Option<&ModuleNamespace> {
         match &self.kind {
             ObjectKind::ModuleNamespace(ns) => Some(ns),
@@ -1612,6 +1697,7 @@ impl Object {
 
     /// Gets the `Collator` data if the object is a `Collator`.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn as_collator(&self) -> Option<&Collator> {
         match self.kind {
@@ -1632,6 +1718,7 @@ impl Object {
 
     /// Checks if it is a `Locale` object.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn is_locale(&self) -> bool {
         matches!(self.kind, ObjectKind::Locale(_))
@@ -1639,6 +1726,7 @@ impl Object {
 
     /// Gets the `Locale` data if the object is a `Locale`.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn as_locale(&self) -> Option<&icu_locid::Locale> {
         match self.kind {
@@ -1649,6 +1737,7 @@ impl Object {
 
     /// Gets the `ListFormat` data if the object is a `ListFormat`.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn as_list_format(&self) -> Option<&ListFormat> {
         match self.kind {
@@ -1659,6 +1748,7 @@ impl Object {
 
     /// Checks if it is a `Segmenter` object.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn is_segmenter(&self) -> bool {
         matches!(self.kind, ObjectKind::Segmenter(_))
@@ -1666,6 +1756,7 @@ impl Object {
 
     /// Gets the `Segmenter` data if the object is a `Segmenter`.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn as_segmenter(&self) -> Option<&Segmenter> {
         match self.kind {
@@ -1676,6 +1767,7 @@ impl Object {
 
     /// Gets the `Segments` data if the object is a `Segments`.
     #[inline]
+    #[must_use]
     #[cfg(feature = "intl")]
     pub const fn as_segments(&self) -> Option<&Segments> {
         match self.kind {
@@ -1695,6 +1787,7 @@ impl Object {
     }
 
     /// Return `true` if it is a native object and the native type is `T`.
+    #[must_use]
     pub fn is<T>(&self) -> bool
     where
         T: NativeObject,
@@ -1707,6 +1800,7 @@ impl Object {
 
     /// Downcast a reference to the object,
     /// if the object is type native object type `T`.
+    #[must_use]
     pub fn downcast_ref<T>(&self) -> Option<&T>
     where
         T: NativeObject,
@@ -1733,6 +1827,7 @@ impl Object {
 
     /// Returns the properties of the object.
     #[inline]
+    #[must_use]
     pub const fn properties(&self) -> &PropertyMap {
         &self.properties
     }
@@ -1911,6 +2006,7 @@ impl<'ctx, 'host> FunctionObjectBuilder<'ctx, 'host> {
     }
 
     /// Build the function object.
+    #[must_use]
     pub fn build(self) -> JsFunction {
         let function = Function::new(
             FunctionKind::Native {
@@ -2314,6 +2410,7 @@ impl<'ctx, 'host> ConstructorBuilder<'ctx, 'host> {
     }
 
     /// Build the constructor function object.
+    #[must_use]
     pub fn build(mut self) -> JsFunction {
         // Create the native function
         let function = Function::new(

--- a/boa_engine/src/object/shape/mod.rs
+++ b/boa_engine/src/object/shape/mod.rs
@@ -80,12 +80,14 @@ impl Shape {
 
     /// Returns `true` if it's a shared shape, `false` otherwise.
     #[inline]
+    #[must_use]
     pub const fn is_shared(&self) -> bool {
         matches!(self.inner, Inner::Shared(_))
     }
 
     /// Returns `true` if it's a unique shape, `false` otherwise.
     #[inline]
+    #[must_use]
     pub const fn is_unique(&self) -> bool {
         matches!(self.inner, Inner::Unique(_))
     }
@@ -170,6 +172,7 @@ impl Shape {
     }
 
     /// Get the [`JsPrototype`] of the [`Shape`].
+    #[must_use]
     pub fn prototype(&self) -> JsPrototype {
         match &self.inner {
             Inner::Shared(shape) => shape.prototype(),
@@ -188,6 +191,7 @@ impl Shape {
 
     /// Returns the keys of the [`Shape`], in insertion order.
     #[inline]
+    #[must_use]
     pub fn keys(&self) -> Vec<PropertyKey> {
         match &self.inner {
             Inner::Shared(shape) => shape.keys(),
@@ -197,6 +201,7 @@ impl Shape {
 
     /// Return location in memory of the [`Shape`].
     #[inline]
+    #[must_use]
     pub fn to_addr_usize(&self) -> usize {
         match &self.inner {
             Inner::Shared(shape) => shape.to_addr_usize(),

--- a/boa_engine/src/object/shape/root_shape.rs
+++ b/boa_engine/src/object/shape/root_shape.rs
@@ -21,6 +21,7 @@ impl Default for RootShape {
 
 impl RootShape {
     /// Gets the inner [`SharedShape`].
+    #[must_use]
     pub const fn shape(&self) -> &SharedShape {
         &self.shape
     }

--- a/boa_engine/src/object/shape/shared_shape/mod.rs
+++ b/boa_engine/src/object/shape/shared_shape/mod.rs
@@ -132,14 +132,17 @@ impl SharedShape {
         self.inner.property_count.saturating_sub(1)
     }
     /// Getter for the transition count field.
+    #[must_use]
     pub fn transition_count(&self) -> u16 {
         self.inner.transition_count
     }
     /// Getter for the previous field.
+    #[must_use]
     pub fn previous(&self) -> Option<&Self> {
         self.inner.previous.as_ref()
     }
     /// Get the prototype of the shape.
+    #[must_use]
     pub fn prototype(&self) -> JsPrototype {
         self.inner.prototype.clone()
     }
@@ -161,6 +164,7 @@ impl SharedShape {
         &self.inner.forward_transitions
     }
     /// Check if the shape has the given prototype.
+    #[must_use]
     pub fn has_prototype(&self, prototype: &JsObject) -> bool {
         self.inner
             .prototype

--- a/boa_engine/src/property/mod.rs
+++ b/boa_engine/src/property/mod.rs
@@ -91,6 +91,7 @@ impl PropertyDescriptor {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isaccessordescriptor
     #[inline]
+    #[must_use]
     pub const fn is_accessor_descriptor(&self) -> bool {
         matches!(self.kind, DescriptorKind::Accessor { .. })
     }
@@ -102,6 +103,7 @@ impl PropertyDescriptor {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isdatadescriptor
     #[inline]
+    #[must_use]
     pub const fn is_data_descriptor(&self) -> bool {
         matches!(self.kind, DescriptorKind::Data { .. })
     }
@@ -113,12 +115,14 @@ impl PropertyDescriptor {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-isgenericdescriptor
     #[inline]
+    #[must_use]
     pub const fn is_generic_descriptor(&self) -> bool {
         matches!(self.kind, DescriptorKind::Generic)
     }
 
     /// Returns if the property descriptor is empty.
     #[inline]
+    #[must_use]
     pub const fn is_empty(&self) -> bool {
         self.is_generic_descriptor() && self.enumerable.is_none() && self.configurable.is_none()
     }
@@ -126,6 +130,7 @@ impl PropertyDescriptor {
     /// Returns if the property descriptor is enumerable.
     /// Returns `None` if the `enumerable` field is not set.
     #[inline]
+    #[must_use]
     pub const fn enumerable(&self) -> Option<bool> {
         self.enumerable
     }
@@ -133,6 +138,7 @@ impl PropertyDescriptor {
     /// Returns if the property descriptor is configurable.
     /// Returns `None` if the `configurable` field is not set.
     #[inline]
+    #[must_use]
     pub const fn configurable(&self) -> Option<bool> {
         self.configurable
     }
@@ -140,6 +146,7 @@ impl PropertyDescriptor {
     /// Returns if the property descriptor is writable.
     /// Returns `None` if the `writable` field is not set or the property descriptor is not a data descriptor.
     #[inline]
+    #[must_use]
     pub const fn writable(&self) -> Option<bool> {
         match self.kind {
             DescriptorKind::Data { writable, .. } => writable,
@@ -150,6 +157,7 @@ impl PropertyDescriptor {
     /// Returns the value of the property descriptor.
     /// Returns `None` if the value is not set or the property descriptor is not a data descriptor.
     #[inline]
+    #[must_use]
     pub const fn value(&self) -> Option<&JsValue> {
         match &self.kind {
             DescriptorKind::Data { value, .. } => value.as_ref(),
@@ -160,6 +168,7 @@ impl PropertyDescriptor {
     /// Returns the getter of the property descriptor.
     /// Returns `None` if the getter is not set or the property descriptor is not an accessor descriptor.
     #[inline]
+    #[must_use]
     pub const fn get(&self) -> Option<&JsValue> {
         match &self.kind {
             DescriptorKind::Accessor { get, .. } => get.as_ref(),
@@ -170,6 +179,7 @@ impl PropertyDescriptor {
     /// Returns the setter of the property descriptor.
     /// Returns `None` if the setter is not set or the property descriptor is not an accessor descriptor.
     #[inline]
+    #[must_use]
     pub const fn set(&self) -> Option<&JsValue> {
         match &self.kind {
             DescriptorKind::Accessor { set, .. } => set.as_ref(),
@@ -183,6 +193,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `enumerable` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_enumerable(&self) -> bool {
         self.enumerable
             .expect("[[enumerable]] field not in property descriptor")
@@ -194,6 +205,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `configurable` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_configurable(&self) -> bool {
         self.configurable
             .expect("[[configurable]] field not in property descriptor")
@@ -205,6 +217,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `writable` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_writable(&self) -> bool {
         self.writable()
             .expect("[[writable]] field not in property descriptor")
@@ -216,6 +229,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `value` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_value(&self) -> &JsValue {
         self.value()
             .expect("[[value]] field not in property descriptor")
@@ -227,6 +241,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `getter` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_get(&self) -> &JsValue {
         self.get()
             .expect("[[get]] field not in property descriptor")
@@ -238,6 +253,7 @@ impl PropertyDescriptor {
     ///
     /// Panics if the `setter` field is not set.
     #[inline]
+    #[must_use]
     pub fn expect_set(&self) -> &JsValue {
         self.set()
             .expect("[[set]] field not in property descriptor")
@@ -245,6 +261,7 @@ impl PropertyDescriptor {
 
     /// Returns the kind of the property descriptor.
     #[inline]
+    #[must_use]
     pub const fn kind(&self) -> &DescriptorKind {
         &self.kind
     }
@@ -546,11 +563,13 @@ impl PropertyDescriptorBuilder {
     }
 
     /// Returns a reference to the currently built [`PropertyDescriptor`].
+    #[must_use]
     pub const fn inner(&self) -> &PropertyDescriptor {
         &self.inner
     }
 
     /// Consumes the builder and returns the [`PropertyDescriptor`].
+    #[must_use]
     #[allow(clippy::missing_const_for_fn)]
     pub fn build(self) -> PropertyDescriptor {
         self.inner

--- a/boa_engine/src/realm.rs
+++ b/boa_engine/src/realm.rs
@@ -84,6 +84,7 @@ impl Realm {
     }
 
     /// Gets the intrinsics of this `Realm`.
+    #[must_use]
     pub fn intrinsics(&self) -> &Intrinsics {
         &self.inner.intrinsics
     }

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -54,6 +54,7 @@ struct Inner {
 
 impl Script {
     /// Gets the realm of this script.
+    #[must_use]
     pub fn realm(&self) -> &Realm {
         &self.inner.realm
     }

--- a/boa_engine/src/value/display.rs
+++ b/boa_engine/src/value/display.rs
@@ -251,6 +251,7 @@ pub(crate) fn log_string_from(x: &JsValue, print_internals: bool, print_children
 
 impl JsValue {
     /// A helper function for specifically printing object values
+    #[must_use]
     pub fn display_obj(&self, print_internals: bool) -> String {
         // A simple helper for getting the address of a value
         // TODO: Find a more general place for this, as it can be used in other situations as well

--- a/boa_engine/src/value/equality.rs
+++ b/boa_engine/src/value/equality.rs
@@ -6,6 +6,7 @@ impl JsValue {
     ///
     /// This method is executed when doing strict equality comparisons with the `===` operator.
     /// For more information, check <https://tc39.es/ecma262/#sec-strict-equality-comparison>.
+    #[must_use]
     pub fn strict_equals(&self, other: &Self) -> bool {
         // 1. If Type(x) is different from Type(y), return false.
         if self.get_type() != other.get_type() {
@@ -131,6 +132,7 @@ impl JsValue {
     ///  - [ECMAScript][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-samevalue
+    #[must_use]
     pub fn same_value(x: &Self, y: &Self) -> bool {
         // 1. If Type(x) is different from Type(y), return false.
         if x.get_type() != y.get_type() {
@@ -160,6 +162,7 @@ impl JsValue {
     ///  - [ECMAScript][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-samevaluezero
+    #[must_use]
     pub fn same_value_zero(x: &Self, y: &Self) -> bool {
         if x.get_type() != y.get_type() {
             return false;

--- a/boa_engine/src/value/mod.rs
+++ b/boa_engine/src/value/mod.rs
@@ -133,12 +133,14 @@ impl JsValue {
 
     /// Returns true if the value is an object.
     #[inline]
+    #[must_use]
     pub const fn is_object(&self) -> bool {
         matches!(self, Self::Object(_))
     }
 
     /// Returns the object if the value is object, otherwise `None`.
     #[inline]
+    #[must_use]
     pub const fn as_object(&self) -> Option<&JsObject> {
         match *self {
             Self::Object(ref o) => Some(o),
@@ -153,48 +155,56 @@ impl JsValue {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-iscallable
     #[inline]
+    #[must_use]
     pub fn is_callable(&self) -> bool {
         matches!(self, Self::Object(obj) if obj.is_callable())
     }
 
     /// Returns the callable value if the value is callable, otherwise `None`.
     #[inline]
+    #[must_use]
     pub fn as_callable(&self) -> Option<&JsObject> {
         self.as_object().filter(|obj| obj.is_callable())
     }
 
     /// Returns true if the value is a constructor object.
     #[inline]
+    #[must_use]
     pub fn is_constructor(&self) -> bool {
         matches!(self, Self::Object(obj) if obj.is_constructor())
     }
 
     /// Returns the constructor if the value is a constructor, otherwise `None`.
     #[inline]
+    #[must_use]
     pub fn as_constructor(&self) -> Option<&JsObject> {
         self.as_object().filter(|obj| obj.is_constructor())
     }
 
     /// Returns true if the value is a promise object.
     #[inline]
+    #[must_use]
     pub fn is_promise(&self) -> bool {
         matches!(self, Self::Object(obj) if obj.is_promise())
     }
 
     /// Returns the promise if the value is a promise, otherwise `None`.
     #[inline]
+    #[must_use]
     pub fn as_promise(&self) -> Option<&JsObject> {
         self.as_object().filter(|obj| obj.is_promise())
     }
 
     /// Returns true if the value is a symbol.
     #[inline]
+    #[must_use]
     pub const fn is_symbol(&self) -> bool {
         matches!(self, Self::Symbol(_))
     }
 
     /// Returns the symbol if the value is a symbol, otherwise `None`.
     #[inline]
+    #[must_use]
     pub fn as_symbol(&self) -> Option<JsSymbol> {
         match self {
             Self::Symbol(symbol) => Some(symbol.clone()),
@@ -204,29 +214,34 @@ impl JsValue {
 
     /// Returns true if the value is undefined.
     #[inline]
+    #[must_use]
     pub const fn is_undefined(&self) -> bool {
         matches!(self, Self::Undefined)
     }
 
     /// Returns true if the value is null.
     #[inline]
+    #[must_use]
     pub const fn is_null(&self) -> bool {
         matches!(self, Self::Null)
     }
 
     /// Returns true if the value is null or undefined.
     #[inline]
+    #[must_use]
     pub const fn is_null_or_undefined(&self) -> bool {
         matches!(self, Self::Null | Self::Undefined)
     }
 
     /// Returns true if the value is a 64-bit floating-point number.
     #[inline]
+    #[must_use]
     pub const fn is_double(&self) -> bool {
         matches!(self, Self::Rational(_))
     }
 
     /// Returns true if the value is integer.
+    #[must_use]
     #[allow(clippy::float_cmp)]
     pub fn is_integer(&self) -> bool {
         // If it can fit in a i32 and the truncated version is
@@ -242,12 +257,14 @@ impl JsValue {
 
     /// Returns true if the value is a number.
     #[inline]
+    #[must_use]
     pub const fn is_number(&self) -> bool {
         matches!(self, Self::Rational(_) | Self::Integer(_))
     }
 
     /// Returns the number if the value is a number, otherwise `None`.
     #[inline]
+    #[must_use]
     pub fn as_number(&self) -> Option<f64> {
         match *self {
             Self::Integer(integer) => Some(integer.into()),
@@ -258,12 +275,14 @@ impl JsValue {
 
     /// Returns true if the value is a string.
     #[inline]
+    #[must_use]
     pub const fn is_string(&self) -> bool {
         matches!(self, Self::String(_))
     }
 
     /// Returns the string if the value is a string, otherwise `None`.
     #[inline]
+    #[must_use]
     pub const fn as_string(&self) -> Option<&JsString> {
         match self {
             Self::String(ref string) => Some(string),
@@ -273,12 +292,14 @@ impl JsValue {
 
     /// Returns true if the value is a boolean.
     #[inline]
+    #[must_use]
     pub const fn is_boolean(&self) -> bool {
         matches!(self, Self::Boolean(_))
     }
 
     /// Returns the boolean if the value is a boolean, otherwise `None`.
     #[inline]
+    #[must_use]
     pub const fn as_boolean(&self) -> Option<bool> {
         match self {
             Self::Boolean(boolean) => Some(*boolean),
@@ -288,12 +309,14 @@ impl JsValue {
 
     /// Returns true if the value is a bigint.
     #[inline]
+    #[must_use]
     pub const fn is_bigint(&self) -> bool {
         matches!(self, Self::BigInt(_))
     }
 
     /// Returns an optional reference to a `BigInt` if the value is a `BigInt` primitive.
     #[inline]
+    #[must_use]
     pub const fn as_bigint(&self) -> Option<&JsBigInt> {
         match self {
             Self::BigInt(bigint) => Some(bigint),
@@ -307,6 +330,7 @@ impl JsValue {
     ///  - [ECMAScript][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-toboolean
+    #[must_use]
     pub fn to_boolean(&self) -> bool {
         match *self {
             Self::Symbol(_) | Self::Object(_) => true,
@@ -430,6 +454,7 @@ impl JsValue {
     ///
     /// println!("{}", value.display());
     /// ```
+    #[must_use]
     #[inline]
     pub const fn display(&self) -> ValueDisplay<'_> {
         ValueDisplay {
@@ -929,6 +954,7 @@ impl JsValue {
     /// - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typeof-operator
+    #[must_use]
     pub fn type_of(&self) -> &'static str {
         match *self {
             Self::Rational(_) | Self::Integer(_) => "number",

--- a/boa_engine/src/value/type.rs
+++ b/boa_engine/src/value/type.rs
@@ -35,6 +35,7 @@ impl JsValue {
     /// <https://tc39.es/ecma262/multipage/ecmascript-data-types-and-values.html#sec-ecmascript-language-types>.
     ///
     /// Check [`JsValue::type_of`] if you need to call the `typeof` operator.
+    #[must_use]
     pub const fn get_type(&self) -> Type {
         match *self {
             Self::Rational(_) | Self::Integer(_) => Type::Number,

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -57,6 +57,7 @@ pub struct CallFrame {
 impl CallFrame {
     /// Retrieves the [`CodeBlock`] of this call frame.
     #[inline]
+    #[must_use]
     pub const fn code_block(&self) -> &Gc<CodeBlock> {
         &self.code_block
     }


### PR DESCRIPTION
Following up to re-enable `must_use` clippy rule for boa_engine which was disabled in #3109.

I gave an exception to `set_prototype` because it returns false when it's not extensible but there are some code already checking if it's extensible, so they don't need to check the return value, and it looks like that's a common pattern.