### PR TITLE
Fix remaining TypedArray bugs

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -66,6 +66,18 @@ impl IntrinsicObject for Array {
         .name("values")
         .build();
 
+        let to_string_function = BuiltInBuilder::callable_with_object(
+            realm,
+            realm
+                .intrinsics()
+                .objects()
+                .array_prototype_to_string()
+                .into(),
+            Self::to_string,
+        )
+        .name("toString")
+        .build();
+
         let unscopables_object = Self::unscopables_object();
 
         BuiltInBuilder::from_standard_constructor::<Self>(realm)
@@ -107,7 +119,11 @@ impl IntrinsicObject for Array {
             .method(Self::filter, "filter", 1)
             .method(Self::pop, "pop", 0)
             .method(Self::join, "join", 1)
-            .method(Self::to_string, "toString", 0)
+            .property(
+                utf16!("toString"),
+                to_string_function,
+                Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
+            )
             .method(Self::reverse, "reverse", 0)
             .method(Self::shift, "shift", 0)
             .method(Self::unshift, "unshift", 1)

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -821,6 +821,9 @@ pub struct IntrinsicObjects {
     /// [`%Array.prototype.values%`](https://tc39.es/ecma262/#sec-array.prototype.values)
     array_prototype_values: JsFunction,
 
+    /// [`%Array.prototype.toString%`](https://tc39.es/ecma262/#sec-array.prototype.tostring)
+    array_prototype_to_string: JsFunction,
+
     /// Cached iterator prototypes.
     iterator_prototypes: IteratorPrototypes,
 
@@ -873,6 +876,7 @@ impl Default for IntrinsicObjects {
             json: JsObject::default(),
             throw_type_error: JsFunction::empty_intrinsic_function(false),
             array_prototype_values: JsFunction::empty_intrinsic_function(false),
+            array_prototype_to_string: JsFunction::empty_intrinsic_function(false),
             iterator_prototypes: IteratorPrototypes::default(),
             generator: JsObject::default(),
             async_generator: JsObject::default(),
@@ -904,13 +908,22 @@ impl IntrinsicObjects {
         self.throw_type_error.clone()
     }
 
-    /// Gets the [`%Array.prototype.values%`][spec] intrinsic object.
+    /// Gets the [`%Array.prototype.values%`][spec] intrinsic function.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.values
     #[inline]
     #[must_use]
     pub fn array_prototype_values(&self) -> JsFunction {
         self.array_prototype_values.clone()
+    }
+
+    /// Gets the [`%Array.prototype.toString%`][spec] intrinsic function.
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-array.prototype.tostring
+    #[inline]
+    #[must_use]
+    pub fn array_prototype_to_string(&self) -> JsFunction {
+        self.array_prototype_to_string.clone()
     }
 
     /// Gets the cached iterator prototypes.

--- a/boa_engine/src/object/internal_methods/integer_indexed.rs
+++ b/boa_engine/src/object/internal_methods/integer_indexed.rs
@@ -422,7 +422,7 @@ fn integer_indexed_element_get(obj: &JsObject, index: f64) -> Option<JsValue> {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-integerindexedelementset
-fn integer_indexed_element_set(
+pub(crate) fn integer_indexed_element_set(
     obj: &JsObject,
     index: f64,
     value: &JsValue,

--- a/boa_engine/src/object/internal_methods/mod.rs
+++ b/boa_engine/src/object/internal_methods/mod.rs
@@ -26,6 +26,7 @@ pub(super) mod proxy;
 pub(super) mod string;
 
 pub(crate) use array::ARRAY_EXOTIC_INTERNAL_METHODS;
+pub(crate) use integer_indexed::integer_indexed_element_set;
 
 impl JsObject {
     /// Internal method `[[GetPrototypeOf]]`


### PR DESCRIPTION
This Pull Request fixes the remaining TypedArray bugs.

It changes the following:

- Use the same object for `Array.prototype.toString` and `TypedArray.prototype.toString`.
- Refactor `SetTypedArrayFromArrayLike` to conform to the spec.
- Refactor `TypedArray.prototype.sort` to conform to the spec.
- Add a `U64OrPositiveInfinity` enum to remove some unreachable branches in `TypedArray.prototype.set`.
- Implement `TypedArray.prototype.toLocaleString`.
