### PR TITLE
Implement `String.prototype.isWellFormed` and `String.prototype.toWellFormed`

### DIFF
--- a/test_ignore.toml
+++ b/test_ignore.toml
@@ -9,8 +9,6 @@ features = [
     "IsHTMLDDA",
     "Atomics",
     "change-array-by-copy",
-    "String.prototype.isWellFormed",
-    "String.prototype.toWellFormed",
     "symbols-as-weakmap-keys",
     "intl-normative-optional",
     "Intl.DisplayNames",


### PR DESCRIPTION
This Pull Request changes the following:

- Implement `String.prototype.isWellFormed` and `String.prototype.toWellFormed`
