### PR TITLE
Improve bytecompiler bytecode generation.

### DIFF
--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -1,4 +1,4 @@
-use super::{ByteCompiler, Literal};
+use super::{ByteCompiler, Literal, Operand};
 use crate::vm::{BindingOpcode, CodeBlockFlags, Opcode};
 use boa_ast::{
     expression::Identifier,
@@ -78,8 +78,10 @@ impl ByteCompiler<'_, '_> {
         let code = Gc::new(compiler.finish());
         let index = self.functions.len() as u32;
         self.functions.push(code);
-        self.emit(Opcode::GetFunction, &[index]);
-        self.emit_u8(0);
+        self.emit(
+            Opcode::GetFunction,
+            &[Operand::U32(index), Operand::Bool(false)],
+        );
 
         let class_env: Option<super::Label> = match class.name() {
             Some(name) if class.has_binding_identifier() => {
@@ -127,7 +129,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticGetterByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticGetterByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -140,7 +145,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticSetterByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticSetterByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -153,7 +161,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -166,7 +177,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -179,7 +193,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -192,7 +209,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassStaticMethodByName, &[index]);
+                                self.emit(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    &[Operand::U32(index)],
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -210,32 +230,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateGetter, &[index]);
+                            self.emit(Opcode::SetPrivateGetter, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateSetter, &[index]);
+                            self.emit(Opcode::SetPrivateSetter, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[index]);
+                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[index]);
+                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[index]);
+                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[index]);
+                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
                         }
                     }
                 }
@@ -277,8 +297,10 @@ impl ByteCompiler<'_, '_> {
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
-                    self.emit(Opcode::GetFunction, &[index]);
-                    self.emit_u8(0);
+                    self.emit(
+                        Opcode::GetFunction,
+                        &[Operand::U32(index), Operand::Bool(false)],
+                    );
                     self.emit_opcode(Opcode::PushClassField);
                 }
                 ClassElement::PrivateFieldDefinition(name, field) => {
@@ -310,9 +332,11 @@ impl ByteCompiler<'_, '_> {
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
-                    self.emit(Opcode::GetFunction, &[index]);
-                    self.emit_u8(0);
-                    self.emit(Opcode::PushClassFieldPrivate, &[name_index]);
+                    self.emit(
+                        Opcode::GetFunction,
+                        &[Operand::U32(index), Operand::Bool(false)],
+                    );
+                    self.emit(Opcode::PushClassFieldPrivate, &[Operand::U32(name_index)]);
                 }
                 ClassElement::StaticFieldDefinition(name, field) => {
                     self.emit_opcode(Opcode::Dup);
@@ -353,12 +377,14 @@ impl ByteCompiler<'_, '_> {
                     let code = Gc::new(code);
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
-                    self.emit(Opcode::GetFunction, &[index]);
-                    self.emit_u8(0);
+                    self.emit(
+                        Opcode::GetFunction,
+                        &[Operand::U32(index), Operand::Bool(false)],
+                    );
                     self.emit_opcode(Opcode::SetHomeObjectClass);
-                    self.emit(Opcode::Call, &[0]);
+                    self.emit(Opcode::Call, &[Operand::U32(0)]);
                     if let Some(name_index) = name_index {
-                        self.emit(Opcode::DefineOwnPropertyByName, &[name_index]);
+                        self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(name_index)]);
                     } else {
                         self.emit_opcode(Opcode::DefineOwnPropertyByValue);
                     }
@@ -371,7 +397,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::PushUndefined);
                     }
                     let index = self.get_or_insert_private_name(*name);
-                    self.emit(Opcode::DefinePrivateField, &[index]);
+                    self.emit(Opcode::DefinePrivateField, &[Operand::U32(index)]);
                 }
                 ClassElement::StaticBlock(body) => {
                     self.emit_opcode(Opcode::Dup);
@@ -401,10 +427,12 @@ impl ByteCompiler<'_, '_> {
                     let code = Gc::new(compiler.finish());
                     let index = self.functions.len() as u32;
                     self.functions.push(code);
-                    self.emit(Opcode::GetFunction, &[index]);
-                    self.emit_u8(0);
+                    self.emit(
+                        Opcode::GetFunction,
+                        &[Operand::U32(index), Operand::Bool(false)],
+                    );
                     self.emit_opcode(Opcode::SetHomeObjectClass);
-                    self.emit(Opcode::Call, &[0]);
+                    self.emit(Opcode::Call, &[Operand::U32(0)]);
                     self.emit_opcode(Opcode::Pop);
                 }
                 // TODO: set names for private methods
@@ -414,32 +442,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateGetter, &[index]);
+                            self.emit(Opcode::PushClassPrivateGetter, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateSetter, &[index]);
+                            self.emit(Opcode::PushClassPrivateSetter, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[index]);
+                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[index]);
+                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[index]);
+                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[index]);
+                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
                         }
                     }
                 }
@@ -459,7 +487,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassGetterByName, &[index]);
+                                self.emit(Opcode::DefineClassGetterByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -472,7 +500,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassSetterByName, &[index]);
+                                self.emit(Opcode::DefineClassSetterByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -485,7 +513,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -498,7 +526,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -511,7 +539,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -524,7 +552,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[index]);
+                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bytecompiler::{Access, ByteCompiler, Literal},
+    bytecompiler::{Access, ByteCompiler, Literal, Operand},
     vm::{BindingOpcode, Opcode},
 };
 use boa_ast::{
@@ -40,7 +40,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[index]);
+                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -80,7 +80,10 @@ impl ByteCompiler<'_, '_> {
 
                             self.emit(
                                 Opcode::CopyDataProperties,
-                                &[excluded_keys.len() as u32, additional_excluded_keys_count],
+                                &[
+                                    Operand::U32(excluded_keys.len() as u32),
+                                    Operand::U32(additional_excluded_keys_count),
+                                ],
                             );
                             self.emit_binding(def, *ident);
                         }
@@ -95,7 +98,10 @@ impl ByteCompiler<'_, '_> {
                                     self.interner().resolve_expect(key.sym()).into_common(false),
                                 ));
                             }
-                            self.emit(Opcode::CopyDataProperties, &[excluded_keys.len() as u32, 0]);
+                            self.emit(
+                                Opcode::CopyDataProperties,
+                                &[Operand::U32(excluded_keys.len() as u32), Operand::U32(0)],
+                            );
                             self.access_set(
                                 Access::Property { access },
                                 false,
@@ -112,7 +118,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[index]);
+                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -152,7 +158,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[index]);
+                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bytecompiler::{Access, ByteCompiler},
+    bytecompiler::{Access, ByteCompiler, Operand},
     environments::BindingLocatorError,
     vm::{BindingOpcode, Opcode},
 };
@@ -60,9 +60,9 @@ impl ByteCompiler<'_, '_> {
                     let lex = self.current_environment.is_lex_binding(name);
 
                     if lex {
-                        self.emit(Opcode::GetName, &[index]);
+                        self.emit(Opcode::GetName, &[Operand::U32(index)]);
                     } else {
-                        self.emit(Opcode::GetNameAndLocator, &[index]);
+                        self.emit(Opcode::GetNameAndLocator, &[Operand::U32(index)]);
                     }
 
                     if short_circuit {
@@ -79,14 +79,14 @@ impl ByteCompiler<'_, '_> {
                         match self.set_mutable_binding(name) {
                             Ok(binding) => {
                                 let index = self.get_or_insert_binding(binding);
-                                self.emit(Opcode::SetName, &[index]);
+                                self.emit(Opcode::SetName, &[Operand::U32(index)]);
                             }
                             Err(BindingLocatorError::MutateImmutable) => {
                                 let index = self.get_or_insert_name(name);
-                                self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                                self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
                             }
                             Err(BindingLocatorError::Silent) => {
-                                self.emit(Opcode::Pop, &[]);
+                                self.emit_opcode(Opcode::Pop);
                             }
                         }
                     } else {
@@ -102,7 +102,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
 
-                            self.emit(Opcode::GetPropertyByName, &[index]);
+                            self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -112,7 +112,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit(Opcode::SetPropertyByName, &[index]);
+                            self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }
@@ -145,7 +145,7 @@ impl ByteCompiler<'_, '_> {
                         self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit(Opcode::GetPrivateField, &[index]);
+                        self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
                         if short_circuit {
                             pop_count = 1;
                             early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -155,7 +155,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(opcode);
                         }
 
-                        self.emit(Opcode::SetPrivateField, &[index]);
+                        self.emit(Opcode::SetPrivateField, &[Operand::U32(index)]);
                         if !use_expr {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -169,7 +169,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Swap);
                             self.emit_opcode(Opcode::This);
 
-                            self.emit(Opcode::GetPropertyByName, &[index]);
+                            self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -179,7 +179,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit(Opcode::SetPropertyByName, &[index]);
+                            self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }
@@ -201,8 +201,7 @@ impl ByteCompiler<'_, '_> {
                             }
 
                             self.emit_opcode(Opcode::This);
-                            self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(2);
+                            self.emit(Opcode::RotateRight, &[Operand::U8(2)]);
 
                             self.emit_opcode(Opcode::SetPropertyByValue);
                             if !use_expr {

--- a/boa_engine/src/bytecompiler/expression/binary.rs
+++ b/boa_engine/src/bytecompiler/expression/binary.rs
@@ -3,7 +3,10 @@ use boa_ast::expression::operator::{
     Binary, BinaryInPrivate,
 };
 
-use crate::{bytecompiler::ByteCompiler, vm::Opcode};
+use crate::{
+    bytecompiler::{ByteCompiler, Operand},
+    vm::Opcode,
+};
 
 impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary(&mut self, binary: &Binary, use_expr: bool) {
@@ -21,7 +24,7 @@ impl ByteCompiler<'_, '_> {
                 }
 
                 if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
+                    self.emit_opcode(Opcode::Pop);
                 }
             }
             BinaryOp::Bitwise(op) => {
@@ -36,7 +39,7 @@ impl ByteCompiler<'_, '_> {
                 }
 
                 if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
+                    self.emit_opcode(Opcode::Pop);
                 }
             }
             BinaryOp::Relational(op) => {
@@ -57,7 +60,7 @@ impl ByteCompiler<'_, '_> {
                 }
 
                 if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
+                    self.emit_opcode(Opcode::Pop);
                 }
             }
             BinaryOp::Logical(op) => {
@@ -80,15 +83,15 @@ impl ByteCompiler<'_, '_> {
                 };
 
                 if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
+                    self.emit_opcode(Opcode::Pop);
                 }
             }
             BinaryOp::Comma => {
-                self.emit(Opcode::Pop, &[]);
+                self.emit_opcode(Opcode::Pop);
                 self.compile_expr(binary.rhs(), true);
 
                 if !use_expr {
-                    self.emit(Opcode::Pop, &[]);
+                    self.emit_opcode(Opcode::Pop);
                 }
             }
         };
@@ -97,7 +100,7 @@ impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary_in_private(&mut self, binary: &BinaryInPrivate, use_expr: bool) {
         let index = self.get_or_insert_private_name(*binary.lhs());
         self.compile_expr(binary.rhs(), true);
-        self.emit(Opcode::InPrivate, &[index]);
+        self.emit(Opcode::InPrivate, &[Operand::U32(index)]);
 
         if !use_expr {
             self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -4,7 +4,7 @@ use boa_ast::{
 };
 
 use crate::{
-    bytecompiler::{Access, ByteCompiler},
+    bytecompiler::{Access, ByteCompiler, Operand},
     vm::Opcode,
 };
 
@@ -29,7 +29,7 @@ impl ByteCompiler<'_, '_> {
                     Expression::Identifier(identifier) => {
                         let binding = self.get_binding_value(*identifier);
                         let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::GetNameOrUndefined, &[index]);
+                        self.emit(Opcode::GetNameOrUndefined, &[Operand::U32(index)]);
                     }
                     expr => self.compile_expr(expr, true),
                 }
@@ -45,7 +45,7 @@ impl ByteCompiler<'_, '_> {
         }
 
         if !use_expr {
-            self.emit(Opcode::Pop, &[]);
+            self.emit_opcode(Opcode::Pop);
         }
     }
 }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bytecompiler::{Access, ByteCompiler},
+    bytecompiler::{Access, ByteCompiler, Operand},
     environments::BindingLocatorError,
     vm::Opcode,
 };
@@ -28,9 +28,9 @@ impl ByteCompiler<'_, '_> {
                 let lex = self.current_environment.is_lex_binding(name);
 
                 if lex {
-                    self.emit(Opcode::GetName, &[index]);
+                    self.emit(Opcode::GetName, &[Operand::U32(index)]);
                 } else {
-                    self.emit(Opcode::GetNameAndLocator, &[index]);
+                    self.emit(Opcode::GetNameAndLocator, &[Operand::U32(index)]);
                 }
 
                 self.emit_opcode(opcode);
@@ -44,14 +44,14 @@ impl ByteCompiler<'_, '_> {
                     match self.set_mutable_binding(name) {
                         Ok(binding) => {
                             let index = self.get_or_insert_binding(binding);
-                            self.emit(Opcode::SetName, &[index]);
+                            self.emit(Opcode::SetName, &[Operand::U32(index)]);
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
-                            self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                            self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
                         }
                         Err(BindingLocatorError::Silent) => {
-                            self.emit(Opcode::Pop, &[]);
+                            self.emit_opcode(Opcode::Pop);
                         }
                     }
                 } else {
@@ -67,14 +67,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit(Opcode::GetPropertyByName, &[index]);
+                        self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                         self.emit_opcode(opcode);
                         if post {
-                            self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(4);
+                            self.emit(Opcode::RotateRight, &[Operand::U8(4)]);
                         }
 
-                        self.emit(Opcode::SetPropertyByName, &[index]);
+                        self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -89,8 +88,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::GetPropertyByValuePush);
                         self.emit_opcode(opcode);
                         if post {
-                            self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(5);
+                            self.emit(Opcode::RotateRight, &[Operand::U8(5)]);
                         }
 
                         self.emit_opcode(Opcode::SetPropertyByValue);
@@ -104,14 +102,13 @@ impl ByteCompiler<'_, '_> {
                     self.compile_expr(access.target(), true);
                     self.emit_opcode(Opcode::Dup);
 
-                    self.emit(Opcode::GetPrivateField, &[index]);
+                    self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
                     self.emit_opcode(opcode);
                     if post {
-                        self.emit_opcode(Opcode::RotateRight);
-                        self.emit_u8(3);
+                        self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                     }
 
-                    self.emit(Opcode::SetPrivateField, &[index]);
+                    self.emit(Opcode::SetPrivateField, &[Operand::U32(index)]);
                     if post {
                         self.emit_opcode(Opcode::Pop);
                     }
@@ -125,14 +122,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Swap);
                         self.emit_opcode(Opcode::This);
 
-                        self.emit(Opcode::GetPropertyByName, &[index]);
+                        self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
                         self.emit_opcode(opcode);
                         if post {
-                            self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(3);
+                            self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                         }
 
-                        self.emit(Opcode::SetPropertyByName, &[index]);
+                        self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -146,13 +142,11 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::GetPropertyByValuePush);
                         self.emit_opcode(opcode);
                         if post {
-                            self.emit_opcode(Opcode::RotateRight);
-                            self.emit_u8(2);
+                            self.emit(Opcode::RotateRight, &[Operand::U8(2)]);
                         }
 
                         self.emit_opcode(Opcode::This);
-                        self.emit_opcode(Opcode::RotateRight);
-                        self.emit_u8(2);
+                        self.emit(Opcode::RotateRight, &[Operand::U8(2)]);
 
                         self.emit_opcode(Opcode::SetPropertyByValue);
                         if post {

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -551,8 +551,14 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         if f64::from(value as i32).to_bits() == value.to_bits() {
             self.emit_push_integer(value as i32);
         } else {
-            self.emit_opcode(Opcode::PushRational);
-            self.emit_u64(value.to_bits());
+            let f32_value = value as f32;
+
+            #[allow(clippy::float_cmp)]
+            if f64::from(f32_value) == value {
+                self.emit(Opcode::PushFloat, &[Operand::U32(f32_value.to_bits())]);
+            } else {
+                self.emit(Opcode::PushDouble, &[Operand::U64(value.to_bits())]);
+            }
         }
     }
 

--- a/boa_engine/src/bytecompiler/module.rs
+++ b/boa_engine/src/bytecompiler/module.rs
@@ -1,6 +1,6 @@
 use crate::vm::{BindingOpcode, Opcode};
 
-use super::{ByteCompiler, Literal};
+use super::{ByteCompiler, Literal, Operand};
 use boa_ast::{declaration::ExportDeclaration, expression::Identifier, ModuleItem, ModuleItemList};
 use boa_interner::Sym;
 
@@ -63,8 +63,7 @@ impl ByteCompiler<'_, '_> {
                                 .into_common(false);
                             self.emit_push_literal(Literal::String(default));
                             self.emit_opcode(Opcode::Swap);
-                            self.emit_opcode(Opcode::SetFunctionName);
-                            self.emit_u8(0);
+                            self.emit(Opcode::SetFunctionName, &[Operand::U8(0)]);
                         }
 
                         self.emit_binding(BindingOpcode::InitLet, name);

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -9,7 +9,7 @@ use boa_ast::{
 use boa_interner::Sym;
 
 use crate::{
-    bytecompiler::{Access, ByteCompiler},
+    bytecompiler::{Access, ByteCompiler, Operand},
     environments::BindingLocatorError,
     vm::{BindingOpcode, Opcode},
 };
@@ -69,13 +69,13 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(let_binding_indices) = let_binding_indices {
             for index in &let_binding_indices {
-                self.emit(Opcode::GetName, &[*index]);
+                self.emit(Opcode::GetName, &[Operand::U32(*index)]);
             }
             self.emit_opcode(Opcode::PopEnvironment);
             iteration_env_labels =
                 Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
             for index in let_binding_indices.iter().rev() {
-                self.emit(Opcode::PutLexicalValue, &[*index]);
+                self.emit(Opcode::PutLexicalValue, &[Operand::U32(*index)]);
             }
         }
 
@@ -96,7 +96,7 @@ impl ByteCompiler<'_, '_> {
 
         self.compile_stmt(for_loop.body(), use_expr, true);
 
-        self.emit(Opcode::Jump, &[start_address]);
+        self.emit(Opcode::Jump, &[Operand::U32(start_address)]);
 
         self.patch_jump(exit);
         self.pop_loop_control_info();
@@ -225,7 +225,7 @@ impl ByteCompiler<'_, '_> {
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
-        self.emit(Opcode::Jump, &[start_address]);
+        self.emit(Opcode::Jump, &[Operand::U32(start_address)]);
 
         self.patch_jump(exit);
         self.pop_loop_control_info();
@@ -303,14 +303,14 @@ impl ByteCompiler<'_, '_> {
                 match self.set_mutable_binding(*ident) {
                     Ok(binding) => {
                         let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::DefInitVar, &[index]);
+                        self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
                     }
                     Err(BindingLocatorError::MutateImmutable) => {
                         let index = self.get_or_insert_name(*ident);
-                        self.emit(Opcode::ThrowMutateImmutable, &[index]);
+                        self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
                     }
                     Err(BindingLocatorError::Silent) => {
-                        self.emit(Opcode::Pop, &[]);
+                        self.emit_opcode(Opcode::Pop);
                     }
                 }
             }
@@ -394,7 +394,7 @@ impl ByteCompiler<'_, '_> {
             self.emit_opcode(Opcode::PopEnvironment);
         }
 
-        self.emit(Opcode::Jump, &[start_address]);
+        self.emit(Opcode::Jump, &[Operand::U32(start_address)]);
 
         self.patch_jump(exit);
         self.pop_loop_control_info();
@@ -417,7 +417,7 @@ impl ByteCompiler<'_, '_> {
 
         self.compile_stmt(while_loop.body(), use_expr, true);
 
-        self.emit(Opcode::Jump, &[start_address]);
+        self.emit(Opcode::Jump, &[Operand::U32(start_address)]);
 
         self.patch_jump(exit);
         self.pop_loop_control_info();
@@ -444,7 +444,7 @@ impl ByteCompiler<'_, '_> {
 
         self.compile_stmt(do_while_loop.body(), use_expr, true);
 
-        self.emit(Opcode::Jump, &[condition_label_address]);
+        self.emit(Opcode::Jump, &[Operand::U32(condition_label_address)]);
         self.patch_jump(exit);
 
         self.pop_loop_control_info();

--- a/boa_engine/src/module/source.rs
+++ b/boa_engine/src/module/source.rs
@@ -22,7 +22,7 @@ use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
 use crate::{
     builtins::{promise::PromiseCapability, Promise},
-    bytecompiler::{ByteCompiler, FunctionSpec},
+    bytecompiler::{ByteCompiler, FunctionSpec, Operand},
     environments::{BindingLocator, CompileTimeEnvironment, EnvironmentStack},
     module::ModuleKind,
     object::{FunctionObjectBuilder, JsPromise, RecursionLimiter},
@@ -1501,7 +1501,7 @@ impl SourceTextModule {
                         let binding = compiler.initialize_mutable_binding(name, false);
                         let index = compiler.get_or_insert_binding(binding);
                         compiler.emit_opcode(Opcode::PushUndefined);
-                        compiler.emit(Opcode::DefInitVar, &[index]);
+                        compiler.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
                         // 3. Append dn to declaredVarNames.
                         declared_var_names.push(name);
                     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -340,7 +340,12 @@ impl CodeBlock {
                 *pc += size_of::<i32>();
                 result
             }
-            Opcode::PushRational => {
+            Opcode::PushFloat => {
+                let operand = self.read::<f32>(*pc);
+                *pc += size_of::<f32>();
+                ryu_js::Buffer::new().format(operand).to_string()
+            }
+            Opcode::PushDouble => {
                 let operand = self.read::<f64>(*pc);
                 *pc += size_of::<f64>();
                 ryu_js::Buffer::new().format(operand).to_string()
@@ -676,8 +681,7 @@ impl CodeBlock {
             | Opcode::Reserved55
             | Opcode::Reserved56
             | Opcode::Reserved57
-            | Opcode::Reserved58
-            | Opcode::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
+            | Opcode::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -84,7 +84,13 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Opcode::PushRational => {
+                Opcode::PushFloat => {
+                    pc += size_of::<f32>();
+
+                    graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
+                    graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
+                }
+                Opcode::PushDouble => {
                     pc += size_of::<f64>();
 
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
@@ -611,8 +617,7 @@ impl CodeBlock {
                 | Opcode::Reserved55
                 | Opcode::Reserved56
                 | Opcode::Reserved57
-                | Opcode::Reserved58
-                | Opcode::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
+                | Opcode::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -249,12 +249,19 @@ generate_impl! {
         /// Stack: **=>** value
         PushInt32,
 
+        /// Push `f32` value on the stack.
+        ///
+        /// Operands: value: `f32`
+        ///
+        /// Stack: **=>** value
+        PushFloat,
+
         /// Push `f64` value on the stack.
         ///
         /// Operands: value: `f64`
         ///
         /// Stack: **=>** value
-        PushRational,
+        PushDouble,
 
         /// Push `NaN` integer on the stack.
         ///
@@ -1788,8 +1795,6 @@ generate_impl! {
         Reserved57 => Reserved,
         /// Reserved [`Opcode`].
         Reserved58 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved59 => Reserved,
     }
 }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1255,7 +1255,7 @@ generate_impl! {
 
         /// Get function from the pre-compiled inner functions.
         ///
-        /// Operands: address: `u32`, method: `u8`
+        /// Operands: address: `u32`, is_method: `u8`
         ///
         /// Stack: **=>** func
         GetFunction,

--- a/boa_engine/src/vm/opcode/push/numbers.rs
+++ b/boa_engine/src/vm/opcode/push/numbers.rs
@@ -51,4 +51,5 @@ implement_push_numbers_with_conversion!(PushInt8, i8, "Push `i8` value on the st
 implement_push_numbers_with_conversion!(PushInt16, i16, "Push `i16` value on the stack");
 
 implement_push_numbers_no_conversion!(PushInt32, i32, "Push `i32` value on the stack");
-implement_push_numbers_no_conversion!(PushRational, f64, "Push `f64` value on the stack");
+implement_push_numbers_no_conversion!(PushFloat, f32, "Push `f64` value on the stack");
+implement_push_numbers_no_conversion!(PushDouble, f64, "Push `f64` value on the stack");


### PR DESCRIPTION
This PR adds the `Operand` enum (which represents an instruction operand), and makes `ByteCompiler::emit` take an array of `Operand`s instead of `u32` which allows to emit varying length operands more easily.
