### PR TITLE
Log traces even without message (boa_runtime)

### DIFF
--- a/boa_runtime/src/console/mod.rs
+++ b/boa_runtime/src/console/mod.rs
@@ -354,17 +354,17 @@ impl Console {
     ) -> JsResult<JsValue> {
         if !args.is_empty() {
             logger(LogMessage::Log(formatter(args, context)?), console);
-
-            let stack_trace_dump = context
-                .stack_trace()
-                .map(|frame| frame.code_block().name())
-                .collect::<Vec<_>>()
-                .into_iter()
-                .map(JsString::to_std_string_escaped)
-                .collect::<Vec<_>>()
-                .join("\n");
-            logger(LogMessage::Log(stack_trace_dump), console);
         }
+
+        let stack_trace_dump = context
+            .stack_trace()
+            .map(|frame| frame.code_block().name())
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(JsString::to_std_string_escaped)
+            .collect::<Vec<_>>()
+            .join("\n");
+        logger(LogMessage::Log(stack_trace_dump), console);
 
         Ok(JsValue::undefined())
     }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes boa_runtime console.trace not printing the trace if no argument is given.

It changes the following:
- Change the if statement scope in the trace function of Console
