### PR TITLE
Optimization fast local variables

### DIFF
--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -912,6 +912,14 @@ impl ByteCompiler<'_, '_> {
             }
         }
 
+        if self.can_optimize_local_variables
+            && !self
+                .flags
+                .contains(super::ByteCompilerFlags::USES_ARGUMENTS)
+        {
+            arguments_object_needed = false;
+        }
+
         // 19. If strict is true or hasParameterExpressions is false, then
         //     a. NOTE: Only a single Environment Record is needed for the parameters,
         //        since calls to eval in strict mode code cannot create new bindings which are visible outside of the eval.

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -932,8 +932,11 @@ impl ByteCompiler<'_, '_> {
             // c. Let env be NewDeclarativeEnvironment(calleeEnv).
             // d. Assert: The VariableEnvironment of calleeContext is calleeEnv.
             // e. Set the LexicalEnvironment of calleeContext to env.
-            let _ = self.push_compile_environment(false);
-            additional_env = true;
+
+            if self.can_optimize_local_variables {
+                let _ = self.push_compile_environment(false);
+                additional_env = true;
+            }
         }
 
         // 22. If argumentsObjectNeeded is true, then

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bytecompiler::{Access, ByteCompiler, Operand},
+    bytecompiler::{Access, ByteCompiler, EnvironmentAccess, Operand},
     environments::BindingLocatorError,
     vm::{BindingOpcode, Opcode},
 };
@@ -56,14 +56,26 @@ impl ByteCompiler<'_, '_> {
             match access {
                 Access::Variable { name } => {
                     let binding = self.get_binding_value(name);
-                    let index = self.get_or_insert_binding(binding);
                     let lex = self.current_environment.is_lex_binding(name);
 
-                    if lex {
-                        self.emit_with_varying_operand(Opcode::GetName, index);
-                    } else {
-                        self.emit_with_varying_operand(Opcode::GetNameAndLocator, index);
-                    }
+                    let is_fast = match self.get_or_insert_binding(binding) {
+                        EnvironmentAccess::Fast { index } => {
+                            self.emit_with_varying_operand(Opcode::GetLocal, index);
+                            true
+                        }
+                        EnvironmentAccess::Global { index } => {
+                            self.emit_with_varying_operand(Opcode::GetGlobalName, index);
+                            true
+                        }
+                        EnvironmentAccess::Slow { index } => {
+                            if lex {
+                                self.emit_with_varying_operand(Opcode::GetName, index);
+                            } else {
+                                self.emit_with_varying_operand(Opcode::GetNameAndLocator, index);
+                            }
+                            false
+                        }
+                    };
 
                     if short_circuit {
                         early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -75,12 +87,14 @@ impl ByteCompiler<'_, '_> {
                     if use_expr {
                         self.emit_opcode(Opcode::Dup);
                     }
-                    if lex {
+                    if lex || is_fast {
                         match self.set_mutable_binding(name) {
-                            Ok(binding) => {
-                                let index = self.get_or_insert_binding(binding);
-                                self.emit_with_varying_operand(Opcode::SetName, index);
-                            }
+                            Ok(binding) => self.get_or_insert_binding(binding).emit(
+                                Opcode::SetLocal,
+                                Opcode::SetGlobalName,
+                                Opcode::SetName,
+                                self,
+                            ),
                             Err(BindingLocatorError::MutateImmutable) => {
                                 let index = self.get_or_insert_name(name);
                                 self.emit_with_varying_operand(Opcode::ThrowMutateImmutable, index);

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -175,7 +175,7 @@ impl ByteCompiler<'_, '_> {
                 // stack: value
 
                 if r#yield.delegate() {
-                    if self.in_async() {
+                    if self.is_async() {
                         self.emit_opcode(Opcode::GetAsyncIterator);
                     } else {
                         self.emit_opcode(Opcode::GetIterator);
@@ -192,14 +192,14 @@ impl ByteCompiler<'_, '_> {
                     let (throw_method_undefined, return_method_undefined) =
                         self.emit_opcode_with_two_operands(Opcode::GeneratorDelegateNext);
 
-                    if self.in_async() {
+                    if self.is_async() {
                         self.emit_opcode(Opcode::Pop);
                         self.emit_opcode(Opcode::Await);
                     }
 
                     let (return_gen, exit) =
                         self.emit_opcode_with_two_operands(Opcode::GeneratorDelegateResume);
-                    if self.in_async() {
+                    if self.is_async() {
                         self.emit_opcode(Opcode::IteratorValue);
                         self.async_generator_yield();
                     } else {
@@ -210,7 +210,7 @@ impl ByteCompiler<'_, '_> {
 
                     self.patch_jump(return_gen);
                     self.patch_jump(return_method_undefined);
-                    if self.in_async() {
+                    if self.is_async() {
                         self.emit_opcode(Opcode::Await);
                         self.emit_opcode(Opcode::Pop);
                     }
@@ -219,7 +219,7 @@ impl ByteCompiler<'_, '_> {
                     self.r#return(true);
 
                     self.patch_jump(throw_method_undefined);
-                    self.iterator_close(self.in_async());
+                    self.iterator_close(self.is_async());
                     self.emit_opcode(Opcode::Throw);
 
                     self.patch_jump(exit);

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -24,7 +24,7 @@ impl ByteCompiler<'_, '_> {
                     PropertyName::Literal(name) => {
                         self.compile_expr(expr, true);
                         let index = self.get_or_insert_name((*name).into());
-                        if *name == Sym::__PROTO__ && !self.json_parse {
+                        if *name == Sym::__PROTO__ && !self.json_parse() {
                             self.emit_opcode(Opcode::SetPrototype);
                         } else {
                             self.emit_with_varying_operand(Opcode::DefineOwnPropertyByName, index);

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -28,8 +28,12 @@ impl ByteCompiler<'_, '_> {
                 match unary.target().flatten() {
                     Expression::Identifier(identifier) => {
                         let binding = self.get_binding_value(*identifier);
-                        let index = self.get_or_insert_binding(binding);
-                        self.emit_with_varying_operand(Opcode::GetNameOrUndefined, index);
+                        self.get_or_insert_binding(binding).emit(
+                            Opcode::GetLocal,
+                            Opcode::GetGlobalNameOrUndefined,
+                            Opcode::GetNameOrUndefined,
+                            self,
+                        );
                     }
                     expr => self.compile_expr(expr, true),
                 }

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -2,12 +2,15 @@ use std::rc::Rc;
 
 use crate::{
     builtins::function::ThisMode,
-    bytecompiler::ByteCompiler,
+    bytecompiler::{ByteCompiler, ByteCompilerFlags},
     environments::CompileTimeEnvironment,
     vm::{CodeBlock, CodeBlockFlags, Opcode},
     Context,
 };
-use boa_ast::function::{FormalParameterList, FunctionBody};
+use boa_ast::{
+    function::{FormalParameterList, FunctionBody},
+    operations::can_optimize_local_variables,
+};
 use boa_gc::Gc;
 use boa_interner::Sym;
 
@@ -21,6 +24,8 @@ pub(crate) struct FunctionCompiler {
     strict: bool,
     arrow: bool,
     binding_identifier: Option<Sym>,
+
+    can_optimize: bool,
 }
 
 impl FunctionCompiler {
@@ -33,6 +38,7 @@ impl FunctionCompiler {
             strict: false,
             arrow: false,
             binding_identifier: None,
+            can_optimize: true,
         }
     }
 
@@ -77,6 +83,12 @@ impl FunctionCompiler {
         self
     }
 
+    /// Indicate if the function can be optimized.
+    pub(crate) const fn can_optimize(mut self, can_optimize: bool) -> Self {
+        self.can_optimize = can_optimize;
+        self
+    }
+
     /// Compile a function statement list and it's parameters into bytecode.
     pub(crate) fn compile(
         mut self,
@@ -91,8 +103,11 @@ impl FunctionCompiler {
 
         let mut compiler = ByteCompiler::new(self.name, self.strict, false, outer_env, context);
         compiler.length = length;
-        compiler.in_async = self.r#async;
-        compiler.in_generator = self.generator;
+
+        compiler.flags.set(ByteCompilerFlags::ASYNC, self.r#async);
+        compiler
+            .flags
+            .set(ByteCompilerFlags::GENERATOR, self.generator);
 
         if self.arrow {
             compiler.this_mode = ThisMode::Lexical;
@@ -107,6 +122,9 @@ impl FunctionCompiler {
         // Function environment
         let _ = compiler.push_compile_environment(true);
 
+        compiler.function_environment_index =
+            Some(compiler.current_environment.environment_index());
+
         // Taken from:
         //  - 15.9.3 Runtime Semantics: EvaluateAsyncConciseBody: <https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncconcisebody>
         //  - 15.8.4 Runtime Semantics: EvaluateAsyncFunctionBody: <https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncfunctionbody>
@@ -115,13 +133,16 @@ impl FunctionCompiler {
         // `FunctionDeclarationInstantiation` (so they are propagated).
         //
         // See: 15.6.2 Runtime Semantics: EvaluateAsyncGeneratorBody: https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncgeneratorbody
-        if compiler.in_async() && !compiler.in_generator() {
+        if compiler.is_async() && !compiler.is_generator() {
             // 1. Let promiseCapability be ! NewPromiseCapability(%Promise%).
             //
             // Note: If the promise capability is already set, then we do nothing.
             // This is a deviation from the spec, but it allows to set the promise capability by
             // ExecuteAsyncModule ( module ): <https://tc39.es/ecma262/#sec-execute-async-module>
             compiler.emit_opcode(Opcode::CreatePromiseCapability);
+
+            // Note: We set it to one so we don't pop return value when we return.
+            compiler.current_stack_value_count += 1;
 
             // 2. Let declResult be Completion(FunctionDeclarationInstantiation(functionObject, argumentsList)).
             //
@@ -131,6 +152,19 @@ impl FunctionCompiler {
             // Patched in `ByteCompiler::finish()`.
             compiler.async_handler = Some(compiler.push_handler());
         }
+
+        let can_optimize_params = can_optimize_local_variables(parameters);
+        let can_optimize_body = can_optimize_local_variables(body);
+        // println!("Can optimize params: {can_optimize_params}");
+        // println!("Can optimize body: {can_optimize_body}");
+
+        let can_optimize =
+            can_optimize_params && can_optimize_body && parameters.is_simple() && self.can_optimize;
+
+        println!("Can optimize function: {can_optimize}");
+
+        compiler.can_optimize_local_variables =
+            can_optimize && compiler.function_environment_index.is_some();
 
         let (env_label, additional_env) = compiler.function_declaration_instantiation(
             body,
@@ -144,10 +178,10 @@ impl FunctionCompiler {
         // - 27.6.3.2 AsyncGeneratorStart ( generator, generatorBody ): <https://tc39.es/ecma262/#sec-asyncgeneratorstart>
         //
         // Note: We do handle exceptions thrown by generator body in `AsyncGeneratorStart`.
-        if compiler.in_generator() {
+        if compiler.is_generator() {
             assert!(compiler.async_handler.is_none());
 
-            if compiler.in_async() {
+            if compiler.is_async() {
                 // Patched in `ByteCompiler::finish()`.
                 compiler.async_handler = Some(compiler.push_handler());
             }

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -153,11 +153,14 @@ impl FunctionCompiler {
             compiler.async_handler = Some(compiler.push_handler());
         }
 
-        let can_optimize_params = can_optimize_local_variables(parameters);
-        let can_optimize_body = can_optimize_local_variables(body);
+        let can_optimize_params = can_optimize_local_variables(parameters, self.strict).0;
+        let (can_optimize_body, uses_arguments) = can_optimize_local_variables(body, self.strict);
         // println!("Can optimize params: {can_optimize_params}");
         // println!("Can optimize body: {can_optimize_body}");
 
+        compiler
+            .flags
+            .set(ByteCompilerFlags::USES_ARGUMENTS, uses_arguments);
         let can_optimize =
             can_optimize_params && can_optimize_body && parameters.is_simple() && self.can_optimize;
 

--- a/boa_engine/src/bytecompiler/jump_control.rs
+++ b/boa_engine/src/bytecompiler/jump_control.rs
@@ -102,6 +102,10 @@ impl JumpRecord {
                     return;
                 }
                 JumpRecordAction::PopEnvironments { count } => {
+                    if compiler.can_optimize_local_variables {
+                        continue;
+                    }
+
                     for _ in 0..count {
                         compiler.emit_opcode(Opcode::PopEnvironment);
                     }
@@ -129,7 +133,7 @@ impl JumpRecord {
                     compiler.emit_opcode(Opcode::SetReturnValue);
                 }
 
-                match (compiler.in_async(), compiler.in_generator()) {
+                match (compiler.is_async(), compiler.is_generator()) {
                     // Taken from:
                     //  - 27.6.3.2 AsyncGeneratorStart ( generator, generatorBody ): https://tc39.es/ecma262/#sec-asyncgeneratorstart
                     //

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -279,6 +279,7 @@ bitflags! {
         const IN_EVAL = 0b0001_0000;
         const HAS_EVAL = 0b0010_0000;
         const JSON_PARSE = 0b0100_0000;
+        const USES_ARGUMENTS = 0b1000_0000;
     }
 }
 

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -5,12 +5,16 @@ impl ByteCompiler<'_, '_> {
     /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(&mut self, block: &Block, use_expr: bool) {
         let env_index = self.push_compile_environment(false);
-        self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
+        if !self.can_optimize_local_variables {
+            self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
+        }
 
         self.block_declaration_instantiation(block);
         self.compile_statement_list(block.statement_list(), use_expr, true);
 
         self.pop_compile_environment();
-        self.emit_opcode(Opcode::PopEnvironment);
+        if !self.can_optimize_local_variables {
+            self.emit_opcode(Opcode::PopEnvironment);
+        }
     }
 }

--- a/boa_engine/src/bytecompiler/statement/mod.rs
+++ b/boa_engine/src/bytecompiler/statement/mod.rs
@@ -65,7 +65,7 @@ impl ByteCompiler<'_, '_> {
             Statement::Return(ret) => {
                 if let Some(expr) = ret.target() {
                     self.compile_expr(expr, true);
-                    if self.in_async_generator() {
+                    if self.is_async_generator() {
                         self.emit_opcode(Opcode::Await);
                         self.emit_opcode(Opcode::GeneratorNext);
                     }

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -7,7 +7,9 @@ impl ByteCompiler<'_, '_> {
         self.compile_expr(switch.val(), true);
 
         let env_index = self.push_compile_environment(false);
-        self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
+        if !self.can_optimize_local_variables {
+            self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
+        }
 
         self.block_declaration_instantiation(switch);
 
@@ -51,6 +53,8 @@ impl ByteCompiler<'_, '_> {
         self.pop_switch_control_info();
 
         self.pop_compile_environment();
-        self.emit_opcode(Opcode::PopEnvironment);
+        if !self.can_optimize_local_variables {
+            self.emit_opcode(Opcode::PopEnvironment);
+        }
     }
 }

--- a/boa_engine/src/bytecompiler/utils.rs
+++ b/boa_engine/src/bytecompiler/utils.rs
@@ -50,7 +50,7 @@ impl ByteCompiler<'_, '_> {
         let start = self.next_opcode_location();
         self.emit_opcode(Opcode::IteratorStackEmpty);
         let empty = self.jump_if_true();
-        self.iterator_close(self.in_async_generator());
+        self.iterator_close(self.is_async_generator());
         self.emit(Opcode::Jump, &[Operand::U32(start)]);
         self.patch_jump(empty);
     }
@@ -65,7 +65,7 @@ impl ByteCompiler<'_, '_> {
     /// [yield]: https://tc39.es/ecma262/#sec-yield
     pub(super) fn r#yield(&mut self) {
         // 1. Let generatorKind be GetGeneratorKind().
-        if self.in_async() {
+        if self.is_async() {
             // 2. If generatorKind is async, return ? AsyncGeneratorYield(? Await(value)).
             self.emit_opcode(Opcode::Await);
             self.emit_opcode(Opcode::GeneratorNext);

--- a/boa_engine/src/environments/runtime/mod.rs
+++ b/boa_engine/src/environments/runtime/mod.rs
@@ -474,6 +474,7 @@ pub(crate) struct BindingLocator {
     environment_index: u32,
     binding_index: u32,
     global: bool,
+    lex: bool,
 }
 
 unsafe impl Trace for BindingLocator {
@@ -486,22 +487,25 @@ impl BindingLocator {
         name: Identifier,
         environment_index: u32,
         binding_index: u32,
+        lex: bool,
     ) -> Self {
         Self {
             name,
             environment_index,
             binding_index,
             global: false,
+            lex,
         }
     }
 
     /// Creates a binding locator that indicates that the binding is on the global object.
-    pub(super) const fn global(name: Identifier) -> Self {
+    pub(super) const fn global(name: Identifier, lex: bool) -> Self {
         Self {
             name,
             environment_index: 0,
             binding_index: 0,
             global: true,
+            lex,
         }
     }
 
@@ -513,6 +517,11 @@ impl BindingLocator {
     /// Returns if the binding is located on the global object.
     pub(crate) const fn is_global(&self) -> bool {
         self.global
+    }
+
+    /// Returns if the binding is a lexical binding.
+    pub(crate) const fn is_lex(&self) -> bool {
+        self.lex
     }
 
     /// Returns the environment index of the binding.

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -260,7 +260,9 @@ impl CodeBlock {
                 | Instruction::GetNameAndLocator { .. }
                 | Instruction::GetNameOrUndefined { .. }
                 | Instruction::SetName { .. }
-                | Instruction::DeleteName { .. } => {
+                | Instruction::DeleteName { .. }
+                | Instruction::GetLocal { .. }
+                | Instruction::SetLocal { .. } => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
@@ -287,7 +289,11 @@ impl CodeBlock {
                 | Instruction::PushClassPrivateSetter { .. }
                 | Instruction::PushClassPrivateMethod { .. }
                 | Instruction::InPrivate { .. }
-                | Instruction::ThrowMutateImmutable { .. } => {
+                | Instruction::ThrowMutateImmutable { .. }
+                | Instruction::GetGlobalName { .. }
+                | Instruction::SetGlobalName { .. }
+                | Instruction::GetGlobalNameOrUndefined { .. }
+                | Instruction::DeleteGlobalName { .. } => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
@@ -516,13 +522,7 @@ impl CodeBlock {
                 | Instruction::Reserved49
                 | Instruction::Reserved50
                 | Instruction::Reserved51
-                | Instruction::Reserved52
-                | Instruction::Reserved53
-                | Instruction::Reserved54
-                | Instruction::Reserved55
-                | Instruction::Reserved56
-                | Instruction::Reserved57
-                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved52 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/control_flow/return.rs
+++ b/boa_engine/src/vm/opcode/control_flow/return.rs
@@ -54,3 +54,79 @@ impl Operation for SetReturnValue {
         Ok(CompletionType::Normal)
     }
 }
+
+/// `GetLocal` implements the Opcode Operation for `Opcode::GetLocal`
+///
+/// Operation:
+///  - Sets the return value of a function.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetLocal;
+
+impl GetLocal {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, offset: usize) -> JsResult<CompletionType> {
+        let index = context.vm.frame().fp as usize + offset;
+
+        let value = context.vm.stack[index].clone();
+        context.vm.push(value);
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetLocal {
+    const NAME: &'static str = "GetLocal";
+    const INSTRUCTION: &'static str = "INST - GetLocal";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u8>() as usize;
+        Self::operation(context, offset)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u16>() as usize;
+        Self::operation(context, offset)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u32>() as usize;
+        Self::operation(context, offset)
+    }
+}
+
+/// `SetLocal` implements the Opcode Operation for `Opcode::SetLocal`
+///
+/// Operation:
+///  - Sets the return value of a function.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SetLocal;
+
+impl SetLocal {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, offset: usize) -> JsResult<CompletionType> {
+        let index = context.vm.frame().fp as usize + offset;
+
+        let value = context.vm.pop();
+        context.vm.stack[index] = value;
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetLocal {
+    const NAME: &'static str = "SetLocal";
+    const INSTRUCTION: &'static str = "INST - SetLocal";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u8>() as usize;
+        Self::operation(context, offset)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u16>() as usize;
+        Self::operation(context, offset)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let offset = context.vm.read::<u32>() as usize;
+        Self::operation(context, offset)
+    }
+}

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -99,8 +99,8 @@ impl Operation for DeleteName {
     const INSTRUCTION: &'static str = "INST - DeleteName";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u8>();
-        Self::operation(context, index as usize)
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
     }
 
     fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
@@ -109,8 +109,45 @@ impl Operation for DeleteName {
     }
 
     fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        Self::operation(context, index as usize)
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
+/// `DeleteGlobalName` implements the Opcode Operation for `Opcode::DeleteGlobalName`
+///
+/// Operation:
+///  - Deletes a global property.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DeleteGlobalName;
+
+impl DeleteGlobalName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let key = context.vm.frame().code_block().names[index].clone().into();
+        let deleted = context.global_object().__delete__(&key, context)?;
+
+        context.vm.push(deleted);
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DeleteGlobalName {
+    const NAME: &'static str = "DeleteGlobalName";
+    const INSTRUCTION: &'static str = "INST - DeleteGlobalName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -33,8 +33,8 @@ impl Operation for GetName {
     const INSTRUCTION: &'static str = "INST - GetName";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u8>();
-        Self::operation(context, index as usize)
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
     }
 
     fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
@@ -43,8 +43,93 @@ impl Operation for GetName {
     }
 
     fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        Self::operation(context, index as usize)
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
+/// `GetGlobalName` implements the Opcode Operation for `Opcode::GetGlobalName`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetGlobalName;
+
+impl GetGlobalName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let key = context.vm.frame().code_block().names[index].clone();
+        let global = context.global_object();
+        if !global.has_property(key.clone(), context)? {
+            return Err(JsNativeError::reference()
+                .with_message(format!("{} is not defined", key.to_std_string_escaped()))
+                .into());
+        }
+
+        let value = global.get(key, context)?;
+        context.vm.push(value);
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetGlobalName {
+    const NAME: &'static str = "GetGlobalName";
+    const INSTRUCTION: &'static str = "INST - GetGlobalName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
+/// `GetGlobalNameOrUndefined` implements the Opcode Operation for `Opcode::GetGlobalNameOrUndefined`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct GetGlobalNameOrUndefined;
+
+impl GetGlobalNameOrUndefined {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let key = context.vm.frame().code_block().names[index].clone();
+        let global = context.global_object();
+        if !global.has_property(key.clone(), context)? {
+            context.vm.push(JsValue::undefined());
+            return Ok(CompletionType::Normal);
+        }
+
+        let value = global.get(key, context)?;
+        context.vm.push(value);
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetGlobalNameOrUndefined {
+    const NAME: &'static str = "GetGlobalNameOrUndefined";
+    const INSTRUCTION: &'static str = "INST - GetGlobalNameOrUndefined";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -2036,6 +2036,48 @@ generate_opcodes! {
     /// Stack: **=>**
     PopPrivateEnvironment,
 
+    /// Delete global variable.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: **=>**
+    DeleteGlobalName { index: VaryingOperand },
+
+    /// Get global variable.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: **=>** value
+    GetGlobalName { index: VaryingOperand },
+
+    /// Get global variable or undefined if it does not exist.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: **=>** value
+    GetGlobalNameOrUndefined { index: VaryingOperand },
+
+    /// Set global variable.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: value **=>**
+    SetGlobalName { index: VaryingOperand },
+
+    /// Get fast local variable.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: **=>** value
+    GetLocal { index: VaryingOperand },
+
+    /// Get fast local variable.
+    ///
+    /// Operands: index: `VaryingOperand`
+    ///
+    /// Stack: value **=>**
+    SetLocal { index: VaryingOperand },
+
     /// No-operation instruction, does nothing.
     ///
     /// Operands:
@@ -2161,18 +2203,6 @@ generate_opcodes! {
     Reserved51 => Reserved,
     /// Reserved [`Opcode`].
     Reserved52 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved53 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved54 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved55 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved56 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved57 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved58 => Reserved,
 }
 
 /// Specific opcodes for bindings.


### PR DESCRIPTION
Depends on #3185 

This PR is a WIP, it implements an optimization on function local variables, functions that do not call `eval` directly or variables that are not escaped, we can keep then on the stack after frame pointer and use and offset to index them (`index = fp + offset`). This allows us to eliminate the creation of some of the gc collected environments. Which gives us **huge** performance improvements!

## Benchmarks

#### Main

```text
Uncaught Error: Benchmark had 1 errors
PROGRESS Richards
RESULT Richards 36.0
PROGRESS DeltaBlue
RESULT DeltaBlue 42.2
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 63.2
PROGRESS RayTrace
RESULT RayTrace 147
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 136
ERROR RegExp TypeError: not a constructor
undefined
PROGRESS RegExp
PROGRESS Splay
RESULT Splay 118
PROGRESS NavierStokes
RESULT NavierStokes 136
SCORE 84.6
Uncaught Error: Benchmark had 1 errors
```

#### PR

```
PROGRESS Richards
RESULT Richards 42.3
PROGRESS DeltaBlue
RESULT DeltaBlue 46.5
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 102
PROGRESS RayTrace
RESULT RayTrace 164
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 158
ERROR RegExp TypeError: not a constructor
undefined
PROGRESS RegExp
PROGRESS Splay
RESULT Splay 124
PROGRESS NavierStokes
RESULT NavierStokes 246
SCORE 107
```

Almost 2x improvment on NavierStokes :)