### PR TITLE
Store active runnable and active function in `CallFrame`

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -174,9 +174,7 @@ impl BuiltInConstructor for Array {
         // If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| context.intrinsics().constructors().array().constructor())
                 .into()
         } else {

--- a/boa_engine/src/builtins/async_function/mod.rs
+++ b/boa_engine/src/builtins/async_function/mod.rs
@@ -66,7 +66,7 @@ impl BuiltInConstructor for AsyncFunction {
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
+        let active_function = context.active_function_object().unwrap_or_else(|| {
             context
                 .intrinsics()
                 .constructors()

--- a/boa_engine/src/builtins/async_generator_function/mod.rs
+++ b/boa_engine/src/builtins/async_generator_function/mod.rs
@@ -71,7 +71,7 @@ impl BuiltInConstructor for AsyncGeneratorFunction {
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
+        let active_function = context.active_function_object().unwrap_or_else(|| {
             context
                 .intrinsics()
                 .constructors()

--- a/boa_engine/src/builtins/error/aggregate.rs
+++ b/boa_engine/src/builtins/error/aggregate.rs
@@ -63,9 +63,7 @@ impl BuiltInConstructor for AggregateError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/eval.rs
+++ b/boa_engine/src/builtins/error/eval.rs
@@ -65,9 +65,7 @@ impl BuiltInConstructor for EvalError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/mod.rs
+++ b/boa_engine/src/builtins/error/mod.rs
@@ -165,9 +165,7 @@ impl BuiltInConstructor for Error {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| context.intrinsics().constructors().error().constructor())
                 .into()
         } else {

--- a/boa_engine/src/builtins/error/range.rs
+++ b/boa_engine/src/builtins/error/range.rs
@@ -63,9 +63,7 @@ impl BuiltInConstructor for RangeError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/reference.rs
+++ b/boa_engine/src/builtins/error/reference.rs
@@ -62,9 +62,7 @@ impl BuiltInConstructor for ReferenceError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/syntax.rs
+++ b/boa_engine/src/builtins/error/syntax.rs
@@ -65,9 +65,7 @@ impl BuiltInConstructor for SyntaxError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/type.rs
+++ b/boa_engine/src/builtins/error/type.rs
@@ -73,9 +73,7 @@ impl BuiltInConstructor for TypeError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/error/uri.rs
+++ b/boa_engine/src/builtins/error/uri.rs
@@ -64,9 +64,7 @@ impl BuiltInConstructor for UriError {
         // 1. If NewTarget is undefined, let newTarget be the active function object; else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -256,7 +256,7 @@ impl Eval {
         let env_fp = context.vm.environments.len() as u32;
         context
             .vm
-            .push_frame(CallFrame::new(code_block, None).with_env_fp(env_fp));
+            .push_frame(CallFrame::new(code_block, None, None).with_env_fp(env_fp));
         context.realm().resize_global_env();
 
         let record = context.run();

--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -256,7 +256,7 @@ impl Eval {
         let env_fp = context.vm.environments.len() as u32;
         context
             .vm
-            .push_frame(CallFrame::new(code_block).with_env_fp(env_fp));
+            .push_frame(CallFrame::new(code_block, None).with_env_fp(env_fp));
         context.realm().resize_global_env();
 
         let record = context.run();

--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -532,9 +532,7 @@ impl BuiltInConstructor for BuiltInFunctionObject {
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
         let active_function = context
-            .vm
-            .active_function
-            .clone()
+            .active_function_object()
             .unwrap_or_else(|| context.intrinsics().constructors().function().constructor());
         Self::create_dynamic_function(active_function, new_target, args, false, false, context)
             .map(Into::into)

--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -60,7 +60,6 @@ unsafe impl Trace for GeneratorState {
 pub(crate) struct GeneratorContext {
     pub(crate) environments: EnvironmentStack,
     pub(crate) stack: Vec<JsValue>,
-    pub(crate) active_function: Option<JsObject>,
     pub(crate) call_frame: Option<CallFrame>,
     pub(crate) realm: Realm,
 }
@@ -70,14 +69,12 @@ impl GeneratorContext {
     pub(crate) fn new(
         environments: EnvironmentStack,
         stack: Vec<JsValue>,
-        active_function: Option<JsObject>,
         call_frame: CallFrame,
         realm: Realm,
     ) -> Self {
         Self {
             environments,
             stack,
-            active_function,
             call_frame: Some(call_frame),
             realm,
         }
@@ -90,7 +87,6 @@ impl GeneratorContext {
             environments: context.vm.environments.clone(),
             call_frame: Some(context.vm.frame().clone()),
             stack: context.vm.stack[fp..].to_vec(),
-            active_function: context.vm.active_function.clone(),
             realm: context.realm().clone(),
         };
 
@@ -108,7 +104,6 @@ impl GeneratorContext {
     ) -> CompletionRecord {
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
-        std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
         context.swap_realm(&mut self.realm);
         context
             .vm
@@ -125,7 +120,6 @@ impl GeneratorContext {
 
         std::mem::swap(&mut context.vm.environments, &mut self.environments);
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
-        std::mem::swap(&mut context.vm.active_function, &mut self.active_function);
         context.swap_realm(&mut self.realm);
         self.call_frame = context.vm.pop_frame();
         assert!(self.call_frame.is_some());

--- a/boa_engine/src/builtins/generator_function/mod.rs
+++ b/boa_engine/src/builtins/generator_function/mod.rs
@@ -76,7 +76,7 @@ impl BuiltInConstructor for GeneratorFunction {
         args: &[JsValue],
         context: &mut Context<'_>,
     ) -> JsResult<JsValue> {
-        let active_function = context.vm.active_function.clone().unwrap_or_else(|| {
+        let active_function = context.active_function_object().unwrap_or_else(|| {
             context
                 .intrinsics()
                 .constructors()

--- a/boa_engine/src/builtins/intl/collator/mod.rs
+++ b/boa_engine/src/builtins/intl/collator/mod.rs
@@ -216,9 +216,7 @@ impl BuiltInConstructor for Collator {
         // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| context.intrinsics().constructors().collator().constructor())
                 .into()
         } else {

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -99,9 +99,7 @@ impl BuiltInConstructor for DateTimeFormat {
         // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
         let new_target = &if new_target.is_undefined() {
             context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .unwrap_or_else(|| {
                     context
                         .intrinsics()

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -131,7 +131,7 @@ impl Json {
         let env_fp = context.vm.environments.len() as u32;
         context
             .vm
-            .push_frame(CallFrame::new(code_block).with_env_fp(env_fp));
+            .push_frame(CallFrame::new(code_block, None).with_env_fp(env_fp));
         context.realm().resize_global_env();
         let record = context.run();
         context.vm.pop_frame();

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -131,7 +131,7 @@ impl Json {
         let env_fp = context.vm.environments.len() as u32;
         context
             .vm
-            .push_frame(CallFrame::new(code_block, None).with_env_fp(env_fp));
+            .push_frame(CallFrame::new(code_block, None, None).with_env_fp(env_fp));
         context.realm().resize_global_env();
         let record = context.run();
         context.vm.pop_frame();

--- a/boa_engine/src/builtins/object/mod.rs
+++ b/boa_engine/src/builtins/object/mod.rs
@@ -131,9 +131,7 @@ impl BuiltInConstructor for Object {
         if !new_target.is_undefined()
             && new_target
                 != &context
-                    .vm
-                    .active_function
-                    .clone()
+                    .active_function_object()
                     .unwrap_or_else(|| context.intrinsics().constructors().object().constructor())
                     .into()
         {

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -172,9 +172,7 @@ impl BuiltInConstructor for RegExp {
         if new_target.is_undefined() {
             // a. Let newTarget be the active function object.
             let new_target = context
-                .vm
-                .active_function
-                .clone()
+                .active_function_object()
                 .map_or(JsValue::undefined(), JsValue::new);
 
             // b. If patternIsRegExp is true and flags is undefined, then

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -707,7 +707,12 @@ impl Context<'_> {
         self.strict
     }
 
-    // GetActiveScriptOrModule
+    /// `9.4.1 GetActiveScriptOrModule ( )`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-getactivescriptormodule
     pub(crate) fn get_active_script_or_module(&self) -> Option<ActiveRunnable> {
         // 1. If the execution context stack is empty, return null.
         // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
@@ -721,9 +726,15 @@ impl Context<'_> {
         None
     }
 
+    /// Get `active function object`
+    ///
+    /// More information:
+    ///  - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#active-function-object
     pub(crate) fn active_function_object(&self) -> Option<JsObject> {
-        if self.vm.active_function.is_some() {
-            return self.vm.active_function.clone();
+        if self.vm.native_active_function.is_some() {
+            return self.vm.native_active_function.clone();
         }
 
         if let Some(frame) = self.vm.frames.last() {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     property::{Attribute, PropertyDescriptor, PropertyKey},
     realm::Realm,
     script::Script,
-    vm::{CallFrame, Vm},
+    vm::{ActiveRunnable, CallFrame, Vm},
     JsResult, JsValue, Source,
 };
 use boa_ast::{expression::Identifier, StatementList};
@@ -705,6 +705,20 @@ impl Context<'_> {
     /// Returns `true` if this context is in strict mode.
     pub(crate) const fn is_strict(&self) -> bool {
         self.strict
+    }
+
+    // GetActiveScriptOrModule
+    pub(crate) fn get_active_script_or_module(&self) -> Option<ActiveRunnable> {
+        // 1. If the execution context stack is empty, return null.
+        // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
+        // 3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.
+        for frame in self.vm.frames.iter().rev() {
+            if frame.active_runnable.is_some() {
+                return frame.active_runnable.clone();
+            }
+        }
+
+        None
     }
 }
 

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -720,6 +720,18 @@ impl Context<'_> {
 
         None
     }
+
+    pub(crate) fn active_function_object(&self) -> Option<JsObject> {
+        if self.vm.active_function.is_some() {
+            return self.vm.active_function.clone();
+        }
+
+        if let Some(frame) = self.vm.frames.last() {
+            return frame.active_function.clone();
+        }
+
+        None
+    }
 }
 
 impl<'host> Context<'host> {

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -717,13 +717,11 @@ impl Context<'_> {
         // 1. If the execution context stack is empty, return null.
         // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
         // 3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.
-        for frame in self.vm.frames.iter().rev() {
-            if frame.active_runnable.is_some() {
-                return frame.active_runnable.clone();
-            }
-        }
-
-        None
+        self.vm
+            .frames
+            .iter()
+            .rev()
+            .find_map(|frame| frame.active_runnable.clone())
     }
 
     /// Get `active function object`

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -139,14 +139,11 @@ impl Script {
 
         let old_realm = context.enter_realm(self.inner.realm.clone());
         let active_function = context.vm.active_function.take();
-        let old_active = context
-            .vm
-            .active_runnable
-            .replace(ActiveRunnable::Script(self.clone()));
         let env_fp = context.vm.environments.len() as u32;
-        context
-            .vm
-            .push_frame(CallFrame::new(codeblock).with_env_fp(env_fp));
+        context.vm.push_frame(
+            CallFrame::new(codeblock, Some(ActiveRunnable::Script(self.clone())))
+                .with_env_fp(env_fp),
+        );
 
         // TODO: Here should be https://tc39.es/ecma262/#sec-globaldeclarationinstantiation
 
@@ -155,7 +152,6 @@ impl Script {
         context.vm.pop_frame();
 
         context.vm.active_function = active_function;
-        context.vm.active_runnable = old_active;
         context.enter_realm(old_realm);
 
         context.clear_kept_objects();

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -138,10 +138,9 @@ impl Script {
         let codeblock = self.codeblock(context)?;
 
         let old_realm = context.enter_realm(self.inner.realm.clone());
-        let active_function = context.vm.active_function.take();
         let env_fp = context.vm.environments.len() as u32;
         context.vm.push_frame(
-            CallFrame::new(codeblock, Some(ActiveRunnable::Script(self.clone())))
+            CallFrame::new(codeblock, Some(ActiveRunnable::Script(self.clone())), None)
                 .with_env_fp(env_fp),
         );
 
@@ -151,7 +150,6 @@ impl Script {
         let record = context.run();
         context.vm.pop_frame();
 
-        context.vm.active_function = active_function;
         context.enter_realm(old_realm);
 
         context.clear_kept_objects();

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -39,7 +39,7 @@ pub struct CallFrame {
     /// How many iterations a loop has done.
     pub(crate) loop_iteration_count: u64,
 
-    /// [[ScriptOrModule]]
+    /// \[\[ScriptOrModule\]\]
     pub(crate) active_runnable: Option<ActiveRunnable>,
 
     pub(crate) active_function: Option<JsObject>,

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -12,6 +12,8 @@ use crate::{
 use boa_gc::{Finalize, Gc, Trace};
 use thin_vec::ThinVec;
 
+use super::ActiveRunnable;
+
 /// A `CallFrame` holds the state of a function call.
 #[derive(Clone, Debug, Finalize, Trace)]
 pub struct CallFrame {
@@ -36,6 +38,9 @@ pub struct CallFrame {
 
     /// How many iterations a loop has done.
     pub(crate) loop_iteration_count: u64,
+
+    /// [[ScriptOrModule]]
+    pub(crate) active_runnable: Option<ActiveRunnable>,
 }
 
 /// ---- `CallFrame` public API ----
@@ -51,7 +56,7 @@ impl CallFrame {
 /// ---- `CallFrame` creation methods ----
 impl CallFrame {
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
-    pub(crate) fn new(code_block: Gc<CodeBlock>) -> Self {
+    pub(crate) fn new(code_block: Gc<CodeBlock>, active_runnable: Option<ActiveRunnable>) -> Self {
         Self {
             code_block,
             pc: 0,
@@ -63,6 +68,7 @@ impl CallFrame {
             iterators: ThinVec::new(),
             binding_stack: Vec::new(),
             loop_iteration_count: 0,
+            active_runnable,
         }
     }
 

--- a/boa_engine/src/vm/call_frame/mod.rs
+++ b/boa_engine/src/vm/call_frame/mod.rs
@@ -41,6 +41,8 @@ pub struct CallFrame {
 
     /// [[ScriptOrModule]]
     pub(crate) active_runnable: Option<ActiveRunnable>,
+
+    pub(crate) active_function: Option<JsObject>,
 }
 
 /// ---- `CallFrame` public API ----
@@ -56,7 +58,11 @@ impl CallFrame {
 /// ---- `CallFrame` creation methods ----
 impl CallFrame {
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
-    pub(crate) fn new(code_block: Gc<CodeBlock>, active_runnable: Option<ActiveRunnable>) -> Self {
+    pub(crate) fn new(
+        code_block: Gc<CodeBlock>,
+        active_runnable: Option<ActiveRunnable>,
+        active_function: Option<JsObject>,
+    ) -> Self {
         Self {
             code_block,
             pc: 0,
@@ -69,6 +75,7 @@ impl CallFrame {
             binding_stack: Vec::new(),
             loop_iteration_count: 0,
             active_runnable,
+            active_function,
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1029,7 +1029,7 @@ impl JsObject {
                 let constructor = *constructor;
                 drop(object);
 
-                context.vm.active_function = Some(this_function_object);
+                context.vm.native_active_function = Some(this_function_object);
 
                 let result = if constructor.is_some() {
                     function.call(&JsValue::undefined(), args, context)
@@ -1038,7 +1038,7 @@ impl JsObject {
                 }
                 .map_err(|err| err.inject_realm(context.realm().clone()));
 
-                context.vm.active_function = None;
+                context.vm.native_active_function = None;
 
                 return result;
             }
@@ -1238,7 +1238,7 @@ impl JsObject {
                 let constructor = *constructor;
                 drop(object);
 
-                context.vm.active_function = Some(this_function_object);
+                context.vm.native_active_function = Some(this_function_object);
 
                 let result = function
                     .call(this_target, args, context)
@@ -1269,7 +1269,7 @@ impl JsObject {
                         }
                     });
 
-                context.vm.active_function = None;
+                context.vm.native_active_function = None;
 
                 result
             }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -70,7 +70,6 @@ pub struct Vm {
     pub(crate) environments: EnvironmentStack,
     pub(crate) runtime_limits: RuntimeLimits,
     pub(crate) active_function: Option<JsObject>,
-    pub(crate) active_runnable: Option<ActiveRunnable>,
 
     #[cfg(feature = "trace")]
     pub(crate) trace: bool,
@@ -103,7 +102,6 @@ impl Vm {
             pending_exception: None,
             runtime_limits: RuntimeLimits::default(),
             active_function: None,
-            active_runnable: None,
             #[cfg(feature = "trace")]
             trace: false,
         }

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -69,7 +69,10 @@ pub struct Vm {
     pub(crate) pending_exception: Option<JsError>,
     pub(crate) environments: EnvironmentStack,
     pub(crate) runtime_limits: RuntimeLimits,
-    pub(crate) active_function: Option<JsObject>,
+
+    /// This is used to assign a native (rust) function as the active function,
+    /// because we don't push a frame for them.
+    pub(crate) native_active_function: Option<JsObject>,
 
     #[cfg(feature = "trace")]
     pub(crate) trace: bool,
@@ -101,7 +104,7 @@ impl Vm {
             environments: EnvironmentStack::new(global),
             pending_exception: None,
             runtime_limits: RuntimeLimits::default(),
-            active_function: None,
+            native_active_function: None,
             #[cfg(feature = "trace")]
             trace: false,
         }

--- a/boa_engine/src/vm/opcode/call/mod.rs
+++ b/boa_engine/src/vm/opcode/call/mod.rs
@@ -272,9 +272,7 @@ impl Operation for ImportCall {
         // 1. Let referrer be GetActiveScriptOrModule().
         // 2. If referrer is null, set referrer to the current Realm Record.
         let referrer = context
-            .vm
-            .active_runnable
-            .clone()
+            .get_active_script_or_module()
             .map_or_else(|| Referrer::Realm(context.realm().clone()), Into::into);
 
         // 3. Let argRef be ? Evaluation of AssignmentExpression.

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -39,8 +39,10 @@ impl Operation for Generator {
 
         let code_block = context.vm.frame().code_block().clone();
         let active_runnable = context.vm.frame().active_runnable.clone();
+        let active_function = context.vm.frame().active_function.clone();
         let pc = context.vm.frame().pc;
-        let mut dummy_call_frame = CallFrame::new(code_block, active_runnable);
+        let mut dummy_call_frame =
+            CallFrame::new(code_block, active_runnable, active_function.clone());
         dummy_call_frame.pc = pc;
         let mut call_frame = std::mem::replace(context.vm.frame_mut(), dummy_call_frame);
 
@@ -51,11 +53,8 @@ impl Operation for Generator {
 
         call_frame.fp = 0;
 
-        let this_function_object = context
-            .vm
-            .active_function
-            .clone()
-            .expect("active function should be set to the generator");
+        let this_function_object =
+            active_function.expect("active function should be set to the generator");
 
         let proto = this_function_object
             .get(PROTOTYPE, context)
@@ -84,7 +83,6 @@ impl Operation for Generator {
                 context: Some(GeneratorContext::new(
                     environments,
                     stack,
-                    context.vm.active_function.clone(),
                     call_frame,
                     context.realm().clone(),
                 )),
@@ -96,7 +94,6 @@ impl Operation for Generator {
                     context: GeneratorContext::new(
                         environments,
                         stack,
-                        context.vm.active_function.clone(),
                         call_frame,
                         context.realm().clone(),
                     ),

--- a/boa_engine/src/vm/opcode/generator/mod.rs
+++ b/boa_engine/src/vm/opcode/generator/mod.rs
@@ -38,8 +38,9 @@ impl Operation for Generator {
         let r#async = context.vm.read::<u8>() != 0;
 
         let code_block = context.vm.frame().code_block().clone();
+        let active_runnable = context.vm.frame().active_runnable.clone();
         let pc = context.vm.frame().pc;
-        let mut dummy_call_frame = CallFrame::new(code_block);
+        let mut dummy_call_frame = CallFrame::new(code_block, active_runnable);
         dummy_call_frame.pc = pc;
         let mut call_frame = std::mem::replace(context.vm.frame_mut(), dummy_call_frame);
 

--- a/boa_engine/src/vm/opcode/meta/mod.rs
+++ b/boa_engine/src/vm/opcode/meta/mod.rs
@@ -54,7 +54,7 @@ impl Operation for ImportMeta {
 
         // 1. Let module be GetActiveScriptOrModule().
 
-        let Some(ActiveRunnable::Module(module)) = context.vm.active_runnable.clone() else {
+        let Some(ActiveRunnable::Module(module)) = context.get_active_script_or_module() else {
             unreachable!("2. Assert: module is a Source Text Module Record.");
         };
 


### PR DESCRIPTION
~~Depends on #3185~~

Part of refactoring calling in VM. In this PR active runnable and active function are moved in the `CallFrame`, this allows us to untangle some of the function calling.

It may seem like we are using more memory per ordinary function call, because of CallFrame size increase, but it actuality it's the same, before instead of storing it in the call frame we would spill it on the native rust stack which was filling the stack, contributing to smaller recursion limits.

@nekevss As I see it we already have the execution context stack, that being the `CallFrame`s (just a different name), we just have some work moving some fields that are supposed to be in  an execution context like `[[ScriptOrModule]]` which this PR does, realm needs to be moved too.
