### PR TITLE
Push float opcode

### DIFF
--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -551,8 +551,14 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         if f64::from(value as i32).to_bits() == value.to_bits() {
             self.emit_push_integer(value as i32);
         } else {
-            self.emit_opcode(Opcode::PushRational);
-            self.emit_u64(value.to_bits());
+            let f32_value = value as f32;
+
+            #[allow(clippy::float_cmp)]
+            if f64::from(f32_value) == value {
+                self.emit(Opcode::PushFloat, &[Operand::U32(f32_value.to_bits())]);
+            } else {
+                self.emit(Opcode::PushDouble, &[Operand::U64(value.to_bits())]);
+            }
         }
     }
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -340,7 +340,12 @@ impl CodeBlock {
                 *pc += size_of::<i32>();
                 result
             }
-            Opcode::PushRational => {
+            Opcode::PushFloat => {
+                let operand = self.read::<f32>(*pc);
+                *pc += size_of::<f32>();
+                ryu_js::Buffer::new().format(operand).to_string()
+            }
+            Opcode::PushDouble => {
                 let operand = self.read::<f64>(*pc);
                 *pc += size_of::<f64>();
                 ryu_js::Buffer::new().format(operand).to_string()
@@ -676,8 +681,7 @@ impl CodeBlock {
             | Opcode::Reserved55
             | Opcode::Reserved56
             | Opcode::Reserved57
-            | Opcode::Reserved58
-            | Opcode::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
+            | Opcode::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -84,7 +84,13 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Opcode::PushRational => {
+                Opcode::PushFloat => {
+                    pc += size_of::<f32>();
+
+                    graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
+                    graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
+                }
+                Opcode::PushDouble => {
                     pc += size_of::<f64>();
 
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
@@ -611,8 +617,7 @@ impl CodeBlock {
                 | Opcode::Reserved55
                 | Opcode::Reserved56
                 | Opcode::Reserved57
-                | Opcode::Reserved58
-                | Opcode::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
+                | Opcode::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -249,12 +249,19 @@ generate_impl! {
         /// Stack: **=>** value
         PushInt32,
 
+        /// Push `f32` value on the stack.
+        ///
+        /// Operands: value: `f32`
+        ///
+        /// Stack: **=>** value
+        PushFloat,
+
         /// Push `f64` value on the stack.
         ///
         /// Operands: value: `f64`
         ///
         /// Stack: **=>** value
-        PushRational,
+        PushDouble,
 
         /// Push `NaN` integer on the stack.
         ///
@@ -1788,8 +1795,6 @@ generate_impl! {
         Reserved57 => Reserved,
         /// Reserved [`Opcode`].
         Reserved58 => Reserved,
-        /// Reserved [`Opcode`].
-        Reserved59 => Reserved,
     }
 }
 

--- a/boa_engine/src/vm/opcode/push/numbers.rs
+++ b/boa_engine/src/vm/opcode/push/numbers.rs
@@ -51,4 +51,5 @@ implement_push_numbers_with_conversion!(PushInt8, i8, "Push `i8` value on the st
 implement_push_numbers_with_conversion!(PushInt16, i16, "Push `i16` value on the stack");
 
 implement_push_numbers_no_conversion!(PushInt32, i32, "Push `i32` value on the stack");
-implement_push_numbers_no_conversion!(PushRational, f64, "Push `f64` value on the stack");
+implement_push_numbers_no_conversion!(PushFloat, f32, "Push `f64` value on the stack");
+implement_push_numbers_no_conversion!(PushDouble, f64, "Push `f64` value on the stack");


### PR DESCRIPTION
Depends on #3188 

This PR adds a `PushFloat` opcode that takes a `f32` value, we already have a `PushRational` that pushes a `f64` value. The reason for this additions is to reduce wasted memory usage since we can represent many `f64` in `f32` value (like `0.5`), and conversion from `f32` to `f64` is lossless.
