### PR TITLE
Fix switch statement `break` and `continue` return values

### DIFF
--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -174,18 +174,17 @@ impl ByteCompiler<'_, '_> {
     fn compile_catch_finally_block(&mut self, block: &Block, use_expr: bool) {
         let mut b = block;
 
-        'outer: loop {
+        loop {
             match b.statement_list().first() {
                 Some(StatementListItem::Statement(
                     Statement::Break(_) | Statement::Continue(_),
                 )) => {
                     self.emit_opcode(Opcode::PushUndefined);
                     self.emit_opcode(Opcode::SetReturnValue);
-                    break 'outer;
+                    break;
                 }
                 Some(StatementListItem::Statement(Statement::Block(block))) => {
                     b = block;
-                    continue 'outer;
                 }
                 _ => {
                     break;


### PR DESCRIPTION
This Pull Request fixes the remaining "language/statements/switch" tests with exception of the tco tests.

It changes the following:

This removes the current behaviour of setting the return value to `undefined` whenever there is a  `break` or `continue` statement at the start of a block. This was causing the return value to be unexpectedly overwritten in switch statements.
Instead this is now only implemented for `catch` and `finally` blocks where this behaviour mirrors the `UpdateEmpty` statements in the spec.
