### PR TITLE
Add early errors for `LexicalDeclaration`

### DIFF
--- a/boa_parser/src/parser/statement/declaration/tests.rs
+++ b/boa_parser/src/parser/statement/declaration/tests.rs
@@ -349,3 +349,14 @@ fn multiple_const_declaration() {
         interner,
     );
 }
+
+/// Checks `LexicalDeclaration` early errors.
+#[test]
+fn lexical_declaration_early_errors() {
+    check_invalid_script("let let = 0");
+    check_invalid_script("let a = 0, a = 0");
+    check_invalid_script("const a = 0, a = 0");
+    check_invalid_script("for (let let = 0; ; ) {}");
+    check_invalid_script("for (let a = 0, a = 0; ; ) {}");
+    check_invalid_script("for (const a = 0, a = 0; ; ) {}");
+}


### PR DESCRIPTION
This Pull Request fixes/closes #3206.

It changes the following:

- Add early errors for `LexicalDeclaration`
