### PR TITLE
Lazily download `test262`  repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ yarn-error.log
 tests/js
 .boa_history
 
+# test262 testing suite
+test262
+
 # Profiling
 *.string_data
 *.string_index

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test262"]
-	path = test262
-	url = https://github.com/tc39/test262.git

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -255,10 +255,10 @@ fn main() -> Result<()> {
                 toml::from_str(&input).wrap_err("could not decode tester config file")?
             };
 
-            let test262_commit = match (test262_commit.as_deref(), config.commit()) {
-                (Some("latest"), _) | (None, "" | "latest") => None,
-                (Some(commit), _) | (None, commit) => Some(commit),
-            };
+            let test262_commit = test262_commit
+                .as_deref()
+                .or_else(|| Some(config.commit()))
+                .filter(|s| !["", "latest"].contains(s));
 
             let test262_path = if let Some(path) = test262_path.as_deref() {
                 path

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -99,17 +99,19 @@ use std::{
 /// Structure that contains the configuration of the tester.
 #[derive(Debug, Deserialize)]
 struct Config {
+    #[serde(default)]
     commit: String,
+    #[serde(default)]
     ignored: Ignored,
 }
 
 impl Config {
-    /// Get the `test262` repository commit.
+    /// Get the `Test262` repository commit.
     pub(crate) fn commit(&self) -> &str {
         &self.commit
     }
 
-    /// Get [`Ignored`] `test262` tests and features.
+    /// Get [`Ignored`] `Test262` tests and features.
     pub(crate) const fn ignored(&self) -> &Ignored {
         &self.ignored
     }
@@ -182,7 +184,7 @@ enum Cli {
         )]
         test262_path: Option<PathBuf>,
 
-        /// Specify the Test262 commit when cloning the repository. To checkout to the latest commit set to "latest".
+        /// Override config's Test262 commit. To checkout the latest commit set this to "latest".
         #[arg(long)]
         test262_commit: Option<String>,
 
@@ -253,10 +255,9 @@ fn main() -> Result<()> {
                 toml::from_str(&input).wrap_err("could not decode tester config file")?
             };
 
-            let test262_commit = match test262_commit.as_deref() {
-                Some("latest") => None,
-                Some(commit) => Some(commit),
-                None => Some(config.commit()),
+            let test262_commit = match (test262_commit.as_deref(), config.commit()) {
+                (Some("latest"), _) | (None, "" | "latest") => None,
+                (Some(commit), _) | (None, commit) => Some(commit),
             };
 
             let test262_path = if let Some(path) = test262_path.as_deref() {

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,3 +1,6 @@
+commit = "dd30d83e9e9b838615ac82c9629275b146f8648e"
+
+[ignored]
 # Not implemented yet:
 flags = []
 


### PR DESCRIPTION
This Pull Request fixes/closes #3095 .

This PR makes the downloads the `test262` repository, if we run the `boa_tester` with `run` command and we do not specify the test262 directory.

There is a con with this approach, dependabot can't suggest a updates. We could implement our own checker though.

TODO:

- [x] The commit is hard coded, add a config file for test262 default commit (maybe merge `test_ignore.toml` into it).
  - [x] Add ability to specify commit on test262 clone, via CLI commands
  - [x] Warn user that the current commit is older than test262 HEAD
- [x] Better error reporting