### PR TITLE
Clippy updates: add panics and etc.

### DIFF
--- a/ABOUT.md
+++ b/ABOUT.md
@@ -8,7 +8,7 @@ website][boa-web].
 Try out the most recent release with Boa's live demo
 [playground][boa-playground].
 
-# Boa Crates
+## Boa Crates
 
 - [**`boa_ast`**][ast] - Boa's ECMAScript Abstract Syntax Tree.
 - [**`boa_engine`**][engine] - Boa's implementation of ECMAScript builtin objects and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "boa_ast",
     "boa_cli",

--- a/boa_ast/src/declaration/variable.rs
+++ b/boa_ast/src/declaration/variable.rs
@@ -199,7 +199,7 @@ impl VisitWith for VariableList {
     where
         V: Visitor<'a>,
     {
-        for variable in self.list.iter() {
+        for variable in &*self.list {
             try_break!(visitor.visit_variable(variable));
         }
         ControlFlow::Continue(())
@@ -209,7 +209,7 @@ impl VisitWith for VariableList {
     where
         V: VisitorMut<'a>,
     {
-        for variable in self.list.iter_mut() {
+        for variable in &mut *self.list {
             try_break!(visitor.visit_variable_mut(variable));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/expression/call.rs
+++ b/boa_ast/src/expression/call.rs
@@ -78,7 +78,7 @@ impl VisitWith for Call {
         V: Visitor<'a>,
     {
         try_break!(visitor.visit_expression(&self.function));
-        for expr in self.args.iter() {
+        for expr in &*self.args {
             try_break!(visitor.visit_expression(expr));
         }
         ControlFlow::Continue(())
@@ -89,7 +89,7 @@ impl VisitWith for Call {
         V: VisitorMut<'a>,
     {
         try_break!(visitor.visit_expression_mut(&mut self.function));
-        for expr in self.args.iter_mut() {
+        for expr in &mut *self.args {
             try_break!(visitor.visit_expression_mut(expr));
         }
         ControlFlow::Continue(())
@@ -146,7 +146,7 @@ impl VisitWith for SuperCall {
     where
         V: Visitor<'a>,
     {
-        for expr in self.args.iter() {
+        for expr in &*self.args {
             try_break!(visitor.visit_expression(expr));
         }
         ControlFlow::Continue(())
@@ -156,7 +156,7 @@ impl VisitWith for SuperCall {
     where
         V: VisitorMut<'a>,
     {
-        for expr in self.args.iter_mut() {
+        for expr in &mut *self.args {
             try_break!(visitor.visit_expression_mut(expr));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/expression/literal/object.rs
+++ b/boa_ast/src/expression/literal/object.rs
@@ -206,7 +206,7 @@ impl ToIndentedString for ObjectLiteral {
     fn to_indented_string(&self, interner: &Interner, indent_n: usize) -> String {
         let mut buf = "{\n".to_owned();
         let indentation = "    ".repeat(indent_n + 1);
-        for property in self.properties().iter() {
+        for property in &*self.properties {
             buf.push_str(&match property {
                 PropertyDefinition::IdentifierReference(ident) => {
                     format!("{indentation}{},\n", interner.resolve_expect(ident.sym()))
@@ -324,7 +324,7 @@ impl VisitWith for ObjectLiteral {
     where
         V: Visitor<'a>,
     {
-        for pd in self.properties.iter() {
+        for pd in &*self.properties {
             try_break!(visitor.visit_property_definition(pd));
         }
         ControlFlow::Continue(())
@@ -334,7 +334,7 @@ impl VisitWith for ObjectLiteral {
     where
         V: VisitorMut<'a>,
     {
-        for pd in self.properties.iter_mut() {
+        for pd in &mut *self.properties {
             try_break!(visitor.visit_property_definition_mut(pd));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/expression/literal/template.rs
+++ b/boa_ast/src/expression/literal/template.rs
@@ -70,7 +70,7 @@ impl ToInternedString for TemplateLiteral {
     fn to_interned_string(&self, interner: &Interner) -> String {
         let mut buf = "`".to_owned();
 
-        for elt in self.elements.iter() {
+        for elt in &*self.elements {
             match elt {
                 TemplateElement::String(s) => buf.push_str(&interner.resolve_expect(*s).join(
                     Cow::Borrowed,
@@ -93,7 +93,7 @@ impl VisitWith for TemplateLiteral {
     where
         V: Visitor<'a>,
     {
-        for element in self.elements.iter() {
+        for element in &*self.elements {
             try_break!(visitor.visit_template_element(element));
         }
         ControlFlow::Continue(())
@@ -103,7 +103,7 @@ impl VisitWith for TemplateLiteral {
     where
         V: VisitorMut<'a>,
     {
-        for element in self.elements.iter_mut() {
+        for element in &mut *self.elements {
             try_break!(visitor.visit_template_element_mut(element));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/expression/optional.rs
+++ b/boa_ast/src/expression/optional.rs
@@ -186,7 +186,7 @@ impl VisitWith for Optional {
         V: Visitor<'a>,
     {
         try_break!(visitor.visit_expression(&self.target));
-        for op in self.chain.iter() {
+        for op in &*self.chain {
             try_break!(visitor.visit_optional_operation(op));
         }
         ControlFlow::Continue(())
@@ -197,7 +197,7 @@ impl VisitWith for Optional {
         V: VisitorMut<'a>,
     {
         try_break!(visitor.visit_expression_mut(&mut self.target));
-        for op in self.chain.iter_mut() {
+        for op in &mut *self.chain {
             try_break!(visitor.visit_optional_operation_mut(op));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/expression/tagged_template.rs
+++ b/boa_ast/src/expression/tagged_template.rs
@@ -111,13 +111,13 @@ impl VisitWith for TaggedTemplate {
         V: Visitor<'a>,
     {
         try_break!(visitor.visit_expression(&self.tag));
-        for raw in self.raws.iter() {
+        for raw in &*self.raws {
             try_break!(visitor.visit_sym(raw));
         }
         for cooked in self.cookeds.iter().flatten() {
             try_break!(visitor.visit_sym(cooked));
         }
-        for expr in self.exprs.iter() {
+        for expr in &*self.exprs {
             try_break!(visitor.visit_expression(expr));
         }
         ControlFlow::Continue(())
@@ -128,13 +128,13 @@ impl VisitWith for TaggedTemplate {
         V: VisitorMut<'a>,
     {
         try_break!(visitor.visit_expression_mut(&mut self.tag));
-        for raw in self.raws.iter_mut() {
+        for raw in &mut *self.raws {
             try_break!(visitor.visit_sym_mut(raw));
         }
         for cooked in self.cookeds.iter_mut().flatten() {
             try_break!(visitor.visit_sym_mut(cooked));
         }
-        for expr in self.exprs.iter_mut() {
+        for expr in &mut *self.exprs {
             try_break!(visitor.visit_expression_mut(expr));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/function/class.rs
+++ b/boa_ast/src/function/class.rs
@@ -124,7 +124,7 @@ impl ToIndentedString for Class {
                 block_to_string(expr.body().statements(), interner, indent_n + 1)
             ));
         }
-        for element in self.elements.iter() {
+        for element in &*self.elements {
             buf.push_str(&match element {
                 ClassElement::MethodDefinition(name, method) => {
                     format!(
@@ -394,7 +394,7 @@ impl VisitWith for Class {
         if let Some(func) = &self.constructor {
             try_break!(visitor.visit_function(func));
         }
-        for elem in self.elements.iter() {
+        for elem in &*self.elements {
             try_break!(visitor.visit_class_element(elem));
         }
         ControlFlow::Continue(())
@@ -413,7 +413,7 @@ impl VisitWith for Class {
         if let Some(func) = &mut self.constructor {
             try_break!(visitor.visit_function_mut(func));
         }
-        for elem in self.elements.iter_mut() {
+        for elem in &mut *self.elements {
             try_break!(visitor.visit_class_element_mut(elem));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -151,6 +151,7 @@ impl VisitWith for FormalParameterList {
         for parameter in &*self.parameters {
             try_break!(visitor.visit_formal_parameter(parameter));
         }
+
         ControlFlow::Continue(())
     }
 

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -162,6 +162,7 @@ impl VisitWith for FormalParameterList {
         for parameter in &mut *self.parameters {
             try_break!(visitor.visit_formal_parameter_mut(parameter));
         }
+
         // TODO recompute flags
         ControlFlow::Continue(())
     }

--- a/boa_ast/src/function/parameters.rs
+++ b/boa_ast/src/function/parameters.rs
@@ -148,7 +148,7 @@ impl VisitWith for FormalParameterList {
     where
         V: Visitor<'a>,
     {
-        for parameter in self.parameters.iter() {
+        for parameter in &*self.parameters {
             try_break!(visitor.visit_formal_parameter(parameter));
         }
         ControlFlow::Continue(())
@@ -158,7 +158,7 @@ impl VisitWith for FormalParameterList {
     where
         V: VisitorMut<'a>,
     {
-        for parameter in self.parameters.iter_mut() {
+        for parameter in &mut *self.parameters {
             try_break!(visitor.visit_formal_parameter_mut(parameter));
         }
         // TODO recompute flags

--- a/boa_ast/src/pattern.rs
+++ b/boa_ast/src/pattern.rs
@@ -171,7 +171,7 @@ impl VisitWith for ObjectPattern {
     where
         V: Visitor<'a>,
     {
-        for elem in self.0.iter() {
+        for elem in &*self.0 {
             try_break!(visitor.visit_object_pattern_element(elem));
         }
         ControlFlow::Continue(())
@@ -181,7 +181,7 @@ impl VisitWith for ObjectPattern {
     where
         V: VisitorMut<'a>,
     {
-        for elem in self.0.iter_mut() {
+        for elem in &mut *self.0 {
             try_break!(visitor.visit_object_pattern_element_mut(elem));
         }
         ControlFlow::Continue(())
@@ -249,7 +249,7 @@ impl VisitWith for ArrayPattern {
     where
         V: Visitor<'a>,
     {
-        for elem in self.0.iter() {
+        for elem in &*self.0 {
             try_break!(visitor.visit_array_pattern_element(elem));
         }
         ControlFlow::Continue(())
@@ -259,7 +259,7 @@ impl VisitWith for ArrayPattern {
     where
         V: VisitorMut<'a>,
     {
-        for elem in self.0.iter_mut() {
+        for elem in &mut *self.0 {
             try_break!(visitor.visit_array_pattern_element_mut(elem));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/position.rs
+++ b/boa_ast/src/position.rs
@@ -16,7 +16,11 @@ pub struct Position {
 }
 
 impl Position {
-    /// Creates a new `Position`.
+    /// Creates a new `Position` from Non-Zero values.
+    /// 
+    /// # Panics
+    /// 
+    /// Will panic if the line number or column number is zero.
     #[inline]
     #[track_caller]
     #[must_use]

--- a/boa_ast/src/position.rs
+++ b/boa_ast/src/position.rs
@@ -17,9 +17,9 @@ pub struct Position {
 
 impl Position {
     /// Creates a new `Position` from Non-Zero values.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Will panic if the line number or column number is zero.
     #[inline]
     #[track_caller]

--- a/boa_ast/src/statement/switch.rs
+++ b/boa_ast/src/statement/switch.rs
@@ -158,7 +158,7 @@ impl ToIndentedString for Switch {
     fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let indent = "    ".repeat(indentation);
         let mut buf = format!("switch ({}) {{\n", self.val().to_interned_string(interner));
-        for e in self.cases().iter() {
+        for e in &*self.cases {
             if let Some(condition) = e.condition() {
                 buf.push_str(&format!(
                     "{indent}    case {}:\n{}",
@@ -192,7 +192,7 @@ impl VisitWith for Switch {
         V: Visitor<'a>,
     {
         try_break!(visitor.visit_expression(&self.val));
-        for case in self.cases.iter() {
+        for case in &*self.cases {
             try_break!(visitor.visit_case(case));
         }
         ControlFlow::Continue(())
@@ -203,7 +203,7 @@ impl VisitWith for Switch {
         V: VisitorMut<'a>,
     {
         try_break!(visitor.visit_expression_mut(&mut self.val));
-        for case in self.cases.iter_mut() {
+        for case in &mut *self.cases {
             try_break!(visitor.visit_case_mut(case));
         }
         ControlFlow::Continue(())

--- a/boa_ast/src/statement_list.rs
+++ b/boa_ast/src/statement_list.rs
@@ -162,7 +162,7 @@ impl ToIndentedString for StatementList {
     fn to_indented_string(&self, interner: &Interner, indentation: usize) -> String {
         let mut buf = String::new();
         // Print statements
-        for item in self.statements.iter() {
+        for item in &*self.statements {
             // We rely on the node to add the correct indent.
             buf.push_str(&item.to_indented_string(interner, indentation));
 
@@ -177,7 +177,7 @@ impl VisitWith for StatementList {
     where
         V: Visitor<'a>,
     {
-        for statement in self.statements.iter() {
+        for statement in &*self.statements {
             try_break!(visitor.visit_statement_list_item(statement));
         }
         ControlFlow::Continue(())
@@ -187,7 +187,7 @@ impl VisitWith for StatementList {
     where
         V: VisitorMut<'a>,
     {
-        for statement in self.statements.iter_mut() {
+        for statement in &mut *self.statements {
             try_break!(visitor.visit_statement_list_item_mut(statement));
         }
         ControlFlow::Continue(())

--- a/boa_engine/src/builtins/json/mod.rs
+++ b/boa_engine/src/builtins/json/mod.rs
@@ -684,7 +684,7 @@ impl Json {
                         partial.iter().map(Vec::as_slice),
                         &separator,
                     ))
-                    .chain([utf16!("\n"), &stepback[..], utf16!("}")].into_iter())
+                    .chain([utf16!("\n"), &stepback[..], utf16!("}")])
                     .flatten()
                     .copied()
                     .collect::<Vec<_>>();
@@ -797,7 +797,7 @@ impl Json {
                         partial.iter().map(Cow::as_ref),
                         &separator,
                     ))
-                    .chain([utf16!("\n"), &stepback[..], utf16!("]")].into_iter())
+                    .chain([utf16!("\n"), &stepback[..], utf16!("]")])
                     .flatten()
                     .copied()
                     .collect::<Vec<_>>();

--- a/boa_engine/src/builtins/map/ordered_map.rs
+++ b/boa_engine/src/builtins/map/ordered_map.rs
@@ -45,7 +45,7 @@ pub struct OrderedMap<V, S = RandomState> {
 impl<V: Trace, S: BuildHasher> Finalize for OrderedMap<V, S> {}
 unsafe impl<V: Trace, S: BuildHasher> Trace for OrderedMap<V, S> {
     custom_trace!(this, {
-        for (k, v) in this.map.iter() {
+        for (k, v) in &this.map {
             if let MapKey::Key(key) = k {
                 mark(key);
             }

--- a/boa_engine/src/builtins/regexp/tests.rs
+++ b/boa_engine/src/builtins/regexp/tests.rs
@@ -97,10 +97,10 @@ fn last_index() {
 fn exec() {
     run_test_actions([
         TestAction::run_harness(),
-        TestAction::run(indoc! {r#"
+        TestAction::run(indoc! {r"
                 var re = /quick\s(brown).+?(jumps)/ig;
                 var result = re.exec('The Quick Brown Fox Jumps Over The Lazy Dog');
-            "#}),
+            "}),
         TestAction::assert(indoc! {r#"
             arrayEquals(
                 result,

--- a/boa_engine/src/builtins/set/ordered_set.rs
+++ b/boa_engine/src/builtins/set/ordered_set.rs
@@ -15,7 +15,7 @@ pub struct OrderedSet<S = RandomState> {
 
 unsafe impl<S: BuildHasher> Trace for OrderedSet<S> {
     custom_trace!(this, {
-        for v in this.inner.iter() {
+        for v in &this.inner {
             if let MapKey::Key(v) = v {
                 mark(v);
             }

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -322,7 +322,7 @@ impl String {
         let mut buf = [0; 2];
 
         // 2. For each element next of codePoints, do
-        for arg in args.iter() {
+        for arg in args {
             // a. Let nextCP be ? ToNumber(next).
             let nextcp = arg.to_number(context)?;
 

--- a/boa_engine/src/builtins/string/tests.rs
+++ b/boa_engine/src/builtins/string/tests.rs
@@ -6,12 +6,12 @@ use crate::{js_string, run_test_actions, JsNativeErrorKind, JsValue, TestAction}
 fn length() {
     //TEST262: https://github.com/tc39/test262/blob/master/test/built-ins/String/length.js
     run_test_actions([
-        TestAction::run(indoc! {r#"
+        TestAction::run(indoc! {r"
                 const a = new String(' ');
                 const b = new String('\ud834\udf06');
                 const c = new String(' \b ');
                 const d = new String('中文长度')
-            "#}),
+            "}),
         // unicode surrogate pair length should be 1
         // utf16/usc2 length should be 2
         // utf8 length should be 4
@@ -307,12 +307,12 @@ fn includes_with_regex_arg() {
 fn match_all_one() {
     run_test_actions([
         TestAction::run_harness(),
-        TestAction::run(indoc! {r#"
+        TestAction::run(indoc! {r"
             var groupMatches = 'test1test2'.matchAll(/t(e)(st(\d?))/g);
             var m1 = groupMatches.next();
             var m2 = groupMatches.next();
             var m3 = groupMatches.next();
-        "#}),
+        "}),
         TestAction::assert("!m1.done"),
         TestAction::assert("!m2.done"),
         TestAction::assert("m3.done"),
@@ -553,12 +553,12 @@ fn split() {
                     ['']
                 )
             "#}),
-        TestAction::assert(indoc! {r#"
+        TestAction::assert(indoc! {r"
                 arrayEquals(
                     '\u{1D7D8}\u{1D7D9}\u{1D7DA}\u{1D7DB}'.split(''),
                     ['\uD835', '\uDFD8', '\uD835', '\uDFD9', '\uD835', '\uDFDA', '\uD835', '\uDFDB']
                 )
-            "#}),
+            "}),
     ]);
 }
 

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -119,6 +119,10 @@
     clippy::cast_sign_loss,
     clippy::cast_precision_loss,
     clippy::cast_possible_wrap,
+
+    // Add temporarily - Needs addressing
+    clippy::missing_panics_doc,
+    clippy::arc_with_non_send_sync,
 )]
 
 extern crate static_assertions as sa;

--- a/boa_engine/src/object/property_map.rs
+++ b/boa_engine/src/object/property_map.rs
@@ -26,7 +26,7 @@ impl<K: Trace> Default for OrderedHashMap<K> {
 
 unsafe impl<K: Trace> Trace for OrderedHashMap<K> {
     custom_trace!(this, {
-        for (k, v) in this.0.iter() {
+        for (k, v) in &this.0 {
             mark(k);
             mark(v);
         }

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -109,6 +109,7 @@ impl WellKnown {
     }
 }
 
+// TODO: Address below clippy::arc_with_non_send_sync below.
 /// The inner representation of a JavaScript symbol.
 #[derive(Debug, Clone)]
 struct Inner {

--- a/boa_engine/src/tagged.rs
+++ b/boa_engine/src/tagged.rs
@@ -33,7 +33,7 @@ pub(crate) struct Tagged<T>(NonNull<T>);
 
 impl<T> Clone for Tagged<T> {
     fn clone(&self) -> Self {
-        Self(self.0)
+        *self
     }
 }
 

--- a/boa_gc/src/cell.rs
+++ b/boa_gc/src/cell.rs
@@ -491,12 +491,12 @@ impl<T: Trace + ?Sized + Debug> Debug for GcRefCell<T> {
                 .debug_struct("GcCell")
                 .field("flags", &self.flags.get())
                 .field("value", &self.borrow())
-                .finish(),
+                .finish_non_exhaustive(),
             BorrowState::Writing => f
                 .debug_struct("GcCell")
                 .field("flags", &self.flags.get())
                 .field("value", &"<borrowed>")
-                .finish(),
+                .finish_non_exhaustive(),
         }
     }
 }

--- a/boa_gc/src/internals/gc_box.rs
+++ b/boa_gc/src/internals/gc_box.rs
@@ -80,7 +80,7 @@ impl fmt::Debug for GcBoxHeader {
             .field("marked", &self.is_marked())
             .field("ref_count", &self.ref_count.get())
             .field("non_root_count", &self.get_non_root_count())
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/boa_gc/src/trace.rs
+++ b/boa_gc/src/trace.rs
@@ -265,7 +265,7 @@ impl<T: Trace> Finalize for Box<[T]> {}
 // SAFETY: All the inner elements of the `Box` array are correctly marked.
 unsafe impl<T: Trace> Trace for Box<[T]> {
     custom_trace!(this, {
-        for e in this.iter() {
+        for e in &**this {
             mark(e);
         }
     });
@@ -319,7 +319,7 @@ impl<T: Ord + Trace> Finalize for BinaryHeap<T> {}
 // SAFETY: All the elements of the `BinaryHeap` are correctly marked.
 unsafe impl<T: Ord + Trace> Trace for BinaryHeap<T> {
     custom_trace!(this, {
-        for v in this.iter() {
+        for v in this {
             mark(v);
         }
     });
@@ -350,7 +350,7 @@ impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Finalize for HashMap<K, V, 
 // SAFETY: All the elements of the `HashMap` are correctly marked.
 unsafe impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Trace for HashMap<K, V, S> {
     custom_trace!(this, {
-        for (k, v) in this.iter() {
+        for (k, v) in this {
             mark(k);
             mark(v);
         }
@@ -361,7 +361,7 @@ impl<T: Eq + Hash + Trace, S: BuildHasher> Finalize for HashSet<T, S> {}
 // SAFETY: All the elements of the `HashSet` are correctly marked.
 unsafe impl<T: Eq + Hash + Trace, S: BuildHasher> Trace for HashSet<T, S> {
     custom_trace!(this, {
-        for v in this.iter() {
+        for v in this {
             mark(v);
         }
     });
@@ -371,6 +371,7 @@ impl<T: Eq + Hash + Trace> Finalize for LinkedList<T> {}
 // SAFETY: All the elements of the `LinkedList` are correctly marked.
 unsafe impl<T: Eq + Hash + Trace> Trace for LinkedList<T> {
     custom_trace!(this, {
+        #[allow(clippy::explicit_iter_loop)]
         for v in this.iter() {
             mark(v);
         }
@@ -387,7 +388,7 @@ impl<T: Trace> Finalize for VecDeque<T> {}
 // SAFETY: All the elements of the `VecDeque` are correctly marked.
 unsafe impl<T: Trace> Trace for VecDeque<T> {
     custom_trace!(this, {
-        for v in this.iter() {
+        for v in this {
             mark(v);
         }
     });

--- a/boa_interner/src/interned_str.rs
+++ b/boa_interner/src/interned_str.rs
@@ -46,7 +46,7 @@ impl<Char> InternedStr<Char> {
 
 impl<Char> Clone for InternedStr<Char> {
     fn clone(&self) -> Self {
-        Self { ptr: self.ptr }
+        *self
     }
 }
 

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -355,6 +355,11 @@ impl Interner {
     }
 
     /// Returns the string for the given symbol if any.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the size of both statics is not equal or the interners do
+    /// not have the same size
     #[must_use]
     pub fn resolve(&self, symbol: Sym) -> Option<JSInternedStrRef<'_, '_>> {
         let index = symbol.get() - 1;

--- a/boa_parser/src/lexer/cursor.rs
+++ b/boa_parser/src/lexer/cursor.rs
@@ -313,7 +313,7 @@ where
     /// This expects for the buffer to be fully filled. If it's not, it will fail with an
     /// `UnexpectedEof` I/O error.
     fn fill_bytes(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        for byte in buf.iter_mut() {
+        for byte in &mut *buf {
             *byte = self.next_byte()?.ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::UnexpectedEof,

--- a/boa_parser/src/lexer/tests.rs
+++ b/boa_parser/src/lexer/tests.rs
@@ -18,7 +18,7 @@ fn expect_tokens<R>(lexer: &mut Lexer<R>, expected: &[TokenKind], interner: &mut
 where
     R: Read,
 {
-    for expect in expected.iter() {
+    for expect in expected {
         assert_eq!(&lexer.next(interner).unwrap().unwrap().kind(), &expect);
     }
 
@@ -933,13 +933,13 @@ fn string_codepoint_with_no_braces() {
 fn illegal_code_point_following_numeric_literal() {
     // Checks as per https://tc39.es/ecma262/#sec-literals-numeric-literals that a NumericLiteral cannot
     // be immediately followed by an IdentifierStart where the IdentifierStart
-    let mut lexer = Lexer::new(&br#"17.4\u{2764}"#[..]);
+    let mut lexer = Lexer::new(&br"17.4\u{2764}"[..]);
     let interner = &mut Interner::default();
 
     assert!(
         lexer.next(interner).is_err(),
         "{}",
-        r#"IdentifierStart \u{2764} following NumericLiteral not rejected as expected"#
+        r"IdentifierStart \u{2764} following NumericLiteral not rejected as expected"
     );
 }
 
@@ -961,7 +961,7 @@ fn string_unicode() {
 
 #[test]
 fn string_unicode_escape_with_braces() {
-    let mut lexer = Lexer::new(&br#"'{\u{20ac}\u{a0}\u{a0}}'"#[..]);
+    let mut lexer = Lexer::new(&br"'{\u{20ac}\u{a0}\u{a0}}'"[..]);
     let interner = &mut Interner::default();
 
     let sym =
@@ -970,7 +970,7 @@ fn string_unicode_escape_with_braces() {
 
     expect_tokens(&mut lexer, &expected, interner);
 
-    lexer = Lexer::new(&br#"\u{{a0}"#[..]);
+    lexer = Lexer::new(&br"\u{{a0}"[..]);
 
     if let Error::Syntax(_, pos) = lexer
         .next(interner)
@@ -981,7 +981,7 @@ fn string_unicode_escape_with_braces() {
         panic!("invalid error type");
     }
 
-    lexer = Lexer::new(&br#"\u{{a0}}"#[..]);
+    lexer = Lexer::new(&br"\u{{a0}}"[..]);
 
     if let Error::Syntax(_, pos) = lexer
         .next(interner)
@@ -995,7 +995,7 @@ fn string_unicode_escape_with_braces() {
 
 #[test]
 fn string_unicode_escape_with_braces_2() {
-    let s = r#"'\u{20ac}\u{a0}\u{a0}'"#;
+    let s = r"'\u{20ac}\u{a0}\u{a0}'";
 
     let mut lexer = Lexer::new(s.as_bytes());
     let interner = &mut Interner::default();
@@ -1008,7 +1008,7 @@ fn string_unicode_escape_with_braces_2() {
 
 #[test]
 fn string_with_single_escape() {
-    let s = r#"'\Б'"#;
+    let s = r"'\Б'";
 
     let mut lexer = Lexer::new(s.as_bytes());
     let interner = &mut Interner::default();
@@ -1022,13 +1022,13 @@ fn string_with_single_escape() {
 #[test]
 fn string_legacy_octal_escape() {
     let test_cases = [
-        (r#"'\3'"#, "\u{3}"),
-        (r#"'\03'"#, "\u{3}"),
-        (r#"'\003'"#, "\u{3}"),
-        (r#"'\0003'"#, "\u{0}3"),
-        (r#"'\43'"#, "#"),
-        (r#"'\043'"#, "#"),
-        (r#"'\101'"#, "A"),
+        (r"'\3'", "\u{3}"),
+        (r"'\03'", "\u{3}"),
+        (r"'\003'", "\u{3}"),
+        (r"'\0003'", "\u{0}3"),
+        (r"'\43'", "#"),
+        (r"'\043'", "#"),
+        (r"'\101'", "A"),
     ];
 
     for (s, expected) in &test_cases {
@@ -1062,7 +1062,7 @@ fn string_legacy_octal_escape() {
 
 #[test]
 fn string_zero_escape() {
-    let test_cases = [(r#"'\0'"#, "\u{0}"), (r#"'\0A'"#, "\u{0}A")];
+    let test_cases = [(r"'\0'", "\u{0}"), (r"'\0A'", "\u{0}A")];
 
     for (s, expected) in &test_cases {
         let mut lexer = Lexer::new(s.as_bytes());
@@ -1077,7 +1077,7 @@ fn string_zero_escape() {
 
 #[test]
 fn string_non_octal_decimal_escape() {
-    let test_cases = [(r#"'\8'"#, "8"), (r#"'\9'"#, "9")];
+    let test_cases = [(r"'\8'", "8"), (r"'\9'", "9")];
 
     for (s, expected) in &test_cases {
         let mut lexer = Lexer::new(s.as_bytes());

--- a/boa_parser/src/parser/tests/format/expression.rs
+++ b/boa_parser/src/parser/tests/format/expression.rs
@@ -87,7 +87,7 @@ fn array() {
 #[test]
 fn template() {
     test_formatting(
-        r#"
+        r"
         function tag(t, ...args) {
             let a = [];
             a = a.concat([t[0], t[1], t[2]]);
@@ -97,7 +97,7 @@ fn template() {
         }
         let a = 10;
         tag`result: ${a} \x26 ${a + 10}`;
-        "#,
+        ",
     );
 }
 

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -150,6 +150,10 @@ impl Profiler {
     }
 
     /// Drop the global instance of the profiler.
+    /// 
+    /// # Panics
+    /// 
+    /// Calling `drop` will panic if `INSTANCE` cannot be taken back.
     pub fn drop(&self) {
         // In order to drop the INSTANCE we need to get ownership of it, which isn't possible on a static unless you make it a mutable static
         // mutating statics is unsafe, so we need to wrap it as so.

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -150,9 +150,9 @@ impl Profiler {
     }
 
     /// Drop the global instance of the profiler.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Calling `drop` will panic if `INSTANCE` cannot be taken back.
     pub fn drop(&self) {
         // In order to drop the INSTANCE we need to get ownership of it, which isn't possible on a static unless you make it a mutable static

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -62,7 +62,7 @@ impl TestSuite {
         };
 
         let mut features = FxHashSet::default();
-        for test_iter in self.tests.iter() {
+        for test_iter in &*self.tests {
             features.extend(test_iter.features.iter().map(ToString::to_string));
         }
 

--- a/boa_tester/src/read.rs
+++ b/boa_tester/src/read.rs
@@ -211,7 +211,7 @@ fn read_metadata(test: &Path) -> io::Result<MetaData> {
 
     /// Regular expression to retrieve the metadata of a test.
     static META_REGEX: Lazy<Regex> = Lazy::new(|| {
-        Regex::new(r#"/\*\-{3}((?:.|\n)*)\-{3}\*/"#)
+        Regex::new(r"/\*\-{3}((?:.|\n)*)\-{3}\*/")
             .expect("could not compile metadata regular expression")
     });
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the failing CI on #3232.

It changes the following:

- Adds the ` # Panics` doc to the drop method.

EDIT: This kind of went a bit farther than I intended initially to just about all the lints. Comment is below.
