### PR TITLE
Fix potential stack overflow in boa_parser

### DIFF
--- a/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -26,7 +26,7 @@ const PEEK_BUF_SIZE: usize = (MAX_PEEK_SKIP + 1) * 2 + 1;
 
 #[derive(Debug)]
 pub(super) struct BufferedLexer<R> {
-    lexer: Lexer<R>,
+    lexer: Box<Lexer<R>>,
     peeked: [Option<Token>; PEEK_BUF_SIZE],
     read_index: usize,
     write_index: usize,
@@ -38,7 +38,7 @@ where
 {
     fn from(lexer: Lexer<R>) -> Self {
         Self {
-            lexer,
+            lexer: Box::new(lexer),
             peeked: [
                 None::<Token>,
                 None::<Token>,


### PR DESCRIPTION
By moving the Lexer to the heap.

Alternatively, only moving the cursor also seems to work:

```diff
--- boa_parser/src/lexer/mod.rs
+++ boa_parser/src/lexer/mod.rs
@@ -66,7 +66,7 @@ trait Tokenizer<R> {
 /// Lexer or tokenizer for the Boa JavaScript Engine.
 #[derive(Debug)]
 pub struct Lexer<R> {
-    cursor: Cursor<R>,
+    cursor: Box<Cursor<R>>,
     goal_symbol: InputElement,
 }

@@ -107,7 +107,7 @@ impl<R> Lexer<R> {
         R: Read,
     {
         Self {
-            cursor: Cursor::new(reader),
+            cursor: Box::new(Cursor::new(reader)),
             goal_symbol: InputElement::default(),
         }
     }
```

Let me know what you think.

Fixes #3247 