### PR TITLE
Varying length operand

### DIFF
--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -129,10 +129,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticGetterByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticGetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -145,10 +142,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticSetterByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticSetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -161,10 +155,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticMethodByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -177,10 +168,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticMethodByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -193,10 +181,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticMethodByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -209,10 +194,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(
-                                    Opcode::DefineClassStaticMethodByName,
-                                    &[Operand::U32(index)],
-                                );
+                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -230,32 +212,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateGetter, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateGetter, index);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateSetter, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateSetter, index);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::SetPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPrivateMethod, index);
                         }
                     }
                 }
@@ -336,7 +318,7 @@ impl ByteCompiler<'_, '_> {
                         Opcode::GetFunction,
                         &[Operand::U32(index), Operand::Bool(false)],
                     );
-                    self.emit(Opcode::PushClassFieldPrivate, &[Operand::U32(name_index)]);
+                    self.emit_wide(Opcode::PushClassFieldPrivate, name_index);
                 }
                 ClassElement::StaticFieldDefinition(name, field) => {
                     self.emit_opcode(Opcode::Dup);
@@ -384,7 +366,7 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::SetHomeObjectClass);
                     self.emit(Opcode::Call, &[Operand::U32(0)]);
                     if let Some(name_index) = name_index {
-                        self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(name_index)]);
+                        self.emit_wide(Opcode::DefineOwnPropertyByName, name_index);
                     } else {
                         self.emit_opcode(Opcode::DefineOwnPropertyByValue);
                     }
@@ -397,7 +379,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::PushUndefined);
                     }
                     let index = self.get_or_insert_private_name(*name);
-                    self.emit(Opcode::DefinePrivateField, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefinePrivateField, index);
                 }
                 ClassElement::StaticBlock(body) => {
                     self.emit_opcode(Opcode::Dup);
@@ -442,32 +424,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateGetter, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateGetter, index);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateSetter, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateSetter, index);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit(Opcode::PushClassPrivateMethod, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
                         }
                     }
                 }
@@ -487,7 +469,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassGetterByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassGetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -500,7 +482,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassSetterByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassSetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -513,7 +495,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -526,7 +508,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -539,7 +521,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -552,7 +534,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit(Opcode::DefineClassMethodByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -129,7 +129,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticGetterByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticGetterByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -142,7 +145,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticSetterByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticSetterByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -155,7 +161,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -168,7 +177,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -181,7 +193,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -194,7 +209,10 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassStaticMethodByName, index);
+                                self.emit_varying_width(
+                                    Opcode::DefineClassStaticMethodByName,
+                                    index,
+                                );
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -212,32 +230,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateGetter, index);
+                            self.emit_varying_width(Opcode::SetPrivateGetter, index);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateSetter, index);
+                            self.emit_varying_width(Opcode::SetPrivateSetter, index);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateMethod, index);
+                            self.emit_varying_width(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateMethod, index);
+                            self.emit_varying_width(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateMethod, index);
+                            self.emit_varying_width(Opcode::SetPrivateMethod, index);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::SetPrivateMethod, index);
+                            self.emit_varying_width(Opcode::SetPrivateMethod, index);
                         }
                     }
                 }
@@ -318,7 +336,7 @@ impl ByteCompiler<'_, '_> {
                         Opcode::GetFunction,
                         &[Operand::U32(index), Operand::Bool(false)],
                     );
-                    self.emit_wide(Opcode::PushClassFieldPrivate, name_index);
+                    self.emit_varying_width(Opcode::PushClassFieldPrivate, name_index);
                 }
                 ClassElement::StaticFieldDefinition(name, field) => {
                     self.emit_opcode(Opcode::Dup);
@@ -366,7 +384,7 @@ impl ByteCompiler<'_, '_> {
                     self.emit_opcode(Opcode::SetHomeObjectClass);
                     self.emit(Opcode::Call, &[Operand::U32(0)]);
                     if let Some(name_index) = name_index {
-                        self.emit_wide(Opcode::DefineOwnPropertyByName, name_index);
+                        self.emit_varying_width(Opcode::DefineOwnPropertyByName, name_index);
                     } else {
                         self.emit_opcode(Opcode::DefineOwnPropertyByValue);
                     }
@@ -379,7 +397,7 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::PushUndefined);
                     }
                     let index = self.get_or_insert_private_name(*name);
-                    self.emit_wide(Opcode::DefinePrivateField, index);
+                    self.emit_varying_width(Opcode::DefinePrivateField, index);
                 }
                 ClassElement::StaticBlock(body) => {
                     self.emit_opcode(Opcode::Dup);
@@ -424,32 +442,32 @@ impl ByteCompiler<'_, '_> {
                         MethodDefinition::Get(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateGetter, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateGetter, index);
                         }
                         MethodDefinition::Set(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateSetter, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateSetter, index);
                         }
                         MethodDefinition::Ordinary(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::Async(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::Generator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateMethod, index);
                         }
                         MethodDefinition::AsyncGenerator(expr) => {
                             self.method(expr.into(), class_name);
                             let index = self.get_or_insert_private_name(*name);
-                            self.emit_wide(Opcode::PushClassPrivateMethod, index);
+                            self.emit_varying_width(Opcode::PushClassPrivateMethod, index);
                         }
                     }
                 }
@@ -469,7 +487,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassGetterByName, index);
+                                self.emit_varying_width(Opcode::DefineClassGetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -482,7 +500,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassSetterByName, index);
+                                self.emit_varying_width(Opcode::DefineClassSetterByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -495,7 +513,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassMethodByName, index);
+                                self.emit_varying_width(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -508,7 +526,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassMethodByName, index);
+                                self.emit_varying_width(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -521,7 +539,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassMethodByName, index);
+                                self.emit_varying_width(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);
@@ -534,7 +552,7 @@ impl ByteCompiler<'_, '_> {
                             PropertyName::Literal(name) => {
                                 self.method(expr.into(), class_name);
                                 let index = self.get_or_insert_name((*name).into());
-                                self.emit_wide(Opcode::DefineClassMethodByName, index);
+                                self.emit_varying_width(Opcode::DefineClassMethodByName, index);
                             }
                             PropertyName::Computed(name_node) => {
                                 self.compile_expr(name_node, true);

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -40,7 +40,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                                    self.emit_wide(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -118,7 +118,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                                    self.emit_wide(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -158,7 +158,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                                    self.emit_wide(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);

--- a/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/boa_engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -40,7 +40,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit_wide(Opcode::GetPropertyByName, index);
+                                    self.emit_varying_width(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -118,7 +118,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit_wide(Opcode::GetPropertyByName, index);
+                                    self.emit_varying_width(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);
@@ -158,7 +158,7 @@ impl ByteCompiler<'_, '_> {
                             match name {
                                 PropertyName::Literal(name) => {
                                     let index = self.get_or_insert_name((*name).into());
-                                    self.emit_wide(Opcode::GetPropertyByName, index);
+                                    self.emit_varying_width(Opcode::GetPropertyByName, index);
                                 }
                                 PropertyName::Computed(node) => {
                                     self.compile_expr(node, true);

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -572,7 +572,7 @@ impl ByteCompiler<'_, '_> {
                                     let binding = self.initialize_mutable_binding(f, true);
                                     let index = self.get_or_insert_binding(binding);
                                     self.emit_opcode(Opcode::PushUndefined);
-                                    self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                                    self.emit_wide(Opcode::DefInitVar, index);
                                 }
                             }
 
@@ -744,11 +744,11 @@ impl ByteCompiler<'_, '_> {
                     match self.set_mutable_binding(name) {
                         Ok(binding) => {
                             let index = self.get_or_insert_binding(binding);
-                            self.emit(Opcode::SetName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetName, index);
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
-                            self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::ThrowMutateImmutable, index);
                         }
                         Err(BindingLocatorError::Silent) => {
                             self.emit_opcode(Opcode::Pop);
@@ -761,7 +761,7 @@ impl ByteCompiler<'_, '_> {
                     self.create_mutable_binding(name, !strict);
                     let binding = self.initialize_mutable_binding(name, !strict);
                     let index = self.get_or_insert_binding(binding);
-                    self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefInitVar, index);
                 }
             }
         }
@@ -787,7 +787,7 @@ impl ByteCompiler<'_, '_> {
                     let binding = self.initialize_mutable_binding(name, !strict);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefInitVar, index);
                 }
             }
         }
@@ -1056,14 +1056,14 @@ impl ByteCompiler<'_, '_> {
                         // a. Let initialValue be ! env.GetBindingValue(n, false).
                         let binding = self.get_binding_value(n);
                         let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::GetName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetName, index);
                     }
 
                     // 5. Perform ! varEnv.InitializeBinding(n, initialValue).
                     let binding = self.initialize_mutable_binding(n, true);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefInitVar, index);
 
                     // 6. NOTE: A var with the same name as a formal parameter initially has
                     //          the same value as the corresponding initialized parameter.
@@ -1090,7 +1090,7 @@ impl ByteCompiler<'_, '_> {
                     let binding = self.initialize_mutable_binding(n, true);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefInitVar, index);
                 }
             }
 
@@ -1122,7 +1122,7 @@ impl ByteCompiler<'_, '_> {
                         let binding = self.initialize_mutable_binding(f, true);
                         let index = self.get_or_insert_binding(binding);
                         self.emit_opcode(Opcode::PushUndefined);
-                        self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::DefInitVar, index);
 
                         // c. Append F to instantiatedVarNames.
                         instantiated_var_names.push(f);

--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -572,7 +572,7 @@ impl ByteCompiler<'_, '_> {
                                     let binding = self.initialize_mutable_binding(f, true);
                                     let index = self.get_or_insert_binding(binding);
                                     self.emit_opcode(Opcode::PushUndefined);
-                                    self.emit_wide(Opcode::DefInitVar, index);
+                                    self.emit_varying_width(Opcode::DefInitVar, index);
                                 }
                             }
 
@@ -744,11 +744,11 @@ impl ByteCompiler<'_, '_> {
                     match self.set_mutable_binding(name) {
                         Ok(binding) => {
                             let index = self.get_or_insert_binding(binding);
-                            self.emit_wide(Opcode::SetName, index);
+                            self.emit_varying_width(Opcode::SetName, index);
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
-                            self.emit_wide(Opcode::ThrowMutateImmutable, index);
+                            self.emit_varying_width(Opcode::ThrowMutateImmutable, index);
                         }
                         Err(BindingLocatorError::Silent) => {
                             self.emit_opcode(Opcode::Pop);
@@ -761,7 +761,7 @@ impl ByteCompiler<'_, '_> {
                     self.create_mutable_binding(name, !strict);
                     let binding = self.initialize_mutable_binding(name, !strict);
                     let index = self.get_or_insert_binding(binding);
-                    self.emit_wide(Opcode::DefInitVar, index);
+                    self.emit_varying_width(Opcode::DefInitVar, index);
                 }
             }
         }
@@ -787,7 +787,7 @@ impl ByteCompiler<'_, '_> {
                     let binding = self.initialize_mutable_binding(name, !strict);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit_wide(Opcode::DefInitVar, index);
+                    self.emit_varying_width(Opcode::DefInitVar, index);
                 }
             }
         }
@@ -1056,14 +1056,14 @@ impl ByteCompiler<'_, '_> {
                         // a. Let initialValue be ! env.GetBindingValue(n, false).
                         let binding = self.get_binding_value(n);
                         let index = self.get_or_insert_binding(binding);
-                        self.emit_wide(Opcode::GetName, index);
+                        self.emit_varying_width(Opcode::GetName, index);
                     }
 
                     // 5. Perform ! varEnv.InitializeBinding(n, initialValue).
                     let binding = self.initialize_mutable_binding(n, true);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit_wide(Opcode::DefInitVar, index);
+                    self.emit_varying_width(Opcode::DefInitVar, index);
 
                     // 6. NOTE: A var with the same name as a formal parameter initially has
                     //          the same value as the corresponding initialized parameter.
@@ -1090,7 +1090,7 @@ impl ByteCompiler<'_, '_> {
                     let binding = self.initialize_mutable_binding(n, true);
                     let index = self.get_or_insert_binding(binding);
                     self.emit_opcode(Opcode::PushUndefined);
-                    self.emit_wide(Opcode::DefInitVar, index);
+                    self.emit_varying_width(Opcode::DefInitVar, index);
                 }
             }
 
@@ -1122,7 +1122,7 @@ impl ByteCompiler<'_, '_> {
                         let binding = self.initialize_mutable_binding(f, true);
                         let index = self.get_or_insert_binding(binding);
                         self.emit_opcode(Opcode::PushUndefined);
-                        self.emit_wide(Opcode::DefInitVar, index);
+                        self.emit_varying_width(Opcode::DefInitVar, index);
 
                         // c. Append F to instantiatedVarNames.
                         instantiated_var_names.push(f);

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -60,9 +60,9 @@ impl ByteCompiler<'_, '_> {
                     let lex = self.current_environment.is_lex_binding(name);
 
                     if lex {
-                        self.emit_wide(Opcode::GetName, index);
+                        self.emit_varying_width(Opcode::GetName, index);
                     } else {
-                        self.emit_wide(Opcode::GetNameAndLocator, index);
+                        self.emit_varying_width(Opcode::GetNameAndLocator, index);
                     }
 
                     if short_circuit {
@@ -79,11 +79,11 @@ impl ByteCompiler<'_, '_> {
                         match self.set_mutable_binding(name) {
                             Ok(binding) => {
                                 let index = self.get_or_insert_binding(binding);
-                                self.emit_wide(Opcode::SetName, index);
+                                self.emit_varying_width(Opcode::SetName, index);
                             }
                             Err(BindingLocatorError::MutateImmutable) => {
                                 let index = self.get_or_insert_name(name);
-                                self.emit_wide(Opcode::ThrowMutateImmutable, index);
+                                self.emit_varying_width(Opcode::ThrowMutateImmutable, index);
                             }
                             Err(BindingLocatorError::Silent) => {
                                 self.emit_opcode(Opcode::Pop);
@@ -102,7 +102,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
 
-                            self.emit_wide(Opcode::GetPropertyByName, index);
+                            self.emit_varying_width(Opcode::GetPropertyByName, index);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -112,7 +112,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit_wide(Opcode::SetPropertyByName, index);
+                            self.emit_varying_width(Opcode::SetPropertyByName, index);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }
@@ -145,7 +145,7 @@ impl ByteCompiler<'_, '_> {
                         self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit_wide(Opcode::GetPrivateField, index);
+                        self.emit_varying_width(Opcode::GetPrivateField, index);
                         if short_circuit {
                             pop_count = 1;
                             early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -155,7 +155,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(opcode);
                         }
 
-                        self.emit_wide(Opcode::SetPrivateField, index);
+                        self.emit_varying_width(Opcode::SetPrivateField, index);
                         if !use_expr {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -169,7 +169,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Swap);
                             self.emit_opcode(Opcode::This);
 
-                            self.emit_wide(Opcode::GetPropertyByName, index);
+                            self.emit_varying_width(Opcode::GetPropertyByName, index);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -179,7 +179,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit_wide(Opcode::SetPropertyByName, index);
+                            self.emit_varying_width(Opcode::SetPropertyByName, index);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }

--- a/boa_engine/src/bytecompiler/expression/assign.rs
+++ b/boa_engine/src/bytecompiler/expression/assign.rs
@@ -60,9 +60,9 @@ impl ByteCompiler<'_, '_> {
                     let lex = self.current_environment.is_lex_binding(name);
 
                     if lex {
-                        self.emit(Opcode::GetName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetName, index);
                     } else {
-                        self.emit(Opcode::GetNameAndLocator, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetNameAndLocator, index);
                     }
 
                     if short_circuit {
@@ -79,11 +79,11 @@ impl ByteCompiler<'_, '_> {
                         match self.set_mutable_binding(name) {
                             Ok(binding) => {
                                 let index = self.get_or_insert_binding(binding);
-                                self.emit(Opcode::SetName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::SetName, index);
                             }
                             Err(BindingLocatorError::MutateImmutable) => {
                                 let index = self.get_or_insert_name(name);
-                                self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::ThrowMutateImmutable, index);
                             }
                             Err(BindingLocatorError::Silent) => {
                                 self.emit_opcode(Opcode::Pop);
@@ -102,7 +102,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Dup);
                             self.emit_opcode(Opcode::Dup);
 
-                            self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::GetPropertyByName, index);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -112,7 +112,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPropertyByName, index);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }
@@ -145,7 +145,7 @@ impl ByteCompiler<'_, '_> {
                         self.compile_expr(access.target(), true);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetPrivateField, index);
                         if short_circuit {
                             pop_count = 1;
                             early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -155,7 +155,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(opcode);
                         }
 
-                        self.emit(Opcode::SetPrivateField, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::SetPrivateField, index);
                         if !use_expr {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -169,7 +169,7 @@ impl ByteCompiler<'_, '_> {
                             self.emit_opcode(Opcode::Swap);
                             self.emit_opcode(Opcode::This);
 
-                            self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::GetPropertyByName, index);
                             if short_circuit {
                                 pop_count = 2;
                                 early_exit = Some(self.emit_opcode_with_operand(opcode));
@@ -179,7 +179,7 @@ impl ByteCompiler<'_, '_> {
                                 self.emit_opcode(opcode);
                             }
 
-                            self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPropertyByName, index);
                             if !use_expr {
                                 self.emit_opcode(Opcode::Pop);
                             }

--- a/boa_engine/src/bytecompiler/expression/binary.rs
+++ b/boa_engine/src/bytecompiler/expression/binary.rs
@@ -97,7 +97,7 @@ impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary_in_private(&mut self, binary: &BinaryInPrivate, use_expr: bool) {
         let index = self.get_or_insert_private_name(*binary.lhs());
         self.compile_expr(binary.rhs(), true);
-        self.emit_wide(Opcode::InPrivate, index);
+        self.emit_varying_width(Opcode::InPrivate, index);
 
         if !use_expr {
             self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/expression/binary.rs
+++ b/boa_engine/src/bytecompiler/expression/binary.rs
@@ -3,10 +3,7 @@ use boa_ast::expression::operator::{
     Binary, BinaryInPrivate,
 };
 
-use crate::{
-    bytecompiler::{ByteCompiler, Operand},
-    vm::Opcode,
-};
+use crate::{bytecompiler::ByteCompiler, vm::Opcode};
 
 impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary(&mut self, binary: &Binary, use_expr: bool) {
@@ -100,7 +97,7 @@ impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_binary_in_private(&mut self, binary: &BinaryInPrivate, use_expr: bool) {
         let index = self.get_or_insert_private_name(*binary.lhs());
         self.compile_expr(binary.rhs(), true);
-        self.emit(Opcode::InPrivate, &[Operand::U32(index)]);
+        self.emit_wide(Opcode::InPrivate, index);
 
         if !use_expr {
             self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -228,7 +228,7 @@ impl ByteCompiler<'_, '_> {
                         match access.field() {
                             PropertyAccessField::Const(field) => {
                                 let index = self.get_or_insert_name((*field).into());
-                                self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                                self.emit_wide(Opcode::GetPropertyByName, index);
                             }
                             PropertyAccessField::Expr(field) => {
                                 self.compile_expr(field, true);
@@ -240,7 +240,7 @@ impl ByteCompiler<'_, '_> {
                         self.compile_expr(access.target(), true);
                         self.emit(Opcode::Dup, &[]);
                         let index = self.get_or_insert_private_name(access.field());
-                        self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetPrivateField, index);
                     }
                     expr => {
                         self.compile_expr(expr, true);

--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -228,7 +228,7 @@ impl ByteCompiler<'_, '_> {
                         match access.field() {
                             PropertyAccessField::Const(field) => {
                                 let index = self.get_or_insert_name((*field).into());
-                                self.emit_wide(Opcode::GetPropertyByName, index);
+                                self.emit_varying_width(Opcode::GetPropertyByName, index);
                             }
                             PropertyAccessField::Expr(field) => {
                                 self.compile_expr(field, true);
@@ -240,7 +240,7 @@ impl ByteCompiler<'_, '_> {
                         self.compile_expr(access.target(), true);
                         self.emit(Opcode::Dup, &[]);
                         let index = self.get_or_insert_private_name(access.field());
-                        self.emit_wide(Opcode::GetPrivateField, index);
+                        self.emit_varying_width(Opcode::GetPrivateField, index);
                     }
                     expr => {
                         self.compile_expr(expr, true);

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
                 PropertyDefinition::IdentifierReference(ident) => {
                     let index = self.get_or_insert_name(*ident);
                     self.access_get(Access::Variable { name: *ident }, true);
-                    self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                    self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                 }
                 PropertyDefinition::Property(name, expr) => match name {
                     PropertyName::Literal(name) => {
@@ -27,7 +27,7 @@ impl ByteCompiler<'_, '_> {
                         if *name == Sym::__PROTO__ && !self.json_parse {
                             self.emit_opcode(Opcode::SetPrototype);
                         } else {
-                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                            self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                         }
                     }
                     PropertyName::Computed(name_node) => {
@@ -49,7 +49,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::SetPropertyGetterByName, index);
+                            self.emit_varying_width(Opcode::SetPropertyGetterByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -64,7 +64,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::SetPropertySetterByName, index);
+                            self.emit_varying_width(Opcode::SetPropertySetterByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -79,7 +79,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                            self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -94,7 +94,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                            self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -109,7 +109,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                            self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -124,7 +124,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
+                            self.emit_varying_width(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(

--- a/boa_engine/src/bytecompiler/expression/object_literal.rs
+++ b/boa_engine/src/bytecompiler/expression/object_literal.rs
@@ -18,7 +18,7 @@ impl ByteCompiler<'_, '_> {
                 PropertyDefinition::IdentifierReference(ident) => {
                     let index = self.get_or_insert_name(*ident);
                     self.access_get(Access::Variable { name: *ident }, true);
-                    self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                 }
                 PropertyDefinition::Property(name, expr) => match name {
                     PropertyName::Literal(name) => {
@@ -27,7 +27,7 @@ impl ByteCompiler<'_, '_> {
                         if *name == Sym::__PROTO__ && !self.json_parse {
                             self.emit_opcode(Opcode::SetPrototype);
                         } else {
-                            self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                         }
                     }
                     PropertyName::Computed(name_node) => {
@@ -49,7 +49,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::SetPropertyGetterByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPropertyGetterByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -64,7 +64,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::SetPropertySetterByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetPropertySetterByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -79,7 +79,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -94,7 +94,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -109,7 +109,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(
@@ -124,7 +124,7 @@ impl ByteCompiler<'_, '_> {
                             self.object_method(expr.into());
                             self.emit_opcode(Opcode::SetHomeObject);
                             let index = self.get_or_insert_name((*name).into());
-                            self.emit(Opcode::DefineOwnPropertyByName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::DefineOwnPropertyByName, index);
                         }
                         PropertyName::Computed(name_node) => {
                             self.compile_object_literal_computed_method(

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -29,7 +29,7 @@ impl ByteCompiler<'_, '_> {
                     Expression::Identifier(identifier) => {
                         let binding = self.get_binding_value(*identifier);
                         let index = self.get_or_insert_binding(binding);
-                        self.emit_wide(Opcode::GetNameOrUndefined, index);
+                        self.emit_varying_width(Opcode::GetNameOrUndefined, index);
                     }
                     expr => self.compile_expr(expr, true),
                 }

--- a/boa_engine/src/bytecompiler/expression/unary.rs
+++ b/boa_engine/src/bytecompiler/expression/unary.rs
@@ -4,7 +4,7 @@ use boa_ast::{
 };
 
 use crate::{
-    bytecompiler::{Access, ByteCompiler, Operand},
+    bytecompiler::{Access, ByteCompiler},
     vm::Opcode,
 };
 
@@ -29,7 +29,7 @@ impl ByteCompiler<'_, '_> {
                     Expression::Identifier(identifier) => {
                         let binding = self.get_binding_value(*identifier);
                         let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::GetNameOrUndefined, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetNameOrUndefined, index);
                     }
                     expr => self.compile_expr(expr, true),
                 }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -28,9 +28,9 @@ impl ByteCompiler<'_, '_> {
                 let lex = self.current_environment.is_lex_binding(name);
 
                 if lex {
-                    self.emit(Opcode::GetName, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::GetName, index);
                 } else {
-                    self.emit(Opcode::GetNameAndLocator, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::GetNameAndLocator, index);
                 }
 
                 self.emit_opcode(opcode);
@@ -44,11 +44,11 @@ impl ByteCompiler<'_, '_> {
                     match self.set_mutable_binding(name) {
                         Ok(binding) => {
                             let index = self.get_or_insert_binding(binding);
-                            self.emit(Opcode::SetName, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::SetName, index);
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
-                            self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
+                            self.emit_wide(Opcode::ThrowMutateImmutable, index);
                         }
                         Err(BindingLocatorError::Silent) => {
                             self.emit_opcode(Opcode::Pop);
@@ -67,13 +67,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetPropertyByName, index);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(4)]);
                         }
 
-                        self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::SetPropertyByName, index);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -102,13 +102,13 @@ impl ByteCompiler<'_, '_> {
                     self.compile_expr(access.target(), true);
                     self.emit_opcode(Opcode::Dup);
 
-                    self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::GetPrivateField, index);
                     self.emit_opcode(opcode);
                     if post {
                         self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                     }
 
-                    self.emit(Opcode::SetPrivateField, &[Operand::U32(index)]);
+                    self.emit_wide(Opcode::SetPrivateField, index);
                     if post {
                         self.emit_opcode(Opcode::Pop);
                     }
@@ -122,13 +122,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Swap);
                         self.emit_opcode(Opcode::This);
 
-                        self.emit(Opcode::GetPropertyByName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::GetPropertyByName, index);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                         }
 
-                        self.emit(Opcode::SetPropertyByName, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::SetPropertyByName, index);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }

--- a/boa_engine/src/bytecompiler/expression/update.rs
+++ b/boa_engine/src/bytecompiler/expression/update.rs
@@ -28,9 +28,9 @@ impl ByteCompiler<'_, '_> {
                 let lex = self.current_environment.is_lex_binding(name);
 
                 if lex {
-                    self.emit_wide(Opcode::GetName, index);
+                    self.emit_varying_width(Opcode::GetName, index);
                 } else {
-                    self.emit_wide(Opcode::GetNameAndLocator, index);
+                    self.emit_varying_width(Opcode::GetNameAndLocator, index);
                 }
 
                 self.emit_opcode(opcode);
@@ -44,11 +44,11 @@ impl ByteCompiler<'_, '_> {
                     match self.set_mutable_binding(name) {
                         Ok(binding) => {
                             let index = self.get_or_insert_binding(binding);
-                            self.emit_wide(Opcode::SetName, index);
+                            self.emit_varying_width(Opcode::SetName, index);
                         }
                         Err(BindingLocatorError::MutateImmutable) => {
                             let index = self.get_or_insert_name(name);
-                            self.emit_wide(Opcode::ThrowMutateImmutable, index);
+                            self.emit_varying_width(Opcode::ThrowMutateImmutable, index);
                         }
                         Err(BindingLocatorError::Silent) => {
                             self.emit_opcode(Opcode::Pop);
@@ -67,13 +67,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Dup);
                         self.emit_opcode(Opcode::Dup);
 
-                        self.emit_wide(Opcode::GetPropertyByName, index);
+                        self.emit_varying_width(Opcode::GetPropertyByName, index);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(4)]);
                         }
 
-                        self.emit_wide(Opcode::SetPropertyByName, index);
+                        self.emit_varying_width(Opcode::SetPropertyByName, index);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }
@@ -102,13 +102,13 @@ impl ByteCompiler<'_, '_> {
                     self.compile_expr(access.target(), true);
                     self.emit_opcode(Opcode::Dup);
 
-                    self.emit_wide(Opcode::GetPrivateField, index);
+                    self.emit_varying_width(Opcode::GetPrivateField, index);
                     self.emit_opcode(opcode);
                     if post {
                         self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                     }
 
-                    self.emit_wide(Opcode::SetPrivateField, index);
+                    self.emit_varying_width(Opcode::SetPrivateField, index);
                     if post {
                         self.emit_opcode(Opcode::Pop);
                     }
@@ -122,13 +122,13 @@ impl ByteCompiler<'_, '_> {
                         self.emit_opcode(Opcode::Swap);
                         self.emit_opcode(Opcode::This);
 
-                        self.emit_wide(Opcode::GetPropertyByName, index);
+                        self.emit_varying_width(Opcode::GetPropertyByName, index);
                         self.emit_opcode(opcode);
                         if post {
                             self.emit(Opcode::RotateRight, &[Operand::U8(3)]);
                         }
 
-                        self.emit_wide(Opcode::SetPropertyByName, index);
+                        self.emit_varying_width(Opcode::SetPropertyByName, index);
                         if post {
                             self.emit_opcode(Opcode::Pop);
                         }

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -69,13 +69,13 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(let_binding_indices) = let_binding_indices {
             for index in &let_binding_indices {
-                self.emit(Opcode::GetName, &[Operand::U32(*index)]);
+                self.emit_wide(Opcode::GetName, *index);
             }
             self.emit_opcode(Opcode::PopEnvironment);
             iteration_env_labels =
                 Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
             for index in let_binding_indices.iter().rev() {
-                self.emit(Opcode::PutLexicalValue, &[Operand::U32(*index)]);
+                self.emit_wide(Opcode::PutLexicalValue, *index);
             }
         }
 
@@ -303,11 +303,11 @@ impl ByteCompiler<'_, '_> {
                 match self.set_mutable_binding(*ident) {
                     Ok(binding) => {
                         let index = self.get_or_insert_binding(binding);
-                        self.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::DefInitVar, index);
                     }
                     Err(BindingLocatorError::MutateImmutable) => {
                         let index = self.get_or_insert_name(*ident);
-                        self.emit(Opcode::ThrowMutateImmutable, &[Operand::U32(index)]);
+                        self.emit_wide(Opcode::ThrowMutateImmutable, index);
                     }
                     Err(BindingLocatorError::Silent) => {
                         self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/statement/loop.rs
+++ b/boa_engine/src/bytecompiler/statement/loop.rs
@@ -69,13 +69,13 @@ impl ByteCompiler<'_, '_> {
 
         if let Some(let_binding_indices) = let_binding_indices {
             for index in &let_binding_indices {
-                self.emit_wide(Opcode::GetName, *index);
+                self.emit_varying_width(Opcode::GetName, *index);
             }
             self.emit_opcode(Opcode::PopEnvironment);
             iteration_env_labels =
                 Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
             for index in let_binding_indices.iter().rev() {
-                self.emit_wide(Opcode::PutLexicalValue, *index);
+                self.emit_varying_width(Opcode::PutLexicalValue, *index);
             }
         }
 
@@ -303,11 +303,11 @@ impl ByteCompiler<'_, '_> {
                 match self.set_mutable_binding(*ident) {
                     Ok(binding) => {
                         let index = self.get_or_insert_binding(binding);
-                        self.emit_wide(Opcode::DefInitVar, index);
+                        self.emit_varying_width(Opcode::DefInitVar, index);
                     }
                     Err(BindingLocatorError::MutateImmutable) => {
                         let index = self.get_or_insert_name(*ident);
-                        self.emit_wide(Opcode::ThrowMutateImmutable, index);
+                        self.emit_varying_width(Opcode::ThrowMutateImmutable, index);
                     }
                     Err(BindingLocatorError::Silent) => {
                         self.emit_opcode(Opcode::Pop);

--- a/boa_engine/src/bytecompiler/utils.rs
+++ b/boa_engine/src/bytecompiler/utils.rs
@@ -36,7 +36,7 @@ impl ByteCompiler<'_, '_> {
         let error_msg = self.get_or_insert_literal(Literal::String(js_string!(
             "inner result was not an object"
         )));
-        self.emit_wide(Opcode::ThrowNewTypeError, error_msg);
+        self.emit_varying_width(Opcode::ThrowNewTypeError, error_msg);
 
         self.patch_jump(skip_return);
         self.emit_opcode(Opcode::IteratorPop);

--- a/boa_engine/src/bytecompiler/utils.rs
+++ b/boa_engine/src/bytecompiler/utils.rs
@@ -36,7 +36,7 @@ impl ByteCompiler<'_, '_> {
         let error_msg = self.get_or_insert_literal(Literal::String(js_string!(
             "inner result was not an object"
         )));
-        self.emit(Opcode::ThrowNewTypeError, &[Operand::U32(error_msg)]);
+        self.emit_wide(Opcode::ThrowNewTypeError, error_msg);
 
         self.patch_jump(skip_return);
         self.emit_opcode(Opcode::IteratorPop);

--- a/boa_engine/src/module/source.rs
+++ b/boa_engine/src/module/source.rs
@@ -22,7 +22,7 @@ use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 
 use crate::{
     builtins::{promise::PromiseCapability, Promise},
-    bytecompiler::{ByteCompiler, FunctionSpec, Operand},
+    bytecompiler::{ByteCompiler, FunctionSpec},
     environments::{BindingLocator, CompileTimeEnvironment, EnvironmentStack},
     module::ModuleKind,
     object::{FunctionObjectBuilder, JsPromise, RecursionLimiter},
@@ -1501,7 +1501,7 @@ impl SourceTextModule {
                         let binding = compiler.initialize_mutable_binding(name, false);
                         let index = compiler.get_or_insert_binding(binding);
                         compiler.emit_opcode(Opcode::PushUndefined);
-                        compiler.emit(Opcode::DefInitVar, &[Operand::U32(index)]);
+                        compiler.emit_wide(Opcode::DefInitVar, index);
                         // 3. Append dn to declaredVarNames.
                         declared_var_names.push(name);
                     }

--- a/boa_engine/src/module/source.rs
+++ b/boa_engine/src/module/source.rs
@@ -1501,7 +1501,7 @@ impl SourceTextModule {
                         let binding = compiler.initialize_mutable_binding(name, false);
                         let index = compiler.get_or_insert_binding(binding);
                         compiler.emit_opcode(Opcode::PushUndefined);
-                        compiler.emit_wide(Opcode::DefInitVar, index);
+                        compiler.emit_varying_width(Opcode::DefInitVar, index);
                         // 3. Append dn to declaredVarNames.
                         declared_var_names.push(name);
                     }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -576,7 +576,8 @@ impl CodeBlock {
             | Instruction::SetReturnValue
             | Instruction::Nop => String::new(),
 
-            Instruction::Wide
+            Instruction::Half
+            | Instruction::Wide
             | Instruction::Reserved1
             | Instruction::Reserved2
             | Instruction::Reserved3
@@ -633,8 +634,7 @@ impl CodeBlock {
             | Instruction::Reserved54
             | Instruction::Reserved55
             | Instruction::Reserved56
-            | Instruction::Reserved57
-            | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved57 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }
@@ -679,6 +679,7 @@ impl ToInternedString for CodeBlock {
 
             let varying_operand_kind = match varying_operand_kind {
                 super::VaryingOperandKind::Short => "",
+                super::VaryingOperandKind::Half => ".Half",
                 super::VaryingOperandKind::Wide => ".Wide",
             };
 

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -21,7 +21,8 @@ use std::{cell::Cell, mem::size_of, rc::Rc};
 use thin_vec::ThinVec;
 
 #[cfg(any(feature = "trace", feature = "flowgraph"))]
-use crate::vm::Opcode;
+use super::{Instruction, InstructionIterator};
+
 #[cfg(any(feature = "trace", feature = "flowgraph"))]
 use boa_interner::{Interner, ToInternedString};
 
@@ -300,10 +301,11 @@ impl CodeBlock {
     ///
     /// Returns an empty `String` if no operands are present.
     #[cfg(any(feature = "trace", feature = "flowgraph"))]
-    pub(crate) fn instruction_operands(&self, pc: &mut usize, interner: &Interner) -> String {
-        use super::Instruction;
-
-        let instruction = Instruction::from_bytecode(&self.bytecode, pc);
+    pub(crate) fn instruction_operands(
+        &self,
+        instruction: &Instruction,
+        interner: &Interner,
+    ) -> String {
         match instruction {
             Instruction::SetFunctionName { prefix } => match prefix {
                 0 => "prefix: none",
@@ -319,11 +321,11 @@ impl CodeBlock {
             Instruction::PushInt8 { value } => value.to_string(),
             Instruction::PushInt16 { value } => value.to_string(),
             Instruction::PushInt32 { value } => value.to_string(),
-            Instruction::PushFloat { value } => ryu_js::Buffer::new().format(value).to_string(),
-            Instruction::PushDouble { value } => ryu_js::Buffer::new().format(value).to_string(),
-            Instruction::PushLiteral { index: value }
-            | Instruction::ThrowNewTypeError { message: value }
-            | Instruction::Jump { address: value }
+            Instruction::PushFloat { value } => ryu_js::Buffer::new().format(*value).to_string(),
+            Instruction::PushDouble { value } => ryu_js::Buffer::new().format(*value).to_string(),
+            Instruction::PushLiteral { index }
+            | Instruction::ThrowNewTypeError { message: index } => index.value().to_string(),
+            Instruction::Jump { address: value }
             | Instruction::JumpIfTrue { address: value }
             | Instruction::JumpIfFalse { address: value }
             | Instruction::JumpIfNotUndefined { address: value }
@@ -376,19 +378,19 @@ impl CodeBlock {
             | Instruction::GetFunctionAsync { index, method } => {
                 format!(
                     "{index:04}: '{}' (length: {}), method: {method}",
-                    self.functions[index as usize]
+                    self.functions[*index as usize]
                         .name()
                         .to_std_string_escaped(),
-                    self.functions[index as usize].length
+                    self.functions[*index as usize].length
                 )
             }
             Instruction::GetGenerator { index } | Instruction::GetGeneratorAsync { index } => {
                 format!(
                     "{index:04}: '{}' (length: {})",
-                    self.functions[index as usize]
+                    self.functions[*index as usize]
                         .name()
                         .to_std_string_escaped(),
-                    self.functions[index as usize].length
+                    self.functions[*index as usize].length
                 )
             }
             Instruction::DefVar { index }
@@ -401,12 +403,12 @@ impl CodeBlock {
             | Instruction::SetName { index }
             | Instruction::DeleteName { index } => {
                 format!(
-                    "{index:04}: '{}'",
-                    interner.resolve_expect(self.bindings[index as usize].name().sym()),
+                    "{:04}: '{}'",
+                    index.value(),
+                    interner.resolve_expect(self.bindings[index.value() as usize].name().sym()),
                 )
             }
             Instruction::GetPropertyByName { index }
-            | Instruction::GetMethod { index }
             | Instruction::SetPropertyByName { index }
             | Instruction::DefineOwnPropertyByName { index }
             | Instruction::DefineClassStaticMethodByName { index }
@@ -417,6 +419,8 @@ impl CodeBlock {
             | Instruction::SetPropertySetterByName { index }
             | Instruction::DefineClassStaticSetterByName { index }
             | Instruction::DefineClassSetterByName { index }
+            | Instruction::InPrivate { index }
+            | Instruction::ThrowMutateImmutable { index }
             | Instruction::DeletePropertyByName { index }
             | Instruction::SetPrivateField { index }
             | Instruction::DefinePrivateField { index }
@@ -427,12 +431,11 @@ impl CodeBlock {
             | Instruction::PushClassFieldPrivate { index }
             | Instruction::PushClassPrivateGetter { index }
             | Instruction::PushClassPrivateSetter { index }
-            | Instruction::PushClassPrivateMethod { index }
-            | Instruction::InPrivate { index }
-            | Instruction::ThrowMutateImmutable { index } => {
+            | Instruction::PushClassPrivateMethod { index } => {
                 format!(
-                    "{index:04}: '{}'",
-                    self.names[index as usize].to_std_string_escaped(),
+                    "{:04}: '{}'",
+                    index.value(),
+                    self.names[index.value() as usize].to_std_string_escaped(),
                 )
             }
             Instruction::PushPrivateEnvironment { name_indices } => {
@@ -572,7 +575,9 @@ impl CodeBlock {
             | Instruction::GetReturnValue
             | Instruction::SetReturnValue
             | Instruction::Nop => String::new(),
-            Instruction::Reserved1
+
+            Instruction::Wide
+            | Instruction::Reserved1
             | Instruction::Reserved2
             | Instruction::Reserved3
             | Instruction::Reserved4
@@ -649,15 +654,14 @@ impl ToInternedString for CodeBlock {
             format!("Compiled Output: '{}'", name.to_std_string_escaped()),
         ));
 
-        let mut pc = 0;
-        let mut count = 0;
-        while pc < self.bytecode.len() {
-            let instruction_start_pc = pc;
+        let mut iterator = InstructionIterator::new(&self.bytecode);
 
-            let opcode: Opcode = self.bytecode[instruction_start_pc].into();
-            let opcode = opcode.as_str();
-            let previous_pc = pc;
-            let operands = self.instruction_operands(&mut pc, interner);
+        let mut count = 0;
+        while let Some((instruction_start_pc, varying_operand_kind, instruction)) = iterator.next()
+        {
+            let opcode = instruction.opcode().as_str();
+            let operands = self.instruction_operands(&instruction, interner);
+            let pc = iterator.pc();
 
             let handler = if let Some((i, handler)) = self.find_handler(instruction_start_pc as u32)
             {
@@ -673,8 +677,13 @@ impl ToInternedString for CodeBlock {
                 "   none  ".to_string()
             };
 
+            let varying_operand_kind = match varying_operand_kind {
+                super::VaryingOperandKind::Short => "",
+                super::VaryingOperandKind::Wide => ".Wide",
+            };
+
             f.push_str(&format!(
-                "{previous_pc:06}    {count:04}   {handler}    {opcode:<27}{operands}\n",
+                "{instruction_start_pc:06}    {count:04}   {handler}    {opcode}{varying_operand_kind:<27}{operands}\n",
             ));
             count += 1;
         }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -469,7 +469,8 @@ impl CodeBlock {
                 Instruction::Return => {
                     graph.add_node(previous_pc, NodeShape::Diamond, label.into(), Color::Red);
                 }
-                Instruction::Wide
+                Instruction::Half
+                | Instruction::Wide
                 | Instruction::Reserved1
                 | Instruction::Reserved2
                 | Instruction::Reserved3
@@ -526,8 +527,7 @@ impl CodeBlock {
                 | Instruction::Reserved54
                 | Instruction::Reserved55
                 | Instruction::Reserved56
-                | Instruction::Reserved57
-                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved57 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -14,10 +14,14 @@ pub use edge::*;
 pub use graph::*;
 pub use node::*;
 
-use super::Instruction;
+use super::{Instruction, InstructionIterator};
 
 impl CodeBlock {
     /// Output the [`CodeBlock`] VM instructions into a [`Graph`].
+    ///
+    /// # Panics
+    ///
+    /// TODO:
     #[allow(clippy::match_same_arms)]
     pub fn to_graph(&self, interner: &Interner, graph: &mut SubGraph) {
         // Have to remove any invalid graph chars like `<` or `>`.
@@ -29,18 +33,17 @@ impl CodeBlock {
 
         graph.set_label(name);
 
-        let mut pc = 0;
-        while pc < self.bytecode.len() {
-            let previous_pc = pc;
-            let instruction = Instruction::from_bytecode(&self.bytecode, &mut pc);
+        let mut iterator = InstructionIterator::new(&self.bytecode);
+        while let Some((previous_pc, _, instruction)) = iterator.next() {
             let opcode = instruction.opcode();
             let opcode_str = opcode.as_str();
 
-            let mut tmp = previous_pc;
             let label = format!(
                 "{opcode_str} {}",
-                self.instruction_operands(&mut tmp, interner)
+                self.instruction_operands(&instruction, interner)
             );
+
+            let pc = iterator.pc();
 
             match instruction {
                 Instruction::SetFunctionName { .. } => {
@@ -77,11 +80,7 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Instruction::PushLiteral { index } => {
-                    let operand_str = self.literals[index as usize].display().to_string();
-                    let operand_str = operand_str.escape_debug();
-                    let label = format!("{opcode_str} {operand_str}");
-
+                Instruction::PushLiteral { .. } => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
@@ -271,7 +270,6 @@ impl CodeBlock {
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
                 Instruction::GetPropertyByName { .. }
-                | Instruction::GetMethod { .. }
                 | Instruction::SetPropertyByName { .. }
                 | Instruction::DefineOwnPropertyByName { .. }
                 | Instruction::DefineClassStaticMethodByName { .. }
@@ -471,7 +469,8 @@ impl CodeBlock {
                 Instruction::Return => {
                     graph.add_node(previous_pc, NodeShape::Diamond, label.into(), Color::Red);
                 }
-                Instruction::Reserved1
+                Instruction::Wide
+                | Instruction::Reserved1
                 | Instruction::Reserved2
                 | Instruction::Reserved3
                 | Instruction::Reserved4

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -36,7 +36,7 @@ pub use runtime_limits::RuntimeLimits;
 pub use {
     call_frame::{CallFrame, GeneratorResumeKind},
     code_block::CodeBlock,
-    opcode::{Instruction, InstructionIterator, Opcode},
+    opcode::{Instruction, InstructionIterator, Opcode, VaryingOperand, VaryingOperandKind},
 };
 
 pub(crate) use {
@@ -245,13 +245,16 @@ impl Context<'_> {
     }
 
     fn trace_execute_instruction(&mut self) -> JsResult<CompletionType> {
-        let mut pc = self.vm.frame().pc as usize;
-        let opcode: Opcode = self.vm.frame().code_block.read::<u8>(pc).into();
+        let bytecodes = &self.vm.frame().code_block.bytecode;
+        let pc = self.vm.frame().pc as usize;
+        let (_, varying_operand_kind, instruction) = InstructionIterator::with_pc(bytecodes, pc)
+            .next()
+            .expect("There should be an instruction left");
         let operands = self
             .vm
             .frame()
             .code_block
-            .instruction_operands(&mut pc, self.interner());
+            .instruction_operands(&instruction, self.interner());
 
         let instant = Instant::now();
         let result = self.execute_instruction();
@@ -278,10 +281,16 @@ impl Context<'_> {
             stack
         };
 
+        let varying_operand_kind = match varying_operand_kind {
+            VaryingOperandKind::Short => "",
+            VaryingOperandKind::Wide => ".Wide",
+        };
+
         println!(
-            "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {stack}",
+            "{:<TIME_COLUMN_WIDTH$} {}{:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {stack}",
             format!("{}μs", duration.as_micros()),
-            opcode.as_str(),
+            instruction.opcode().as_str(),
+            varying_operand_kind,
             TIME_COLUMN_WIDTH = Self::TIME_COLUMN_WIDTH,
             OPCODE_COLUMN_WIDTH = Self::OPCODE_COLUMN_WIDTH,
             OPERAND_COLUMN_WIDTH = Self::OPERAND_COLUMN_WIDTH,

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -283,6 +283,7 @@ impl Context<'_> {
 
         let varying_operand_kind = match varying_operand_kind {
             VaryingOperandKind::Short => "",
+            VaryingOperandKind::Half => ".Half",
             VaryingOperandKind::Wide => ".Wide",
         };
 

--- a/boa_engine/src/vm/opcode/binary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/mod.rs
@@ -105,13 +105,9 @@ impl Operation for In {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct InPrivate;
 
-impl Operation for InPrivate {
-    const NAME: &'static str = "InPrivate";
-    const INSTRUCTION: &'static str = "INST - InPrivate";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl InPrivate {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let rhs = context.vm.pop();
 
         let Some(rhs) = rhs.as_object() else {
@@ -135,6 +131,21 @@ impl Operation for InPrivate {
             context.vm.push(false);
         }
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for InPrivate {
+    const NAME: &'static str = "InPrivate";
+    const INSTRUCTION: &'static str = "INST - InPrivate";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/binary_ops/mod.rs
+++ b/boa_engine/src/vm/opcode/binary_ops/mod.rs
@@ -143,6 +143,11 @@ impl Operation for InPrivate {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -139,6 +139,11 @@ impl Operation for ThrowNewTypeError {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)

--- a/boa_engine/src/vm/opcode/control_flow/throw.rs
+++ b/boa_engine/src/vm/opcode/control_flow/throw.rs
@@ -117,13 +117,9 @@ impl Operation for MaybeException {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ThrowNewTypeError;
 
-impl Operation for ThrowNewTypeError {
-    const NAME: &'static str = "ThrowNewTypeError";
-    const INSTRUCTION: &'static str = "INST - ThrowNewTypeError";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let msg = context.vm.frame().code_block.literals[index as usize]
+impl ThrowNewTypeError {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let msg = context.vm.frame().code_block.literals[index]
             .as_string()
             .expect("throw message must be a string")
             .clone();
@@ -131,5 +127,20 @@ impl Operation for ThrowNewTypeError {
             .to_std_string()
             .expect("throw message must be an ASCII string");
         Err(JsNativeError::typ().with_message(msg).into())
+    }
+}
+
+impl Operation for ThrowNewTypeError {
+    const NAME: &'static str = "ThrowNewTypeError";
+    const INSTRUCTION: &'static str = "INST - ThrowNewTypeError";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -13,18 +13,12 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassStaticGetterByName;
 
-impl Operation for DefineClassStaticGetterByName {
-    const NAME: &'static str = "DefineClassStaticGetterByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassStaticGetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -56,6 +50,21 @@ impl Operation for DefineClassStaticGetterByName {
     }
 }
 
+impl Operation for DefineClassStaticGetterByName {
+    const NAME: &'static str = "DefineClassStaticGetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticGetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `DefineClassGetterByName` implements the Opcode Operation for `Opcode::DefineClassGetterByName`
 ///
 /// Operation:
@@ -63,18 +72,12 @@ impl Operation for DefineClassStaticGetterByName {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassGetterByName;
 
-impl Operation for DefineClassGetterByName {
-    const NAME: &'static str = "DefineClassGetterByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassGetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassGetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -109,6 +112,21 @@ impl Operation for DefineClassGetterByName {
             context,
         )?;
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DefineClassGetterByName {
+    const NAME: &'static str = "DefineClassGetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassGetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -59,6 +59,11 @@ impl Operation for DefineClassStaticGetterByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -121,6 +126,11 @@ impl Operation for DefineClassGetterByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -55,6 +55,11 @@ impl Operation for DefineClassStaticMethodByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -113,6 +118,11 @@ impl Operation for DefineClassMethodByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -13,18 +13,12 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassStaticMethodByName;
 
-impl Operation for DefineClassStaticMethodByName {
-    const NAME: &'static str = "DefineClassStaticMethodByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassStaticMethodByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassStaticMethodByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -52,6 +46,21 @@ impl Operation for DefineClassStaticMethodByName {
     }
 }
 
+impl Operation for DefineClassStaticMethodByName {
+    const NAME: &'static str = "DefineClassStaticMethodByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticMethodByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `DefineClassMethodByName` implements the Opcode Operation for `Opcode::DefineClassMethodByName`
 ///
 /// Operation:
@@ -59,18 +68,12 @@ impl Operation for DefineClassStaticMethodByName {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassMethodByName;
 
-impl Operation for DefineClassMethodByName {
-    const NAME: &'static str = "DefineClassMethodByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassMethodByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassMethodByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -101,6 +104,21 @@ impl Operation for DefineClassMethodByName {
             context,
         )?;
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DefineClassMethodByName {
+    const NAME: &'static str = "DefineClassMethodByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassMethodByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -60,6 +60,11 @@ impl Operation for DefineClassStaticSetterByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -124,6 +129,11 @@ impl Operation for DefineClassSetterByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -13,18 +13,12 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassStaticSetterByName;
 
-impl Operation for DefineClassStaticSetterByName {
-    const NAME: &'static str = "DefineClassStaticSetterByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassStaticSetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class = context.vm.pop();
         let class = class.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -57,6 +51,21 @@ impl Operation for DefineClassStaticSetterByName {
     }
 }
 
+impl Operation for DefineClassStaticSetterByName {
+    const NAME: &'static str = "DefineClassStaticSetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassStaticSetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `DefineClassSetterByName` implements the Opcode Operation for `Opcode::DefineClassSetterByName`
 ///
 /// Operation:
@@ -64,18 +73,12 @@ impl Operation for DefineClassStaticSetterByName {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineClassSetterByName;
 
-impl Operation for DefineClassSetterByName {
-    const NAME: &'static str = "DefineClassSetterByName";
-    const INSTRUCTION: &'static str = "INST - DefineClassSetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineClassSetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let function = context.vm.pop();
         let class_proto = context.vm.pop();
         let class_proto = class_proto.as_object().expect("class must be object");
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         {
             let function_object = function
                 .as_object()
@@ -112,6 +115,21 @@ impl Operation for DefineClassSetterByName {
         )?;
 
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DefineClassSetterByName {
+    const NAME: &'static str = "DefineClassSetterByName";
+    const INSTRUCTION: &'static str = "INST - DefineClassSetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -16,14 +16,11 @@ pub(crate) use own_property::*;
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefVar;
 
-impl Operation for DefVar {
-    const NAME: &'static str = "DefVar";
-    const INSTRUCTION: &'static str = "INST - DefVar";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+impl DefVar {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         // TODO: spec specifies to return `empty` on empty vars, but we're trying to initialize.
-        let index = context.vm.read::<u32>();
-        let binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        let binding_locator = context.vm.frame().code_block.bindings[index];
 
         if binding_locator.is_global() {
             // already initialized at compile time
@@ -31,10 +28,25 @@ impl Operation for DefVar {
             context.vm.environments.put_value_if_uninitialized(
                 binding_locator.environment_index(),
                 binding_locator.binding_index(),
-                JsValue::Undefined,
+                JsValue::undefined(),
             );
         }
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DefVar {
+    const NAME: &'static str = "DefVar";
+    const INSTRUCTION: &'static str = "INST - DefVar";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 
@@ -45,14 +57,10 @@ impl Operation for DefVar {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefInitVar;
 
-impl Operation for DefInitVar {
-    const NAME: &'static str = "DefInitVar";
-    const INSTRUCTION: &'static str = "INST - DefInitVar";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefInitVar {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
 
         context.find_runtime_binding(&mut binding_locator)?;
 
@@ -66,6 +74,21 @@ impl Operation for DefInitVar {
     }
 }
 
+impl Operation for DefInitVar {
+    const NAME: &'static str = "DefInitVar";
+    const INSTRUCTION: &'static str = "INST - DefInitVar";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
+    }
+}
+
 /// `PutLexicalValue` implements the Opcode Operation for `Opcode::PutLexicalValue`
 ///
 /// Operation:
@@ -73,19 +96,32 @@ impl Operation for DefInitVar {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PutLexicalValue;
 
-impl Operation for PutLexicalValue {
-    const NAME: &'static str = "PutLexicalValue";
-    const INSTRUCTION: &'static str = "INST - PutLexicalValue";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl PutLexicalValue {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
-        let binding_locator = context.vm.frame().code_block.bindings[index as usize];
+        let binding_locator = context.vm.frame().code_block.bindings[index];
         context.vm.environments.put_lexical_value(
             binding_locator.environment_index(),
             binding_locator.binding_index(),
             value,
         );
+
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for PutLexicalValue {
+    const NAME: &'static str = "PutLexicalValue";
+    const INSTRUCTION: &'static str = "INST - PutLexicalValue";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -44,6 +44,11 @@ impl Operation for DefVar {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)
@@ -83,6 +88,11 @@ impl Operation for DefInitVar {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)
@@ -118,6 +128,11 @@ impl Operation for PutLexicalValue {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -44,6 +44,11 @@ impl Operation for DefineOwnPropertyByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)

--- a/boa_engine/src/vm/opcode/define/own_property.rs
+++ b/boa_engine/src/vm/opcode/define/own_property.rs
@@ -11,12 +11,8 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefineOwnPropertyByName;
 
-impl Operation for DefineOwnPropertyByName {
-    const NAME: &'static str = "DefineOwnPropertyByName";
-    const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DefineOwnPropertyByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = if let Some(object) = object.as_object() {
@@ -24,7 +20,7 @@ impl Operation for DefineOwnPropertyByName {
         } else {
             object.to_object(context)?
         };
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+        let name = context.vm.frame().code_block.names[index].clone();
         object.__define_own_property__(
             &name.into(),
             PropertyDescriptor::builder()
@@ -36,6 +32,21 @@ impl Operation for DefineOwnPropertyByName {
             context,
         )?;
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DefineOwnPropertyByName {
+    const NAME: &'static str = "DefineOwnPropertyByName";
+    const INSTRUCTION: &'static str = "INST - DefineOwnPropertyByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -11,17 +11,11 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DeletePropertyByName;
 
-impl Operation for DeletePropertyByName {
-    const NAME: &'static str = "DeletePropertyByName";
-    const INSTRUCTION: &'static str = "INST - DeletePropertyByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl DeletePropertyByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let object = value.to_object(context)?;
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         let result = object.__delete__(&key, context)?;
         if !result && context.vm.frame().code_block.strict() {
             return Err(JsNativeError::typ()
@@ -30,6 +24,21 @@ impl Operation for DeletePropertyByName {
         }
         context.vm.push(result);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DeletePropertyByName {
+    const NAME: &'static str = "DeletePropertyByName";
+    const INSTRUCTION: &'static str = "INST - DeletePropertyByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 
@@ -67,13 +76,9 @@ impl Operation for DeletePropertyByValue {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DeleteName;
 
-impl Operation for DeleteName {
-    const NAME: &'static str = "DeleteName";
-    const INSTRUCTION: &'static str = "INST - DeleteName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl DeleteName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
 
         context.find_runtime_binding(&mut binding_locator)?;
 
@@ -81,6 +86,21 @@ impl Operation for DeleteName {
 
         context.vm.push(deleted);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for DeleteName {
+    const NAME: &'static str = "DeleteName";
+    const INSTRUCTION: &'static str = "INST - DeleteName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 

--- a/boa_engine/src/vm/opcode/delete/mod.rs
+++ b/boa_engine/src/vm/opcode/delete/mod.rs
@@ -36,6 +36,11 @@ impl Operation for DeletePropertyByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -96,6 +101,11 @@ impl Operation for DeleteName {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -37,6 +37,11 @@ impl Operation for GetName {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)
@@ -68,6 +73,11 @@ impl Operation for GetLocator {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
@@ -109,6 +119,11 @@ impl Operation for GetNameAndLocator {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
@@ -158,6 +173,11 @@ impl Operation for GetNameOrUndefined {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {

--- a/boa_engine/src/vm/opcode/get/name.rs
+++ b/boa_engine/src/vm/opcode/get/name.rs
@@ -11,13 +11,9 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetName;
 
-impl Operation for GetName {
-    const NAME: &'static str = "GetName";
-    const INSTRUCTION: &'static str = "INST - GetName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl GetName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -32,6 +28,21 @@ impl Operation for GetName {
     }
 }
 
+impl Operation for GetName {
+    const NAME: &'static str = "GetName";
+    const INSTRUCTION: &'static str = "INST - GetName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
+    }
+}
+
 /// `GetLocator` implements the Opcode Operation for `Opcode::GetLocator`
 ///
 /// Operation:
@@ -39,18 +50,29 @@ impl Operation for GetName {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetLocator;
 
-impl Operation for GetLocator {
-    const NAME: &'static str = "GetLocator";
-    const INSTRUCTION: &'static str = "INST - GetLocator";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl GetLocator {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
         context.find_runtime_binding(&mut binding_locator)?;
 
         context.vm.frame_mut().binding_stack.push(binding_locator);
 
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetLocator {
+    const NAME: &'static str = "GetLocator";
+    const INSTRUCTION: &'static str = "INST - GetLocator";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 
@@ -62,13 +84,9 @@ impl Operation for GetLocator {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetNameAndLocator;
 
-impl Operation for GetNameAndLocator {
-    const NAME: &'static str = "GetNameAndLocator";
-    const INSTRUCTION: &'static str = "INST - GetNameAndLocator";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl GetNameAndLocator {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
         context.find_runtime_binding(&mut binding_locator)?;
         let value = context.get_binding(binding_locator)?.ok_or_else(|| {
             let name = context
@@ -84,6 +102,21 @@ impl Operation for GetNameAndLocator {
     }
 }
 
+impl Operation for GetNameAndLocator {
+    const NAME: &'static str = "GetNameAndLocator";
+    const INSTRUCTION: &'static str = "INST - GetNameAndLocator";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
+    }
+}
+
 /// `GetNameOrUndefined` implements the Opcode Operation for `Opcode::GetNameOrUndefined`
 ///
 /// Operation:
@@ -91,13 +124,9 @@ impl Operation for GetNameAndLocator {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetNameOrUndefined;
 
-impl Operation for GetNameOrUndefined {
-    const NAME: &'static str = "GetNameOrUndefined";
-    const INSTRUCTION: &'static str = "INST - GetNameOrUndefined";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl GetNameOrUndefined {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
 
         let is_global = binding_locator.is_global();
 
@@ -119,5 +148,20 @@ impl Operation for GetNameOrUndefined {
 
         context.vm.push(value);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetNameOrUndefined {
+    const NAME: &'static str = "GetNameOrUndefined";
+    const INSTRUCTION: &'static str = "INST - GetNameOrUndefined";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -37,6 +37,11 @@ impl Operation for GetPrivateField {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)

--- a/boa_engine/src/vm/opcode/get/private.rs
+++ b/boa_engine/src/vm/opcode/get/private.rs
@@ -10,13 +10,9 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetPrivateField;
 
-impl Operation for GetPrivateField {
-    const NAME: &'static str = "GetPrivateField";
-    const INSTRUCTION: &'static str = "INST - GetPrivateField";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl GetPrivateField {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let base_obj = value.to_object(context)?;
 
@@ -29,5 +25,20 @@ impl Operation for GetPrivateField {
         let result = base_obj.private_get(&name, context)?;
         context.vm.push(result);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetPrivateField {
+    const NAME: &'static str = "GetPrivateField";
+    const INSTRUCTION: &'static str = "INST - GetPrivateField";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -1,7 +1,7 @@
 use crate::{
     property::PropertyKey,
     vm::{opcode::Operation, CompletionType},
-    Context, JsResult, JsValue,
+    Context, JsResult,
 };
 
 /// `GetPropertyByName` implements the Opcode Operation for `Opcode::GetPropertyByName`
@@ -11,13 +11,8 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct GetPropertyByName;
 
-impl Operation for GetPropertyByName {
-    const NAME: &'static str = "GetPropertyByName";
-    const INSTRUCTION: &'static str = "INST - GetPropertyByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-
+impl GetPropertyByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let receiver = context.vm.pop();
         let value = context.vm.pop();
         let object = if let Some(object) = value.as_object() {
@@ -26,13 +21,26 @@ impl Operation for GetPropertyByName {
             value.to_object(context)?
         };
 
-        let key = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let key = context.vm.frame().code_block.names[index].clone().into();
         let result = object.__get__(&key, receiver, context)?;
 
         context.vm.push(result);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for GetPropertyByName {
+    const NAME: &'static str = "GetPropertyByName";
+    const INSTRUCTION: &'static str = "INST - GetPropertyByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 
@@ -78,31 +86,6 @@ impl Operation for GetPropertyByValue {
         let result = object.__get__(&key, receiver, context)?;
 
         context.vm.push(result);
-        Ok(CompletionType::Normal)
-    }
-}
-
-/// `GetMethod` implements the Opcode Operation for `Opcode::GetMethod`
-///
-/// Operation:
-///  - Get a property method or undefined if the property is null or undefined.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct GetMethod;
-
-impl Operation for GetMethod {
-    const NAME: &'static str = "GetMethod";
-    const INSTRUCTION: &'static str = "INST - GetMethod";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let key = context.vm.frame().code_block.names[index as usize].clone();
-        let value = context.vm.pop();
-
-        let method = value.get_method(key, context)?;
-        context.vm.push(value);
-        context
-            .vm
-            .push(method.map(JsValue::from).unwrap_or_default());
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/get/property.rs
+++ b/boa_engine/src/vm/opcode/get/property.rs
@@ -38,6 +38,11 @@ impl Operation for GetPropertyByName {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -437,6 +437,10 @@ macro_rules! generate_opcodes {
         }
 
         /// This represents a VM instruction, it contains both opcode and operands.
+        ///
+        // TODO: An instruction should be a representation of a valid executable instruction (opcode + operands),
+        //       so variants like `ResevedN`, or operand width prefix modifiers, idealy shouldn't
+        //       be a part of `Instruction`.
         #[derive(Debug, Clone, PartialEq)]
         #[repr(u8)]
         pub enum Instruction {
@@ -2035,18 +2039,18 @@ generate_opcodes! {
     /// Stack: **=>**
     Nop,
 
-    /// Half modifier
+    /// Half [`Opcode`] prefix operand modifier, makes all ([`VaryingOperand`])s of an instruction [`u16`] sized.
     ///
-    /// Operands: opcode (and operands if any).
+    /// Operands: opcode (operands if any).
     ///
-    /// Stack: **=>**
+    /// Stack: The stack changes based on the opcode that is being prefixed.
     Half,
 
-    /// Wide modifier
+    /// Wide [`Opcode`] prefix operand modifier, makes all ([`VaryingOperand`])s of an instruction [`u32`] sized.
     ///
-    /// Operands: opcode (and operands if any).
+    /// Operands: opcode (operands if any).
     ///
-    /// Stack: **=>**
+    /// Stack: The stack changes based on the opcode that is being prefixed.
     Wide,
 
     /// Reserved [`Opcode`].

--- a/boa_engine/src/vm/opcode/modifier.rs
+++ b/boa_engine/src/vm/opcode/modifier.rs
@@ -1,0 +1,21 @@
+use crate::{vm::CompletionType, Context, JsResult};
+
+use super::{Opcode, Operation};
+
+/// `Wide` implements the Opcode Operation for `Opcode::Wide`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Wide;
+
+impl Operation for Wide {
+    const NAME: &'static str = "Wide";
+    const INSTRUCTION: &'static str = "INST - Wide";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let opcode = context.vm.read::<u8>() as usize;
+
+        Opcode::EXECUTE_FNS[256 + opcode](context)
+    }
+}

--- a/boa_engine/src/vm/opcode/modifier.rs
+++ b/boa_engine/src/vm/opcode/modifier.rs
@@ -2,6 +2,24 @@ use crate::{vm::CompletionType, Context, JsResult};
 
 use super::{Opcode, Operation};
 
+/// `Half` implements the Opcode Operation for `Opcode::Half`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Half;
+
+impl Operation for Half {
+    const NAME: &'static str = "Half";
+    const INSTRUCTION: &'static str = "INST - Half";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let opcode = context.vm.read::<u8>() as usize;
+
+        Opcode::EXECUTE_FNS[256 + opcode](context)
+    }
+}
+
 /// `Wide` implements the Opcode Operation for `Opcode::Wide`
 ///
 /// Operation:
@@ -16,6 +34,6 @@ impl Operation for Wide {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let opcode = context.vm.read::<u8>() as usize;
 
-        Opcode::EXECUTE_FNS[256 + opcode](context)
+        Opcode::EXECUTE_FNS[256 * 2 + opcode](context)
     }
 }

--- a/boa_engine/src/vm/opcode/modifier.rs
+++ b/boa_engine/src/vm/opcode/modifier.rs
@@ -5,7 +5,7 @@ use super::{Opcode, Operation};
 /// `Half` implements the Opcode Operation for `Opcode::Half`
 ///
 /// Operation:
-///  - TODO: doc
+///  - [`Opcode`] prefix operand modifier, makes all varying operands of an instruction [`u16`] sized.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Half;
 
@@ -23,7 +23,7 @@ impl Operation for Half {
 /// `Wide` implements the Opcode Operation for `Opcode::Wide`
 ///
 /// Operation:
-///  - TODO: doc
+///  - TODO: [`Opcode`] prefix operand modifier, makes all varying operands of an instruction [`u16`] sized.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Wide;
 

--- a/boa_engine/src/vm/opcode/nop/mod.rs
+++ b/boa_engine/src/vm/opcode/nop/mod.rs
@@ -34,6 +34,10 @@ impl Operation for Reserved {
         unreachable!("Reserved opcodes are unreachable!")
     }
 
+    fn half_execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
+        unreachable!("Half.Reserved opcodes are unreachable!")
+    }
+
     fn wide_execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
         unreachable!("Wide.Reserved opcodes are unreachable!")
     }

--- a/boa_engine/src/vm/opcode/nop/mod.rs
+++ b/boa_engine/src/vm/opcode/nop/mod.rs
@@ -33,4 +33,8 @@ impl Operation for Reserved {
     fn execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
         unreachable!("Reserved opcodes are unreachable!")
     }
+
+    fn wide_execute(_: &mut Context<'_>) -> JsResult<CompletionType> {
+        unreachable!("Wide.Reserved opcodes are unreachable!")
+    }
 }

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -52,13 +52,10 @@ impl Operation for PushClassField {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushClassFieldPrivate;
 
-impl Operation for PushClassFieldPrivate {
-    const NAME: &'static str = "PushClassFieldPrivate";
-    const INSTRUCTION: &'static str = "INST - PushClassFieldPrivate";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl PushClassFieldPrivate {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let field_function_value = context.vm.pop();
         let class_value = context.vm.pop();
 
@@ -84,5 +81,20 @@ impl Operation for PushClassFieldPrivate {
                 JsFunction::from_object_unchecked(field_function_object.clone()),
             );
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for PushClassFieldPrivate {
+    const NAME: &'static str = "PushClassFieldPrivate";
+    const INSTRUCTION: &'static str = "INST - PushClassFieldPrivate";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -93,6 +93,11 @@ impl Operation for PushClassFieldPrivate {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -13,13 +13,10 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushClassPrivateMethod;
 
-impl Operation for PushClassPrivateMethod {
-    const NAME: &'static str = "PushClassPrivateMethod";
-    const INSTRUCTION: &'static str = "INST - PushClassPrivateMethod";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl PushClassPrivateMethod {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let method = context.vm.pop();
         let method_object = method.as_callable().expect("method must be callable");
 
@@ -55,6 +52,21 @@ impl Operation for PushClassPrivateMethod {
     }
 }
 
+impl Operation for PushClassPrivateMethod {
+    const NAME: &'static str = "PushClassPrivateMethod";
+    const INSTRUCTION: &'static str = "INST - PushClassPrivateMethod";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `PushClassPrivateGetter` implements the Opcode Operation for `Opcode::PushClassPrivateGetter`
 ///
 /// Operation:
@@ -62,13 +74,10 @@ impl Operation for PushClassPrivateMethod {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushClassPrivateGetter;
 
-impl Operation for PushClassPrivateGetter {
-    const NAME: &'static str = "PushClassPrivateGetter";
-    const INSTRUCTION: &'static str = "INST - PushClassPrivateGetter";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl PushClassPrivateGetter {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let getter = context.vm.pop();
         let getter_object = getter.as_callable().expect("getter must be callable");
         let class = context.vm.pop();
@@ -94,6 +103,21 @@ impl Operation for PushClassPrivateGetter {
     }
 }
 
+impl Operation for PushClassPrivateGetter {
+    const NAME: &'static str = "PushClassPrivateGetter";
+    const INSTRUCTION: &'static str = "INST - PushClassPrivateGetter";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `PushClassPrivateSetter` implements the Opcode Operation for `Opcode::PushClassPrivateSetter`
 ///
 /// Operation:
@@ -101,13 +125,10 @@ impl Operation for PushClassPrivateGetter {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushClassPrivateSetter;
 
-impl Operation for PushClassPrivateSetter {
-    const NAME: &'static str = "PushClassPrivateSetter";
-    const INSTRUCTION: &'static str = "INST - PushClassPrivateSetter";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl PushClassPrivateSetter {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let setter = context.vm.pop();
         let setter_object = setter.as_callable().expect("getter must be callable");
         let class = context.vm.pop();
@@ -130,5 +151,20 @@ impl Operation for PushClassPrivateSetter {
             .expect("setter must be function object");
         function.set_class_object(class_object.clone());
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for PushClassPrivateSetter {
+    const NAME: &'static str = "PushClassPrivateSetter";
+    const INSTRUCTION: &'static str = "INST - PushClassPrivateSetter";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -61,6 +61,11 @@ impl Operation for PushClassPrivateMethod {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -112,6 +117,11 @@ impl Operation for PushClassPrivateGetter {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -160,6 +170,11 @@ impl Operation for PushClassPrivateSetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 

--- a/boa_engine/src/vm/opcode/push/literal.rs
+++ b/boa_engine/src/vm/opcode/push/literal.rs
@@ -28,6 +28,11 @@ impl Operation for PushLiteral {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)

--- a/boa_engine/src/vm/opcode/push/literal.rs
+++ b/boa_engine/src/vm/opcode/push/literal.rs
@@ -10,14 +10,26 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushLiteral;
 
+impl PushLiteral {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let value = context.vm.frame().code_block.literals[index].clone();
+        context.vm.push(value);
+        Ok(CompletionType::Normal)
+    }
+}
+
 impl Operation for PushLiteral {
     const NAME: &'static str = "PushLiteral";
     const INSTRUCTION: &'static str = "INST - PushLiteral";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>() as usize;
-        let value = context.vm.frame().code_block.literals[index].clone();
-        context.vm.push(value);
-        Ok(CompletionType::Normal)
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -33,6 +33,11 @@ impl Operation for ThrowMutateImmutable {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)
@@ -72,6 +77,11 @@ impl Operation for SetName {
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>();
         Self::operation(context, index as usize)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
     }
 
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {

--- a/boa_engine/src/vm/opcode/set/name.rs
+++ b/boa_engine/src/vm/opcode/set/name.rs
@@ -11,13 +11,9 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct ThrowMutateImmutable;
 
-impl Operation for ThrowMutateImmutable {
-    const NAME: &'static str = "ThrowMutateImmutable";
-    const INSTRUCTION: &'static str = "INST - ThrowMutateImmutable";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = &context.vm.frame().code_block.names[index as usize];
+impl ThrowMutateImmutable {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = &context.vm.frame().code_block.names[index];
 
         Err(JsNativeError::typ()
             .with_message(format!(
@@ -28,6 +24,21 @@ impl Operation for ThrowMutateImmutable {
     }
 }
 
+impl Operation for ThrowMutateImmutable {
+    const NAME: &'static str = "ThrowMutateImmutable";
+    const INSTRUCTION: &'static str = "INST - ThrowMutateImmutable";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
+    }
+}
+
 /// `SetName` implements the Opcode Operation for `Opcode::SetName`
 ///
 /// Operation:
@@ -35,13 +46,9 @@ impl Operation for ThrowMutateImmutable {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetName;
 
-impl Operation for SetName {
-    const NAME: &'static str = "SetName";
-    const INSTRUCTION: &'static str = "INST - SetName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index as usize];
+impl SetName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let mut binding_locator = context.vm.frame().code_block.bindings[index];
         let value = context.vm.pop();
 
         context.find_runtime_binding(&mut binding_locator)?;
@@ -55,6 +62,21 @@ impl Operation for SetName {
         )?;
 
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetName {
+    const NAME: &'static str = "SetName";
+    const INSTRUCTION: &'static str = "INST - SetName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -13,13 +13,9 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPrivateField;
 
-impl Operation for SetPrivateField {
-    const NAME: &'static str = "SetPrivateField";
-    const INSTRUCTION: &'static str = "INST - SetPrivateField";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl SetPrivateField {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let object = context.vm.pop();
         let base_obj = object.to_object(context)?;
@@ -36,6 +32,21 @@ impl Operation for SetPrivateField {
     }
 }
 
+impl Operation for SetPrivateField {
+    const NAME: &'static str = "SetPrivateField";
+    const INSTRUCTION: &'static str = "INST - SetPrivateField";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `DefinePrivateField` implements the Opcode Operation for `Opcode::DefinePrivateField`
 ///
 /// Operation:
@@ -43,13 +54,10 @@ impl Operation for SetPrivateField {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DefinePrivateField;
 
-impl Operation for DefinePrivateField {
-    const NAME: &'static str = "DefinePrivateField";
-    const INSTRUCTION: &'static str = "INST - DefinePrivateField";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl DefinePrivateField {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = object
@@ -64,6 +72,21 @@ impl Operation for DefinePrivateField {
     }
 }
 
+impl Operation for DefinePrivateField {
+    const NAME: &'static str = "DefinePrivateField";
+    const INSTRUCTION: &'static str = "INST - DefinePrivateField";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `SetPrivateMethod` implements the Opcode Operation for `Opcode::SetPrivateMethod`
 ///
 /// Operation:
@@ -71,13 +94,10 @@ impl Operation for DefinePrivateField {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPrivateMethod;
 
-impl Operation for SetPrivateMethod {
-    const NAME: &'static str = "SetPrivateMethod";
-    const INSTRUCTION: &'static str = "INST - SetPrivateMethod";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl SetPrivateMethod {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let value = value.as_callable().expect("method must be callable");
 
@@ -111,6 +131,21 @@ impl Operation for SetPrivateMethod {
     }
 }
 
+impl Operation for SetPrivateMethod {
+    const NAME: &'static str = "SetPrivateMethod";
+    const INSTRUCTION: &'static str = "INST - SetPrivateMethod";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `SetPrivateSetter` implements the Opcode Operation for `Opcode::SetPrivateSetter`
 ///
 /// Operation:
@@ -118,13 +153,10 @@ impl Operation for SetPrivateMethod {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPrivateSetter;
 
-impl Operation for SetPrivateSetter {
-    const NAME: &'static str = "SetPrivateSetter";
-    const INSTRUCTION: &'static str = "INST - SetPrivateSetter";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl SetPrivateSetter {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let value = value.as_callable().expect("setter must be callable");
         let object = context.vm.pop();
@@ -149,6 +181,21 @@ impl Operation for SetPrivateSetter {
     }
 }
 
+impl Operation for SetPrivateSetter {
+    const NAME: &'static str = "SetPrivateSetter";
+    const INSTRUCTION: &'static str = "INST - SetPrivateSetter";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
+    }
+}
+
 /// `SetPrivateGetter` implements the Opcode Operation for `Opcode::SetPrivateGetter`
 ///
 /// Operation:
@@ -156,13 +203,10 @@ impl Operation for SetPrivateSetter {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPrivateGetter;
 
-impl Operation for SetPrivateGetter {
-    const NAME: &'static str = "SetPrivateGetter";
-    const INSTRUCTION: &'static str = "INST - SetPrivateGetter";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-        let name = context.vm.frame().code_block.names[index as usize].clone();
+impl SetPrivateGetter {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block.names[index].clone();
         let value = context.vm.pop();
         let value = value.as_callable().expect("getter must be callable");
         let object = context.vm.pop();
@@ -184,5 +228,20 @@ impl Operation for SetPrivateGetter {
         function.set_class_object(object.clone());
 
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetPrivateGetter {
+    const NAME: &'static str = "SetPrivateGetter";
+    const INSTRUCTION: &'static str = "INST - SetPrivateGetter";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -41,6 +41,11 @@ impl Operation for SetPrivateField {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -78,6 +83,11 @@ impl Operation for DefinePrivateField {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 
@@ -140,6 +150,11 @@ impl Operation for SetPrivateMethod {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -190,6 +205,11 @@ impl Operation for SetPrivateSetter {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -237,6 +257,11 @@ impl Operation for SetPrivateGetter {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -14,13 +14,8 @@ use crate::{
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPropertyByName;
 
-impl Operation for SetPropertyByName {
-    const NAME: &'static str = "SetPropertyByName";
-    const INSTRUCTION: &'static str = "INST - SetPropertyByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
-
+impl SetPropertyByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let receiver = context.vm.pop();
         let object = context.vm.pop();
@@ -30,9 +25,7 @@ impl Operation for SetPropertyByName {
             object.to_object(context)?
         };
 
-        let name: PropertyKey = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let name: PropertyKey = context.vm.frame().code_block.names[index].clone().into();
 
         let succeeded = object.__set__(name.clone(), value.clone(), receiver, context)?;
         if !succeeded && context.vm.frame().code_block.strict() {
@@ -42,6 +35,21 @@ impl Operation for SetPropertyByName {
         }
         context.vm.stack.push(value);
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetPropertyByName {
+    const NAME: &'static str = "SetPropertyByName";
+    const INSTRUCTION: &'static str = "INST - SetPropertyByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>();
+        Self::operation(context, index as usize)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>();
+        Self::operation(context, index as usize)
     }
 }
 
@@ -156,18 +164,12 @@ impl Operation for SetPropertyByValue {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPropertyGetterByName;
 
-impl Operation for SetPropertyGetterByName {
-    const NAME: &'static str = "SetPropertyGetterByName";
-    const INSTRUCTION: &'static str = "INST - SetPropertyGetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl SetPropertyGetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = object.to_object(context)?;
-        let name = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let name = context.vm.frame().code_block.names[index].clone().into();
         let set = object
             .__get_own_property__(&name, context)?
             .as_ref()
@@ -184,6 +186,21 @@ impl Operation for SetPropertyGetterByName {
             context,
         )?;
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetPropertyGetterByName {
+    const NAME: &'static str = "SetPropertyGetterByName";
+    const INSTRUCTION: &'static str = "INST - SetPropertyGetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 
@@ -230,18 +247,12 @@ impl Operation for SetPropertyGetterByValue {
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SetPropertySetterByName;
 
-impl Operation for SetPropertySetterByName {
-    const NAME: &'static str = "SetPropertySetterByName";
-    const INSTRUCTION: &'static str = "INST - SetPropertySetterByName";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let index = context.vm.read::<u32>();
+impl SetPropertySetterByName {
+    fn operation(context: &mut Context<'_>, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let object = context.vm.pop();
         let object = object.to_object(context)?;
-        let name = context.vm.frame().code_block.names[index as usize]
-            .clone()
-            .into();
+        let name = context.vm.frame().code_block.names[index].clone().into();
         let get = object
             .__get_own_property__(&name, context)?
             .as_ref()
@@ -258,6 +269,21 @@ impl Operation for SetPropertySetterByName {
             context,
         )?;
         Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for SetPropertySetterByName {
+    const NAME: &'static str = "SetPropertySetterByName";
+    const INSTRUCTION: &'static str = "INST - SetPropertySetterByName";
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index)
     }
 }
 

--- a/boa_engine/src/vm/opcode/set/property.rs
+++ b/boa_engine/src/vm/opcode/set/property.rs
@@ -47,6 +47,11 @@ impl Operation for SetPropertyByName {
         Self::operation(context, index as usize)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>();
         Self::operation(context, index as usize)
@@ -198,6 +203,11 @@ impl Operation for SetPropertyGetterByName {
         Self::operation(context, index)
     }
 
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index)
+    }
+
     fn wide_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u32>() as usize;
         Self::operation(context, index)
@@ -278,6 +288,11 @@ impl Operation for SetPropertySetterByName {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index)
+    }
+
+    fn half_execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let index = context.vm.read::<u16>() as usize;
         Self::operation(context, index)
     }
 


### PR DESCRIPTION
Depends on #3201 

Currently almost all operands are `u32` size, this is because it is enough for most cases, but we waste space since most of the time the size is smaller than `u8::MAX`.

This is an optimization that reduces that size of the operands of bytecode instructions, by default if the instruction is executed then it is assumed that the operands are `u8` type. When we need a larger size we prefix the opcode with a modifier (`Half` for `u16` or `Wide` for `u32`).

This allows us to greatly reduce the memory footprint of the generated bytecode.

V8 does this optimization, but it is not exclusive to v8 bytecode, since most CISC architectures have this as well (x86 being of of them).

