### PR TITLE
Add ECMAScript 14 to `boa_tester`

### DIFF
--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -80,16 +80,11 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-iterator-helpers
     "iterator-helpers" => SpecEdition::ESNext,
 
-    // Part of the next ES14 edition
+    // Part of the next ES15 edition
     "Atomics.waitAsync"  => SpecEdition::ESNext,
-    "array-find-from-last" => SpecEdition::ESNext,
-    "change-array-by-copy" => SpecEdition::ESNext,
-    "hashbang" => SpecEdition::ESNext,
-    "Intl-enumeration" => SpecEdition::ESNext,
     "regexp-v-flag" => SpecEdition::ESNext,
     "String.prototype.isWellFormed" => SpecEdition::ESNext,
     "String.prototype.toWellFormed" => SpecEdition::ESNext,
-    "symbols-as-weakmap-keys" => SpecEdition::ESNext,
 
     // Standard language features
 
@@ -97,6 +92,7 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "align-detached-buffer-semantics-with-web-reality" => SpecEdition::ES12,
     "arbitrary-module-namespace-names" => SpecEdition::ES13,
     "ArrayBuffer" => SpecEdition::ES6,
+    "array-find-from-last" => SpecEdition::ES14,
     "Array.prototype.at" => SpecEdition::ES13,
     "Array.prototype.flat" => SpecEdition::ES10,
     "Array.prototype.flatMap" => SpecEdition::ES10,
@@ -108,6 +104,7 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "Atomics" => SpecEdition::ES8,
     "BigInt" => SpecEdition::ES11,
     "caller" => SpecEdition::ES5,
+    "change-array-by-copy" => SpecEdition::ES14,
     "class" => SpecEdition::ES6,
     "class-fields-private" => SpecEdition::ES13,
     "class-fields-private-in" => SpecEdition::ES13,
@@ -144,10 +141,12 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "Float64Array" => SpecEdition::ES6,
     "generators" => SpecEdition::ES6,
     "globalThis" => SpecEdition::ES11,
+    "hashbang" => SpecEdition::ES14,
     "import.meta" => SpecEdition::ES11,
     "Int8Array" => SpecEdition::ES6,
     "Int16Array" => SpecEdition::ES6,
     "Int32Array" => SpecEdition::ES6,
+    "Intl-enumeration" => SpecEdition::ES14,
     "intl-normative-optional" => SpecEdition::ES8,
     "Intl.DateTimeFormat-datetimestyle" => SpecEdition::ES12,
     "Intl.DateTimeFormat-dayPeriod" => SpecEdition::ES8,
@@ -203,6 +202,7 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "String.prototype.trimStart" => SpecEdition::ES10,
     "super" => SpecEdition::ES6,
     "Symbol" => SpecEdition::ES6,
+    "symbols-as-weakmap-keys" => SpecEdition::ES14,
     "Symbol.asyncIterator" => SpecEdition::ES9,
     "Symbol.hasInstance" => SpecEdition::ES6,
     "Symbol.isConcatSpreadable" => SpecEdition::ES6,
@@ -293,11 +293,15 @@ pub(crate) enum SpecEdition {
     ///
     /// <https://262.ecma-international.org/13.0>
     ES13,
+    /// ECMAScript 14th Edition
+    ///
+    /// <https://262.ecma-international.org/14.0>
+    ES14,
     /// The edition being worked on right now.
     ///
     /// A draft is currently available [here](https://tc39.es/ecma262).
     #[default]
-    ESNext,
+    ESNext = 255,
 }
 
 impl Display for SpecEdition {
@@ -355,6 +359,7 @@ impl SpecEdition {
             Self::ES11,
             Self::ES12,
             Self::ES13,
+            Self::ES14,
             Self::ESNext,
         ]
         .into_iter()

--- a/boa_tester/src/edition.rs
+++ b/boa_tester/src/edition.rs
@@ -87,7 +87,6 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "String.prototype.toWellFormed" => SpecEdition::ESNext,
 
     // Standard language features
-
     "AggregateError" => SpecEdition::ES12,
     "align-detached-buffer-semantics-with-web-reality" => SpecEdition::ES12,
     "arbitrary-module-namespace-names" => SpecEdition::ES13,

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -484,7 +484,7 @@ impl<'de> Deserialize<'de> for VersionedStats {
         } = inner;
         let es14 = es14.unwrap_or(es13);
 
-        Ok(VersionedStats {
+        Ok(Self {
             es5,
             es6,
             es7,

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -434,7 +434,7 @@ impl AddAssign for Statistics {
 }
 
 /// Represents tests statistics separated by ECMAScript edition
-#[derive(Default, Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Copy, Clone, Serialize)]
 struct VersionedStats {
     es5: Statistics,
     es6: Statistics,
@@ -445,6 +445,58 @@ struct VersionedStats {
     es11: Statistics,
     es12: Statistics,
     es13: Statistics,
+    es14: Statistics,
+}
+
+impl<'de> Deserialize<'de> for VersionedStats {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Inner {
+            es5: Statistics,
+            es6: Statistics,
+            es7: Statistics,
+            es8: Statistics,
+            es9: Statistics,
+            es10: Statistics,
+            es11: Statistics,
+            es12: Statistics,
+            es13: Statistics,
+            #[serde(default)]
+            es14: Option<Statistics>,
+        }
+
+        let inner = Inner::deserialize(deserializer)?;
+
+        let Inner {
+            es5,
+            es6,
+            es7,
+            es8,
+            es9,
+            es10,
+            es11,
+            es12,
+            es13,
+            es14,
+        } = inner;
+        let es14 = es14.unwrap_or(es13);
+
+        Ok(VersionedStats {
+            es5,
+            es6,
+            es7,
+            es8,
+            es9,
+            es10,
+            es11,
+            es12,
+            es13,
+            es14,
+        })
+    }
 }
 
 impl VersionedStats {
@@ -471,6 +523,7 @@ impl VersionedStats {
             SpecEdition::ES11 => self.es11,
             SpecEdition::ES12 => self.es12,
             SpecEdition::ES13 => self.es13,
+            SpecEdition::ES14 => self.es14,
             SpecEdition::ESNext => return None,
         };
         Some(stats)
@@ -489,6 +542,7 @@ impl VersionedStats {
             SpecEdition::ES11 => &mut self.es11,
             SpecEdition::ES12 => &mut self.es12,
             SpecEdition::ES13 => &mut self.es13,
+            SpecEdition::ES14 => &mut self.es14,
             SpecEdition::ESNext => return None,
         };
         Some(stats)
@@ -509,6 +563,7 @@ impl Add for VersionedStats {
             es11: self.es11 + rhs.es11,
             es12: self.es12 + rhs.es12,
             es13: self.es13 + rhs.es13,
+            es14: self.es14 + rhs.es14,
         }
     }
 }
@@ -524,6 +579,7 @@ impl AddAssign for VersionedStats {
         self.es11 += rhs.es11;
         self.es12 += rhs.es12;
         self.es13 += rhs.es13;
+        self.es14 += rhs.es14;
     }
 }
 


### PR DESCRIPTION
Depends on #3274.

This needs to be merged after the conformance webpage PR is merged, ~which I'll link here when I finish it~ which is linked above.