### PR TITLE
Fix GitHub coverage workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --workspace --features intl --ignore-tests --engine llvm --out Xml
+          args: --workspace --features intl --ignore-tests --engine llvm --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
 


### PR DESCRIPTION
For some reason `tarpaulin` no longer recognises the "Xml" format output spelled with a upper case 'X'.

Change `Xml` to `xml`


Error:
```
Run actions-rs/cargo@v1
/home/runner/.cargo/bin/cargo tarpaulin --workspace --features intl --ignore-tests --engine llvm --out Xml
error: invalid value 'Xml' for '--out [<FMT>...]'
Error:   [possible values: json, stdout, xml, html, lcov]

  tip: a similar value exists: 'xml'

For more information, try '--help'.
Error: The process '/home/runner/.cargo/bin/cargo' failed with exit code 2
```