### PR TITLE
Bump `rust-version` to 1.71

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 [workspace.package]
 edition = "2021"
 version = "0.17.0"
-rust-version = "1.66"
+rust-version = "1.71"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
 license = "Unlicense OR MIT"

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -264,7 +264,7 @@ impl CodeBlock {
     /// # Safety
     ///
     /// Does not check if read happens out-of-bounds.
-    pub(crate) unsafe fn read_unchecked<T>(&self, offset: usize) -> T
+    pub(crate) const unsafe fn read_unchecked<T>(&self, offset: usize) -> T
     where
         T: Readable,
     {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -96,7 +96,7 @@ use thin_vec::ThinVec;
 /// # Safety
 ///
 /// Does not check if read happens out-of-bounds.
-pub(crate) unsafe fn read_unchecked<T>(bytes: &[u8], offset: usize) -> T
+pub(crate) const unsafe fn read_unchecked<T>(bytes: &[u8], offset: usize) -> T
 where
     T: Readable,
 {


### PR DESCRIPTION
Just to ensure our repo correctly reports our MSRV for users that want to use the `main` branch.