### PR TITLE
Implement `Gc::new_cyclic`

### DIFF
--- a/boa_gc/src/pointers/ephemeron.rs
+++ b/boa_gc/src/pointers/ephemeron.rs
@@ -44,6 +44,7 @@ impl<K: Trace, V: Trace + Clone> Ephemeron<K, V> {
 
 impl<K: Trace, V: Trace> Ephemeron<K, V> {
     /// Creates a new `Ephemeron`.
+    #[must_use]
     pub fn new(key: &Gc<K>, value: V) -> Self {
         let inner_ptr = Allocator::alloc_ephemeron(EphemeronBox::new(key, value));
         Self { inner_ptr }
@@ -72,7 +73,7 @@ impl<K: Trace, V: Trace> Ephemeron<K, V> {
     /// This function is unsafe because improper use may lead to memory corruption, double-free,
     /// or misbehaviour of the garbage collector.
     #[must_use]
-    const unsafe fn from_raw(inner_ptr: NonNull<EphemeronBox<K, V>>) -> Self {
+    pub(crate) const unsafe fn from_raw(inner_ptr: NonNull<EphemeronBox<K, V>>) -> Self {
         Self { inner_ptr }
     }
 }

--- a/boa_gc/src/pointers/gc.rs
+++ b/boa_gc/src/pointers/gc.rs
@@ -52,8 +52,6 @@ impl<T: Trace> Gc<T> {
             Ephemeron::from_raw(Allocator::alloc_ephemeron(EphemeronBox::new_empty())).into()
         };
 
-        // If `data_fn` panics, `weak` will be dropped here, giving the GC an opportunity to
-        // deallocate it before exiting. This ensures unwind safety.
         let gc = Self::new(data_fn(&weak));
 
         // SAFETY:

--- a/boa_gc/src/pointers/weak.rs
+++ b/boa_gc/src/pointers/weak.rs
@@ -20,7 +20,8 @@ impl<T: Trace> WeakGc<T> {
         }
     }
 
-    /// Upgrade returns a `Gc` pointer for the internal value if valid, or None if the value was already garbage collected.
+    /// Upgrade returns a `Gc` pointer for the internal value if the pointer is still live, or `None`
+    /// if the value was already garbage collected.
     #[must_use]
     pub fn upgrade(&self) -> Option<Gc<T>> {
         self.inner.value()
@@ -30,6 +31,11 @@ impl<T: Trace> WeakGc<T> {
     #[must_use]
     pub fn is_upgradable(&self) -> bool {
         self.inner.has_value()
+    }
+
+    #[must_use]
+    pub(crate) const fn inner(&self) -> &Ephemeron<T, Gc<T>> {
+        &self.inner
     }
 }
 


### PR DESCRIPTION
This is just the corresponding replacement for the [`Rc::new_cyclic`](https://doc.rust-lang.org/std/rc/struct.Rc.html#method.new_cyclic) method, which showed to be useful while I was trying to improve some patterns in our modules implementation.
