### PR TITLE
fix: add 'static lifetime

### DIFF
--- a/boa_engine/src/builtins/generator/mod.rs
+++ b/boa_engine/src/builtins/generator/mod.rs
@@ -172,7 +172,7 @@ impl IntrinsicObject for Generator {
 }
 
 impl Generator {
-    const NAME: &str = "Generator";
+    const NAME: &'static str = "Generator";
 
     /// `Generator.prototype.next ( value )`
     ///


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

- compile error:

```text
error: `&` without an explicit lifetime name cannot be used here
   --> boa_engine/src/builtins/generator/mod.rs:175:17
    |
175 |     const NAME: &str = "Generator";
    |                 ^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
note: the lint level is defined here
   --> boa_engine/src/lib.rs:59:5
    |
59  |     future_incompatible,
    |     ^^^^^^^^^^^^^^^^^^^
    = note: `#[deny(elided_lifetimes_in_associated_constant)]` implied by `#[deny(future_incompatible)]`
help: use the `'static` lifetime
    |
175 |     const NAME: &'static str = "Generator";

```
