### PR TITLE
Fix tagged template `this` in strict mode

### DIFF
--- a/boa_engine/src/bytecompiler/expression/mod.rs
+++ b/boa_engine/src/bytecompiler/expression/mod.rs
@@ -243,9 +243,8 @@ impl ByteCompiler<'_, '_> {
                         self.emit(Opcode::GetPrivateField, &[Operand::U32(index)]);
                     }
                     expr => {
+                        self.emit_opcode(Opcode::PushUndefined);
                         self.compile_expr(expr, true);
-                        self.emit_opcode(Opcode::This);
-                        self.emit_opcode(Opcode::Swap);
                     }
                 }
 

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -1441,9 +1441,8 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                         kind = CallKind::CallEval;
                     }
                 }
-                self.compile_expr(expr, true);
                 self.emit_opcode(Opcode::PushUndefined);
-                self.emit_opcode(Opcode::Swap);
+                self.compile_expr(expr, true);
             }
             expr => {
                 self.compile_expr(expr, true);


### PR DESCRIPTION
In strict mode `this` should be undefined.

Causing test262 test to fail: [`test/language/expressions/tagged-template/call-expression-context-strict.js`](https://github.com/tc39/test262/blob/main/test/language/expressions/tagged-template/call-expression-context-strict.js)

Additionally this remove the unneeded `swap` opcode when calling functions.