### PR TITLE
Replace #[deny] with #[warn]

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,8 @@ jobs:
     name: Misc
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1.0.7

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -27,6 +27,7 @@ jobs:
     timeout-minutes: 60
     env:
       WASM_PACK_PATH: ~/.cargo/bin/wasm-pack
+      RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1.0.7

--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -18,8 +18,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -31,6 +30,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -58,6 +58,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -6,8 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -19,6 +18,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -46,6 +46,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -52,8 +52,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -65,6 +64,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -92,6 +92,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -10,8 +10,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -23,6 +22,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -51,6 +51,10 @@
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
 
+    // clippy allowed by default
+    clippy::dbg_macro,
+    clippy::undocumented_unsafe_blocks,
+
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,
     clippy::correctness,
@@ -60,7 +64,6 @@
     clippy::perf,
     clippy::pedantic,
     clippy::nursery,
-    clippy::undocumented_unsafe_blocks
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -19,7 +19,7 @@
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -31,6 +31,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -41,6 +42,7 @@
     single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,
+    unreachable_pub,
     unsafe_op_in_unsafe_fn,
     unused_import_braces,
     unused_lifetimes,
@@ -56,6 +58,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -16,8 +16,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -29,6 +28,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -36,6 +36,7 @@
     missing_debug_implementations,
     non_ascii_idents,
     noop_method_call,
+    single_use_lifetimes,
     trivial_casts,
     trivial_numeric_casts,
     unreachable_pub,
@@ -55,6 +56,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -6,8 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -19,6 +18,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -46,6 +46,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -16,8 +16,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -29,6 +28,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -56,6 +56,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -13,8 +13,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -26,6 +25,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -53,6 +53,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_runtime/src/lib.rs
+++ b/boa_runtime/src/lib.rs
@@ -46,8 +46,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -59,6 +58,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -87,6 +87,9 @@
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
 
+    // clippy allowed by default
+    clippy::dbg_macro,
+
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,
     clippy::correctness,
@@ -96,7 +99,6 @@
     clippy::perf,
     clippy::pedantic,
     clippy::nursery,
-    clippy::undocumented_unsafe_blocks
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -9,8 +9,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -22,6 +21,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -49,6 +49,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -6,8 +6,7 @@
     html_favicon_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg"
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
-#![warn(missing_docs, clippy::dbg_macro)]
-#![deny(
+#![warn(
     // rustc lint groups https://doc.rust-lang.org/rustc/lints/groups.html
     warnings,
     future_incompatible,
@@ -19,6 +18,7 @@
     unused,
 
     // rustc allowed-by-default lints https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html
+    missing_docs,
     macro_use_extern_crate,
     meta_variable_misuse,
     missing_abi,
@@ -46,6 +46,9 @@
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
+
+    // clippy allowed by default
+    clippy::dbg_macro,
 
     // clippy categories https://doc.rust-lang.org/clippy/
     clippy::all,


### PR DESCRIPTION
See https://rust-unofficial.github.io/patterns/anti_patterns/deny-warnings.html for context.

This also improves a bit the prototyping experience, since now we can compile and run with warnings even if there are missing docs or suboptimal code patterns.