### PR TITLE
Format code snippets in docs

### DIFF
--- a/boa_ast/src/statement/switch.rs
+++ b/boa_ast/src/statement/switch.rs
@@ -1,5 +1,4 @@
 //! Switch node.
-//!
 use crate::{
     expression::Expression,
     statement::Statement,

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -1,5 +1,4 @@
 //! A ECMAScript REPL implementation based on boa_engine.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_engine/src/context/hooks.rs
+++ b/boa_engine/src/context/hooks.rs
@@ -22,10 +22,8 @@ use super::intrinsics::Intrinsics;
 /// ```
 /// use boa_engine::{
 ///     context::{Context, ContextBuilder, HostHooks},
-///     JsNativeError,
-///     JsResult,
 ///     realm::Realm,
-///     Source
+///     JsNativeError, JsResult, Source,
 /// };
 ///
 /// struct Hooks;
@@ -36,13 +34,18 @@ use super::intrinsics::Intrinsics;
 ///         _realm: Realm,
 ///         context: &mut Context<'_>,
 ///     ) -> JsResult<()> {
-///         Err(JsNativeError::typ().with_message("eval calls not available").into())
+///         Err(JsNativeError::typ()
+///             .with_message("eval calls not available")
+///             .into())
 ///     }
 /// }
 /// let hooks: &dyn HostHooks = &Hooks; // Can have additional state.
 /// let context = &mut ContextBuilder::new().host_hooks(hooks).build().unwrap();
 /// let result = context.eval(Source::from_bytes(r#"eval("let a = 5")"#));
-/// assert_eq!(result.unwrap_err().to_string(), "TypeError: eval calls not available");
+/// assert_eq!(
+///     result.unwrap_err().to_string(),
+///     "TypeError: eval calls not available"
+/// );
 /// ```
 ///
 /// [`Host Hooks`]: https://tc39.es/ecma262/#sec-host-hooks-summary

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -50,8 +50,7 @@ use crate::vm::RuntimeLimits;
 /// use boa_engine::{
 ///     object::ObjectInitializer,
 ///     property::{Attribute, PropertyDescriptor},
-///     Context,
-///     Source
+///     Context, Source,
 /// };
 ///
 /// let script = r#"

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -165,7 +165,8 @@ impl JsError {
     /// ```rust
     /// # use boa_engine::{Context, JsError, JsNativeError};
     /// let context = &mut Context::default();
-    /// let error: JsError = JsNativeError::eval().with_message("invalid script").into();
+    /// let error: JsError =
+    ///     JsNativeError::eval().with_message("invalid script").into();
     /// let error_val = error.to_opaque(context);
     ///
     /// assert!(error_val.as_object().unwrap().borrow().is_error());
@@ -345,7 +346,8 @@ impl JsError {
     ///
     /// ```rust
     /// # use boa_engine::{JsError, JsNativeError, JsValue};
-    /// let error: JsError = JsNativeError::error().with_message("Unknown error").into();
+    /// let error: JsError =
+    ///     JsNativeError::error().with_message("Unknown error").into();
     ///
     /// assert!(error.as_native().is_some());
     ///

--- a/boa_engine/src/job.rs
+++ b/boa_engine/src/job.rs
@@ -253,7 +253,10 @@ pub trait JobQueue {
 /// can be done by passing a reference to it to the [`ContextBuilder`]:
 ///
 /// ```
-/// use boa_engine::{context::ContextBuilder, job::{JobQueue, IdleJobQueue}};
+/// use boa_engine::{
+///     context::ContextBuilder,
+///     job::{IdleJobQueue, JobQueue},
+/// };
 ///
 /// let queue: &dyn JobQueue = &IdleJobQueue;
 /// let context = ContextBuilder::new().job_queue(queue).build();

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -45,7 +45,6 @@
 //!
 //! [ecma-402]: https://tc39.es/ecma402
 //! [examples]: https://github.com/boa-dev/boa/tree/main/boa_examples
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -628,7 +628,10 @@ impl Module {
     /// # use boa_engine::module::{ModuleLoader, SimpleModuleLoader};
     /// let loader = &SimpleModuleLoader::new(Path::new(".")).unwrap();
     /// let dyn_loader: &dyn ModuleLoader = loader;
-    /// let mut context = &mut Context::builder().module_loader(dyn_loader).build().unwrap();
+    /// let mut context = &mut Context::builder()
+    ///     .module_loader(dyn_loader)
+    ///     .build()
+    ///     .unwrap();
     ///
     /// let source = Source::from_bytes("1 + 3");
     ///
@@ -640,7 +643,10 @@ impl Module {
     ///
     /// context.run_jobs();
     ///
-    /// assert_eq!(promise.state().unwrap(), PromiseState::Fulfilled(JsValue::undefined()));
+    /// assert_eq!(
+    ///     promise.state().unwrap(),
+    ///     PromiseState::Fulfilled(JsValue::undefined())
+    /// );
     /// ```
     #[allow(dropping_copy_types)]
     #[inline]

--- a/boa_engine/src/object/builtins/jsdataview.rs
+++ b/boa_engine/src/object/builtins/jsdataview.rs
@@ -27,7 +27,8 @@ use std::ops::Deref;
 /// let array_buffer = JsArrayBuffer::new(4, context)?;
 ///
 /// // Create a new Dataview from pre-existing ArrayBuffer
-/// let data_view = JsDataView::from_js_array_buffer(&array_buffer, None, None, context)?;
+/// let data_view =
+///     JsDataView::from_js_array_buffer(&array_buffer, None, None, context)?;
 ///
 /// # Ok(())
 /// # }

--- a/boa_engine/src/object/builtins/jsdate.rs
+++ b/boa_engine/src/object/builtins/jsdate.rs
@@ -18,19 +18,22 @@ use crate::{
 /// Create a `JsDate` object and set date to December 4 1995
 ///
 /// ```
-/// use boa_engine::{object::builtins::JsDate, Context, JsValue, JsResult};
+/// use boa_engine::{object::builtins::JsDate, Context, JsResult, JsValue};
 ///
 /// fn main() -> JsResult<()> {
-/// // JS mutable Context
-/// let context = &mut Context::default();
+///     // JS mutable Context
+///     let context = &mut Context::default();
 ///
-/// let date = JsDate::new(context);
+///     let date = JsDate::new(context);
 ///
-/// date.set_full_year(&[1995.into(), 11.into(), 4.into()], context)?;
+///     date.set_full_year(&[1995.into(), 11.into(), 4.into()], context)?;
 ///
-/// assert_eq!(date.to_date_string(context)?, JsValue::from("Mon Dec 04 1995"));
+///     assert_eq!(
+///         date.to_date_string(context)?,
+///         JsValue::from("Mon Dec 04 1995")
+///     );
 ///
-/// Ok(())
+///     Ok(())
 /// }
 /// ```
 #[derive(Debug, Clone, Trace, Finalize)]

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -35,7 +35,6 @@ use std::ops::Deref;
 /// # Ok(())
 /// # }
 /// ```
-///
 #[derive(Debug, Clone, Trace, Finalize)]
 pub struct JsRegExp {
     inner: JsObject,

--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -2152,7 +2152,11 @@ impl<'realm> FunctionObjectBuilder<'realm> {
 /// let object = ObjectInitializer::new(&mut context)
 ///     .property("hello", "world", Attribute::all())
 ///     .property(1, 1, Attribute::all())
-///     .function(NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())), "func", 0)
+///     .function(
+///         NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())),
+///         "func",
+///         0,
+///     )
 ///     .build();
 /// ```
 ///

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -89,7 +89,7 @@ fn alloc_overflow() -> ! {
 /// ```
 /// # use boa_engine::js_string;
 /// # use boa_engine::string::utf16;
-/// const NAME: &[u16]  = utf16!("human! ");
+/// const NAME: &[u16] = utf16!("human! ");
 /// let greeting = js_string!("Hello, ");
 /// let msg = js_string!(&greeting, &NAME, utf16!("Nice to meet you!"));
 ///

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -155,7 +155,6 @@ pub struct CodeBlock {
     pub(crate) handlers: ThinVec<Handler>,
 
     /// Compile time environments in this function.
-    ///
     // Safety: Nothing in CompileTimeEnvironment needs tracing, so this is safe.
     //
     // TODO(#3034): Maybe changing this to Gc after garbage collection would be better than Rc.

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -438,7 +438,6 @@ macro_rules! generate_opcodes {
 ///
 /// This trait should be implemented for a struct that corresponds with
 /// any arm of the `OpCode` enum.
-///
 pub(crate) trait Operation {
     const NAME: &'static str;
     const INSTRUCTION: &'static str;

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -3,7 +3,6 @@
 //! # Crate Overview
 //! **`boa_gc`** is a mark-sweep garbage collector that implements a [`Trace`] and [`Finalize`] trait
 //! for garbage collected values.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -9,7 +9,6 @@
 //! to `usize`, and also it's easier to store, since instead of a heap-allocated string, you only
 //! need to store a `usize`. This reduces memory consumption and improves performance in the
 //! compiler.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -1,5 +1,4 @@
 //! Macros for the Boa JavaScript engine.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -9,7 +9,6 @@
 //! [spec]: https://tc39.es/ecma262
 //! [lex]: https://tc39.es/ecma262/#sec-ecmascript-language-lexical-grammar
 //! [grammar]: https://tc39.es/ecma262/#sec-ecmascript-language-expressions
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_parser/src/parser/cursor/buffered_lexer/tests.rs
+++ b/boa_parser/src/parser/cursor/buffered_lexer/tests.rs
@@ -266,7 +266,7 @@ fn skip_peeked_terminators() {
             .unwrap()
             .expect("Some value expected")
             .kind(),
-        TokenKind::identifier(interner.get_or_intern_static("B", utf16!("B"))) // This value is after the line terminator
+        TokenKind::identifier(interner.get_or_intern_static("B", utf16!("B"))) /* This value is after the line terminator */
     );
 
     assert_eq!(

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -6,7 +6,6 @@
 //! see Boa's page on [profiling][profiler-md].
 //!
 //! [profiler-md]: https://github.com/boa-dev/boa/blob/main/docs/profiling.md
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_runtime/src/lib.rs
+++ b/boa_runtime/src/lib.rs
@@ -37,9 +37,7 @@
 //!         # panic!("An error occured in boa_runtime's js_code");
 //!     }
 //! };
-//!
 //! ```
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -2,7 +2,6 @@
 //!
 //! This crate will run the full ECMAScript test suite (Test262) and report compliance of the
 //! `boa` engine.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -1,5 +1,4 @@
 //! An ECMAScript WASM implementation based on boa_engine.
-//!
 #![doc = include_str!("../ABOUT.md")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/boa-dev/boa/main/assets/logo.svg",


### PR DESCRIPTION
Uses `cargo +nightly fmt -- --config=format_code_in_doc_comments=true --config=doc_comment_code_block_width=80` to format all docs with code blocks.