### PR TITLE
Introduce experimental features

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl,experimental
       - name: Test docs
-        run: cargo test --doc --profile ci --all-features
+        run: cargo test --doc --profile ci --features annex-b,intl,experimental
 
   msrv:
     name: Minimum supported Rust version

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: tarpaulin
-          args: --workspace --features intl --ignore-tests --engine llvm --out xml
+          args: --workspace --features annex-b,intl,experimental --ignore-tests --engine llvm --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v3
 
@@ -62,9 +62,9 @@ jobs:
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
-        run: cargo nextest run --profile ci --cargo-profile ci --features intl
+        run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl,experimental
       - name: Test docs
-        run: cargo test --doc --profile ci --features intl
+        run: cargo test --doc --profile ci --all-features
 
   msrv:
     name: Minimum supported Rust version

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -27,7 +27,7 @@ phf = { workspace = true, features = ["macros"] }
 pollster.workspace = true
 
 [features]
-default = ["boa_engine/annex-b", "boa_engine/intl"]
+default = ["boa_engine/annex-b", "boa_engine/experimental", "boa_engine/intl"]
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 jemallocator.workspace = true

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -46,6 +46,9 @@ trace = []
 # Enable Boa's additional ECMAScript features for web browsers.
 annex-b = ["boa_parser/annex-b"]
 
+# Enable experimental features, like Stage 3 proposals.
+experimental = []
+
 [dependencies]
 boa_interner.workspace = true
 boa_gc = { workspace = true, features = [ "thinvec" ] }

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -1216,7 +1216,7 @@ impl ObjectTemplates {
 
         #[cfg(feature = "experimental")]
         let with_resolvers = {
-            let mut with_resolvers = ObjectTemplate::new(root_shape);
+            let mut with_resolvers = ordinary_object.clone();
 
             with_resolvers
                 // 4. Perform ! CreateDataPropertyOrThrow(obj, "promise", promiseCapability.[[Promise]]).

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -4,6 +4,7 @@ use boa_gc::{Finalize, Trace};
 
 use crate::{
     builtins::{iterable::IteratorPrototypes, uri::UriFunctions},
+    js_string,
     object::{
         shape::{shared_shape::template::ObjectTemplate, RootShape},
         JsFunction, JsObject, ObjectData, CONSTRUCTOR, PROTOTYPE,
@@ -1100,6 +1101,9 @@ pub(crate) struct ObjectTemplates {
     function_with_prototype_without_proto: ObjectTemplate,
 
     namespace: ObjectTemplate,
+
+    #[cfg(feature = "experimental")]
+    with_resolvers: ObjectTemplate,
 }
 
 impl ObjectTemplates {
@@ -1110,7 +1114,7 @@ impl ObjectTemplates {
         let ordinary_object =
             ObjectTemplate::with_prototype(root_shape, constructors.object().prototype());
         let mut array = ObjectTemplate::new(root_shape);
-        let length_property_key: PropertyKey = "length".into();
+        let length_property_key: PropertyKey = js_string!("length").into();
         array.property(
             length_property_key.clone(),
             Attribute::WRITABLE | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
@@ -1129,7 +1133,7 @@ impl ObjectTemplates {
         );
         string.set_prototype(constructors.string().prototype());
 
-        let name_property_key: PropertyKey = "name".into();
+        let name_property_key: PropertyKey = js_string!("name").into();
         let mut function = ObjectTemplate::new(root_shape);
         function.property(
             length_property_key.clone(),
@@ -1184,7 +1188,7 @@ impl ObjectTemplates {
         // [[Get]]: %ThrowTypeError%, [[Set]]: %ThrowTypeError%, [[Enumerable]]: false,
         // [[Configurable]]: false }).
         unmapped_arguments.accessor(
-            "callee".into(),
+            js_string!("callee").into(),
             true,
             true,
             Attribute::NON_ENUMERABLE | Attribute::PERMANENT,
@@ -1193,22 +1197,37 @@ impl ObjectTemplates {
         // 21. Perform ! DefinePropertyOrThrow(obj, "callee", PropertyDescriptor {
         // [[Value]]: func, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: true }).
         mapped_arguments.property(
-            "callee".into(),
+            js_string!("callee").into(),
             Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
         );
 
         let mut iterator_result = ordinary_object.clone();
         iterator_result.property(
-            "value".into(),
+            js_string!("value").into(),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::ENUMERABLE,
         );
         iterator_result.property(
-            "done".into(),
+            js_string!("done").into(),
             Attribute::WRITABLE | Attribute::CONFIGURABLE | Attribute::ENUMERABLE,
         );
 
         let mut namespace = ObjectTemplate::new(root_shape);
         namespace.property(JsSymbol::to_string_tag().into(), Attribute::empty());
+
+        #[cfg(feature = "experimental")]
+        let with_resolvers = {
+            let mut with_resolvers = ObjectTemplate::new(root_shape);
+
+            with_resolvers
+                // 4. Perform ! CreateDataPropertyOrThrow(obj, "promise", promiseCapability.[[Promise]]).
+                .property(js_string!("promise").into(), Attribute::all())
+                // 5. Perform ! CreateDataPropertyOrThrow(obj, "resolve", promiseCapability.[[Resolve]]).
+                .property(js_string!("resolve").into(), Attribute::all())
+                // 6. Perform ! CreateDataPropertyOrThrow(obj, "reject", promiseCapability.[[Reject]]).
+                .property(js_string!("reject").into(), Attribute::all());
+
+            with_resolvers
+        };
 
         Self {
             iterator_result,
@@ -1228,6 +1247,8 @@ impl ObjectTemplates {
             function_without_proto,
             function_with_prototype_without_proto,
             namespace,
+            #[cfg(feature = "experimental")]
+            with_resolvers,
         }
     }
 
@@ -1403,5 +1424,17 @@ impl ObjectTemplates {
     /// 1. `@@toStringTag`: (`READONLY`, `NON_ENUMERABLE`, `PERMANENT`)
     pub(crate) const fn namespace(&self) -> &ObjectTemplate {
         &self.namespace
+    }
+
+    /// Cached object from the `Promise.withResolvers` method.
+    ///
+    /// Transitions:
+    ///
+    /// 1. `"promise"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 2. `"resolve"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    /// 3. `"reject"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
+    #[cfg(feature = "experimental")]
+    pub(crate) const fn with_resolvers(&self) -> &ObjectTemplate {
+        &self.with_resolvers
     }
 }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -823,7 +823,7 @@ pub(crate) fn create_function_object(
 /// Creates a new function object.
 ///
 /// This is prefered over [`create_function_object`] if prototype is [`None`],
-/// because it constructs the funtion from a pre-initialized object template,
+/// because it constructs the function from a pre-initialized object template,
 /// with all the properties and prototype set.
 pub(crate) fn create_function_object_fast(
     code: Gc<CodeBlock>,

--- a/boa_tester/Cargo.toml
+++ b/boa_tester/Cargo.toml
@@ -31,4 +31,4 @@ comfy-table = "7.0.1"
 serde_repr = "0.1.16"
 
 [features]
-default = ["boa_engine/intl", "boa_engine/annex-b"]
+default = ["boa_engine/intl", "boa_engine/experimental", "boa_engine/annex-b"]

--- a/boa_wasm/Cargo.toml
+++ b/boa_wasm/Cargo.toml
@@ -19,7 +19,7 @@ chrono = { workspace = true, default-features = false, features = ["clock", "std
 console_error_panic_hook = "0.1.7"
 
 [features]
-default = ["boa_engine/annex-b"]
+default = ["boa_engine/annex-b", "boa_engine/intl", "boa_engine/experimental"]
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -66,9 +66,6 @@ features = [
     # https://github.com/tc39/proposal-iterator-helpers
     "iterator-helpers",
 
-    # https://github.com/tc39/proposal-promise-with-resolvers
-    "promise-with-resolvers",
-
     ### Non-standard
     "caller",
 


### PR DESCRIPTION
Related to #3277

Since the Temporal PR is as big as it gets, I thought it would be good to introduce the experimental flag in a separate PR, which should reduce the review work a bit.
This also introduces the [`Promise.withResolvers`](https://github.com/tc39/proposal-promise-with-resolvers) method, just so that there's at least some feature using the flag.
