### PR TITLE
Truncate environment stack on non-caught native error

### DIFF
--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -1347,6 +1347,8 @@ impl JsObject {
                     ),
                 );
 
+                let environment = context.vm.environments.current();
+
                 if code.has_parameters_env_bindings() {
                     last_env -= 1;
                     context
@@ -1391,8 +1393,6 @@ impl JsObject {
                 let argument_count = args.len();
                 let parameters_count = code.params.as_ref().len();
 
-                let has_binding_identifier = code.has_binding_identifier();
-
                 context.vm.push_frame(
                     CallFrame::new(code, script_or_module, Some(self.clone()))
                         .with_argument_count(argument_count as u32)
@@ -1410,16 +1410,6 @@ impl JsObject {
                 context.vm.pop_frame();
 
                 std::mem::swap(&mut environments, &mut context.vm.environments);
-
-                let environment = if has_binding_identifier {
-                    environments.truncate(environments_len + 2);
-                    let environment = environments.pop();
-                    environments.pop();
-                    environment
-                } else {
-                    environments.truncate(environments_len + 1);
-                    environments.pop()
-                };
 
                 let result = record
                     .consume()

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -377,9 +377,16 @@ impl Context<'_> {
                         match native_error.kind {
                             #[cfg(feature = "fuzz")]
                             JsNativeErrorKind::NoInstructionsRemain => {
+                                self.vm
+                                    .environments
+                                    .truncate(self.vm.frame().env_fp as usize);
+                                self.vm.stack.truncate(self.vm.frame().fp as usize);
                                 return CompletionRecord::Throw(err);
                             }
                             JsNativeErrorKind::RuntimeLimit => {
+                                self.vm
+                                    .environments
+                                    .truncate(self.vm.frame().env_fp as usize);
                                 self.vm.stack.truncate(self.vm.frame().fp as usize);
                                 return CompletionRecord::Throw(err);
                             }
@@ -394,6 +401,9 @@ impl Context<'_> {
                         continue;
                     }
 
+                    self.vm
+                        .environments
+                        .truncate(self.vm.frame().env_fp as usize);
                     self.vm.stack.truncate(self.vm.frame().fp as usize);
                     return CompletionRecord::Throw(err);
                 }

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -357,3 +357,12 @@ fn empty_return_values() {
         "#}),
     ]);
 }
+
+#[test]
+fn truncate_environments_on_non_caught_native_error() {
+    let source = "with (new Proxy({}, {has: p => false})) {a}";
+    run_test_actions([
+        TestAction::assert_native_error(source, JsNativeErrorKind::Reference, "a is not defined"),
+        TestAction::assert_native_error(source, JsNativeErrorKind::Reference, "a is not defined"),
+    ]);
+}


### PR DESCRIPTION
When an native error is thrown and not caught it only truncates the value stack, the environment stack is not changed this causes panics if we run code than access the environment.

For example
```js
with (new Proxy({}, {has: p => false})) {a}
```

Running this code twice causes a panic (`boa file.js file.js`).

```
panicked at 'environment must be declarative', boa_engine/src/vm/opcode/define/mod.rs:114:33
```