### PR TITLE
Remove unused class environments

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -225,9 +225,6 @@ pub struct OrdinaryFunction {
     /// The `[[HomeObject]]` internal slot.
     pub(crate) home_object: Option<JsObject>,
 
-    /// The class object that this function is associated with.
-    pub(crate) class_object: Option<JsObject>,
-
     /// The `[[ScriptOrModule]]` internal slot.
     pub(crate) script_or_module: Option<ActiveRunnable>,
 
@@ -320,11 +317,6 @@ impl OrdinaryFunction {
         {
             private_methods.push((name, method));
         }
-    }
-
-    ///  Sets the class object.
-    pub(crate) fn set_class_object(&mut self, object: JsObject) {
-        self.class_object = Some(object);
     }
 
     /// Gets the `Realm` from where this function originates.

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -21,7 +21,6 @@ pub(crate) struct FunctionCompiler {
     strict: bool,
     arrow: bool,
     binding_identifier: Option<Sym>,
-    class_name: Option<Sym>,
 }
 
 impl FunctionCompiler {
@@ -34,7 +33,6 @@ impl FunctionCompiler {
             strict: false,
             arrow: false,
             binding_identifier: None,
-            class_name: None,
         }
     }
 
@@ -79,12 +77,6 @@ impl FunctionCompiler {
         self
     }
 
-    /// Indicate if the function has a class associated with it.
-    pub(crate) const fn class_name(mut self, class_name: Sym) -> Self {
-        self.class_name = Some(class_name);
-        self
-    }
-
     /// Compile a function statement list and it's parameters into bytecode.
     pub(crate) fn compile(
         mut self,
@@ -104,11 +96,6 @@ impl FunctionCompiler {
 
         if self.arrow {
             compiler.this_mode = ThisMode::Lexical;
-        }
-
-        if let Some(class_name) = self.class_name {
-            compiler.push_compile_environment(false);
-            compiler.create_immutable_binding(class_name.into(), true);
         }
 
         if let Some(binding_identifier) = self.binding_identifier {
@@ -181,10 +168,6 @@ impl FunctionCompiler {
         compiler.pop_compile_environment();
 
         if self.binding_identifier.is_some() {
-            compiler.pop_compile_environment();
-        }
-
-        if self.class_name.is_some() {
             compiler.pop_compile_environment();
         }
 

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -1378,7 +1378,7 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
     }
 
     /// Compile a class method AST Node into bytecode.
-    fn method(&mut self, function: FunctionSpec<'_>, class_name: Sym) {
+    fn method(&mut self, function: FunctionSpec<'_>) {
         let (generator, r#async, arrow) = (
             function.kind.is_generator(),
             function.kind.is_async(),
@@ -1409,7 +1409,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
             .strict(true)
             .arrow(arrow)
             .binding_identifier(binding_identifier)
-            .class_name(class_name)
             .compile(
                 parameters,
                 body,

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -357,7 +357,6 @@ impl CodeBlock {
                 | Instruction::PushClassPrototype
                 | Instruction::SetClassPrototype
                 | Instruction::SetHomeObject
-                | Instruction::SetHomeObjectClass
                 | Instruction::Add
                 | Instruction::Sub
                 | Instruction::Div
@@ -522,7 +521,8 @@ impl CodeBlock {
                 | Instruction::Reserved54
                 | Instruction::Reserved55
                 | Instruction::Reserved56
-                | Instruction::Reserved57 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved57
+                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/define/class/getter.rs
+++ b/boa_engine/src/vm/opcode/define/class/getter.rs
@@ -1,6 +1,5 @@
 use crate::{
     builtins::function::set_function_name,
-    object::CONSTRUCTOR,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsString,
@@ -29,7 +28,6 @@ impl DefineClassStaticGetterByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
         let set = class
             .__get_own_property__(&key, context)?
@@ -93,13 +91,6 @@ impl DefineClassGetterByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
         let set = class_proto
             .__get_own_property__(&key, context)?
@@ -169,7 +160,6 @@ impl Operation for DefineClassStaticGetterByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
         let set = class
             .__get_own_property__(&key, context)?
@@ -219,13 +209,6 @@ impl Operation for DefineClassGetterByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
         let set = class_proto
             .__get_own_property__(&key, context)?

--- a/boa_engine/src/vm/opcode/define/class/method.rs
+++ b/boa_engine/src/vm/opcode/define/class/method.rs
@@ -1,6 +1,5 @@
 use crate::{
     builtins::function::set_function_name,
-    object::CONSTRUCTOR,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult,
@@ -29,7 +28,6 @@ impl DefineClassStaticMethodByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
 
         class.__define_own_property__(
@@ -89,13 +87,6 @@ impl DefineClassMethodByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
 
         class_proto.__define_own_property__(
@@ -161,7 +152,6 @@ impl Operation for DefineClassStaticMethodByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
 
         class.define_property_or_throw(
@@ -207,13 +197,6 @@ impl Operation for DefineClassMethodByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
 
         class_proto.__define_own_property__(

--- a/boa_engine/src/vm/opcode/define/class/setter.rs
+++ b/boa_engine/src/vm/opcode/define/class/setter.rs
@@ -1,6 +1,5 @@
 use crate::{
     builtins::function::set_function_name,
-    object::CONSTRUCTOR,
     property::PropertyDescriptor,
     vm::{opcode::Operation, CompletionType},
     Context, JsResult, JsString,
@@ -29,7 +28,6 @@ impl DefineClassStaticSetterByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
         let get = class
             .__get_own_property__(&key, context)?
@@ -94,13 +92,6 @@ impl DefineClassSetterByName {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
         let get = class_proto
             .__get_own_property__(&key, context)?
@@ -172,7 +163,6 @@ impl Operation for DefineClassStaticSetterByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class.clone());
-            function_mut.set_class_object(class.clone());
         }
         let get = class
             .__get_own_property__(&key, context)?
@@ -224,13 +214,6 @@ impl Operation for DefineClassSetterByValue {
                 .as_function_mut()
                 .expect("method must be function object");
             function_mut.set_home_object(class_proto.clone());
-            let class = class_proto
-                .get(CONSTRUCTOR, context)
-                .expect("class prototype must have constructor")
-                .as_object()
-                .expect("class must be object")
-                .clone();
-            function_mut.set_class_object(class);
         }
         let get = class_proto
             .__get_own_property__(&key, context)?

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -736,13 +736,6 @@ generate_opcodes! {
     /// Stack: home, function **=>** home, function
     SetHomeObject,
 
-    /// Set home object internal slot of a class method.
-    ///
-    /// Operands:
-    ///
-    /// Stack: home, function **=>** home, function
-    SetHomeObjectClass,
-
     /// Set the prototype of an object if the value is an object or null.
     ///
     /// Operands:
@@ -2178,6 +2171,8 @@ generate_opcodes! {
     Reserved56 => Reserved,
     /// Reserved [`Opcode`].
     Reserved57 => Reserved,
+    /// Reserved [`Opcode`].
+    Reserved58 => Reserved,
 }
 
 /// Specific opcodes for bindings.

--- a/boa_engine/src/vm/opcode/push/class/field.rs
+++ b/boa_engine/src/vm/opcode/push/class/field.rs
@@ -32,7 +32,6 @@ impl Operation for PushClassField {
             .as_object()
             .expect("class must be function object");
         field_function.set_home_object(class_object.clone());
-        field_function.set_class_object(class_object.clone());
         class_object
             .borrow_mut()
             .as_function_mut()
@@ -70,7 +69,6 @@ impl PushClassFieldPrivate {
             .as_object()
             .expect("class must be function object");
         field_function.set_home_object(class_object.clone());
-        field_function.set_class_object(class_object.clone());
 
         class_object
             .borrow_mut()

--- a/boa_engine/src/vm/opcode/push/class/private.rs
+++ b/boa_engine/src/vm/opcode/push/class/private.rs
@@ -44,11 +44,6 @@ impl PushClassPrivateMethod {
                 PrivateElement::Method(method_object.clone()),
             );
 
-        let mut method_object_mut = method_object.borrow_mut();
-        let function = method_object_mut
-            .as_function_mut()
-            .expect("method must be function object");
-        function.set_class_object(class_object.clone());
         Ok(CompletionType::Normal)
     }
 }
@@ -100,11 +95,7 @@ impl PushClassPrivateGetter {
                     setter: None,
                 },
             );
-        let mut getter_object_mut = getter_object.borrow_mut();
-        let function = getter_object_mut
-            .as_function_mut()
-            .expect("getter must be function object");
-        function.set_class_object(class_object.clone());
+
         Ok(CompletionType::Normal)
     }
 }
@@ -156,11 +147,7 @@ impl PushClassPrivateSetter {
                     setter: Some(setter_object.clone()),
                 },
             );
-        let mut setter_object_mut = setter_object.borrow_mut();
-        let function = setter_object_mut
-            .as_function_mut()
-            .expect("setter must be function object");
-        function.set_class_object(class_object.clone());
+
         Ok(CompletionType::Normal)
     }
 }

--- a/boa_engine/src/vm/opcode/set/home_object.rs
+++ b/boa_engine/src/vm/opcode/set/home_object.rs
@@ -33,35 +33,3 @@ impl Operation for SetHomeObject {
         Ok(CompletionType::Normal)
     }
 }
-
-/// `SetHomeObjectClass` implements the Opcode Operation for `Opcode::SetHomeObjectClass`
-///
-/// Operation:
-///  - Set home object internal slot of a function object.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct SetHomeObjectClass;
-
-impl Operation for SetHomeObjectClass {
-    const NAME: &'static str = "SetHomeObjectClass";
-    const INSTRUCTION: &'static str = "INST - SetHomeObjectClass";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let function = context.vm.pop();
-        let home = context.vm.pop();
-
-        {
-            let function_object = function.as_object().expect("must be object");
-            let home_object = home.as_object().expect("must be object");
-            let mut function_object_mut = function_object.borrow_mut();
-            let function_mut = function_object_mut
-                .as_function_mut()
-                .expect("must be function object");
-            function_mut.set_home_object(home_object.clone());
-            function_mut.set_class_object(home_object.clone());
-        }
-
-        context.vm.push(home);
-        context.vm.push(function);
-        Ok(CompletionType::Normal)
-    }
-}

--- a/boa_engine/src/vm/opcode/set/private.rs
+++ b/boa_engine/src/vm/opcode/set/private.rs
@@ -132,11 +132,6 @@ impl SetPrivateMethod {
             object.private_name(name),
             PrivateElement::Method(value.clone()),
         );
-        let mut value_mut = value.borrow_mut();
-        let function = value_mut
-            .as_function_mut()
-            .expect("method must be a function");
-        function.set_class_object(object.clone());
 
         Ok(CompletionType::Normal)
     }
@@ -187,11 +182,6 @@ impl SetPrivateSetter {
                 setter: Some(value.clone()),
             },
         );
-        let mut value_mut = value.borrow_mut();
-        let function = value_mut
-            .as_function_mut()
-            .expect("method must be a function");
-        function.set_class_object(object.clone());
 
         Ok(CompletionType::Normal)
     }
@@ -242,11 +232,6 @@ impl SetPrivateGetter {
                 setter: None,
             },
         );
-        let mut value_mut = value.borrow_mut();
-        let function = value_mut
-            .as_function_mut()
-            .expect("method must be a function");
-        function.set_class_object(object.clone());
 
         Ok(CompletionType::Normal)
     }


### PR DESCRIPTION
Building on #3328 this removes a bunch of unneeded class environments that where more of a hack to get the class name binding in some places. This also enables removing the `class_object` from `FunctionKind`.