### PR TITLE
Improve CI testing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
   tests:
-    name: Run tests
+    name: Test
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -70,7 +70,7 @@ jobs:
         run: cargo test --doc --profile ci --features annex-b,intl,experimental
 
   msrv:
-    name: Minimum supported Rust version
+    name: MSRV
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -88,10 +88,11 @@ jobs:
         run: cargo check --all-features --all-targets
 
   fmt:
-    name: Format
+    name: Formatting
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1.0.7
         with:
           toolchain: stable
@@ -120,13 +121,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: clippy
-      - name: Lint (All features)
+      - name: Clippy (All features)
         run: cargo workspaces exec cargo clippy --all-features --all-targets -- -D warnings
-      - name: Lint (No features)
+      - name: Clippy (No features)
         run: cargo workspaces exec cargo clippy --no-default-features --all-targets -- -D warnings
 
   docs:
-    name: Check documentation
+    name: Documentation
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -140,12 +141,12 @@ jobs:
           profile: minimal
       - uses: Swatinem/rust-cache@v2
         with:
-          key: rustdoc
+          key: docs
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
   build-fuzz:
-    name: Build fuzzers
+    name: Fuzzing
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -163,11 +164,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           key: build-fuzz
-      - name: Build fuzzers
+      - name: Build fuzz
         run: cargo fuzz build -s none
 
   build-run-examples:
-    name: Build & Run examples
+    name: Build & run examples
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build tests
         run: cargo test --no-run --profile ci
       # this order is faster according to rust-analyzer
-      - name: Build (Workspace)
+      - name: Build
         run: cargo build --all-targets --quiet --profile ci --features annex-b,intl,experimental
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
@@ -122,9 +122,9 @@ jobs:
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
-      - name: Build (No features)
-        run: cargo workspaces exec cargo build --all-features --all-targets --profile ci
       - name: Build (All features)
+        run: cargo workspaces exec cargo build --all-features --all-targets --profile ci
+      - name: Build (No features)
         run: cargo workspaces exec cargo build --no-default-features --all-targets --profile ci
 
       - name: Build fuzzers

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,9 @@ on:
   merge_group:
     types: [checks_requested]
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
   coverage:
     name: Coverage
@@ -38,7 +41,7 @@ jobs:
         uses: codecov/codecov-action@v3
 
   tests:
-    name: Build and Test
+    name: Run tests
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -84,12 +87,24 @@ jobs:
       - name: Check compilation
         run: cargo check --all-features --all-targets
 
-  misc:
-    name: Misc
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    env:
-      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          components: rustfmt
+      - name: Format (rustfmt)
+        run: cargo fmt --all --check
+
+  clippy:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1.0.7
@@ -97,11 +112,49 @@ jobs:
           toolchain: stable
           override: true
           profile: minimal
-          components: rustfmt, clippy
+          components: clippy
       - name: Install cargo-workspaces
         uses: actions-rs/install@v0.1
         with:
           crate: cargo-workspaces
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clippy
+      - name: Lint (All features)
+        run: cargo workspaces exec cargo clippy --all-features --all-targets -- -D warnings
+      - name: Lint (No features)
+        run: cargo workspaces exec cargo clippy --no-default-features --all-targets -- -D warnings
+
+  docs:
+    name: Check documentation
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      RUSTDOCFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: rustdoc
+      - name: Generate documentation
+        run: cargo doc -v --document-private-items --all-features
+
+  build-fuzz:
+    name: Build fuzzers
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
       - name: Install cargo-fuzz
         uses: actions-rs/install@v0.1
         with:
@@ -109,26 +162,33 @@ jobs:
           version: latest
       - uses: Swatinem/rust-cache@v2
         with:
-          key: misc
+          key: build-fuzz
+      - name: Build fuzzers
+        run: cargo fuzz build -s none
 
-      - name: Format (rustfmt)
-        run: cargo fmt --all --check
-
-      - name: Lint (All features)
-        run: cargo workspaces exec cargo clippy --all-features --all-targets -- -D warnings
-      - name: Lint (No features)
-        run: cargo workspaces exec cargo clippy --no-default-features --all-targets -- -D warnings
-
-      - name: Generate documentation
-        run: cargo doc -v --document-private-items --all-features
+  build-run-examples:
+    name: Build & Run examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Install cargo-workspaces
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-workspaces
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: build-run-examples
 
       - name: Build (All features)
         run: cargo workspaces exec cargo build --all-features --all-targets --profile ci
       - name: Build (No features)
         run: cargo workspaces exec cargo build --no-default-features --all-targets --profile ci
-
-      - name: Build fuzzers
-        run: cargo fuzz build -s none
 
       - name: Run examples
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,22 +57,14 @@ jobs:
       - name: Build tests
         run: cargo test --no-run --profile ci
       # this order is faster according to rust-analyzer
-      - name: Build
-        run: cargo build --all-targets --quiet --profile ci
+      - name: Build (Workspace)
+        run: cargo build --all-targets --quiet --profile ci --features annex-b,intl,experimental
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
         run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl,experimental
       - name: Test docs
         run: cargo test --doc --profile ci --features annex-b,intl,experimental
-      - name: Build boa_ast crate
-        run: cargo build -p boa_ast
-      - name: Build boa_cli crate
-        run: cargo build -p boa_cli
-      - name: Build boa_parser crate
-        run: cargo build -p boa_parser
-      - name: Build boa_runtime crate
-        run: cargo build -p boa_runtime
 
   msrv:
     name: Minimum supported Rust version
@@ -106,27 +98,41 @@ jobs:
           override: true
           profile: minimal
           components: rustfmt, clippy
-      - uses: actions-rs/install@v0.1
+      - name: Install cargo-workspaces
+        uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-workspaces
+      - name: Install cargo-fuzz
+        uses: actions-rs/install@v0.1
         with:
           crate: cargo-fuzz
           version: latest
       - uses: Swatinem/rust-cache@v2
         with:
           key: misc
+
       - name: Format (rustfmt)
         run: cargo fmt --all --check
+
       - name: Lint (All features)
-        run: cargo clippy --all-features --all-targets
+        run: cargo workspaces exec --no-bail cargo clippy --all-features --all-targets -- -D warnings
       - name: Lint (No features)
-        run: cargo clippy -p boa_engine --no-default-features --all-targets
+        run: cargo workspaces exec --no-bail cargo clippy --no-default-features --all-targets -- -D warnings
+
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
-      - name: Build
-        run: cargo build --all-targets --quiet --profile ci
+
+      - name: Build (No features)
+        run: cargo workspaces exec --no-bail cargo build --all-features --all-targets --profile ci
+      - name: Build (All features)
+        run: cargo workspaces exec --no-bail cargo build --no-default-features --all-targets --profile ci
+
       - name: Build fuzzers
         run: cargo fuzz build -s none
-      - run: cd boa_examples
-      - name: Build examples
-        run: cargo build --quiet --profile ci
-      - name: Run example classes
-        run: cargo run --bin classes --profile ci
+
+      - name: Run examples
+        run: |
+          cd boa_examples
+          cargo run -p boa_examples --bin 2>&1 \
+            | grep -E '^ ' \
+            | xargs -n1 sh -c 'cargo run -p boa_examples --profile ci --bin $0 || exit 255'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,17 +115,17 @@ jobs:
         run: cargo fmt --all --check
 
       - name: Lint (All features)
-        run: cargo workspaces exec --no-bail cargo clippy --all-features --all-targets -- -D warnings
+        run: cargo workspaces exec cargo clippy --all-features --all-targets -- -D warnings
       - name: Lint (No features)
-        run: cargo workspaces exec --no-bail cargo clippy --no-default-features --all-targets -- -D warnings
+        run: cargo workspaces exec cargo clippy --no-default-features --all-targets -- -D warnings
 
       - name: Generate documentation
         run: cargo doc -v --document-private-items --all-features
 
       - name: Build (No features)
-        run: cargo workspaces exec --no-bail cargo build --all-features --all-targets --profile ci
+        run: cargo workspaces exec cargo build --all-features --all-targets --profile ci
       - name: Build (All features)
-        run: cargo workspaces exec --no-bail cargo build --no-default-features --all-targets --profile ci
+        run: cargo workspaces exec cargo build --no-default-features --all-targets --profile ci
 
       - name: Build fuzzers
         run: cargo fuzz build -s none

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,7 @@ dependencies = [
  "boa_interner",
  "boa_parser",
  "boa_runtime",
+ "chrono",
  "futures-util",
  "smol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ clap = "4.4.6"
 colored = "2.0.4"
 fast-float = "0.2.0"
 hashbrown = { version = "0.14.1", default-features = false }
-indexmap = "2.0.1"
+indexmap = { version = "2.0.1", default-features = false }
 indoc = "2.0.4"
 jemallocator = "0.5.4"
 num-bigint = "0.4.4"

--- a/boa_ast/Cargo.toml
+++ b/boa_ast/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-serde = ["dep:serde", "boa_interner/serde", "bitflags/serde"]
+serde = ["dep:serde", "boa_interner/serde", "bitflags/serde", "num-bigint/serde"]
 arbitrary = ["dep:arbitrary", "boa_interner/arbitrary", "num-bigint/arbitrary"]
 
 [dependencies]

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -59,9 +59,7 @@
     clippy::pedantic,
     clippy::nursery,
 )]
-#![allow(clippy::option_if_let_else, clippy::redundant_pub_crate)]
-
-use boa_ast as _;
+#![allow(unused_crate_dependencies, clippy::option_if_let_else, clippy::redundant_pub_crate)]
 
 mod debug;
 mod helper;
@@ -92,12 +90,17 @@ use std::{
     target_arch = "x86_64",
     target_os = "linux",
     target_env = "gnu",
+    feature = "dhat"
+))]
+use jemallocator as _;
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_os = "linux",
+    target_env = "gnu",
     not(feature = "dhat")
 ))]
-#[cfg_attr(
-    all(target_arch = "x86_64", target_os = "linux", target_env = "gnu"),
-    global_allocator
-)]
+#[global_allocator]
 static ALLOC: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[cfg(feature = "dhat")]

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -59,7 +59,11 @@
     clippy::pedantic,
     clippy::nursery,
 )]
-#![allow(unused_crate_dependencies, clippy::option_if_let_else, clippy::redundant_pub_crate)]
+#![allow(
+    unused_crate_dependencies,
+    clippy::option_if_let_else,
+    clippy::redundant_pub_crate
+)]
 
 mod debug;
 mod helper;

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -65,7 +65,7 @@ rustc-hash = { workspace = true, features = ["std"] }
 num-bigint = { workspace = true, features = ["serde"] }
 num-integer = "0.1.45"
 bitflags.workspace = true
-indexmap.workspace = true
+indexmap = { workspace = true, features = ["std"] }
 ryu-js = "0.2.2"
 chrono = { workspace = true, default-features = false, features = ["clock", "std"] }
 fast-float.workspace = true

--- a/boa_engine/src/vm/mod.rs
+++ b/boa_engine/src/vm/mod.rs
@@ -32,6 +32,8 @@ mod runtime_limits;
 #[cfg(feature = "flowgraph")]
 pub mod flowgraph;
 
+// TODO: see if this can be exposed on all features.
+#[allow(unused_imports)]
 pub(crate) use opcode::{Instruction, InstructionIterator, Opcode, VaryingOperandKind};
 pub use runtime_limits::RuntimeLimits;
 pub use {

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -398,6 +398,8 @@ macro_rules! generate_opcodes {
         impl Opcode {
             const MAX: usize = 2usize.pow(8) * 3;
 
+            // TODO: see if this can be exposed on all features.
+            #[allow(unused)]
             const NAMES: [&'static str; Self::MAX] = [
                 $(<generate_opcodes!(name $Variant $(=> $mapping)?)>::NAME),*,
                 $(<generate_opcodes!(name $Variant $(=> $mapping)?)>::NAME),*,
@@ -406,6 +408,8 @@ macro_rules! generate_opcodes {
 
             /// Name of this opcode.
             #[must_use]
+            // TODO: see if this can be exposed on all features.
+            #[allow(unused)]
             pub(crate) const fn as_str(self) -> &'static str {
                 Self::NAMES[self as usize]
             }
@@ -505,6 +509,8 @@ macro_rules! generate_opcodes {
             /// Get the [`Opcode`] of the [`Instruction`].
             #[inline]
             #[must_use]
+            // TODO: see if this can be exposed on all features.
+            #[allow(unused)]
             pub(crate) const fn opcode(&self) -> Opcode {
                 match self {
                     $(
@@ -2193,6 +2199,8 @@ pub(crate) struct InstructionIterator<'bytecode> {
     pc: usize,
 }
 
+// TODO: see if this can be exposed on all features.
+#[allow(unused)]
 impl<'bytecode> InstructionIterator<'bytecode> {
     /// Create a new [`InstructionIterator`] from bytecode array.
     #[inline]

--- a/boa_examples/Cargo.toml
+++ b/boa_examples/Cargo.toml
@@ -16,5 +16,6 @@ boa_interner.workspace = true
 boa_gc.workspace = true
 boa_parser.workspace = true
 boa_runtime.workspace = true
+chrono.workspace = true
 smol = "1.3.0"
 futures-util = "0.3.28"

--- a/boa_examples/src/bin/commuter_visitor.rs
+++ b/boa_examples/src/bin/commuter_visitor.rs
@@ -65,8 +65,7 @@ impl<'ast> VisitorMut<'ast> for CommutorVisitor {
 }
 
 fn main() {
-    let mut parser =
-        Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
+    let mut parser = Parser::new(Source::from_filepath(Path::new("./scripts/calc.js")).unwrap());
     let mut ctx = Context::default();
 
     let mut script = parser.parse_script(ctx.interner_mut()).unwrap();

--- a/boa_examples/src/bin/loadfile.rs
+++ b/boa_examples/src/bin/loadfile.rs
@@ -1,31 +1,31 @@
 // This example shows how to load, parse and execute JS code from a source file
 // (./scripts/helloworld.js)
 
-use std::path::Path;
+use std::{error::Error, path::Path};
 
-use boa_engine::{Context, Source};
+use boa_engine::{js_string, property::Attribute, Context, Source};
+use boa_runtime::Console;
 
-fn main() {
+/// Adds the custom runtime to the context.
+fn add_runtime(context: &mut Context<'_>) {
+    // We first add the `console` object, to be able to call `console.log()`.
+    let console = Console::init(context);
+    context
+        .register_global_property(js_string!(Console::NAME), console, Attribute::all())
+        .expect("the console builtin shouldn't exist");
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
     let js_file_path = "./scripts/helloworld.js";
 
-    match Source::from_filepath(Path::new(js_file_path)) {
-        Ok(src) => {
-            // Instantiate the execution context
-            let mut context = Context::default();
-            // Parse the source code
-            match context.eval(src) {
-                Ok(res) => {
-                    println!(
-                        "{}",
-                        res.to_string(&mut context).unwrap().to_std_string_escaped()
-                    );
-                }
-                Err(e) => {
-                    // Pretty print the error
-                    eprintln!("Uncaught {e}");
-                }
-            };
-        }
-        Err(msg) => eprintln!("Error: {msg}"),
-    }
+    let source = Source::from_filepath(Path::new(js_file_path))?;
+
+    // Instantiate the execution context
+    let mut context = Context::default();
+    // Add the runtime intrisics
+    add_runtime(&mut context);
+    // Parse the source code and print the result
+    println!("{}", context.eval(source)?.display());
+
+    Ok(())
 }

--- a/boa_examples/src/bin/modulehandler.rs
+++ b/boa_examples/src/bin/modulehandler.rs
@@ -3,75 +3,78 @@
 
 use boa_engine::{
     js_string, native_function::NativeFunction, prelude::JsObject, property::Attribute, Context,
-    JsResult, JsValue, Source,
+    JsArgs, JsNativeError, JsResult, JsValue, Source,
 };
-use std::fs::read_to_string;
+use boa_runtime::Console;
+use std::{error::Error, fs::read_to_string};
 
-fn main() {
+/// Adds the custom runtime to the context.
+fn add_runtime(context: &mut Context<'_>) {
+    // We first add the `console` object, to be able to call `console.log()`.
+    let console = Console::init(context);
+    context
+        .register_global_property(js_string!(Console::NAME), console, Attribute::all())
+        .expect("the console builtin shouldn't exist");
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
     let js_file_path = "./scripts/calctest.js";
-    let buffer = read_to_string(js_file_path);
-
-    if buffer.is_err() {
-        println!("Error: {}", buffer.unwrap_err());
-        return;
-    }
+    let buffer = read_to_string(js_file_path)?;
 
     // Creating the execution context
     let mut ctx = Context::default();
+
+    // Adding the runtime intrinsics to the context
+    add_runtime(&mut ctx);
 
     // Adding custom implementation that mimics 'require'
     ctx.register_global_callable(
         js_string!("require"),
         0,
         NativeFunction::from_fn_ptr(require),
-    )
-    .unwrap();
+    )?;
 
     // Adding custom object that mimics 'module.exports'
     let moduleobj = JsObject::default();
-    moduleobj
-        .set(
-            js_string!("exports"),
-            JsValue::from(js_string!(" ")),
-            false,
-            &mut ctx,
-        )
-        .unwrap();
+    moduleobj.set(
+        js_string!("exports"),
+        JsValue::from(js_string!(" ")),
+        false,
+        &mut ctx,
+    )?;
+
     ctx.register_global_property(
         js_string!("module"),
         JsValue::from(moduleobj),
         Attribute::default(),
-    )
-    .unwrap();
+    )?;
 
     // Instantiating the engine with the execution context
     // Loading, parsing and executing the JS code from the source file
-    ctx.eval(Source::from_bytes(&buffer.unwrap())).unwrap();
+    ctx.eval(Source::from_bytes(&buffer))?;
+
+    Ok(())
 }
 
 // Custom implementation that mimics the 'require' module loader
 fn require(_: &JsValue, args: &[JsValue], ctx: &mut Context<'_>) -> JsResult<JsValue> {
-    let arg = args.get(0).unwrap();
+    let arg = args.get_or_undefined(0);
 
     // BUG: Dev branch seems to be passing string arguments along with quotes
-    let libfile = arg
-        .to_string(ctx)
-        .expect("Failed to convert to string")
-        .to_std_string_escaped();
+    let libfile = arg.to_string(ctx)?.to_std_string_escaped();
 
     // Read the module source file
     println!("Loading: {libfile}");
-    let buffer = read_to_string(libfile);
-    if let Err(error) = buffer {
-        println!("Error: {error}");
-        Ok(JsValue::Rational(-1.0))
-    } else {
-        // Load and parse the module source
-        ctx.eval(Source::from_bytes(&buffer.unwrap())).unwrap();
+    let buffer =
+        read_to_string(libfile).map_err(|e| JsNativeError::typ().with_message(e.to_string()))?;
+    // Load and parse the module source
+    ctx.eval(Source::from_bytes(&buffer))?;
 
-        // Access module.exports and return as ResultValue
-        let global_obj = ctx.global_object();
-        let module = global_obj.get(js_string!("module"), ctx).unwrap();
-        module.as_object().unwrap().get(js_string!("exports"), ctx)
-    }
+    // Access module.exports and return as ResultValue
+    let global_obj = ctx.global_object();
+    let module = global_obj.get(js_string!("module"), ctx)?;
+    module
+        .as_object()
+        .ok_or_else(|| JsNativeError::typ().with_message("`exports` property was not an object"))?
+        .get(js_string!("exports"), ctx)
 }

--- a/boa_examples/src/bin/modules.rs
+++ b/boa_examples/src/bin/modules.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     "#;
 
     // This can be overriden with any custom implementation of `ModuleLoader`.
-    let loader = &SimpleModuleLoader::new("./boa_examples/scripts/modules")?;
+    let loader = &SimpleModuleLoader::new("./scripts/modules")?;
     let dyn_loader: &dyn ModuleLoader = loader;
 
     // Just need to cast to a `ModuleLoader` before passing it to the builder.
@@ -39,7 +39,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // Simulate as if the "fake" module is located in the modules root, just to ensure that
     // the loader won't double load in case someone tries to import "./main.mjs".
     loader.insert(
-        Path::new("./boa_examples/scripts/modules")
+        Path::new("./scripts/modules")
             .canonicalize()?
             .join("main.mjs"),
         module.clone(),

--- a/boa_examples/src/bin/runtime_limits.rs
+++ b/boa_examples/src/bin/runtime_limits.rs
@@ -21,11 +21,11 @@ fn main() {
 
     // Here we exceed the limit by 1 iteration and a `RuntimeLimit` error is thrown.
     //
-    // This error cannot be caught in JavaScript it propagates to rust caller.
+    // This error cannot be caught in JavaScript, it can only be caught in Rust code.
     let result = context.eval(Source::from_bytes(
         r"
             try {
-                for (let i = 0; i < 11; ++i) { }
+                for (let i = 0; i < 12; ++i) { }
             } catch (e) {
 
             }
@@ -33,7 +33,7 @@ fn main() {
     ));
     assert!(result.is_err());
 
-    // Preventing an infinity loops
+    // Preventing an infinite loop
     let result = context.eval(Source::from_bytes(
         r"
             while (true) { }
@@ -44,7 +44,7 @@ fn main() {
     // The limit applies to all types of loops.
     let result = context.eval(Source::from_bytes(
         r"
-            for (let e of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]) { }
+            for (let e of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]) { }
         ",
     ));
     assert!(result.is_err());

--- a/boa_examples/src/bin/symbol_visitor.rs
+++ b/boa_examples/src/bin/symbol_visitor.rs
@@ -24,8 +24,7 @@ impl<'ast> Visitor<'ast> for SymbolVisitor {
 }
 
 fn main() {
-    let mut parser =
-        Parser::new(Source::from_filepath(Path::new("boa_examples/scripts/calc.js")).unwrap());
+    let mut parser = Parser::new(Source::from_filepath(Path::new("./scripts/calc.js")).unwrap());
     let mut ctx = Context::default();
 
     let script = parser.parse_script(ctx.interner_mut()).unwrap();

--- a/boa_interner/Cargo.toml
+++ b/boa_interner/Cargo.toml
@@ -11,8 +11,8 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["std"]
-std = ["once_cell/std"]
+serde = ["dep:serde"]
+arbitrary = ["dep:arbitrary"]
 
 [dependencies]
 boa_macros.workspace = true
@@ -20,7 +20,7 @@ boa_gc.workspace = true
 phf = { workspace = true, default-features = false, features = ["macros"] }
 rustc-hash = { workspace = true, default-features = false }
 static_assertions.workspace = true
-once_cell = { workspace = true, default-features = false, features = ["critical-section"]}
+once_cell = { workspace = true, features = ["std"]}
 indexmap.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 arbitrary = { workspace = true, features = ["derive"], optional = true }

--- a/boa_runtime/src/console/mod.rs
+++ b/boa_runtime/src/console/mod.rs
@@ -135,6 +135,7 @@ impl Console {
     pub const NAME: &'static str = "console";
 
     /// Initializes the `console` built-in object.
+    #[allow(clippy::too_many_lines)]
     pub fn init(context: &mut Context<'_>) -> JsObject {
         fn console_method(
             f: fn(&JsValue, &[JsValue], &Console, &mut Context<'_>) -> JsResult<JsValue>,

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -14,12 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,15 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d098ff73c1ca148721f37baad5ea6a465a13f9573aba8641fbbbae8164a54e"
 dependencies = [
  "derive_arbitrary",
-]
-
-[[package]]
-name = "atomic-polyfill"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
-dependencies = [
- "critical-section",
 ]
 
 [[package]]
@@ -105,6 +90,7 @@ dependencies = [
  "num-traits",
  "num_enum",
  "once_cell",
+ "paste",
  "pollster",
  "rand",
  "regress",
@@ -137,7 +123,7 @@ version = "0.17.0"
 dependencies = [
  "boa_macros",
  "boa_profiler",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "thin-vec",
 ]
 
@@ -148,7 +134,7 @@ dependencies = [
  "arbitrary",
  "boa_gc",
  "boa_macros",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "indexmap",
  "once_cell",
  "phf",
@@ -228,19 +214,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
-name = "critical-section"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -308,12 +288,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
  "ahash",
- "allocator-api2",
 ]
 
 [[package]]
@@ -459,12 +438,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.1",
 ]
 
 [[package]]
@@ -603,10 +582,6 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-dependencies = [
- "atomic-polyfill",
- "critical-section",
-]
 
 [[package]]
 name = "parking_lot_core"
@@ -620,6 +595,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "phf"
@@ -874,18 +855,18 @@ checksum = "aac81b6fd6beb5884b0cf3321b8117e6e5d47ecb6fc89f414cfdcca8b2fe2dd8"
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
Just some small improvements in our CI to ensure we're testing everything.

One unfortunate thing I realized is that `cargo clippy -- -D warnings` apparently doesn't work with our current setup, somehow. I _think_ clippy is interpreting our crate global warns as overriding the command argument `-D warnings`, but it seems that this was fixed on https://github.com/rust-lang/rust-clippy/issues/5749. Maybe the bug reappeared for workspaces?

Anyways, I confirmed that the warnings do error with the [new `[lints]` section for `Cargo.toml`](https://github.com/rust-lang/rfcs/pull/3389), so this should be fixed when Rustc 1.74 releases. I'll probably open a new draft PR for that, just to have a reminder to merge the changes at that time. In the meantime, let's just ensure we check the actions for any warnings before merging any PR.
