### PR TITLE
Fix `super()` construction with default parameters

### DIFF
--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -1030,8 +1030,8 @@ impl ByteCompiler<'_, '_> {
             //          visibility of declarations in the function body.
             // b. Let varEnv be NewDeclarativeEnvironment(env).
             // c. Set the VariableEnvironment of calleeContext to varEnv.
-            self.push_compile_environment(true);
-            env_label = Some(self.emit_opcode_with_operand(Opcode::PushFunctionEnvironment));
+            self.push_compile_environment(false);
+            env_label = Some(self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment));
 
             // d. Let instantiatedVarNames be a new empty List.
             let mut instantiated_var_names = Vec::new();

--- a/boa_engine/src/environments/compile.rs
+++ b/boa_engine/src/environments/compile.rs
@@ -291,9 +291,4 @@ impl CompileTimeEnvironment {
     pub(crate) fn outer(&self) -> Option<Rc<Self>> {
         self.outer.clone()
     }
-
-    /// Gets the environment index of this environment.
-    pub(crate) const fn environment_index(&self) -> u32 {
-        self.environment_index
-    }
 }

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -361,9 +361,6 @@ impl CodeBlock {
             | Instruction::ConcatToString { value_count: value } => value.value().to_string(),
             Instruction::PushDeclarativeEnvironment {
                 compile_environments_index,
-            }
-            | Instruction::PushFunctionEnvironment {
-                compile_environments_index,
             } => compile_environments_index.to_string(),
             Instruction::CopyDataProperties {
                 excluded_key_count: value1,
@@ -643,7 +640,8 @@ impl CodeBlock {
             | Instruction::Reserved53
             | Instruction::Reserved54
             | Instruction::Reserved55
-            | Instruction::Reserved56 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved56
+            | Instruction::Reserved57 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -226,8 +226,7 @@ impl CodeBlock {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
                 }
-                Instruction::PushDeclarativeEnvironment { .. }
-                | Instruction::PushFunctionEnvironment { .. } => {
+                Instruction::PushDeclarativeEnvironment { .. } => {
                     let random = rand::random();
 
                     graph.add_node(
@@ -522,7 +521,8 @@ impl CodeBlock {
                 | Instruction::Reserved53
                 | Instruction::Reserved54
                 | Instruction::Reserved55
-                | Instruction::Reserved56 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved56
+                | Instruction::Reserved57 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1757,13 +1757,6 @@ generate_opcodes! {
     /// Stack: object **=>**
     PushObjectEnvironment,
 
-    /// Push a function environment.
-    ///
-    /// Operands: compile_environments_index: `u32`
-    ///
-    /// Stack: **=>**
-    PushFunctionEnvironment { compile_environments_index: u32 },
-
     /// Pop the current environment.
     ///
     /// Operands:
@@ -2183,6 +2176,8 @@ generate_opcodes! {
     Reserved55 => Reserved,
     /// Reserved [`Opcode`].
     Reserved56 => Reserved,
+    /// Reserved [`Opcode`].
+    Reserved57 => Reserved,
 }
 
 /// Specific opcodes for bindings.

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -26,30 +26,6 @@ impl Operation for PushDeclarativeEnvironment {
     }
 }
 
-/// `PushFunctionEnvironment` implements the Opcode Operation for `Opcode::PushFunctionEnvironment`
-///
-/// Operation:
-///  - Push a function environment.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct PushFunctionEnvironment;
-
-impl Operation for PushFunctionEnvironment {
-    const NAME: &'static str = "PushFunctionEnvironment";
-    const INSTRUCTION: &'static str = "INST - PushFunctionEnvironment";
-
-    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let compile_environments_index = context.vm.read::<u32>();
-        let compile_environment = context.vm.frame().code_block.compile_environments
-            [compile_environments_index as usize]
-            .clone();
-        context
-            .vm
-            .environments
-            .push_function_inherit(compile_environment);
-        Ok(CompletionType::Normal)
-    }
-}
-
 /// `PushObjectEnvironment` implements the Opcode Operation for `Opcode::PushObjectEnvironment`
 ///
 /// Operation:

--- a/boa_engine/src/vm/tests.rs
+++ b/boa_engine/src/vm/tests.rs
@@ -366,3 +366,24 @@ fn truncate_environments_on_non_caught_native_error() {
         TestAction::assert_native_error(source, JsNativeErrorKind::Reference, "a is not defined"),
     ]);
 }
+
+#[test]
+fn super_construction_with_paramater_expression() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            class Person {
+                constructor(name) {
+                    this.name = name;
+                }
+            }
+
+            class Student extends Person {
+                constructor(name = 'unknown') {
+                    super(name);
+                }
+            }
+        "#}),
+        TestAction::assert_eq("new Student().name", js_string!("unknown")),
+        TestAction::assert_eq("new Student('Jack').name", js_string!("Jack")),
+    ]);
+}


### PR DESCRIPTION
Fixes the class `super()` construction error thrown when the derived class has default parameters.

For example (used as a test case):
```JavaScript
class Person {
    constructor(name) {
        this.name = name;
    }
}

class Student extends Person {
    constructor(name = 'unknown') {
        super(name);
    }
}

new Student() // Throws an error that this is not initialized.
```

This PR breaks two test262 tests:

```
test/language/eval-code/direct/arrow-fn-body-cntns-arguments-func-decl-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
test/language/eval-code/direct/arrow-fn-body-cntns-arguments-var-bind-arrow-func-declare-arguments-assign-incl-def-param-arrow-arguments.js
```

But I _think_ this is due to the following steps that we haven't implement in [`FunctionDeclarationInstantiation`](https://tc39.es/ecma262/#sec-functiondeclarationinstantiation):

```
30. If strict is false, then
    30.a. Let lexEnv be NewDeclarativeEnvironment(varEnv).
    30.b. NOTE: Non-strict functions use a separate Environment Record for top-level lexical
       declarations so that a direct eval can determine whether any var scoped declarations
       introduced by the eval code conflict with pre-existing top-level lexically scoped declarations.
       This is not needed for strict functions because a strict direct eval always
       places all declarations into a new Environment Record.
```