### PR TITLE
Make environments opcodes use varying operands

### DIFF
--- a/boa_engine/src/builtins/eval/mod.rs
+++ b/boa_engine/src/builtins/eval/mod.rs
@@ -232,16 +232,13 @@ impl Eval {
             context,
         );
 
-        compiler.push_compile_environment(strict);
-
-        let push_env = compiler.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
+        let env_index = compiler.push_compile_environment(strict);
+        compiler.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
 
         compiler.eval_declaration_instantiation(&body, strict)?;
         compiler.compile_statement_list(body.statements(), true, false);
 
-        let env_index = compiler.pop_compile_environment();
-        compiler.patch_jump_with_target(push_env, env_index);
-
+        compiler.pop_compile_environment();
         compiler.emit_opcode(Opcode::PopEnvironment);
 
         let code_block = Gc::new(compiler.finish());

--- a/boa_engine/src/bytecompiler/env.rs
+++ b/boa_engine/src/bytecompiler/env.rs
@@ -6,29 +6,32 @@ use boa_ast::expression::Identifier;
 
 impl ByteCompiler<'_, '_> {
     /// Push either a new declarative or function environment on the compile time environment stack.
-    pub(crate) fn push_compile_environment(&mut self, function_scope: bool) {
+    #[must_use]
+    pub(crate) fn push_compile_environment(&mut self, function_scope: bool) -> u32 {
         self.current_open_environments_count += 1;
+
         self.current_environment = Rc::new(CompileTimeEnvironment::new(
             self.current_environment.clone(),
             function_scope,
         ));
+
+        let index = self.compile_environments.len() as u32;
+        self.compile_environments
+            .push(self.current_environment.clone());
+
+        index
     }
 
     /// Pops the top compile time environment and returns its index in the compile time environments array.
     #[track_caller]
-    pub(crate) fn pop_compile_environment(&mut self) -> u32 {
+    pub(crate) fn pop_compile_environment(&mut self) {
         self.current_open_environments_count -= 1;
-        let index = self.compile_environments.len() as u32;
-        self.compile_environments
-            .push(self.current_environment.clone());
 
         let outer = self
             .current_environment
             .outer()
             .expect("cannot pop the global environment");
         self.current_environment = outer;
-
-        index
     }
 
     /// Get the binding locator of the binding at bytecode compile time.

--- a/boa_engine/src/bytecompiler/function.rs
+++ b/boa_engine/src/bytecompiler/function.rs
@@ -100,12 +100,12 @@ impl FunctionCompiler {
 
         if let Some(binding_identifier) = self.binding_identifier {
             compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
-            compiler.push_compile_environment(false);
+            let _ = compiler.push_compile_environment(false);
             compiler.create_immutable_binding(binding_identifier.into(), self.strict);
         }
 
         // Function environment
-        compiler.push_compile_environment(true);
+        let _ = compiler.push_compile_environment(true);
 
         // Taken from:
         //  - 15.9.3 Runtime Semantics: EvaluateAsyncConciseBody: <https://tc39.es/ecma262/#sec-runtime-semantics-evaluateasyncconcisebody>
@@ -155,9 +155,8 @@ impl FunctionCompiler {
 
         compiler.compile_statement_list(body.statements(), false, false);
 
-        if let Some(env_labels) = env_label {
-            let env_index = compiler.pop_compile_environment();
-            compiler.patch_jump_with_target(env_labels, env_index);
+        if env_label {
+            compiler.pop_compile_environment();
         }
 
         if additional_env {

--- a/boa_engine/src/bytecompiler/statement/block.rs
+++ b/boa_engine/src/bytecompiler/statement/block.rs
@@ -4,15 +4,13 @@ use boa_ast::statement::Block;
 impl ByteCompiler<'_, '_> {
     /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(&mut self, block: &Block, use_expr: bool) {
-        self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
+        let env_index = self.push_compile_environment(false);
+        self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
 
         self.block_declaration_instantiation(block);
         self.compile_statement_list(block.statement_list(), use_expr, true);
 
-        let env_index = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_index);
-
+        self.pop_compile_environment();
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/bytecompiler/statement/switch.rs
+++ b/boa_engine/src/bytecompiler/statement/switch.rs
@@ -6,8 +6,8 @@ impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_switch(&mut self, switch: &Switch, use_expr: bool) {
         self.compile_expr(switch.val(), true);
 
-        self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
+        let env_index = self.push_compile_environment(false);
+        self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
 
         self.block_declaration_instantiation(switch);
 
@@ -50,8 +50,7 @@ impl ByteCompiler<'_, '_> {
 
         self.pop_switch_control_info();
 
-        let env_index = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_index);
+        self.pop_compile_environment();
         self.emit_opcode(Opcode::PopEnvironment);
     }
 }

--- a/boa_engine/src/bytecompiler/statement/try.rs
+++ b/boa_engine/src/bytecompiler/statement/try.rs
@@ -111,8 +111,8 @@ impl ByteCompiler<'_, '_> {
     pub(crate) fn compile_catch_stmt(&mut self, catch: &Catch, _has_finally: bool, use_expr: bool) {
         // stack: exception
 
-        self.push_compile_environment(false);
-        let push_env = self.emit_opcode_with_operand(Opcode::PushDeclarativeEnvironment);
+        let env_index = self.push_compile_environment(false);
+        self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
 
         if let Some(binding) = catch.parameter() {
             match binding {
@@ -133,8 +133,7 @@ impl ByteCompiler<'_, '_> {
 
         self.compile_catch_finally_block(catch.block(), use_expr);
 
-        let env_index = self.pop_compile_environment();
-        self.patch_jump_with_target(push_env, env_index);
+        self.pop_compile_environment();
         self.emit_opcode(Opcode::PopEnvironment);
     }
 

--- a/boa_engine/src/bytecompiler/statement/with.rs
+++ b/boa_engine/src/bytecompiler/statement/with.rs
@@ -5,7 +5,8 @@ impl ByteCompiler<'_, '_> {
     /// Compile a [`With`] `boa_ast` node
     pub(crate) fn compile_with(&mut self, with: &With, use_expr: bool) {
         self.compile_expr(with.expression(), true);
-        self.push_compile_environment(false);
+
+        let _ = self.push_compile_environment(false);
         self.emit_opcode(Opcode::PushObjectEnvironment);
 
         self.compile_stmt(with.statement(), use_expr, true);

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -363,7 +363,7 @@ impl CodeBlock {
             | Instruction::ConcatToString { value_count: value } => value.value().to_string(),
             Instruction::PushDeclarativeEnvironment {
                 compile_environments_index,
-            } => compile_environments_index.to_string(),
+            } => compile_environments_index.value().to_string(),
             Instruction::CopyDataProperties {
                 excluded_key_count: value1,
                 excluded_key_count_computed: value2,
@@ -1061,7 +1061,7 @@ impl JsObject {
 
         let env_fp = context.vm.environments.len() as u32;
 
-        let mut last_env = code.compile_environments.len() - 1;
+        let mut last_env = 0;
 
         if code.has_binding_identifier() {
             let index = context
@@ -1072,7 +1072,7 @@ impl JsObject {
                 .vm
                 .environments
                 .put_lexical_value(index, 0, self.clone().into());
-            last_env -= 1;
+            last_env += 1;
         }
 
         context.vm.environments.push_function(
@@ -1081,7 +1081,7 @@ impl JsObject {
         );
 
         if code.has_parameters_env_bindings() {
-            last_env -= 1;
+            last_env += 1;
             context
                 .vm
                 .environments
@@ -1202,7 +1202,7 @@ impl JsObject {
 
         let new_target = this_target.as_object().expect("must be object");
 
-        let mut last_env = code.compile_environments.len() - 1;
+        let mut last_env = 0;
 
         if code.has_binding_identifier() {
             let index = context
@@ -1213,7 +1213,7 @@ impl JsObject {
                 .vm
                 .environments
                 .put_lexical_value(index, 0, self.clone().into());
-            last_env -= 1;
+            last_env += 1;
         }
 
         context.vm.environments.push_function(
@@ -1230,7 +1230,7 @@ impl JsObject {
         let environment = context.vm.environments.current();
 
         if code.has_parameters_env_bindings() {
-            last_env -= 1;
+            last_env += 1;
             context
                 .vm
                 .environments

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -1738,10 +1738,10 @@ generate_opcodes! {
 
     /// Push a declarative environment.
     ///
-    /// Operands: compile_environments_index: `u32`
+    /// Operands: compile_environments_index: `VaryingOperand`
     ///
     /// Stack: **=>**
-    PushDeclarativeEnvironment { compile_environments_index: u32 },
+    PushDeclarativeEnvironment { compile_environments_index: VaryingOperand },
 
     /// Push an object environment.
     ///

--- a/boa_engine/src/vm/opcode/push/environment.rs
+++ b/boa_engine/src/vm/opcode/push/environment.rs
@@ -12,17 +12,36 @@ use boa_gc::Gc;
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct PushDeclarativeEnvironment;
 
+impl PushDeclarativeEnvironment {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(
+        context: &mut Context<'_>,
+        compile_environments_index: usize,
+    ) -> JsResult<CompletionType> {
+        let compile_environment =
+            context.vm.frame().code_block.compile_environments[compile_environments_index].clone();
+        context.vm.environments.push_lexical(compile_environment);
+        Ok(CompletionType::Normal)
+    }
+}
+
 impl Operation for PushDeclarativeEnvironment {
     const NAME: &'static str = "PushDeclarativeEnvironment";
     const INSTRUCTION: &'static str = "INST - PushDeclarativeEnvironment";
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
-        let compile_environments_index = context.vm.read::<u32>();
-        let compile_environment = context.vm.frame().code_block.compile_environments
-            [compile_environments_index as usize]
-            .clone();
-        context.vm.environments.push_lexical(compile_environment);
-        Ok(CompletionType::Normal)
+        let compile_environments_index = context.vm.read::<u8>() as usize;
+        Self::operation(context, compile_environments_index)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let compile_environments_index = context.vm.read::<u16>() as usize;
+        Self::operation(context, compile_environments_index)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let compile_environments_index = context.vm.read::<u32>() as usize;
+        Self::operation(context, compile_environments_index)
     }
 }
 
@@ -98,7 +117,6 @@ impl Operation for PopPrivateEnvironment {
 
     fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
         context.vm.environments.pop_private();
-
         Ok(CompletionType::Normal)
     }
 }


### PR DESCRIPTION
Depends on #3332 

Makes environment push opcodes that take index use varying operands, this required a bit of a refactor so we store environments pushed starting at zero, not in reversed order.