### PR TITLE
Improve highlighter performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,7 +334,6 @@ dependencies = [
 name = "boa_cli"
 version = "0.17.0"
 dependencies = [
- "boa_ast",
  "boa_engine",
  "boa_gc",
  "boa_interner",

--- a/boa_cli/Cargo.toml
+++ b/boa_cli/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 
 [dependencies]
 boa_engine = { workspace = true, features = ["deser", "flowgraph", "trace"] }
-boa_ast = { workspace = true, features = ["serde"] }
 boa_parser.workspace = true
 boa_gc.workspace = true
 boa_interner.workspace = true

--- a/boa_cli/src/debug/mod.rs
+++ b/boa_cli/src/debug/mod.rs
@@ -59,6 +59,7 @@ fn create_boa_object(context: &mut Context<'_>) -> JsObject {
         .build()
 }
 
+#[allow(clippy::redundant_pub_crate)]
 pub(crate) fn init_boa_debug_object(context: &mut Context<'_>) {
     let boa_object = create_boa_object(context);
     context

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -59,11 +59,6 @@
     clippy::pedantic,
     clippy::nursery,
 )]
-#![allow(
-    unused_crate_dependencies,
-    clippy::option_if_let_else,
-    clippy::redundant_pub_crate
-)]
 
 mod debug;
 mod helper;


### PR DESCRIPTION
This PR moves the compilation of the `Regex` used by the highlighter to the `RLHelper` itself, since this avoids having to recompile the regex every time a line is highlighted. Also adds some small improvements and lint fixes.