### PR TITLE
Fix new lints for Rust 1.73

### DIFF
--- a/boa_ast/src/lib.rs
+++ b/boa_ast/src/lib.rs
@@ -70,7 +70,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -57,7 +57,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 
 mod debug;

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -730,7 +730,7 @@ impl String {
                 Ok(js_string!(result).into())
             }
             // 5. If n is 0, return the empty String.
-            IntegerOrInfinity::Integer(n) if n == 0 => Ok(js_string!().into()),
+            IntegerOrInfinity::Integer(0) => Ok(js_string!().into()),
             // 4. If n < 0 or n is +∞, throw a RangeError exception.
             _ => Err(JsNativeError::range()
                 .with_message(

--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -1098,7 +1098,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
         for variable in decl.0.as_ref() {
             match variable.binding() {
                 Binding::Identifier(ident) => {
-                    let ident = ident;
                     if let Some(expr) = variable.init() {
                         self.compile_expr(expr, true);
                         self.emit_binding(BindingOpcode::InitVar, *ident);
@@ -1126,7 +1125,6 @@ impl<'ctx, 'host> ByteCompiler<'ctx, 'host> {
                 for variable in decls.as_ref() {
                     match variable.binding() {
                         Binding::Identifier(ident) => {
-                            let ident = ident;
                             if let Some(expr) = variable.init() {
                                 self.compile_expr(expr, true);
                             } else {

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -103,7 +103,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     // Currently throws a false positive regarding dependencies that are only used in benchmarks.

--- a/boa_engine/src/string/mod.rs
+++ b/boa_engine/src/string/mod.rs
@@ -843,7 +843,7 @@ impl PartialEq<JsString> for str {
 
 impl PartialOrd for JsString {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self[..].partial_cmp(other)
+        Some(self.cmp(other))
     }
 }
 

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -340,7 +340,7 @@ impl PartialEq for JsSymbol {
 impl PartialOrd for JsSymbol {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.hash().partial_cmp(&other.hash())
+        Some(self.cmp(other))
     }
 }
 

--- a/boa_engine/src/value/conversions/mod.rs
+++ b/boa_engine/src/value/conversions/mod.rs
@@ -165,6 +165,7 @@ impl From<JsObject> for JsValue {
 
 impl From<()> for JsValue {
     #[inline]
+    #[allow(clippy::pedantic)] // didn't want to increase our MSRV for just a lint.
     fn from(_: ()) -> Self {
         let _timer = Profiler::global().start_event("From<()>", "value");
 

--- a/boa_engine/src/value/operations.rs
+++ b/boa_engine/src/value/operations.rs
@@ -477,7 +477,7 @@ impl JsValue {
             ),
             Self::String(ref str) => Self::new(-str.to_number()),
             Self::Rational(num) => Self::new(-num),
-            Self::Integer(num) if num == 0 => Self::new(-f64::from(0)),
+            Self::Integer(0) => Self::new(-f64::from(0)),
             Self::Integer(num) => Self::new(-num),
             Self::Boolean(true) => Self::new(1),
             Self::Boolean(false) | Self::Null => Self::new(0),

--- a/boa_gc/src/lib.rs
+++ b/boa_gc/src/lib.rs
@@ -62,7 +62,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::module_name_repetitions,
@@ -329,7 +328,7 @@ impl Collector {
         }
     }
 
-    fn trace_non_roots(gc: &mut BoaGc) {
+    fn trace_non_roots(gc: &BoaGc) {
         // Count all the handles located in GC heap.
         // Then, we can find whether there is a reference from other places, and they are the roots.
         let mut strong = &gc.strong_start;
@@ -522,7 +521,7 @@ impl Collector {
     }
 
     // Clean up the heap when BoaGc is dropped
-    fn dump(gc: &mut BoaGc) {
+    fn dump(gc: &BoaGc) {
         // Weak maps have to be dropped first, since the process dereferences GcBoxes.
         // This can be done without initializing a dropguard since no GcBox's are being dropped.
         let weak_map_head = &gc.weak_map_start;

--- a/boa_icu_provider/src/lib.rs
+++ b/boa_icu_provider/src/lib.rs
@@ -70,7 +70,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(elided_lifetimes_in_paths)]
 #![cfg_attr(not(feature = "bin"), no_std)]

--- a/boa_interner/src/lib.rs
+++ b/boa_interner/src/lib.rs
@@ -67,7 +67,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::redundant_pub_crate,

--- a/boa_macros/src/lib.rs
+++ b/boa_macros/src/lib.rs
@@ -57,7 +57,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 
 use proc_macro::TokenStream;

--- a/boa_parser/src/error/mod.rs
+++ b/boa_parser/src/error/mod.rs
@@ -183,38 +183,31 @@ impl fmt::Display for Error {
                 found,
                 span,
                 context,
-            } => write!(
-                f,
-                "expected {}, got '{found}' in {context} at line {}, col {}",
-                if expected.len() == 1 {
-                    format!(
-                        "token '{}'",
-                        expected.first().expect("already checked that length is 1")
-                    )
-                } else {
-                    format!(
-                        "one of {}",
-                        expected
-                            .iter()
-                            .enumerate()
-                            .map(|(i, t)| {
-                                format!(
-                                    "{}'{t}'",
-                                    if i == 0 {
-                                        ""
-                                    } else if i == expected.len() - 1 {
-                                        " or "
-                                    } else {
-                                        ", "
-                                    },
-                                )
-                            })
-                            .collect::<String>()
-                    )
-                },
-                span.start().line_number(),
-                span.start().column_number()
-            ),
+            } => {
+                write!(f, "expected ")?;
+                match &**expected {
+                    [single] => write!(f, "token '{single}'")?,
+                    expected => {
+                        write!(f, "one of ")?;
+                        for (i, token) in expected.iter().enumerate() {
+                            let prefix = if i == 0 {
+                                ""
+                            } else if i == expected.len() - 1 {
+                                " or "
+                            } else {
+                                ", "
+                            };
+                            write!(f, "{prefix}'{token}'")?;
+                        }
+                    }
+                }
+                write!(
+                    f,
+                    ", got '{found}' in {context} at line {}, col {}",
+                    span.start().line_number(),
+                    span.start().column_number()
+                )
+            }
             Self::Unexpected {
                 found,
                 span,

--- a/boa_parser/src/lib.rs
+++ b/boa_parser/src/lib.rs
@@ -67,7 +67,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/boa_parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -62,7 +62,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         fn parse_const_access(
             token: &Token,
-            interner: &mut Interner,
+            interner: &Interner,
         ) -> ParseResult<OptionalOperationKind> {
             let item = match token.kind() {
                 TokenKind::IdentifierName((name, _)) => {

--- a/boa_profiler/src/lib.rs
+++ b/boa_profiler/src/lib.rs
@@ -64,7 +64,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![cfg_attr(not(feature = "profiler"), no_std)]
 

--- a/boa_runtime/src/lib.rs
+++ b/boa_runtime/src/lib.rs
@@ -96,7 +96,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::module_name_repetitions,

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -634,7 +634,7 @@ fn register_print_fn(context: &mut Context<'_>, async_result: AsyncResult) {
                 let mut result = async_result.inner.borrow_mut();
 
                 match *result {
-                    UninitResult::Uninit | UninitResult::Ok(_) => {
+                    UninitResult::Uninit | UninitResult::Ok(()) => {
                         if message == "Test262:AsyncTestComplete" {
                             *result = UninitResult::Ok(());
                         } else {

--- a/boa_tester/src/main.rs
+++ b/boa_tester/src/main.rs
@@ -60,7 +60,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 #![allow(
     clippy::too_many_lines,

--- a/boa_wasm/src/lib.rs
+++ b/boa_wasm/src/lib.rs
@@ -57,7 +57,6 @@
     clippy::complexity,
     clippy::perf,
     clippy::pedantic,
-    clippy::nursery,
 )]
 
 use boa_engine::{Context, Source};


### PR DESCRIPTION
This also removes the `clippy::nursery` lint level because it's filled with experimental lints that most of the time show warnings on false-positives.
