### PR TITLE
Add `Context::create_realm`

### DIFF
--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -513,6 +513,17 @@ impl<'host> Context<'host> {
         std::mem::replace(&mut self.realm, realm)
     }
 
+    /// Create a new Realm with the default global bindings.
+    pub fn create_realm(&mut self) -> JsResult<Realm> {
+        let realm = Realm::create(&*self.host_hooks, &self.root_shape);
+
+        let old_realm = self.enter_realm(realm);
+
+        builtins::set_default_global_bindings(self)?;
+
+        Ok(self.enter_realm(old_realm))
+    }
+
     /// Get the [`RootShape`].
     #[inline]
     #[must_use]


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes issue described in this [discord thread](https://discord.com/channels/595323158140158003/1152240246474412052).

It changes the following:
- Provides a function for creating Realms with the default global bindings.