### PR TITLE
Implement `[[HostDefined]]` for `Module` and `Script`

### DIFF
--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     realm::Realm,
     Context, JsError, JsResult, JsString, JsValue,
 };
-use crate::{js_string, JsNativeError, NativeFunction, HostDefined};
+use crate::{js_string, HostDefined, JsNativeError, NativeFunction};
 
 /// The referrer from which a load request of a module originates.
 #[derive(Debug, Clone)]

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     realm::Realm,
     Context, JsError, JsResult, JsString, JsValue,
 };
-use crate::{js_string, JsNativeError, NativeFunction};
+use crate::{js_string, JsNativeError, NativeFunction, HostDefined};
 
 /// The referrer from which a load request of a module originates.
 #[derive(Debug, Clone)]
@@ -276,7 +276,6 @@ impl std::fmt::Debug for Module {
             .field("environment", &self.inner.environment)
             .field("namespace", &self.inner.namespace)
             .field("kind", &self.inner.kind)
-            .field("host_defined", &self.inner.host_defined)
             .finish()
     }
 }
@@ -287,7 +286,7 @@ struct Inner {
     environment: GcRefCell<Option<Gc<DeclarativeEnvironment>>>,
     namespace: GcRefCell<Option<JsObject>>,
     kind: ModuleKind,
-    host_defined: (),
+    host_defined: HostDefined,
 }
 
 /// The kind of a [`Module`].
@@ -372,7 +371,7 @@ impl Module {
                 environment: GcRefCell::default(),
                 namespace: GcRefCell::default(),
                 kind: ModuleKind::SourceText(src.clone()),
-                host_defined: (),
+                host_defined: HostDefined::default(),
             }),
         };
 
@@ -386,6 +385,15 @@ impl Module {
     #[must_use]
     pub fn realm(&self) -> &Realm {
         &self.inner.realm
+    }
+
+    /// Returns the [`ECMAScript specification`][spec] defined [`\[\[HostDefined\]\]`][`HostDefined`] field of the [`Module`].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-abstract-module-records
+    #[inline]
+    #[must_use]
+    pub fn host_defined(&self) -> &HostDefined {
+        &self.inner.host_defined
     }
 
     /// Gets the kind of this `Module`.

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -20,7 +20,7 @@ use crate::{
     bytecompiler::ByteCompiler,
     realm::Realm,
     vm::{ActiveRunnable, CallFrame, CodeBlock},
-    Context, JsResult, JsString, JsValue, Module,
+    Context, JsResult, JsString, JsValue, Module, HostDefined,
 };
 
 /// ECMAScript's [**Script Record**][spec].
@@ -37,7 +37,6 @@ impl std::fmt::Debug for Script {
             .field("realm", &self.inner.realm.addr())
             .field("code", &self.inner.source)
             .field("loaded_modules", &self.inner.loaded_modules)
-            .field("host_defined", &self.inner.host_defined)
             .finish()
     }
 }
@@ -49,7 +48,7 @@ struct Inner {
     source: boa_ast::Script,
     codeblock: GcRefCell<Option<Gc<CodeBlock>>>,
     loaded_modules: GcRefCell<FxHashMap<JsString, Module>>,
-    host_defined: (),
+    host_defined: HostDefined,
 }
 
 impl Script {
@@ -57,6 +56,14 @@ impl Script {
     #[must_use]
     pub fn realm(&self) -> &Realm {
         &self.inner.realm
+    }
+
+    /// Returns the [`ECMAScript specification`][spec] defined [`\[\[HostDefined\]\]`][`HostDefined`] field of the [`Module`].
+    ///
+    /// [spec]: https://tc39.es/ecma262/#script-record
+    #[must_use]
+    pub fn host_defined(&self) -> &HostDefined {
+        &self.inner.host_defined
     }
 
     /// Gets the loaded modules of this script.
@@ -91,7 +98,7 @@ impl Script {
                 source: code,
                 codeblock: GcRefCell::default(),
                 loaded_modules: GcRefCell::default(),
-                host_defined: (),
+                host_defined: HostDefined::default(),
             }),
         })
     }

--- a/boa_engine/src/script.rs
+++ b/boa_engine/src/script.rs
@@ -20,7 +20,7 @@ use crate::{
     bytecompiler::ByteCompiler,
     realm::Realm,
     vm::{ActiveRunnable, CallFrame, CodeBlock},
-    Context, JsResult, JsString, JsValue, Module, HostDefined,
+    Context, HostDefined, JsResult, JsString, JsValue, Module,
 };
 
 /// ECMAScript's [**Script Record**][spec].


### PR DESCRIPTION
This Pull Request closes #3379.

It changes the following:

- Implements the `[[HostDefined]]` field for `Module` and `Script`
