### PR TITLE
Fix compilation for targets without `AtomicU64`

### DIFF
--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -123,7 +123,6 @@
 
     // Add temporarily - Needs addressing
     clippy::missing_panics_doc,
-    clippy::arc_with_non_send_sync,
 )]
 
 extern crate static_assertions as sa;

--- a/boa_engine/src/lib.rs
+++ b/boa_engine/src/lib.rs
@@ -125,6 +125,9 @@
     clippy::missing_panics_doc,
 )]
 
+#[cfg(not(target_has_atomic = "ptr"))]
+compile_error!("Boa requires a lock free `AtomicUsize` in order to work properly.");
+
 extern crate static_assertions as sa;
 
 pub mod bigint;

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -33,23 +33,22 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use std::{
     hash::{Hash, Hasher},
-    sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc,
-    },
+    sync::{atomic::Ordering, Arc},
 };
+
+use portable_atomic::AtomicUsize;
 
 /// Reserved number of symbols.
 ///
 /// This is where the well known symbol live
 /// and internal engine symbols.
-const RESERVED_SYMBOL_HASHES: u64 = 127;
+const RESERVED_SYMBOL_HASHES: usize = 127;
 
-fn get_id() -> Option<u64> {
+fn get_id() -> Option<usize> {
     // Symbol hash.
     //
     // For now this is an incremented u64 number.
-    static SYMBOL_HASH_COUNT: AtomicU64 = AtomicU64::new(RESERVED_SYMBOL_HASHES + 1);
+    static SYMBOL_HASH_COUNT: AtomicUsize = AtomicUsize::new(RESERVED_SYMBOL_HASHES + 1);
 
     SYMBOL_HASH_COUNT
         .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
@@ -114,11 +113,7 @@ impl WellKnown {
         }
     }
 
-    const fn hash(self) -> u64 {
-        self as u64
-    }
-
-    const fn tag(self) -> usize {
+    const fn hash(self) -> usize {
         self as usize
     }
 
@@ -127,12 +122,12 @@ impl WellKnown {
     }
 }
 
-// TODO: Address below clippy::arc_with_non_send_sync below.
 /// The inner representation of a JavaScript symbol.
 #[derive(Debug, Clone)]
 struct Inner {
-    hash: u64,
-    description: Option<JsString>,
+    hash: usize,
+    // must be a `Vec`, since this needs to be shareable between many threads.
+    description: Option<Vec<u16>>,
 }
 
 /// This represents a JavaScript symbol primitive.
@@ -158,7 +153,7 @@ macro_rules! well_known_symbols {
         $(
             $(#[$attr])* pub(crate) const fn $name() -> JsSymbol {
                 JsSymbol {
-                    repr: Tagged::from_tag($variant.tag()),
+                    repr: Tagged::from_tag($variant.hash()),
                 }
             }
         )+
@@ -173,7 +168,10 @@ impl JsSymbol {
     #[must_use]
     pub fn new(description: Option<JsString>) -> Option<Self> {
         let hash = get_id()?;
-        let arc = Arc::new(Inner { hash, description });
+        let arc = Arc::new(Inner {
+            hash,
+            description: description.map(|s| Vec::from(&*s)),
+        });
 
         Some(Self {
             // SAFETY: Pointers returned by `Arc::into_raw` must be non-null.
@@ -188,8 +186,8 @@ impl JsSymbol {
         match self.repr.unwrap() {
             UnwrappedTagged::Ptr(ptr) => {
                 // SAFETY: `ptr` comes from `Arc`, which ensures the validity of the pointer
-                // as long as we corrently call `Arc::from_raw` on `Drop`.
-                unsafe { ptr.as_ref().description.clone() }
+                // as long as we correctly call `Arc::from_raw` on `Drop`.
+                unsafe { ptr.as_ref().description.as_ref().map(|v| js_string!(&**v)) }
             }
             UnwrappedTagged::Tag(tag) => {
                 // SAFETY: All tagged reprs always come from `WellKnown` itself, making
@@ -223,7 +221,7 @@ impl JsSymbol {
     /// The hash is guaranteed to be unique.
     #[inline]
     #[must_use]
-    pub fn hash(&self) -> u64 {
+    pub fn hash(&self) -> usize {
         match self.repr.unwrap() {
             UnwrappedTagged::Ptr(ptr) => {
                 // SAFETY: `ptr` comes from `Arc`, which ensures the validity of the pointer

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -33,10 +33,11 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 use std::{
     hash::{Hash, Hasher},
-    sync::{atomic::Ordering, Arc},
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
 };
-
-use portable_atomic::AtomicUsize;
 
 /// Reserved number of symbols.
 ///

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -126,7 +126,7 @@ impl WellKnown {
 #[derive(Debug, Clone)]
 struct Inner {
     hash: u64,
-    // must be a `Vec`, since this needs to be shareable between many threads.
+    // must be a `Box`, since this needs to be shareable between many threads.
     description: Option<Box<[u16]>>,
 }
 

--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -128,7 +128,7 @@ impl WellKnown {
 struct Inner {
     hash: usize,
     // must be a `Vec`, since this needs to be shareable between many threads.
-    description: Option<Vec<u16>>,
+    description: Option<Box<[u16]>>,
 }
 
 /// This represents a JavaScript symbol primitive.
@@ -171,7 +171,7 @@ impl JsSymbol {
         let hash = get_id()?;
         let arc = Arc::new(Inner {
             hash,
-            description: description.map(|s| Vec::from(&*s)),
+            description: description.map(|s| Box::from(&*s)),
         });
 
         Some(Self {

--- a/boa_gc/src/trace.rs
+++ b/boa_gc/src/trace.rs
@@ -11,10 +11,7 @@ use std::{
     },
     path::{Path, PathBuf},
     rc::Rc,
-    sync::atomic::{
-        AtomicBool, AtomicI16, AtomicI32, AtomicI64, AtomicI8, AtomicIsize, AtomicU16, AtomicU32,
-        AtomicU64, AtomicU8, AtomicUsize,
-    },
+    sync::atomic,
 };
 
 /// Substitute for the [`Drop`] trait for garbage collected types.
@@ -161,19 +158,23 @@ simple_empty_finalize_trace![
     NonZeroI64,
     NonZeroU64,
     NonZeroI128,
-    NonZeroU128,
-    AtomicBool,
-    AtomicIsize,
-    AtomicUsize,
-    AtomicI8,
-    AtomicU8,
-    AtomicI16,
-    AtomicU16,
-    AtomicI32,
-    AtomicU32,
-    AtomicI64,
-    AtomicU64
+    NonZeroU128
 ];
+
+#[cfg(target_has_atomic = "8")]
+simple_empty_finalize_trace![atomic::AtomicBool, atomic::AtomicI8, atomic::AtomicU8];
+
+#[cfg(target_has_atomic = "16")]
+simple_empty_finalize_trace![atomic::AtomicI16, atomic::AtomicU16];
+
+#[cfg(target_has_atomic = "32")]
+simple_empty_finalize_trace![atomic::AtomicI32, atomic::AtomicU32];
+
+#[cfg(target_has_atomic = "64")]
+simple_empty_finalize_trace![atomic::AtomicI64, atomic::AtomicU64];
+
+#[cfg(target_has_atomic = "ptr")]
+simple_empty_finalize_trace![atomic::AtomicIsize, atomic::AtomicUsize];
 
 impl<T: Trace, const N: usize> Finalize for [T; N] {}
 // SAFETY:


### PR DESCRIPTION
Closes #2599 
Also addresses the clippy lint that we had disabled temporarily.
