### PR TITLE
Optimize `shift` for dense arrays

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -1159,20 +1159,17 @@ impl Array {
         }
 
         // Small optimization for arrays using dense properties
+        // TODO: this optimization could be generalized to many other objects with
+        // slot-based dense property maps.
         if o.is_array() {
             let mut o_borrow = o.borrow_mut();
             if let Some(dense) = o_borrow.properties_mut().dense_indexed_properties_mut() {
-                let value = if !dense.is_empty() {
+                if len <= dense.len() as u64 {
                     let v = dense.remove(0);
-                    v
-                } else {
-                    JsValue::undefined()
-                };
-                drop(o_borrow);
-
-                Self::set_length(&o, len - 1, context)?;
-
-                return Ok(value);
+                    drop(o_borrow);
+                    Self::set_length(&o, len - 1, context)?;
+                    return Ok(v);
+                }
             }
         }
 

--- a/boa_engine/src/object/property_map.rs
+++ b/boa_engine/src/object/property_map.rs
@@ -55,7 +55,7 @@ enum IndexedProperties {
     /// are not data descriptors with with a value field, writable field set to `true`, configurable field set to `true`, enumerable field set to `true`.
     ///
     /// This method uses more space, since we also have to store the property descriptors, not just the value.
-    /// It is also slower because we need to to a hash lookup.
+    /// It is also slower because we need to do a hash lookup.
     Sparse(Box<FxHashMap<u32, PropertyDescriptor>>),
 }
 
@@ -150,7 +150,7 @@ impl IndexedProperties {
         replaced
     }
 
-    /// Inserts a property descriptor with the specified key.
+    /// Removes a property descriptor with the specified key.
     fn remove(&mut self, key: u32) -> bool {
         let vec = match self {
             Self::Sparse(map) => {


### PR DESCRIPTION
fixes #3402.

This optimizes it for the common case. It would be cool to see if we can somehow change the definition of `IndexedProperties` to also allow these optimizations when arrays have empty slots.
