### PR TITLE
Fix Array.join when the array contains itself

### DIFF
--- a/boa_engine/src/builtins/array/mod.rs
+++ b/boa_engine/src/builtins/array/mod.rs
@@ -1000,8 +1000,8 @@ impl Array {
             }
             // b. Let element be ? Get(O, ! ToString(𝔽(k))).
             let element = o.get(k, context)?;
-            // c. If element is undefined or null, let next be the empty String; otherwise, let next be ? ToString(element).
-            let next = if element.is_null_or_undefined() {
+            // c. If element is undefined, null or the array itself, let next be the empty String; otherwise, let next be ? ToString(element).
+            let next = if element.is_null_or_undefined() || &element == this {
                 js_string!()
             } else {
                 element.to_string(context)?

--- a/boa_engine/src/builtins/array/tests.rs
+++ b/boa_engine/src/builtins/array/tests.rs
@@ -77,6 +77,7 @@ fn join() {
         TestAction::assert_eq("[].join('.')", js_string!()),
         TestAction::assert_eq("['a'].join('.')", js_string!("a")),
         TestAction::assert_eq("['a', 'b', 'c'].join('.')", js_string!("a.b.c")),
+        TestAction::assert_eq("let a=[];a[0]=a;a[1]=a;a[2]=a;a.join()", js_string!(",,")),
     ]);
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->
 
The documentation doesn't specify how the join function should handle cases where the array contains itself, but other engines treat it as an empty string.

```
let b = []
b[0] = b;
b[1] = b;
b[2] = b;

// expect output: ",,"
console.log(b.join(','))
```
 
