### PR TITLE
Disallow changing type of already created objects

### DIFF
--- a/boa_ast/src/expression/regexp.rs
+++ b/boa_ast/src/expression/regexp.rs
@@ -35,21 +35,21 @@ pub struct RegExpLiteral {
 }
 
 impl RegExpLiteral {
-    /// Create a new [`RegExp`].
+    /// Create a new [`RegExpLiteral`].
     #[inline]
     #[must_use]
     pub const fn new(pattern: Sym, flags: Sym) -> Self {
         Self { pattern, flags }
     }
 
-    /// Get the pattern part of the [`RegExp`].
+    /// Get the pattern part of the [`RegExpLiteral`].
     #[inline]
     #[must_use]
     pub const fn pattern(&self) -> Sym {
         self.pattern
     }
 
-    /// Get the flags part of the [`RegExp`].
+    /// Get the flags part of the [`RegExpLiteral`].
     #[inline]
     #[must_use]
     pub const fn flags(&self) -> Sym {

--- a/boa_cli/src/main.rs
+++ b/boa_cli/src/main.rs
@@ -325,7 +325,7 @@ fn evaluate_files(
                 Err(v) => eprintln!("Uncaught {v}"),
             }
         } else if args.module {
-            let result = (|| {
+            let result: JsResult<PromiseState> = (|| {
                 let module = Module::parse(Source::from_bytes(&buffer), None, context)?;
 
                 loader.insert(
@@ -334,10 +334,10 @@ fn evaluate_files(
                     module.clone(),
                 );
 
-                let promise = module.load_link_evaluate(context)?;
+                let promise = module.load_link_evaluate(context);
 
                 context.run_jobs();
-                promise.state()
+                Ok(promise.state())
             })();
 
             match result {

--- a/boa_engine/src/builtins/regexp/mod.rs
+++ b/boa_engine/src/builtins/regexp/mod.rs
@@ -1887,12 +1887,11 @@ impl RegExp {
         {
             let mut obj = this.borrow_mut();
 
-            // Should just override the already existing `lastIndex` property.
-            obj.properties_mut().storage[0] = 0.into();
-
             *obj.as_regexp_mut()
                 .expect("already checked that the object was a RegExp") = regexp;
         }
+
+        this.set(utf16!("lastIndex"), 0, true, context)?;
 
         Ok(this.into())
     }

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -1323,6 +1323,7 @@ pub(crate) struct ObjectTemplates {
     symbol: ObjectTemplate,
     bigint: ObjectTemplate,
     boolean: ObjectTemplate,
+
     regexp: ObjectTemplate,
     regexp_without_proto: ObjectTemplate,
 

--- a/boa_engine/src/context/intrinsics.rs
+++ b/boa_engine/src/context/intrinsics.rs
@@ -1323,6 +1323,8 @@ pub(crate) struct ObjectTemplates {
     symbol: ObjectTemplate,
     bigint: ObjectTemplate,
     boolean: ObjectTemplate,
+    regexp: ObjectTemplate,
+    regexp_without_proto: ObjectTemplate,
 
     unmapped_arguments: ObjectTemplate,
     mapped_arguments: ObjectTemplate,
@@ -1368,6 +1370,12 @@ impl ObjectTemplates {
             Attribute::READONLY | Attribute::PERMANENT | Attribute::NON_ENUMERABLE,
         );
         string.set_prototype(constructors.string().prototype());
+
+        let mut regexp_without_prototype = ObjectTemplate::new(root_shape);
+        regexp_without_prototype.property(js_string!("lastIndex").into(), Attribute::WRITABLE);
+
+        let mut regexp = regexp_without_prototype.clone();
+        regexp.set_prototype(constructors.regexp().prototype());
 
         let name_property_key: PropertyKey = js_string!("name").into();
         let mut function = ObjectTemplate::new(root_shape);
@@ -1474,6 +1482,8 @@ impl ObjectTemplates {
             symbol,
             bigint,
             boolean,
+            regexp,
+            regexp_without_proto: regexp_without_prototype,
             unmapped_arguments,
             mapped_arguments,
             function_with_prototype,
@@ -1562,6 +1572,25 @@ impl ObjectTemplates {
     /// 1. `__proto__`: `Boolean.prototype`
     pub(crate) const fn boolean(&self) -> &ObjectTemplate {
         &self.boolean
+    }
+
+    /// Cached regexp object template.
+    ///
+    /// Transitions:
+    ///
+    /// 1. `"lastIndex"`: (`WRITABLE` , `PERMANENT`,`NON_ENUMERABLE`)
+    pub(crate) const fn regexp(&self) -> &ObjectTemplate {
+        &self.regexp
+    }
+
+    /// Cached regexp object template without `__proto__` template.
+    ///
+    /// Transitions:
+    ///
+    /// 1. `"lastIndex"`: (`WRITABLE` , `PERMANENT`,`NON_ENUMERABLE`)
+    /// 2. `__proto__`: `RegExp.prototype`
+    pub(crate) const fn regexp_without_proto(&self) -> &ObjectTemplate {
+        &self.regexp_without_proto
     }
 
     /// Cached unmapped arguments object template.

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -75,7 +75,9 @@ use self::intrinsics::StandardConstructor;
 /// let arg = ObjectInitializer::new(&mut context)
 ///     .property(js_string!("x"), 12, Attribute::READONLY)
 ///     .build();
-/// context.register_global_property(js_string!("arg"), arg, Attribute::all());
+/// context
+///     .register_global_property(js_string!("arg"), arg, Attribute::all())
+///     .expect("property shouldn't exist");
 ///
 /// let value = context.eval(Source::from_bytes("test(arg)")).unwrap();
 ///

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -484,21 +484,27 @@ impl Module {
         let promise = self
             .load(context)
             .then(
-                Some(NativeFunction::from_copy_closure_with_captures(
-                    |_, _, module, context| {
-                        module.link(context)?;
-                        Ok(JsValue::undefined())
-                    },
-                    self.clone(),
-                )),
+                Some(
+                    NativeFunction::from_copy_closure_with_captures(
+                        |_, _, module, context| {
+                            module.link(context)?;
+                            Ok(JsValue::undefined())
+                        },
+                        self.clone(),
+                    )
+                    .to_js_function(context.realm()),
+                ),
                 None,
                 context,
             )
             .then(
-                Some(NativeFunction::from_copy_closure_with_captures(
-                    |_, _, module, context| Ok(module.evaluate(context).into()),
-                    self.clone(),
-                )),
+                Some(
+                    NativeFunction::from_copy_closure_with_captures(
+                        |_, _, module, context| Ok(module.evaluate(context).into()),
+                        self.clone(),
+                    )
+                    .to_js_function(context.realm()),
+                ),
                 None,
                 context,
             );

--- a/boa_engine/src/module/mod.rs
+++ b/boa_engine/src/module/mod.rs
@@ -47,7 +47,7 @@ use crate::{
     builtins::promise::{PromiseCapability, PromiseState},
     environments::DeclarativeEnvironment,
     js_string,
-    object::{FunctionObjectBuilder, JsObject, JsPromise, ObjectData},
+    object::{JsObject, JsPromise, ObjectData},
     realm::Realm,
     Context, HostDefined, JsError, JsResult, JsString, JsValue, NativeFunction,
 };
@@ -430,7 +430,7 @@ impl Module {
             ModuleKind::Synthetic(synth) => {
                 // a. Let promise be ! module.Evaluate().
                 let promise: JsPromise = synth.evaluate(context);
-                let state = promise.state()?;
+                let state = promise.state();
                 match state {
                     PromiseState::Pending => {
                         unreachable!("b. Assert: promise.[[PromiseState]] is not pending.")
@@ -467,59 +467,47 @@ impl Module {
     ///
     /// loader.insert(Path::new("main.mjs").to_path_buf(), module.clone());
     ///
-    /// let promise = module.load_link_evaluate(context).unwrap();
+    /// let promise = module.load_link_evaluate(context);
     ///
     /// context.run_jobs();
     ///
     /// assert_eq!(
-    ///     promise.state().unwrap(),
+    ///     promise.state(),
     ///     PromiseState::Fulfilled(JsValue::undefined())
     /// );
     /// ```
     #[allow(dropping_copy_types)]
     #[inline]
-    pub fn load_link_evaluate(&self, context: &mut Context<'_>) -> JsResult<JsPromise> {
+    pub fn load_link_evaluate(&self, context: &mut Context<'_>) -> JsPromise {
         let main_timer = Profiler::global().start_event("Module evaluation", "Main");
 
         let promise = self
             .load(context)
             .then(
-                Some(
-                    FunctionObjectBuilder::new(
-                        context.realm(),
-                        NativeFunction::from_copy_closure_with_captures(
-                            |_, _, module, context| {
-                                module.link(context)?;
-                                Ok(JsValue::undefined())
-                            },
-                            self.clone(),
-                        ),
-                    )
-                    .build(),
-                ),
+                Some(NativeFunction::from_copy_closure_with_captures(
+                    |_, _, module, context| {
+                        module.link(context)?;
+                        Ok(JsValue::undefined())
+                    },
+                    self.clone(),
+                )),
                 None,
                 context,
-            )?
+            )
             .then(
-                Some(
-                    FunctionObjectBuilder::new(
-                        context.realm(),
-                        NativeFunction::from_copy_closure_with_captures(
-                            |_, _, module, context| Ok(module.evaluate(context).into()),
-                            self.clone(),
-                        ),
-                    )
-                    .build(),
-                ),
+                Some(NativeFunction::from_copy_closure_with_captures(
+                    |_, _, module, context| Ok(module.evaluate(context).into()),
+                    self.clone(),
+                )),
                 None,
                 context,
-            )?;
+            );
 
         // The main_timer needs to be dropped before the Profiler is.
         drop(main_timer);
         Profiler::global().drop();
 
-        Ok(promise)
+        promise
     }
 
     /// Abstract operation [`GetModuleNamespace ( module )`][spec].

--- a/boa_engine/src/module/synthetic.rs
+++ b/boa_engine/src/module/synthetic.rs
@@ -198,7 +198,6 @@ impl SyntheticModule {
     pub(super) fn load(context: &mut Context<'_>) -> JsPromise {
         // 1. Return ! PromiseResolve(%Promise%, undefined).
         JsPromise::resolve(JsValue::undefined(), context)
-            .expect("creating a promise from the %Promise% constructor must not fail")
     }
 
     /// Concrete method [`GetExportedNames ( [ exportStarSet ] )`][spec].

--- a/boa_engine/src/native_function.rs
+++ b/boa_engine/src/native_function.rs
@@ -6,8 +6,10 @@
 use boa_gc::{custom_trace, Finalize, Gc, Trace};
 
 use crate::{
-    builtins::function::ConstructorKind, object::JsPromise, realm::Realm, Context, JsResult,
-    JsValue,
+    builtins::function::ConstructorKind,
+    object::{FunctionObjectBuilder, JsFunction, JsPromise},
+    realm::Realm,
+    Context, JsResult, JsValue,
 };
 
 /// The required signature for all native built-in function pointers.
@@ -301,5 +303,13 @@ impl NativeFunction {
             Inner::PointerFn(f) => f(this, args, context),
             Inner::Closure(ref c) => c.call(this, args, context),
         }
+    }
+
+    /// Converts this `NativeFunction` into a `JsFunction` without setting its name or length.
+    ///
+    /// Useful to create functions that will only be used once, such as callbacks.
+    #[must_use]
+    pub fn to_js_function(self, realm: &Realm) -> JsFunction {
+        FunctionObjectBuilder::new(realm, self).build()
     }
 }

--- a/boa_engine/src/object/builtins/jsfunction.rs
+++ b/boa_engine/src/object/builtins/jsfunction.rs
@@ -1,13 +1,15 @@
 //! A Rust API wrapper for Boa's `Function` Builtin ECMAScript Object
 use crate::{
+    builtins::function::ConstructorKind,
+    native_function::NativeFunctionObject,
     object::{
         internal_methods::function::{
             NATIVE_CONSTRUCTOR_INTERNAL_METHODS, NATIVE_FUNCTION_INTERNAL_METHODS,
         },
-        JsObject, JsObjectType, Object,
+        JsObject, JsObjectType, Object, ObjectKind,
     },
     value::TryFromJs,
-    Context, JsNativeError, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue, NativeFunction,
 };
 use boa_gc::{Finalize, Trace};
 use std::ops::Deref;
@@ -32,7 +34,11 @@ impl JsFunction {
     pub(crate) fn empty_intrinsic_function(constructor: bool) -> Self {
         Self {
             inner: JsObject::from_object_and_vtable(
-                Object::default(),
+                Object::with_kind(ObjectKind::NativeFunction(NativeFunctionObject {
+                    f: NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())),
+                    constructor: constructor.then_some(ConstructorKind::Base),
+                    realm: None,
+                })),
                 if constructor {
                     &NATIVE_CONSTRUCTOR_INTERNAL_METHODS
                 } else {

--- a/boa_engine/src/object/builtins/jsregexp.rs
+++ b/boa_engine/src/object/builtins/jsregexp.rs
@@ -60,15 +60,7 @@ impl JsRegExp {
     where
         S: Into<JsValue>,
     {
-        let constructor = &context
-            .intrinsics()
-            .constructors()
-            .regexp()
-            .constructor()
-            .into();
-        let obj = RegExp::alloc(constructor, context)?;
-
-        let regexp = RegExp::initialize(obj, &pattern.into(), &flags.into(), context)?
+        let regexp = RegExp::initialize(None, &pattern.into(), &flags.into(), context)?
             .as_object()
             .expect("RegExp::initialize must return a RegExp object")
             .clone();

--- a/boa_engine/src/object/operations.rs
+++ b/boa_engine/src/object/operations.rs
@@ -720,8 +720,8 @@ impl JsObject {
             return Ok(fun.realm().clone());
         }
 
-        if let ObjectKind::NativeFunction { realm, .. } = constructor.kind() {
-            return Ok(realm.clone());
+        if let ObjectKind::NativeFunction(f) = constructor.kind() {
+            return Ok(f.realm.clone().unwrap_or_else(|| context.realm().clone()));
         }
 
         if let Some(bound) = constructor.as_bound_function() {

--- a/boa_examples/src/bin/modules.rs
+++ b/boa_examples/src/bin/modules.rs
@@ -56,29 +56,35 @@ fn main() -> Result<(), Box<dyn Error>> {
         // which allows async loads and async fetches.
         .load(context)
         .then(
-            Some(NativeFunction::from_copy_closure_with_captures(
-                |_, _, module, context| {
-                    // After loading, link all modules by resolving the imports
-                    // and exports on the full module graph, initializing module
-                    // environments. This returns a plain `Err` since all modules
-                    // must link at the same time.
-                    module.link(context)?;
-                    Ok(JsValue::undefined())
-                },
-                module.clone(),
-            )),
+            Some(
+                NativeFunction::from_copy_closure_with_captures(
+                    |_, _, module, context| {
+                        // After loading, link all modules by resolving the imports
+                        // and exports on the full module graph, initializing module
+                        // environments. This returns a plain `Err` since all modules
+                        // must link at the same time.
+                        module.link(context)?;
+                        Ok(JsValue::undefined())
+                    },
+                    module.clone(),
+                )
+                .to_js_function(context.realm()),
+            ),
             None,
             context,
         )
         .then(
-            Some(NativeFunction::from_copy_closure_with_captures(
-                // Finally, evaluate the root module.
-                // This returns a `JsPromise` since a module could have
-                // top-level await statements, which defers module execution to the
-                // job queue.
-                |_, _, module, context| Ok(module.evaluate(context).into()),
-                module.clone(),
-            )),
+            Some(
+                NativeFunction::from_copy_closure_with_captures(
+                    // Finally, evaluate the root module.
+                    // This returns a `JsPromise` since a module could have
+                    // top-level await statements, which defers module execution to the
+                    // job queue.
+                    |_, _, module, context| Ok(module.evaluate(context).into()),
+                    module.clone(),
+                )
+                .to_js_function(context.realm()),
+            ),
             None,
             context,
         );

--- a/boa_examples/src/bin/synthetic.rs
+++ b/boa_examples/src/bin/synthetic.rs
@@ -59,13 +59,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     // This uses the utility function to load, link and evaluate a module without having to deal
     // with callbacks. For an example demonstrating the whole lifecycle of a module, see
     // `modules.rs`
-    let promise_result = module.load_link_evaluate(context)?;
+    let promise_result = module.load_link_evaluate(context);
 
     // Very important to push forward the job queue after queueing promises.
     context.run_jobs();
 
     // Checking if the final promise didn't return an error.
-    match promise_result.state()? {
+    match promise_result.state() {
         PromiseState::Pending => return Err("module didn't execute!".into()),
         PromiseState::Fulfilled(v) => {
             assert_eq!(v, JsValue::undefined())

--- a/boa_tester/src/exec/mod.rs
+++ b/boa_tester/src/exec/mod.rs
@@ -250,17 +250,11 @@ impl Test {
                         module.clone(),
                     );
 
-                    let promise = match module.load_link_evaluate(context) {
-                        Ok(promise) => promise,
-                        Err(err) => return (false, format!("Uncaught {err}")),
-                    };
+                    let promise = module.load_link_evaluate(context);
 
                     context.run_jobs();
 
-                    match promise
-                        .state()
-                        .expect("tester can only use builtin promises")
-                    {
+                    match promise.state() {
                         PromiseState::Pending => {
                             return (false, "module should have been executed".to_string())
                         }
@@ -364,10 +358,7 @@ impl Test {
 
                 context.run_jobs();
 
-                match promise
-                    .state()
-                    .expect("tester can only use builtin promises")
-                {
+                match promise.state() {
                     PromiseState::Pending => {
                         return (false, "module didn't try to load".to_string())
                     }
@@ -428,10 +419,7 @@ impl Test {
 
                     context.run_jobs();
 
-                    match promise
-                        .state()
-                        .expect("tester can only use builtin promises")
-                    {
+                    match promise.state() {
                         PromiseState::Pending => {
                             return (false, "module didn't try to load".to_string())
                         }
@@ -449,10 +437,7 @@ impl Test {
 
                     context.run_jobs();
 
-                    match promise
-                        .state()
-                        .expect("tester can only use builtin promises")
-                    {
+                    match promise.state() {
                         PromiseState::Pending => {
                             return (false, "module didn't try to evaluate".to_string())
                         }


### PR DESCRIPTION
This allows us to cleanup some of our `Js` method wrappers for built-ins, like `JsPromise` which I've already cleaned up in this PR.
