### PR TITLE
Gassification: Expose instruction limits

### DIFF
--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -513,6 +513,17 @@ impl<'host> Context<'host> {
         std::mem::replace(&mut self.realm, realm)
     }
 
+    /// Create a new Realm with the default global bindings.
+    pub fn create_realm(&mut self) -> JsResult<Realm> {
+        let realm = Realm::create(&*self.host_hooks, &self.root_shape);
+
+        let old_realm = self.enter_realm(realm);
+
+        builtins::set_default_global_bindings(self)?;
+
+        Ok(self.enter_realm(old_realm))
+    }
+
     /// Get the [`RootShape`].
     #[inline]
     #[must_use]

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -524,6 +524,12 @@ impl<'host> Context<'host> {
         Ok(self.enter_realm(old_realm))
     }
 
+    /// Get the remaining instruction count
+    #[cfg(freature = "fuzz")]
+    #[inline]
+    pub const fn instructions_remaining(&self) -> u64 {
+        self.instructions_remaining
+    }
     /// Get the [`RootShape`].
     #[inline]
     #[must_use]

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -93,7 +93,7 @@ pub struct Context<'host> {
 
     /// Number of instructions remaining before a forced exit
     #[cfg(feature = "fuzz")]
-    pub(crate) instructions_remaining: usize,
+    pub instructions_remaining: usize,
 
     pub(crate) vm: Vm,
 
@@ -524,12 +524,6 @@ impl<'host> Context<'host> {
         Ok(self.enter_realm(old_realm))
     }
 
-    /// Get the remaining instruction count
-    #[cfg(freature = "fuzz")]
-    #[inline]
-    pub const fn instructions_remaining(&self) -> u64 {
-        self.instructions_remaining
-    }
     /// Get the [`RootShape`].
     #[inline]
     #[must_use]

--- a/boa_engine/src/error.rs
+++ b/boa_engine/src/error.rs
@@ -819,9 +819,7 @@ impl JsNativeError {
             JsNativeErrorKind::Uri => (constructors.uri_error().prototype(), ErrorKind::Uri),
             #[cfg(feature = "fuzz")]
             JsNativeErrorKind::NoInstructionsRemain => {
-                unreachable!(
-                    "The NoInstructionsRemain native error cannot be converted to an opaque type."
-                )
+                (constructors.eval_error().prototype(), ErrorKind::Eval)
             }
             JsNativeErrorKind::RuntimeLimit => {
                 panic!("The RuntimeLimit native error cannot be converted to an opaque type.")


### PR DESCRIPTION
Exposes the instruction counter and fix a bug allowing unreachable behaviour.

* If the "fuzz" feature is enabled the `instructions_remaining` counter is a public property.
* The `NoInstructionsRemaining` error can now be converted into a javascript error, preventing boa from panicking if the error is thrown async 
