### PR TITLE
Move `arguments` object creation to bytecode

### DIFF
--- a/boa_engine/src/bytecompiler/mod.rs
+++ b/boa_engine/src/bytecompiler/mod.rs
@@ -275,7 +275,7 @@ pub struct ByteCompiler<'ctx, 'host> {
     json_parse: bool,
 
     // TODO: remove when we separate scripts from the context
-    context: &'ctx mut Context<'host>,
+    pub(crate) context: &'ctx mut Context<'host>,
 
     #[cfg(feature = "annex-b")]
     annex_b_function_names: Vec<Identifier>,

--- a/boa_engine/src/context/mod.rs
+++ b/boa_engine/src/context/mod.rs
@@ -718,7 +718,7 @@ impl Context<'_> {
     /// [spec]: https://tc39.es/ecma262/#sec-createglobalfunctionbinding
     pub(crate) fn create_global_function_binding(
         &mut self,
-        name: Identifier,
+        name: JsString,
         function: JsObject,
         configurable: bool,
     ) -> JsResult<()> {
@@ -727,8 +727,7 @@ impl Context<'_> {
         let global_object = self.realm().global_object().clone();
 
         // 3. Let existingProp be ? globalObject.[[GetOwnProperty]](N).
-        let name = PropertyKey::from(self.interner().resolve_expect(name.sym()).utf16());
-        let existing_prop = global_object.__get_own_property__(&name, self)?;
+        let existing_prop = global_object.__get_own_property__(&name.clone().into(), self)?;
 
         // 4. If existingProp is undefined or existingProp.[[Configurable]] is true, then
         let desc = if existing_prop.is_none()

--- a/boa_engine/src/vm/flowgraph/mod.rs
+++ b/boa_engine/src/vm/flowgraph/mod.rs
@@ -451,6 +451,9 @@ impl CodeBlock {
                 | Instruction::MaybeException
                 | Instruction::CheckReturn
                 | Instruction::BindThisValue
+                | Instruction::CreateMappedArgumentsObject
+                | Instruction::CreateUnmappedArgumentsObject
+                | Instruction::CreateGlobalFunctionBinding { .. }
                 | Instruction::Nop => {
                     graph.add_node(previous_pc, NodeShape::None, label.into(), Color::None);
                     graph.add_edge(previous_pc, pc, None, Color::None, EdgeStyle::Line);
@@ -517,10 +520,7 @@ impl CodeBlock {
                 | Instruction::Reserved55
                 | Instruction::Reserved56
                 | Instruction::Reserved57
-                | Instruction::Reserved58
-                | Instruction::Reserved59
-                | Instruction::Reserved60
-                | Instruction::Reserved61 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/boa_engine/src/vm/opcode/arguments.rs
+++ b/boa_engine/src/vm/opcode/arguments.rs
@@ -1,0 +1,64 @@
+use crate::{
+    builtins::function::arguments::Arguments,
+    vm::{CallFrame, CompletionType},
+    Context, JsResult,
+};
+
+use super::Operation;
+
+/// `CreateMappedArgumentsObject` implements the Opcode Operation for `Opcode::CreateMappedArgumentsObject`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CreateMappedArgumentsObject;
+
+impl Operation for CreateMappedArgumentsObject {
+    const NAME: &'static str = "CreateMappedArgumentsObject";
+    const INSTRUCTION: &'static str = "INST - CreateMappedArgumentsObject";
+    const COST: u8 = 8;
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let arguments_start = context.vm.frame().fp as usize + CallFrame::FIRST_ARGUMENT_POSITION;
+        let function_object = context
+            .vm
+            .frame()
+            .function(&context.vm)
+            .clone()
+            .expect("there should be a function object");
+        let code = context.vm.frame().code_block().clone();
+        let args = context.vm.stack[arguments_start..].to_vec();
+
+        let env = context.vm.environments.current();
+        let arguments = Arguments::create_mapped_arguments_object(
+            &function_object,
+            &code.params,
+            &args,
+            env.declarative_expect(),
+            context,
+        );
+        context.vm.push(arguments);
+        Ok(CompletionType::Normal)
+    }
+}
+
+/// `CreateUnmappedArgumentsObject` implements the Opcode Operation for `Opcode::CreateUnmappedArgumentsObject`
+///
+/// Operation:
+///  - TODO: doc
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CreateUnmappedArgumentsObject;
+
+impl Operation for CreateUnmappedArgumentsObject {
+    const NAME: &'static str = "CreateUnmappedArgumentsObject";
+    const INSTRUCTION: &'static str = "INST - CreateUnmappedArgumentsObject";
+    const COST: u8 = 4;
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let arguments_start = context.vm.frame().fp as usize + CallFrame::FIRST_ARGUMENT_POSITION;
+        let args = context.vm.stack[arguments_start..].to_vec();
+        let arguments = Arguments::create_unmapped_arguments_object(&args, context);
+        context.vm.push(arguments);
+        Ok(CompletionType::Normal)
+    }
+}

--- a/boa_engine/src/vm/opcode/define/mod.rs
+++ b/boa_engine/src/vm/opcode/define/mod.rs
@@ -141,3 +141,56 @@ impl Operation for PutLexicalValue {
         Self::operation(context, index as usize)
     }
 }
+
+/// `CreateGlobalFunctionBinding` implements the Opcode Operation for `Opcode::CreateGlobalFunctionBinding`
+///
+/// Operation:
+/// - Performs [`CreateGlobalFunctionBinding ( N, V, D )`][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-createglobalfunctionbinding
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CreateGlobalFunctionBinding;
+
+impl CreateGlobalFunctionBinding {
+    #[allow(clippy::unnecessary_wraps)]
+    fn operation(
+        context: &mut Context<'_>,
+        index: usize,
+        configurable: bool,
+    ) -> JsResult<CompletionType> {
+        let name = context.vm.frame().code_block().constant_string(index);
+        let value = context.vm.pop();
+
+        let function = value
+            .as_object()
+            .expect("valeu should be an function")
+            .clone();
+        context.create_global_function_binding(name, function, configurable)?;
+
+        Ok(CompletionType::Normal)
+    }
+}
+
+impl Operation for CreateGlobalFunctionBinding {
+    const NAME: &'static str = "CreateGlobalFunctionBinding";
+    const INSTRUCTION: &'static str = "INST - CreateGlobalFunctionBinding";
+    const COST: u8 = 2;
+
+    fn execute(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let configurable = context.vm.read::<u8>() != 0;
+        let index = context.vm.read::<u8>() as usize;
+        Self::operation(context, index, configurable)
+    }
+
+    fn execute_with_u16_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let configurable = context.vm.read::<u8>() != 0;
+        let index = context.vm.read::<u16>() as usize;
+        Self::operation(context, index, configurable)
+    }
+
+    fn execute_with_u32_operands(context: &mut Context<'_>) -> JsResult<CompletionType> {
+        let configurable = context.vm.read::<u8>() != 0;
+        let index = context.vm.read::<u32>() as usize;
+        Self::operation(context, index, configurable)
+    }
+}

--- a/boa_engine/src/vm/opcode/mod.rs
+++ b/boa_engine/src/vm/opcode/mod.rs
@@ -4,6 +4,7 @@ use std::iter::FusedIterator;
 use crate::{vm::CompletionType, Context, JsResult, JsValue};
 
 // Operation modules
+mod arguments;
 mod r#await;
 mod binary_ops;
 mod call;
@@ -34,6 +35,8 @@ mod unary_ops;
 mod value;
 
 // Operation structs
+#[doc(inline)]
+pub(crate) use arguments::*;
 #[doc(inline)]
 pub(crate) use binary_ops::*;
 #[doc(inline)]
@@ -2053,6 +2056,35 @@ generate_opcodes! {
     /// Stack: **=>**
     PopPrivateEnvironment,
 
+    /// Creates a mapped `arguments` object.
+    ///
+    /// Performs [`10.4.4.7 CreateMappedArgumentsObject ( func, formals, argumentsList, env )`]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-createunmappedargumentsobject
+    ///
+    /// Operands:
+    ///
+    /// Stack: **=>** `arguments`
+    CreateMappedArgumentsObject,
+
+    /// Creates an unmapped `arguments` object.
+    ///
+    /// Performs: [`10.4.4.6 CreateUnmappedArgumentsObject ( argumentsList )`]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-createmappedargumentsobject
+    ///
+    /// Stack: **=>** `arguments`
+    CreateUnmappedArgumentsObject,
+
+    /// Performs [`CreateGlobalFunctionBinding ( N, V, D )`][spec]
+    ///
+    /// Operands: configurable: `bool`, `name_index`: `VaryingOperand`
+    ///
+    /// Stack: `value` **=>**
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-createglobalfunctionbinding
+    CreateGlobalFunctionBinding { configurable: bool, name_index: VaryingOperand },
+
     /// No-operation instruction, does nothing.
     ///
     /// Operands:
@@ -2190,12 +2222,6 @@ generate_opcodes! {
     Reserved57 => Reserved,
     /// Reserved [`Opcode`].
     Reserved58 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved59 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved60 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved61 => Reserved,
 }
 
 /// Specific opcodes for bindings.


### PR DESCRIPTION
Moves creation of `arguments` object creation from function internal methods, this allows us to remove the checks for `arguments` object creation for functions that don't create it and would make #3194 easier since we can have `arguments` be moves into the stack and accessed as a fast local, instead of accessing it through environments.

While doing this I discovered a bug that happens when we create a function in `eval`, which was creating the functions and initializing the function, before the `eval` environment's `PushDeclarativeEnvironment` is executed. Fixed by delaying creation of function by adding the `CreateGlobalFunctionBinding` opcode.
