### PR TITLE
Move parameter environment creation to bytecode

### DIFF
--- a/boa_engine/src/bytecompiler/declarations.rs
+++ b/boa_engine/src/bytecompiler/declarations.rs
@@ -4,7 +4,7 @@ use crate::{
     bytecompiler::{ByteCompiler, FunctionCompiler, FunctionSpec, NodeKind},
     environments::CompileTimeEnvironment,
     js_string,
-    vm::{create_function_object_fast, BindingOpcode, CodeBlockFlags, Opcode},
+    vm::{create_function_object_fast, BindingOpcode, Opcode},
     JsNativeError, JsResult,
 };
 use boa_ast::{
@@ -909,8 +909,8 @@ impl ByteCompiler<'_, '_> {
             // c. Let env be NewDeclarativeEnvironment(calleeEnv).
             // d. Assert: The VariableEnvironment of calleeContext is calleeEnv.
             // e. Set the LexicalEnvironment of calleeContext to env.
-            let _ = self.push_compile_environment(false);
-            self.code_block_flags |= CodeBlockFlags::PARAMETERS_ENV_BINDINGS;
+            let env_index = self.push_compile_environment(false);
+            self.emit_with_varying_operand(Opcode::PushDeclarativeEnvironment, env_index);
         };
 
         let env = self.lexical_environment.clone();

--- a/boa_engine/src/object/internal_methods/function.rs
+++ b/boa_engine/src/object/internal_methods/function.rs
@@ -113,14 +113,6 @@ pub(crate) fn function_call(
         FunctionSlots::new(this, function_object.clone(), None),
     );
 
-    if code.has_parameters_env_bindings() {
-        last_env += 1;
-        context
-            .vm
-            .environments
-            .push_lexical(code.constant_compile_time_environment(last_env));
-    }
-
     Ok(CallValue::Ready)
 }
 
@@ -215,14 +207,6 @@ fn function_construct(
             ),
         ),
     );
-
-    if code.has_parameters_env_bindings() {
-        last_env += 1;
-        context
-            .vm
-            .environments
-            .push_lexical(code.constant_compile_time_environment(last_env));
-    }
 
     // Insert `this` value
     context

--- a/boa_engine/src/vm/code_block.rs
+++ b/boa_engine/src/vm/code_block.rs
@@ -56,20 +56,17 @@ bitflags! {
         /// The `[[IsClassConstructor]]` internal slot.
         const IS_CLASS_CONSTRUCTOR = 0b0000_0100;
 
-        /// Does this function have a parameters environment.
-        const PARAMETERS_ENV_BINDINGS = 0b0000_1000;
-
         /// The `[[ClassFieldInitializerName]]` internal slot.
-        const IN_CLASS_FIELD_INITIALIZER = 0b0001_0000;
+        const IN_CLASS_FIELD_INITIALIZER = 0b0000_1000;
 
         /// `[[ConstructorKind]]`
-        const IS_DERIVED_CONSTRUCTOR = 0b0010_0000;
+        const IS_DERIVED_CONSTRUCTOR = 0b0001_0000;
 
-        const IS_ASYNC = 0b0100_0000;
-        const IS_GENERATOR = 0b0000_1000_0000;
+        const IS_ASYNC = 0b0010_0000;
+        const IS_GENERATOR = 0b0100_0000;
 
         /// Arrow and method functions don't have `"prototype"` property.
-        const HAS_PROTOTYPE_PROPERTY = 0b0001_0000_0000;
+        const HAS_PROTOTYPE_PROPERTY = 0b1000_0000;
 
         /// Trace instruction execution to `stdout`.
         #[cfg(feature = "trace")]
@@ -219,13 +216,6 @@ impl CodeBlock {
         self.flags
             .get()
             .contains(CodeBlockFlags::HAS_BINDING_IDENTIFIER)
-    }
-
-    /// Does this function have a parameters environment.
-    pub(crate) fn has_parameters_env_bindings(&self) -> bool {
-        self.flags
-            .get()
-            .contains(CodeBlockFlags::PARAMETERS_ENV_BINDINGS)
     }
 
     /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.


### PR DESCRIPTION
Depends on #3432 

Moves parameters environments creation to bytecode, removes checks for functions that don't need it.
