### PR TITLE
Move ordinary function `[[ConstructorKind]]` to `CodeBlock`

### DIFF
--- a/boa_engine/src/builtins/function/mod.rs
+++ b/boa_engine/src/builtins/function/mod.rs
@@ -147,9 +147,6 @@ unsafe impl Trace for ClassFieldDefinition {
 pub(crate) enum FunctionKind {
     /// A bytecode function.
     Ordinary {
-        /// The `[[ConstructorKind]]` internal slot.
-        constructor_kind: ConstructorKind,
-
         /// The `[[Fields]]` internal slot.
         fields: ThinVec<ClassFieldDefinition>,
 
@@ -248,15 +245,8 @@ impl OrdinaryFunction {
     }
 
     /// Returns true if the function object is a derived constructor.
-    pub(crate) const fn is_derived_constructor(&self) -> bool {
-        if let FunctionKind::Ordinary {
-            constructor_kind, ..
-        } = self.kind
-        {
-            constructor_kind.is_derived()
-        } else {
-            false
-        }
+    pub(crate) fn is_derived_constructor(&self) -> bool {
+        self.code.is_derived_constructor()
     }
 
     /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.
@@ -330,9 +320,9 @@ impl OrdinaryFunction {
         &self.kind
     }
 
-    /// Gets a mutable reference to the [`FunctionKind`] of the `Function`.
-    pub(crate) fn kind_mut(&mut self) -> &mut FunctionKind {
-        &mut self.kind
+    /// Check if function is [`FunctionKind::Ordinary`].
+    pub(crate) const fn is_ordinary(&self) -> bool {
+        matches!(self.kind(), FunctionKind::Ordinary { .. })
     }
 }
 

--- a/boa_engine/src/bytecompiler/class.rs
+++ b/boa_engine/src/bytecompiler/class.rs
@@ -80,6 +80,12 @@ impl ByteCompiler<'_, '_> {
         }
         compiler.emit_opcode(Opcode::SetReturnValue);
 
+        // 17. If ClassHeritageopt is present, set F.[[ConstructorKind]] to derived.
+        compiler.code_block_flags.set(
+            CodeBlockFlags::IS_DERIVED_CONSTRUCTOR,
+            class.super_ref().is_some(),
+        );
+
         let code = Gc::new(compiler.finish());
         let index = self.push_function_to_constants(code);
         self.emit(

--- a/boa_engine/src/vm/opcode/push/class/mod.rs
+++ b/boa_engine/src/vm/opcode/push/class/mod.rs
@@ -1,5 +1,4 @@
 use crate::{
-    builtins::function::{ConstructorKind, FunctionKind},
     error::JsNativeError,
     object::PROTOTYPE,
     vm::{opcode::Operation, CompletionType},
@@ -68,21 +67,6 @@ impl Operation for PushClassPrototype {
         if let Some(constructor_parent) = constructor_parent {
             class_object.set_prototype(Some(constructor_parent));
         }
-
-        let mut class_object_mut = class_object.borrow_mut();
-        let class_function = class_object_mut
-            .as_function_mut()
-            .expect("class must be function object");
-
-        // 17. If ClassHeritageopt is present, set F.[[ConstructorKind]] to derived.
-        if let FunctionKind::Ordinary {
-            constructor_kind, ..
-        } = class_function.kind_mut()
-        {
-            *constructor_kind = ConstructorKind::Derived;
-        }
-
-        drop(class_object_mut);
 
         context.vm.push(class);
         context.vm.push(proto_parent);


### PR DESCRIPTION
Since the `[[ConstructorKind]]` is known at compile time and it doesn't change, this moves it to `CodeBlock` in the `CodeBlockFlags` bitflags.
