### PR TITLE
`[[HostDefined]]` Improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,7 @@ dependencies = [
  "fixed_decimal",
  "float-cmp",
  "futures-lite 2.0.1",
+ "hashbrown 0.14.2",
  "icu_calendar",
  "icu_casemap",
  "icu_collator",

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -110,6 +110,7 @@ writeable = { workspace = true, optional = true }
 yoke = { workspace = true, optional = true }
 zerofrom = { workspace = true, optional = true }
 fixed_decimal = { workspace = true, features = ["ryu"], optional = true}
+hashbrown.workspace = true
 
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 web-time = { version = "0.2.3", optional = true }

--- a/boa_gc/src/trace.rs
+++ b/boa_gc/src/trace.rs
@@ -349,6 +349,22 @@ unsafe impl<T: Trace> Trace for BTreeSet<T> {
     });
 }
 
+impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Finalize
+    for hashbrown::hash_map::HashMap<K, V, S>
+{
+}
+// SAFETY: All the elements of the `HashMap` are correctly marked.
+unsafe impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Trace
+    for hashbrown::hash_map::HashMap<K, V, S>
+{
+    custom_trace!(this, {
+        for (k, v) in this {
+            mark(k);
+            mark(v);
+        }
+    });
+}
+
 impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Finalize for HashMap<K, V, S> {}
 // SAFETY: All the elements of the `HashMap` are correctly marked.
 unsafe impl<K: Eq + Hash + Trace, V: Trace, S: BuildHasher> Trace for HashMap<K, V, S> {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

# Context

**Related PRs**: #3370 

Currently `HostDefined` doesn't permit you to mutably borrow two objects from the `[[HostDefined]]` field since the `FxHashMap` is wrapped under a `GcRefCell`.

# Description    

This PR implements a `get_mut_many` (from `hashbrown`'s `HashMap`) method to permit accessing several `NativeObject`s using a `NativeTuple`.

Additionally, this commit takes the opportunity to provide automatic downcasting on the `insert` and `remove` methods for `[[HostDefined]]`.
