### PR TITLE
Make well_known_symbols functions pub

### DIFF
--- a/boa_engine/src/symbol.rs
+++ b/boa_engine/src/symbol.rs
@@ -151,7 +151,7 @@ unsafe impl Trace for JsSymbol {
 macro_rules! well_known_symbols {
     ( $( $(#[$attr:meta])* ($name:ident, $variant:path) ),+$(,)? ) => {
         $(
-            $(#[$attr])* pub(crate) const fn $name() -> JsSymbol {
+            $(#[$attr])* pub const fn $name() -> JsSymbol {
                 JsSymbol {
                     // the cast shouldn't matter since we only have 127 const symbols
                     repr: Tagged::from_tag($variant.hash() as usize),


### PR DESCRIPTION
This Pull Request makes the `well_known_symbols` functions -- `boa_engine::symbol::JsSymbol::iterator() -> JsSymbol` etc -- `pub` instead of `pub(crate)`.

This is supposed to allow embedders to get hold of well-known symbols in Rust code, e.g. to implement iterable native objects, etc.

(Have I missed some better way to do this?)