### PR TITLE
Add `Object::set_native_object_data`

### DIFF
--- a/boa_engine/src/object/mod.rs
+++ b/boa_engine/src/object/mod.rs
@@ -78,6 +78,7 @@ use boa_gc::{custom_trace, Finalize, Trace, WeakGc};
 use std::{
     any::{Any, TypeId},
     fmt::{self, Debug},
+    mem,
     ops::{Deref, DerefMut},
 };
 
@@ -1986,6 +1987,19 @@ impl Object {
     pub fn as_native_object(&self) -> Option<&dyn NativeObject> {
         match self.kind {
             ObjectKind::NativeObject(ref object) => Some(object.as_ref()),
+            _ => None,
+        }
+    }
+
+    /// Sets the native object data returning the previous data, if the
+    /// object is a 'NativeObject'.
+    #[inline]
+    pub fn set_native_object_data<T: NativeObject>(
+        &mut self,
+        data: T,
+    ) -> Option<Box<dyn NativeObject>> {
+        match self.kind {
+            ObjectKind::NativeObject(ref mut object) => Some(mem::replace(object, Box::new(data))),
             _ => None,
         }
     }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Related issue: #3314 

This PR permits one to set the native object data of a `Object` using `Object::set_native_object_data`.

```rust
use boa_engine::{Context, object::ObjectInitializer};
let context = &mut Context::default();
let js_unit = ObjectInitializer::with_native((), context).build();

// Now stores 42 instead of unit
let _ = js_unit.borrow_mut().set_native_object_data(42u8);
```