### PR TITLE
Js typed array methods

### DIFF
--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -488,7 +488,11 @@ impl BuiltinTypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.copywithin
-    fn copy_within(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn copy_within(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Let taRecord be ? ValidateTypedArray(O, seq-cst).
         let (ta, buf_len) = TypedArray::validate(this, Ordering::SeqCst)?;

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -2436,7 +2436,7 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.tolocalestring
     /// [spec-402]: https://402.ecma-international.org/10.0/#sup-array.prototype.tolocalestring
-    fn to_locale_string(
+    pub(crate) fn to_locale_string(
         this: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -2608,7 +2608,11 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype-@@tostringtag
     #[allow(clippy::unnecessary_wraps)]
-    fn to_string_tag(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn to_string_tag(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. If Type(O) is not Object, return undefined.
         // 3. If O does not have a [[TypedArrayName]] internal slot, return undefined.

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -402,7 +402,7 @@ impl BuiltinTypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-get-%typedarray%.prototype.buffer
-    fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn buffer(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let O be the this value.
         // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
         // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -120,7 +120,7 @@ impl IntrinsicObject for BuiltinTypedArray {
             .method(Self::find_index, js_string!("findIndex"), 1)
             .method(Self::find_last, js_string!("findLast"), 1)
             .method(Self::find_last_index, js_string!("findLastIndex"), 1)
-            .method(Self::foreach, js_string!("forEach"), 1)
+            .method(Self::for_each, js_string!("forEach"), 1)
             .method(Self::includes, js_string!("includes"), 1)
             .method(Self::index_of, js_string!("indexOf"), 1)
             .method(Self::join, js_string!("join"), 1)
@@ -998,7 +998,7 @@ impl BuiltinTypedArray {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-%typedarray%.prototype.foreach
-    pub(crate) fn foreach(
+    pub(crate) fn for_each(
         this: &JsValue,
         args: &[JsValue],
         context: &mut Context,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -61,7 +61,27 @@ impl JsTypedArray {
         BuiltinTypedArray::at(&self.inner.clone().into(), &[index.into().into()], context)
     }
 
+
+    /// Returns the `ArrayBuffer` referenced by this typed array at construction time.
+    /// 
     /// Calls `TypedArray.prototype.buffer()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{js_string, JsResult, object::{builtins::{JsUint8Array, JsArrayBuffer}}, property::{PropertyKey}, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array_buffer8 = JsArrayBuffer::new(8, context)?;
+    /// let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
+    /// assert_eq!(
+    ///     array.buffer(context)?.as_object().unwrap().get(PropertyKey::String(js_string!("byteLength")), context).unwrap(), 
+    ///     JsValue::new(8)
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     #[inline]
     pub fn buffer(&self, context: &mut Context) -> JsResult<JsValue> {
         BuiltinTypedArray::buffer(&self.inner.clone().into(), &[], context)

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -842,6 +842,30 @@ impl JsTypedArray {
                 .expect("`with` must always return a `TypedArray` on success"),
         })
     }
+
+    /// It is a getter that returns the same string as the typed array constructor's name. 
+    /// It returns `Ok(JsValue::Undefined)` if the this value is not one of the typed array subclasses.
+    /// 
+    /// Returns `TypedArray.prototype.toStringTag()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, js_string, object::{builtins::{JsUint8Array}}, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    /// let tag = array.to_string_tag(context)?.to_string(context)?;
+    /// assert_eq!(tag, js_string!("Uint8Array"));
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn to_string_tag(&self, context: &mut Context) -> JsResult<JsValue> {
+        BuiltinTypedArray::to_string_tag(&self.inner.clone().into(), &[], context)
+    }
 }
 
 impl From<JsTypedArray> for JsObject {

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -331,6 +331,56 @@ impl JsTypedArray {
         }
     }
 
+    /// Iterates the typed array in reverse order and returns the value of 
+    /// the first element that satisfies the provided testing function. 
+    /// If no elements satisfy the testing function, `JsResult::Ok(None)` is returned.  
+    /// 
+    /// Calls `TypedArray.prototype.findLast()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::JsUint8Array, FunctionObjectBuilder}, NativeFunction, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    /// let context = &mut Context::default();
+    /// let data: Vec<u8> = (0..=255).collect();
+    /// let array = JsUint8Array::from_iter(data, context)?;
+    ///
+    /// let lower_than_200_predicate = FunctionObjectBuilder::new(
+    ///     context.realm(),
+    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///         let element = args
+    ///             .first()
+    ///             .cloned()
+    ///             .unwrap_or_default()
+    ///             .as_number()
+    ///             .expect("error at number conversion");
+    ///         Ok(JsValue::Boolean(element < 200.0))
+    ///     }),
+    /// )
+    /// .build();
+    /// assert_eq!(
+    ///     array.find_last(lower_than_200_predicate.clone(), None, context),
+    ///     Ok(JsValue::Integer(199))
+    /// );
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn find_last(
+        &self,
+        predicate: JsFunction,
+        this_arg: Option<JsValue>,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        BuiltinTypedArray::find_last(
+            &self.inner.clone().into(),
+            &[predicate.into(), this_arg.into_or_undefined()],
+            context,
+        )
+    }
+
     /// Calls `TypedArray.prototype.indexOf()`.
     pub fn index_of<T>(
         &self,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -155,6 +155,50 @@ impl JsTypedArray {
         Ok(self.clone())
     }
 
+    /// Returns a new typed array on the same `ArrayBuffer` store and with the same element 
+    /// types as for this typed array. 
+    /// The begin offset is inclusive and the end offset is exclusive. 
+    ///
+    /// Calls `TypedArray.prototype.subarray()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::JsUint8Array}, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    /// let subarray2_6 = array.subarray(2, 6, context)?;
+    /// assert_eq!(subarray2_6.length(context)?, 4);
+    /// assert_eq!(subarray2_6.get(0, context)?, JsValue::new(3.0));
+    /// assert_eq!(subarray2_6.get(1, context)?, JsValue::new(4.0));
+    /// assert_eq!(subarray2_6.get(2, context)?, JsValue::new(5.0));
+    /// assert_eq!(subarray2_6.get(3, context)?, JsValue::new(6.0));
+    /// let subarray4_6 = array.subarray(-4, 6, context)?;
+    /// assert_eq!(subarray4_6.length(context)?, 2);
+    /// assert_eq!(subarray4_6.get(0, context)?, JsValue::new(5.0));
+    /// assert_eq!(subarray4_6.get(1, context)?, JsValue::new(6.0));
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn subarray(&self, begin: i64, end: i64, context: &mut Context) -> JsResult<Self> {
+        let subarray = BuiltinTypedArray::subarray(
+            &self.inner.clone().into(),
+            &[begin.into(), end.into()],
+            context,
+        )?;
+
+        Ok(Self {
+            inner: subarray
+                .as_object()
+                .cloned()
+                .expect("`subarray` must always return a `TypedArray` on success"),
+        })
+    }
+
     /// Calls `TypedArray.prototype.filter()`.
     #[inline]
     pub fn filter(

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -61,9 +61,8 @@ impl JsTypedArray {
         BuiltinTypedArray::at(&self.inner.clone().into(), &[index.into().into()], context)
     }
 
-
     /// Returns the `ArrayBuffer` referenced by this typed array at construction time.
-    /// 
+    ///
     /// Calls `TypedArray.prototype.buffer()`.
     ///
     /// # Examples
@@ -76,7 +75,7 @@ impl JsTypedArray {
     /// let array_buffer8 = JsArrayBuffer::new(8, context)?;
     /// let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
     /// assert_eq!(
-    ///     array.buffer(context)?.as_object().unwrap().get(PropertyKey::String(js_string!("byteLength")), context).unwrap(), 
+    ///     array.buffer(context)?.as_object().unwrap().get(PropertyKey::String(js_string!("byteLength")), context).unwrap(),
     ///     JsValue::new(8)
     /// );
     /// # Ok(())
@@ -109,7 +108,7 @@ impl JsTypedArray {
         )
     }
 
-    /// Function that created the instance object. It is the hidden `TypedArray` constructor function, 
+    /// Function that created the instance object. It is the hidden `TypedArray` constructor function,
     /// but each typed array subclass also defines its own constructor property.
     ///
     /// Returns `TypedArray.prototype.constructor`.
@@ -137,9 +136,9 @@ impl JsTypedArray {
         BuiltinTypedArray::constructor(&self.inner.clone().into(), &[], context)
     }
 
-    /// Shallow copies part of this typed array to another location in the same typed 
+    /// Shallow copies part of this typed array to another location in the same typed
     /// array and returns this typed array without modifying its length.
-    /// 
+    ///
     /// Returns `TypedArray.prototype.copyWithin()`.
     ///
     /// # Examples
@@ -260,9 +259,9 @@ impl JsTypedArray {
         Ok(self.clone())
     }
 
-    /// Returns a new typed array on the same `ArrayBuffer` store and with the same element 
-    /// types as for this typed array. 
-    /// The begin offset is inclusive and the end offset is exclusive. 
+    /// Returns a new typed array on the same `ArrayBuffer` store and with the same element
+    /// types as for this typed array.
+    /// The begin offset is inclusive and the end offset is exclusive.
     ///
     /// Calls `TypedArray.prototype.subarray()`.
     ///
@@ -400,8 +399,8 @@ impl JsTypedArray {
         Ok(self.clone())
     }
 
-    /// Stores multiple values in the typed array, reading input values from a specified array. 
-    /// 
+    /// Stores multiple values in the typed array, reading input values from a specified array.
+    ///
     /// Returns `TypedArray.prototype.set()`.
     ///
     ///
@@ -483,7 +482,7 @@ impl JsTypedArray {
         )
     }
 
-    /// Returns the index of the first element in an array that satisfies the 
+    /// Returns the index of the first element in an array that satisfies the
     /// provided testing function.
     /// If no elements satisfy the testing function, `JsResult::Ok(None)` is returned.
     ///
@@ -541,10 +540,10 @@ impl JsTypedArray {
         }
     }
 
-    /// Iterates the typed array in reverse order and returns the value of 
-    /// the first element that satisfies the provided testing function. 
+    /// Iterates the typed array in reverse order and returns the value of
+    /// the first element that satisfies the provided testing function.
     /// If no elements satisfy the testing function, `JsResult::Ok(None)` is returned.  
-    /// 
+    ///
     /// Calls `TypedArray.prototype.findLast()`.
     ///
     /// # Examples
@@ -591,10 +590,10 @@ impl JsTypedArray {
         )
     }
 
-    /// Iterates the typed array in reverse order and returns the index of 
-    /// the first element that satisfies the provided testing function. 
+    /// Iterates the typed array in reverse order and returns the index of
+    /// the first element that satisfies the provided testing function.
     /// If no elements satisfy the testing function, `JsResult::OK(None)` is returned.
-    /// 
+    ///
     /// Calls `TypedArray.prototype.findLastIndex()`.
     ///
     /// # Examples
@@ -649,8 +648,8 @@ impl JsTypedArray {
         }
     }
 
-    /// Executes a provided function once for each typed array element. 
-    /// 
+    /// Executes a provided function once for each typed array element.
+    ///
     /// Calls `TypedArray.prototype.forEach()`.
     ///
     /// # Examples
@@ -702,9 +701,9 @@ impl JsTypedArray {
         )
     }
 
-    /// Determines whether a typed array includes a certain value among its entries, 
+    /// Determines whether a typed array includes a certain value among its entries,
     /// returning true or false as appropriate.
-    /// 
+    ///
     /// Calls `TypedArray.prototype.includes()`.
     ///
     /// # Examples
@@ -863,9 +862,9 @@ impl JsTypedArray {
         })
     }
 
-    /// It is a getter that returns the same string as the typed array constructor's name. 
+    /// It is a getter that returns the same string as the typed array constructor's name.
     /// It returns `Ok(JsValue::Undefined)` if the this value is not one of the typed array subclasses.
-    /// 
+    ///
     /// Returns `TypedArray.prototype.toStringTag()`.
     ///
     /// # Examples

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -61,6 +61,12 @@ impl JsTypedArray {
         BuiltinTypedArray::at(&self.inner.clone().into(), &[index.into().into()], context)
     }
 
+    /// Calls `TypedArray.prototype.buffer()`.
+    #[inline]
+    pub fn buffer(&self, context: &mut Context) -> JsResult<JsValue> {
+        BuiltinTypedArray::buffer(&self.inner.clone().into(), &[], context)
+    }
+
     /// Returns `TypedArray.prototype.byteLength`.
     #[inline]
     pub fn byte_length(&self, context: &mut Context) -> JsResult<usize> {

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -381,6 +381,64 @@ impl JsTypedArray {
         )
     }
 
+    /// Iterates the typed array in reverse order and returns the index of 
+    /// the first element that satisfies the provided testing function. 
+    /// If no elements satisfy the testing function, `JsResult::OK(None)` is returned.
+    /// 
+    /// Calls `TypedArray.prototype.findLastIndex()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::JsUint8Array, FunctionObjectBuilder}, NativeFunction, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    /// let context = &mut Context::default();
+    /// let data: Vec<u8> = (0..=255).collect();
+    /// let array = JsUint8Array::from_iter(data, context)?;
+    ///
+    /// let lower_than_200_predicate = FunctionObjectBuilder::new(
+    ///     context.realm(),
+    ///     NativeFunction::from_fn_ptr(|_this, args, _context| {
+    ///         let element = args
+    ///             .first()
+    ///             .cloned()
+    ///             .unwrap_or_default()
+    ///             .as_number()
+    ///             .expect("error at number conversion");
+    ///         Ok(JsValue::Boolean(element < 200.0))
+    ///     }),
+    /// )
+    /// .build();
+    /// assert_eq!(
+    ///     array.find_last(lower_than_200_predicate.clone(), None, context),
+    ///     Ok(JsValue::Integer(199))
+    /// );
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn find_last_index(
+        &self,
+        predicate: JsFunction,
+        this_arg: Option<JsValue>,
+        context: &mut Context,
+    ) -> JsResult<Option<u64>> {
+        let index = BuiltinTypedArray::find_last_index(
+            &self.inner.clone().into(),
+            &[predicate.into(), this_arg.into_or_undefined()],
+            context,
+        )?
+        .as_number()
+        .expect("TypedArray.prototype.findLastIndex() should always return number");
+
+        if index >= 0.0 {
+            Ok(Some(index as u64))
+        } else {
+            Ok(None)
+        }
+    }
+
     /// Calls `TypedArray.prototype.indexOf()`.
     pub fn index_of<T>(
         &self,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -695,7 +695,7 @@ impl JsTypedArray {
         this_arg: Option<JsValue>,
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        BuiltinTypedArray::foreach(
+        BuiltinTypedArray::for_each(
             &self.inner.clone().into(),
             &[callback.into(), this_arg.into_or_undefined()],
             context,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -284,6 +284,21 @@ impl JsTypedArray {
         })
     }
 
+    /// Calls `TypedArray.prototype.toLocaleString()`
+    #[inline]
+    pub fn to_locale_string(
+        &self,
+        reserved1: Option<JsValue>,
+        reserved2: Option<JsValue>,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        BuiltinTypedArray::to_locale_string(
+            &self.inner.clone().into(),
+            &[reserved1.into_or_undefined(), reserved2.into_or_undefined()],
+            context,
+        )
+    }
+
     /// Calls `TypedArray.prototype.filter()`.
     #[inline]
     pub fn filter(

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -89,6 +89,34 @@ impl JsTypedArray {
         )
     }
 
+    /// Function that created the instance object. It is the hidden `TypedArray` constructor function, 
+    /// but each typed array subclass also defines its own constructor property.
+    ///
+    /// Returns `TypedArray.prototype.constructor`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::JsUint8Array}, JsNativeError, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array = JsUint8Array::from_iter(vec![1, 2, 3, 4, 5], context)?;
+    /// assert_eq!(
+    ///     Err(JsNativeError::typ()
+    ///         .with_message("the TypedArray constructor should never be called directly")
+    ///         .into()),
+    ///     array.constructor(context)
+    /// );
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn constructor(&self, context: &mut Context) -> JsResult<JsValue> {
+        BuiltinTypedArray::constructor(&self.inner.clone().into(), &[], context)
+    }
+
     /// Calls `TypedArray.prototype.fill()`.
     pub fn fill<T>(
         &self,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -117,6 +117,57 @@ impl JsTypedArray {
         BuiltinTypedArray::constructor(&self.inner.clone().into(), &[], context)
     }
 
+    /// Shallow copies part of this typed array to another location in the same typed 
+    /// array and returns this typed array without modifying its length.
+    /// 
+    /// Returns `TypedArray.prototype.copyWithin()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, JsValue, object::{builtins::{JsUint8Array}}, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    /// array.copy_within(3, 1, Some(3), context)?;
+    /// assert_eq!(array.get(0, context)?, JsValue::new(1.0));
+    /// assert_eq!(array.get(1, context)?, JsValue::new(2.0));
+    /// assert_eq!(array.get(2, context)?, JsValue::new(3.0));
+    /// assert_eq!(array.get(3, context)?, JsValue::new(2.0));
+    /// assert_eq!(array.get(4, context)?, JsValue::new(3.0));
+    /// assert_eq!(array.get(5, context)?, JsValue::new(6.0));
+    /// assert_eq!(array.get(6, context)?, JsValue::new(7.0));
+    /// assert_eq!(array.get(7, context)?, JsValue::new(8.0));
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn copy_within<T>(
+        &self,
+        target: T,
+        start: u64,
+        end: Option<u64>,
+        context: &mut Context,
+    ) -> JsResult<Self>
+    where
+        T: Into<JsValue>,
+    {
+        let object = BuiltinTypedArray::copy_within(
+            &self.inner.clone().into(),
+            &[target.into(), start.into(), end.into_or_undefined()],
+            context,
+        )?;
+
+        Ok(Self {
+            inner: object
+                .as_object()
+                .cloned()
+                .expect("`copyWithin` must always return a `TypedArray` on success"),
+        })
+    }
+
     /// Calls `TypedArray.prototype.fill()`.
     pub fn fill<T>(
         &self,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -492,6 +492,52 @@ impl JsTypedArray {
         )
     }
 
+    /// Determines whether a typed array includes a certain value among its entries, 
+    /// returning true or false as appropriate.
+    /// 
+    /// Calls `TypedArray.prototype.includes()`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::JsUint8Array}, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let data: Vec<u8> = (0..=255).collect();
+    /// let array = JsUint8Array::from_iter(data, context)?;
+    ///
+    /// assert_eq!(array.includes(JsValue::new(2), None, context), Ok(true));
+    /// let empty_array = JsUint8Array::from_iter(vec![], context)?;
+    /// assert_eq!(
+    ///     empty_array.includes(JsValue::new(2), None, context),
+    ///     Ok(false)
+    /// );
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn includes<T>(
+        &self,
+        search_element: T,
+        from_index: Option<u64>,
+        context: &mut Context,
+    ) -> JsResult<bool>
+    where
+        T: Into<JsValue>,
+    {
+        let result = BuiltinTypedArray::includes(
+            &self.inner.clone().into(),
+            &[search_element.into(), from_index.into_or_undefined()],
+            context,
+        )?
+        .as_boolean()
+        .expect("TypedArray.prototype.includes should always return boolean");
+
+        Ok(result)
+    }
+
     /// Calls `TypedArray.prototype.indexOf()`.
     pub fn index_of<T>(
         &self,

--- a/core/engine/src/object/builtins/jstypedarray.rs
+++ b/core/engine/src/object/builtins/jstypedarray.rs
@@ -236,6 +236,52 @@ impl JsTypedArray {
         Ok(self.clone())
     }
 
+    /// Stores multiple values in the typed array, reading input values from a specified array. 
+    /// 
+    /// Returns `TypedArray.prototype.set()`.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use boa_engine::{JsResult, object::{builtins::{JsUint8Array, JsArray, JsArrayBuffer}}, JsValue, Context};
+    /// # fn main() -> JsResult<()> {
+    ///
+    /// let context = &mut Context::default();
+    /// let array_buffer8 = JsArrayBuffer::new(8, context)?;
+    /// let initialized8_array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
+    /// initialized8_array.set_values(
+    ///   JsArray::from_iter(vec![JsValue::new(1), JsValue::new(2)], context).into(),
+    ///   Some(3),
+    ///   context,
+    /// )?;
+    /// assert_eq!(initialized8_array.get(0, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(1, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(2, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(3, context)?, JsValue::new(1.0));
+    /// assert_eq!(initialized8_array.get(4, context)?, JsValue::new(2.0));
+    /// assert_eq!(initialized8_array.get(5, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(6, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(7, context)?, JsValue::new(0));
+    /// assert_eq!(initialized8_array.get(8, context)?, JsValue::Undefined);
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn set_values(
+        &self,
+        source: JsValue,
+        offset: Option<u64>,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        BuiltinTypedArray::set(
+            &self.inner.clone().into(),
+            &[source, offset.into_or_undefined()],
+            context,
+        )
+    }
+
     /// Calls `TypedArray.prototype.slice()`.
     #[inline]
     pub fn slice(

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -159,6 +159,12 @@ fn main() -> JsResult<()> {
     assert_eq!(subarray4_6.get(0, context)?, JsValue::new(5.0));
     assert_eq!(subarray4_6.get(1, context)?, JsValue::new(6.0));
 
+    // buffer
+    let array_buffer8 = JsArrayBuffer::new(8, context)?;
+    let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
+
+    assert!(array.buffer(context)?.as_object().unwrap().is_buffer());
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -49,7 +49,7 @@ fn main() -> JsResult<()> {
         context.realm(),
         NativeFunction::from_fn_ptr(|_this, args, _context| {
             let element = args
-                .get(0)
+                .first()
                 .cloned()
                 .unwrap_or_default()
                 .as_number()
@@ -68,7 +68,7 @@ fn main() -> JsResult<()> {
         context.realm(),
         NativeFunction::from_fn_ptr(|_this, args, _context| {
             let element = args
-                .get(0)
+                .first()
                 .cloned()
                 .unwrap_or_default()
                 .as_number()
@@ -100,7 +100,7 @@ fn main() -> JsResult<()> {
         NativeFunction::from_copy_closure_with_captures(
             |_, args, captures, inner_context| {
                 let element = args
-                    .get(0)
+                    .first()
                     .cloned()
                     .unwrap_or_default()
                     .to_uint8(inner_context)

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -173,6 +173,18 @@ fn main() -> JsResult<()> {
         array.constructor(context)
     );
 
+    // copyWithin
+    let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    array.copy_within(3, 1, Some(3), context)?;
+    assert_eq!(array.get(0, context)?, JsValue::new(1.0));
+    assert_eq!(array.get(1, context)?, JsValue::new(2.0));
+    assert_eq!(array.get(2, context)?, JsValue::new(3.0));
+    assert_eq!(array.get(3, context)?, JsValue::new(2.0));
+    assert_eq!(array.get(4, context)?, JsValue::new(3.0));
+    assert_eq!(array.get(5, context)?, JsValue::new(6.0));
+    assert_eq!(array.get(6, context)?, JsValue::new(7.0));
+    assert_eq!(array.get(7, context)?, JsValue::new(8.0));
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -8,7 +8,7 @@ use boa_engine::{
         FunctionObjectBuilder,
     },
     property::Attribute,
-    Context, JsResult, JsValue,
+    Context, JsNativeError, JsResult, JsValue,
 };
 use boa_gc::{Gc, GcRefCell};
 
@@ -164,6 +164,14 @@ fn main() -> JsResult<()> {
     let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
 
     assert!(array.buffer(context)?.as_object().unwrap().is_buffer());
+
+    // constructor
+    assert_eq!(
+        Err(JsNativeError::typ()
+            .with_message("the TypedArray constructor should never be called directly")
+            .into()),
+        array.constructor(context)
+    );
 
     context
         .register_global_property(

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -75,8 +75,16 @@ fn main() -> JsResult<()> {
     .build();
 
     assert_eq!(
-        array.find_last(lower_than_200_predicate, None, context),
+        array.find_last(lower_than_200_predicate.clone(), None, context),
         Ok(JsValue::Integer(199))
+    );
+
+    let data: Vec<u8> = vec![90, 120, 150, 180, 210, 240];
+    let array = JsUint8Array::from_iter(data, context)?;
+
+    assert_eq!(
+        array.find_last_index(lower_than_200_predicate, None, context),
+        Ok(Some(3))
     );
 
     context

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -3,7 +3,10 @@
 use boa_engine::{
     js_string,
     native_function::NativeFunction,
-    object::{builtins::JsUint8Array, FunctionObjectBuilder},
+    object::{
+        builtins::{JsArray, JsArrayBuffer, JsUint8Array},
+        FunctionObjectBuilder,
+    },
     property::Attribute,
     Context, JsResult, JsValue,
 };
@@ -123,6 +126,24 @@ fn main() -> JsResult<()> {
         empty_array.includes(JsValue::new(2), None, context),
         Ok(false)
     );
+
+    // set
+    let array_buffer8 = JsArrayBuffer::new(8, context)?;
+    let initialized8_array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
+    initialized8_array.set_values(
+        JsArray::from_iter(vec![JsValue::new(1), JsValue::new(2)], context).into(),
+        Some(3),
+        context,
+    )?;
+    assert_eq!(initialized8_array.get(0, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(1, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(2, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(3, context)?, JsValue::new(1.0));
+    assert_eq!(initialized8_array.get(4, context)?, JsValue::new(2.0));
+    assert_eq!(initialized8_array.get(5, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(6, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(7, context)?, JsValue::new(0));
+    assert_eq!(initialized8_array.get(8, context)?, JsValue::Undefined);
 
     context
         .register_global_property(

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -7,7 +7,7 @@ use boa_engine::{
         builtins::{JsArray, JsArrayBuffer, JsUint8Array},
         FunctionObjectBuilder,
     },
-    property::Attribute,
+    property::{Attribute, PropertyKey},
     Context, JsNativeError, JsResult, JsValue,
 };
 use boa_gc::{Gc, GcRefCell};
@@ -163,7 +163,10 @@ fn main() -> JsResult<()> {
     let array_buffer8 = JsArrayBuffer::new(8, context)?;
     let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
 
-    assert!(array.buffer(context)?.as_object().unwrap().is_buffer());
+    assert_eq!(
+        array.buffer(context)?.as_object().unwrap().get(PropertyKey::String(js_string!("byteLength")), context).unwrap(), 
+        JsValue::new(8)
+    );
 
     // constructor
     assert_eq!(

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -60,6 +60,25 @@ fn main() -> JsResult<()> {
         Ok(Some(11))
     );
 
+    let lower_than_200_predicate = FunctionObjectBuilder::new(
+        context.realm(),
+        NativeFunction::from_fn_ptr(|_this, args, _context| {
+            let element = args
+                .get(0)
+                .cloned()
+                .unwrap_or_default()
+                .as_number()
+                .expect("error at number conversion");
+            Ok(JsValue::Boolean(element < 200.0))
+        }),
+    )
+    .build();
+
+    assert_eq!(
+        array.find_last(lower_than_200_predicate, None, context),
+        Ok(JsValue::Integer(199))
+    );
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -116,6 +116,14 @@ fn main() -> JsResult<()> {
     let borrow = *num_to_modify.borrow();
     assert_eq!(borrow, 15u8);
 
+    // includes
+    assert_eq!(array.includes(JsValue::new(2), None, context), Ok(true));
+    let empty_array = JsUint8Array::from_iter(vec![], context)?;
+    assert_eq!(
+        empty_array.includes(JsValue::new(2), None, context),
+        Ok(false)
+    );
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -41,6 +41,25 @@ fn main() -> JsResult<()> {
         JsValue::new(sum)
     );
 
+    let greter_than_10_predicate = FunctionObjectBuilder::new(
+        context.realm(),
+        NativeFunction::from_fn_ptr(|_this, args, _context| {
+            let element = args
+                .get(0)
+                .cloned()
+                .unwrap_or_default()
+                .as_number()
+                .expect("error at number conversion");
+            Ok(JsValue::Boolean(element > 10.0))
+        }),
+    )
+    .build();
+
+    assert_eq!(
+        array.find_index(greter_than_10_predicate, None, context),
+        Ok(Some(11))
+    );
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -164,7 +164,12 @@ fn main() -> JsResult<()> {
     let array = JsUint8Array::from_array_buffer(array_buffer8, context)?;
 
     assert_eq!(
-        array.buffer(context)?.as_object().unwrap().get(PropertyKey::String(js_string!("byteLength")), context).unwrap(), 
+        array
+            .buffer(context)?
+            .as_object()
+            .unwrap()
+            .get(PropertyKey::String(js_string!("byteLength")), context)
+            .unwrap(),
         JsValue::new(8)
     );
 

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -185,6 +185,17 @@ fn main() -> JsResult<()> {
     assert_eq!(array.get(6, context)?, JsValue::new(7.0));
     assert_eq!(array.get(7, context)?, JsValue::new(8.0));
 
+    // toLocaleString
+    // let array = JsUint32Array::from_iter(vec![500, 8123, 12], context)?;
+    // let locales: Option<JsValue> = Some(js_string!("de-DE").into());
+    // let options = Some(context.eval(Source::from_bytes(
+    //     r##"let options = { style: "currency", currency: "EUR" }; options;"##,
+    // ))?);
+    // assert_eq!(
+    //     array.to_locale_string(locales, options, context)?,
+    //     js_string!("500,00 €,8.123,00 €,12,00 €").into()
+    // );
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -196,6 +196,11 @@ fn main() -> JsResult<()> {
     //     js_string!("500,00 €,8.123,00 €,12,00 €").into()
     // );
 
+    // toStringTag
+    let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    let tag = array.to_string_tag(context)?.to_string(context)?;
+    assert_eq!(tag, js_string!("Uint8Array"));
+
     context
         .register_global_property(
             js_string!("myUint8Array"),

--- a/examples/src/bin/jstypedarray.rs
+++ b/examples/src/bin/jstypedarray.rs
@@ -145,6 +145,20 @@ fn main() -> JsResult<()> {
     assert_eq!(initialized8_array.get(7, context)?, JsValue::new(0));
     assert_eq!(initialized8_array.get(8, context)?, JsValue::Undefined);
 
+    // subarray
+    let array = JsUint8Array::from_iter(vec![1u8, 2u8, 3u8, 4u8, 5u8, 6u8, 7u8, 8u8], context)?;
+    let subarray2_6 = array.subarray(2, 6, context)?;
+    assert_eq!(subarray2_6.length(context)?, 4);
+    assert_eq!(subarray2_6.get(0, context)?, JsValue::new(3.0));
+    assert_eq!(subarray2_6.get(1, context)?, JsValue::new(4.0));
+    assert_eq!(subarray2_6.get(2, context)?, JsValue::new(5.0));
+    assert_eq!(subarray2_6.get(3, context)?, JsValue::new(6.0));
+
+    let subarray4_6 = array.subarray(-4, 6, context)?;
+    assert_eq!(subarray4_6.length(context)?, 2);
+    assert_eq!(subarray4_6.get(0, context)?, JsValue::new(5.0));
+    assert_eq!(subarray4_6.get(1, context)?, JsValue::new(6.0));
+
     context
         .register_global_property(
             js_string!("myUint8Array"),


### PR DESCRIPTION
This Pull Request pertains to issue #3252

It implements the following JsTypedArray methods:

- get buffer
- constructor
- copyWithin
- find_index
- find_last
- find_last_index
- foreach
- includes
- set
- subarray
- toLocaleString*
- toStringTag

Hi guys!
I'd like to create this draft pull request to share my work on the issue through examples and seek feedback. Is that alright with you? I'll gradually compile this post as I make progress on the issue.
