### PR TITLE
Transition `Intl` types to `NativeObject` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,6 +517,7 @@ dependencies = [
  "boa_macros",
  "boa_profiler",
  "hashbrown 0.14.3",
+ "icu_locid",
  "thin-vec",
 ]
 

--- a/boa_engine/Cargo.toml
+++ b/boa_engine/Cargo.toml
@@ -57,7 +57,7 @@ js = ["dep:web-time"]
 
 [dependencies]
 boa_interner.workspace = true
-boa_gc = { workspace = true, features = [ "thinvec" ] }
+boa_gc = { workspace = true, features = [ "thin-vec", "icu" ] }
 boa_profiler.workspace = true
 boa_macros.workspace = true
 boa_ast.workspace = true

--- a/boa_engine/src/builtins/intl/collator/mod.rs
+++ b/boa_engine/src/builtins/intl/collator/mod.rs
@@ -42,7 +42,7 @@ mod options;
 pub(crate) use options::*;
 
 #[derive(Debug)]
-pub struct Collator {
+pub(crate) struct Collator {
     locale: Locale,
     collation: Value,
     numeric: bool,
@@ -350,7 +350,7 @@ impl BuiltInConstructor for Collator {
         let collator = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            ObjectData::collator(Self {
+            ObjectData::native_object(Self {
                 locale,
                 collation,
                 numeric,
@@ -414,7 +414,7 @@ impl Collator {
         })?;
         let collator_obj = this.clone();
         let mut collator = this.borrow_mut();
-        let collator = collator.as_collator_mut().ok_or_else(|| {
+        let collator = collator.downcast_mut::<Self>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`resolvedOptions` can only be called on a `Collator` object")
         })?;
@@ -436,7 +436,7 @@ impl Collator {
                         // 2. Assert: Type(collator) is Object and collator has an [[InitializedCollator]] internal slot.
                         let collator = collator.borrow();
                         let collator = collator
-                            .as_collator()
+                            .downcast_ref::<Self>()
                             .expect("checked above that the object was a collator object");
 
                         // 3. If x is not provided, let x be undefined.
@@ -483,7 +483,7 @@ impl Collator {
             JsNativeError::typ()
                 .with_message("`resolvedOptions` can only be called on a `Collator` object")
         })?;
-        let collator = collator.as_collator().ok_or_else(|| {
+        let collator = collator.downcast_ref::<Self>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`resolvedOptions` can only be called on a `Collator` object")
         })?;

--- a/boa_engine/src/builtins/intl/date_time_format.rs
+++ b/boa_engine/src/builtins/intl/date_time_format.rs
@@ -40,7 +40,7 @@ impl OptionType for HourCycle {
 
 /// JavaScript `Intl.DateTimeFormat` object.
 #[derive(Debug, Clone, Trace, Finalize)]
-pub struct DateTimeFormat {
+pub(crate) struct DateTimeFormat {
     initialized_date_time_format: bool,
     locale: JsString,
     calendar: JsString,
@@ -123,7 +123,7 @@ impl BuiltInConstructor for DateTimeFormat {
         let date_time_format = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            ObjectData::date_time_format(Box::new(Self {
+            ObjectData::native_object(Self {
                 initialized_date_time_format: true,
                 locale: js_string!("en-US"),
                 calendar: js_string!("gregory"),
@@ -143,7 +143,7 @@ impl BuiltInConstructor for DateTimeFormat {
                 hour_cycle: js_string!("h24"),
                 pattern: js_string!("{hour}:{minute}"),
                 bound_format: js_string!("undefined"),
-            })),
+            }),
         );
 
         // TODO 3. Perform ? InitializeDateTimeFormat(dateTimeFormat, locales, options).

--- a/boa_engine/src/builtins/intl/locale/mod.rs
+++ b/boa_engine/src/builtins/intl/locale/mod.rs
@@ -206,7 +206,7 @@ impl BuiltInConstructor for Locale {
 
         let mut tag = if let Some(tag) = tag
             .as_object()
-            .and_then(|obj| obj.borrow().as_locale().cloned())
+            .and_then(|obj| obj.borrow().downcast_ref::<icu_locid::Locale>().cloned())
         {
             // a. Let tag be tag.[[Locale]].
             tag
@@ -371,7 +371,7 @@ impl BuiltInConstructor for Locale {
         let locale = JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            ObjectData::locale(tag),
+            ObjectData::native_object(tag),
         );
 
         // 37. Return locale.
@@ -398,7 +398,7 @@ impl Locale {
             JsNativeError::typ().with_message("`maximize` can only be called on a `Locale` object")
         })?;
         let mut loc = loc
-            .as_locale()
+            .downcast_ref::<icu_locid::Locale>()
             .ok_or_else(|| {
                 JsNativeError::typ()
                     .with_message("`maximize` can only be called on a `Locale` object")
@@ -413,7 +413,7 @@ impl Locale {
         Ok(JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            ObjectData::locale(loc),
+            ObjectData::native_object(loc),
         )
         .into())
     }
@@ -436,7 +436,7 @@ impl Locale {
             JsNativeError::typ().with_message("`minimize` can only be called on a `Locale` object")
         })?;
         let mut loc = loc
-            .as_locale()
+            .downcast_ref::<icu_locid::Locale>()
             .ok_or_else(|| {
                 JsNativeError::typ()
                     .with_message("`minimize` can only be called on a `Locale` object")
@@ -451,7 +451,7 @@ impl Locale {
         Ok(JsObject::from_proto_and_data_with_shared_shape(
             context.root_shape(),
             prototype,
-            ObjectData::locale(loc),
+            ObjectData::native_object(loc),
         )
         .into())
     }
@@ -469,7 +469,7 @@ impl Locale {
         let loc = this.as_object().map(JsObject::borrow).ok_or_else(|| {
             JsNativeError::typ().with_message("`toString` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ().with_message("`toString` can only be called on a `Locale` object")
         })?;
 
@@ -491,7 +491,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get baseName` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get baseName` can only be called on a `Locale` object")
         })?;
@@ -515,7 +515,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get calendar` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get calendar` can only be called on a `Locale` object")
         })?;
@@ -544,7 +544,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get caseFirst` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get caseFirst` can only be called on a `Locale` object")
         })?;
@@ -573,7 +573,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get collation` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get collation` can only be called on a `Locale` object")
         })?;
@@ -602,7 +602,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get hourCycle` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get hourCycle` can only be called on a `Locale` object")
         })?;
@@ -631,7 +631,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get numeric` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get numeric` can only be called on a `Locale` object")
         })?;
@@ -668,7 +668,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get numberingSystem` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get numberingSystem` can only be called on a `Locale` object")
         })?;
@@ -697,7 +697,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get language` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get language` can only be called on a `Locale` object")
         })?;
@@ -722,7 +722,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get script` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get script` can only be called on a `Locale` object")
         })?;
@@ -752,7 +752,7 @@ impl Locale {
             JsNativeError::typ()
                 .with_message("`get region` can only be called on a `Locale` object")
         })?;
-        let loc = loc.as_locale().ok_or_else(|| {
+        let loc = loc.downcast_ref::<icu_locid::Locale>().ok_or_else(|| {
             JsNativeError::typ()
                 .with_message("`get region` can only be called on a `Locale` object")
         })?;

--- a/boa_engine/src/builtins/intl/locale/utils.rs
+++ b/boa_engine/src/builtins/intl/locale/utils.rs
@@ -80,7 +80,7 @@ pub(crate) fn canonicalize_locale_list(
     let o = if locales.is_string()
         || locales
             .as_object()
-            .map_or(false, |o| o.borrow().is_locale())
+            .map_or(false, |o| o.borrow().is::<Locale>())
     {
         // a. Let O be CreateArrayFromList(« locales »).
         Array::create_array_from_list([locales.clone()], context)
@@ -113,7 +113,7 @@ pub(crate) fn canonicalize_locale_list(
             // iii. If Type(kValue) is Object and kValue has an [[InitializedLocale]] internal slot, then
             let mut tag = if let Some(tag) = k_value
                 .as_object()
-                .and_then(|obj| obj.borrow().as_locale().cloned())
+                .and_then(|obj| obj.borrow().downcast_ref::<Locale>().cloned())
             {
                 // 1. Let tag be kValue.[[Locale]].
                 tag

--- a/boa_engine/src/builtins/string/mod.rs
+++ b/boa_engine/src/builtins/string/mod.rs
@@ -1425,7 +1425,7 @@ impl String {
                     .map(JsObject::borrow)
                     .expect("constructor must return a JsObject");
                 let collator = collator
-                    .as_collator()
+                    .downcast_ref::<crate::builtins::intl::Collator>()
                     .expect("constructor must return a `Collator` object")
                     .collator();
 

--- a/boa_gc/Cargo.toml
+++ b/boa_gc/Cargo.toml
@@ -11,15 +11,18 @@ repository.workspace = true
 rust-version.workspace = true
 
 [features]
-# Enable default implementatio of trace and finalize thin-vec crate
-thinvec = ["thin-vec"]
+# Enable default implementations of trace and finalize for the thin-vec crate
+thin-vec = ["dep:thin-vec"]
+# Enable default implementations of trace and finalize for some `ICU4X` types
+icu = ["dep:icu_locid"]
 
 [dependencies]
 boa_profiler.workspace = true
 boa_macros.workspace = true
+hashbrown = { workspace = true, features = ["ahash", "raw"] }
 
 thin-vec = { workspace = true, optional = true }
-hashbrown = { workspace = true, features = ["ahash", "raw"] }
+icu_locid = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/boa_gc/src/trace.rs
+++ b/boa_gc/src/trace.rs
@@ -438,3 +438,24 @@ unsafe impl<T: Trace> Trace for Cell<Option<T>> {
         }
     });
 }
+
+#[cfg(feature = "icu")]
+mod icu {
+    use icu_locid::{LanguageIdentifier, Locale};
+
+    use crate::{Finalize, Trace};
+
+    impl Finalize for LanguageIdentifier {}
+
+    // SAFETY: `LanguageIdentifier` doesn't have any traceable data.
+    unsafe impl Trace for LanguageIdentifier {
+        empty_trace!();
+    }
+
+    impl Finalize for Locale {}
+
+    // SAFETY: `LanguageIdentifier` doesn't have any traceable data.
+    unsafe impl Trace for Locale {
+        empty_trace!();
+    }
+}


### PR DESCRIPTION
Related to #3487.

This makes our `Object` implementation a lot simpler (saves us a lot of feature gates), so we should see if we can move other non-perf related objects to this.