### PR TITLE
Reduce `WeakGc<T>` memory usage

### DIFF
--- a/boa_gc/src/pointers/gc.rs
+++ b/boa_gc/src/pointers/gc.rs
@@ -59,7 +59,7 @@ impl<T: Trace> Gc<T> {
         //   `unsafe` block.
         // - `set_kv`: `weak` is a newly created `EphemeronBox`, meaning it isn't possible to
         //   collect it since `weak` is still live.
-        unsafe { weak.inner().inner_ptr().as_mut().set(&gc, gc.clone()) }
+        unsafe { weak.inner().inner_ptr().as_mut().set(&gc, ()) }
 
         gc
     }


### PR DESCRIPTION
Makes inner storage of `WeakGc<T>` store `()` in place of `Ephemeron` value, instead of a clone of the `Gc<T>`, which is already stored in the key.

Reducing the size by the width of one pointer.
