### PR TITLE
Refactor vm calling convention to allow locals

### DIFF
--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1035,12 +1035,12 @@ fn function_construct(
         .with_env_fp(env_fp)
         .with_flags(CallFrameFlags::CONSTRUCT);
 
-    context.vm.push_frame(frame);
-
     let len = context.vm.stack.len();
 
+    context.vm.push_frame(frame);
+
     // NOTE(HalidOdat): +1 because we insert `this` value below.
-    context.vm.frame_mut().fp = len as u32 + 1;
+    context.vm.frame_mut().rp = len as u32 + 1;
 
     let mut last_env = 0;
 

--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -69,13 +69,13 @@ impl GeneratorContext {
         let mut frame = context.vm.frame().clone();
         frame.environments = context.vm.environments.clone();
         frame.realm = context.realm().clone();
-        let fp = frame.restore_fp() as usize;
+        let fp = frame.fp() as usize;
         let stack = context.vm.stack.split_off(fp);
 
-        frame.fp = CallFrame::FUNCTION_PROLOGUE + frame.argument_count;
+        frame.rp = CallFrame::FUNCTION_PROLOGUE + frame.argument_count;
 
         // NOTE: Since we get a pre-built call frame with stack, and we reuse them.
-        //       So we don't need to push the locals in subsuquent calls.
+        //       So we don't need to push the locals in subsequent calls.
         frame.flags |= CallFrameFlags::LOCALS_ALREADY_PUSHED;
 
         Self {
@@ -93,10 +93,10 @@ impl GeneratorContext {
     ) -> CompletionRecord {
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         let frame = self.call_frame.take().expect("should have a call frame");
-        let fp = frame.fp;
+        let rp = frame.rp;
         context.vm.push_frame(frame);
 
-        context.vm.frame_mut().fp = fp;
+        context.vm.frame_mut().rp = rp;
         context.vm.frame_mut().set_exit_early(true);
 
         if let Some(value) = value {

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -327,8 +327,7 @@ impl<'ctx> ByteCompiler<'ctx> {
             params: FormalParameterList::default(),
             current_open_environments_count: 0,
 
-            // This starts at two because the first value is the `this` value, then function object.
-            current_stack_value_count: 2,
+            current_stack_value_count: 0,
             code_block_flags,
             handlers: ThinVec::default(),
             ic: Vec::default(),

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -255,6 +255,8 @@ pub struct ByteCompiler<'ctx> {
     /// The number of arguments expected.
     pub(crate) length: u32,
 
+    pub(crate) locals_count: u32,
+
     /// \[\[ThisMode\]\]
     pub(crate) this_mode: ThisMode,
 
@@ -327,6 +329,7 @@ impl<'ctx> ByteCompiler<'ctx> {
             params: FormalParameterList::default(),
             current_open_environments_count: 0,
 
+            locals_count: 0,
             current_stack_value_count: 0,
             code_block_flags,
             handlers: ThinVec::default(),
@@ -1520,9 +1523,17 @@ impl<'ctx> ByteCompiler<'ctx> {
         }
         self.r#return(false);
 
+        if self.is_async_generator() {
+            self.locals_count += 1;
+        }
+        for handler in &mut self.handlers {
+            handler.stack_count += self.locals_count;
+        }
+
         CodeBlock {
             name: self.function_name,
             length: self.length,
+            locals_count: self.locals_count,
             this_mode: self.this_mode,
             params: self.params,
             bytecode: self.bytecode.into_boxed_slice(),

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -324,7 +324,7 @@ impl SyntheticModule {
         // 11. Suspend moduleContext and remove it from the execution context stack.
         // 12. Resume the context that is now on the top of the execution context stack as the running execution context.
         let frame = context.vm.pop_frame().expect("there should be a frame");
-        context.vm.stack.truncate(frame.fp as usize);
+        frame.restore_stack(&mut context.vm);
 
         // 13. Let pc be ! NewPromiseCapability(%Promise%).
         let (promise, ResolvingFunctions { resolve, reject }) = JsPromise::new_pending(context);

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -132,7 +132,7 @@ impl CallFrame {
     pub(crate) const FUNCTION_PROLOGUE: u32 = 2;
     pub(crate) const THIS_POSITION: u32 = 2;
     pub(crate) const FUNCTION_POSITION: u32 = 1;
-    pub(crate) const ASYNC_GENERATOR_OBJECT_LOCAL_INDEX: u32 = 0;
+    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: u32 = 0;
 
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
     pub(crate) fn new(
@@ -216,7 +216,7 @@ impl CallFrame {
             return None;
         }
 
-        self.local(Self::ASYNC_GENERATOR_OBJECT_LOCAL_INDEX, stack)
+        self.local(Self::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX, stack)
             .as_object()
             .cloned()
     }

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -37,6 +37,10 @@ pub struct CallFrame {
     pub(crate) code_block: Gc<CodeBlock>,
     pub(crate) pc: u32,
     /// The register pointer, points to the first register in the stack.
+    ///
+    // TODO: Check if storing the frame pointer instead of argument count and computing the
+    //       argument count based on the pointers would be better for accessing the arguments
+    //       and the elements before the register pointer.
     pub(crate) rp: u32,
     pub(crate) argument_count: u32,
     pub(crate) env_fp: u32,

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -177,6 +177,8 @@ pub struct CodeBlock {
     /// The number of arguments expected.
     pub(crate) length: u32,
 
+    pub(crate) locals_count: u32,
+
     /// \[\[ThisMode\]\]
     pub(crate) this_mode: ThisMode,
 
@@ -216,6 +218,7 @@ impl CodeBlock {
             name,
             flags: Cell::new(flags),
             length,
+            locals_count: 0,
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
             handlers: ThinVec::default(),
@@ -284,6 +287,13 @@ impl CodeBlock {
     /// Returns true if this function an generator function.
     pub(crate) fn is_generator(&self) -> bool {
         self.flags.get().contains(CodeBlockFlags::IS_GENERATOR)
+    }
+
+    /// Returns true if this function a async generator function.
+    pub(crate) fn is_async_generator(&self) -> bool {
+        self.flags
+            .get()
+            .contains(CodeBlockFlags::IS_ASYNC | CodeBlockFlags::IS_GENERATOR)
     }
 
     /// Returns true if this function an async function.

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -162,6 +162,17 @@ impl Vm {
         std::mem::swap(&mut self.environments, &mut frame.environments);
         std::mem::swap(&mut self.realm, &mut frame.realm);
 
+        // NOTE: We need to check if we already pushed the locals,
+        //       since generator-like functions push the same call
+        //       frame with pre-built stack.
+        if !frame.locals_already_pushed() {
+            let locals_count = frame.code_block().locals_count;
+            self.stack.resize_with(
+                current_stack_length + locals_count as usize,
+                JsValue::undefined,
+            );
+        }
+
         self.frames.push(frame);
     }
 

--- a/core/engine/src/vm/opcode/arguments.rs
+++ b/core/engine/src/vm/opcode/arguments.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtins::function::arguments::{MappedArguments, UnmappedArguments},
-    vm::{CallFrame, CompletionType},
+    vm::CompletionType,
     Context, JsResult,
 };
 
@@ -19,7 +19,6 @@ impl Operation for CreateMappedArgumentsObject {
     const COST: u8 = 8;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let arguments_start = context.vm.frame().fp as usize + CallFrame::FIRST_ARGUMENT_POSITION;
         let function_object = context
             .vm
             .frame()
@@ -27,7 +26,7 @@ impl Operation for CreateMappedArgumentsObject {
             .clone()
             .expect("there should be a function object");
         let code = context.vm.frame().code_block().clone();
-        let args = context.vm.stack[arguments_start..].to_vec();
+        let args = context.vm.frame().arguments(&context.vm).to_vec();
 
         let env = context.vm.environments.current();
         let arguments = MappedArguments::new(
@@ -55,8 +54,7 @@ impl Operation for CreateUnmappedArgumentsObject {
     const COST: u8 = 4;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let arguments_start = context.vm.frame().fp as usize + CallFrame::FIRST_ARGUMENT_POSITION;
-        let args = context.vm.stack[arguments_start..].to_vec();
+        let args = context.vm.frame().arguments(&context.vm).to_vec();
         let arguments = UnmappedArguments::new(&args, context);
         context.vm.push(arguments);
         Ok(CompletionType::Normal)

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -49,17 +49,16 @@ impl Operation for Await {
                     // d. Resume the suspended evaluation of asyncContext using NormalCompletion(value) as the result of the operation that suspended it.
                     let mut gen = captures.borrow_mut().take().expect("should only run once");
 
+                    // NOTE: We need to get the object before resuming, since it could clear the stack.
+                    let async_generator = gen.async_generator_object();
+
                     gen.resume(
                         Some(args.get_or_undefined(0).clone()),
                         GeneratorResumeKind::Normal,
                         context,
                     );
 
-                    if let Some(async_generator) = gen
-                        .call_frame
-                        .as_ref()
-                        .and_then(|f| f.async_generator.clone())
-                    {
+                    if let Some(async_generator) = async_generator {
                         async_generator
                             .downcast_mut::<AsyncGenerator>()
                             .expect("must be async generator")
@@ -92,17 +91,16 @@ impl Operation for Await {
 
                     let mut gen = captures.borrow_mut().take().expect("should only run once");
 
+                    // NOTE: We need to get the object before resuming, since it could clear the stack.
+                    let async_generator = gen.async_generator_object();
+
                     gen.resume(
                         Some(args.get_or_undefined(0).clone()),
                         GeneratorResumeKind::Throw,
                         context,
                     );
 
-                    if let Some(async_generator) = gen
-                        .call_frame
-                        .as_ref()
-                        .and_then(|f| f.async_generator.clone())
-                    {
+                    if let Some(async_generator) = async_generator {
                         async_generator
                             .downcast_mut::<AsyncGenerator>()
                             .expect("must be async generator")

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -82,7 +82,7 @@ impl Operation for Generator {
             let fp = frame
                 .call_frame
                 .as_ref()
-                .map_or(0, |frame| frame.fp as usize);
+                .map_or(0, |frame| frame.rp as usize);
             frame.stack[fp] = generator.clone().into();
 
             let mut gen = generator

--- a/core/engine/src/vm/opcode/generator/yield_stm.rs
+++ b/core/engine/src/vm/opcode/generator/yield_stm.rs
@@ -38,14 +38,13 @@ impl Operation for AsyncGeneratorYield {
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
         let value = context.vm.pop();
 
-        let async_gen = context
+        let async_generator_object = context
             .vm
             .frame()
-            .async_generator
-            .clone()
+            .async_generator_object(&context.vm.stack)
             .expect("`AsyncGeneratorYield` must only be called inside async generators");
         let completion = Ok(value);
-        let next = async_gen
+        let next = async_generator_object
             .downcast_mut::<AsyncGenerator>()
             .expect("must be async generator object")
             .queue
@@ -55,7 +54,7 @@ impl Operation for AsyncGeneratorYield {
         // TODO: 7. Let previousContext be the second to top element of the execution context stack.
         AsyncGenerator::complete_step(&next, completion, false, None, context);
 
-        let mut generator_object_mut = async_gen.borrow_mut();
+        let mut generator_object_mut = async_generator_object.borrow_mut();
         let gen = generator_object_mut
             .downcast_mut::<AsyncGenerator>()
             .expect("must be async generator object");

--- a/core/engine/src/vm/opcode/get/argument.rs
+++ b/core/engine/src/vm/opcode/get/argument.rs
@@ -13,12 +13,10 @@ pub(crate) struct GetArgument;
 impl GetArgument {
     #[allow(clippy::unnecessary_wraps)]
     fn operation(context: &mut Context, index: usize) -> JsResult<CompletionType> {
-        let fp = context.vm.frame().fp as usize;
-        let argument_index = fp + 2;
-        let argument_count = context.vm.frame().argument_count as usize;
-
-        let value = context.vm.stack[argument_index..(argument_index + argument_count)]
-            .get(index)
+        let value = context
+            .vm
+            .frame()
+            .argument(index, &context.vm)
             .cloned()
             .unwrap_or_default();
         context.vm.push(value);

--- a/core/engine/src/vm/opcode/rest_parameter/mod.rs
+++ b/core/engine/src/vm/opcode/rest_parameter/mod.rs
@@ -17,11 +17,11 @@ impl Operation for RestParameterInit {
     const COST: u8 = 6;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let arg_count = context.vm.frame().argument_count as usize;
+        let argument_count = context.vm.frame().argument_count as usize;
         let param_count = context.vm.frame().code_block().params.as_ref().len();
 
-        let array = if arg_count >= param_count {
-            let rest_count = arg_count - param_count + 1;
+        let array = if argument_count >= param_count {
+            let rest_count = argument_count - param_count + 1;
             let args = context.vm.pop_n_values(rest_count);
             Array::create_array_from_list(args, context)
         } else {


### PR DESCRIPTION
This PR makes storing locals after `fp` much easier by moving the `fp` at the end of the stack that the caller sets up, making the frame pointer the in the middle, the locals start at fp and accessing the caller setup values we offset back instead.

This adds a local ( /register :wink: ) count variable to `CodeBlock`.

Checkout [`call_frame.rs`](https://github.com/boa-dev/boa/blob/93d7a48850cb6ffdeb8634e08f0e6fe88328141b/boa_engine/src/vm/call_frame/mod.rs#L84) for the new calling convention.

This makes #3194 easier and allows us to move stuff from the call frame that is only for a specific type of function (like `async` promise capability or generator function) reducing the size of the call frame and only paying for things the user uses.

Moves async generator object out of `CallFrame` to the stack. Reducing the usage of memory of a CallFrame for non-async-generator functions.
