### PR TITLE
Simplify `Icu` API

### DIFF
--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -17,8 +17,8 @@ use crate::{
         OrdinaryObject,
     },
     context::{
+        icu::IntlProvider,
         intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
-        BoaProvider,
     },
     js_string,
     native_function::NativeFunction,
@@ -79,7 +79,7 @@ impl Service for Collator {
 
     type LocaleOptions = CollatorLocaleOptions;
 
-    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: &BoaProvider) {
+    fn resolve(locale: &mut Locale, options: &mut Self::LocaleOptions, provider: &IntlProvider) {
         let collation = options
             .collation
             .take()
@@ -274,8 +274,11 @@ impl BuiltInConstructor for Collator {
 
         // 18. Let relevantExtensionKeys be %Collator%.[[RelevantExtensionKeys]].
         // 19. Let r be ResolveLocale(%Collator%.[[AvailableLocales]], requestedLocales, opt, relevantExtensionKeys, localeData).
-        let mut locale =
-            resolve_locale::<Self>(&requested_locales, &mut intl_options, context.icu());
+        let mut locale = resolve_locale::<Self>(
+            &requested_locales,
+            &mut intl_options,
+            context.intl_provider(),
+        );
 
         let collator_locale = {
             // `collator_locale` needs to be different from the resolved locale because ECMA402 doesn't
@@ -332,7 +335,7 @@ impl BuiltInConstructor for Collator {
             .unzip();
 
         let collator =
-            NativeCollator::try_new_unstable(context.icu().provider(), &collator_locale, {
+            NativeCollator::try_new_unstable(context.intl_provider(), &collator_locale, {
                 let mut options = icu_collator::CollatorOptions::new();
                 options.strength = strength;
                 options.case_level = case_level;

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -126,7 +126,7 @@ impl BuiltInConstructor for ListFormat {
                 matcher,
                 ..Default::default()
             },
-            context.icu(),
+            context.intl_provider(),
         );
 
         // 11. Let type be ? GetOption(options, "type", string, « "conjunction", "disjunction", "unit" », "conjunction").
@@ -144,17 +144,17 @@ impl BuiltInConstructor for ListFormat {
         let data_locale = DataLocale::from(&locale);
         let formatter = match typ {
             ListFormatType::Conjunction => ListFormatter::try_new_and_with_length_unstable(
-                context.icu().provider(),
+                context.intl_provider(),
                 &data_locale,
                 style,
             ),
             ListFormatType::Disjunction => ListFormatter::try_new_or_with_length_unstable(
-                context.icu().provider(),
+                context.intl_provider(),
                 &data_locale,
                 style,
             ),
             ListFormatType::Unit => ListFormatter::try_new_unit_with_length_unstable(
-                context.icu().provider(),
+                context.intl_provider(),
                 &data_locale,
                 style,
             ),

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -249,7 +249,10 @@ impl BuiltInConstructor for Locale {
             let region = get_option(options, utf16!("region"), context)?;
 
             // 10. Set tag to ! CanonicalizeUnicodeLocaleId(tag).
-            context.icu().locale_canonicalizer().canonicalize(&mut tag);
+            context
+                .intl_provider()
+                .locale_canonicalizer()
+                .canonicalize(&mut tag);
 
             // Skipping some boilerplate since this is easier to do using the `Locale` type, but putting the
             // spec for completion.
@@ -280,7 +283,10 @@ impl BuiltInConstructor for Locale {
             }
 
             // 17. Return ! CanonicalizeUnicodeLocaleId(tag).
-            context.icu().locale_canonicalizer().canonicalize(&mut tag);
+            context
+                .intl_provider()
+                .locale_canonicalizer()
+                .canonicalize(&mut tag);
         }
 
         // 12. Let opt be a new Record.
@@ -363,7 +369,10 @@ impl BuiltInConstructor for Locale {
             tag.extensions.unicode.keywords.set(key!("nu"), nu);
         }
 
-        context.icu().locale_canonicalizer().canonicalize(&mut tag);
+        context
+            .intl_provider()
+            .locale_canonicalizer()
+            .canonicalize(&mut tag);
 
         // 6. Let locale be ? OrdinaryCreateFromConstructor(NewTarget, "%Locale.prototype%", internalSlotsList).
         let prototype =
@@ -403,7 +412,7 @@ impl Locale {
             .clone();
 
         // 3. Let maximal be the result of the Add Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set maximal to loc.[[Locale]].
-        context.icu().locale_expander().maximize(&mut loc);
+        context.intl_provider().locale_expander().maximize(&mut loc);
 
         // 4. Return ! Construct(%Locale%, maximal).
         let prototype = context.intrinsics().constructors().locale().prototype();
@@ -439,7 +448,7 @@ impl Locale {
             .clone();
 
         // 3. Let minimal be the result of the Remove Likely Subtags algorithm applied to loc.[[Locale]]. If an error is signaled, set minimal to loc.[[Locale]].
-        context.icu().locale_expander().minimize(&mut loc);
+        context.intl_provider().locale_expander().minimize(&mut loc);
 
         // 4. Return ! Construct(%Locale%, minimal).
         let prototype = context.intrinsics().constructors().locale().prototype();

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInObject, IntrinsicObject},
-    context::{intrinsics::Intrinsics, BoaProvider},
+    context::{icu::IntlProvider, intrinsics::Intrinsics},
     js_string,
     object::JsObject,
     property::Attribute,
@@ -172,7 +172,7 @@ trait Service {
     fn resolve(
         _locale: &mut icu_locid::Locale,
         _options: &mut Self::LocaleOptions,
-        _provider: &BoaProvider,
+        _provider: &IntlProvider,
     ) {
     }
 }

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -143,16 +143,16 @@ impl BuiltInConstructor for PluralRules {
                 matcher,
                 ..Default::default()
             },
-            context.icu(),
+            context.intl_provider(),
         );
 
         let native = match rule_type {
             PluralRuleType::Cardinal => PluralRulesWithRanges::try_new_cardinal_unstable(
-                context.icu().provider(),
+                context.intl_provider(),
                 &DataLocale::from(&locale),
             ),
             PluralRuleType::Ordinal => PluralRulesWithRanges::try_new_ordinal_unstable(
-                context.icu().provider(),
+                context.intl_provider(),
                 &DataLocale::from(&locale),
             ),
             _ => {

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -146,7 +146,7 @@ impl BuiltInConstructor for Segmenter {
                 matcher,
                 ..Default::default()
             },
-            context.icu(),
+            context.intl_provider(),
         );
 
         // 12. Let granularity be ? GetOption(options, "granularity", string, « "grapheme", "word", "sentence" », "grapheme").
@@ -155,14 +155,14 @@ impl BuiltInConstructor for Segmenter {
 
         let native = match granularity {
             Granularity::Grapheme => {
-                GraphemeClusterSegmenter::try_new_unstable(context.icu().provider())
+                GraphemeClusterSegmenter::try_new_unstable(context.intl_provider())
                     .map(|s| NativeSegmenter::Grapheme(Box::new(s)))
             }
 
-            Granularity::Word => WordSegmenter::try_new_auto_unstable(context.icu().provider())
+            Granularity::Word => WordSegmenter::try_new_auto_unstable(context.intl_provider())
                 .map(|s| NativeSegmenter::Word(Box::new(s))),
 
-            Granularity::Sentence => SentenceSegmenter::try_new_unstable(context.icu().provider())
+            Granularity::Sentence => SentenceSegmenter::try_new_unstable(context.intl_provider())
                 .map(|s| NativeSegmenter::Sentence(Box::new(s))),
         }
         .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -1754,16 +1754,16 @@ impl String {
                 .next()
                 // 3. Else,
                 //     a. Let requestedLocale be ! DefaultLocale().
-                .unwrap_or_else(|| default_locale(context.icu().locale_canonicalizer()))
+                .unwrap_or_else(|| default_locale(context.intl_provider().locale_canonicalizer()))
                 .id;
             // 4. Let noExtensionsLocale be the String value that is requestedLocale with any Unicode locale extension sequences (6.2.1) removed.
             // 5. Let availableLocales be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
             // 6. Let locale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
             // 7. If locale is undefined, set locale to "und".
-            let lang = best_available_locale::<CaseMapV1Marker>(lang, context.icu().provider())
+            let lang = best_available_locale::<CaseMapV1Marker>(lang, context.intl_provider())
                 .unwrap_or(LanguageIdentifier::UND);
 
-            let casemapper = context.icu().case_mapper();
+            let casemapper = context.intl_provider().case_mapper();
 
             // 8. Let codePoints be StringToCodePoints(S).
             let result = string.map_valid_segments(|segment| {
@@ -2143,7 +2143,7 @@ impl String {
             }
             #[cfg(feature = "intl")]
             {
-                context.icu().string_normalizers()
+                context.intl_provider().string_normalizers()
             }
         };
 

--- a/core/engine/src/context/icu.rs
+++ b/core/engine/src/context/icu.rs
@@ -103,7 +103,7 @@ impl Debug for IntlProvider {
 }
 
 impl IntlProvider {
-    /// Creates a new [`Icu`] from a [`BufferProvider`].
+    /// Creates a new [`IntlProvider`] from a [`BufferProvider`].
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Hides `BoaProvider` to be crate-private, which makes the overall API easier for users.