### PR TITLE
Implment Tail Call Optimization

### DIFF
--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -1512,24 +1512,25 @@ impl<'ctx> ByteCompiler<'ctx> {
 
     fn optimize(bytecode: &mut Vec<u8>, flags: CodeBlockFlags) {
         // only perform Tail Call Optimisation in strict mode
-        if flags.contains(CodeBlockFlags::STRICT) {
+        if flags.contains(CodeBlockFlags::STRICT) && flags.is_ordinary() {
             // if a sequence of Call, SetReturnValue, CheckReturn, Return is found
             // replace Call with TailCall to allow frame elimination
             for i in 0..bytecode.len() {
                 let opcode: Opcode = bytecode[i].into();
-                if matches!(opcode, Opcode::Call) {
-                    if bytecode.len() > i + 5 {
-                        let second = bytecode[i + 2].into();
-                        let third = bytecode[i + 3].into();
-                        let fourth = bytecode[i + 4].into();
-                        if let (Opcode::SetReturnValue, Opcode::CheckReturn, Opcode::Return) =
-                            (second, third, fourth)
-                        {
-                            bytecode[i] = Opcode::TailCall as u8;
-                        }
-                    } else {
-                        return;
-                    }
+                if !matches!(opcode, Opcode::Call) {
+                    continue;
+                }
+                if bytecode.len() <= i + 5 {
+                    return;
+                }
+
+                let second = bytecode[i + 2].into();
+                let third = bytecode[i + 3].into();
+                let fourth = bytecode[i + 4].into();
+                if let (Opcode::SetReturnValue, Opcode::CheckReturn, Opcode::Return) =
+                    (second, third, fourth)
+                {
+                    bytecode[i] = Opcode::TailCall as u8;
                 }
             }
         }

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -91,7 +91,7 @@ impl CallFrame {
     ///    \            /
     ///     ------------
     ///     |
-    /// function prolugue
+    /// function prologue
     /// ```
     pub(crate) const FUNCTION_PROLOGUE: usize = 2;
     pub(crate) const THIS_POSITION: usize = 0;

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -76,6 +76,47 @@ bitflags! {
     }
 }
 
+impl CodeBlockFlags {
+    /// Check if the function is traced.
+    #[cfg(feature = "trace")]
+    pub(crate) fn traceable(&self) -> bool {
+        self.contains(CodeBlockFlags::TRACEABLE)
+    }
+    /// Check if the function is a class constructor.
+    pub(crate) fn is_class_constructor(&self) -> bool {
+        self.contains(CodeBlockFlags::IS_CLASS_CONSTRUCTOR)
+    }
+    /// Check if the function is in strict mode.
+    pub(crate) fn strict(&self) -> bool {
+        self.contains(CodeBlockFlags::STRICT)
+    }
+    /// Indicates if the function is an expression and has a binding identifier.
+    pub(crate) fn has_binding_identifier(&self) -> bool {
+        self.contains(CodeBlockFlags::HAS_BINDING_IDENTIFIER)
+    }
+    /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.
+    pub(crate) fn in_class_field_initializer(&self) -> bool {
+        self.contains(CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER)
+    }
+    /// Returns true if this function is a derived constructor.
+    pub(crate) fn is_derived_constructor(&self) -> bool {
+        self.contains(CodeBlockFlags::IS_DERIVED_CONSTRUCTOR)
+    }
+    /// Returns true if this function an async function.
+    pub(crate) fn is_async(self) -> bool {
+        self.contains(CodeBlockFlags::IS_ASYNC)
+    }
+
+    /// Returns true if this function an generator function.
+    pub(crate) fn is_generator(self) -> bool {
+        self.contains(CodeBlockFlags::IS_GENERATOR)
+    }
+    /// Returns true if this function an async function.
+    pub(crate) fn is_ordinary(self) -> bool {
+        !self.is_async() && !self.is_generator()
+    }
+}
+
 // SAFETY: Nothing in CodeBlockFlags needs tracing, so this is safe.
 unsafe impl Trace for CodeBlockFlags {
     empty_trace!();
@@ -232,7 +273,7 @@ impl CodeBlock {
     /// Check if the function is traced.
     #[cfg(feature = "trace")]
     pub(crate) fn traceable(&self) -> bool {
-        self.flags.get().contains(CodeBlockFlags::TRACEABLE)
+        self.flags.get().traceable()
     }
     /// Enable or disable instruction tracing to `stdout`.
     #[cfg(feature = "trace")]
@@ -245,50 +286,42 @@ impl CodeBlock {
 
     /// Check if the function is a class constructor.
     pub(crate) fn is_class_constructor(&self) -> bool {
-        self.flags
-            .get()
-            .contains(CodeBlockFlags::IS_CLASS_CONSTRUCTOR)
+        self.flags.get().is_class_constructor()
     }
 
     /// Check if the function is in strict mode.
     pub(crate) fn strict(&self) -> bool {
-        self.flags.get().contains(CodeBlockFlags::STRICT)
+        self.flags.get().strict()
     }
 
     /// Indicates if the function is an expression and has a binding identifier.
     pub(crate) fn has_binding_identifier(&self) -> bool {
-        self.flags
-            .get()
-            .contains(CodeBlockFlags::HAS_BINDING_IDENTIFIER)
+        self.flags.get().has_binding_identifier()
     }
 
     /// Does this function have the `[[ClassFieldInitializerName]]` internal slot set to non-empty value.
     pub(crate) fn in_class_field_initializer(&self) -> bool {
-        self.flags
-            .get()
-            .contains(CodeBlockFlags::IN_CLASS_FIELD_INITIALIZER)
+        self.flags.get().in_class_field_initializer()
     }
 
     /// Returns true if this function is a derived constructor.
     pub(crate) fn is_derived_constructor(&self) -> bool {
-        self.flags
-            .get()
-            .contains(CodeBlockFlags::IS_DERIVED_CONSTRUCTOR)
+        self.flags.get().is_derived_constructor()
     }
 
     /// Returns true if this function an async function.
     pub(crate) fn is_async(&self) -> bool {
-        self.flags.get().contains(CodeBlockFlags::IS_ASYNC)
+        self.flags.get().is_async()
     }
 
     /// Returns true if this function an generator function.
     pub(crate) fn is_generator(&self) -> bool {
-        self.flags.get().contains(CodeBlockFlags::IS_GENERATOR)
+        self.flags.get().is_generator()
     }
 
     /// Returns true if this function an async function.
     pub(crate) fn is_ordinary(&self) -> bool {
-        !self.is_async() && !self.is_generator()
+        self.flags.get().is_ordinary()
     }
 
     /// Returns true if this function has the `"prototype"` property when function object is created.

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -444,6 +444,9 @@ impl CodeBlock {
             | Instruction::Call {
                 argument_count: value,
             }
+            | Instruction::TailCall {
+                argument_count: value,
+            }
             | Instruction::New {
                 argument_count: value,
             }
@@ -746,8 +749,7 @@ impl CodeBlock {
             | Instruction::Reserved54
             | Instruction::Reserved55
             | Instruction::Reserved56
-            | Instruction::Reserved57
-            | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved57 => unreachable!("Reserved opcodes are unreachable"),
         }
     }
 }

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -201,6 +201,7 @@ impl CodeBlock {
                 }
                 Instruction::CallEval { .. }
                 | Instruction::Call { .. }
+                | Instruction::TailCall { .. }
                 | Instruction::New { .. }
                 | Instruction::SuperCall { .. }
                 | Instruction::ConcatToString { .. }
@@ -515,8 +516,7 @@ impl CodeBlock {
                 | Instruction::Reserved54
                 | Instruction::Reserved55
                 | Instruction::Reserved56
-                | Instruction::Reserved57
-                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved57 => unreachable!("Reserved opcodes are unreachable"),
             }
         }
 

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -1700,6 +1700,13 @@ generate_opcodes! {
     /// Stack: this, func, argument_1, ... argument_n **=>** result
     Call { argument_count: VaryingOperand },
 
+    /// Tail call a function.
+    ///
+    /// Operands: argument_count: `u32`
+    ///
+    /// Stack: this, func, argument_1, ... argument_n **=>**
+    TailCall { argument_count: VaryingOperand },
+
     /// Call a function where the arguments contain spreads.
     ///
     /// Operands:
@@ -2220,8 +2227,6 @@ generate_opcodes! {
     Reserved56 => Reserved,
     /// Reserved [`Opcode`].
     Reserved57 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved58 => Reserved,
 }
 
 /// Specific opcodes for bindings.


### PR DESCRIPTION
This Pull Request implements Tail Call Optimization as described in the [spec](https://tc39.es/ecma262/#sec-tail-position-calls)

It changes the following:

- introduce a new instruction `TailCall` that can is compatible with `Call` and will perform `TCO` if possible
- introduce `ByteCompiler::optimize` that introduces optimizations to the bytecode code

While the spec says that TCO should be implemented most engines do not currently support it. Apple's JavaScriptCore is the only mainstream implementation as far as I am aware. When it was first introduced V8 implemented it but after Firefox and Internet Explorer pushed back and it was clear not all browsers would have it V8 dropped it to avoid maintaining unnecessary code.

Given that I wanted to get all of @boa-dev/maintainers opinions on implementing these parts of the spec that aren't technically required. I did it mostly as a challenge since it is a topic I find interesting so I understand if the choice is to not incorporate the code.