### PR TITLE
Implement inline caching tests and cleanup

### DIFF
--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -577,8 +577,6 @@ pub(crate) fn ordinary_has_property(
     // 2. Let hasOwn be ? O.[[GetOwnProperty]](P).
     // 3. If hasOwn is not undefined, return true.
     if obj.__get_own_property__(key, context)?.is_some() {
-        context.slot().attributes |= SlotAttributes::FOUND;
-
         Ok(true)
     } else {
         // 4. Let parent be ? O.[[GetPrototypeOf]]().
@@ -627,8 +625,6 @@ pub(crate) fn ordinary_get(
             }
         }
         Some(ref desc) => {
-            context.slot().attributes |= SlotAttributes::FOUND;
-
             match desc.kind() {
                 // 4. If IsDataDescriptor(desc) is true, return desc.[[Value]].
                 DescriptorKind::Data {
@@ -746,8 +742,6 @@ pub(crate) fn ordinary_set(
         // ii. Return ? CreateDataProperty(Receiver, P, V).
         return receiver.create_data_property_with_slot(key, value, context);
     }
-
-    context.slot().attributes |= SlotAttributes::FOUND;
 
     // 4. Assert: IsAccessorDescriptor(ownDesc) is true.
     debug_assert!(own_desc.is_accessor_descriptor());
@@ -902,7 +896,6 @@ pub(crate) fn validate_and_apply_property_descriptor(
                 },
                 slot,
             );
-            slot.attributes |= SlotAttributes::FOUND;
         }
 
         // e. Return true.

--- a/core/engine/src/object/property_map.rs
+++ b/core/engine/src/object/property_map.rs
@@ -291,8 +291,9 @@ impl PropertyMap {
             out_slot.index = slot.index;
 
             // Remove all descriptor attributes, but keep inline caching bits.
-            out_slot.attributes =
-                (out_slot.attributes & SlotAttributes::INLINE_CACHE_BITS) | slot.attributes;
+            out_slot.attributes = (out_slot.attributes & SlotAttributes::INLINE_CACHE_BITS)
+                | slot.attributes
+                | SlotAttributes::FOUND;
             return Some(self.get_storage(slot));
         }
 

--- a/core/engine/src/object/shape/mod.rs
+++ b/core/engine/src/object/shape/mod.rs
@@ -231,7 +231,7 @@ impl From<SharedShape> for Shape {
 }
 
 /// Represents a weak reaference to an object's [`Shape`].
-#[derive(Debug, Trace, Finalize, Clone)]
+#[derive(Debug, Trace, Finalize, Clone, PartialEq)]
 pub(crate) enum WeakShape {
     Unique(WeakUniqueShape),
     Shared(WeakSharedShape),
@@ -249,6 +249,19 @@ impl WeakShape {
             WeakShape::Shared(shape) => shape.to_addr_usize(),
             WeakShape::Unique(shape) => shape.to_addr_usize(),
             WeakShape::None => 0,
+        }
+    }
+
+    /// Return location in memory of the [`Shape`].
+    ///
+    /// Returns `0` if the shape has been freed.
+    #[inline]
+    #[must_use]
+    pub(crate) fn upgrade(&self) -> Option<Shape> {
+        match self {
+            WeakShape::Shared(shape) => Some(shape.upgrade()?.into()),
+            WeakShape::Unique(shape) => Some(shape.upgrade()?.into()),
+            WeakShape::None => None,
         }
     }
 }

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -482,7 +482,7 @@ impl SharedShape {
 }
 
 /// Represents a weak reference to [`SharedShape`].
-#[derive(Debug, Trace, Finalize, Clone)]
+#[derive(Debug, Trace, Finalize, Clone, PartialEq)]
 pub(crate) struct WeakSharedShape {
     inner: WeakGc<Inner>,
 }
@@ -497,6 +497,16 @@ impl WeakSharedShape {
         self.inner.upgrade().map_or(0, |inner| {
             let ptr: *const _ = inner.as_ref();
             ptr as usize
+        })
+    }
+
+    /// Upgrade returns a [`SharedShape`] pointer for the internal value if the pointer is still live,
+    /// or [`None`] if the value was already garbage collected.
+    #[inline]
+    #[must_use]
+    pub(crate) fn upgrade(&self) -> Option<SharedShape> {
+        Some(SharedShape {
+            inner: self.inner.upgrade()?,
         })
     }
 }

--- a/core/engine/src/object/shape/slot.rs
+++ b/core/engine/src/object/shape/slot.rs
@@ -45,6 +45,11 @@ impl SlotAttributes {
     pub(crate) const fn is_cachable(self) -> bool {
         !self.contains(Self::NOT_CACHABLE) && self.contains(Self::FOUND)
     }
+
+    #[cfg(test)]
+    pub(crate) const fn in_prototype(self) -> bool {
+        self.contains(Self::PROTOTYPE)
+    }
 }
 
 /// Represents an [`u32`] index and it's slot attributes of an element in a object storage.
@@ -67,6 +72,11 @@ impl Slot {
 
     pub(crate) const fn is_cachable(self) -> bool {
         self.attributes.is_cachable()
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn in_prototype(self) -> bool {
+        self.attributes.in_prototype()
     }
 
     /// Get the width of the slot.

--- a/core/engine/src/object/shape/unique_shape.rs
+++ b/core/engine/src/object/shape/unique_shape.rs
@@ -241,7 +241,7 @@ impl UniqueShape {
 }
 
 /// Represents a weak reference to [`UniqueShape`].
-#[derive(Debug, Clone, Trace, Finalize)]
+#[derive(Debug, Clone, Trace, Finalize, PartialEq)]
 pub(crate) struct WeakUniqueShape {
     inner: WeakGc<Inner>,
 }
@@ -256,6 +256,16 @@ impl WeakUniqueShape {
         self.inner.upgrade().map_or(0, |inner| {
             let ptr: *const _ = inner.as_ref();
             ptr as usize
+        })
+    }
+
+    /// Upgrade returns a [`UniqueShape`] pointer for the internal value if the pointer is still live,
+    /// or [`None`] if the value was already garbage collected.
+    #[inline]
+    #[must_use]
+    pub(crate) fn upgrade(&self) -> Option<UniqueShape> {
+        Some(UniqueShape {
+            inner: self.inner.upgrade()?,
         })
     }
 }

--- a/core/engine/src/vm/inline_cache/mod.rs
+++ b/core/engine/src/vm/inline_cache/mod.rs
@@ -1,0 +1,61 @@
+use std::cell::Cell;
+
+use boa_gc::GcRefCell;
+use boa_macros::{Finalize, Trace};
+
+use crate::{
+    object::shape::{slot::Slot, Shape, WeakShape},
+    JsString,
+};
+
+#[cfg(test)]
+mod tests;
+
+/// An inline cache entry for a property access.
+#[derive(Clone, Debug, Trace, Finalize)]
+pub(crate) struct InlineCache {
+    /// The property that is accessed.
+    pub(crate) name: JsString,
+
+    /// A pointer is kept to the shape to avoid the shape from being deallocated.
+    pub(crate) shape: GcRefCell<WeakShape>,
+
+    /// The [`Slot`] of the property.
+    #[unsafe_ignore_trace]
+    pub(crate) slot: Cell<Slot>,
+}
+
+impl InlineCache {
+    pub(crate) const fn new(name: JsString) -> Self {
+        Self {
+            name,
+            shape: GcRefCell::new(WeakShape::None),
+            slot: Cell::new(Slot::new()),
+        }
+    }
+
+    pub(crate) fn set(&self, shape: &Shape, slot: Slot) {
+        *self.shape.borrow_mut() = shape.into();
+        self.slot.set(slot);
+    }
+
+    pub(crate) fn slot(&self) -> Slot {
+        self.slot.get()
+    }
+
+    /// Returns true, if the [`InlineCache`]'s shape matches with the given shape.
+    ///
+    /// Otherwise we reset the internal weak reference to [`WeakShape::None`],
+    /// so it can be deallocated by the GC.
+    pub(crate) fn match_or_reset(&self, shape: &Shape) -> Option<(Shape, Slot)> {
+        let mut old = self.shape.borrow_mut();
+
+        let old_upgraded = old.upgrade();
+        if old_upgraded.as_ref().map_or(0, Shape::to_addr_usize) == shape.to_addr_usize() {
+            return old_upgraded.map(|shape| (shape, self.slot()));
+        }
+
+        *old = WeakShape::None;
+        None
+    }
+}

--- a/core/engine/src/vm/inline_cache/tests.rs
+++ b/core/engine/src/vm/inline_cache/tests.rs
@@ -1,0 +1,367 @@
+use boa_gc::Gc;
+use boa_parser::Source;
+
+use crate::{
+    builtins::{function::OrdinaryFunction, OrdinaryObject},
+    js_string,
+    object::{
+        internal_methods::InternalMethodContext,
+        shape::{slot::SlotAttributes, WeakShape},
+        ObjectInitializer,
+    },
+    property::{Attribute, PropertyDescriptor, PropertyKey},
+    vm::CodeBlock,
+    Context, JsObject, JsResult, JsValue,
+};
+
+#[test]
+fn get_own_property_internal_method() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    o.set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__get_own_property__(&property, context)
+        .expect("should not fail");
+
+    assert!(
+        !context.slot().in_prototype(),
+        "Since it's an owned property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an owned property, this should be cachable"
+    );
+
+    let shape = o.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+#[test]
+fn get_internal_method() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    o.set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__get__(&property, o.clone().into(), context)
+        .expect("should not fail");
+
+    assert!(
+        !context.slot().in_prototype(),
+        "Since it's an owned property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an owned property, this should be cachable"
+    );
+
+    let shape = o.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+#[test]
+fn get_internal_method_in_prototype() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    let prototype = context.intrinsics().constructors().object().prototype();
+
+    prototype
+        .set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__get__(&property, o.clone().into(), context)
+        .expect("should not fail");
+
+    assert!(
+        context.slot().in_prototype(),
+        "Since it's an prototype property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an prototype property, this should be cachable"
+    );
+
+    let shape = prototype.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+#[test]
+fn define_own_property_internal_method_non_existant_property() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    o.set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__define_own_property__(
+        &property,
+        PropertyDescriptor::builder()
+            .value(value)
+            .writable(true)
+            .configurable(true)
+            .enumerable(true)
+            .build(),
+        context,
+    )
+    .expect("should not fail");
+
+    assert!(
+        !context.slot().in_prototype(),
+        "Since it's an owned property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an owned property, this should be cachable"
+    );
+
+    let shape = o.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+#[test]
+fn define_own_property_internal_method_existing_property_property() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    o.set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    o.__define_own_property__(
+        &property,
+        PropertyDescriptor::builder()
+            .value(value)
+            .writable(true)
+            .configurable(true)
+            .enumerable(true)
+            .build(),
+        &mut context.into(),
+    )
+    .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__define_own_property__(
+        &property,
+        PropertyDescriptor::builder()
+            .value(value + 100)
+            .writable(true)
+            .configurable(true)
+            .enumerable(true)
+            .build(),
+        context,
+    )
+    .expect("should not fail");
+
+    assert!(
+        !context.slot().in_prototype(),
+        "Since it's an owned property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an owned property, this should be cachable"
+    );
+
+    let shape = o.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+#[test]
+fn set_internal_method() {
+    let context = &mut Context::default();
+
+    let o = context
+        .intrinsics()
+        .templates()
+        .ordinary_object()
+        .create(OrdinaryObject, Vec::default());
+
+    let property: PropertyKey = js_string!("prop").into();
+    let value = 100;
+
+    o.set(property.clone(), value, true, context)
+        .expect("should not fail");
+
+    let context = &mut InternalMethodContext::new(context);
+
+    assert_eq!(context.slot().index, 0);
+    assert_eq!(context.slot().attributes, SlotAttributes::empty());
+
+    o.__set__(property.clone(), value.into(), o.clone().into(), context)
+        .expect("should not fail");
+
+    assert!(
+        !context.slot().in_prototype(),
+        "Since it's an owned property, the prototype bit should not be set"
+    );
+
+    assert!(
+        context.slot().is_cachable(),
+        "Since it's an owned property, this should be cachable"
+    );
+
+    let shape = o.borrow().shape().clone();
+
+    let slot = shape.lookup(&property);
+
+    assert!(slot.is_some(), "the property should be found in the object");
+
+    let slot = slot.expect("the property should be found in the object");
+
+    assert_eq!(context.slot().index, slot.index);
+}
+
+fn get_codeblock(value: &JsValue) -> Option<(JsObject, Gc<CodeBlock>)> {
+    let object = value.as_object()?.clone();
+    let code = object.downcast_ref::<OrdinaryFunction>()?.code.clone();
+
+    Some((object, code))
+}
+
+#[test]
+fn set_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
+    let context = &mut Context::default();
+    let function = context.eval(Source::from_bytes("(function (o) { return o.test; })"))?;
+    let (function, code) = get_codeblock(&function).unwrap();
+
+    assert_eq!(code.ic.len(), 1);
+    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::None);
+
+    let o = ObjectInitializer::new(context)
+        .property(js_string!("test"), 0, Attribute::all())
+        .build();
+    let o_shape = o.borrow().shape().clone();
+
+    function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
+
+    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::from(&o_shape));
+
+    Ok(())
+}
+
+#[test]
+fn get_property_by_name_set_inline_cache_on_property_load() -> JsResult<()> {
+    let context = &mut Context::default();
+    let function = context.eval(Source::from_bytes("(function (o) { o.test = 30; })"))?;
+    let (function, code) = get_codeblock(&function).unwrap();
+
+    assert_eq!(code.ic.len(), 1);
+    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::None);
+
+    let o = ObjectInitializer::new(context)
+        .property(js_string!("test"), 0, Attribute::all())
+        .build();
+    let o_shape = o.borrow().shape().clone();
+
+    function.call(&JsValue::undefined(), &[o.clone().into()], context)?;
+
+    assert_eq!(code.ic[0].shape.borrow().clone(), WeakShape::from(&o_shape));
+
+    Ok(())
+}

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -19,12 +19,14 @@ use crate::sys::time::Instant;
 mod call_frame;
 mod code_block;
 mod completion_record;
+mod inline_cache;
 mod opcode;
-
 mod runtime_limits;
 
 #[cfg(feature = "flowgraph")]
 pub mod flowgraph;
+
+pub(crate) use inline_cache::InlineCache;
 
 // TODO: see if this can be exposed on all features.
 #[allow(unused_imports)]
@@ -39,7 +41,6 @@ pub(crate) use {
     call_frame::CallFrameFlags,
     code_block::{
         create_function_object, create_function_object_fast, CodeBlockFlags, Constant, Handler,
-        InlineCache,
     },
     completion_record::CompletionRecord,
     opcode::BindingOpcode,

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -23,45 +23,38 @@ impl GetPropertyByName {
         };
 
         let ic = &context.vm.frame().code_block().ic[index];
-        let mut slot = ic.slot();
-        if slot.is_cachable() {
-            let object_borrowed = object.borrow();
-            if ic.matches(object_borrowed.shape()) {
-                let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
-                    let prototype = object
-                        .borrow()
-                        .properties()
-                        .shape
-                        .prototype()
-                        .expect("prototype should have value");
-                    let prototype = prototype.borrow();
-                    prototype.properties().storage[slot.index as usize].clone()
-                } else {
-                    object_borrowed.properties().storage[slot.index as usize].clone()
-                };
+        let object_borrowed = object.borrow();
+        if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+            let mut result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
+                let prototype = shape.prototype().expect("prototype should have value");
+                let prototype = prototype.borrow();
+                prototype.properties().storage[slot.index as usize].clone()
+            } else {
+                object_borrowed.properties().storage[slot.index as usize].clone()
+            };
 
-                drop(object_borrowed);
-                if slot.attributes.has_get() && result.is_object() {
-                    result = result.as_object().expect("should contain getter").call(
-                        &receiver,
-                        &[],
-                        context,
-                    )?;
-                }
-                context.vm.push(result);
-                return Ok(CompletionType::Normal);
+            drop(object_borrowed);
+            if slot.attributes.has_get() && result.is_object() {
+                result = result.as_object().expect("should contain getter").call(
+                    &receiver,
+                    &[],
+                    context,
+                )?;
             }
+            context.vm.push(result);
+            return Ok(CompletionType::Normal);
         }
+
+        drop(object_borrowed);
 
         let key: PropertyKey = ic.name.clone().into();
 
         let context = &mut InternalMethodContext::new(context);
         let result = object.__get__(&key, receiver, context)?;
 
-        slot = *context.slot();
-
         // Cache the property.
-        if slot.attributes.is_cachable() {
+        let slot = *context.slot();
+        if slot.is_cachable() {
             let ic = &context.vm.frame().code_block.ic[index];
             let object_borrowed = object.borrow();
             let shape = object_borrowed.shape();

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -27,52 +27,43 @@ impl SetPropertyByName {
         };
 
         let ic = &context.vm.frame().code_block().ic[index];
-        let mut slot = ic.slot();
-        if slot.is_cachable() {
-            let object_borrowed = object.borrow();
-            if ic.matches(object_borrowed.shape()) {
-                let slot_index = slot.index as usize;
 
-                if slot.attributes.is_accessor_descriptor() {
-                    let result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
-                        let prototype = object_borrowed
-                            .properties()
-                            .shape
-                            .prototype()
-                            .expect("prototype should have value");
-                        let prototype = prototype.borrow();
+        let object_borrowed = object.borrow();
+        if let Some((shape, slot)) = ic.match_or_reset(object_borrowed.shape()) {
+            let slot_index = slot.index as usize;
 
-                        prototype.properties().storage[slot_index + 1].clone()
-                    } else {
-                        object_borrowed.properties().storage[slot_index + 1].clone()
-                    };
+            if slot.attributes.is_accessor_descriptor() {
+                let result = if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
+                    let prototype = shape.prototype().expect("prototype should have value");
+                    let prototype = prototype.borrow();
 
-                    drop(object_borrowed);
-                    if slot.attributes.has_set() && result.is_object() {
-                        result.as_object().expect("should contain getter").call(
-                            &receiver,
-                            &[value.clone()],
-                            context,
-                        )?;
-                    }
-                } else if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
-                    let prototype = object_borrowed
-                        .properties()
-                        .shape
-                        .prototype()
-                        .expect("prototype should have value");
-                    let mut prototype = prototype.borrow_mut();
-
-                    prototype.properties_mut().storage[slot_index] = value.clone();
+                    prototype.properties().storage[slot_index + 1].clone()
                 } else {
-                    drop(object_borrowed);
-                    let mut object_borrowed = object.borrow_mut();
-                    object_borrowed.properties_mut().storage[slot_index] = value.clone();
+                    object_borrowed.properties().storage[slot_index + 1].clone()
+                };
+
+                drop(object_borrowed);
+                if slot.attributes.has_set() && result.is_object() {
+                    result.as_object().expect("should contain getter").call(
+                        &receiver,
+                        &[value.clone()],
+                        context,
+                    )?;
                 }
-                context.vm.push(value);
-                return Ok(CompletionType::Normal);
+            } else if slot.attributes.contains(SlotAttributes::PROTOTYPE) {
+                let prototype = shape.prototype().expect("prototype should have value");
+                let mut prototype = prototype.borrow_mut();
+
+                prototype.properties_mut().storage[slot_index] = value.clone();
+            } else {
+                drop(object_borrowed);
+                let mut object_borrowed = object.borrow_mut();
+                object_borrowed.properties_mut().storage[slot_index] = value.clone();
             }
+            context.vm.push(value);
+            return Ok(CompletionType::Normal);
         }
+        drop(object_borrowed);
 
         let name: PropertyKey = ic.name.clone().into();
 
@@ -84,9 +75,8 @@ impl SetPropertyByName {
                 .into());
         }
 
-        slot = *context.slot();
-
         // Cache the property.
+        let slot = *context.slot();
         if succeeded && slot.is_cachable() {
             let ic = &context.vm.frame().code_block.ic[index];
             let object_borrowed = object.borrow();


### PR DESCRIPTION
It changes the following:

- Implements some tests for internal method inline chaching
- Test object internal methods
- Test `Get` and `Set` inline caching opcodes
- Cleanup