### PR TITLE
Temporal Parser Cleanup/Fixes

### DIFF
--- a/core/temporal/src/components/month_day.rs
+++ b/core/temporal/src/components/month_day.rs
@@ -1,10 +1,12 @@
 //! This module implements `MonthDay` and any directly related algorithms.
 
+use std::str::FromStr;
+
 use crate::{
     components::calendar::CalendarSlot,
     iso::{IsoDate, IsoDateSlots},
     options::ArithmeticOverflow,
-    TemporalResult,
+    TemporalError, TemporalResult,
 };
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
@@ -34,6 +36,18 @@ impl MonthDay {
         Ok(Self::new_unchecked(iso, calendar))
     }
 
+    /// Returns the `month` value of `MonthDay`.
+    #[must_use]
+    pub fn month(&self) -> u8 {
+        self.iso.month()
+    }
+
+    /// Returns the `day` value of `MonthDay`.
+    #[must_use]
+    pub fn day(&self) -> u8 {
+        self.iso.day()
+    }
+
     #[inline]
     #[must_use]
     /// Returns a reference to `MonthDay`'s `CalendarSlot`
@@ -47,5 +61,22 @@ impl IsoDateSlots for MonthDay {
     /// Returns this structs `IsoDate`.
     fn iso_date(&self) -> IsoDate {
         self.iso
+    }
+}
+
+impl FromStr for MonthDay {
+    type Err = TemporalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let record = crate::parser::parse_month_day(s)?;
+
+        let calendar = record.calendar.unwrap_or("iso8601".into());
+
+        Self::new(
+            record.date.month,
+            record.date.day,
+            CalendarSlot::Identifier(calendar),
+            ArithmeticOverflow::Reject,
+        )
     }
 }

--- a/core/temporal/src/components/month_day.rs
+++ b/core/temporal/src/components/month_day.rs
@@ -24,8 +24,8 @@ impl MonthDay {
         Self { iso, calendar }
     }
 
-    #[inline]
     /// Creates a new valid `MonthDay`.
+    #[inline]
     pub fn new(
         month: i32,
         day: i32,
@@ -37,20 +37,22 @@ impl MonthDay {
     }
 
     /// Returns the `month` value of `MonthDay`.
+    #[inline]
     #[must_use]
     pub fn month(&self) -> u8 {
         self.iso.month()
     }
 
     /// Returns the `day` value of `MonthDay`.
+    #[inline]
     #[must_use]
     pub fn day(&self) -> u8 {
         self.iso.day()
     }
 
+    /// Returns a reference to `MonthDay`'s `CalendarSlot`
     #[inline]
     #[must_use]
-    /// Returns a reference to `MonthDay`'s `CalendarSlot`
     pub fn calendar(&self) -> &CalendarSlot {
         &self.calendar
     }

--- a/core/temporal/src/components/year_month.rs
+++ b/core/temporal/src/components/year_month.rs
@@ -1,10 +1,12 @@
 //! This module implements `YearMonth` and any directly related algorithms.
 
+use std::str::FromStr;
+
 use crate::{
     components::calendar::CalendarSlot,
     iso::{IsoDate, IsoDateSlots},
     options::ArithmeticOverflow,
-    TemporalResult,
+    TemporalError, TemporalResult,
 };
 
 /// The native Rust implementation of `Temporal.YearMonth`.
@@ -36,6 +38,18 @@ impl YearMonth {
         Ok(Self::new_unchecked(iso, calendar))
     }
 
+    /// Returns the `year` value for this `YearMonth`.
+    #[must_use]
+    pub fn year(&self) -> i32 {
+        self.iso.year()
+    }
+
+    /// Returns the `month` value for this `YearMonth`.
+    #[must_use]
+    pub fn month(&self) -> u8 {
+        self.iso.month()
+    }
+
     #[inline]
     #[must_use]
     /// Returns a reference to `YearMonth`'s `CalendarSlot`
@@ -49,5 +63,23 @@ impl IsoDateSlots for YearMonth {
     /// Returns this `YearMonth`'s `IsoDate`
     fn iso_date(&self) -> IsoDate {
         self.iso
+    }
+}
+
+impl FromStr for YearMonth {
+    type Err = TemporalError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let record = crate::parser::parse_year_month(s)?;
+
+        let calendar = record.calendar.unwrap_or("iso8601".into());
+
+        Self::new(
+            record.date.year,
+            record.date.month,
+            None,
+            CalendarSlot::Identifier(calendar),
+            ArithmeticOverflow::Reject,
+        )
     }
 }

--- a/core/temporal/src/components/year_month.rs
+++ b/core/temporal/src/components/year_month.rs
@@ -39,12 +39,14 @@ impl YearMonth {
     }
 
     /// Returns the `year` value for this `YearMonth`.
+    #[inline]
     #[must_use]
     pub fn year(&self) -> i32 {
         self.iso.year()
     }
 
     /// Returns the `month` value for this `YearMonth`.
+    #[inline]
     #[must_use]
     pub fn month(&self) -> u8 {
         self.iso.month()

--- a/core/temporal/src/parser/annotations.rs
+++ b/core/temporal/src/parser/annotations.rs
@@ -1,5 +1,6 @@
 /// Parsing for Temporal's `Annotations`.
 use crate::{
+    assert_syntax,
     parser::{
         grammar::{
             is_a_key_char, is_a_key_leading_char, is_annotation_close,
@@ -38,10 +39,11 @@ pub(crate) fn parse_annotation_set(
 ) -> TemporalResult<AnnotationSet> {
     // Parse the first annotation.
     let tz_annotation = time_zone::parse_ambiguous_tz_annotation(cursor)?;
-
-    if tz_annotation.is_none() && zoned {
-        return Err(TemporalError::syntax()
-            .with_message("iso8601 ZonedDateTime requires a TimeZoneAnnotation."));
+    if zoned {
+        assert_syntax!(
+            tz_annotation.is_some(),
+            "TimeZone annotation must exist for ZonedDateTime."
+        );
     }
 
     // Parse any `Annotations`
@@ -97,32 +99,27 @@ pub(crate) fn parse_annotations(cursor: &mut Cursor) -> TemporalResult<Recognize
 
 /// Parse an annotation with an `AnnotationKey`=`AnnotationValue` pair.
 fn parse_kv_annotation(cursor: &mut Cursor) -> TemporalResult<KeyValueAnnotation> {
-    debug_assert!(cursor.check_or(false, is_annotation_open));
+    assert_syntax!(
+        is_annotation_open(cursor.abrupt_next()?),
+        "Invalid annotation open character."
+    );
 
-    let potential_critical = cursor.next().ok_or_else(TemporalError::abrupt_end)?;
-    let (leading_char, critical) = if is_critical_flag(potential_critical) {
-        (cursor.next().ok_or_else(TemporalError::abrupt_end)?, true)
-    } else {
-        (potential_critical, false)
-    };
-
-    if !is_a_key_leading_char(leading_char) {
-        return Err(TemporalError::syntax().with_message("Invalid AnnotationKey leading character"));
-    }
+    let critical = cursor.check_or(false, is_critical_flag);
+    cursor.advance_if(critical);
 
     // Parse AnnotationKey.
     let annotation_key = parse_annotation_key(cursor)?;
-
-    debug_assert!(cursor.check_or(false, is_annotation_key_value_separator));
-    // Advance past the '=' character.
-    cursor.advance();
+    assert_syntax!(
+        is_annotation_key_value_separator(cursor.abrupt_next()?),
+        "Invalid annotation key-value separator"
+    );
 
     // Parse AnnotationValue.
     let annotation_value = parse_annotation_value(cursor)?;
-
-    // Assert that we are at the annotation close and advance cursor past annotation to close.
-    debug_assert!(cursor.check_or(false, is_annotation_close));
-    cursor.advance();
+    assert_syntax!(
+        is_annotation_close(cursor.abrupt_next()?),
+        "Invalid annotion closing character"
+    );
 
     Ok(KeyValueAnnotation {
         key: annotation_key,
@@ -134,16 +131,22 @@ fn parse_kv_annotation(cursor: &mut Cursor) -> TemporalResult<KeyValueAnnotation
 /// Parse an `AnnotationKey`.
 fn parse_annotation_key(cursor: &mut Cursor) -> TemporalResult<String> {
     let key_start = cursor.pos();
+    assert_syntax!(
+        is_a_key_leading_char(cursor.abrupt_next()?),
+        "Invalid key leading character."
+    );
+
     while let Some(potential_key_char) = cursor.next() {
         // End of key.
-        if is_annotation_key_value_separator(potential_key_char) {
+        if cursor.check_or(false, is_annotation_key_value_separator) {
             // Return found key
             return Ok(cursor.slice(key_start, cursor.pos()));
         }
 
-        if !is_a_key_char(potential_key_char) {
-            return Err(TemporalError::syntax().with_message("Invalid AnnotationKey Character"));
-        }
+        assert_syntax!(
+            is_a_key_char(potential_key_char),
+            "Invalid annotation key character."
+        );
     }
 
     Err(TemporalError::abrupt_end())
@@ -152,29 +155,26 @@ fn parse_annotation_key(cursor: &mut Cursor) -> TemporalResult<String> {
 /// Parse an `AnnotationValue`.
 fn parse_annotation_value(cursor: &mut Cursor) -> TemporalResult<String> {
     let value_start = cursor.pos();
+    cursor.advance();
     while let Some(potential_value_char) = cursor.next() {
-        if is_annotation_close(potential_value_char) {
+        if cursor.check_or(false, is_annotation_close) {
             // Return the determined AnnotationValue.
             return Ok(cursor.slice(value_start, cursor.pos()));
         }
 
         if is_hyphen(potential_value_char) {
-            if !cursor
-                .peek_n(1)
-                .map_or(false, is_annotation_value_component)
-            {
-                return Err(TemporalError::syntax()
-                    .with_message("Missing AttributeValueComponent after '-'"));
-            }
+            assert_syntax!(
+                cursor.peek().map_or(false, is_annotation_value_component),
+                "Missing annotation value compoenent after '-'"
+            );
             cursor.advance();
             continue;
         }
 
-        if !is_annotation_value_component(potential_value_char) {
-            return Err(
-                TemporalError::syntax().with_message("Invalid character in AnnotationValue")
-            );
-        }
+        assert_syntax!(
+            is_annotation_value_component(potential_value_char),
+            "Invalid annotation value component character."
+        );
     }
 
     Err(TemporalError::abrupt_end())

--- a/core/temporal/src/parser/annotations.rs
+++ b/core/temporal/src/parser/annotations.rs
@@ -39,10 +39,9 @@ pub(crate) fn parse_annotation_set(
 ) -> TemporalResult<AnnotationSet> {
     // Parse the first annotation.
     let tz_annotation = time_zone::parse_ambiguous_tz_annotation(cursor)?;
-    if zoned {
-        assert_syntax!(
-            tz_annotation.is_some(),
-            "TimeZone annotation must exist for ZonedDateTime."
+    if tz_annotation.is_none() && zoned {
+        return Err(
+            TemporalError::syntax().with_message("ZonedDateTime must have a TimeZone annotation.")
         );
     }
 

--- a/core/temporal/src/parser/datetime.rs
+++ b/core/temporal/src/parser/datetime.rs
@@ -1,6 +1,7 @@
 //! Parsing for Temporal's ISO8601 `Date` and `DateTime`.
 
 use crate::{
+    assert_syntax,
     parser::{
         annotations,
         grammar::{is_date_time_separator, is_sign, is_utc_designator},
@@ -67,12 +68,13 @@ pub(crate) fn parse_annotated_date_time(
 
     // Peek Annotation presence
     // Throw error if annotation does not exist and zoned is true, else return.
-    let annotation_check = cursor.check_or(false, is_annotation_open);
-    if !annotation_check {
+    if !cursor.check_or(false, is_annotation_open) {
         if flags.contains(DateTimeFlags::ZONED) {
             return Err(TemporalError::syntax()
                 .with_message("ZonedDateTime must have a TimeZoneAnnotation."));
         }
+
+        cursor.close()?;
 
         return Ok(IsoParseRecord {
             date: date_time.date,
@@ -100,6 +102,8 @@ pub(crate) fn parse_annotated_date_time(
     } else {
         None
     };
+
+    cursor.close()?;
 
     Ok(IsoParseRecord {
         date: date_time.date,
@@ -134,10 +138,7 @@ fn parse_date_time(
 
     let time = time::parse_time_spec(cursor)?;
 
-    let time_zone = if cursor
-        .check(|ch| is_sign(ch) || is_utc_designator(ch))
-        .unwrap_or(false)
-    {
+    let time_zone = if cursor.check_or(false, |ch| is_sign(ch) || is_utc_designator(ch)) {
         Some(time_zone::parse_date_time_utc(cursor)?)
     } else {
         if utc_required {
@@ -156,93 +157,35 @@ fn parse_date_time(
 /// Parses `Date` record.
 fn parse_date(cursor: &mut Cursor) -> TemporalResult<DateRecord> {
     let year = parse_date_year(cursor)?;
-    let divided = cursor
+    let hyphenated = cursor
         .check(is_hyphen)
         .ok_or_else(TemporalError::abrupt_end)?;
 
-    if divided {
-        cursor.advance();
-    }
+    cursor.advance_if(hyphenated);
 
     let month = parse_date_month(cursor)?;
 
-    if cursor.check_or(false, is_hyphen) {
-        if !divided {
-            return Err(TemporalError::syntax().with_message("Invalid date separator"));
-        }
-        cursor.advance();
+    if hyphenated {
+        assert_syntax!(cursor.check_or(false, is_hyphen), "Invalid hyphen usage.");
     }
+    cursor.advance_if(cursor.check_or(false, is_hyphen));
 
     let day = parse_date_day(cursor)?;
 
     Ok(DateRecord { year, month, day })
 }
 
-/// Determines if the string can be parsed as a `DateSpecYearMonth`.
-pub(crate) fn peek_year_month(cursor: &Cursor) -> TemporalResult<bool> {
-    let mut ym_peek = if is_sign(cursor.peek().ok_or_else(TemporalError::abrupt_end)?) {
-        7
-    } else {
-        4
-    };
-
-    if cursor
-        .peek_n(ym_peek)
-        .map(is_hyphen)
-        .ok_or_else(TemporalError::abrupt_end)?
-    {
-        ym_peek += 1;
-    }
-
-    ym_peek += 2;
-
-    if cursor.peek_n(ym_peek).map_or(true, is_annotation_open) {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
-}
+// ==== `YearMonth` and `MonthDay` parsing functions ====
 
 /// Parses a `DateSpecYearMonth`
 pub(crate) fn parse_year_month(cursor: &mut Cursor) -> TemporalResult<(i32, i32)> {
     let year = parse_date_year(cursor)?;
 
-    if cursor.check_or(false, is_hyphen) {
-        cursor.advance();
-    }
+    cursor.advance_if(cursor.check_or(false, is_hyphen));
 
     let month = parse_date_month(cursor)?;
 
     Ok((year, month))
-}
-
-/// Determines if the string can be parsed as a `DateSpecYearMonth`.
-pub(crate) fn peek_month_day(cursor: &Cursor) -> TemporalResult<bool> {
-    let mut md_peek = if cursor
-        .peek_n(1)
-        .map(is_hyphen)
-        .ok_or_else(TemporalError::abrupt_end)?
-    {
-        4
-    } else {
-        2
-    };
-
-    if cursor
-        .peek_n(md_peek)
-        .map(is_hyphen)
-        .ok_or_else(TemporalError::abrupt_end)?
-    {
-        md_peek += 1;
-    }
-
-    md_peek += 2;
-
-    if cursor.peek_n(md_peek).map_or(true, is_annotation_open) {
-        Ok(true)
-    } else {
-        Ok(false)
-    }
 }
 
 /// Parses a `DateSpecMonthDay`
@@ -251,7 +194,7 @@ pub(crate) fn parse_month_day(cursor: &mut Cursor) -> TemporalResult<(i32, i32)>
         .check(is_hyphen)
         .ok_or_else(TemporalError::abrupt_end)?;
     let dash_two = cursor
-        .peek_n(1)
+        .peek()
         .map(is_hyphen)
         .ok_or_else(TemporalError::abrupt_end)?;
 
@@ -262,9 +205,8 @@ pub(crate) fn parse_month_day(cursor: &mut Cursor) -> TemporalResult<(i32, i32)>
     }
 
     let month = parse_date_month(cursor)?;
-    if cursor.check_or(false, is_hyphen) {
-        cursor.advance();
-    }
+
+    cursor.advance_if(cursor.check_or(false, is_hyphen));
 
     let day = parse_date_day(cursor)?;
 
@@ -274,26 +216,20 @@ pub(crate) fn parse_month_day(cursor: &mut Cursor) -> TemporalResult<(i32, i32)>
 // ==== Unit Parsers ====
 
 fn parse_date_year(cursor: &mut Cursor) -> TemporalResult<i32> {
-    if is_sign(cursor.peek().ok_or_else(TemporalError::abrupt_end)?) {
+    if cursor.check_or(false, is_sign) {
+        let sign = if cursor.expect_next() == '+' { 1 } else { -1 };
         let year_start = cursor.pos();
-        let sign = if cursor.check_or(false, |ch| ch == '+') {
-            1
-        } else {
-            -1
-        };
-
-        cursor.advance();
 
         for _ in 0..6 {
-            let year_digit = cursor.peek().ok_or_else(TemporalError::abrupt_end)?;
-            if !year_digit.is_ascii_digit() {
-                return Err(TemporalError::syntax().with_message("DateYear must contain digit"));
-            }
-            cursor.advance();
+            let year_digit = cursor.abrupt_next()?;
+            assert_syntax!(
+                year_digit.is_ascii_digit(),
+                "Year must be made up of digits."
+            );
         }
 
-        let year_string = cursor.slice(year_start + 1, cursor.pos());
-        let year_value = year_string
+        let year_value = cursor
+            .slice(year_start, cursor.pos())
             .parse::<i32>()
             .map_err(|e| TemporalError::syntax().with_message(e.to_string()))?;
 
@@ -304,21 +240,28 @@ fn parse_date_year(cursor: &mut Cursor) -> TemporalResult<i32> {
             return Err(TemporalError::syntax().with_message("Cannot have negative 0 years."));
         }
 
-        return Ok(sign * year_value);
+        let year = sign * year_value;
+
+        if !(-271_820..=275_760).contains(&year) {
+            return Err(TemporalError::range()
+                .with_message("Year is outside of the minimum supported range."));
+        }
+
+        return Ok(year);
     }
 
     let year_start = cursor.pos();
 
     for _ in 0..4 {
-        let year_digit = cursor.peek().ok_or_else(TemporalError::abrupt_end)?;
-        if !year_digit.is_ascii_digit() {
-            return Err(TemporalError::syntax().with_message("DateYear must contain digit"));
-        }
-        cursor.advance();
+        let year_digit = cursor.abrupt_next()?;
+        assert_syntax!(
+            year_digit.is_ascii_digit(),
+            "Year must be made up of digits."
+        );
     }
 
-    let year_string = cursor.slice(year_start, cursor.pos());
-    let year_value = year_string
+    let year_value = cursor
+        .slice(year_start, cursor.pos())
         .parse::<i32>()
         .map_err(|e| TemporalError::syntax().with_message(e.to_string()))?;
 
@@ -326,25 +269,33 @@ fn parse_date_year(cursor: &mut Cursor) -> TemporalResult<i32> {
 }
 
 fn parse_date_month(cursor: &mut Cursor) -> TemporalResult<i32> {
+    let start = cursor.pos();
+    for _ in 0..2 {
+        let digit = cursor.abrupt_next()?;
+        assert_syntax!(digit.is_ascii_digit(), "Month must be a digit");
+    }
     let month_value = cursor
-        .slice(cursor.pos(), cursor.pos() + 2)
+        .slice(start, cursor.pos())
         .parse::<i32>()
         .map_err(|e| TemporalError::syntax().with_message(e.to_string()))?;
     if !(1..=12).contains(&month_value) {
         return Err(TemporalError::syntax().with_message("DateMonth must be in a range of 1-12"));
     }
-    cursor.advance_n(2);
     Ok(month_value)
 }
 
 fn parse_date_day(cursor: &mut Cursor) -> TemporalResult<i32> {
+    let start = cursor.pos();
+    for _ in 0..2 {
+        let digit = cursor.abrupt_next()?;
+        assert_syntax!(digit.is_ascii_digit(), "Date must be a digit");
+    }
     let day_value = cursor
-        .slice(cursor.pos(), cursor.pos() + 2)
+        .slice(start, cursor.pos())
         .parse::<i32>()
         .map_err(|e| TemporalError::syntax().with_message(e.to_string()))?;
     if !(1..=31).contains(&day_value) {
         return Err(TemporalError::syntax().with_message("DateDay must be in a range of 1-31"));
     }
-    cursor.advance_n(2);
     Ok(day_value)
 }

--- a/core/temporal/src/parser/datetime.rs
+++ b/core/temporal/src/parser/datetime.rs
@@ -185,6 +185,11 @@ pub(crate) fn parse_year_month(cursor: &mut Cursor) -> TemporalResult<(i32, i32)
 
     let month = parse_date_month(cursor)?;
 
+    assert_syntax!(
+        cursor.check_or(true, is_annotation_open),
+        "Expected an end or AnnotationOpen"
+    );
+
     Ok((year, month))
 }
 
@@ -209,6 +214,11 @@ pub(crate) fn parse_month_day(cursor: &mut Cursor) -> TemporalResult<(i32, i32)>
     cursor.advance_if(cursor.check_or(false, is_hyphen));
 
     let day = parse_date_day(cursor)?;
+
+    assert_syntax!(
+        cursor.check_or(true, is_annotation_open),
+        "Expected an end or AnnotationOpen"
+    );
 
     Ok((month, day))
 }

--- a/core/temporal/src/parser/mod.rs
+++ b/core/temporal/src/parser/mod.rs
@@ -47,7 +47,6 @@ pub(crate) fn parse_instant(target: &str) -> TemporalResult<IsoParseRecord> {
 }
 
 /// A utility function for parsing a `YearMonth` string
-#[allow(unused)]
 pub(crate) fn parse_year_month(target: &str) -> TemporalResult<IsoParseRecord> {
     let mut cursor = Cursor::new(target);
     let ym = datetime::parse_year_month(&mut cursor);
@@ -82,7 +81,6 @@ pub(crate) fn parse_year_month(target: &str) -> TemporalResult<IsoParseRecord> {
 }
 
 /// A utilty function for parsing a `MonthDay` String.
-#[allow(unused)]
 pub(crate) fn parse_month_day(target: &str) -> TemporalResult<IsoParseRecord> {
     let mut cursor = Cursor::new(target);
     let md = datetime::parse_month_day(&mut cursor);

--- a/core/temporal/src/parser/mod.rs
+++ b/core/temporal/src/parser/mod.rs
@@ -22,7 +22,7 @@ mod tests;
 // TODO: optimize where possible.
 
 /// `assert_syntax!` is a parser specific utility macro for asserting a syntax test, and returning a
-/// the provided message if the test fails.
+/// `SyntaxError` with the provided message if the test fails.
 #[macro_export]
 macro_rules! assert_syntax {
     ($cond:expr, $msg:literal) => {
@@ -53,10 +53,7 @@ pub(crate) fn parse_year_month(target: &str) -> TemporalResult<IsoParseRecord> {
 
     let Ok(year_month) = ym else {
         cursor.pos = 0;
-        return datetime::parse_annotated_date_time(
-            DateTimeFlags::empty(),
-            &mut Cursor::new(target),
-        );
+        return datetime::parse_annotated_date_time(DateTimeFlags::empty(), &mut cursor);
     };
 
     let calendar = if cursor.check_or(false, is_annotation_open) {

--- a/core/temporal/src/parser/tests.rs
+++ b/core/temporal/src/parser/tests.rs
@@ -222,6 +222,6 @@ fn temporal_invalid_iso_datetime_strings() {
 
     for invalid_target in INVALID_DATETIME_STRINGS {
         let error_result = invalid_target.parse::<DateTime>();
-        assert!(error_result.is_err())
+        assert!(error_result.is_err());
     }
 }

--- a/core/temporal/src/parser/tests.rs
+++ b/core/temporal/src/parser/tests.rs
@@ -53,7 +53,10 @@ fn temporal_year_parsing() {
     assert_eq!(result_good.iso_date().year(), 2020);
 
     let err_result = bad_year.parse::<DateTime>();
-    assert!(err_result.is_err());
+    assert!(
+        err_result.is_err(),
+        "Invalid extended year parsing: \"{bad_year}\" should fail to parse."
+    );
 }
 
 #[test]
@@ -83,6 +86,7 @@ fn temporal_year_month() {
         "2020-11[u-ca=iso8601]",
         "+00202011",
         "202011[u-ca=iso8601]",
+        "+002020-11-07T12:28:32[!u-ca=iso8601]",
     ];
 
     for ym in possible_year_months {
@@ -95,7 +99,13 @@ fn temporal_year_month() {
 
 #[test]
 fn temporal_month_day() {
-    let possible_month_day = ["11-07", "1107[+04:00]", "--11-07", "--1107[+04:00]"];
+    let possible_month_day = [
+        "11-07",
+        "1107[+04:00]",
+        "--11-07",
+        "--1107[+04:00]",
+        "+002020-11-07T12:28:32[!u-ca=iso8601]",
+    ];
 
     for md in possible_month_day {
         let result = md.parse::<MonthDay>().unwrap();
@@ -115,7 +125,10 @@ fn temporal_invalid_annotations() {
 
     for invalid in invalid_annotations {
         let err_result = invalid.parse::<MonthDay>();
-        assert!(err_result.is_err());
+        assert!(
+            err_result.is_err(),
+            "Invalid ISO annotation parsing: \"{invalid}\" should fail parsing."
+        );
     }
 }
 
@@ -146,7 +159,10 @@ fn temporal_duration_parsing() {
 
     for dur in durations {
         let ok_result = Duration::from_str(dur);
-        assert!(ok_result.is_ok());
+        assert!(
+            ok_result.is_ok(),
+            "Failing to parse a valid ISO 8601 target: \"{dur}\" should pass."
+        );
     }
 
     let sub_second = durations[2].parse::<Duration>().unwrap();
@@ -173,7 +189,10 @@ fn temporal_invalid_durations() {
 
     for test in invalids {
         let err = test.parse::<Duration>();
-        assert!(err.is_err());
+        assert!(
+            err.is_err(),
+            "Invalid ISO8601 Duration target: \"{test}\" should fail duration parsing."
+        );
     }
 }
 
@@ -222,6 +241,9 @@ fn temporal_invalid_iso_datetime_strings() {
 
     for invalid_target in INVALID_DATETIME_STRINGS {
         let error_result = invalid_target.parse::<DateTime>();
-        assert!(error_result.is_err());
+        assert!(
+            error_result.is_err(),
+            "Invalid ISO8601 `DateTime` target: \"{invalid_target}\" should fail parsing."
+        );
     }
 }

--- a/core/temporal/src/parser/tests.rs
+++ b/core/temporal/src/parser/tests.rs
@@ -1,11 +1,8 @@
 use std::str::FromStr;
 
 use crate::{
-    components::{DateTime, Duration},
-    parser::{
-        parse_date_time, Cursor, TemporalInstantString, TemporalMonthDayString,
-        TemporalYearMonthString,
-    },
+    components::{DateTime, Duration, MonthDay, YearMonth},
+    parser::{parse_date_time, Cursor, TemporalInstantString},
 };
 
 #[test]
@@ -81,7 +78,7 @@ fn temporal_annotated_date_time() {
 
 #[test]
 fn temporal_year_month() {
-    let possible_year_months = &[
+    let possible_year_months = [
         "+002020-11",
         "2020-11[u-ca=iso8601]",
         "+00202011",
@@ -89,14 +86,10 @@ fn temporal_year_month() {
     ];
 
     for ym in possible_year_months {
-        let result = TemporalYearMonthString::parse(&mut Cursor::new(ym)).unwrap();
+        let result = ym.parse::<YearMonth>().unwrap();
 
-        assert_eq!(result.year, 2020);
-        assert_eq!(result.month, 11);
-
-        if let Some(calendar) = result.calendar {
-            assert_eq!(calendar, "iso8601");
-        }
+        assert_eq!(result.year(), 2020);
+        assert_eq!(result.month(), 11);
     }
 }
 
@@ -105,10 +98,10 @@ fn temporal_month_day() {
     let possible_month_day = ["11-07", "1107[+04:00]", "--11-07", "--1107[+04:00]"];
 
     for md in possible_month_day {
-        let result = TemporalMonthDayString::parse(&mut Cursor::new(md)).unwrap();
+        let result = md.parse::<MonthDay>().unwrap();
 
-        assert_eq!(result.month, 11);
-        assert_eq!(result.day, 7);
+        assert_eq!(result.month(), 11);
+        assert_eq!(result.day(), 7);
     }
 }
 
@@ -121,7 +114,7 @@ fn temporal_invalid_annotations() {
     ];
 
     for invalid in invalid_annotations {
-        let err_result = TemporalMonthDayString::parse(&mut Cursor::new(invalid));
+        let err_result = invalid.parse::<MonthDay>();
         assert!(err_result.is_err());
     }
 }
@@ -181,5 +174,54 @@ fn temporal_invalid_durations() {
     for test in invalids {
         let err = test.parse::<Duration>();
         assert!(err.is_err());
+    }
+}
+
+#[test]
+fn temporal_invalid_iso_datetime_strings() {
+    // NOTE: The below tests were initially pulled from test262's `argument-string-invalid`
+    const INVALID_DATETIME_STRINGS: [&str; 34] = [
+        "", // 1
+        "invalid iso8601",
+        "2020-01-00",
+        "2020-01-32",
+        "2020-02-30",
+        "2021-02-29",
+        "2020-00-01",
+        "2020-13-01",
+        "2020-01-01T",
+        "2020-01-01T25:00:00",
+        "2020-01-01T01:60:00",
+        "2020-01-01T01:60:61",
+        "2020-01-01junk",
+        "2020-01-01T00:00:00junk",
+        "2020-01-01T00:00:00+00:00junk",
+        "2020-01-01T00:00:00+00:00[UTC]junk",
+        "2020-01-01T00:00:00+00:00[UTC][u-ca=iso8601]junk",
+        "02020-01-01",
+        "2020-001-01",
+        "2020-01-001",
+        "2020-01-01T001",
+        "2020-01-01T01:001",
+        "2020-01-01T01:01:001",
+        "2020-W01-1",
+        "2020-001",
+        "+0002020-01-01",
+        // TODO: Add the non-existent calendar test back to the test cases.
+        // may be valid in other contexts, but insufficient information for PlainDate:
+        "2020-01",
+        "+002020-01",
+        "01-01",
+        "2020-W01",
+        "P1Y",
+        "-P12Y",
+        // valid, but outside the supported range:
+        "-999999-01-01",
+        "+999999-01-01",
+    ];
+
+    for invalid_target in INVALID_DATETIME_STRINGS {
+        let error_result = invalid_target.parse::<DateTime>();
+        assert!(error_result.is_err())
     }
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR addresses some of the issues that was causing the parser to panic when running the test suite, along with some general cleanup of the parser.

It changes the following:

- Implements `FromStr` for `MonthDay` and `YearMonth` (also removes the ym and dm peeks)
- Attempts to clean up the general logic in the parser and adds some utility methods to the `Cursor`
- Adds a large amount of invalid `DateTime` parsing cases to the parser tests from `test262`.
