### PR TITLE
Move `PromiseCapability` to stack

### DIFF
--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -75,8 +75,8 @@ impl GeneratorContext {
         frame.rp = CallFrame::FUNCTION_PROLOGUE + frame.argument_count;
 
         // NOTE: Since we get a pre-built call frame with stack, and we reuse them.
-        //       So we don't need to push the locals in subsequent calls.
-        frame.flags |= CallFrameFlags::LOCALS_ALREADY_PUSHED;
+        //       So we don't need to push the registers in subsequent calls.
+        frame.flags |= CallFrameFlags::REGISTERS_ALREADY_PUSHED;
 
         Self {
             call_frame: Some(frame),

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -168,10 +168,10 @@ pub(crate) use if_abrupt_reject_promise;
 #[derive(Debug, Clone, Finalize)]
 pub(crate) struct PromiseCapability {
     /// The `[[Promise]]` field.
-    promise: JsObject,
+    pub(crate) promise: JsObject,
 
     /// The resolving functions,
-    functions: ResolvingFunctions,
+    pub(crate) functions: ResolvingFunctions,
 }
 
 // SAFETY: manually implementing `Trace` to allow destructuring.

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -1523,8 +1523,13 @@ impl<'ctx> ByteCompiler<'ctx> {
         }
         self.r#return(false);
 
-        if self.is_async_generator() {
-            self.locals_count += 1;
+        if self.is_async() {
+            // NOTE: +3 for the promise capability
+            self.locals_count += 3;
+            if self.is_generator() {
+                // NOTE: +1 for the async generator function
+                self.locals_count += 1;
+            }
         }
         for handler in &mut self.handlers {
             handler.stack_count += self.locals_count;

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -255,7 +255,7 @@ pub struct ByteCompiler<'ctx> {
     /// The number of arguments expected.
     pub(crate) length: u32,
 
-    pub(crate) locals_count: u32,
+    pub(crate) register_count: u32,
 
     /// \[\[ThisMode\]\]
     pub(crate) this_mode: ThisMode,
@@ -329,7 +329,7 @@ impl<'ctx> ByteCompiler<'ctx> {
             params: FormalParameterList::default(),
             current_open_environments_count: 0,
 
-            locals_count: 0,
+            register_count: 0,
             current_stack_value_count: 0,
             code_block_flags,
             handlers: ThinVec::default(),
@@ -1525,20 +1525,23 @@ impl<'ctx> ByteCompiler<'ctx> {
 
         if self.is_async() {
             // NOTE: +3 for the promise capability
-            self.locals_count += 3;
+            self.register_count += 3;
             if self.is_generator() {
                 // NOTE: +1 for the async generator function
-                self.locals_count += 1;
+                self.register_count += 1;
             }
         }
+
+        // NOTE: Offset the handlers stack count so we don't pop the registers
+        //       when a exception is thrown.
         for handler in &mut self.handlers {
-            handler.stack_count += self.locals_count;
+            handler.stack_count += self.register_count;
         }
 
         CodeBlock {
             name: self.function_name,
             length: self.length,
-            locals_count: self.locals_count,
+            register_count: self.register_count,
             this_mode: self.this_mode,
             params: self.params,
             bytecode: self.bytecode.into_boxed_slice(),

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -298,7 +298,7 @@ impl CallFrame {
         &stack[at as usize]
     }
 
-    /// Returns the local at the given index.
+    /// Sets the local at the given index.
     ///
     /// # Panics
     ///

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -3,9 +3,12 @@
 //! This module will provides everything needed to implement the `CallFrame`
 
 use crate::{
-    builtins::{iterable::IteratorRecord, promise::PromiseCapability},
+    builtins::{
+        iterable::IteratorRecord,
+        promise::{PromiseCapability, ResolvingFunctions},
+    },
     environments::{BindingLocator, EnvironmentStack},
-    object::JsObject,
+    object::{JsFunction, JsObject},
     realm::Realm,
     vm::CodeBlock,
     JsValue,
@@ -44,7 +47,6 @@ pub struct CallFrame {
     pub(crate) rp: u32,
     pub(crate) argument_count: u32,
     pub(crate) env_fp: u32,
-    pub(crate) promise_capability: Option<PromiseCapability>,
 
     // Iterators and their `[[Done]]` flags that must be closed when an abrupt completion is thrown.
     pub(crate) iterators: ThinVec<IteratorRecord>,
@@ -132,7 +134,10 @@ impl CallFrame {
     pub(crate) const FUNCTION_PROLOGUE: u32 = 2;
     pub(crate) const THIS_POSITION: u32 = 2;
     pub(crate) const FUNCTION_POSITION: u32 = 1;
-    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: u32 = 0;
+    pub(crate) const PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX: u32 = 0;
+    pub(crate) const PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX: u32 = 1;
+    pub(crate) const PROMISE_CAPABILITY_REJECT_REGISTER_INDEX: u32 = 2;
+    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: u32 = 3;
 
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
     pub(crate) fn new(
@@ -147,7 +152,6 @@ impl CallFrame {
             rp: 0,
             env_fp: 0,
             argument_count: 0,
-            promise_capability: None,
             iterators: ThinVec::new(),
             binding_stack: Vec::new(),
             loop_iteration_count: 0,
@@ -221,6 +225,68 @@ impl CallFrame {
             .cloned()
     }
 
+    pub(crate) fn promise_capability(&self, stack: &[JsValue]) -> Option<PromiseCapability> {
+        if !self.code_block().is_async() {
+            return None;
+        }
+
+        let promise = self
+            .local(Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX, stack)
+            .as_object()
+            .cloned()?;
+        let resolve = self
+            .local(Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX, stack)
+            .as_object()
+            .cloned()
+            .and_then(JsFunction::from_object)?;
+        let reject = self
+            .local(Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX, stack)
+            .as_object()
+            .cloned()
+            .and_then(JsFunction::from_object)?;
+
+        Some(PromiseCapability {
+            promise,
+            functions: ResolvingFunctions { resolve, reject },
+        })
+    }
+
+    pub(crate) fn set_promise_capability(
+        &self,
+        stack: &mut [JsValue],
+        promise_capability: Option<&PromiseCapability>,
+    ) {
+        debug_assert!(
+            self.code_block().is_async(),
+            "Only async functions have a promise capability"
+        );
+
+        self.set_local(
+            Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX,
+            promise_capability
+                .map(PromiseCapability::promise)
+                .cloned()
+                .map_or_else(JsValue::undefined, Into::into),
+            stack,
+        );
+        self.set_local(
+            Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX,
+            promise_capability
+                .map(PromiseCapability::resolve)
+                .cloned()
+                .map_or_else(JsValue::undefined, Into::into),
+            stack,
+        );
+        self.set_local(
+            Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX,
+            promise_capability
+                .map(PromiseCapability::reject)
+                .cloned()
+                .map_or_else(JsValue::undefined, Into::into),
+            stack,
+        );
+    }
+
     /// Returns the local at the given index.
     ///
     /// # Panics
@@ -230,6 +296,17 @@ impl CallFrame {
         debug_assert!(index < self.code_block().locals_count);
         let at = self.rp + index;
         &stack[at as usize]
+    }
+
+    /// Returns the local at the given index.
+    ///
+    /// # Panics
+    ///
+    /// If the index is out of bounds.
+    pub(crate) fn set_local(&self, index: u32, value: JsValue, stack: &mut [JsValue]) {
+        debug_assert!(index < self.code_block().locals_count);
+        let at = self.rp + index;
+        stack[at as usize] = value;
     }
 
     /// Does this have the [`CallFrameFlags::EXIT_EARLY`] flag.

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -177,7 +177,7 @@ pub struct CodeBlock {
     /// The number of arguments expected.
     pub(crate) length: u32,
 
-    pub(crate) locals_count: u32,
+    pub(crate) register_count: u32,
 
     /// \[\[ThisMode\]\]
     pub(crate) this_mode: ThisMode,
@@ -218,7 +218,7 @@ impl CodeBlock {
             name,
             flags: Cell::new(flags),
             length,
-            locals_count: 0,
+            register_count: 0,
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
             handlers: ThinVec::default(),

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -162,13 +162,13 @@ impl Vm {
         std::mem::swap(&mut self.environments, &mut frame.environments);
         std::mem::swap(&mut self.realm, &mut frame.realm);
 
-        // NOTE: We need to check if we already pushed the locals,
+        // NOTE: We need to check if we already pushed the registers,
         //       since generator-like functions push the same call
         //       frame with pre-built stack.
-        if !frame.locals_already_pushed() {
-            let locals_count = frame.code_block().locals_count;
+        if !frame.registers_already_pushed() {
+            let register_count = frame.code_block().register_count;
             self.stack.resize_with(
-                current_stack_length + locals_count as usize,
+                current_stack_length + register_count as usize,
                 JsValue::undefined,
             );
         }

--- a/core/engine/src/vm/opcode/generator/mod.rs
+++ b/core/engine/src/vm/opcode/generator/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     vm::{
         call_frame::GeneratorResumeKind,
         opcode::{Operation, ReThrow},
-        CompletionType,
+        CallFrame, CompletionType,
     },
     Context, JsError, JsObject, JsResult, JsValue,
 };
@@ -79,11 +79,12 @@ impl Operation for Generator {
         };
 
         if r#async {
-            let fp = frame
+            let rp = frame
                 .call_frame
                 .as_ref()
                 .map_or(0, |frame| frame.rp as usize);
-            frame.stack[fp] = generator.clone().into();
+            frame.stack[rp + CallFrame::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX as usize] =
+                generator.clone().into();
 
             let mut gen = generator
                 .downcast_mut::<AsyncGenerator>()


### PR DESCRIPTION
Depends on #3496 

Moves the promise capability to stack. Reduces call frame for non-async functions by 48 bytes.
