### PR TITLE
Add UTF-16 input parsing

### DIFF
--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -99,7 +99,7 @@ impl Eval {
 
         // 2. If Type(x) is not String, return x.
         // TODO: rework parser to take an iterator of `u32` unicode codepoints
-        let Some(x) = x.as_string().map(JsString::to_std_string_escaped) else {
+        let Some(x) = x.as_string() else {
             return Ok(x.clone());
         };
 
@@ -118,7 +118,7 @@ impl Eval {
         //     b. If script is a List of errors, throw a SyntaxError exception.
         //     c. If script Contains ScriptBody is false, return undefined.
         //     d. Let body be the ScriptBody of script.
-        let mut parser = Parser::new(Source::from_bytes(&x));
+        let mut parser = Parser::new(Source::from_utf16(x));
         parser.set_identifier(context.next_parser_identifier());
         if strict {
             parser.set_strict();

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -5,6 +5,7 @@ mod hooks;
 pub(crate) mod icu;
 pub mod intrinsics;
 
+use boa_parser::source::ReadChar;
 pub use hooks::{DefaultHooks, HostHooks};
 
 #[cfg(feature = "intl")]
@@ -14,7 +15,7 @@ use intrinsics::Intrinsics;
 
 #[cfg(not(feature = "intl"))]
 pub use std::marker::PhantomData;
-use std::{cell::Cell, io::Read, path::Path, rc::Rc};
+use std::{cell::Cell, path::Path, rc::Rc};
 
 use crate::{
     builtins,
@@ -185,7 +186,7 @@ impl Context {
     /// Note that this won't run any scheduled promise jobs; you need to call [`Context::run_jobs`]
     /// on the context or [`JobQueue::run_jobs`] on the provided queue to run them.
     #[allow(clippy::unit_arg, dropping_copy_types)]
-    pub fn eval<R: Read>(&mut self, src: Source<'_, R>) -> JsResult<JsValue> {
+    pub fn eval<R: ReadChar>(&mut self, src: Source<'_, R>) -> JsResult<JsValue> {
         let main_timer = Profiler::global().start_event("Script evaluation", "Main");
 
         let result = Script::parse(src, None, self)?.evaluate(self);

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -25,6 +25,7 @@ mod loader;
 mod namespace;
 mod source;
 mod synthetic;
+use boa_parser::source::ReadChar;
 pub use loader::*;
 pub use namespace::ModuleNamespace;
 use source::SourceTextModule;
@@ -33,7 +34,6 @@ pub use synthetic::{SyntheticModule, SyntheticModuleInitializer};
 use std::cell::{Cell, RefCell};
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::io::Read;
 use std::rc::Rc;
 
 use rustc_hash::FxHashSet;
@@ -141,7 +141,7 @@ impl Module {
     /// Parses the provided `src` as an ECMAScript module, returning an error if parsing fails.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parsemodule
-    pub fn parse<R: Read>(
+    pub fn parse<R: ReadChar>(
         src: Source<'_, R>,
         realm: Option<Realm>,
         context: &mut Context,

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -8,10 +8,8 @@
 //! [spec]: https://tc39.es/ecma262/#sec-scripts
 //! [script]: https://tc39.es/ecma262/#sec-script-records
 
-use std::io::Read;
-
 use boa_gc::{Finalize, Gc, GcRefCell, Trace};
-use boa_parser::{Parser, Source};
+use boa_parser::{source::ReadChar, Parser, Source};
 use boa_profiler::Profiler;
 use rustc_hash::FxHashMap;
 
@@ -76,7 +74,7 @@ impl Script {
     /// Parses the provided `src` as an ECMAScript script, returning an error if parsing fails.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-parse-script
-    pub fn parse<R: Read>(
+    pub fn parse<R: ReadChar>(
         src: Source<'_, R>,
         realm: Option<Realm>,
         context: &mut Context,

--- a/core/engine/src/tests/operators.rs
+++ b/core/engine/src/tests/operators.rs
@@ -334,7 +334,7 @@ fn assignment_to_non_assignable_ctd() {
             TestAction::assert_native_error(
                 src,
                 JsNativeErrorKind::Syntax,
-                "Invalid left-hand side in assignment at line 1, col 13",
+                "Invalid left-hand side in assignment at line 1, col 12",
             )
         }),
     );

--- a/core/engine/src/tests/operators.rs
+++ b/core/engine/src/tests/operators.rs
@@ -362,7 +362,7 @@ fn multicharacter_assignment_to_non_assignable_ctd() {
                 TestAction::assert_native_error(
                     src,
                     JsNativeErrorKind::Syntax,
-                    "Invalid left-hand side in assignment at line 1, col 13",
+                    "Invalid left-hand side in assignment at line 1, col 12",
                 )
             }),
     );
@@ -397,7 +397,7 @@ fn multicharacter_bitwise_assignment_to_non_assignable_ctd() {
             TestAction::assert_native_error(
                 src,
                 JsNativeErrorKind::Syntax,
-                "Invalid left-hand side in assignment at line 1, col 13",
+                "Invalid left-hand side in assignment at line 1, col 12",
             )
         }),
     );

--- a/core/parser/src/lexer/comment.rs
+++ b/core/parser/src/lexer/comment.rs
@@ -74,7 +74,7 @@ impl<R> Tokenizer<R> for MultiLineComment {
         while let Some(ch) = cursor.next_char()? {
             let tried_ch = char::try_from(ch);
             match tried_ch {
-                Ok(c) if c == '*' && cursor.next_is(b'/')? => {
+                Ok(c) if c == '*' && cursor.next_if(0x2F /* / */)? => {
                     return Ok(Token::new(
                         if new_line {
                             TokenKind::LineTerminator

--- a/core/parser/src/lexer/comment.rs
+++ b/core/parser/src/lexer/comment.rs
@@ -1,10 +1,10 @@
 //! Boa's lexing for ECMAScript comments.
 
 use crate::lexer::{Cursor, Error, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Lexes a single line comment.
 ///
@@ -26,7 +26,7 @@ impl<R> Tokenizer<R> for SingleLineComment {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("SingleLineComment", "Lexing");
 
@@ -66,7 +66,7 @@ impl<R> Tokenizer<R> for MultiLineComment {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("MultiLineComment", "Lexing");
 
@@ -115,7 +115,7 @@ impl<R> Tokenizer<R> for HashbangComment {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("Hashbang", "Lexing");
 

--- a/core/parser/src/lexer/cursor.rs
+++ b/core/parser/src/lexer/cursor.rs
@@ -128,21 +128,6 @@ where
         })
     }
 
-    /// Applies the predicate to the next UTF-8 character and returns the result.
-    /// Returns false if there is no next character, otherwise returns the result from the
-    /// predicate on the ascii char
-    ///
-    /// The buffer is not incremented.
-    #[cfg(test)]
-    pub(super) fn next_is_char_pred<F>(&mut self, pred: &F) -> io::Result<bool>
-    where
-        F: Fn(u32) -> bool,
-    {
-        let _timer = Profiler::global().start_event("cursor::next_is_char_pred()", "Lexing");
-
-        Ok(self.peek_char()?.map_or(false, pred))
-    }
-
     /// Fills the buffer with all bytes until the stop byte is found.
     /// Returns error when reaching the end of the buffer.
     ///
@@ -179,34 +164,6 @@ where
                 return Ok(());
             } else if let Some(byte) = self.next_byte()? {
                 buf.push(byte);
-            } else {
-                // next_is_pred will return false if the next value is None so the None case should already be handled.
-                unreachable!();
-            }
-        }
-    }
-
-    /// Fills the buffer with characters until the first character for which the predicate (pred) is false.
-    /// It also stops when there is no next character.
-    ///
-    /// Note that all characters up until the stop character are added to the buffer, including the character right before.
-    #[cfg(test)]
-    pub(super) fn take_while_char_pred<F>(&mut self, buf: &mut Vec<u8>, pred: &F) -> io::Result<()>
-    where
-        F: Fn(u32) -> bool,
-    {
-        let _timer = Profiler::global().start_event("cursor::take_while_char_pred()", "Lexing");
-
-        loop {
-            if !self.next_is_char_pred(pred)? {
-                return Ok(());
-            } else if let Some(ch) = self.peek_char()? {
-                for _ in 0..utf8_len(ch) {
-                    buf.push(
-                        self.next_byte()?
-                            .expect("already checked that the next character exists"),
-                    );
-                }
             } else {
                 // next_is_pred will return false if the next value is None so the None case should already be handled.
                 unreachable!();

--- a/core/parser/src/lexer/identifier.rs
+++ b/core/parser/src/lexer/identifier.rs
@@ -100,7 +100,7 @@ impl Identifier {
         let _timer = Profiler::global().start_event("Identifier::take_identifier_name", "Lexing");
 
         let mut contains_escaped_chars = false;
-        let mut identifier_name = if init == '\\' && cursor.next_is(b'u')? {
+        let mut identifier_name = if init == '\\' && cursor.next_if(0x75 /* u */)? {
             let ch = StringLiteral::take_unicode_escape_sequence(cursor, start_pos)?;
 
             if Self::is_identifier_start(ch) {
@@ -119,10 +119,10 @@ impl Identifier {
 
         loop {
             let ch = match cursor.peek_char()? {
-                Some(0x005C /* \ */) if cursor.peek_n(2)?.get(1) == Some(&0x75) /* u */ => {
+                Some(0x005C /* \ */) if cursor.peek_n(2)?[1] == Some(0x75) /* u */ => {
                     let pos = cursor.pos();
-                    let _next = cursor.next_byte();
-                    let _next = cursor.next_byte();
+                    let _next = cursor.next_char();
+                    let _next = cursor.next_char();
                     let ch = StringLiteral::take_unicode_escape_sequence(cursor, pos)?;
 
                     if Self::is_identifier_part(ch) {

--- a/core/parser/src/lexer/identifier.rs
+++ b/core/parser/src/lexer/identifier.rs
@@ -3,10 +3,10 @@
 use crate::lexer::{
     token::ContainsEscapeSequence, Cursor, Error, StringLiteral, Token, TokenKind, Tokenizer,
 };
+use crate::source::ReadChar;
 use boa_ast::{Keyword, Position, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Identifier lexing.
 ///
@@ -60,7 +60,7 @@ impl<R> Tokenizer<R> for Identifier {
         interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("Identifier", "Lexing");
 
@@ -95,7 +95,7 @@ impl Identifier {
         init: char,
     ) -> Result<(String, bool), Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("Identifier::take_identifier_name", "Lexing");
 

--- a/core/parser/src/lexer/mod.rs
+++ b/core/parser/src/lexer/mod.rs
@@ -257,7 +257,7 @@ impl<R> Lexer<R> {
                     if self
                         .cursor
                         .peek_char()?
-                        .filter(|c| (48..=57).contains(c))
+                        .filter(|c| (0x30..=0x39/* 0..=9 */).contains(c))
                         .is_some()
                     {
                         NumberLiteral::new(b'.').lex(&mut self.cursor, start, interner)

--- a/core/parser/src/lexer/number.rs
+++ b/core/parser/src/lexer/number.rs
@@ -1,12 +1,13 @@
 //! This module implements lexing for number literals (123, 787) used in ECMAScript.
 
 use crate::lexer::{token::Numeric, Cursor, Error, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
 use num_bigint::BigInt;
 use num_traits::{ToPrimitive, Zero};
-use std::{io::Read, str};
+use std::str;
 
 /// Number literal lexing.
 ///
@@ -64,7 +65,7 @@ fn take_signed_integer<R>(
     kind: NumericKind,
 ) -> Result<(), Error>
 where
-    R: Read,
+    R: ReadChar,
 {
     // The next part must be SignedInteger.
     // This is optionally a '+' or '-' followed by 1 or more DecimalDigits.
@@ -122,7 +123,7 @@ fn take_integer<R>(
     separator_allowed: bool,
 ) -> Result<(), Error>
 where
-    R: Read,
+    R: ReadChar,
 {
     let mut prev_is_underscore = false;
     let mut pos = cursor.pos();
@@ -168,7 +169,7 @@ where
 /// [spec]: https://tc39.es/ecma262/#sec-literals-numeric-literals
 fn check_after_numeric_literal<R>(cursor: &mut Cursor<R>) -> Result<(), Error>
 where
-    R: Read,
+    R: ReadChar,
 {
     if cursor.next_is_ascii_pred(&|ch| ch.is_ascii_alphanumeric() || ch == '$' || ch == '_')? {
         Err(Error::syntax(
@@ -188,7 +189,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("NumberLiteral", "Lexing");
 

--- a/core/parser/src/lexer/number.rs
+++ b/core/parser/src/lexer/number.rs
@@ -68,25 +68,32 @@ where
 {
     // The next part must be SignedInteger.
     // This is optionally a '+' or '-' followed by 1 or more DecimalDigits.
-    match cursor.next_byte()? {
-        Some(b'+') => {
+    match cursor.next_char()? {
+        Some(0x2B /* + */) => {
             buf.push(b'+');
             if !cursor.next_is_ascii_pred(&|ch| ch.is_digit(kind.base()))? {
                 // A digit must follow the + or - symbol.
                 return Err(Error::syntax("No digit found after + symbol", cursor.pos()));
             }
         }
-        Some(b'-') => {
+        Some(0x2D /* - */) => {
             buf.push(b'-');
             if !cursor.next_is_ascii_pred(&|ch| ch.is_digit(kind.base()))? {
                 // A digit must follow the + or - symbol.
                 return Err(Error::syntax("No digit found after - symbol", cursor.pos()));
             }
         }
-        Some(byte) => {
-            let ch = char::from(byte);
-            if ch.is_ascii() && ch.is_digit(kind.base()) {
-                buf.push(byte);
+        Some(c) => {
+            if let Some(ch) = char::from_u32(c) {
+                if ch.is_ascii() && ch.is_digit(kind.base()) {
+                    #[allow(clippy::cast_possible_truncation)]
+                    buf.push(c as u8);
+                } else {
+                    return Err(Error::syntax(
+                        "When lexing exponential value found unexpected char",
+                        cursor.pos(),
+                    ));
+                }
             } else {
                 return Err(Error::syntax(
                     "When lexing exponential value found unexpected char",
@@ -121,12 +128,8 @@ where
     let mut pos = cursor.pos();
     while cursor.next_is_ascii_pred(&|c| c.is_digit(kind.base()) || c == '_')? {
         pos = cursor.pos();
-        match cursor.next_byte()? {
-            Some(c) if char::from(c).is_digit(kind.base()) => {
-                prev_is_underscore = false;
-                buf.push(c);
-            }
-            Some(b'_') if separator_allowed => {
+        match cursor.next_char()? {
+            Some(0x5F /* _ */) if separator_allowed => {
                 if prev_is_underscore {
                     return Err(Error::syntax(
                         "only one underscore is allowed as numeric separator",
@@ -135,8 +138,15 @@ where
                 }
                 prev_is_underscore = true;
             }
-            Some(b'_') if !separator_allowed => {
+            Some(0x5F /* _ */) if !separator_allowed => {
                 return Err(Error::syntax("separator is not allowed", pos));
+            }
+            Some(c) => {
+                if char::from_u32(c).map(|ch| ch.is_digit(kind.base())) == Some(true) {
+                    prev_is_underscore = false;
+                    #[allow(clippy::cast_possible_truncation)]
+                    buf.push(c as u8);
+                }
             }
             _ => (),
         }
@@ -187,13 +197,14 @@ impl<R> Tokenizer<R> for NumberLiteral {
         // Default assume the number is a base 10 integer.
         let mut kind = NumericKind::Integer(10);
 
-        let c = cursor.peek();
+        let c = cursor.peek_char();
         let mut legacy_octal = false;
 
         if self.init == b'0' {
             if let Some(ch) = c? {
                 match ch {
-                    b'x' | b'X' => {
+                    // x | X
+                    0x0078 | 0x0058 => {
                         // Remove the initial '0' from buffer.
                         cursor.next_char()?.expect("x or X character vanished");
                         buf.pop();
@@ -209,7 +220,8 @@ impl<R> Tokenizer<R> for NumberLiteral {
                             ));
                         }
                     }
-                    b'o' | b'O' => {
+                    // o | O
+                    0x006F | 0x004F => {
                         // Remove the initial '0' from buffer.
                         cursor.next_char()?.expect("o or O character vanished");
                         buf.pop();
@@ -225,7 +237,8 @@ impl<R> Tokenizer<R> for NumberLiteral {
                             ));
                         }
                     }
-                    b'b' | b'B' => {
+                    // b | B
+                    0x0062 | 0x0042 => {
                         // Remove the initial '0' from buffer.
                         cursor.next_char()?.expect("b or B character vanished");
                         buf.pop();
@@ -241,7 +254,8 @@ impl<R> Tokenizer<R> for NumberLiteral {
                             ));
                         }
                     }
-                    b'n' => {
+                    // n
+                    0x006E => {
                         cursor.next_char()?.expect("n character vanished");
 
                         // DecimalBigIntegerLiteral '0n'
@@ -252,37 +266,41 @@ impl<R> Tokenizer<R> for NumberLiteral {
                     }
                     byte => {
                         legacy_octal = true;
-                        let ch = char::from(byte);
-                        if ch.is_digit(8) {
-                            // LegacyOctalIntegerLiteral, or a number with leading 0s.
-                            if cursor.strict() {
-                                // LegacyOctalIntegerLiteral is forbidden with strict mode true.
-                                return Err(Error::syntax(
-                                    "implicit octal literals are not allowed in strict mode",
-                                    start_pos,
-                                ));
-                            }
+                        if let Some(ch) = char::from_u32(byte) {
+                            if ch.is_digit(8) {
+                                // LegacyOctalIntegerLiteral, or a number with leading 0s.
+                                if cursor.strict() {
+                                    // LegacyOctalIntegerLiteral is forbidden with strict mode true.
+                                    return Err(Error::syntax(
+                                        "implicit octal literals are not allowed in strict mode",
+                                        start_pos,
+                                    ));
+                                }
 
-                            // Remove the initial '0' from buffer.
-                            buf.pop();
+                                // Remove the initial '0' from buffer.
+                                buf.pop();
 
-                            buf.push(cursor.next_byte()?.expect("'0' character vanished"));
+                                #[allow(clippy::cast_possible_truncation)]
+                                buf.push(cursor.next_char()?.expect("'0' character vanished") as u8);
 
-                            take_integer(&mut buf, cursor, NumericKind::Integer(8), false)?;
+                                take_integer(&mut buf, cursor, NumericKind::Integer(8), false)?;
 
-                            if !cursor.next_is_ascii_pred(&|c| c.is_ascii_digit() || c == '_')? {
-                                // LegacyOctalIntegerLiteral
-                                kind = NumericKind::Integer(8);
-                            }
-                        } else if ch.is_ascii_digit() {
-                            // Indicates a numerical digit comes after then 0 but it isn't an octal digit
-                            // so therefore this must be a number with an unneeded leading 0. This is
-                            // forbidden in strict mode.
-                            if cursor.strict() {
-                                return Err(Error::syntax(
-                                    "leading 0's are not allowed in strict mode",
-                                    start_pos,
-                                ));
+                                if !cursor
+                                    .next_is_ascii_pred(&|c| c.is_ascii_digit() || c == '_')?
+                                {
+                                    // LegacyOctalIntegerLiteral
+                                    kind = NumericKind::Integer(8);
+                                }
+                            } else if ch.is_ascii_digit() {
+                                // Indicates a numerical digit comes after then 0 but it isn't an octal digit
+                                // so therefore this must be a number with an unneeded leading 0. This is
+                                // forbidden in strict mode.
+                                if cursor.strict() {
+                                    return Err(Error::syntax(
+                                        "leading 0's are not allowed in strict mode",
+                                        start_pos,
+                                    ));
+                                }
                             }
                         } // Else indicates that the symbol is a non-number.
                     }
@@ -298,12 +316,12 @@ impl<R> Tokenizer<R> for NumberLiteral {
         }
 
         let next = if self.init == b'.' {
-            Some(b'.')
+            Some(0x002E /* . */)
         } else {
             // Consume digits and separators until a non-digit non-separator
             // character is encountered or all the characters are consumed.
             take_integer(&mut buf, cursor, kind, !legacy_octal)?;
-            cursor.peek()?
+            cursor.peek_char()?
         };
 
         // The non-digit character could be:
@@ -311,7 +329,7 @@ impl<R> Tokenizer<R> for NumberLiteral {
         // '.' To indicate a decimal separator.
         // 'e' | 'E' To indicate an ExponentPart.
         match next {
-            Some(b'n') => {
+            Some(0x006E /* n */) => {
                 // DecimalBigIntegerLiteral
                 // Lexing finished.
                 // Consume the n
@@ -321,21 +339,21 @@ impl<R> Tokenizer<R> for NumberLiteral {
                         cursor.pos(),
                     ));
                 }
-                cursor.next_byte()?.expect("n character vanished");
+                cursor.next_char()?.expect("n character vanished");
 
                 kind = kind.to_bigint();
             }
-            Some(b'.') => {
+            Some(0x002E /* . */) => {
                 if kind.base() == 10 {
                     // Only base 10 numbers can have a decimal separator.
                     // Number literal lexing finished if a . is found for a number in a different base.
                     if self.init != b'.' {
-                        cursor.next_byte()?.expect("'.' token vanished");
+                        cursor.next_char()?.expect("'.' token vanished");
                         buf.push(b'.'); // Consume the .
                     }
                     kind = NumericKind::Rational;
 
-                    if cursor.peek()? == Some(b'_') {
+                    if cursor.peek_char()? == Some(0x005F /* _ */) {
                         return Err(Error::syntax(
                             "numeric separator not allowed after '.'",
                             cursor.pos(),
@@ -348,10 +366,10 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
                     // The non-digit character at this point must be an 'e' or 'E' to indicate an Exponent Part.
                     // Another '.' or 'n' is not allowed.
-                    match cursor.peek()? {
-                        Some(b'e' | b'E') => {
+                    match cursor.peek_char()? {
+                        Some(0x0065 /*e */ | 0x0045 /* E */) => {
                             // Consume the ExponentIndicator.
-                            cursor.next_byte()?.expect("e or E token vanished");
+                            cursor.next_char()?.expect("e or E token vanished");
 
                             buf.push(b'E');
 
@@ -363,9 +381,9 @@ impl<R> Tokenizer<R> for NumberLiteral {
                     }
                 }
             }
-            Some(b'e' | b'E') => {
+            Some(0x0065 /*e */ | 0x0045 /* E */) => {
                 kind = NumericKind::Rational;
-                cursor.next_byte()?.expect("e or E character vanished"); // Consume the ExponentIndicator.
+                cursor.next_char()?.expect("e or E character vanished"); // Consume the ExponentIndicator.
                 buf.push(b'E');
                 take_signed_integer(&mut buf, cursor, kind)?;
             }

--- a/core/parser/src/lexer/operator.rs
+++ b/core/parser/src/lexer/operator.rs
@@ -1,10 +1,10 @@
 //! Boa's lexing for ECMAScript operators (+, - etc.).
 
 use crate::lexer::{Cursor, Error, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Punctuator, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// `vop` tests the next token to see if we're on an assign operation of just a plain binary operation.
 ///
@@ -83,7 +83,7 @@ impl<R> Tokenizer<R> for Operator {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("Operator", "Lexing");
 

--- a/core/parser/src/lexer/operator.rs
+++ b/core/parser/src/lexer/operator.rs
@@ -123,7 +123,7 @@ impl<R> Tokenizer<R> for Operator {
                             Ok(Punctuator::Coalesce)
                         )
                     }
-                    Some(0x2E /* . */) if !matches!(second, Some(second) if (0x30..=0x39).contains(&second)) =>
+                    Some(0x2E /* . */) if !matches!(second, Some(second) if (0x30..=0x39 /* 0..=9 */).contains(&second)) =>
                     {
                         cursor.next_char()?.expect(". vanished");
                         Ok(Token::new(

--- a/core/parser/src/lexer/private_identifier.rs
+++ b/core/parser/src/lexer/private_identifier.rs
@@ -1,10 +1,10 @@
 //! Boa's lexing for ECMAScript private identifiers (#foo, #myvar, etc.).
 
 use crate::lexer::{identifier::Identifier, Cursor, Error, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Private Identifier lexing.
 ///
@@ -30,7 +30,7 @@ impl<R> Tokenizer<R> for PrivateIdentifier {
         interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("PrivateIdentifier", "Lexing");
 

--- a/core/parser/src/lexer/private_identifier.rs
+++ b/core/parser/src/lexer/private_identifier.rs
@@ -37,7 +37,7 @@ impl<R> Tokenizer<R> for PrivateIdentifier {
         if let Some(next_ch) = cursor.next_char()? {
             if let Ok(c) = char::try_from(next_ch) {
                 match c {
-                    '\\' if cursor.peek()? == Some(b'u') => {
+                    '\\' if cursor.peek_char()? == Some(0x0075 /* u */) => {
                         let (name, _) = Identifier::take_identifier_name(cursor, start_pos, c)?;
                         Ok(Token::new(
                             TokenKind::PrivateIdentifier(interner.get_or_intern(name.as_str())),

--- a/core/parser/src/lexer/regex.rs
+++ b/core/parser/src/lexer/regex.rs
@@ -7,7 +7,7 @@ use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use regress::{Flags, Regex};
 use std::{
-    io::{self, ErrorKind, Read},
+    io::Read,
     str::{self, FromStr},
 };
 
@@ -43,7 +43,7 @@ impl<R> Tokenizer<R> for RegexLiteral {
 
         // Lex RegularExpressionBody.
         loop {
-            match cursor.next_byte()? {
+            match cursor.next_char()? {
                 None => {
                     // Abrupt end.
                     return Err(Error::syntax(
@@ -53,47 +53,35 @@ impl<R> Tokenizer<R> for RegexLiteral {
                 }
                 Some(b) => {
                     match b {
-                        b'/' if !is_class_char => break, // RegularExpressionBody finished.
-                        b'[' => {
+                        // /
+                        0x2F if !is_class_char => break, // RegularExpressionBody finished.
+                        // [
+                        0x5B => {
                             is_class_char = true;
                             body.push(b);
                         }
-                        b']' if is_class_char => {
+                        // ]
+                        0x5D if is_class_char => {
                             is_class_char = false;
                             body.push(b);
                         }
-                        b'\n' | b'\r' => {
+                        // \n | \r | \u{2028} | \u{2029}
+                        0xA | 0xD | 0x2028 | 0x2029 => {
                             // Not allowed in Regex literal.
                             return Err(Error::syntax(
                                 "new lines are not allowed in regular expressions",
                                 cursor.pos(),
                             ));
                         }
-                        0xE2 if (cursor.peek_n(2)? == [0x80, 0xA8]
-                            || cursor.peek_n(2)? == [0x80, 0xA9]) =>
-                        {
-                            // '\u{2028}' (e2 80 a8) and '\u{2029}' (e2 80 a9) are not allowed
-                            return Err(Error::syntax(
-                                "new lines are not allowed in regular expressions",
-                                cursor.pos(),
-                            ));
-                        }
-                        b'\\' => {
+                        // \
+                        0x5C => {
                             // Escape sequence
-                            body.push(b'\\');
-                            if let Some(sc) = cursor.next_byte()? {
+                            body.push(b);
+                            if let Some(sc) = cursor.next_char()? {
                                 match sc {
-                                    b'\n' | b'\r' => {
+                                    // \n | \r | \u{2028} | \u{2029}
+                                    0xA | 0xD | 0x2028 | 0x2029 => {
                                         // Not allowed in Regex literal.
-                                        return Err(Error::syntax(
-                                            "new lines are not allowed in regular expressions",
-                                            cursor.pos(),
-                                        ));
-                                    }
-                                    0xE2 if (cursor.peek_n(2)? == [0x80, 0xA8]
-                                        || cursor.peek_n(2)? == [0x80, 0xA9]) =>
-                                    {
-                                        // '\u{2028}' (e2 80 a8) and '\u{2029}' (e2 80 a9) are not allowed
                                         return Err(Error::syntax(
                                             "new lines are not allowed in regular expressions",
                                             cursor.pos(),
@@ -119,28 +107,35 @@ impl<R> Tokenizer<R> for RegexLiteral {
         let flags_start = cursor.pos();
         cursor.take_while_ascii_pred(&mut flags, &char::is_alphabetic)?;
 
+        // SAFETY: We have already checked that the bytes are valid UTF-8.
         let flags_str = unsafe { str::from_utf8_unchecked(flags.as_slice()) };
-        if let Ok(body_str) = str::from_utf8(body.as_slice()) {
-            if let Err(error) = Regex::with_flags(body_str, flags_str) {
+
+        let mut body_str = String::with_capacity(body.len());
+        for c in body {
+            if let Some(ch) = char::from_u32(c) {
+                body_str.push(ch);
+            } else {
                 return Err(Error::Syntax(
-                    format!("Invalid regular expression literal: {error}").into(),
+                    "Invalid UTF-8 character in regular expressions".into(),
                     start_pos,
                 ));
             }
-
-            Ok(Token::new(
-                TokenKind::regular_expression_literal(
-                    interner.get_or_intern(body_str),
-                    parse_regex_flags(flags_str, flags_start, interner)?,
-                ),
-                Span::new(start_pos, cursor.pos()),
-            ))
-        } else {
-            Err(Error::from(io::Error::new(
-                ErrorKind::InvalidData,
-                "Invalid UTF-8 character in regular expressions",
-            )))
         }
+
+        if let Err(error) = Regex::with_flags(&body_str, flags_str) {
+            return Err(Error::Syntax(
+                format!("Invalid regular expression literal: {error}").into(),
+                start_pos,
+            ));
+        }
+
+        Ok(Token::new(
+            TokenKind::regular_expression_literal(
+                interner.get_or_intern(body_str.as_str()),
+                parse_regex_flags(flags_str, flags_start, interner)?,
+            ),
+            Span::new(start_pos, cursor.pos()),
+        ))
     }
 }
 

--- a/core/parser/src/lexer/regex.rs
+++ b/core/parser/src/lexer/regex.rs
@@ -1,15 +1,13 @@
 //! Boa's lexing for ECMAScript regex literals.
 
 use crate::lexer::{Cursor, Error, Span, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use bitflags::bitflags;
 use boa_ast::Position;
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use regress::{Flags, Regex};
-use std::{
-    io::Read,
-    str::{self, FromStr},
-};
+use std::str::{self, FromStr};
 
 /// Regex literal lexing.
 ///
@@ -34,7 +32,7 @@ impl<R> Tokenizer<R> for RegexLiteral {
         interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("RegexLiteral", "Lexing");
 

--- a/core/parser/src/lexer/spread.rs
+++ b/core/parser/src/lexer/spread.rs
@@ -1,10 +1,10 @@
 //! Boa's lexing for ECMAScript spread (...) literals.
 
 use crate::lexer::{Cursor, Error, Token, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Punctuator, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Spread literal lexing.
 ///
@@ -34,7 +34,7 @@ impl<R> Tokenizer<R> for SpreadLiteral {
         _interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("SpreadLiteral", "Lexing");
 

--- a/core/parser/src/lexer/spread.rs
+++ b/core/parser/src/lexer/spread.rs
@@ -39,8 +39,8 @@ impl<R> Tokenizer<R> for SpreadLiteral {
         let _timer = Profiler::global().start_event("SpreadLiteral", "Lexing");
 
         // . or ...
-        if cursor.next_is(b'.')? {
-            if cursor.next_is(b'.')? {
+        if cursor.next_if(0x2E /* . */)? {
+            if cursor.next_if(0x2E /* . */)? {
                 Ok(Token::new(
                     Punctuator::Spread.into(),
                     Span::new(start_pos, cursor.pos()),

--- a/core/parser/src/lexer/string.rs
+++ b/core/parser/src/lexer/string.rs
@@ -1,10 +1,11 @@
 //! Boa's lexing for ECMAScript string literals.
 
 use crate::lexer::{token::EscapeSequence, Cursor, Error, Token, TokenKind, Tokenizer};
+use crate::source::ReadChar;
 use boa_ast::{Position, Span};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::{self, ErrorKind, Read};
+use std::io::{self, ErrorKind};
 
 /// String literal lexing.
 ///
@@ -81,7 +82,7 @@ impl<R> Tokenizer<R> for StringLiteral {
         interner: &mut Interner,
     ) -> Result<Token, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let _timer = Profiler::global().start_event("StringLiteral", "Lexing");
 
@@ -116,7 +117,7 @@ impl StringLiteral {
         strict: bool,
     ) -> Result<(Vec<u16>, Span, EscapeSequence), Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let mut buf = Vec::new();
         let mut escape_sequence = EscapeSequence::empty();
@@ -169,7 +170,7 @@ impl StringLiteral {
         is_template_literal: bool,
     ) -> Result<(Option<u32>, EscapeSequence), Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let escape_ch = cursor.next_char()?.ok_or_else(|| {
             Error::from(io::Error::new(
@@ -253,7 +254,7 @@ impl StringLiteral {
         start_pos: Position,
     ) -> Result<u32, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         // Support \u{X..X} (Unicode CodePoint)
         if cursor.next_if(0x7B /* { */)? {
@@ -328,7 +329,7 @@ impl StringLiteral {
         start_pos: Position,
     ) -> Result<u32, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         let mut buffer = [0u32; 2];
         buffer[0] = cursor
@@ -365,7 +366,7 @@ impl StringLiteral {
         init_byte: u8,
     ) -> Result<u32, Error>
     where
-        R: Read,
+        R: ReadChar,
     {
         // Grammar: OctalDigit
         let mut code_point = u32::from(init_byte - b'0');

--- a/core/parser/src/lexer/string.rs
+++ b/core/parser/src/lexer/string.rs
@@ -191,7 +191,7 @@ impl StringLiteral {
             0x005C /* \ */ => (Some(0x005C /* \ */), EscapeSequence::OTHER),
             0x0030 /* 0 */ if cursor
                 .peek_char()?
-                .filter(|c| (48..=57).contains(c))
+                .filter(|c| (0x30..=0x39 /* 0..=9 */).contains(c))
                 .is_none() =>
                 (Some(0x0000 /* NULL */), EscapeSequence::OTHER),
             0x0078 /* x */ => {
@@ -374,16 +374,16 @@ impl StringLiteral {
         // Grammar: ZeroToThree OctalDigit
         // Grammar: FourToSeven OctalDigit
         if let Some(c) = cursor.peek_char()? {
-            if (48..=55).contains(&c) {
+            if (0x30..=0x37/* 0..=7 */).contains(&c) {
                 cursor.next_char()?;
-                code_point = (code_point * 8) + c - 48;
+                code_point = (code_point * 8) + c - 0x30 /* 0 */;
 
-                if (48..=51).contains(&init_byte) {
+                if (0x30..=0x33/* 0..=3 */).contains(&init_byte) {
                     // Grammar: ZeroToThree OctalDigit OctalDigit
                     if let Some(c) = cursor.peek_char()? {
-                        if (48..=55).contains(&c) {
+                        if (0x30..=0x37/* 0..=7 */).contains(&c) {
                             cursor.next_char()?;
-                            code_point = (code_point * 8) + c - 48;
+                            code_point = (code_point * 8) + c - 0x30 /* 0 */;
                         }
                     }
                 }

--- a/core/parser/src/lexer/tests.rs
+++ b/core/parser/src/lexer/tests.rs
@@ -827,56 +827,6 @@ fn take_while_ascii_pred_non_ascii_stop() {
 }
 
 #[test]
-fn take_while_char_pred_simple() {
-    let mut cur = Cursor::new(&b"abcdefghijk"[..]);
-
-    let mut buf: Vec<u8> = Vec::new();
-
-    cur.take_while_char_pred(&mut buf, &|c| {
-        c == 'a' as u32 || c == 'b' as u32 || c == 'c' as u32
-    })
-    .unwrap();
-
-    assert_eq!(str::from_utf8(buf.as_slice()).unwrap(), "abc");
-}
-
-#[test]
-fn take_while_char_pred_immediate_stop() {
-    let mut cur = Cursor::new(&b"abcdefghijk"[..]);
-
-    let mut buf: Vec<u8> = Vec::new();
-
-    cur.take_while_char_pred(&mut buf, &|_| false).unwrap();
-
-    assert_eq!(str::from_utf8(buf.as_slice()).unwrap(), "");
-}
-
-#[test]
-fn take_while_char_pred_entire_str() {
-    let mut cur = Cursor::new(&b"abcdefghijk"[..]);
-
-    let mut buf: Vec<u8> = Vec::new();
-
-    cur.take_while_char_pred(&mut buf, &|_| true).unwrap();
-
-    assert_eq!(str::from_utf8(buf.as_slice()).unwrap(), "abcdefghijk");
-}
-
-#[test]
-fn take_while_char_pred_utf8_char() {
-    let mut cur = Cursor::new("abc😀defghijk".as_bytes());
-
-    let mut buf: Vec<u8> = Vec::new();
-
-    cur.take_while_char_pred(&mut buf, &|c| {
-        char::try_from(c).map_or(false, |c| c == 'a' || c == 'b' || c == 'c' || c == '😀')
-    })
-    .unwrap();
-
-    assert_eq!(str::from_utf8(buf.as_slice()).unwrap(), "abc😀");
-}
-
-#[test]
 fn illegal_following_numeric_literal() {
     // Checks as per https://tc39.es/ecma262/#sec-literals-numeric-literals that a NumericLiteral cannot
     // be immediately followed by an IdentifierStart or DecimalDigit.

--- a/core/parser/src/lib.rs
+++ b/core/parser/src/lib.rs
@@ -28,7 +28,7 @@
 pub mod error;
 pub mod lexer;
 pub mod parser;
-mod source;
+pub mod source;
 
 pub use error::Error;
 pub use lexer::Lexer;

--- a/core/parser/src/parser/cursor/buffered_lexer/mod.rs
+++ b/core/parser/src/parser/cursor/buffered_lexer/mod.rs
@@ -1,12 +1,12 @@
 use crate::{
     lexer::{InputElement, Lexer, Token, TokenKind},
     parser::ParseResult,
+    source::{ReadChar, UTF8Input},
     Error,
 };
 use boa_ast::Position;
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 #[cfg(test)]
 mod tests;
@@ -34,7 +34,7 @@ pub(super) struct BufferedLexer<R> {
 
 impl<R> From<Lexer<R>> for BufferedLexer<R>
 where
-    R: Read,
+    R: ReadChar,
 {
     fn from(lexer: Lexer<R>) -> Self {
         Self {
@@ -58,16 +58,22 @@ where
 
 impl<R> From<R> for BufferedLexer<R>
 where
-    R: Read,
+    R: ReadChar,
 {
     fn from(reader: R) -> Self {
         Lexer::new(reader).into()
     }
 }
 
+impl<'a> From<&'a [u8]> for BufferedLexer<UTF8Input<&'a [u8]>> {
+    fn from(reader: &'a [u8]) -> Self {
+        Lexer::from(reader).into()
+    }
+}
+
 impl<R> BufferedLexer<R>
 where
-    R: Read,
+    R: ReadChar,
 {
     /// Sets the goal symbol for the lexer.
     pub(super) fn set_goal(&mut self, elm: InputElement) {

--- a/core/parser/src/parser/cursor/mod.rs
+++ b/core/parser/src/parser/cursor/mod.rs
@@ -4,12 +4,12 @@ mod buffered_lexer;
 use crate::{
     lexer::{InputElement, Lexer, Token, TokenKind},
     parser::{OrAbrupt, ParseResult},
+    source::ReadChar,
     Error,
 };
 use boa_ast::{Position, Punctuator};
 use boa_interner::Interner;
 use buffered_lexer::BufferedLexer;
-use std::io::Read;
 
 /// The result of a peek for a semicolon.
 #[derive(Debug)]
@@ -41,7 +41,7 @@ pub(super) struct Cursor<R> {
 
 impl<R> Cursor<R>
 where
-    R: Read,
+    R: ReadChar,
 {
     /// Creates a new cursor with the given reader.
     pub(super) fn new(reader: R) -> Self {

--- a/core/parser/src/parser/expression/assignment/arrow_function.rs
+++ b/core/parser/src/parser/expression/assignment/arrow_function.rs
@@ -17,6 +17,7 @@ use crate::{
         name_in_lexically_declared_names, AllowAwait, AllowIn, AllowYield, Cursor, OrAbrupt,
         TokenParser,
     },
+    source::ReadChar,
 };
 use ast::operations::{bound_names, lexically_declared_names};
 use boa_ast::{
@@ -30,7 +31,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Arrow function parsing.
 ///
@@ -73,7 +73,7 @@ impl ArrowFunction {
 
 impl<R> TokenParser<R> for ArrowFunction
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::ArrowFunction;
 
@@ -186,7 +186,7 @@ impl ConciseBody {
 
 impl<R> TokenParser<R> for ConciseBody
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::FunctionBody;
 
@@ -236,7 +236,7 @@ impl ExpressionBody {
 
 impl<R> TokenParser<R> for ExpressionBody
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/assignment/async_arrow_function.rs
+++ b/core/parser/src/parser/expression/assignment/async_arrow_function.rs
@@ -16,6 +16,7 @@ use crate::{
         function::{FormalParameters, FunctionBody},
         name_in_lexically_declared_names, AllowIn, AllowYield, Cursor, OrAbrupt, TokenParser,
     },
+    source::ReadChar,
 };
 use ast::{
     operations::{bound_names, contains, lexically_declared_names, ContainsSymbol},
@@ -31,7 +32,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Async arrow function parsing.
 ///
@@ -66,7 +66,7 @@ impl AsyncArrowFunction {
 
 impl<R> TokenParser<R> for AsyncArrowFunction
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::AsyncArrowFunction;
 
@@ -174,7 +174,7 @@ impl AsyncConciseBody {
 
 impl<R> TokenParser<R> for AsyncConciseBody
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::FunctionBody;
 

--- a/core/parser/src/parser/expression/assignment/conditional.rs
+++ b/core/parser/src/parser/expression/assignment/conditional.rs
@@ -13,6 +13,7 @@ use crate::{
         expression::{AssignmentExpression, ShortCircuitExpression},
         AllowAwait, AllowIn, AllowYield, Cursor, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{
     expression::{operator::Conditional, Identifier},
@@ -20,7 +21,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Conditional expression parsing.
 ///
@@ -63,7 +63,7 @@ impl ConditionalExpression {
 
 impl<R> TokenParser<R> for ConditionalExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/assignment/exponentiation.rs
+++ b/core/parser/src/parser/expression/assignment/exponentiation.rs
@@ -13,6 +13,7 @@ use crate::{
         expression::{unary::UnaryExpression, update::UpdateExpression},
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{
     expression::{
@@ -23,7 +24,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an exponentiation expression.
 ///
@@ -62,7 +62,7 @@ impl ExponentiationExpression {
 
 impl<R> TokenParser<R> for ExponentiationExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         name_in_lexically_declared_names, AllowAwait, AllowIn, AllowYield, Cursor, OrAbrupt,
         ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -37,7 +38,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 pub(super) use exponentiation::ExponentiationExpression;
 
@@ -92,7 +92,7 @@ impl AssignmentExpression {
 
 impl<R> TokenParser<R> for AssignmentExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/assignment/yield.rs
+++ b/core/parser/src/parser/expression/assignment/yield.rs
@@ -11,11 +11,11 @@ use super::AssignmentExpression;
 use crate::{
     lexer::TokenKind,
     parser::{cursor::Cursor, AllowAwait, AllowIn, OrAbrupt, ParseResult, TokenParser},
+    source::ReadChar,
 };
 use boa_ast::{expression::Yield, Expression, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// `YieldExpression` parsing.
 ///
@@ -47,7 +47,7 @@ impl YieldExpression {
 
 impl<R> TokenParser<R> for YieldExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/await_expr.rs
+++ b/core/parser/src/parser/expression/await_expr.rs
@@ -11,10 +11,10 @@ use super::unary::UnaryExpression;
 use crate::{
     lexer::TokenKind,
     parser::{AllowYield, Cursor, ParseResult, TokenParser},
+    source::ReadChar,
 };
 use boa_ast::{expression::Await, Keyword};
 use boa_interner::Interner;
-use std::io::Read;
 
 /// Parses an await expression.
 ///
@@ -43,7 +43,7 @@ impl AwaitExpression {
 
 impl<R> TokenParser<R> for AwaitExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Await;
 

--- a/core/parser/src/parser/expression/identifiers.rs
+++ b/core/parser/src/parser/expression/identifiers.rs
@@ -8,12 +8,12 @@
 use crate::{
     lexer::TokenKind,
     parser::{cursor::Cursor, AllowAwait, AllowYield, OrAbrupt, ParseResult, TokenParser},
+    source::ReadChar,
     Error,
 };
 use boa_ast::expression::Identifier as AstIdentifier;
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Identifier reference parsing.
 ///
@@ -44,7 +44,7 @@ impl IdentifierReference {
 
 impl<R> TokenParser<R> for IdentifierReference
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstIdentifier;
 
@@ -98,7 +98,7 @@ impl BindingIdentifier {
 
 impl<R> TokenParser<R> for BindingIdentifier
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstIdentifier;
 
@@ -153,7 +153,7 @@ pub(in crate::parser) struct Identifier;
 
 impl<R> TokenParser<R> for Identifier
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstIdentifier;
 

--- a/core/parser/src/parser/expression/left_hand_side/arguments.rs
+++ b/core/parser/src/parser/expression/left_hand_side/arguments.rs
@@ -13,12 +13,12 @@ use crate::{
         expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult,
         TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{expression::Spread, Expression, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a list of arguments.
 ///
@@ -50,7 +50,7 @@ impl Arguments {
 
 impl<R> TokenParser<R> for Arguments
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Box<[Expression]>;
 

--- a/core/parser/src/parser/expression/left_hand_side/call.rs
+++ b/core/parser/src/parser/expression/left_hand_side/call.rs
@@ -14,6 +14,7 @@ use crate::{
         expression::{left_hand_side::template::TaggedTemplateLiteral, Expression},
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::function::PrivateName;
@@ -27,7 +28,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a call expression.
 ///
@@ -63,7 +63,7 @@ impl CallExpression {
 
 impl<R> TokenParser<R> for CallExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
@@ -115,7 +115,7 @@ impl CallExpressionTail {
 
 impl<R> TokenParser<R> for CallExpressionTail
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 

--- a/core/parser/src/parser/expression/left_hand_side/member.rs
+++ b/core/parser/src/parser/expression/left_hand_side/member.rs
@@ -14,6 +14,7 @@ use crate::{
         },
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::function::PrivateName;
@@ -29,7 +30,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a member expression.
 ///
@@ -62,7 +62,7 @@ impl MemberExpression {
 
 impl<R> TokenParser<R> for MemberExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 

--- a/core/parser/src/parser/expression/left_hand_side/mod.rs
+++ b/core/parser/src/parser/expression/left_hand_side/mod.rs
@@ -30,6 +30,7 @@ use crate::{
         },
         AllowAwait, AllowYield, Cursor, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -38,7 +39,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a left hand side expression.
 ///
@@ -73,7 +73,7 @@ impl LeftHandSideExpression {
 
 impl<R> TokenParser<R> for LeftHandSideExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 
@@ -87,7 +87,7 @@ where
         /// initialization of `lhs` would make it very hard to return an expression over all
         /// possible branches of the `if let`s. Instead, we extract the check into its own function,
         /// then use it inside the condition of a simple `if ... else` expression.
-        fn is_keyword_call<R: Read>(
+        fn is_keyword_call<R: ReadChar>(
             keyword: Keyword,
             cursor: &mut Cursor<R>,
             interner: &mut Interner,

--- a/core/parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/core/parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         cursor::Cursor, expression::left_hand_side::arguments::Arguments, expression::Expression,
         AllowAwait, AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::function::PrivateName;
@@ -17,7 +18,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an optional expression.
 ///
@@ -55,7 +55,7 @@ impl OptionalExpression {
 
 impl<R> TokenParser<R> for OptionalExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Optional;
 

--- a/core/parser/src/parser/expression/left_hand_side/template.rs
+++ b/core/parser/src/parser/expression/left_hand_side/template.rs
@@ -4,12 +4,12 @@ use crate::{
         cursor::Cursor, expression::Expression, AllowAwait, AllowYield, OrAbrupt, ParseResult,
         TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{self as ast, expression::TaggedTemplate, Position, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a tagged template.
 ///
@@ -48,7 +48,7 @@ impl TaggedTemplateLiteral {
 
 impl<R> TokenParser<R> for TaggedTemplateLiteral
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = TaggedTemplate;
 

--- a/core/parser/src/parser/expression/mod.rs
+++ b/core/parser/src/parser/expression/mod.rs
@@ -25,6 +25,7 @@ use crate::{
         expression::assignment::ExponentiationExpression, AllowAwait, AllowIn, AllowYield, Cursor,
         OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -41,7 +42,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 pub(super) use self::{assignment::AssignmentExpression, primary::Initializer};
 pub(in crate::parser) use {
@@ -73,7 +73,7 @@ macro_rules! expression {
     ($name:ident, $lower:ident, [$( $op:path ),*], [$( $low_param:ident ),*], $goal:expr ) => {
         impl<R> TokenParser<R> for $name
         where
-            R: Read
+            R: ReadChar
         {
             type Output = ast::Expression;
 
@@ -142,7 +142,7 @@ impl Expression {
 
 impl<R> TokenParser<R> for Expression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
@@ -264,7 +264,7 @@ impl ShortCircuitExpression {
 
 impl<R> TokenParser<R> for ShortCircuitExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
@@ -558,7 +558,7 @@ impl RelationalExpression {
 
 impl<R> TokenParser<R> for RelationalExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 

--- a/core/parser/src/parser/expression/primary/array_initializer/mod.rs
+++ b/core/parser/src/parser/expression/primary/array_initializer/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         expression::AssignmentExpression, AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult,
         TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -24,7 +25,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an array literal.
 ///
@@ -56,7 +56,7 @@ impl ArrayLiteral {
 
 impl<R> TokenParser<R> for ArrayLiteral
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = literal::ArrayLiteral;
 

--- a/core/parser/src/parser/expression/primary/async_function_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/async_function_expression/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         function::{FormalParameters, FunctionBody},
         name_in_lexically_declared_names, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -18,7 +19,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Async Function expression parsing.
 ///
@@ -45,7 +45,7 @@ impl AsyncFunctionExpression {
 
 impl<R> TokenParser<R> for AsyncFunctionExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AsyncFunction;
 

--- a/core/parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         function::{FormalParameters, FunctionBody},
         name_in_lexically_declared_names, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -27,7 +28,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Async Generator Expression Parsing
 ///
@@ -52,7 +52,7 @@ impl AsyncGeneratorExpression {
 
 impl<R> TokenParser<R> for AsyncGeneratorExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     //The below needs to be implemented in ast::node
     type Output = AsyncGenerator;

--- a/core/parser/src/parser/expression/primary/class_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/class_expression/mod.rs
@@ -4,11 +4,11 @@ use crate::{
         expression::BindingIdentifier, statement::ClassTail, AllowAwait, AllowYield, Cursor,
         OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{expression::Identifier, function::Class, Keyword};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Class expression parsing.
 ///
@@ -41,7 +41,7 @@ impl ClassExpression {
 
 impl<R> TokenParser<R> for ClassExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Class;
 

--- a/core/parser/src/parser/expression/primary/function_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/function_expression/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         function::{FormalParameters, FunctionBody},
         name_in_lexically_declared_names, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -27,7 +28,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Function expression parsing.
 ///
@@ -54,7 +54,7 @@ impl FunctionExpression {
 
 impl<R> TokenParser<R> for FunctionExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Function;
 

--- a/core/parser/src/parser/expression/primary/generator_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/generator_expression/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         function::{FormalParameters, FunctionBody},
         name_in_lexically_declared_names, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -27,7 +28,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Generator expression parsing.
 ///
@@ -54,7 +54,7 @@ impl GeneratorExpression {
 
 impl<R> TokenParser<R> for GeneratorExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Generator;
 

--- a/core/parser/src/parser/expression/primary/mod.rs
+++ b/core/parser/src/parser/expression/primary/mod.rs
@@ -39,6 +39,7 @@ use crate::{
         statement::{ArrayBindingPattern, ObjectBindingPattern},
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::expression::RegExpLiteral as AstRegExp;
@@ -57,7 +58,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 pub(in crate::parser) use object_initializer::Initializer;
 
@@ -94,7 +94,7 @@ impl PrimaryExpression {
 
 impl<R> TokenParser<R> for PrimaryExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
@@ -312,7 +312,7 @@ impl CoverParenthesizedExpressionAndArrowParameterList {
 
 impl<R> TokenParser<R> for CoverParenthesizedExpressionAndArrowParameterList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Expression;
 

--- a/core/parser/src/parser/expression/primary/object_initializer/mod.rs
+++ b/core/parser/src/parser/expression/primary/object_initializer/mod.rs
@@ -21,6 +21,7 @@ use crate::{
         name_in_lexically_declared_names, AllowAwait, AllowIn, AllowYield, Cursor, OrAbrupt,
         ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -40,7 +41,6 @@ use boa_ast::{
 use boa_interner::{Interner, Sym};
 use boa_macros::utf16;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an object literal.
 ///
@@ -72,7 +72,7 @@ impl ObjectLiteral {
 
 impl<R> TokenParser<R> for ObjectLiteral
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = literal::ObjectLiteral;
 
@@ -169,7 +169,7 @@ impl PropertyDefinition {
 
 impl<R> TokenParser<R> for PropertyDefinition
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = property::PropertyDefinition;
 
@@ -574,7 +574,7 @@ impl PropertyName {
 
 impl<R> TokenParser<R> for PropertyName
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = property::PropertyName;
 
@@ -650,7 +650,7 @@ impl ClassElementName {
 
 impl<R> TokenParser<R> for ClassElementName
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = property::ClassElementName;
 
@@ -712,7 +712,7 @@ impl Initializer {
 
 impl<R> TokenParser<R> for Initializer
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 
@@ -753,7 +753,7 @@ impl GeneratorMethod {
 
 impl<R> TokenParser<R> for GeneratorMethod
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (property::ClassElementName, MethodDefinition);
 
@@ -855,7 +855,7 @@ impl AsyncGeneratorMethod {
 
 impl<R> TokenParser<R> for AsyncGeneratorMethod
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (property::ClassElementName, MethodDefinition);
 
@@ -971,7 +971,7 @@ impl AsyncMethod {
 
 impl<R> TokenParser<R> for AsyncMethod
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (property::ClassElementName, MethodDefinition);
 
@@ -1064,7 +1064,7 @@ impl CoverInitializedName {
 
 impl<R> TokenParser<R> for CoverInitializedName
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = property::PropertyDefinition;
 

--- a/core/parser/src/parser/expression/primary/template/mod.rs
+++ b/core/parser/src/parser/expression/primary/template/mod.rs
@@ -10,6 +10,7 @@
 use crate::{
     lexer::TokenKind,
     parser::{expression::Expression, AllowAwait, AllowYield, Cursor, ParseResult, TokenParser},
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -18,7 +19,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a template literal.
 ///
@@ -54,7 +54,7 @@ impl TemplateLiteral {
 
 impl<R> TokenParser<R> for TemplateLiteral
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = literal::TemplateLiteral;
 

--- a/core/parser/src/parser/expression/unary.rs
+++ b/core/parser/src/parser/expression/unary.rs
@@ -13,6 +13,7 @@ use crate::{
         expression::{await_expr::AwaitExpression, update::UpdateExpression},
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -25,7 +26,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a unary expression.
 ///
@@ -60,7 +60,7 @@ impl UnaryExpression {
 
 impl<R> TokenParser<R> for UnaryExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/expression/update.rs
+++ b/core/parser/src/parser/expression/update.rs
@@ -14,6 +14,7 @@ use crate::{
         },
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -28,7 +29,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an update expression.
 ///
@@ -87,7 +87,7 @@ fn as_simple(
 
 impl<R> TokenParser<R> for UpdateExpression
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 

--- a/core/parser/src/parser/function/mod.rs
+++ b/core/parser/src/parser/function/mod.rs
@@ -17,6 +17,7 @@ use crate::{
         statement::{ArrayBindingPattern, ObjectBindingPattern, StatementList},
         AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::{
@@ -31,7 +32,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Formal parameters parsing.
 ///
@@ -63,7 +63,7 @@ impl FormalParameters {
 
 impl<R> TokenParser<R> for FormalParameters
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = FormalParameterList;
 
@@ -173,7 +173,7 @@ impl UniqueFormalParameters {
 
 impl<R> TokenParser<R> for UniqueFormalParameters
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = FormalParameterList;
 
@@ -245,7 +245,7 @@ impl BindingRestElement {
 
 impl<R> TokenParser<R> for BindingRestElement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::FormalParameter;
 
@@ -340,7 +340,7 @@ impl FormalParameter {
 
 impl<R> TokenParser<R> for FormalParameter
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::FormalParameter;
 
@@ -448,7 +448,7 @@ impl FunctionStatementList {
 
 impl<R> TokenParser<R> for FunctionStatementList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::function::FunctionBody;
 

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         cursor::Cursor,
         function::{FormalParameters, FunctionStatementList},
     },
+    source::ReadChar,
     Error, Source,
 };
 use boa_ast::{
@@ -29,7 +30,7 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use rustc_hash::FxHashSet;
-use std::{io::Read, path::Path};
+use std::path::Path;
 
 use self::statement::ModuleItemList;
 
@@ -38,7 +39,7 @@ use self::statement::ModuleItemList;
 /// This makes it possible to abstract over the underlying implementation of a parser.
 trait TokenParser<R>: Sized
 where
-    R: Read,
+    R: ReadChar,
 {
     /// Output type for the parser.
     type Output; // = Node; waiting for https://github.com/rust-lang/rust/issues/29661
@@ -121,7 +122,7 @@ pub struct Parser<'a, R> {
     cursor: Cursor<R>,
 }
 
-impl<'a, R: Read> Parser<'a, R> {
+impl<'a, R: ReadChar> Parser<'a, R> {
     /// Create a new `Parser` with a `Source` as the input to parse.
     pub fn new(source: Source<'a, R>) -> Self {
         Self {
@@ -152,7 +153,7 @@ impl<'a, R: Read> Parser<'a, R> {
     /// [spec]: https://tc39.es/ecma262/#prod-Module
     pub fn parse_module(&mut self, interner: &mut Interner) -> ParseResult<boa_ast::Module>
     where
-        R: Read,
+        R: ReadChar,
     {
         ModuleParser.parse(&mut self.cursor, interner)
     }
@@ -211,7 +212,7 @@ impl<R> Parser<'_, R> {
     /// Set the parser strict mode to true.
     pub fn set_strict(&mut self)
     where
-        R: Read,
+        R: ReadChar,
     {
         self.cursor.set_strict(true);
     }
@@ -219,7 +220,7 @@ impl<R> Parser<'_, R> {
     /// Set the parser JSON mode to true.
     pub fn set_json_parse(&mut self)
     where
-        R: Read,
+        R: ReadChar,
     {
         self.cursor.set_json_parse(true);
     }
@@ -227,7 +228,7 @@ impl<R> Parser<'_, R> {
     /// Set the unique identifier for the parser.
     pub fn set_identifier(&mut self, identifier: u32)
     where
-        R: Read,
+        R: ReadChar,
     {
         self.cursor.set_identifier(identifier);
     }
@@ -254,7 +255,7 @@ impl ScriptParser {
 
 impl<R> TokenParser<R> for ScriptParser
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = boa_ast::Script;
 
@@ -315,7 +316,7 @@ impl ScriptBody {
 
 impl<R> TokenParser<R> for ScriptBody
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = StatementList;
 
@@ -387,7 +388,7 @@ struct ModuleParser;
 
 impl<R> TokenParser<R> for ModuleParser
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = boa_ast::Module;
 

--- a/core/parser/src/parser/statement/block/mod.rs
+++ b/core/parser/src/parser/statement/block/mod.rs
@@ -16,6 +16,7 @@ use crate::{
         statement::StatementList, AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt,
         ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -25,7 +26,6 @@ use boa_ast::{
 use boa_interner::Interner;
 use boa_profiler::Profiler;
 use rustc_hash::FxHashMap;
-use std::io::Read;
 
 /// The possible `TokenKind` which indicate the end of a block statement.
 const BLOCK_BREAK_TOKENS: [TokenKind; 1] = [TokenKind::Punctuator(Punctuator::CloseBlock)];
@@ -71,7 +71,7 @@ impl Block {
 
 impl<R> TokenParser<R> for Block
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = statement::Block;
 

--- a/core/parser/src/parser/statement/break_stm/mod.rs
+++ b/core/parser/src/parser/statement/break_stm/mod.rs
@@ -17,11 +17,11 @@ use crate::{
         expression::LabelIdentifier,
         AllowAwait, AllowYield, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{statement::Break, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Break statement parsing
 ///
@@ -53,7 +53,7 @@ impl BreakStatement {
 
 impl<R> TokenParser<R> for BreakStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Break;
 

--- a/core/parser/src/parser/statement/continue_stm/mod.rs
+++ b/core/parser/src/parser/statement/continue_stm/mod.rs
@@ -17,11 +17,11 @@ use crate::{
         expression::LabelIdentifier,
         AllowAwait, AllowYield, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{statement::Continue, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// For statement parsing
 ///
@@ -53,7 +53,7 @@ impl ContinueStatement {
 
 impl<R> TokenParser<R> for ContinueStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Continue;
 

--- a/core/parser/src/parser/statement/declaration/export.rs
+++ b/core/parser/src/parser/statement/declaration/export.rs
@@ -17,6 +17,7 @@ use crate::{
         statement::{declaration::ClassDeclaration, variable::VariableStatement},
         Error, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{
     declaration::{ExportDeclaration as AstExportDeclaration, ReExportKind},
@@ -24,7 +25,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 use super::{
     hoistable::{AsyncFunctionDeclaration, AsyncGeneratorDeclaration, GeneratorDeclaration},
@@ -42,7 +42,7 @@ pub(in crate::parser) struct ExportDeclaration;
 
 impl<R> TokenParser<R> for ExportDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstExportDeclaration;
 
@@ -233,7 +233,7 @@ struct NamedExports;
 
 impl<R> TokenParser<R> for NamedExports
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Box<[boa_ast::declaration::ExportSpecifier]>;
 
@@ -298,7 +298,7 @@ pub(super) struct ModuleExportName;
 
 impl<R> TokenParser<R> for ModuleExportName
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (Sym, bool);
 
@@ -338,7 +338,7 @@ struct ExportSpecifier;
 
 impl<R> TokenParser<R> for ExportSpecifier
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = boa_ast::declaration::ExportSpecifier;
 

--- a/core/parser/src/parser/statement/declaration/hoistable/async_function_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/async_function_decl/mod.rs
@@ -1,13 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::parser::{
-    statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-    AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+use crate::{
+    parser::{
+        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+        AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+    },
+    source::ReadChar,
 };
 use boa_ast::{function::AsyncFunction, Keyword};
 use boa_interner::Interner;
-use std::io::Read;
 
 /// Async Function declaration parsing.
 ///
@@ -72,7 +74,7 @@ impl CallableDeclaration for AsyncFunctionDeclaration {
 
 impl<R> TokenParser<R> for AsyncFunctionDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AsyncFunction;
 

--- a/core/parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/async_generator_decl/mod.rs
@@ -6,13 +6,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::parser::{
-    statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-    AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+use crate::{
+    parser::{
+        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+        AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+    },
+    source::ReadChar,
 };
 use boa_ast::{function::AsyncGenerator, Keyword, Punctuator};
 use boa_interner::Interner;
-use std::io::Read;
 
 /// Async Generator Declaration Parser
 ///
@@ -85,7 +87,7 @@ impl CallableDeclaration for AsyncGeneratorDeclaration {
 
 impl<R> TokenParser<R> for AsyncGeneratorDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AsyncGenerator;
 

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/mod.rs
@@ -12,6 +12,7 @@ use crate::{
         statement::StatementList,
         AllowAwait, AllowDefault, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::{
@@ -31,7 +32,6 @@ use boa_ast::{
 use boa_interner::{Interner, Sym};
 use boa_macros::utf16;
 use rustc_hash::{FxHashMap, FxHashSet};
-use std::io::Read;
 
 /// Class declaration parsing.
 ///
@@ -66,7 +66,7 @@ impl ClassDeclaration {
 
 impl<R> TokenParser<R> for ClassDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Class;
 
@@ -143,7 +143,7 @@ impl ClassTail {
 
 impl<R> TokenParser<R> for ClassTail
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Class;
 
@@ -237,7 +237,7 @@ impl ClassHeritage {
 
 impl<R> TokenParser<R> for ClassHeritage
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Expression;
 
@@ -289,7 +289,7 @@ impl ClassBody {
 
 impl<R> TokenParser<R> for ClassBody
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (Option<Function>, Vec<function::ClassElement>);
 
@@ -570,7 +570,7 @@ impl ClassElement {
 
 impl<R> TokenParser<R> for ClassElement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = (Option<Function>, Option<function::ClassElement>);
 

--- a/core/parser/src/parser/statement/declaration/hoistable/function_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/function_decl/mod.rs
@@ -1,13 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::parser::{
-    statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-    AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+use crate::{
+    parser::{
+        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+        AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+    },
+    source::ReadChar,
 };
 use boa_ast::{function::Function, Keyword};
 use boa_interner::Interner;
-use std::io::Read;
 
 /// Function declaration parsing.
 ///
@@ -70,7 +72,7 @@ impl CallableDeclaration for FunctionDeclaration {
 
 impl<R> TokenParser<R> for FunctionDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Function;
 

--- a/core/parser/src/parser/statement/declaration/hoistable/generator_decl/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/generator_decl/mod.rs
@@ -1,13 +1,15 @@
 #[cfg(test)]
 mod tests;
 
-use crate::parser::{
-    statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
-    AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+use crate::{
+    parser::{
+        statement::declaration::hoistable::{parse_callable_declaration, CallableDeclaration},
+        AllowAwait, AllowDefault, AllowYield, Cursor, ParseResult, TokenParser,
+    },
+    source::ReadChar,
 };
 use boa_ast::{function::Generator, Keyword, Punctuator};
 use boa_interner::Interner;
-use std::io::Read;
 
 /// Generator declaration parsing.
 ///
@@ -72,7 +74,7 @@ impl CallableDeclaration for GeneratorDeclaration {
 
 impl<R> TokenParser<R> for GeneratorDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Generator;
 

--- a/core/parser/src/parser/statement/declaration/hoistable/mod.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/mod.rs
@@ -24,6 +24,7 @@ use crate::{
         statement::LexError,
         AllowAwait, AllowDefault, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -35,7 +36,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 pub(in crate::parser) use self::{
     async_function_decl::AsyncFunctionDeclaration, async_generator_decl::AsyncGeneratorDeclaration,
@@ -74,7 +74,7 @@ impl HoistableDeclaration {
 
 impl<R> TokenParser<R> for HoistableDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Declaration;
 
@@ -145,7 +145,7 @@ trait CallableDeclaration {
 }
 
 // This is a helper function to not duplicate code in the individual callable declaration parsers.
-fn parse_callable_declaration<R: Read, C: CallableDeclaration>(
+fn parse_callable_declaration<R: ReadChar, C: CallableDeclaration>(
     c: &C,
     cursor: &mut Cursor<R>,
     interner: &mut Interner,

--- a/core/parser/src/parser/statement/declaration/import.rs
+++ b/core/parser/src/parser/statement/declaration/import.rs
@@ -16,6 +16,7 @@ use crate::{
         statement::{declaration::FromClause, BindingIdentifier},
         Error, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{
     declaration::{
@@ -27,7 +28,6 @@ use boa_ast::{
 };
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses an import declaration.
 ///
@@ -40,7 +40,7 @@ pub(in crate::parser) struct ImportDeclaration;
 
 impl ImportDeclaration {
     /// Tests if the next node is an `ImportDeclaration`.
-    pub(in crate::parser) fn test<R: Read>(
+    pub(in crate::parser) fn test<R: ReadChar>(
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> ParseResult<bool> {
@@ -71,7 +71,7 @@ impl ImportDeclaration {
 
 impl<R> TokenParser<R> for ImportDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstImportDeclaration;
 
@@ -171,7 +171,7 @@ struct ImportedBinding;
 
 impl<R> TokenParser<R> for ImportedBinding
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Identifier;
 
@@ -192,7 +192,7 @@ struct NamedImports;
 
 impl<R> TokenParser<R> for NamedImports
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Box<[AstImportSpecifier]>;
 
@@ -288,7 +288,7 @@ struct ImportSpecifier;
 
 impl<R> TokenParser<R> for ImportSpecifier
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = AstImportSpecifier;
 
@@ -373,7 +373,7 @@ struct NameSpaceImport;
 
 impl<R> TokenParser<R> for NameSpaceImport
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Identifier;
 

--- a/core/parser/src/parser/statement/declaration/lexical.rs
+++ b/core/parser/src/parser/statement/declaration/lexical.rs
@@ -15,6 +15,7 @@ use crate::{
         statement::{ArrayBindingPattern, BindingIdentifier, ObjectBindingPattern},
         AllowAwait, AllowIn, AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::operations::bound_names;
@@ -22,7 +23,6 @@ use boa_ast::{self as ast, declaration::Variable, pattern::Pattern, Keyword, Pun
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use rustc_hash::FxHashSet;
-use std::io::Read;
 
 /// Parses a lexical declaration.
 ///
@@ -62,7 +62,7 @@ impl LexicalDeclaration {
 
 impl<R> TokenParser<R> for LexicalDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::declaration::LexicalDeclaration;
 
@@ -167,7 +167,7 @@ impl BindingList {
 
 impl<R> TokenParser<R> for BindingList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::declaration::LexicalDeclaration;
 
@@ -276,7 +276,7 @@ impl LexicalBinding {
 
 impl<R> TokenParser<R> for LexicalBinding
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Variable;
 

--- a/core/parser/src/parser/statement/declaration/mod.rs
+++ b/core/parser/src/parser/statement/declaration/mod.rs
@@ -25,12 +25,12 @@ pub(in crate::parser) use self::{
 use crate::{
     lexer::TokenKind,
     parser::{AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser},
+    source::ReadChar,
     Error,
 };
 use boa_ast::{self as ast, Keyword};
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Parses a declaration.
 ///
@@ -61,7 +61,7 @@ impl Declaration {
 
 impl<R> TokenParser<R> for Declaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Declaration;
 
@@ -116,7 +116,7 @@ impl FromClause {
 
 impl<R> TokenParser<R> for FromClause
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::declaration::ModuleSpecifier;
 

--- a/core/parser/src/parser/statement/expression/mod.rs
+++ b/core/parser/src/parser/statement/expression/mod.rs
@@ -3,12 +3,12 @@ use crate::{
     parser::{
         expression::Expression, AllowAwait, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{Keyword, Punctuator, Statement};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Expression statement parsing.
 ///
@@ -38,7 +38,7 @@ impl ExpressionStatement {
 
 impl<R> TokenParser<R> for ExpressionStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Statement;
 

--- a/core/parser/src/parser/statement/if_stm/mod.rs
+++ b/core/parser/src/parser/statement/if_stm/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         statement::{declaration::FunctionDeclaration, Statement},
         AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -16,7 +17,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// If statement parsing.
 ///
@@ -53,7 +53,7 @@ impl IfStatement {
 
 impl<R> TokenParser<R> for IfStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = If;
 

--- a/core/parser/src/parser/statement/iteration/do_while_statement.rs
+++ b/core/parser/src/parser/statement/iteration/do_while_statement.rs
@@ -13,12 +13,12 @@ use crate::{
         expression::Expression, statement::Statement, AllowAwait, AllowReturn, AllowYield, Cursor,
         OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{statement::DoWhileLoop, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Do...while statement parsing
 ///
@@ -57,7 +57,7 @@ impl DoWhileStatement {
 
 impl<R> TokenParser<R> for DoWhileStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = DoWhileLoop;
 

--- a/core/parser/src/parser/statement/iteration/for_statement.rs
+++ b/core/parser/src/parser/statement/iteration/for_statement.rs
@@ -15,6 +15,7 @@ use crate::{
         statement::{variable::VariableDeclarationList, Statement},
         AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::{
@@ -32,7 +33,6 @@ use boa_ast::{
 use boa_interner::{Interner, Sym};
 use boa_profiler::Profiler;
 use rustc_hash::FxHashSet;
-use std::io::Read;
 
 /// For statement parsing
 ///
@@ -71,7 +71,7 @@ impl ForStatement {
 
 impl<R> TokenParser<R> for ForStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Statement;
 

--- a/core/parser/src/parser/statement/iteration/while_statement.rs
+++ b/core/parser/src/parser/statement/iteration/while_statement.rs
@@ -3,12 +3,12 @@ use crate::{
         expression::Expression, statement::Statement, AllowAwait, AllowReturn, AllowYield, Cursor,
         OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{statement::WhileLoop, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// While statement parsing
 ///
@@ -47,7 +47,7 @@ impl WhileStatement {
 
 impl<R> TokenParser<R> for WhileStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = WhileLoop;
 

--- a/core/parser/src/parser/statement/labelled_stm/mod.rs
+++ b/core/parser/src/parser/statement/labelled_stm/mod.rs
@@ -6,12 +6,12 @@ use crate::{
         statement::{declaration::FunctionDeclaration, AllowAwait, AllowReturn, Statement},
         AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{self as ast, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Labelled Statement Parsing
 ///
@@ -45,7 +45,7 @@ impl LabelledStatement {
 
 impl<R> TokenParser<R> for LabelledStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::statement::Labelled;
 

--- a/core/parser/src/parser/statement/mod.rs
+++ b/core/parser/src/parser/statement/mod.rs
@@ -44,6 +44,7 @@ use crate::{
         expression::{BindingIdentifier, Initializer, PropertyName},
         AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::{
@@ -58,7 +59,6 @@ use boa_ast::{
 use boa_interner::Interner;
 use boa_macros::utf16;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 pub(in crate::parser) use declaration::ClassTail;
 
@@ -113,7 +113,7 @@ impl Statement {
 
 impl<R> TokenParser<R> for Statement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::Statement;
 
@@ -273,7 +273,7 @@ impl StatementList {
 
 impl<R> TokenParser<R> for StatementList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::StatementList;
 
@@ -404,7 +404,7 @@ impl StatementListItem {
 
 impl<R> TokenParser<R> for StatementListItem
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = ast::StatementListItem;
 
@@ -474,7 +474,7 @@ impl ObjectBindingPattern {
 
 impl<R> TokenParser<R> for ObjectBindingPattern
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Vec<ObjectPatternElement>;
 
@@ -719,7 +719,7 @@ impl ArrayBindingPattern {
 
 impl<R> TokenParser<R> for ArrayBindingPattern
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Vec<ArrayPatternElement>;
 
@@ -905,7 +905,7 @@ pub(super) struct ModuleItemList;
 
 impl<R> TokenParser<R> for ModuleItemList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = boa_ast::ModuleItemList;
 
@@ -955,7 +955,7 @@ struct ModuleItem;
 
 impl<R> TokenParser<R> for ModuleItem
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = boa_ast::ModuleItem;
 

--- a/core/parser/src/parser/statement/return_stm/mod.rs
+++ b/core/parser/src/parser/statement/return_stm/mod.rs
@@ -5,11 +5,11 @@ use crate::{
         expression::Expression,
         AllowAwait, AllowYield, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{statement::Return, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Return statement parsing
 ///
@@ -41,7 +41,7 @@ impl ReturnStatement {
 
 impl<R> TokenParser<R> for ReturnStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Return;
 

--- a/core/parser/src/parser/statement/switch/mod.rs
+++ b/core/parser/src/parser/statement/switch/mod.rs
@@ -7,6 +7,7 @@ use crate::{
         expression::Expression, statement::StatementList, AllowAwait, AllowReturn, AllowYield,
         Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use ast::operations::{lexically_declared_names_legacy, var_declared_names};
@@ -14,7 +15,6 @@ use boa_ast::{self as ast, statement, statement::Switch, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
 use rustc_hash::FxHashMap;
-use std::io::Read;
 
 /// The possible `TokenKind` which indicate the end of a case statement.
 const CASE_BREAK_TOKENS: [TokenKind; 3] = [
@@ -56,7 +56,7 @@ impl SwitchStatement {
 
 impl<R> TokenParser<R> for SwitchStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Switch;
 
@@ -141,7 +141,7 @@ impl CaseBlock {
 
 impl<R> TokenParser<R> for CaseBlock
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Box<[statement::Case]>;
 

--- a/core/parser/src/parser/statement/throw/mod.rs
+++ b/core/parser/src/parser/statement/throw/mod.rs
@@ -4,11 +4,11 @@ mod tests;
 use crate::{
     lexer::TokenKind,
     parser::{expression::Expression, AllowAwait, AllowYield, Cursor, ParseResult, TokenParser},
+    source::ReadChar,
 };
 use boa_ast::{statement::Throw, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// For statement parsing
 ///
@@ -40,7 +40,7 @@ impl ThrowStatement {
 
 impl<R> TokenParser<R> for ThrowStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Throw;
 

--- a/core/parser/src/parser/statement/try_stm/catch.rs
+++ b/core/parser/src/parser/statement/try_stm/catch.rs
@@ -4,6 +4,7 @@ use crate::{
         statement::{block::Block, ArrayBindingPattern, BindingIdentifier, ObjectBindingPattern},
         AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -14,7 +15,6 @@ use boa_ast::{
 use boa_interner::Interner;
 use boa_profiler::Profiler;
 use rustc_hash::FxHashSet;
-use std::io::Read;
 
 /// Catch parsing
 ///
@@ -49,7 +49,7 @@ impl Catch {
 
 impl<R> TokenParser<R> for Catch
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = statement::Catch;
 
@@ -149,7 +149,7 @@ impl CatchParameter {
 
 impl<R> TokenParser<R> for CatchParameter
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Binding;
 

--- a/core/parser/src/parser/statement/try_stm/finally.rs
+++ b/core/parser/src/parser/statement/try_stm/finally.rs
@@ -1,10 +1,13 @@
-use crate::parser::{
-    statement::block::Block, AllowAwait, AllowReturn, AllowYield, Cursor, ParseResult, TokenParser,
+use crate::{
+    parser::{
+        statement::block::Block, AllowAwait, AllowReturn, AllowYield, Cursor, ParseResult,
+        TokenParser,
+    },
+    source::ReadChar,
 };
 use boa_ast::{statement, Keyword};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Finally parsing
 ///
@@ -39,7 +42,7 @@ impl Finally {
 
 impl<R> TokenParser<R> for Finally
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = statement::Finally;
 

--- a/core/parser/src/parser/statement/try_stm/mod.rs
+++ b/core/parser/src/parser/statement/try_stm/mod.rs
@@ -9,6 +9,7 @@ use super::block::Block;
 use crate::{
     lexer::TokenKind,
     parser::{AllowAwait, AllowReturn, AllowYield, Cursor, OrAbrupt, ParseResult, TokenParser},
+    source::ReadChar,
     Error,
 };
 use boa_ast::{
@@ -17,7 +18,6 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// Try...catch statement parsing
 ///
@@ -52,7 +52,7 @@ impl TryStatement {
 
 impl<R> TokenParser<R> for TryStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Try;
 

--- a/core/parser/src/parser/statement/variable/mod.rs
+++ b/core/parser/src/parser/statement/variable/mod.rs
@@ -8,6 +8,7 @@ use crate::{
         statement::{ArrayBindingPattern, BindingIdentifier, ObjectBindingPattern},
         AllowAwait, AllowIn, AllowYield, OrAbrupt, ParseResult, TokenParser,
     },
+    source::ReadChar,
 };
 use boa_ast::{
     declaration::{VarDeclaration, Variable},
@@ -15,7 +16,7 @@ use boa_ast::{
 };
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::{convert::TryInto, io::Read};
+use std::convert::TryInto;
 
 /// Variable statement parsing.
 ///
@@ -49,7 +50,7 @@ impl VariableStatement {
 
 impl<R> TokenParser<R> for VariableStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = VarDeclaration;
 
@@ -103,7 +104,7 @@ impl VariableDeclarationList {
 
 impl<R> TokenParser<R> for VariableDeclarationList
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = VarDeclaration;
 
@@ -158,7 +159,7 @@ impl VariableDeclaration {
 
 impl<R> TokenParser<R> for VariableDeclaration
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = Variable;
 

--- a/core/parser/src/parser/statement/with/mod.rs
+++ b/core/parser/src/parser/statement/with/mod.rs
@@ -5,12 +5,12 @@ use crate::{
         cursor::Cursor, expression::Expression, statement::Statement, AllowAwait, AllowReturn,
         AllowYield, ParseResult, TokenParser,
     },
+    source::ReadChar,
     Error,
 };
 use boa_ast::{statement::With, Keyword, Punctuator};
 use boa_interner::Interner;
 use boa_profiler::Profiler;
-use std::io::Read;
 
 /// With statement parsing.
 ///
@@ -49,7 +49,7 @@ impl WithStatement {
 
 impl<R> TokenParser<R> for WithStatement
 where
-    R: Read,
+    R: ReadChar,
 {
     type Output = With;
 

--- a/core/parser/src/source/utf16.rs
+++ b/core/parser/src/source/utf16.rs
@@ -1,0 +1,65 @@
+use super::ReadChar;
+use std::io;
+
+/// Input for UTF-16 encoded sources.
+#[derive(Debug)]
+pub struct UTF16Input<'a> {
+    input: &'a [u16],
+    index: usize,
+}
+
+impl<'a> UTF16Input<'a> {
+    /// Creates a new `UTF16Input` from a UTF-16 encoded slice e.g. <code>[&\[u16\]][slice]</code>.
+    ///
+    /// [slice]: std::slice
+    #[must_use]
+    pub const fn new(input: &'a [u16]) -> Self {
+        Self { input, index: 0 }
+    }
+}
+
+impl ReadChar for UTF16Input<'_> {
+    /// Retrieves the next unchecked char in u32 code point.
+    fn next_char(&mut self) -> io::Result<Option<u32>> {
+        let Some(u1) = self.input.get(self.index).copied() else {
+            return Ok(None);
+        };
+
+        self.index += 1;
+
+        // If the code unit is not a high surrogate, it is not the start of a surrogate pair.
+        if !is_high_surrogate(u1) {
+            return Ok(Some(u1.into()));
+        }
+
+        let Some(u2) = self.input.get(self.index).copied() else {
+            return Ok(Some(u1.into()));
+        };
+
+        // If the code unit is not a low surrogate, it is not a surrogate pair.
+        if !is_low_surrogate(u2) {
+            return Ok(Some(u1.into()));
+        }
+
+        self.index += 1;
+
+        Ok(Some(code_point_from_surrogates(u1, u2)))
+    }
+}
+
+const SURROGATE_HIGH_START: u16 = 0xD800;
+const SURROGATE_HIGH_END: u16 = 0xDBFF;
+const SURROGATE_LOW_START: u16 = 0xDC00;
+const SURROGATE_LOW_END: u16 = 0xDFFF;
+
+fn is_high_surrogate(b: u16) -> bool {
+    (SURROGATE_HIGH_START..=SURROGATE_HIGH_END).contains(&b)
+}
+
+fn is_low_surrogate(b: u16) -> bool {
+    (SURROGATE_LOW_START..=SURROGATE_LOW_END).contains(&b)
+}
+
+fn code_point_from_surrogates(high: u16, low: u16) -> u32 {
+    ((u32::from(high & 0x3ff)) << 10 | u32::from(low & 0x3ff)) + 0x1_0000
+}

--- a/core/parser/src/source/utf8.rs
+++ b/core/parser/src/source/utf8.rs
@@ -28,27 +28,26 @@ impl<R: Read> ReadChar for UTF8Input<R> {
     fn next_char(&mut self) -> io::Result<Option<u32>> {
         // Decode UTF-8
         let x = match self.next_byte()? {
-            Some(b) if b < 128 => return Ok(Some(u32::from(b))),
-            Some(b) => b,
-            None => return Ok(None),
+            Some(b) if b >= 128 => b,         // UTF-8 codepoint
+            b => return Ok(b.map(u32::from)), // ASCII or None
         };
 
         // Multibyte case follows
         // Decode from a byte combination out of: [[[x y] z] w]
         // NOTE: Performance is sensitive to the exact formulation here
         let init = utf8_first_byte(x, 2);
-        let y = unwrap_or_0(self.next_byte()?);
+        let y = self.next_byte()?.unwrap_or(0);
         let mut ch = utf8_acc_cont_byte(init, y);
         if x >= 0xE0 {
             // [[x y z] w] case
             // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
-            let z = unwrap_or_0(self.next_byte()?);
+            let z = self.next_byte()?.unwrap_or(0);
             let y_z = utf8_acc_cont_byte(u32::from(y & CONT_MASK), z);
             ch = init << 12 | y_z;
             if x >= 0xF0 {
                 // [x y z w] case
                 // use only the lower 3 bits of `init`
-                let w = unwrap_or_0(self.next_byte()?);
+                let w = self.next_byte()?.unwrap_or(0);
                 ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
             }
         };
@@ -70,8 +69,4 @@ fn utf8_first_byte(byte: u8, width: u32) -> u32 {
 /// Returns the value of `ch` updated with continuation byte `byte`.
 fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
     (ch << 6) | u32::from(byte & CONT_MASK)
-}
-
-fn unwrap_or_0(opt: Option<u8>) -> u8 {
-    opt.unwrap_or(0)
 }

--- a/core/parser/src/source/utf8.rs
+++ b/core/parser/src/source/utf8.rs
@@ -1,0 +1,77 @@
+use super::ReadChar;
+use std::io::{self, Bytes, Read};
+
+/// Input for UTF-8 encoded sources.
+#[derive(Debug)]
+pub struct UTF8Input<R> {
+    input: Bytes<R>,
+}
+
+impl<R: Read> UTF8Input<R> {
+    /// Creates a new `UTF8Input` from a UTF-8 encoded source.
+    pub(crate) fn new(iter: R) -> Self {
+        Self {
+            input: iter.bytes(),
+        }
+    }
+}
+
+impl<R: Read> UTF8Input<R> {
+    /// Retrieves the next byte
+    fn next_byte(&mut self) -> io::Result<Option<u8>> {
+        self.input.next().transpose()
+    }
+}
+
+impl<R: Read> ReadChar for UTF8Input<R> {
+    /// Retrieves the next unchecked char in u32 code point.
+    fn next_char(&mut self) -> io::Result<Option<u32>> {
+        // Decode UTF-8
+        let x = match self.next_byte()? {
+            Some(b) if b < 128 => return Ok(Some(u32::from(b))),
+            Some(b) => b,
+            None => return Ok(None),
+        };
+
+        // Multibyte case follows
+        // Decode from a byte combination out of: [[[x y] z] w]
+        // NOTE: Performance is sensitive to the exact formulation here
+        let init = utf8_first_byte(x, 2);
+        let y = unwrap_or_0(self.next_byte()?);
+        let mut ch = utf8_acc_cont_byte(init, y);
+        if x >= 0xE0 {
+            // [[x y z] w] case
+            // 5th bit in 0xE0 .. 0xEF is always clear, so `init` is still valid
+            let z = unwrap_or_0(self.next_byte()?);
+            let y_z = utf8_acc_cont_byte(u32::from(y & CONT_MASK), z);
+            ch = init << 12 | y_z;
+            if x >= 0xF0 {
+                // [x y z w] case
+                // use only the lower 3 bits of `init`
+                let w = unwrap_or_0(self.next_byte()?);
+                ch = (init & 7) << 18 | utf8_acc_cont_byte(y_z, w);
+            }
+        };
+
+        Ok(Some(ch))
+    }
+}
+
+/// Mask of the value bits of a continuation byte.
+const CONT_MASK: u8 = 0b0011_1111;
+
+/// Returns the initial codepoint accumulator for the first byte.
+/// The first byte is special, only want bottom 5 bits for width 2, 4 bits
+/// for width 3, and 3 bits for width 4.
+fn utf8_first_byte(byte: u8, width: u32) -> u32 {
+    u32::from(byte & (0x7F >> width))
+}
+
+/// Returns the value of `ch` updated with continuation byte `byte`.
+fn utf8_acc_cont_byte(ch: u32, byte: u8) -> u32 {
+    (ch << 6) | u32::from(byte & CONT_MASK)
+}
+
+fn unwrap_or_0(opt: Option<u8>) -> u8 {
+    opt.unwrap_or(0)
+}


### PR DESCRIPTION
We currently have UTF-16 handling at runtime trough our `JsString` type. But one thing that is missing is support for UTF-16 input handling itself. One case where this is relevant for boa itself it in the handling of `eval`. Because we only allow UTF-8 input, we have to convert the input of `eval` to UTF-8 before parsing it.

To solve this, I added a `ReadChar` trait to the parser crate that allows the parser to handle different input encodings. The parsing itself is done on unicode code points. To make this work I removed all of the parsing that was done on bytes, since that was assuming that we only handle UTF-8 inputs. Most of that work is in https://github.com/boa-dev/boa/commit/55752f2b683867c2787ebf528d760ed333e6e136.

I added a UTF-16 input type. To get some first positive results I also adjusted the regex parsing to work for non UTF-8 inputs. That should give us some `eval` and regex related tests that pass now.