### PR TITLE
Update `boa_temporal` Time Zone design

### DIFF
--- a/core/engine/src/builtins/temporal/time_zone/custom.rs
+++ b/core/engine/src/builtins/temporal/time_zone/custom.rs
@@ -1,0 +1,76 @@
+//! A custom `TimeZone` object.
+use crate::{property::PropertyKey, string::utf16, Context, JsObject, JsValue};
+
+use boa_gc::{Finalize, Trace};
+use boa_temporal::{
+    components::{tz::TzProtocol, Instant},
+    TemporalError, TemporalResult,
+};
+use num_bigint::BigInt;
+
+#[derive(Debug, Clone, Trace, Finalize)]
+pub(crate) struct JsCustomTimeZone {
+    tz: JsObject,
+}
+
+impl TzProtocol for JsCustomTimeZone {
+    fn get_offset_nanos_for(&self, ctx: &mut dyn std::any::Any) -> TemporalResult<BigInt> {
+        let context = ctx
+            .downcast_mut::<Context>()
+            .expect("Context was not provided for a CustomTz");
+
+        let method = self
+            .tz
+            .get(utf16!("getOffsetNanosFor"), context)
+            .expect("Method must exist for the custom calendar to be valid.");
+
+        let result = method
+            .as_callable()
+            .expect("is method")
+            .call(&method, &[], context)
+            .map_err(|e| TemporalError::general(e.to_string()))?;
+
+        // TODO (nekevss): Validate that the below conversion is fine vs. matching to JsValue::BigInt()
+        let Some(bigint) = result.as_bigint() else {
+            return Err(TemporalError::r#type()
+                .with_message("Expected BigInt return from getOffsetNanosFor"));
+        };
+
+        Ok(bigint.as_inner().clone())
+    }
+
+    fn get_possible_instant_for(
+        &self,
+        ctx: &mut dyn std::any::Any,
+    ) -> TemporalResult<Vec<Instant>> {
+        let _context = ctx
+            .downcast_mut::<Context>()
+            .expect("Context was not provided for a CustomTz");
+
+        // TODO: Implement once Instant has been migrated to `boa_temporal`'s Instant.
+        Err(TemporalError::range().with_message("Not yet implemented."))
+    }
+
+    fn id(&self, ctx: &mut dyn std::any::Any) -> TemporalResult<String> {
+        let context = ctx
+            .downcast_mut::<Context>()
+            .expect("Context was not provided for a CustomTz");
+
+        let ident = self
+            .tz
+            .__get__(
+                &PropertyKey::from(utf16!("id")),
+                JsValue::undefined(),
+                &mut context.into(),
+            )
+            .expect("Method must exist for the custom calendar to be valid.");
+
+        let JsValue::String(id) = ident else {
+            return Err(
+                TemporalError::r#type().with_message("Invalid custom Time Zone identifier type.")
+            );
+        };
+
+        Ok(id.to_std_string_escaped())
+    }
+}

--- a/core/temporal/src/components/duration.rs
+++ b/core/temporal/src/components/duration.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use std::{any::Any, str::FromStr};
 
-use super::calendar::CalendarProtocol;
+use super::{calendar::CalendarProtocol, tz::TzProtocol};
 
 // ==== `DateDuration` ====
 
@@ -1161,7 +1161,7 @@ impl Duration {
     ///   seconds, milliseconds, microseconds, nanoseconds, increment, unit,
     ///   roundingMode [ , plainRelativeTo [, zonedRelativeTo [, precalculatedDateTime]]] )`
     #[allow(clippy::type_complexity)]
-    pub fn round_duration<C: CalendarProtocol>(
+    pub fn round_duration<C: CalendarProtocol, Z: TzProtocol>(
         &self,
         unbalance_date_duration: DateDuration,
         increment: f64,
@@ -1169,7 +1169,7 @@ impl Duration {
         rounding_mode: TemporalRoundingMode,
         relative_targets: (
             Option<&Date<C>>,
-            Option<&ZonedDateTime<C>>,
+            Option<&ZonedDateTime<C, Z>>,
             Option<&DateTime<C>>,
         ),
         context: &mut dyn Any,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

The updates on this branch is to bring the time zone implementation in line with the design from #3522 and related to #1804.

It changes the following:

- Changes `TimeZoneSlot` to the below

```rust
pub enum TimeZoneSlot<Z: TzProtocol> {
    /// A native `TimeZone` representation.
    Tz(TimeZone),
    /// A Custom `TimeZone` that implements the `TzProtocol`.
    Protocol(Z),
}
```

- Adds the custom time zone object (with a `Trace` impl).

Notably, as further context on the below, Time Zones right now is mostly the structure/scaffolding with limited functionality. We'll need to figure out a good way to handle tz system calls and IANA mapping (whether that be using some `icu4x` provider or baking something ourselves based from the IANA tz database) to really build this out functionality wise and test it, at least imo. If anyone has any thoughts, let me know 😄