### PR TITLE
`Date` refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,21 +50,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,7 +388,6 @@ dependencies = [
  "boa_temporal",
  "bytemuck",
  "cfg-if",
- "chrono",
  "criterion",
  "dashmap",
  "fast-float",
@@ -610,7 +594,6 @@ name = "boa_wasm"
 version = "0.17.0"
 dependencies = [
  "boa_engine",
- "chrono",
  "console_error_panic_hook",
  "getrandom",
  "wasm-bindgen",
@@ -711,20 +694,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
-dependencies = [
- "android-tzdata",
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "ciborium"
@@ -887,12 +856,6 @@ name = "const_fn"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "core_maths"
@@ -1569,29 +1532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4267,15 +4207,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ dependencies = [
  "textwrap",
  "thin-vec",
  "thiserror",
+ "time 0.3.31",
  "web-time",
  "writeable",
  "yoke",
@@ -464,9 +465,9 @@ dependencies = [
  "boa_interner",
  "boa_parser",
  "boa_runtime",
- "chrono",
  "futures-util",
  "smol",
+ "time 0.3.31",
 ]
 
 [[package]]
@@ -600,6 +601,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_yaml",
+ "time 0.3.31",
  "toml 0.8.8",
 ]
 
@@ -3193,7 +3195,7 @@ checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
 dependencies = [
  "colored",
  "log",
- "time 0.3.30",
+ "time 0.3.31",
  "windows-sys 0.48.0",
 ]
 
@@ -3508,18 +3510,19 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num_threads",
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.15",
+ "time-macros 0.2.16",
 ]
 
 [[package]]
@@ -3540,9 +3543,9 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ serde = "1.0.195"
 static_assertions = "1.1.0"
 textwrap = "0.16.0"
 thin-vec = "0.2.13"
+time = {version = "0.3.31", no-default-features = true, features = ["local-offset", "large-dates", "wasm-bindgen"]}
 
 # ICU4X
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ boa_temporal = { version = "~0.17.0", path = "core/temporal" }
 # Shared deps
 arbitrary = "1"
 bitflags = "2.4.2"
-chrono = { version = "0.4.31", default-features = false }
 clap = "4.4.18"
 colored = "2.1.0"
 fast-float = "0.2.0"
@@ -67,7 +66,7 @@ serde = "1.0.195"
 static_assertions = "1.1.0"
 textwrap = "0.16.0"
 thin-vec = "0.2.13"
-time = {version = "0.3.31", no-default-features = true, features = ["local-offset", "large-dates", "wasm-bindgen"]}
+time = {version = "0.3.31", no-default-features = true, features = ["local-offset", "large-dates", "wasm-bindgen", "parsing", "formatting", "macros"]}
 
 # ICU4X
 

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -93,6 +93,7 @@ bytemuck = { version = "1.14.0", features = ["derive"] }
 arrayvec = "0.7.4"
 intrusive-collections = "0.9.6"
 cfg-if = "1.0.0"
+time.workspace = true
 
 # intl deps
 boa_icu_provider = {workspace = true, features = ["std"], optional = true }

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -74,7 +74,6 @@ num-integer = "0.1.45"
 bitflags.workspace = true
 indexmap = { workspace = true, features = ["std"] }
 ryu-js = "1.0.0"
-chrono = { workspace = true, default-features = false, features = ["clock", "std"] }
 fast-float.workspace = true
 once_cell = { workspace = true, features = ["std"] }
 tap = "1.0.1"

--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -50,7 +50,7 @@ pub(super) fn day(t: f64) -> f64 {
 /// [spec]: https://tc39.es/ecma262/#sec-timewithinday
 pub(super) fn time_within_day(t: f64) -> f64 {
     // 1. Return 𝔽(ℝ(t) modulo ℝ(msPerDay)).
-    modulo(t, MS_PER_DAY)
+    t.rem_euclid(MS_PER_DAY)
 }
 
 /// Abstract operation `DaysInYear ( y )`
@@ -64,17 +64,17 @@ fn days_in_year(y: f64) -> u16 {
     let ry = y;
 
     // 2. If (ry modulo 400) = 0, return 366𝔽.
-    if modulo(ry, 400.0) == 0.0 {
+    if ry.rem_euclid(400.0) == 0.0 {
         return 366;
     }
 
     // 3. If (ry modulo 100) = 0, return 365𝔽.
-    if modulo(ry, 100.0) == 0.0 {
+    if ry.rem_euclid(100.0) == 0.0 {
         return 365;
     }
 
     // 4. If (ry modulo 4) = 0, return 366𝔽.
-    if modulo(ry, 4.0) == 0.0 {
+    if ry.rem_euclid(4.0) == 0.0 {
         return 366;
     }
 
@@ -256,7 +256,7 @@ pub(super) fn date_from_time(t: f64) -> u8 {
 /// [spec]: https://tc39.es/ecma262/#sec-weekday
 pub(super) fn week_day(t: f64) -> u8 {
     // 1. Return 𝔽(ℝ(Day(t) + 4𝔽) modulo 7).
-    modulo(day(t) + 4.0, 7.0) as u8
+    (day(t) + 4.0).rem_euclid(7.0) as u8
 }
 
 /// Abstract operation `HourFromTime ( t )`
@@ -267,7 +267,7 @@ pub(super) fn week_day(t: f64) -> u8 {
 /// [spec]: https://tc39.es/ecma262/#sec-hourfromtime
 pub(super) fn hour_from_time(t: f64) -> u8 {
     // 1. Return 𝔽(floor(ℝ(t / msPerHour)) modulo HoursPerDay).
-    modulo((t / MS_PER_HOUR).floor(), HOURS_PER_DAY) as u8
+    ((t / MS_PER_HOUR).floor()).rem_euclid(HOURS_PER_DAY) as u8
 }
 
 /// Abstract operation `MinFromTime ( t )`
@@ -278,7 +278,7 @@ pub(super) fn hour_from_time(t: f64) -> u8 {
 /// [spec]: https://tc39.es/ecma262/#sec-minfromtime
 pub(super) fn min_from_time(t: f64) -> u8 {
     // 1. Return 𝔽(floor(ℝ(t / msPerMinute)) modulo MinutesPerHour).
-    modulo((t / MS_PER_MINUTE).floor(), MINUTES_PER_HOUR) as u8
+    ((t / MS_PER_MINUTE).floor()).rem_euclid(MINUTES_PER_HOUR) as u8
 }
 
 /// Abstract operation `SecFromTime ( t )`
@@ -289,7 +289,7 @@ pub(super) fn min_from_time(t: f64) -> u8 {
 /// [spec]: https://tc39.es/ecma262/#sec-secfromtime
 pub(super) fn sec_from_time(t: f64) -> u8 {
     // 1. Return 𝔽(floor(ℝ(t / msPerSecond)) modulo SecondsPerMinute).
-    modulo((t / MS_PER_SECOND).floor(), SECONDS_PER_MINUTE) as u8
+    ((t / MS_PER_SECOND).floor()).rem_euclid(SECONDS_PER_MINUTE) as u8
 }
 
 /// Abstract operation `msFromTime ( t )`
@@ -300,7 +300,7 @@ pub(super) fn sec_from_time(t: f64) -> u8 {
 /// [spec]: https://tc39.es/ecma262/#sec-msfromtime
 pub(super) fn ms_from_time(t: f64) -> u16 {
     // 1. Return 𝔽(ℝ(t) modulo ℝ(msPerSecond)).
-    modulo(t, MS_PER_SECOND) as u16
+    t.rem_euclid(MS_PER_SECOND) as u16
 }
 
 /// Abstract operation `LocalTime ( t )`
@@ -386,7 +386,7 @@ pub(super) fn make_day(year: f64, month: f64, date: f64) -> f64 {
     }
 
     // 7. Let mn be 𝔽(ℝ(m) modulo 12).
-    let mn = modulo(m, 12.0) as u8;
+    let mn = m.rem_euclid(12.0) as u8;
 
     // 8. Find a finite time value t such that YearFromTime(t) is ym, MonthFromTime(t) is mn,
     //    and DateFromTime(t) is 1𝔽;
@@ -670,17 +670,8 @@ pub(super) fn to_date_string_t(tv: f64, hooks: &dyn HostHooks) -> JsString {
     )
 }
 
-fn modulo(n: f64, m: f64) -> f64 {
-    let r = n % m;
-    if r >= 0.0 {
-        r.floor()
-    } else {
-        (r + m).floor()
-    }
-}
-
 fn local_timezone_offset_seconds(t: f64, hooks: &dyn HostHooks) -> i32 {
-    let millis = modulo(t, MS_PER_SECOND);
+    let millis = t.rem_euclid(MS_PER_SECOND);
     let seconds = ((t - millis) / MS_PER_SECOND) as i64;
     hooks.local_timezone_offset_seconds(seconds)
 }

--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -1,202 +1,730 @@
-use crate::{context::HostHooks, value::IntegerOrNan, JsString};
-use chrono::{DateTime, Datelike, Duration, NaiveDate, NaiveDateTime, Timelike};
+use crate::{context::HostHooks, js_string, value::IntegerOrInfinity, JsString};
+use boa_macros::utf16;
+use chrono::{DateTime, NaiveDateTime};
 use std::{iter::Peekable, str::Chars};
 
-/// The absolute maximum value of a timestamp
-pub(super) const MAX_TIMESTAMP: i64 = 864 * 10i64.pow(13);
-/// The number of milliseconds in a second.
-pub(super) const MILLIS_PER_SECOND: i64 = 1000;
-/// The number of milliseconds in a minute.
-pub(super) const MILLIS_PER_MINUTE: i64 = MILLIS_PER_SECOND * 60;
-/// The number of milliseconds in an hour.
-pub(super) const MILLIS_PER_HOUR: i64 = MILLIS_PER_MINUTE * 60;
-/// The number of milliseconds in a day.
-pub(super) const MILLIS_PER_DAY: i64 = MILLIS_PER_HOUR * 24;
-
-// https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-values-and-time-range
+// Time-related Constants
 //
-// The smaller range supported by a time value as specified in this section is approximately -273,790 to 273,790
-// years relative to 1970.
-pub(super) const MIN_YEAR: i64 = -300_000;
-pub(super) const MAX_YEAR: i64 = -MIN_YEAR;
-pub(super) const MIN_MONTH: i64 = MIN_YEAR * 12;
-pub(super) const MAX_MONTH: i64 = MAX_YEAR * 12;
+// More info:
+// - [ECMAScript reference][spec]
+//
+// https://tc39.es/ecma262/#sec-time-related-constants
 
-/// Calculates the absolute day number from the year number.
-pub(super) const fn day_from_year(year: i64) -> i64 {
-    // Taken from https://chromium.googlesource.com/v8/v8/+/refs/heads/main/src/date/date.cc#496
-    // Useful to avoid negative divisions and overflows on 32-bit platforms (if we plan to support them).
-    const YEAR_DELTA: i64 = 399_999;
-    const fn day(year: i64) -> i64 {
-        let year = year + YEAR_DELTA;
-        365 * year + year / 4 - year / 100 + year / 400
-    }
+// HoursPerDay = 24
+const HOURS_PER_DAY: f64 = 24.0;
 
-    assert!(MIN_YEAR <= year && year <= MAX_YEAR);
-    day(year) - day(1970)
+// MinutesPerHour = 60
+const MINUTES_PER_HOUR: f64 = 60.0;
+
+// SecondsPerMinute = 60
+const SECONDS_PER_MINUTE: f64 = 60.0;
+
+// msPerSecond = 1000𝔽
+const MS_PER_SECOND: f64 = 1000.0;
+
+// msPerMinute = 60000𝔽 = msPerSecond × 𝔽(SecondsPerMinute)
+pub(super) const MS_PER_MINUTE: f64 = MS_PER_SECOND * SECONDS_PER_MINUTE;
+
+// msPerHour = 3600000𝔽 = msPerMinute × 𝔽(MinutesPerHour)
+const MS_PER_HOUR: f64 = MS_PER_MINUTE * MINUTES_PER_HOUR;
+
+// msPerDay = 86400000𝔽 = msPerHour × 𝔽(HoursPerDay)
+const MS_PER_DAY: f64 = MS_PER_HOUR * HOURS_PER_DAY;
+
+/// Abstract operation `Day ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-day
+pub(super) fn day(t: f64) -> f64 {
+    // 1. Return 𝔽(floor(ℝ(t / msPerDay))).
+    (t / MS_PER_DAY).floor()
 }
 
-/// Abstract operation [`MakeTime`][spec].
+/// Abstract operation `TimeWithinDay ( t )`
 ///
-/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-maketime
-pub(crate) fn make_time(hour: i64, min: i64, sec: i64, ms: i64) -> Option<i64> {
-    // 1. If hour is not finite or min is not finite or sec is not finite or ms is not finite, return NaN.
-    // 2. Let h be 𝔽(! ToIntegerOrInfinity(hour)).
-    // 3. Let m be 𝔽(! ToIntegerOrInfinity(min)).
-    // 4. Let s be 𝔽(! ToIntegerOrInfinity(sec)).
-    // 5. Let milli be 𝔽(! ToIntegerOrInfinity(ms)).
-
-    // 6. Let t be ((h * msPerHour + m * msPerMinute) + s * msPerSecond) + milli, performing the arithmetic according to IEEE 754-2019 rules (that is, as if using the ECMAScript operators * and +).
-    // 7. Return t.
-
-    let h_ms = hour.checked_mul(MILLIS_PER_HOUR)?;
-    let m_ms = min.checked_mul(MILLIS_PER_MINUTE)?;
-    let s_ms = sec.checked_mul(MILLIS_PER_SECOND)?;
-
-    h_ms.checked_add(m_ms)?.checked_add(s_ms)?.checked_add(ms)
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timewithinday
+pub(super) fn time_within_day(t: f64) -> f64 {
+    // 1. Return 𝔽(ℝ(t) modulo ℝ(msPerDay)).
+    modulo(t, MS_PER_DAY)
 }
 
-/// Abstract operation [`MakeDay`][spec].
+/// Abstract operation `DaysInYear ( y )`
 ///
-/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-makeday
-pub(crate) fn make_day(mut year: i64, mut month: i64, date: i64) -> Option<i64> {
-    // 1. If year is not finite or month is not finite or date is not finite, return NaN.
-    // 2. Let y be 𝔽(! ToIntegerOrInfinity(year)).
-    // 3. Let m be 𝔽(! ToIntegerOrInfinity(month)).
-    // 4. Let dt be 𝔽(! ToIntegerOrInfinity(date)).
-    if !(MIN_YEAR..=MAX_YEAR).contains(&year) || !(MIN_MONTH..=MAX_MONTH).contains(&month) {
-        return None;
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-daysinyear
+fn days_in_year(y: f64) -> u16 {
+    // 1. Let ry be ℝ(y).
+    let ry = y;
+
+    // 2. If (ry modulo 400) = 0, return 366𝔽.
+    if modulo(ry, 400.0) == 0.0 {
+        return 366;
     }
 
-    // At this point, we've already asserted that year and month are much less than its theoretical
-    // maximum and minimum values (i64::MAX/MIN), so we don't need to do checked operations.
+    // 3. If (ry modulo 100) = 0, return 365𝔽.
+    if modulo(ry, 100.0) == 0.0 {
+        return 365;
+    }
 
-    // 5. Let ym be y + 𝔽(floor(ℝ(m) / 12)).
-    // 6. If ym is not finite, return NaN.
-    year += month / 12;
-    // 7. Let mn be 𝔽(ℝ(m) modulo 12).
-    month %= 12;
-    if month < 0 {
-        month += 12;
+    // 4. If (ry modulo 4) = 0, return 366𝔽.
+    if modulo(ry, 4.0) == 0.0 {
+        return 366;
+    }
+
+    // 5. Return 365𝔽.
+    365
+}
+
+/// Abstract operation `DayFromYear ( y )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-dayfromyear
+fn day_from_year(y: f64) -> f64 {
+    // 1. Let ry be ℝ(y).
+    // 2. NOTE: In the following steps, each _numYearsN_ is the number of years divisible by N
+    //          that occur between the epoch and the start of year y.
+    //          (The number is negative if y is before the epoch.)
+
+    // 3. Let numYears1 be (ry - 1970).
+    let num_years_1 = y - 1970.0;
+
+    // 4. Let numYears4 be floor((ry - 1969) / 4).
+    let num_years_4 = ((y - 1969.0) / 4.0).floor();
+
+    // 5. Let numYears100 be floor((ry - 1901) / 100).
+    let num_years_100 = ((y - 1901.0) / 100.0).floor();
+
+    // 6. Let numYears400 be floor((ry - 1601) / 400).
+    let num_years_400 = ((y - 1601.0) / 400.0).floor();
+
+    // 7. Return 𝔽(365 × numYears1 + numYears4 - numYears100 + numYears400).
+    365.0 * num_years_1 + num_years_4 - num_years_100 + num_years_400
+}
+
+/// Abstract operation `TimeFromYear ( y )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timefromyear
+fn time_from_year(y: f64) -> f64 {
+    // 1. Return msPerDay × DayFromYear(y).
+    MS_PER_DAY * day_from_year(y)
+}
+
+/// Abstract operation `YearFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-yearfromtime
+pub(super) fn year_from_time(t: f64) -> i32 {
+    const MS_PER_AVERAGE_YEAR: f64 = 12.0 * 30.436_875 * MS_PER_DAY;
+
+    // 1. Return the largest integral Number y (closest to +∞) such that TimeFromYear(y) ≤ t.
+    let mut year = (((t + MS_PER_AVERAGE_YEAR / 2.0) / MS_PER_AVERAGE_YEAR).floor()) as i32 + 1970;
+    if time_from_year(year.into()) > t {
         year -= 1;
     }
+    year
+}
 
-    // 8. Find a finite time value t such that YearFromTime(t) is ym and MonthFromTime(t) is mn and DateFromTime(t) is
-    // 1𝔽; but if this is not possible (because some argument is out of range), return NaN.
-    let month = usize::try_from(month).expect("month must be between 0 and 11 at this point");
+/// Abstract operation `DayWithinYear ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-daywithinyear
+fn day_within_year(t: f64) -> u16 {
+    // 1. Return Day(t) - DayFromYear(YearFromTime(t)).
+    (day(t) - day_from_year(year_from_time(t).into())) as u16
+}
 
-    let mut day = day_from_year(year);
+/// Abstract operation `InLeapYear ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-inleapyear
+fn in_leap_year(t: f64) -> u16 {
+    // 1. If DaysInYear(YearFromTime(t)) is 366𝔽, return 1𝔽; else return +0𝔽.
+    (days_in_year(year_from_time(t).into()) == 366).into()
+}
 
-    // Consider leap years when calculating the cumulative days added to the year from the input month
-    if (year % 4 != 0) || (year % 100 == 0 && year % 400 != 0) {
-        day += [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][month];
-    } else {
-        day += [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 305, 335][month];
+/// Abstract operation `MonthFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-monthfromtime
+pub(super) fn month_from_time(t: f64) -> u8 {
+    // 1. Let inLeapYear be InLeapYear(t).
+    let in_leap_year = in_leap_year(t);
+
+    // 2. Let dayWithinYear be DayWithinYear(t).
+    let day_within_year = day_within_year(t);
+
+    match day_within_year {
+        // 3. If dayWithinYear < 31𝔽, return +0𝔽.
+        t if t < 31 => 0,
+        // 4. If dayWithinYear < 59𝔽 + inLeapYear, return 1𝔽.
+        t if t < 59 + in_leap_year => 1,
+        // 5. If dayWithinYear < 90𝔽 + inLeapYear, return 2𝔽.
+        t if t < 90 + in_leap_year => 2,
+        // 6. If dayWithinYear < 120𝔽 + inLeapYear, return 3𝔽.
+        t if t < 120 + in_leap_year => 3,
+        // 7. If dayWithinYear < 151𝔽 + inLeapYear, return 4𝔽.
+        t if t < 151 + in_leap_year => 4,
+        // 8. If dayWithinYear < 181𝔽 + inLeapYear, return 5𝔽.
+        t if t < 181 + in_leap_year => 5,
+        // 9. If dayWithinYear < 212𝔽 + inLeapYear, return 6𝔽.
+        t if t < 212 + in_leap_year => 6,
+        // 10. If dayWithinYear < 243𝔽 + inLeapYear, return 7𝔽.
+        t if t < 243 + in_leap_year => 7,
+        // 11. If dayWithinYear < 273𝔽 + inLeapYear, return 8𝔽.
+        t if t < 273 + in_leap_year => 8,
+        // 12. If dayWithinYear < 304𝔽 + inLeapYear, return 9𝔽.
+        t if t < 304 + in_leap_year => 9,
+        // 13. If dayWithinYear < 334𝔽 + inLeapYear, return 10𝔽.
+        t if t < 334 + in_leap_year => 10,
+        // 14. Assert: dayWithinYear < 365𝔽 + inLeapYear.
+        // 15. Return 11𝔽.
+        _ => 11,
     }
+}
+
+/// Abstract operation `DateFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-datefromtime
+pub(super) fn date_from_time(t: f64) -> u8 {
+    // 1. Let inLeapYear be InLeapYear(t).
+    let in_leap_year = in_leap_year(t);
+
+    // 2. Let dayWithinYear be DayWithinYear(t).
+    let day_within_year = day_within_year(t);
+
+    // 3. Let month be MonthFromTime(t).
+    let month = month_from_time(t);
+
+    let date = match month {
+        // 4. If month is +0𝔽, return dayWithinYear + 1𝔽.
+        0 => day_within_year + 1,
+        // 5. If month is 1𝔽, return dayWithinYear - 30𝔽.
+        1 => day_within_year - 30,
+        // 6. If month is 2𝔽, return dayWithinYear - 58𝔽 - inLeapYear.
+        2 => day_within_year - 58 - in_leap_year,
+        // 7. If month is 3𝔽, return dayWithinYear - 89𝔽 - inLeapYear.
+        3 => day_within_year - 89 - in_leap_year,
+        // 8. If month is 4𝔽, return dayWithinYear - 119𝔽 - inLeapYear.
+        4 => day_within_year - 119 - in_leap_year,
+        // 9. If month is 5𝔽, return dayWithinYear - 150𝔽 - inLeapYear.
+        5 => day_within_year - 150 - in_leap_year,
+        // 10. If month is 6𝔽, return dayWithinYear - 180𝔽 - inLeapYear.
+        6 => day_within_year - 180 - in_leap_year,
+        // 11. If month is 7𝔽, return dayWithinYear - 211𝔽 - inLeapYear.
+        7 => day_within_year - 211 - in_leap_year,
+        // 12. If month is 8𝔽, return dayWithinYear - 242𝔽 - inLeapYear.
+        8 => day_within_year - 242 - in_leap_year,
+        // 13. If month is 9𝔽, return dayWithinYear - 272𝔽 - inLeapYear.
+        9 => day_within_year - 272 - in_leap_year,
+        // 14. If month is 10𝔽, return dayWithinYear - 303𝔽 - inLeapYear.
+        10 => day_within_year - 303 - in_leap_year,
+        // 15. Assert: month is 11𝔽.
+        // 16. Return dayWithinYear - 333𝔽 - inLeapYear.
+        _ => day_within_year - 333 - in_leap_year,
+    };
+    date as u8
+}
+
+/// Abstract operation `WeekDay ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-weekday
+pub(super) fn week_day(t: f64) -> u8 {
+    // 1. Return 𝔽(ℝ(Day(t) + 4𝔽) modulo 7).
+    modulo(day(t) + 4.0, 7.0) as u8
+}
+
+/// Abstract operation `HourFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-hourfromtime
+pub(super) fn hour_from_time(t: f64) -> u8 {
+    // 1. Return 𝔽(floor(ℝ(t / msPerHour)) modulo HoursPerDay).
+    modulo((t / MS_PER_HOUR).floor(), HOURS_PER_DAY) as u8
+}
+
+/// Abstract operation `MinFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-minfromtime
+pub(super) fn min_from_time(t: f64) -> u8 {
+    // 1. Return 𝔽(floor(ℝ(t / msPerMinute)) modulo MinutesPerHour).
+    modulo((t / MS_PER_MINUTE).floor(), MINUTES_PER_HOUR) as u8
+}
+
+/// Abstract operation `SecFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-secfromtime
+pub(super) fn sec_from_time(t: f64) -> u8 {
+    // 1. Return 𝔽(floor(ℝ(t / msPerSecond)) modulo SecondsPerMinute).
+    modulo((t / MS_PER_SECOND).floor(), SECONDS_PER_MINUTE) as u8
+}
+
+/// Abstract operation `msFromTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-msfromtime
+pub(super) fn ms_from_time(t: f64) -> u16 {
+    // 1. Return 𝔽(ℝ(t) modulo ℝ(msPerSecond)).
+    modulo(t, MS_PER_SECOND) as u16
+}
+
+/// Abstract operation `LocalTime ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-localtime
+pub(super) fn local_time(t: f64, hooks: &dyn HostHooks) -> f64 {
+    t + f64::from(local_timezone_offset_seconds(t, hooks)) * MS_PER_SECOND
+}
+
+/// Abstract operation `UTC ( t )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-utc-t
+pub(super) fn utc_t(t: f64, hooks: &dyn HostHooks) -> f64 {
+    // 1. If t is not finite, return NaN.
+    if !t.is_finite() {
+        return f64::NAN;
+    }
+
+    t - f64::from(local_timezone_offset_seconds(t, hooks)) * MS_PER_SECOND
+}
+
+/// Abstract operation `MakeTime ( hour, min, sec, ms )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-maketime
+pub(super) fn make_time(hour: f64, min: f64, sec: f64, ms: f64) -> f64 {
+    // 1. If hour is not finite, min is not finite, sec is not finite, or ms is not finite, return NaN.
+    if !hour.is_finite() || !min.is_finite() || !sec.is_finite() || !ms.is_finite() {
+        return f64::NAN;
+    }
+
+    // 2. Let h be 𝔽(! ToIntegerOrInfinity(hour)).
+    let h = hour.abs().floor().copysign(hour);
+
+    // 3. Let m be 𝔽(! ToIntegerOrInfinity(min)).
+    let m = min.abs().floor().copysign(min);
+
+    // 4. Let s be 𝔽(! ToIntegerOrInfinity(sec)).
+    let s = sec.abs().floor().copysign(sec);
+
+    // 5. Let milli be 𝔽(! ToIntegerOrInfinity(ms)).
+    let milli = ms.abs().floor().copysign(ms);
+
+    // 6. Return ((h × msPerHour + m × msPerMinute) + s × msPerSecond) + milli.
+    ((h * MS_PER_HOUR + m * MS_PER_MINUTE) + s * MS_PER_SECOND) + milli
+}
+
+/// Abstract operation `MakeDay ( year, month, date )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-makeday
+pub(super) fn make_day(year: f64, month: f64, date: f64) -> f64 {
+    // 1. If year is not finite, month is not finite, or date is not finite, return NaN.
+    if !year.is_finite() || !month.is_finite() || !date.is_finite() {
+        return f64::NAN;
+    }
+
+    // 2. Let y be 𝔽(! ToIntegerOrInfinity(year)).
+    let y = year.abs().floor().copysign(year);
+
+    // 3. Let m be 𝔽(! ToIntegerOrInfinity(month)).
+    let m = month.abs().floor().copysign(month);
+
+    // 4. Let dt be 𝔽(! ToIntegerOrInfinity(date)).
+    let dt = date.abs().floor().copysign(date);
+
+    // 5. Let ym be y + 𝔽(floor(ℝ(m) / 12)).
+    let ym = y + (m / 12.0).floor();
+
+    // 6. If ym is not finite, return NaN.
+    if !ym.is_finite() {
+        return f64::NAN;
+    }
+
+    // 7. Let mn be 𝔽(ℝ(m) modulo 12).
+    let mn = modulo(m, 12.0) as u8;
+
+    // 8. Find a finite time value t such that YearFromTime(t) is ym, MonthFromTime(t) is mn,
+    //    and DateFromTime(t) is 1𝔽;
+    //    but if this is not possible (because some argument is out of range), return NaN.
+    let rest = if mn > 1 { 1.0 } else { 0.0 };
+    let days_within_year_to_end_of_month = match mn {
+        0 => 0.0,
+        1 => 31.0,
+        2 => 59.0,
+        3 => 90.0,
+        4 => 120.0,
+        5 => 151.0,
+        6 => 181.0,
+        7 => 212.0,
+        8 => 243.0,
+        9 => 273.0,
+        10 => 304.0,
+        11 => 334.0,
+        12 => 365.0,
+        _ => unreachable!(),
+    };
+    let t =
+        (day_from_year(ym + rest) - 365.0 * rest + days_within_year_to_end_of_month) * MS_PER_DAY;
 
     // 9. Return Day(t) + dt - 1𝔽.
-    (day - 1).checked_add(date)
+    day(t) + dt - 1.0
 }
 
-/// Abstract operation [`MakeDate`][spec].
+/// Abstract operation `MakeDate ( day, time )`
 ///
-/// [spec]: https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-makedate
-pub(crate) fn make_date(day: i64, time: i64) -> Option<i64> {
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-makedate
+pub(super) fn make_date(day: f64, time: f64) -> f64 {
     // 1. If day is not finite or time is not finite, return NaN.
-    // 2. Let tv be day × msPerDay + time.
-    // 3. If tv is not finite, return NaN.
-    // 4. Return tv.
-    day.checked_mul(MILLIS_PER_DAY)?.checked_add(time)
-}
-
-/// Abstract operation [`TimeClip`][spec]
-/// Returns the timestamp (number of milliseconds) if it is in the expected range.
-/// Otherwise, returns `None`.
-///
-/// [spec]: https://tc39.es/ecma262/#sec-timeclip
-pub(super) fn time_clip(time: i64) -> Option<i64> {
-    // 1. If time is not finite, return NaN.
-    // 2. If abs(ℝ(time)) > 8.64 × 10^15, return NaN.
-    // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
-    (time.checked_abs()? <= MAX_TIMESTAMP).then_some(time)
-}
-
-#[derive(Default, Debug, Clone, Copy)]
-pub(super) struct DateParameters {
-    pub(super) year: Option<IntegerOrNan>,
-    pub(super) month: Option<IntegerOrNan>,
-    pub(super) date: Option<IntegerOrNan>,
-    pub(super) hour: Option<IntegerOrNan>,
-    pub(super) minute: Option<IntegerOrNan>,
-    pub(super) second: Option<IntegerOrNan>,
-    pub(super) millisecond: Option<IntegerOrNan>,
-}
-
-/// Replaces some (or all) parameters of `date` with the specified parameters
-pub(super) fn replace_params<const LOCAL: bool>(
-    datetime: i64,
-    params: DateParameters,
-    hooks: &dyn HostHooks,
-) -> Option<i64> {
-    let datetime = NaiveDateTime::from_timestamp_millis(datetime)?;
-    let DateParameters {
-        year,
-        month,
-        date,
-        hour,
-        minute,
-        second,
-        millisecond,
-    } = params;
-
-    let datetime = if LOCAL {
-        hooks.local_from_utc(datetime).naive_local()
-    } else {
-        datetime
-    };
-
-    let year = match year {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.year()),
-    };
-    let month = match month {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.month() - 1),
-    };
-    let date = match date {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.day()),
-    };
-    let hour = match hour {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.hour()),
-    };
-    let minute = match minute {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.minute()),
-    };
-    let second = match second {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.second()),
-    };
-    let millisecond = match millisecond {
-        Some(i) => i.as_integer()?,
-        None => i64::from(datetime.timestamp_subsec_millis()),
-    };
-
-    let new_day = make_day(year, month, date)?;
-    let new_time = make_time(hour, minute, second, millisecond)?;
-    let mut ts = make_date(new_day, new_time)?;
-
-    if LOCAL {
-        ts = hooks
-            .local_from_naive_local(NaiveDateTime::from_timestamp_millis(ts)?)
-            .earliest()?
-            .naive_utc()
-            .timestamp_millis();
+    if !day.is_finite() || !time.is_finite() {
+        return f64::NAN;
     }
 
-    time_clip(ts)
+    // 2. Let tv be day × msPerDay + time.
+    let tv = day * MS_PER_DAY + time;
+
+    // 3. If tv is not finite, return NaN.
+    if !tv.is_finite() {
+        return f64::NAN;
+    }
+
+    // 4. Return tv.
+    tv
+}
+
+/// Abstract operation `MakeFullYear ( year )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-makefullyear
+pub(super) fn make_full_year(year: f64) -> f64 {
+    // 1. If year is NaN, return NaN.
+    if year.is_nan() {
+        return f64::NAN;
+    }
+
+    // 2. Let truncated be ! ToIntegerOrInfinity(year).
+    let truncated = IntegerOrInfinity::from(year);
+
+    // 3. If truncated is in the inclusive interval from 0 to 99, return 1900𝔽 + 𝔽(truncated).
+    // 4. Return 𝔽(truncated).
+    match truncated {
+        IntegerOrInfinity::Integer(i) if (0..=99).contains(&i) => 1900.0 + i as f64,
+        IntegerOrInfinity::Integer(i) => i as f64,
+        IntegerOrInfinity::PositiveInfinity => f64::INFINITY,
+        IntegerOrInfinity::NegativeInfinity => f64::NEG_INFINITY,
+    }
+}
+
+/// Abstract operation `TimeClip ( time )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timeclip
+pub(crate) fn time_clip(time: f64) -> f64 {
+    // 1. If time is not finite, return NaN.
+    if !time.is_finite() {
+        return f64::NAN;
+    }
+
+    // 2. If abs(ℝ(time)) > 8.64 × 10**15, return NaN.
+    if time.abs() > 8.64e15 {
+        return f64::NAN;
+    }
+
+    // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
+    let time = time.trunc();
+    if time.abs() == 0.0 {
+        return 0.0;
+    }
+
+    time
+}
+
+/// Abstract operation `TimeString ( tv )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timestring
+pub(super) fn time_string(tv: f64) -> JsString {
+    // 1. Let hour be ToZeroPaddedDecimalString(ℝ(HourFromTime(tv)), 2).
+    let hour = pad_two(hour_from_time(tv));
+
+    // 2. Let minute be ToZeroPaddedDecimalString(ℝ(MinFromTime(tv)), 2).
+    let minute = pad_two(min_from_time(tv));
+
+    // 3. Let second be ToZeroPaddedDecimalString(ℝ(SecFromTime(tv)), 2).
+    let second = pad_two(sec_from_time(tv));
+
+    // 4. Return the string-concatenation of
+    //  hour,
+    //  ":",
+    //  minute,
+    //  ":",
+    //  second,
+    //  the code unit 0x0020 (SPACE),
+    //  and "GMT".
+    js_string!(
+        &hour,
+        utf16!(":"),
+        &minute,
+        utf16!(":"),
+        &second,
+        utf16!(" GMT")
+    )
+}
+
+/// Abstract operation `DateString ( tv )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-datestring
+pub(super) fn date_string(tv: f64) -> JsString {
+    // 1. Let weekday be the Name of the entry in Table 63 with the Number WeekDay(tv).
+    let weekday = match week_day(tv) {
+        0 => utf16!("Sun"),
+        1 => utf16!("Mon"),
+        2 => utf16!("Tue"),
+        3 => utf16!("Wed"),
+        4 => utf16!("Thu"),
+        5 => utf16!("Fri"),
+        6 => utf16!("Sat"),
+        _ => unreachable!(),
+    };
+
+    // 2. Let month be the Name of the entry in Table 64 with the Number MonthFromTime(tv).
+    let month = match month_from_time(tv) {
+        0 => utf16!("Jan"),
+        1 => utf16!("Feb"),
+        2 => utf16!("Mar"),
+        3 => utf16!("Apr"),
+        4 => utf16!("May"),
+        5 => utf16!("Jun"),
+        6 => utf16!("Jul"),
+        7 => utf16!("Aug"),
+        8 => utf16!("Sep"),
+        9 => utf16!("Oct"),
+        10 => utf16!("Nov"),
+        11 => utf16!("Dec"),
+        _ => unreachable!(),
+    };
+
+    // 3. Let day be ToZeroPaddedDecimalString(ℝ(DateFromTime(tv)), 2).
+    let day = pad_two(date_from_time(tv));
+
+    // 4. Let yv be YearFromTime(tv).
+    let yv = year_from_time(tv);
+
+    // 5. If yv is +0𝔽 or yv > +0𝔽, let yearSign be the empty String; otherwise, let yearSign be "-".
+    let year_sign = if yv >= 0 { utf16!("") } else { utf16!("-") };
+
+    // 6. Let paddedYear be ToZeroPaddedDecimalString(abs(ℝ(yv)), 4).
+    let yv = yv.unsigned_abs();
+    let padded_year = if yv >= 100_000 {
+        js_string!(&pad_six(yv))
+    } else if yv >= 10000 {
+        js_string!(&pad_five(yv))
+    } else {
+        js_string!(&pad_four(yv))
+    };
+
+    // 7. Return the string-concatenation of
+    // weekday,
+    // the code unit 0x0020 (SPACE),
+    // month,
+    // the code unit 0x0020 (SPACE),
+    // day,
+    // the code unit 0x0020 (SPACE),
+    // yearSign,
+    // and paddedYear.
+    js_string!(
+        weekday,
+        utf16!(" "),
+        month,
+        utf16!(" "),
+        &day,
+        utf16!(" "),
+        year_sign,
+        &padded_year
+    )
+}
+
+/// Abstract operation `TimeZoneString ( tv )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-timezoneestring
+pub(super) fn time_zone_string(t: f64, hooks: &dyn HostHooks) -> JsString {
+    // 1. Let systemTimeZoneIdentifier be SystemTimeZoneIdentifier().
+    // 2. If IsTimeZoneOffsetString(systemTimeZoneIdentifier) is true, then
+    //     a. Let offsetNs be ParseTimeZoneOffsetString(systemTimeZoneIdentifier).
+    // 3. Else,
+    //     a. Let offsetNs be GetNamedTimeZoneOffsetNanoseconds(systemTimeZoneIdentifier, ℤ(ℝ(tv) × 10**6)).
+    // 4. Let offset be 𝔽(truncate(offsetNs / 10**6)).
+    let offset = f64::from(local_timezone_offset_seconds(t, hooks)) * MS_PER_SECOND;
+    //let offset = hooks.local_timezone_offset_seconds((t / MS_PER_SECOND).floor() as i64);
+
+    // 5. If offset is +0𝔽 or offset > +0𝔽, then
+    let (offset_sign, abs_offset) = if offset >= 0.0 {
+        // a. Let offsetSign be "+".
+        // b. Let absOffset be offset.
+        (utf16!("+"), offset)
+    }
+    // 6. Else,
+    else {
+        // a. Let offsetSign be "-".
+        // b. Let absOffset be -offset.
+        (utf16!("-"), -offset)
+    };
+
+    // 7. Let offsetMin be ToZeroPaddedDecimalString(ℝ(MinFromTime(absOffset)), 2).
+    let offset_min = pad_two(min_from_time(abs_offset));
+
+    // 8. Let offsetHour be ToZeroPaddedDecimalString(ℝ(HourFromTime(absOffset)), 2).
+    let offset_hour = pad_two(hour_from_time(abs_offset));
+
+    // 9. Let tzName be an implementation-defined string that is either the empty String or the
+    // string-concatenation of the code unit 0x0020 (SPACE), the code unit 0x0028 (LEFT PARENTHESIS),
+    // an implementation-defined timezone name, and the code unit 0x0029 (RIGHT PARENTHESIS).
+    // 10. Return the string-concatenation of offsetSign, offsetHour, offsetMin, and tzName.
+    js_string!(offset_sign, &offset_hour, &offset_min)
+}
+
+/// Abstract operation `ToDateString ( tv )`
+///
+/// More info:
+/// - [ECMAScript reference][spec]
+///
+/// [spec]: https://tc39.es/ecma262/#sec-todatestring
+pub(super) fn to_date_string_t(tv: f64, hooks: &dyn HostHooks) -> JsString {
+    // 1. If tv is NaN, return "Invalid Date".
+    if tv.is_nan() {
+        return JsString::from("Invalid Date");
+    }
+
+    // 2. Let t be LocalTime(tv).
+    let t = local_time(tv, hooks);
+
+    // 3. Return the string-concatenation of
+    // DateString(t),
+    // the code unit 0x0020 (SPACE),
+    // TimeString(t),
+    // and TimeZoneString(tv).
+    js_string!(
+        &date_string(t),
+        utf16!(" "),
+        &time_string(t),
+        &time_zone_string(t, hooks)
+    )
+}
+
+fn modulo(n: f64, m: f64) -> f64 {
+    let r = n % m;
+    if r >= 0.0 {
+        r.floor()
+    } else {
+        (r + m).floor()
+    }
+}
+
+fn local_timezone_offset_seconds(t: f64, hooks: &dyn HostHooks) -> i32 {
+    let millis = modulo(t, MS_PER_SECOND);
+    let seconds = ((t - millis) / MS_PER_SECOND) as i64;
+    hooks.local_timezone_offset_seconds(seconds)
+}
+
+pub(super) fn pad_two(t: u8) -> [u16; 2] {
+    if t < 10 {
+        [0x30, 0x30 + u16::from(t)]
+    } else {
+        [0x30 + (u16::from(t) / 10), 0x30 + (u16::from(t) % 10)]
+    }
+}
+
+pub(super) fn pad_three(t: u16) -> [u16; 3] {
+    [0x30 + t / 100, 0x30 + ((t / 10) % 10), 0x30 + (t % 10)]
+}
+
+pub(super) fn pad_four(t: u32) -> [u16; 4] {
+    [
+        0x30 + (t / 1000) as u16,
+        0x30 + ((t / 100) % 10) as u16,
+        0x30 + ((t / 10) % 10) as u16,
+        0x30 + (t % 10) as u16,
+    ]
+}
+
+pub(super) fn pad_five(t: u32) -> [u16; 5] {
+    [
+        0x30 + (t / 10_000) as u16,
+        0x30 + ((t / 1000) % 10) as u16,
+        0x30 + ((t / 100) % 10) as u16,
+        0x30 + ((t / 10) % 10) as u16,
+        0x30 + (t % 10) as u16,
+    ]
+}
+
+pub(super) fn pad_six(t: u32) -> [u16; 6] {
+    [
+        0x30 + (t / 100_000) as u16,
+        0x30 + ((t / 10_000) % 10) as u16,
+        0x30 + ((t / 1000) % 10) as u16,
+        0x30 + ((t / 100) % 10) as u16,
+        0x30 + ((t / 10) % 10) as u16,
+        0x30 + (t % 10) as u16,
+    ]
 }
 
 /// Parse a date string according to the steps specified in [`Date.parse`][spec].
@@ -216,7 +744,7 @@ pub(super) fn parse_date(date: &JsString, hooks: &dyn HostHooks) -> Option<i64> 
 
     // Date Time String Format: 'YYYY-MM-DDTHH:mm:ss.sssZ'
     if let Some(dt) = DateParser::new(&date, hooks).parse() {
-        return Some(dt.timestamp_millis());
+        return Some(dt);
     }
 
     // `toString` format: `Thu Jan 01 1970 00:00:00 GMT+0000`
@@ -245,7 +773,7 @@ struct DateParser<'a> {
     minute: u32,
     second: u32,
     millisecond: u32,
-    offset: Duration,
+    offset: i64,
 }
 
 impl<'a> DateParser<'a> {
@@ -260,7 +788,7 @@ impl<'a> DateParser<'a> {
             minute: 0,
             second: 0,
             millisecond: 0,
-            offset: Duration::minutes(0),
+            offset: 0,
         }
     }
 
@@ -280,28 +808,55 @@ impl<'a> DateParser<'a> {
         })
     }
 
-    fn finish(&mut self) -> Option<NaiveDateTime> {
+    fn finish(&mut self) -> Option<i64> {
         if self.input.peek().is_some() {
             return None;
         }
 
-        NaiveDate::from_ymd_opt(self.year, self.month, self.day)
-            .and_then(|date| {
-                date.and_hms_milli_opt(self.hour, self.minute, self.second, self.millisecond)
-            })
-            .map(|dt| dt + self.offset)
+        let date = make_date(
+            make_day(self.year.into(), (self.month - 1).into(), self.day.into()),
+            make_time(
+                self.hour.into(),
+                self.minute.into(),
+                self.second.into(),
+                self.millisecond.into(),
+            ),
+        );
+
+        let date = date + (self.offset as f64) * MS_PER_MINUTE;
+
+        let t = time_clip(date);
+        if t.is_finite() {
+            Some(t as i64)
+        } else {
+            None
+        }
     }
 
-    fn finish_local(&mut self) -> Option<NaiveDateTime> {
-        self.finish().and_then(|dt| {
-            self.hooks
-                .local_from_naive_local(dt)
-                .earliest()
-                .map(|dt| dt.naive_utc())
-        })
+    fn finish_local(&mut self) -> Option<i64> {
+        if self.input.peek().is_some() {
+            return None;
+        }
+
+        let date = make_date(
+            make_day(self.year.into(), (self.month - 1).into(), self.day.into()),
+            make_time(
+                self.hour.into(),
+                self.minute.into(),
+                self.second.into(),
+                self.millisecond.into(),
+            ),
+        );
+
+        let t = time_clip(utc_t(date, self.hooks));
+        if t.is_finite() {
+            Some(t as i64)
+        } else {
+            None
+        }
     }
 
-    fn parse(&mut self) -> Option<NaiveDateTime> {
+    fn parse(&mut self) -> Option<i64> {
         self.parse_year()?;
         match self.input.peek() {
             Some('T') => return self.parse_time(),
@@ -310,6 +865,9 @@ impl<'a> DateParser<'a> {
         }
         self.next_expect('-')?;
         self.month = u32::from(self.next_digit()?) * 10 + u32::from(self.next_digit()?);
+        if self.month < 1 || self.month > 12 {
+            return None;
+        }
         match self.input.peek() {
             Some('T') => return self.parse_time(),
             None => return self.finish(),
@@ -317,6 +875,9 @@ impl<'a> DateParser<'a> {
         }
         self.next_expect('-')?;
         self.day = u32::from(self.next_digit()?) * 10 + u32::from(self.next_digit()?);
+        if self.day < 1 || self.day > 31 {
+            return None;
+        }
         match self.input.peek() {
             Some('T') => self.parse_time(),
             _ => self.finish(),
@@ -358,11 +919,17 @@ impl<'a> DateParser<'a> {
         }
     }
 
-    fn parse_time(&mut self) -> Option<NaiveDateTime> {
+    fn parse_time(&mut self) -> Option<i64> {
         self.next_expect('T')?;
         self.hour = u32::from(self.next_digit()?) * 10 + u32::from(self.next_digit()?);
+        if self.hour > 24 {
+            return None;
+        }
         self.next_expect(':')?;
         self.minute = u32::from(self.next_digit()?) * 10 + u32::from(self.next_digit()?);
+        if self.minute > 59 {
+            return None;
+        }
         match self.input.peek() {
             Some(':') => {}
             None => return self.finish_local(),
@@ -373,6 +940,9 @@ impl<'a> DateParser<'a> {
         }
         self.next_expect(':')?;
         self.second = u32::from(self.next_digit()?) * 10 + u32::from(self.next_digit()?);
+        if self.second > 59 {
+            return None;
+        }
         match self.input.peek() {
             Some('.') => {}
             None => return self.finish_local(),
@@ -397,30 +967,40 @@ impl<'a> DateParser<'a> {
         match self.input.next() {
             Some('Z') => return Some(()),
             Some('+') => {
-                self.offset = -Duration::hours(
-                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?),
-                );
+                let offset_hour =
+                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?);
+                if offset_hour > 23 {
+                    return None;
+                }
+                self.offset = -offset_hour * 60;
                 if self.input.peek().is_none() {
                     return Some(());
                 }
                 self.next_expect(':')?;
-                self.offset = self.offset
-                    + -Duration::minutes(
-                        i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?),
-                    );
+                let offset_minute =
+                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?);
+                if offset_minute > 59 {
+                    return None;
+                }
+                self.offset += -offset_minute;
             }
             Some('-') => {
-                self.offset = Duration::hours(
-                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?),
-                );
+                let offset_hour =
+                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?);
+                if offset_hour > 23 {
+                    return None;
+                }
+                self.offset = offset_hour * 60;
                 if self.input.peek().is_none() {
                     return Some(());
                 }
                 self.next_expect(':')?;
-                self.offset = self.offset
-                    + Duration::minutes(
-                        i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?),
-                    );
+                let offset_minute =
+                    i64::from(self.next_digit()?) * 10 + i64::from(self.next_digit()?);
+                if offset_minute > 59 {
+                    return None;
+                }
+                self.offset += offset_minute;
             }
             _ => return None,
         }

--- a/core/engine/src/object/builtins/jsdate.rs
+++ b/core/engine/src/object/builtins/jsdate.rs
@@ -1,8 +1,4 @@
 //! A Rust API wrapper for Boa's `Date` ECMAScript Builtin Object.
-use std::ops::Deref;
-
-use boa_gc::{Finalize, Trace};
-use chrono::DateTime;
 
 use crate::{
     builtins::Date,
@@ -10,6 +6,9 @@ use crate::{
     value::TryFromJs,
     Context, JsNativeError, JsResult, JsValue,
 };
+use boa_gc::{Finalize, Trace};
+use std::ops::Deref;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 /// `JsDate` is a wrapper for JavaScript `JsDate` builtin object
 ///
@@ -551,9 +550,9 @@ impl JsDate {
             .to_string(context)?
             .to_std_string()
             .map_err(|_| JsNativeError::typ().with_message("unpaired surrogate on date string"))?;
-        let date_time = DateTime::parse_from_rfc3339(&string)
+        let t = OffsetDateTime::parse(&string, &Rfc3339)
             .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
-        let date_time = Date::new(date_time.naive_local().timestamp_millis() as f64);
+        let date_time = Date::new((t.unix_timestamp() * 1000 + i64::from(t.millisecond())) as f64);
 
         Ok(Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(

--- a/core/engine/src/object/builtins/jsdate.rs
+++ b/core/engine/src/object/builtins/jsdate.rs
@@ -553,7 +553,7 @@ impl JsDate {
             .map_err(|_| JsNativeError::typ().with_message("unpaired surrogate on date string"))?;
         let date_time = DateTime::parse_from_rfc3339(&string)
             .map_err(|err| JsNativeError::typ().with_message(err.to_string()))?;
-        let date_time = Date::new(Some(date_time.naive_local().timestamp_millis()));
+        let date_time = Date::new(date_time.naive_local().timestamp_millis() as f64);
 
         Ok(Self {
             inner: JsObject::from_proto_and_data_with_shared_shape(

--- a/core/engine/src/value/integer.rs
+++ b/core/engine/src/value/integer.rs
@@ -99,26 +99,3 @@ impl PartialOrd<IntegerOrInfinity> for i64 {
         }
     }
 }
-
-/// Represents the result of the `to_integer_or_nan` method.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum IntegerOrNan {
-    Integer(i64),
-    Nan,
-}
-
-impl IntegerOrNan {
-    /// Gets the wrapped `i64` if the variant is an `Integer`.
-    pub(crate) const fn as_integer(self) -> Option<i64> {
-        match self {
-            Self::Integer(i) => Some(i),
-            Self::Nan => None,
-        }
-    }
-}
-
-impl From<IntegerOrInfinity> for IntegerOrNan {
-    fn from(ior: IntegerOrInfinity) -> Self {
-        ior.as_integer().map_or(Self::Nan, IntegerOrNan::Integer)
-    }
-}

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -45,7 +45,7 @@ pub use self::{
 #[doc(inline)]
 pub use boa_macros::TryFromJs;
 
-pub(crate) use self::{conversions::IntoOrUndefined, integer::IntegerOrNan};
+pub(crate) use self::conversions::IntoOrUndefined;
 
 static TWO_E_64: Lazy<BigInt> = Lazy::new(|| {
     const TWO_E_64: u128 = 2u128.pow(64);
@@ -853,22 +853,6 @@ impl JsValue {
 
         // Continues on `IntegerOrInfinity::from::<f64>`
         Ok(IntegerOrInfinity::from(number))
-    }
-
-    /// Modified abstract operation `ToIntegerOrInfinity ( argument )`.
-    ///
-    /// This function is almost the same as [`Self::to_integer_or_infinity`], but with the exception
-    /// that this will return `Nan` if [`Self::to_number`] returns a non-finite number.
-    pub(crate) fn to_integer_or_nan(&self, context: &mut Context) -> JsResult<IntegerOrNan> {
-        // 1. Let number be ? ToNumber(argument).
-        let number = self.to_number(context)?;
-
-        if number.is_nan() {
-            return Ok(IntegerOrNan::Nan);
-        }
-
-        // Continues on `IntegerOrInfinity::from::<f64>`
-        Ok(IntegerOrInfinity::from(number).into())
     }
 
     /// Converts a value to a double precision floating point.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ boa_interner.workspace = true
 boa_gc.workspace = true
 boa_parser.workspace = true
 boa_runtime.workspace = true
-chrono.workspace = true
+time.workspace = true
 smol = "2.0.0"
 futures-util = "0.3.30"
 

--- a/examples/src/bin/jsdate.rs
+++ b/examples/src/bin/jsdate.rs
@@ -1,22 +1,15 @@
 use boa_engine::{
     context::HostHooks, js_string, object::builtins::JsDate, Context, JsResult, JsValue,
 };
-use chrono::{DateTime, FixedOffset, LocalResult, NaiveDateTime, TimeZone};
 
 struct CustomTimezone;
 
 // This pins the local timezone to a system-agnostic value; in this case, UTC+3
 impl HostHooks for CustomTimezone {
-    fn local_from_utc(&self, utc: NaiveDateTime) -> DateTime<FixedOffset> {
-        FixedOffset::east_opt(3 * 3600)
-            .unwrap()
-            .from_utc_datetime(&utc)
-    }
-
-    fn local_from_naive_local(&self, local: NaiveDateTime) -> LocalResult<DateTime<FixedOffset>> {
-        FixedOffset::east_opt(3 * 3600)
-            .unwrap()
-            .from_local_datetime(&local)
+    fn local_timezone_offset_seconds(&self, _: i64) -> i32 {
+        time::UtcOffset::from_hms(3, 0, 0)
+            .expect("must be valid offset")
+            .whole_seconds()
     }
 }
 

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -15,7 +15,6 @@ rust-version.workspace = true
 boa_engine = { workspace = true, features = ["js"] }
 wasm-bindgen = { version = "0.2.90", default-features = false }
 getrandom = { version = "0.2.12", features = ["js"] }
-chrono = { workspace = true, default-features = false, features = ["clock", "std", "wasmbind"] }
 console_error_panic_hook = "0.1.7"
 
 [features]

--- a/ffi/wasm/src/lib.rs
+++ b/ffi/wasm/src/lib.rs
@@ -7,7 +7,6 @@
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 
 use boa_engine::{Context, Source};
-use chrono as _;
 use getrandom as _;
 use wasm_bindgen::prelude::*;
 

--- a/tests/tester/Cargo.toml
+++ b/tests/tester/Cargo.toml
@@ -31,6 +31,7 @@ phf = { workspace = true, features = ["macros"] }
 comfy-table = "7.1.0"
 serde_repr = "0.1.18"
 bus = "2.4.1"
+time.workspace = true
 
 [features]
 default = ["boa_engine/intl", "boa_engine/experimental", "boa_engine/annex-b"]

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -192,6 +192,12 @@ const DEFAULT_TEST262_DIRECTORY: &str = "test262";
 
 /// Program entry point.
 fn main() -> Result<()> {
+    // Safety: This is needed because we run tests in multiple threads.
+    // It is safe because tests do not modify the environment.
+    unsafe {
+        time::util::local_offset::set_soundness(time::util::local_offset::Soundness::Unsound);
+    }
+
     // initializes the monotonic clock.
     Lazy::force(&START);
     color_eyre::install()?;


### PR DESCRIPTION
This pull request refactors the `Date` builtin to align it with the spec and enable all tests to pass.

The date operations by `chrono` are removed. This is necessary, because `chrono` only allows a limited date range from `Jan 1, 262145 BCE` to `Dec 31, 262143 CE`. The spec allows for dates from `-271821-04-20T00:00:00.000Z` to `+275760-09-13T00:00:00.000Z`. Instead most datetime specific operations are now performed by the functions that the spec specifies. The only thing that is done by the `time` create is the calculation of local timzone offsets. All other usages of `chrono` are also removed so we can remove the dependency.
