### PR TITLE
Temporal: Update `Date` builtin with `boa_temporal` and fixes

### DIFF
--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -67,7 +67,7 @@ impl Now {
     #[allow(clippy::unnecessary_wraps)]
     fn time_zone_id(_: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Return ! SystemTimeZone().
-        Ok(system_time_zone(context).expect("retrieving the system timezone must not fail"))
+        system_time_zone(context)
     }
 
     /// `Temporal.Now.instant()`

--- a/core/temporal/src/components/date.rs
+++ b/core/temporal/src/components/date.rs
@@ -1,5 +1,7 @@
 //! This module implements `Date` and any directly related algorithms.
 
+use tinystr::TinyAsciiStr;
+
 use crate::{
     components::{
         calendar::{CalendarProtocol, CalendarSlot},
@@ -72,29 +74,29 @@ impl<C: CalendarProtocol> Date<C> {
 
     #[inline]
     #[must_use]
-    /// Returns this `Date`'s year value.
-    pub const fn year(&self) -> i32 {
+    /// Returns this `Date`'s ISO year value.
+    pub const fn iso_year(&self) -> i32 {
         self.iso.year()
     }
 
     #[inline]
     #[must_use]
-    /// Returns this `Date`'s month value.
-    pub const fn month(&self) -> u8 {
+    /// Returns this `Date`'s ISO month value.
+    pub const fn iso_month(&self) -> u8 {
         self.iso.month()
     }
 
     #[inline]
     #[must_use]
-    /// Returns this `Date`'s day value.
-    pub const fn day(&self) -> u8 {
+    /// Returns this `Date`'s ISO day value.
+    pub const fn iso_day(&self) -> u8 {
         self.iso.day()
     }
 
     #[inline]
     #[must_use]
     /// Returns the `Date`'s inner `IsoDate` record.
-    pub const fn iso_date(&self) -> IsoDate {
+    pub const fn iso(&self) -> IsoDate {
         self.iso
     }
 
@@ -120,6 +122,179 @@ impl<C: CalendarProtocol> Date<C> {
     #[must_use]
     pub fn days_until(&self, other: &Self) -> i32 {
         other.iso.to_epoch_days() - self.iso.to_epoch_days()
+    }
+}
+
+// ==== Calendar-derived Public API ====
+
+impl<C: CalendarProtocol> Date<C> {
+    /// Returns the calendar year value with provided context.
+    pub fn contextual_year(&self, context: &mut dyn Any) -> TemporalResult<i32> {
+        self.calendar.year(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar year value.
+    pub fn year(&self) -> TemporalResult<i32> {
+        self.contextual_year(&mut ())
+    }
+
+    /// Returns the calendar month value with provided context.
+    pub fn contextual_month(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+        self.calendar.month(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar month value.
+    pub fn month(&self) -> TemporalResult<u8> {
+        self.contextual_month(&mut ())
+    }
+
+    /// Returns the calendar month code value with provided context.
+    pub fn contextual_month_code(&self, context: &mut dyn Any) -> TemporalResult<TinyAsciiStr<4>> {
+        self.calendar.month_code(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar month code value.
+    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+        self.contextual_month_code(&mut ())
+    }
+
+    /// Returns the calendar day value with provided context.
+    pub fn contextual_day(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+        self.calendar.day(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar day value.
+    pub fn day(&self) -> TemporalResult<u8> {
+        self.contextual_day(&mut ())
+    }
+
+    /// Returns the calendar day of week value with provided context.
+    pub fn contextual_day_of_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.day_of_week(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar day of week value.
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
+        self.contextual_day_of_week(&mut ())
+    }
+
+    /// Returns the calendar day of year value with provided context.
+    pub fn contextual_day_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.day_of_week(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar day of year value.
+    pub fn day_of_year(&self) -> TemporalResult<u16> {
+        self.contextual_day_of_week(&mut ())
+    }
+
+    /// Returns the calendar week of year value with provided context.
+    pub fn contextual_week_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.week_of_year(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar week of year value.
+    pub fn week_of_year(&self) -> TemporalResult<u16> {
+        self.contextual_week_of_year(&mut ())
+    }
+
+    /// Returns the calendar year of week value with provided context.
+    pub fn contextual_year_of_week(&self, context: &mut dyn Any) -> TemporalResult<i32> {
+        self.calendar.year_of_week(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar year of week value.
+    pub fn year_of_week(&self) -> TemporalResult<i32> {
+        self.contextual_year_of_week(&mut ())
+    }
+
+    /// Returns the calendar days in week value with provided context.
+    pub fn contextual_days_in_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.days_in_week(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar days in week value.
+    pub fn days_in_week(&self) -> TemporalResult<u16> {
+        self.contextual_days_in_week(&mut ())
+    }
+
+    /// Returns the calendar days in month value with provided context.
+    pub fn contextual_days_in_month(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.days_in_month(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar days in month value.
+    pub fn days_in_month(&self) -> TemporalResult<u16> {
+        self.contextual_days_in_month(&mut ())
+    }
+
+    /// Returns the calendar days in year value with provided context.
+    pub fn contextual_days_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.days_in_year(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar days in year value.
+    pub fn days_in_year(&self) -> TemporalResult<u16> {
+        self.contextual_days_in_year(&mut ())
+    }
+
+    /// Returns the calendar months in year value with provided context.
+    pub fn contextual_months_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+        self.calendar.months_in_year(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns the calendar months in year value.
+    pub fn months_in_year(&self) -> TemporalResult<u16> {
+        self.contextual_months_in_year(&mut ())
+    }
+
+    /// Returns whether the date is in a leap year for the given calendar with provided context.
+    pub fn contextual_in_leap_year(&self, context: &mut dyn Any) -> TemporalResult<bool> {
+        self.calendar.in_leap_year(
+            &super::calendar::CalendarDateLike::Date(self.clone()),
+            context,
+        )
+    }
+
+    /// Returns returns whether the date in a leap year for the given calendar.
+    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+        self.contextual_in_leap_year(&mut ())
     }
 }
 

--- a/core/temporal/src/components/duration/date.rs
+++ b/core/temporal/src/components/duration/date.rs
@@ -212,7 +212,7 @@ impl DateDuration {
                 fractional_days += f64::from(months_weeks_in_days);
 
                 // k. Let isoResult be ! AddISODate(plainRelativeTo.[[ISOYear]]. plainRelativeTo.[[ISOMonth]], plainRelativeTo.[[ISODay]], 0, 0, 0, truncate(fractionalDays), "constrain").
-                let iso_result = plain_relative_to.iso_date().add_iso_date(
+                let iso_result = plain_relative_to.iso().add_iso_date(
                     &DateDuration::new_unchecked(0.0, 0.0, 0.0, fractional_days.trunc()),
                     ArithmeticOverflow::Constrain,
                 )?;

--- a/core/temporal/src/iso.rs
+++ b/core/temporal/src/iso.rs
@@ -171,11 +171,11 @@ impl IsoDate {
     ) -> TemporalResult<Self> {
         match overflow {
             ArithmeticOverflow::Constrain => {
-                let m = month.clamp(1, 12);
+                let month = month.clamp(1, 12);
                 let days_in_month = utils::iso_days_in_month(year, month);
                 let d = day.clamp(1, days_in_month);
                 // NOTE: Values are clamped in a u8 range.
-                Ok(Self::new_unchecked(year, m as u8, d as u8))
+                Ok(Self::new_unchecked(year, month as u8, d as u8))
             }
             ArithmeticOverflow::Reject => {
                 if !is_valid_date(year, month, day) {

--- a/core/temporal/src/utils.rs
+++ b/core/temporal/src/utils.rs
@@ -305,7 +305,7 @@ pub(crate) fn iso_days_in_month(year: i32, month: i32) -> i32 {
         1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
         4 | 6 | 9 | 11 => 30,
         2 => 28 + mathematical_in_leap_year(epoch_time_for_year(year)),
-        _ => unreachable!("an invalid month value is an implementation error."),
+        _ => unreachable!("ISODaysInMonth panicking is an implementation error."),
     }
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to #1804. This begins to add functionality in `boa_temporal` to the Temporal builtins (with hopefully more to come).

It changes the following:

- Adds some methods to `Date` in `boa_temporal`.
- Implements some of the existing and pre-existing `Date` methods for the `PlainDate` builtin.
- There are some bug fixes for some tests in test262 also that were panicking. 
