### PR TITLE
Implement non-erased `JsObject`s

### DIFF
--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -207,7 +207,9 @@ impl BuiltInConstructor for ArrayBuffer {
         let byte_length = args.get_or_undefined(0).to_index(context)?;
 
         // 3. Return ? AllocateArrayBuffer(NewTarget, byteLength).
-        Ok(Self::allocate(new_target, byte_length, context)?.into())
+        Ok(Self::allocate(new_target, byte_length, context)?
+            .upcast()
+            .into())
     }
 }
 
@@ -384,7 +386,7 @@ impl ArrayBuffer {
         constructor: &JsValue,
         byte_length: u64,
         context: &mut Context,
-    ) -> JsResult<JsObject> {
+    ) -> JsResult<JsObject<ArrayBuffer>> {
         // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] »).
         let prototype = get_prototype_from_constructor(
             constructor,
@@ -397,7 +399,7 @@ impl ArrayBuffer {
 
         // 3. Set obj.[[ArrayBufferData]] to block.
         // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
-        let obj = JsObject::from_proto_and_data_with_shared_shape(
+        let obj = JsObject::new(
             context.root_shape(),
             prototype,
             Self {

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -120,7 +120,7 @@ impl SliceRef<'_> {
     ///  - [ECMAScript reference][spec]
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-clonearraybuffer
-    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObject> {
+    pub(crate) fn clone(&self, context: &mut Context) -> JsResult<JsObject<ArrayBuffer>> {
         // 1. Assert: IsDetachedBuffer(srcBuffer) is false.
 
         // 2. Let targetBuffer be ? AllocateArrayBuffer(%ArrayBuffer%, srcLength).
@@ -140,12 +140,10 @@ impl SliceRef<'_> {
 
         // 4. Let targetBlock be targetBuffer.[[ArrayBufferData]].
         {
-            let mut target_buffer = target_buffer
-                .downcast_mut::<ArrayBuffer>()
-                .expect("This must be an ArrayBuffer");
+            let mut target_buffer = target_buffer.borrow_mut();
             let target_block = target_buffer
                 .data
-                .as_deref_mut()
+                .data_mut()
                 .expect("ArrayBuffer cannot be detached here");
 
             // 5. Perform CopyDataBlockBytes(targetBlock, 0, srcBlock, srcByteOffset, srcLength).

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -1043,7 +1043,7 @@ where
     Ok(default(realm.intrinsics().constructors()).prototype())
 }
 
-pub(crate) fn non_existant_call(
+fn non_existant_call(
     _obj: &JsObject,
     _argument_count: usize,
     context: &mut Context,
@@ -1054,7 +1054,7 @@ pub(crate) fn non_existant_call(
         .into())
 }
 
-pub(crate) fn non_existant_construct(
+fn non_existant_construct(
     _obj: &JsObject,
     _argument_count: usize,
     context: &mut Context,

--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -31,7 +31,6 @@ use boa_gc::{Finalize, Trace};
 use std::{
     any::{Any, TypeId},
     fmt::Debug,
-    ops::Deref,
 };
 
 #[cfg(test)]
@@ -51,10 +50,7 @@ pub(crate) use builtins::*;
 pub use datatypes::JsData;
 pub use jsobject::*;
 
-pub(crate) trait JsObjectType:
-    Into<JsValue> + Into<JsObject> + Deref<Target = JsObject>
-{
-}
+pub(crate) trait JsObjectType: Into<JsValue> + Into<JsObject> {}
 
 /// Const `constructor`, usually set on prototypes as a key to point to their respective constructor object.
 pub const CONSTRUCTOR: &[u16] = utf16!("constructor");
@@ -189,7 +185,7 @@ pub struct Object<T: ?Sized> {
     /// The `[[PrivateElements]]` internal slot.
     private_elements: ThinVec<(PrivateName, PrivateElement)>,
     /// The inner object data
-    data: T,
+    pub(crate) data: T,
 }
 
 impl<T: Default> Default for Object<T> {

--- a/core/gc/src/internals/ephemeron_box.rs
+++ b/core/gc/src/internals/ephemeron_box.rs
@@ -1,8 +1,5 @@
 use crate::{trace::Trace, Gc, GcBox, Tracer};
-use std::{
-    cell::UnsafeCell,
-    ptr::{self, NonNull},
-};
+use std::{cell::UnsafeCell, ptr::NonNull};
 
 use super::GcHeader;
 
@@ -35,13 +32,6 @@ impl<K: Trace + ?Sized, V: Trace> EphemeronBox<K, V> {
             header: GcHeader::new(),
             data: UnsafeCell::new(None),
         }
-    }
-
-    /// Returns `true` if the two references refer to the same `EphemeronBox`.
-    pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        // Use .header to ignore fat pointer vtables, to work around
-        // https://github.com/rust-lang/rust/issues/46139
-        ptr::eq(&this.header, &other.header)
     }
 
     /// Returns a reference to the ephemeron's value or None.

--- a/core/gc/src/internals/gc_box.rs
+++ b/core/gc/src/internals/gc_box.rs
@@ -1,5 +1,4 @@
 use crate::Trace;
-use std::ptr::{self};
 
 use super::{vtable_of, DropFn, GcHeader, RunFinalizerFn, TraceFn, TraceNonRootsFn, VTable};
 
@@ -25,13 +24,6 @@ impl<T: Trace> GcBox<T> {
 }
 
 impl<T: Trace + ?Sized> GcBox<T> {
-    /// Returns `true` if the two references refer to the same `GcBox`.
-    pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        // Use .header to ignore fat pointer vtables, to work around
-        // https://github.com/rust-lang/rust/issues/46139
-        ptr::eq(&this.header, &other.header)
-    }
-
     /// Returns a reference to the `GcBox`'s value.
     pub(crate) const fn value(&self) -> &T {
         &self.value

--- a/core/gc/src/pointers/ephemeron.rs
+++ b/core/gc/src/pointers/ephemeron.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use std::ptr::NonNull;
 
+use super::addr_eq;
+
 /// A key-value pair where the value becomes unaccesible when the key is garbage collected.
 ///
 /// You can read more about ephemerons on:
@@ -70,7 +72,7 @@ impl<K: Trace + ?Sized, V: Trace> Ephemeron<K, V> {
     /// Returns `true` if the two `Ephemeron`s point to the same allocation.
     #[must_use]
     pub fn ptr_eq(this: &Self, other: &Self) -> bool {
-        EphemeronBox::ptr_eq(this.inner(), other.inner())
+        addr_eq(this.inner(), other.inner())
     }
 
     pub(crate) fn inner_ptr(&self) -> NonNull<EphemeronBox<K, V>> {

--- a/core/gc/src/pointers/mod.rs
+++ b/core/gc/src/pointers/mod.rs
@@ -12,3 +12,9 @@ pub use weak_map::WeakMap;
 
 pub(crate) use gc::NonTraceable;
 pub(crate) use weak_map::RawWeakMap;
+
+// Replace with std::ptr::addr_eq when 1.76 releases
+#[allow(clippy::ptr_as_ptr, clippy::ptr_eq)]
+fn addr_eq<T: ?Sized, U: ?Sized>(p: *const T, q: *const U) -> bool {
+    (p as *const ()) == (q as *const ())
+}

--- a/examples/src/bin/jsarraybuffer.rs
+++ b/examples/src/bin/jsarraybuffer.rs
@@ -29,7 +29,7 @@ fn main() -> JsResult<()> {
     let array_buffer = JsArrayBuffer::from_byte_block(blob_of_data, context)?;
 
     // This the byte length of the new array buffer will be the length of block of data.
-    let byte_length = array_buffer.byte_length(context);
+    let byte_length = array_buffer.byte_length();
     assert_eq!(byte_length, 256);
 
     // We can now create an typed array to access the data.
@@ -40,7 +40,8 @@ fn main() -> JsResult<()> {
     }
 
     // We can create a Dataview from a JsArrayBuffer
-    let dataview = JsDataView::from_js_array_buffer(&array_buffer, None, Some(100_u64), context)?;
+    let dataview =
+        JsDataView::from_js_array_buffer(array_buffer.clone(), None, Some(100_u64), context)?;
 
     let dataview_length = dataview.byte_length(context)?;
 


### PR DESCRIPTION
This PR implements non-erased `JsObject`s aka `JsObject<T>`. This allows accessing the inner data of an object without having to call `downcast_ref/mut` every time, which is a big ergonomics win that should avoid calling `expect` a lot of times.

This is an MVP that doesn't support calling internal methods using a `JsObject<T>`; adding support for that would require a slight redesign on the API. However, the current MVP is enough to support most of the use cases of the API in our builtin wrappers.

This also uses the new API to improve the `JsArrayBuffer` wrapper on some parts, but it still needs some more work that can be done on subsequent PRs.

Thanks to @HalidOdat for [nerd-sniping me into implementing this](https://github.com/boa-dev/boa/pull/3610#discussion_r1465893269) 🤣