### PR TITLE
Update regress to v0.8.0 and use UTF16 / UCS2 matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,20 +1510,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.7",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash 0.8.7",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -2795,11 +2793,11 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed9969cad8051328011596bf549629f1b800cf1731e7964b1eef8dfc480d2c2"
+checksum = "4f5f39ba4513916c1b2657b72af6ec671f091cd637992f58d0ede5cae4e5dea0"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.3",
  "memchr",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 
 exclude = [
     "tests/fuzz", # Does weird things on Windows tests
-    "tests/src" # Just a hack to have fuzz inside tests
+    "tests/src",  # Just a hack to have fuzz inside tests
 ]
 
 [workspace.package]
@@ -59,7 +59,7 @@ once_cell = { version = "1.19.0", default-features = false }
 phf = { version = "0.11.2", default-features = false }
 pollster = "0.3.0"
 regex = "1.10.3"
-regress = "0.7.1"
+regress = { version="0.8.0", features = ["utf16"]}
 rustc-hash = { version = "1.1.0", default-features = false }
 serde_json = "1.0.111"
 serde = "1.0.195"

--- a/core/engine/src/builtins/regexp/tests.rs
+++ b/core/engine/src/builtins/regexp/tests.rs
@@ -125,7 +125,7 @@ fn no_panic_on_parse_fail() {
         TestAction::assert_native_error(
             r"var re = /]/u;",
             JsNativeErrorKind::Syntax,
-            "Invalid regular expression literal: Unbalanced bracket at line 1, col 10",
+            "Invalid regular expression literal: Invalid atom character at line 1, col 10",
         ),
         TestAction::assert_native_error(
             r"var re = /a{/u;",

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -16,6 +16,7 @@ features = [
     "Intl.RelativeTimeFormat",
     "Intl-enumeration",
     "Intl.NumberFormat-v3",
+    "regexp-v-flag",
 
     ### Pending proposals
 
@@ -68,12 +69,6 @@ features = [
 
     ### Non-standard
     "caller",
-
-    ### RegExp tests that check individual codepoints.
-    ### They are not useful considering the cpu time they waste.
-    "regexp-unicode-property-escapes",
 ]
 
-# RegExp tests that check individual codepoints.
-# They are not useful considering the cpu time they waste.
-tests = ["CharacterClassEscapes", "NumberFormat"]
+tests = ["NumberFormat"]


### PR DESCRIPTION
This Pull Request changes the following:

- Update regress to v0.8.0
- Use regress UTF16 / UCS2 matching
- Enable ignored regexp tests
