### PR TITLE
Cleanup 262 tester and stabilize some experimental features

### DIFF
--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -54,7 +54,8 @@ impl IntrinsicObject for Map {
             .name(js_string!("entries"))
             .build();
 
-        let obj = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+            .static_method(Self::group_by, js_string!("groupBy"), 2)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -89,12 +90,8 @@ impl IntrinsicObject for Map {
                 Some(get_size),
                 None,
                 Attribute::CONFIGURABLE,
-            );
-
-        #[cfg(feature = "experimental")]
-        let obj = { obj.static_method(Self::group_by, js_string!("groupBy"), 2) };
-
-        obj.build();
+            )
+            .build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -516,8 +513,7 @@ impl Map {
 
     /// [`Map.groupBy ( items, callbackfn )`][spec]
     ///
-    /// [spec]: https://tc39.es/proposal-array-grouping/#sec-map.groupby
-    #[cfg(feature = "experimental")]
+    /// [spec]: https://tc39.es/ecma262/#sec-map.groupby
     pub(crate) fn group_by(
         _: &JsValue,
         args: &[JsValue],
@@ -535,7 +531,7 @@ impl Map {
         // 1. Let groups be ? GroupBy(items, callbackfn, zero).
 
         // `GroupBy`
-        // https://tc39.es/proposal-array-grouping/#sec-group-by
+        // https://tc39.es/ecma262/#sec-groupby
         // inlined to change the key type.
 
         // 1. Perform ? RequireObjectCoercible(items).

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -60,7 +60,7 @@ impl IntrinsicObject for OrdinaryObject {
             .name(js_string!("set __proto__"))
             .build();
 
-        let obj = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .inherits(None)
             .accessor(
                 utf16!("__proto__"),
@@ -135,12 +135,9 @@ impl IntrinsicObject for OrdinaryObject {
                 1,
             )
             .static_method(Self::has_own, js_string!("hasOwn"), 2)
-            .static_method(Self::from_entries, js_string!("fromEntries"), 1);
-
-        #[cfg(feature = "experimental")]
-        let obj = { obj.static_method(Self::group_by, js_string!("groupBy"), 2) };
-
-        obj.build();
+            .static_method(Self::from_entries, js_string!("fromEntries"), 1)
+            .static_method(Self::group_by, js_string!("groupBy"), 2)
+            .build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -1348,8 +1345,7 @@ impl OrdinaryObject {
 
     /// [`Object.groupBy ( items, callbackfn )`][spec]
     ///
-    /// [spec]: https://tc39.es/proposal-array-grouping/#sec-object.groupby
-    #[cfg(feature = "experimental")]
+    /// [spec]: https://tc39.es/ecma262/#sec-object.groupby
     pub(crate) fn group_by(
         _: &JsValue,
         args: &[JsValue],

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -340,13 +340,14 @@ impl IntrinsicObject for Promise {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::all, js_string!("all"), 1)
             .static_method(Self::all_settled, js_string!("allSettled"), 1)
             .static_method(Self::any, js_string!("any"), 1)
             .static_method(Self::race, js_string!("race"), 1)
             .static_method(Self::reject, js_string!("reject"), 1)
             .static_method(Self::resolve, js_string!("resolve"), 1)
+            .static_method(Self::with_resolvers, crate::js_string!("withResolvers"), 0)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -361,13 +362,8 @@ impl IntrinsicObject for Promise {
                 JsSymbol::to_string_tag(),
                 Self::NAME,
                 Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE,
-            );
-
-        #[cfg(feature = "experimental")]
-        let builder =
-            builder.static_method(Self::with_resolvers, crate::js_string!("withResolvers"), 0);
-
-        builder.build();
+            )
+            .build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -471,8 +467,7 @@ impl Promise {
     /// Creates a new promise that is pending, and returns that promise plus the resolve and reject
     /// functions associated with it.
     ///
-    /// [spec]: https://tc39.es/proposal-promise-with-resolvers/#sec-promise.withResolvers
-    #[cfg(feature = "experimental")]
+    /// [spec]: https://tc39.es/ecma262/#sec-promise.withResolvers
     pub(crate) fn with_resolvers(
         this: &JsValue,
         _args: &[JsValue],

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -347,7 +347,7 @@ impl IntrinsicObject for Promise {
             .static_method(Self::race, js_string!("race"), 1)
             .static_method(Self::reject, js_string!("reject"), 1)
             .static_method(Self::resolve, js_string!("resolve"), 1)
-            .static_method(Self::with_resolvers, crate::js_string!("withResolvers"), 0)
+            .static_method(Self::with_resolvers, js_string!("withResolvers"), 0)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -1350,7 +1350,6 @@ pub(crate) struct ObjectTemplates {
 
     namespace: ObjectTemplate,
 
-    #[cfg(feature = "experimental")]
     with_resolvers: ObjectTemplate,
 }
 
@@ -1381,10 +1380,10 @@ impl ObjectTemplates {
         );
         string.set_prototype(constructors.string().prototype());
 
-        let mut regexp_without_prototype = ObjectTemplate::new(root_shape);
-        regexp_without_prototype.property(js_string!("lastIndex").into(), Attribute::WRITABLE);
+        let mut regexp_without_proto = ObjectTemplate::new(root_shape);
+        regexp_without_proto.property(js_string!("lastIndex").into(), Attribute::WRITABLE);
 
-        let mut regexp = regexp_without_prototype.clone();
+        let mut regexp = regexp_without_proto.clone();
         regexp.set_prototype(constructors.regexp().prototype());
 
         let name_property_key: PropertyKey = js_string!("name").into();
@@ -1472,7 +1471,6 @@ impl ObjectTemplates {
         let mut namespace = ObjectTemplate::new(root_shape);
         namespace.property(JsSymbol::to_string_tag().into(), Attribute::empty());
 
-        #[cfg(feature = "experimental")]
         let with_resolvers = {
             let mut with_resolvers = ordinary_object.clone();
 
@@ -1497,7 +1495,7 @@ impl ObjectTemplates {
             bigint,
             boolean,
             regexp,
-            regexp_without_proto: regexp_without_prototype,
+            regexp_without_proto,
             unmapped_arguments,
             mapped_arguments,
             function_with_prototype,
@@ -1509,7 +1507,6 @@ impl ObjectTemplates {
             function_without_proto,
             function_with_prototype_without_proto,
             namespace,
-            #[cfg(feature = "experimental")]
             with_resolvers,
         }
     }
@@ -1738,7 +1735,6 @@ impl ObjectTemplates {
     /// 1. `"promise"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
     /// 2. `"resolve"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
     /// 3. `"reject"`: (`WRITABLE`, `ENUMERABLE`, `CONFIGURABLE`)
-    #[cfg(feature = "experimental")]
     pub(crate) const fn with_resolvers(&self) -> &ObjectTemplate {
         &self.with_resolvers
     }

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "6cbb6da9473c56d95358d8e679c5a6d2b4574efb"
+commit = "e4f91b6381d7694265031caad0c71d733ac132f3"
 
 [ignored]
 # Not implemented yet:

--- a/tests/tester/src/edition.rs
+++ b/tests/tester/src/edition.rs
@@ -41,10 +41,6 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-json-modules
     "json-modules"  => SpecEdition::ESNext,
 
-    // Resizable Arraybuffer
-    // https://github.com/tc39/proposal-resizablearraybuffer
-    "resizable-arraybuffer" => SpecEdition::ESNext,
-
     // ArrayBuffer transfer
     // https://github.com/tc39/proposal-arraybuffer-transfer
     "arraybuffer-transfer" => SpecEdition::ESNext,
@@ -56,10 +52,6 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // ShadowRealm, née Callable Boundary Realms
     // https://github.com/tc39/proposal-realms
     "ShadowRealm" => SpecEdition::ESNext,
-
-    // Array.prototype.group & Array.prototype.groupToMap
-    // https://github.com/tc39/proposal-array-grouping
-    "array-grouping" => SpecEdition::ESNext,
 
     // Intl.DurationFormat
     // https://github.com/tc39/proposal-intl-duration-format
@@ -73,7 +65,8 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-duplicate-named-capturing-groups
     "regexp-duplicate-named-groups" => SpecEdition::ESNext,
 
-    // https://tc39.es/proposal-array-from-async/
+    // Array.fromAsync
+    // https://github.com/tc39/proposal-array-from-async
     "Array.fromAsync" => SpecEdition::ESNext,
 
     // JSON.parse with source
@@ -84,10 +77,6 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-iterator-helpers
     "iterator-helpers" => SpecEdition::ESNext,
 
-    // Promise.withResolvers
-    // https://github.com/tc39/proposal-promise-with-resolvers
-    "promise-with-resolvers" => SpecEdition::ESNext,
-
     // Set methods
     // https://github.com/tc39/proposal-set-methods
     "set-methods" => SpecEdition::ESNext,
@@ -97,6 +86,9 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     "regexp-v-flag" => SpecEdition::ESNext,
     "String.prototype.isWellFormed" => SpecEdition::ESNext,
     "String.prototype.toWellFormed" => SpecEdition::ESNext,
+    "resizable-arraybuffer" => SpecEdition::ESNext,
+    "promise-with-resolvers" => SpecEdition::ESNext,
+    "array-grouping" => SpecEdition::ESNext,
 
     // Standard language features
     "AggregateError" => SpecEdition::ES12,


### PR DESCRIPTION
Bumps the test262 repo, cleans up our feature list and stabilizes the experimental features `promise-with-resolvers` and `array-grouping`.
