### PR TITLE
Implement resizable buffers

### DIFF
--- a/core/engine/src/builtins/array_buffer/tests.rs
+++ b/core/engine/src/builtins/array_buffer/tests.rs
@@ -4,10 +4,10 @@ use crate::Context;
 fn create_byte_data_block() {
     let context = &mut Context::default();
     // Sunny day
-    assert!(super::create_byte_data_block(100, context).is_ok());
+    assert!(super::create_byte_data_block(100, None, context).is_ok());
 
     // Rainy day
-    assert!(super::create_byte_data_block(u64::MAX, context).is_err());
+    assert!(super::create_byte_data_block(u64::MAX, None, context).is_err());
 }
 
 #[test]

--- a/core/engine/src/builtins/atomics/futex.rs
+++ b/core/engine/src/builtins/atomics/futex.rs
@@ -273,6 +273,7 @@ pub(super) enum AtomicsWaitResult {
 // our implementation guarantees that `SharedArrayBuffer` is always aligned to `u64` at minimum.
 pub(super) unsafe fn wait<E: Element + PartialEq>(
     buffer: &SharedArrayBuffer,
+    buf_len: usize,
     offset: usize,
     check: E,
     timeout: Option<Duration>,
@@ -287,7 +288,7 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
 
     let time_info = timeout.map(|timeout| (Instant::now(), timeout));
 
-    let buffer = &buffer.data()[offset..];
+    let buffer = &buffer.bytes_with_len(buf_len)[offset..];
 
     // 13. Let elementType be TypedArrayElementType(typedArray).
     // 14. Let w be GetValueFromBuffer(buffer, indexedPosition, elementType, true, SeqCst).
@@ -380,7 +381,7 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
 
 /// Notifies at most `count` agents waiting on the memory address pointed to by `buffer[offset..]`.
 pub(super) fn notify(buffer: &SharedArrayBuffer, offset: usize, count: u64) -> JsResult<u64> {
-    let addr = buffer.data()[offset..].as_ptr().addr();
+    let addr = buffer.as_ptr().addr() + offset;
 
     // 7. Let WL be GetWaiterList(block, indexedPosition).
     // 8. Perform EnterCriticalSection(WL).

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -511,11 +511,11 @@ pub(crate) enum TypedArrayElement {
 }
 
 impl TypedArrayElement {
-    /// Converts the element into its extended bytes representation as a `u64`.
+    /// Converts the element into its extended bytes representation as an `u64`.
     ///
     /// This is guaranteed to never fail, since all numeric types supported by JS are less than
     /// 8 bytes long.
-    pub(crate) fn to_bytes(self) -> u64 {
+    pub(crate) fn to_bits(self) -> u64 {
         #[allow(clippy::cast_lossless)]
         match self {
             TypedArrayElement::Int8(num) => num as u64,

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -210,7 +210,7 @@ pub trait HostHooks {
     /// exhaust the virtual memory address space and to reduce interoperability risk.
     ///
     ///
-    /// [specification]: https://tc39.es/ecma262/multipage/structured-data.html#sec-resizable-arraybuffer-guidelines
+    /// [specification]: https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines
     fn max_buffer_size(&self, _context: &mut Context) -> u64 {
         1_610_612_736 // 1.5 GiB
     }

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -61,6 +61,7 @@ impl JsArrayBuffer {
                 .constructor()
                 .into(),
             byte_length as u64,
+            None,
             context,
         )?;
 
@@ -236,7 +237,7 @@ impl JsArrayBuffer {
     #[inline]
     #[must_use]
     pub fn data(&self) -> Option<GcRef<'_, [u8]>> {
-        GcRef::try_map(self.inner.borrow(), |o| o.data.data())
+        GcRef::try_map(self.inner.borrow(), |o| o.data.bytes())
     }
 
     /// Get a mutable reference to the [`JsArrayBuffer`]'s data.
@@ -269,7 +270,7 @@ impl JsArrayBuffer {
     #[inline]
     #[must_use]
     pub fn data_mut(&self) -> Option<GcRefMut<'_, Object<ArrayBuffer>, [u8]>> {
-        GcRefMut::try_map(self.inner.borrow_mut(), |o| o.data.data_mut())
+        GcRefMut::try_map(self.inner.borrow_mut(), |o| o.data.bytes_mut())
     }
 }
 

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -7,7 +7,7 @@ use crate::{
     Context, JsResult, JsValue,
 };
 use boa_gc::{Finalize, Trace};
-use std::ops::Deref;
+use std::{ops::Deref, sync::atomic::Ordering};
 
 /// `JsSharedArrayBuffer` provides a wrapper for Boa's implementation of the ECMAScript `ArrayBuffer` object
 #[derive(Debug, Clone, Trace, Finalize)]
@@ -42,6 +42,7 @@ impl JsSharedArrayBuffer {
                 .constructor()
                 .into(),
             byte_length as u64,
+            None,
             context,
         )?;
 
@@ -83,7 +84,7 @@ impl JsSharedArrayBuffer {
     #[inline]
     #[must_use]
     pub fn byte_length(&self) -> usize {
-        self.borrow().data.len()
+        self.borrow().data.len(Ordering::SeqCst)
     }
 
     /// Gets the raw buffer of this `JsSharedArrayBuffer`.

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -9,7 +9,6 @@ features = [
 
     "FinalizationRegistry",
     "IsHTMLDDA",
-    "resizable-arraybuffer",
     "symbols-as-weakmap-keys",
     "intl-normative-optional",
     "Intl.DisplayNames",


### PR DESCRIPTION
A bit of a complex implementation, but happy with the new design overall. Open for suggestions though!

This implements:
- Resizable array buffers.
  - Allows `ArrayBuffer` to resize, but it's limited to a `maxByteLength` parameter passed at construction time.
  - Allows `SharedArrayBuffer` to grow (shrinking is disallowed by the spec), also limited to a `maxByteLength` parameter.
    It uses an `AtomicUsize` to track the current length, which should be enough to ensure thread-safety.
- Retrofits `Atomics`, `TypedArray` and `DataView` to use the new buffers.
- Makes `memmove`, `memcpy` and `copy_shared_to_shared` more low level, computing using pointers.
  The previous design used slices to do debug assertions before copying memory, but this made the API a bit clunkier to use, and some of the assertions weren't even needed by some callers.

EDIT: Forgot to mention that this doesn't add methods to resize `JsArrayBuffer` and `JsSharedArrayBuffer`, but this can be added later after some design work.