### PR TITLE
Fix tests results upload

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -37,6 +37,12 @@ jobs:
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
 
+      - name: Checkout GitHub pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
       # Run the test suite.
       - name: Run the test262 test suite
         run: |
@@ -46,12 +52,6 @@ jobs:
           cd ..
 
       # Run the results comparison
-      - name: Checkout GitHub pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
       - name: Compare results
         if: github.event_name == 'pull_request'
         id: compare
@@ -100,6 +100,11 @@ jobs:
             ${{ steps.compare.outputs.comment }}
 
       # Commit changes to GitHub pages.
+      - name: Checkout GitHub pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
       - name: Commit files
         if: github.event_name == 'push'
         run: |

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -37,13 +37,7 @@ jobs:
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run the test suite and upload the results
-      - name: Checkout GitHub pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
+      # Run the test suite.
       - name: Run the test262 test suite
         run: |
           cd boa
@@ -52,6 +46,12 @@ jobs:
           cd ..
 
       # Run the results comparison
+      - name: Checkout GitHub pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: gh-pages
+
       - name: Compare results
         if: github.event_name == 'pull_request'
         id: compare

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -101,6 +101,7 @@ jobs:
 
       # Commit changes to GitHub pages.
       - name: Checkout GitHub pages
+        if: github.event_name == 'push'
         uses: actions/checkout@v4
         with:
           ref: gh-pages


### PR DESCRIPTION
Since the 262 tests action now takes a bit longer we had multiple cases where the `git push` to the `gh-pages` branch on `main` did not work because the pulled `gh-pages` branch was outdated.

This PR attempts to solve this by moving the checkout action for the `gh-pages` branch after the running of the tests. In most cases this should solve the issue.