### PR TITLE
Temporal: Refactor Calendar protocol for `JsObject`s

### DIFF
--- a/core/engine/src/builtins/temporal/calendar/mod.rs
+++ b/core/engine/src/builtins/temporal/calendar/mod.rs
@@ -1074,12 +1074,7 @@ pub(crate) fn to_temporal_calendar_slot_value(
         }
 
         // c. Return temporalCalendarLike.
-        match calendar_like.clone().downcast::<Calendar>() {
-            Ok(cal) => return Ok(cal.borrow().data().slot.clone()),
-            Err(custom) => {
-                return Ok(CalendarSlot::Protocol(custom.clone()));
-            }
-        }
+        return Ok(CalendarSlot::Protocol(calendar_like.clone()));
     }
 
     // 3. If temporalCalendarLike is not a String, throw a TypeError exception.

--- a/core/engine/src/builtins/temporal/calendar/mod.rs
+++ b/core/engine/src/builtins/temporal/calendar/mod.rs
@@ -33,11 +33,6 @@ use boa_temporal::{
 
 mod object;
 
-/*
-#[doc(inline)]
-pub(crate) use object::JsObject;
-*/
-
 #[cfg(test)]
 mod tests;
 /// The `Temporal.Calendar` object.
@@ -1079,7 +1074,12 @@ pub(crate) fn to_temporal_calendar_slot_value(
         }
 
         // c. Return temporalCalendarLike.
-        return Ok(CalendarSlot::Protocol(calendar_like.clone()));
+        match calendar_like.clone().downcast::<Calendar>() {
+            Ok(cal) => return Ok(cal.borrow().data().slot.clone()),
+            Err(custom) => {
+                return Ok(CalendarSlot::Protocol(custom.clone()));
+            }
+        }
     }
 
     // 3. If temporalCalendarLike is not a String, throw a TypeError exception.

--- a/core/engine/src/builtins/temporal/calendar/mod.rs
+++ b/core/engine/src/builtins/temporal/calendar/mod.rs
@@ -33,15 +33,17 @@ use boa_temporal::{
 
 mod object;
 
+/*
 #[doc(inline)]
-pub(crate) use object::JsCustomCalendar;
+pub(crate) use object::JsObject;
+*/
 
 #[cfg(test)]
 mod tests;
 /// The `Temporal.Calendar` object.
 #[derive(Debug, Finalize, JsData)]
 pub struct Calendar {
-    slot: CalendarSlot<JsCustomCalendar>,
+    slot: CalendarSlot<JsObject>,
 }
 
 unsafe impl Trace for Calendar {
@@ -55,7 +57,7 @@ unsafe impl Trace for Calendar {
 }
 
 impl Calendar {
-    pub(crate) fn new(slot: CalendarSlot<JsCustomCalendar>) -> Self {
+    pub(crate) fn new(slot: CalendarSlot<JsObject>) -> Self {
         Self { slot }
     }
 }
@@ -155,7 +157,7 @@ impl BuiltInConstructor for Calendar {
 
         // 4. Return ? CreateTemporalCalendar(id, NewTarget).
         create_temporal_calendar(
-            CalendarSlot::<JsCustomCalendar>::from_str(&id.to_std_string_escaped())?,
+            CalendarSlot::<JsObject>::from_str(&id.to_std_string_escaped())?,
             Some(new_target.clone()),
             context,
         )
@@ -956,7 +958,7 @@ impl Calendar {
 
 /// 12.2.1 `CreateTemporalCalendar ( identifier [ , newTarget ] )`
 pub(crate) fn create_temporal_calendar(
-    identifier: CalendarSlot<JsCustomCalendar>,
+    identifier: CalendarSlot<JsObject>,
     new_target: Option<JsValue>,
     context: &mut Context,
 ) -> JsResult<JsValue> {
@@ -992,23 +994,21 @@ fn extract_from_temporal_type<DF, DTF, YMF, MDF, ZDTF, Ret>(
     zoned_datetime_f: ZDTF,
 ) -> JsResult<Option<Ret>>
 where
-    DF: FnOnce(&PlainDate) -> JsResult<Option<Ret>>,
-    DTF: FnOnce(&PlainDateTime) -> JsResult<Option<Ret>>,
-    YMF: FnOnce(&PlainYearMonth) -> JsResult<Option<Ret>>,
-    MDF: FnOnce(&PlainMonthDay) -> JsResult<Option<Ret>>,
-    ZDTF: FnOnce(&ZonedDateTime) -> JsResult<Option<Ret>>,
+    DF: FnOnce(JsObject<PlainDate>) -> JsResult<Option<Ret>>,
+    DTF: FnOnce(JsObject<PlainDateTime>) -> JsResult<Option<Ret>>,
+    YMF: FnOnce(JsObject<PlainYearMonth>) -> JsResult<Option<Ret>>,
+    MDF: FnOnce(JsObject<PlainMonthDay>) -> JsResult<Option<Ret>>,
+    ZDTF: FnOnce(JsObject<ZonedDateTime>) -> JsResult<Option<Ret>>,
 {
-    let o = object.borrow();
-
-    if let Some(date) = o.downcast_ref::<PlainDate>() {
+    if let Ok(date) = object.clone().downcast::<PlainDate>() {
         return date_f(date);
-    } else if let Some(dt) = o.downcast_ref::<PlainDateTime>() {
+    } else if let Ok(dt) = object.clone().downcast::<PlainDateTime>() {
         return datetime_f(dt);
-    } else if let Some(ym) = o.downcast_ref::<PlainYearMonth>() {
+    } else if let Ok(ym) = object.clone().downcast::<PlainYearMonth>() {
         return year_month_f(ym);
-    } else if let Some(md) = o.downcast_ref::<PlainMonthDay>() {
+    } else if let Ok(md) = object.clone().downcast::<PlainMonthDay>() {
         return month_day_f(md);
-    } else if let Some(dt) = o.downcast_ref::<ZonedDateTime>() {
+    } else if let Ok(dt) = object.clone().downcast::<ZonedDateTime>() {
         return zoned_datetime_f(dt);
     }
 
@@ -1020,15 +1020,15 @@ where
 pub(crate) fn get_temporal_calendar_slot_value_with_default(
     item: &JsObject,
     context: &mut Context,
-) -> JsResult<CalendarSlot<JsCustomCalendar>> {
+) -> JsResult<CalendarSlot<JsObject>> {
     // 1. If item has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]], [[InitializedTemporalMonthDay]], [[InitializedTemporalYearMonth]], or [[InitializedTemporalZonedDateTime]] internal slot, then
     // a. Return item.[[Calendar]].
     if let Some(calendar) = extract_from_temporal_type(
         item,
-        |d| Ok(Some(d.inner.calendar().clone())),
-        |dt| Ok(Some(dt.inner.calendar().clone())),
-        |ym| Ok(Some(ym.inner.calendar().clone())),
-        |md| Ok(Some(md.inner.calendar().clone())),
+        |d| Ok(Some(d.borrow().data().inner.calendar().clone())),
+        |dt| Ok(Some(dt.borrow().data().inner.calendar().clone())),
+        |ym| Ok(Some(ym.borrow().data().inner.calendar().clone())),
+        |md| Ok(Some(md.borrow().data().inner.calendar().clone())),
         |zdt| {
             Err(JsNativeError::range()
                 .with_message("Not yet implemented.")
@@ -1049,7 +1049,7 @@ pub(crate) fn get_temporal_calendar_slot_value_with_default(
 pub(crate) fn to_temporal_calendar_slot_value(
     calendar_like: &JsValue,
     context: &mut Context,
-) -> JsResult<CalendarSlot<JsCustomCalendar>> {
+) -> JsResult<CalendarSlot<JsObject>> {
     // 1. If temporalCalendarLike is undefined and default is present, then
     // a. Assert: IsBuiltinCalendar(default) is true.
     // b. Return default.
@@ -1061,11 +1061,11 @@ pub(crate) fn to_temporal_calendar_slot_value(
         // i. Return temporalCalendarLike.[[Calendar]].
         if let Some(calendar) = extract_from_temporal_type(
             calendar_like,
-            |d| Ok(Some(d.inner.calendar().clone())),
-            |dt| Ok(Some(dt.inner.calendar().clone())),
-            |ym| Ok(Some(ym.inner.calendar().clone())),
-            |md| Ok(Some(md.inner.calendar().clone())),
-            |zdt| Ok(Some(zdt.inner.calendar().clone())),
+            |d| Ok(Some(d.borrow().data().inner.calendar().clone())),
+            |dt| Ok(Some(dt.borrow().data().inner.calendar().clone())),
+            |ym| Ok(Some(ym.borrow().data().inner.calendar().clone())),
+            |md| Ok(Some(md.borrow().data().inner.calendar().clone())),
+            |zdt| Ok(Some(zdt.borrow().data().inner.calendar().clone())),
         )? {
             return Ok(calendar);
         }
@@ -1078,10 +1078,8 @@ pub(crate) fn to_temporal_calendar_slot_value(
                 .into());
         }
 
-        // Types: Box<dyn CalendarProtocol> <- UserCalendar
-        let custom = JsCustomCalendar::new(calendar_like);
         // c. Return temporalCalendarLike.
-        return Ok(CalendarSlot::Protocol(custom));
+        return Ok(CalendarSlot::Protocol(calendar_like.clone()));
     }
 
     // 3. If temporalCalendarLike is not a String, throw a TypeError exception.
@@ -1094,7 +1092,7 @@ pub(crate) fn to_temporal_calendar_slot_value(
     // 4. Let identifier be ? ParseTemporalCalendarString(temporalCalendarLike).
     // 5. If IsBuiltinCalendar(identifier) is false, throw a RangeError exception.
     // 6. Return the ASCII-lowercase of identifier.
-    Ok(CalendarSlot::<JsCustomCalendar>::from_str(
+    Ok(CalendarSlot::<JsObject>::from_str(
         &calendar_id.to_std_string_escaped(),
     )?)
 }
@@ -1111,7 +1109,7 @@ fn object_implements_calendar_protocol(calendar_like: &JsObject, context: &mut C
 fn to_calendar_date_like(
     date_like: &JsValue,
     context: &mut Context,
-) -> JsResult<CalendarDateLike<JsCustomCalendar>> {
+) -> JsResult<CalendarDateLike<JsObject>> {
     let Some(obj) = date_like.as_object() else {
         let date = temporal::plain_date::to_temporal_date(date_like, None, context)?;
 
@@ -1120,9 +1118,9 @@ fn to_calendar_date_like(
 
     let Some(date_like) = extract_from_temporal_type(
         obj,
-        |d| Ok(Some(CalendarDateLike::Date(d.inner.clone()))),
-        |dt| Ok(Some(CalendarDateLike::DateTime(dt.inner.clone()))),
-        |ym| Ok(Some(CalendarDateLike::YearMonth(ym.inner.clone()))),
+        |d| Ok(Some(CalendarDateLike::CustomDate(d))),
+        |dt| Ok(Some(CalendarDateLike::CustomDateTime(dt))),
+        |ym| Ok(Some(CalendarDateLike::CustomYearMonth(ym))),
         |_| Ok(None),
         |_| Ok(None),
     )?

--- a/core/engine/src/builtins/temporal/calendar/object.rs
+++ b/core/engine/src/builtins/temporal/calendar/object.rs
@@ -257,7 +257,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -303,7 +303,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -349,7 +349,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         let JsValue::String(result) = val else {
@@ -380,7 +380,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -426,7 +426,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -474,7 +474,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -522,7 +522,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -570,7 +570,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -611,7 +611,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -658,7 +658,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -708,7 +708,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -756,7 +756,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         // Validate the return value.
@@ -806,7 +806,7 @@ impl CalendarProtocol for JsObject {
         let val = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[date_like], context)
+            .call(&self.clone().into(), &[date_like], context)
             .map_err(|err| TemporalError::general(err.to_string()))?;
 
         let JsValue::Boolean(result) = val else {
@@ -835,7 +835,7 @@ impl CalendarProtocol for JsObject {
         let result = method
             .as_callable()
             .expect("is method")
-            .call(&self.calendar.clone().into(), &[fields_js.into()], context)
+            .call(&self.clone().into(), &[fields_js.into()], context)
             .map_err(|e| TemporalError::general(e.to_string()))?;
 
         // validate result and map to a `Vec<String>`
@@ -886,7 +886,7 @@ impl CalendarProtocol for JsObject {
             .as_callable()
             .expect("is method")
             .call(
-                &self.calendar.clone().into(),
+                &self.clone().into(),
                 &[fields.into(), add_fields.into()],
                 context,
             )
@@ -909,7 +909,7 @@ impl CalendarProtocol for JsObject {
         let identifier = self
             .__get__(
                 &PropertyKey::from(utf16!("id")),
-                self.calendar.clone().into(),
+                self.clone().into(),
                 &mut context.into(),
             )
             .expect("method must exist on a object that implements the CalendarProtocol.");

--- a/core/engine/src/builtins/temporal/calendar/object.rs
+++ b/core/engine/src/builtins/temporal/calendar/object.rs
@@ -14,11 +14,10 @@ use crate::{
 };
 use std::any::Any;
 
-use boa_gc::{Finalize, Trace};
 use boa_macros::utf16;
 use boa_temporal::{
     components::{
-        calendar::{CalendarDateLike, CalendarProtocol},
+        calendar::{CalendarDateLike, CalendarProtocol, DateTypes},
         Date, Duration, MonthDay, YearMonth,
     },
     options::ArithmeticOverflow,
@@ -26,28 +25,23 @@ use boa_temporal::{
 };
 use num_traits::ToPrimitive;
 use plain_date::PlainDate;
+use plain_date_time::PlainDateTime;
 use plain_month_day::PlainMonthDay;
 use plain_year_month::PlainYearMonth;
 
-/// A user-defined, custom calendar that is only known at runtime
-/// and executed at runtime.
-///
-/// A user-defined calendar implements all of the `CalendarProtocolMethods`
-/// and therefore satisfies the requirements to be used as a calendar.
-#[derive(Debug, Clone, Trace, Finalize)]
-pub(crate) struct JsCustomCalendar {
-    calendar: JsObject,
+/// The custom data types for a Custom `JsObject` Calendar.
+#[derive(Debug, Clone, Copy)]
+pub struct CustomDateLikes;
+
+impl DateTypes<JsObject> for CustomDateLikes {
+    type Date = JsObject<PlainDate>;
+    type DateTime = JsObject<PlainDateTime>;
+    type YearMonth = JsObject<PlainYearMonth>;
+    type MonthDay = JsObject<PlainMonthDay>;
 }
 
-impl JsCustomCalendar {
-    pub(crate) fn new(calendar: &JsObject) -> Self {
-        Self {
-            calendar: calendar.clone(),
-        }
-    }
-}
-
-impl CalendarProtocol for JsCustomCalendar {
+impl CalendarProtocol for JsObject {
+    type DateLikes = CustomDateLikes;
     fn date_from_fields(
         &self,
         fields: &mut TemporalFields,
@@ -59,7 +53,6 @@ impl CalendarProtocol for JsCustomCalendar {
             .expect("Context was not provided for a CustomCalendar.");
 
         let method = self
-            .calendar
             .get(utf16!("dateFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -82,7 +75,7 @@ impl CalendarProtocol for JsCustomCalendar {
                 TemporalError::general("dateFromFields must be implemented as a callable method.")
             })?
             .call(
-                &self.calendar.clone().into(),
+                &self.clone().into(),
                 &[fields.into(), overflow_obj.into()],
                 context,
             )
@@ -105,13 +98,12 @@ impl CalendarProtocol for JsCustomCalendar {
         fields: &mut TemporalFields,
         overflow: ArithmeticOverflow,
         context: &mut dyn Any,
-    ) -> TemporalResult<YearMonth<JsCustomCalendar>> {
+    ) -> TemporalResult<YearMonth<JsObject>> {
         let context = context
             .downcast_mut::<Context>()
             .expect("Context was not provided for a CustomCalendar.");
 
         let method = self
-            .calendar
             .get(utf16!("yearMonthFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -136,7 +128,7 @@ impl CalendarProtocol for JsCustomCalendar {
                 )
             })?
             .call(
-                &self.calendar.clone().into(),
+                &self.clone().into(),
                 &[fields.into(), overflow_obj.into()],
                 context,
             )
@@ -159,13 +151,12 @@ impl CalendarProtocol for JsCustomCalendar {
         fields: &mut TemporalFields,
         overflow: ArithmeticOverflow,
         context: &mut dyn Any,
-    ) -> TemporalResult<MonthDay<JsCustomCalendar>> {
+    ) -> TemporalResult<MonthDay<JsObject>> {
         let context = context
             .downcast_mut::<Context>()
             .expect("Context was not provided for a CustomCalendar.");
 
         let method = self
-            .calendar
             .get(utf16!("yearMonthFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -190,7 +181,7 @@ impl CalendarProtocol for JsCustomCalendar {
                 )
             })?
             .call(
-                &self.calendar.clone().into(),
+                &self.clone().into(),
                 &[fields.into(), overflow_obj.into()],
                 context,
             )
@@ -210,19 +201,19 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn date_add(
         &self,
-        _date: &Date<JsCustomCalendar>,
+        _date: &Date<JsObject>,
         _duration: &Duration,
         _overflow: ArithmeticOverflow,
         _context: &mut dyn Any,
-    ) -> TemporalResult<Date<JsCustomCalendar>> {
+    ) -> TemporalResult<Date<JsObject>> {
         // TODO
         Err(TemporalError::general("Not yet implemented."))
     }
 
     fn date_until(
         &self,
-        _one: &Date<JsCustomCalendar>,
-        _two: &Date<JsCustomCalendar>,
+        _one: &Date<JsObject>,
+        _two: &Date<JsObject>,
         _largest_unit: boa_temporal::options::TemporalUnit,
         _context: &mut dyn Any,
     ) -> TemporalResult<Duration> {
@@ -232,7 +223,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn era(
         &self,
-        _: &CalendarDateLike<JsCustomCalendar>,
+        _: &CalendarDateLike<JsObject>,
         _: &mut dyn Any,
     ) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         // Return undefined as custom calendars do not implement -> Currently.
@@ -241,7 +232,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn era_year(
         &self,
-        _: &CalendarDateLike<JsCustomCalendar>,
+        _: &CalendarDateLike<JsObject>,
         _: &mut dyn Any,
     ) -> TemporalResult<Option<i32>> {
         // Return undefined as custom calendars do not implement -> Currently.
@@ -250,7 +241,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<i32> {
         let context = context
@@ -260,7 +251,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("year")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -297,7 +287,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn month(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u8> {
         let context = context
@@ -307,7 +297,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("month")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -344,7 +333,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn month_code(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<TinyAsciiStr<4>> {
         let context = context
@@ -354,7 +343,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("monthCode")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -376,7 +364,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn day(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u8> {
         let context = context
@@ -386,7 +374,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("day")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -423,7 +410,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn day_of_week(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -433,7 +420,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("dayOfWeek")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -472,7 +458,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn day_of_year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -482,7 +468,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("dayOfYear")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -521,7 +506,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn week_of_year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -531,7 +516,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("weekOfYear")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -570,7 +554,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn year_of_week(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<i32> {
         let context = context
@@ -580,7 +564,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("yearOfWeek")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -612,7 +595,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn days_in_week(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -622,7 +605,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("daysInWeek")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -661,7 +643,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn days_in_month(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -671,7 +653,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("daysInMonth")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
         let val = method
@@ -711,7 +692,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn days_in_year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -721,7 +702,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("daysInYear")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -760,7 +740,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn months_in_year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<u16> {
         let context = context
@@ -770,7 +750,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("monthsInYear")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -811,7 +790,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
     fn in_leap_year(
         &self,
-        date_like: &CalendarDateLike<JsCustomCalendar>,
+        date_like: &CalendarDateLike<JsObject>,
         context: &mut dyn Any,
     ) -> TemporalResult<bool> {
         let context = context
@@ -821,7 +800,6 @@ impl CalendarProtocol for JsCustomCalendar {
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("inLeapYear")), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
 
@@ -851,7 +829,6 @@ impl CalendarProtocol for JsCustomCalendar {
         );
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("fields")), context)
             .expect("method must exist on an object that implements the CalendarProtocol.");
 
@@ -902,7 +879,6 @@ impl CalendarProtocol for JsCustomCalendar {
             .map_err(|e| TemporalError::general(e.to_string()))?;
 
         let method = self
-            .calendar
             .get(PropertyKey::from(utf16!("mergeFields")), context)
             .expect("method must exist on an object that implements the CalendarProtocol.");
 
@@ -931,7 +907,6 @@ impl CalendarProtocol for JsCustomCalendar {
             .expect("Context was not provided for a CustomCalendar.");
 
         let identifier = self
-            .calendar
             .__get__(
                 &PropertyKey::from(utf16!("id")),
                 self.calendar.clone().into(),
@@ -949,7 +924,7 @@ impl CalendarProtocol for JsCustomCalendar {
 
 /// Utility function for converting `Temporal`'s `CalendarDateLike` to it's `Boa` specific `JsObject`.
 pub(crate) fn date_like_to_object(
-    date_like: &CalendarDateLike<JsCustomCalendar>,
+    date_like: &CalendarDateLike<JsObject>,
     context: &mut Context,
 ) -> TemporalResult<JsValue> {
     match date_like {
@@ -961,13 +936,9 @@ pub(crate) fn date_like_to_object(
                 .map_err(|e| TemporalError::general(e.to_string()))
                 .map(Into::into)
         }
-        CalendarDateLike::MonthDay(md) => {
-            plain_month_day::create_temporal_month_day(md.clone(), None, context)
-                .map_err(|e| TemporalError::general(e.to_string()))
-        }
-        CalendarDateLike::YearMonth(ym) => {
-            plain_year_month::create_temporal_year_month(ym.clone(), None, context)
-                .map_err(|e| TemporalError::general(e.to_string()))
-        }
+        CalendarDateLike::CustomMonthDay(md) => Ok(md.clone().upcast().into()),
+        CalendarDateLike::CustomYearMonth(ym) => Ok(ym.clone().upcast().into()),
+        CalendarDateLike::CustomDate(pd) => Ok(pd.clone().upcast().into()),
+        CalendarDateLike::CustomDateTime(pdt) => Ok(pdt.clone().upcast().into()),
     }
 }

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -17,6 +17,9 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 
+#[cfg(test)]
+mod tests;
+
 use boa_temporal::{
     components::{
         calendar::{CalendarSlot, GetCalendarSlot},

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -17,24 +17,40 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 
-use boa_temporal::components::DateTime as InnerDateTime;
-
-use super::JsCustomCalendar;
+use boa_temporal::{
+    components::{
+        calendar::{CalendarSlot, GetCalendarSlot},
+        DateTime as InnerDateTime,
+    },
+    iso::{IsoDate, IsoDateSlots},
+};
 
 /// The `Temporal.PlainDateTime` object.
 #[derive(Debug, Clone, Trace, Finalize, JsData)]
 #[boa_gc(unsafe_empty_trace)] // TODO: Remove this!!! `InnerDateTime` could contain `Trace` types.
 pub struct PlainDateTime {
-    pub(crate) inner: InnerDateTime<JsCustomCalendar>,
+    pub(crate) inner: InnerDateTime<JsObject>,
 }
 
 impl PlainDateTime {
-    fn new(inner: InnerDateTime<JsCustomCalendar>) -> Self {
+    fn new(inner: InnerDateTime<JsObject>) -> Self {
         Self { inner }
     }
 
-    pub(crate) fn inner(&self) -> &InnerDateTime<JsCustomCalendar> {
+    pub(crate) fn inner(&self) -> &InnerDateTime<JsObject> {
         &self.inner
+    }
+}
+
+impl IsoDateSlots for JsObject<PlainDateTime> {
+    fn iso_date(&self) -> IsoDate {
+        self.borrow().data().inner.iso_date()
+    }
+}
+
+impl GetCalendarSlot<JsObject> for JsObject<PlainDateTime> {
+    fn get_calendar(&self) -> CalendarSlot<JsObject> {
+        self.borrow().data().inner.get_calendar()
     }
 }
 
@@ -343,50 +359,65 @@ impl PlainDateTime {
 
     /// 5.3.4 get `Temporal.PlainDateTime.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_year(&date, context)?.into())
     }
 
     /// 5.3.5 get `Temporal.PlainDateTime.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_month(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_month(&date, context)?.into())
     }
 
     /// 5.3.6 get Temporal.PlainDateTime.prototype.monthCode
     fn get_month_code(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(JsString::from(date.inner.contextual_month_code(context)?.as_str()).into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(JsString::from(
+            InnerDateTime::<JsObject>::contextualized_month_code(&date, context)?.as_str(),
+        )
+        .into())
     }
 
     /// 5.3.7 get `Temporal.PlainDateTime.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_day(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_day(&date, context)?.into())
     }
 
     /// 5.3.8 get `Temporal.PlainDateTime.prototype.hour`
@@ -481,62 +512,77 @@ impl PlainDateTime {
 
     /// 5.3.14 get `Temporal.PlainDateTime.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_day_of_week(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_day_of_week(&date, context)?.into())
     }
 
     /// 5.3.15 get `Temporal.PlainDateTime.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_day_of_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_day_of_year(&date, context)?.into())
     }
 
     /// 5.3.16 get `Temporal.PlainDateTime.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_week_of_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_week_of_year(&date, context)?.into())
     }
 
     /// 5.3.17 get `Temporal.PlainDateTime.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_year_of_week(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_year_of_week(&date, context)?.into())
     }
 
     /// 5.3.18 get `Temporal.PlainDateTime.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_days_in_week(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_days_in_week(&date, context)?.into())
     }
 
     /// 5.3.19 get `Temporal.PlainDateTime.prototype.daysInMonth`
@@ -545,26 +591,32 @@ impl PlainDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_days_in_month(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_days_in_month(&date, context)?.into())
     }
 
     /// 5.3.20 get `Temporal.PlainDateTime.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_days_in_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_days_in_year(&date, context)?.into())
     }
 
     /// 5.3.21 get `Temporal.PlainDateTime.prototype.monthsInYear`
@@ -573,33 +625,39 @@ impl PlainDateTime {
         _: &[JsValue],
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_months_in_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_months_in_year(&date, context)?.into())
     }
 
     /// 5.3.22 get `Temporal.PlainDateTime.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        let date = this
+        let obj = this
             .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
-            })?;
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
 
-        Ok(date.inner.contextual_in_leap_year(context)?.into())
+        let Ok(date) = obj.clone().downcast::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDateTime object.")
+                .into());
+        };
+
+        Ok(InnerDateTime::<JsObject>::contextualized_in_leap_year(&date, context)?.into())
     }
 }
 
 // ==== `PlainDateTime` Abstract Operations` ====
 
 pub(crate) fn create_temporal_datetime(
-    inner: InnerDateTime<JsCustomCalendar>,
+    inner: InnerDateTime<JsObject>,
     new_target: Option<&JsValue>,
     context: &mut Context,
 ) -> JsResult<JsObject> {

--- a/core/engine/src/builtins/temporal/plain_date_time/tests.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/tests.rs
@@ -1,0 +1,10 @@
+use crate::{run_test_actions, TestAction};
+
+#[test]
+fn pdt_year_of_week_basic() {
+    run_test_actions([
+        TestAction::run("let calendar = Temporal.Calendar.from('iso8601')"),
+        TestAction::run("let pdt = new Temporal.PlainDateTime(1976, 11, 18, 15, 23, 30, 123, 456, 789, calendar)"),
+        TestAction::assert_eq("pdt.yearOfWeek", 1976),
+    ]);
+}

--- a/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
@@ -14,12 +14,12 @@ use boa_temporal::components::{
     ZonedDateTime as InnerZdt,
 };
 
-use super::{JsCustomCalendar, JsCustomTimeZone};
+use super::JsCustomTimeZone;
 
 /// The `Temporal.ZonedDateTime` object.
 #[derive(Debug, Clone, Finalize, JsData)]
 pub struct ZonedDateTime {
-    pub(crate) inner: InnerZdt<JsCustomCalendar, JsCustomTimeZone>,
+    pub(crate) inner: InnerZdt<JsObject, JsCustomTimeZone>,
 }
 
 unsafe impl Trace for ZonedDateTime {

--- a/core/temporal/src/components/date.rs
+++ b/core/temporal/src/components/date.rs
@@ -15,7 +15,10 @@ use crate::{
 };
 use std::{any::Any, str::FromStr};
 
-use super::duration::TimeDuration;
+use super::{
+    calendar::{CalendarDateLike, DateTypes, GetCalendarSlot},
+    duration::TimeDuration,
+};
 
 /// The native Rust implementation of `Temporal.PlainDate`.
 #[derive(Debug, Default, Clone)]
@@ -67,7 +70,7 @@ impl<C: CalendarProtocol> Date<C> {
     /// Creates a `Date` from a `DateTime`.
     pub fn from_datetime(dt: &DateTime<C>) -> Self {
         Self {
-            iso: *dt.iso_date(),
+            iso: dt.iso_date(),
             calendar: dt.calendar().clone(),
         }
     }
@@ -127,174 +130,211 @@ impl<C: CalendarProtocol> Date<C> {
 
 // ==== Calendar-derived Public API ====
 
-impl<C: CalendarProtocol> Date<C> {
-    /// Returns the calendar year value with provided context.
-    pub fn contextual_year(&self, context: &mut dyn Any) -> TemporalResult<i32> {
-        self.calendar.year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
-    }
-
+impl Date<()> {
     /// Returns the calendar year value.
     pub fn year(&self) -> TemporalResult<i32> {
-        self.contextual_year(&mut ())
-    }
-
-    /// Returns the calendar month value with provided context.
-    pub fn contextual_month(&self, context: &mut dyn Any) -> TemporalResult<u8> {
-        self.calendar.month(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .year(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar month value.
     pub fn month(&self) -> TemporalResult<u8> {
-        self.contextual_month(&mut ())
-    }
-
-    /// Returns the calendar month code value with provided context.
-    pub fn contextual_month_code(&self, context: &mut dyn Any) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar.month_code(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .month(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar month code value.
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.contextual_month_code(&mut ())
-    }
-
-    /// Returns the calendar day value with provided context.
-    pub fn contextual_day(&self, context: &mut dyn Any) -> TemporalResult<u8> {
-        self.calendar.day(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .month_code(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar day value.
     pub fn day(&self) -> TemporalResult<u8> {
-        self.contextual_day(&mut ())
-    }
-
-    /// Returns the calendar day of week value with provided context.
-    pub fn contextual_day_of_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.day_of_week(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .day(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar day of week value.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
-        self.contextual_day_of_week(&mut ())
-    }
-
-    /// Returns the calendar day of year value with provided context.
-    pub fn contextual_day_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.day_of_year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .day_of_week(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar day of year value.
     pub fn day_of_year(&self) -> TemporalResult<u16> {
-        self.contextual_day_of_year(&mut ())
-    }
-
-    /// Returns the calendar week of year value with provided context.
-    pub fn contextual_week_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.week_of_year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .day_of_year(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar week of year value.
     pub fn week_of_year(&self) -> TemporalResult<u16> {
-        self.contextual_week_of_year(&mut ())
-    }
-
-    /// Returns the calendar year of week value with provided context.
-    pub fn contextual_year_of_week(&self, context: &mut dyn Any) -> TemporalResult<i32> {
-        self.calendar.year_of_week(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .week_of_year(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week(&self) -> TemporalResult<i32> {
-        self.contextual_year_of_week(&mut ())
-    }
-
-    /// Returns the calendar days in week value with provided context.
-    pub fn contextual_days_in_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_week(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .year_of_week(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_week(&mut ())
-    }
-
-    /// Returns the calendar days in month value with provided context.
-    pub fn contextual_days_in_month(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_month(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_week(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_month(&mut ())
-    }
-
-    /// Returns the calendar days in year value with provided context.
-    pub fn contextual_days_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_month(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_year(&mut ())
-    }
-
-    /// Returns the calendar months in year value with provided context.
-    pub fn contextual_months_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.months_in_year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_year(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
-        self.contextual_months_in_year(&mut ())
-    }
-
-    /// Returns whether the date is in a leap year for the given calendar with provided context.
-    pub fn contextual_in_leap_year(&self, context: &mut dyn Any) -> TemporalResult<bool> {
-        self.calendar.in_leap_year(
-            &super::calendar::CalendarDateLike::Date(self.clone()),
-            context,
-        )
+        self.calendar
+            .months_in_year(&CalendarDateLike::Date(self.clone()), &mut ())
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        self.contextual_in_leap_year(&mut ())
+        self.calendar
+            .in_leap_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+}
+
+// NOTE(nekevss): The clone below should ideally not change the memory address, but that may
+// not be true across all cases. I.e., it should be fine as long as the clone is simply a
+// reference count increment. Need to test.
+impl<C: CalendarProtocol> Date<C> {
+    /// Returns the calendar year value with provided context.
+    pub fn contextualized_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<i32> {
+        this.get_calendar()
+            .year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar month value with provided context.
+    pub fn contextualized_month(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u8> {
+        this.get_calendar()
+            .month(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar month code value with provided context.
+    pub fn contextualized_month_code(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<TinyAsciiStr<4>> {
+        this.get_calendar()
+            .month_code(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar day value with provided context.
+    pub fn contextualized_day(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u8> {
+        this.get_calendar()
+            .day(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar day of week value with provided context.
+    pub fn contextualized_day_of_week(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .day_of_week(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar day of year value with provided context.
+    pub fn contextualized_day_of_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .day_of_year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar week of year value with provided context.
+    pub fn contextualized_week_of_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .week_of_year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar year of week value with provided context.
+    pub fn contextualized_year_of_week(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<i32> {
+        this.get_calendar()
+            .year_of_week(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar days in week value with provided context.
+    pub fn contextualized_days_in_week(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_week(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar days in month value with provided context.
+    pub fn contextualized_days_in_month(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_month(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar days in year value with provided context.
+    pub fn contextualized_days_in_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns the calendar months in year value with provided context.
+    pub fn contextualized_months_in_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .months_in_year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+
+    /// Returns whether the date is in a leap year for the given calendar with provided context.
+    pub fn contextualized_in_leap_year(
+        this: &<C::DateLikes as DateTypes<C>>::Date,
+        context: &mut dyn Any,
+    ) -> TemporalResult<bool> {
+        this.get_calendar()
+            .in_leap_year(&CalendarDateLike::CustomDate(this.clone()), context)
+    }
+}
+
+impl<C: CalendarProtocol> GetCalendarSlot<C> for Date<C> {
+    fn get_calendar(&self) -> CalendarSlot<C> {
+        self.calendar.clone()
     }
 }
 

--- a/core/temporal/src/components/datetime.rs
+++ b/core/temporal/src/components/datetime.rs
@@ -14,6 +14,8 @@ use crate::{
 use std::{any::Any, str::FromStr};
 use tinystr::TinyAsciiStr;
 
+use super::calendar::{CalendarDateLike, DateTypes, GetCalendarSlot};
+
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[derive(Debug, Default, Clone)]
 pub struct DateTime<C: CalendarProtocol> {
@@ -47,13 +49,6 @@ impl<C: CalendarProtocol> DateTime<C> {
     ) -> TemporalResult<Self> {
         let iso = IsoDateTime::from_epoch_nanos(&instant.nanos, offset)?;
         Ok(Self { iso, calendar })
-    }
-
-    /// Returns the inner `IsoDate` value.
-    #[inline]
-    #[must_use]
-    pub(crate) fn iso_date(&self) -> &IsoDate {
-        self.iso.date()
     }
 }
 
@@ -170,178 +165,219 @@ impl<C: CalendarProtocol> DateTime<C> {
 
 // ==== Calendar-derived public API ====
 
-impl<C: CalendarProtocol> DateTime<C> {
-    /// Returns the calendar year value with provided context.
-    pub fn contextual_year(&self, context: &mut dyn Any) -> TemporalResult<i32> {
-        self.calendar.year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
-    }
-
+// TODO: Revert to `DateTime<C>`.
+impl DateTime<()> {
     /// Returns the calendar year value.
     pub fn year(&self) -> TemporalResult<i32> {
-        self.contextual_year(&mut ())
-    }
-
-    /// Returns the calendar month value with provided context.
-    pub fn contextual_month(&self, context: &mut dyn Any) -> TemporalResult<u8> {
-        self.calendar.month(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .year(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar month value.
     pub fn month(&self) -> TemporalResult<u8> {
-        self.contextual_month(&mut ())
-    }
-
-    /// Returns the calendar month code value with provided context.
-    pub fn contextual_month_code(&self, context: &mut dyn Any) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar.month_code(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .month(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar month code value.
     pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.contextual_month_code(&mut ())
-    }
-
-    /// Returns the calendar day value with provided context.
-    pub fn contextual_day(&self, context: &mut dyn Any) -> TemporalResult<u8> {
-        self.calendar.day(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .month_code(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar day value.
     pub fn day(&self) -> TemporalResult<u8> {
-        self.contextual_day(&mut ())
-    }
-
-    /// Returns the calendar day of week value with provided context.
-    pub fn contextual_day_of_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.day_of_week(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .day(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar day of week value.
     pub fn day_of_week(&self) -> TemporalResult<u16> {
-        self.contextual_day_of_week(&mut ())
-    }
-
-    /// Returns the calendar day of year value with provided context.
-    pub fn contextual_day_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.day_of_year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .day_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar day of year value.
     pub fn day_of_year(&self) -> TemporalResult<u16> {
-        self.contextual_day_of_year(&mut ())
-    }
-
-    /// Returns the calendar week of year value with provided context.
-    pub fn contextual_week_of_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.week_of_year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .day_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar week of year value.
     pub fn week_of_year(&self) -> TemporalResult<u16> {
-        self.contextual_week_of_year(&mut ())
-    }
-
-    /// Returns the calendar year of week value with provided context.
-    pub fn contextual_year_of_week(&self, context: &mut dyn Any) -> TemporalResult<i32> {
-        self.calendar.year_of_week(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .week_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar year of week value.
     pub fn year_of_week(&self) -> TemporalResult<i32> {
-        self.contextual_year_of_week(&mut ())
-    }
-
-    /// Returns the calendar days in week value with provided context.
-    pub fn contextual_days_in_week(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_week(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .year_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in week value.
     pub fn days_in_week(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_week(&mut ())
-    }
-
-    /// Returns the calendar days in month value with provided context.
-    pub fn contextual_days_in_month(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_month(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in month value.
     pub fn days_in_month(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_month(&mut ())
-    }
-
-    /// Returns the calendar days in year value with provided context.
-    pub fn contextual_days_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.days_in_year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_month(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar days in year value.
     pub fn days_in_year(&self) -> TemporalResult<u16> {
-        self.contextual_days_in_year(&mut ())
-    }
-
-    /// Returns the calendar months in year value with provided context.
-    pub fn contextual_months_in_year(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        self.calendar.months_in_year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .days_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns the calendar months in year value.
     pub fn months_in_year(&self) -> TemporalResult<u16> {
-        self.contextual_months_in_year(&mut ())
-    }
-
-    /// Returns whether the date is in a leap year for the given calendar with provided context.
-    pub fn contextual_in_leap_year(&self, context: &mut dyn Any) -> TemporalResult<bool> {
-        self.calendar.in_leap_year(
-            &super::calendar::CalendarDateLike::DateTime(self.clone()),
-            context,
-        )
+        self.calendar
+            .months_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
     }
 
     /// Returns returns whether the date in a leap year for the given calendar.
     pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        self.contextual_in_leap_year(&mut ())
+        self.calendar
+            .in_leap_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+}
+
+impl<C: CalendarProtocol> DateTime<C> {
+    /// Returns the calendar year value with provided context.
+    pub fn contextualized_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<i32> {
+        this.get_calendar()
+            .year(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar month value with provided context.
+    pub fn contextualized_month(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u8> {
+        this.get_calendar()
+            .month(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar month code value with provided context.
+    pub fn contextualized_month_code(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<TinyAsciiStr<4>> {
+        this.get_calendar()
+            .month_code(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar day value with provided context.
+    pub fn contextualized_day(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u8> {
+        this.get_calendar()
+            .day(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar day of week value with provided context.
+    pub fn contextualized_day_of_week(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .day_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar day of year value with provided context.
+    pub fn contextualized_day_of_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .day_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar week of year value with provided context.
+    pub fn contextualized_week_of_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .week_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar year of week value with provided context.
+    pub fn contextualized_year_of_week(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<i32> {
+        this.get_calendar()
+            .year_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar days in week value with provided context.
+    pub fn contextualized_days_in_week(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar days in month value with provided context.
+    pub fn contextualized_days_in_month(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_month(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar days in year value with provided context.
+    pub fn contextualized_days_in_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .days_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns the calendar months in year value with provided context.
+    pub fn contextualized_months_in_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<u16> {
+        this.get_calendar()
+            .months_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
+    }
+
+    /// Returns whether the date is in a leap year for the given calendar with provided context.
+    pub fn contextualized_in_leap_year(
+        this: &<C::DateLikes as DateTypes<C>>::DateTime,
+        context: &mut dyn Any,
+    ) -> TemporalResult<bool> {
+        this.get_calendar()
+            .in_leap_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 }
 
 // ==== Trait impls ====
+
+impl<C: CalendarProtocol> GetCalendarSlot<C> for DateTime<C> {
+    fn get_calendar(&self) -> CalendarSlot<C> {
+        self.calendar.clone()
+    }
+}
+
+impl<C: CalendarProtocol> IsoDateSlots for DateTime<C> {
+    fn iso_date(&self) -> IsoDate {
+        *self.iso.date()
+    }
+}
 
 impl<C: CalendarProtocol> FromStr for DateTime<C> {
     type Err = TemporalError;

--- a/core/temporal/src/components/month_day.rs
+++ b/core/temporal/src/components/month_day.rs
@@ -9,7 +9,7 @@ use crate::{
     TemporalError, TemporalResult,
 };
 
-use super::calendar::CalendarProtocol;
+use super::calendar::{CalendarProtocol, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.PlainMonthDay`
 #[derive(Debug, Default, Clone)]
@@ -57,6 +57,12 @@ impl<C: CalendarProtocol> MonthDay<C> {
     #[must_use]
     pub fn calendar(&self) -> &CalendarSlot<C> {
         &self.calendar
+    }
+}
+
+impl<C: CalendarProtocol> GetCalendarSlot<C> for MonthDay<C> {
+    fn get_calendar(&self) -> CalendarSlot<C> {
+        self.calendar.clone()
     }
 }
 

--- a/core/temporal/src/components/year_month.rs
+++ b/core/temporal/src/components/year_month.rs
@@ -9,7 +9,7 @@ use crate::{
     TemporalError, TemporalResult,
 };
 
-use super::calendar::CalendarProtocol;
+use super::calendar::{CalendarProtocol, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.YearMonth`.
 #[derive(Debug, Default, Clone)]
@@ -54,11 +54,18 @@ impl<C: CalendarProtocol> YearMonth<C> {
         self.iso.month
     }
 
+    /// Returns the Calendar value.
     #[inline]
     #[must_use]
-    /// Returns a reference to `YearMonth`'s `CalendarSlot`
     pub fn calendar(&self) -> &CalendarSlot<C> {
         &self.calendar
+    }
+}
+
+impl<C: CalendarProtocol> GetCalendarSlot<C> for YearMonth<C> {
+    /// Returns a reference to `YearMonth`'s `CalendarSlot`
+    fn get_calendar(&self) -> CalendarSlot<C> {
+        self.calendar.clone()
     }
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to ongoing #1804.

So a little background.

There was a [test](https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/PlainDateTime/prototype/dayOfWeek/custom.js) I noticed that, in theory, we should have been passing, but weren't.

The reason we weren't was due to only passing the inner date representation through the library, and recreating the `PlainDate` once into the custom calendar impl. But this meant that we couldn't do the strict equality `compareArray` asserts.

So after some initial prototyping about an `AnyDateLike` trait. I had a sidebar with @jedel1043, and he had a good idea of using an associated trait. 😄

Let me know what you all think!

It changes the following:

- Adds `DateLike` associated Type to `CalendarProtocol`
- Updates the API for the above change.
