### PR TITLE
Simplify Temporal APIs

### DIFF
--- a/core/engine/src/builtins/temporal/calendar/object.rs
+++ b/core/engine/src/builtins/temporal/calendar/object.rs
@@ -12,12 +12,11 @@ use crate::{
     property::PropertyKey,
     Context, JsObject, JsString, JsValue,
 };
-use std::any::Any;
 
 use boa_macros::utf16;
 use boa_temporal::{
     components::{
-        calendar::{CalendarDateLike, CalendarProtocol, DateTypes},
+        calendar::{CalendarDateLike, CalendarProtocol},
         Date, Duration, MonthDay, YearMonth,
     },
     options::ArithmeticOverflow,
@@ -29,29 +28,18 @@ use plain_date_time::PlainDateTime;
 use plain_month_day::PlainMonthDay;
 use plain_year_month::PlainYearMonth;
 
-/// The custom data types for a Custom `JsObject` Calendar.
-#[derive(Debug, Clone, Copy)]
-pub struct CustomDateLikes;
-
-impl DateTypes<JsObject> for CustomDateLikes {
+impl CalendarProtocol for JsObject {
     type Date = JsObject<PlainDate>;
     type DateTime = JsObject<PlainDateTime>;
     type YearMonth = JsObject<PlainYearMonth>;
     type MonthDay = JsObject<PlainMonthDay>;
-}
-
-impl CalendarProtocol for JsObject {
-    type DateLikes = CustomDateLikes;
+    type Context = Context;
     fn date_from_fields(
         &self,
         fields: &mut TemporalFields,
         overflow: ArithmeticOverflow,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<Date<Self>> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let method = self
             .get(utf16!("dateFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
@@ -97,12 +85,8 @@ impl CalendarProtocol for JsObject {
         &self,
         fields: &mut TemporalFields,
         overflow: ArithmeticOverflow,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<YearMonth<JsObject>> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let method = self
             .get(utf16!("yearMonthFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
@@ -150,12 +134,8 @@ impl CalendarProtocol for JsObject {
         &self,
         fields: &mut TemporalFields,
         overflow: ArithmeticOverflow,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<MonthDay<JsObject>> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let method = self
             .get(utf16!("yearMonthFromFields"), context)
             .expect("method must exist on a object that implements the CalendarProtocol.");
@@ -204,7 +184,7 @@ impl CalendarProtocol for JsObject {
         _date: &Date<JsObject>,
         _duration: &Duration,
         _overflow: ArithmeticOverflow,
-        _context: &mut dyn Any,
+        _context: &mut Context,
     ) -> TemporalResult<Date<JsObject>> {
         // TODO
         Err(TemporalError::general("Not yet implemented."))
@@ -215,7 +195,7 @@ impl CalendarProtocol for JsObject {
         _one: &Date<JsObject>,
         _two: &Date<JsObject>,
         _largest_unit: boa_temporal::options::TemporalUnit,
-        _context: &mut dyn Any,
+        _context: &mut Context,
     ) -> TemporalResult<Duration> {
         // TODO
         Err(TemporalError::general("Not yet implemented."))
@@ -224,7 +204,7 @@ impl CalendarProtocol for JsObject {
     fn era(
         &self,
         _: &CalendarDateLike<JsObject>,
-        _: &mut dyn Any,
+        _: &mut Context,
     ) -> TemporalResult<Option<TinyAsciiStr<16>>> {
         // Return undefined as custom calendars do not implement -> Currently.
         Ok(None)
@@ -233,7 +213,7 @@ impl CalendarProtocol for JsObject {
     fn era_year(
         &self,
         _: &CalendarDateLike<JsObject>,
-        _: &mut dyn Any,
+        _: &mut Context,
     ) -> TemporalResult<Option<i32>> {
         // Return undefined as custom calendars do not implement -> Currently.
         Ok(None)
@@ -242,12 +222,8 @@ impl CalendarProtocol for JsObject {
     fn year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<i32> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -288,12 +264,8 @@ impl CalendarProtocol for JsObject {
     fn month(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u8> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -334,12 +306,8 @@ impl CalendarProtocol for JsObject {
     fn month_code(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<TinyAsciiStr<4>> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -365,12 +333,8 @@ impl CalendarProtocol for JsObject {
     fn day(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u8> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -411,12 +375,8 @@ impl CalendarProtocol for JsObject {
     fn day_of_week(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -459,12 +419,8 @@ impl CalendarProtocol for JsObject {
     fn day_of_year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -507,12 +463,8 @@ impl CalendarProtocol for JsObject {
     fn week_of_year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -555,12 +507,8 @@ impl CalendarProtocol for JsObject {
     fn year_of_week(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<i32> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -596,12 +544,8 @@ impl CalendarProtocol for JsObject {
     fn days_in_week(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -644,12 +588,8 @@ impl CalendarProtocol for JsObject {
     fn days_in_month(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -693,12 +633,8 @@ impl CalendarProtocol for JsObject {
     fn days_in_year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -741,12 +677,8 @@ impl CalendarProtocol for JsObject {
     fn months_in_year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<u16> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -791,12 +723,8 @@ impl CalendarProtocol for JsObject {
     fn in_leap_year(
         &self,
         date_like: &CalendarDateLike<JsObject>,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<bool> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let date_like = date_like_to_object(date_like, context)?;
 
         let method = self
@@ -818,11 +746,7 @@ impl CalendarProtocol for JsObject {
         Ok(result)
     }
 
-    fn fields(&self, fields: Vec<String>, context: &mut dyn Any) -> TemporalResult<Vec<String>> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
+    fn fields(&self, fields: Vec<String>, context: &mut Context) -> TemporalResult<Vec<String>> {
         let fields_js = Array::create_array_from_list(
             fields.iter().map(|s| JsString::from(s.clone()).into()),
             context,
@@ -867,12 +791,8 @@ impl CalendarProtocol for JsObject {
         &self,
         fields: &TemporalFields,
         additional_fields: &TemporalFields,
-        context: &mut dyn Any,
+        context: &mut Context,
     ) -> TemporalResult<TemporalFields> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
         let fields = JsObject::from_temporal_fields(fields, context)
             .map_err(|e| TemporalError::general(e.to_string()))?;
         let add_fields = JsObject::from_temporal_fields(additional_fields, context)
@@ -901,11 +821,7 @@ impl CalendarProtocol for JsObject {
         object_to_temporal_fields(&o, context).map_err(|e| TemporalError::general(e.to_string()))
     }
 
-    fn identifier(&self, context: &mut dyn Any) -> TemporalResult<String> {
-        let context = context
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomCalendar.");
-
+    fn identifier(&self, context: &mut Context) -> TemporalResult<String> {
         let identifier = self
             .__get__(
                 &PropertyKey::from(utf16!("id")),

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -284,7 +284,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::year(&date, context)?.into())
     }
 
     /// 3.3.5 get `Temporal.PlainDate.prototype.month`
@@ -299,7 +299,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_month(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::month(&date, context)?.into())
     }
 
     /// 3.3.6 get Temporal.PlainDate.prototype.monthCode
@@ -315,7 +315,7 @@ impl PlainDate {
         };
 
         Ok(JsString::from(
-            InnerDate::<JsObject>::contextualized_month_code(&date, context)?.as_str(),
+            InnerDate::<JsObject>::month_code(&date, context)?.as_str(),
         )
         .into())
     }
@@ -332,7 +332,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_day(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::day(&date, context)?.into())
     }
 
     /// 3.3.8 get `Temporal.PlainDate.prototype.dayOfWeek`
@@ -347,7 +347,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_day_of_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::day_of_week(&date, context)?.into())
     }
 
     /// 3.3.9 get `Temporal.PlainDate.prototype.dayOfYear`
@@ -362,7 +362,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_day_of_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::day_of_year(&date, context)?.into())
     }
 
     /// 3.3.10 get `Temporal.PlainDate.prototype.weekOfYear`
@@ -377,7 +377,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_week_of_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::week_of_year(&date, context)?.into())
     }
 
     /// 3.3.11 get `Temporal.PlainDate.prototype.yearOfWeek`
@@ -392,7 +392,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_year_of_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::year_of_week(&date, context)?.into())
     }
 
     /// 3.3.12 get `Temporal.PlainDate.prototype.daysInWeek`
@@ -407,7 +407,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_days_in_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::days_in_week(&date, context)?.into())
     }
 
     /// 3.3.13 get `Temporal.PlainDate.prototype.daysInMonth`
@@ -426,7 +426,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_days_in_month(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::days_in_month(&date, context)?.into())
     }
 
     /// 3.3.14 get `Temporal.PlainDate.prototype.daysInYear`
@@ -441,7 +441,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_days_in_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::days_in_year(&date, context)?.into())
     }
 
     /// 3.3.15 get `Temporal.PlainDate.prototype.monthsInYear`
@@ -460,7 +460,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_months_in_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::months_in_year(&date, context)?.into())
     }
 
     /// 3.3.16 get `Temporal.PlainDate.prototype.inLeapYear`
@@ -475,7 +475,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::contextualized_in_leap_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::in_leap_year(&date, context)?.into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -314,10 +314,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(JsString::from(
-            InnerDate::<JsObject>::month_code(&date, context)?.as_str(),
-        )
-        .into())
+        Ok(JsString::from(InnerDate::<JsObject>::month_code(&date, context)?.as_str()).into())
     }
 
     /// 3.3.7 get `Temporal.PlainDate.prototype.day`

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -284,7 +284,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_year(&date, context)?.into())
     }
 
     /// 3.3.5 get `Temporal.PlainDate.prototype.month`
@@ -299,7 +299,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::month(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_month(&date, context)?.into())
     }
 
     /// 3.3.6 get Temporal.PlainDate.prototype.monthCode
@@ -314,7 +314,10 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(JsString::from(InnerDate::<JsObject>::month_code(&date, context)?.as_str()).into())
+        Ok(
+            JsString::from(InnerDate::<JsObject>::contextual_month_code(&date, context)?.as_str())
+                .into(),
+        )
     }
 
     /// 3.3.7 get `Temporal.PlainDate.prototype.day`
@@ -329,7 +332,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::day(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_day(&date, context)?.into())
     }
 
     /// 3.3.8 get `Temporal.PlainDate.prototype.dayOfWeek`
@@ -344,7 +347,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::day_of_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_day_of_week(&date, context)?.into())
     }
 
     /// 3.3.9 get `Temporal.PlainDate.prototype.dayOfYear`
@@ -359,7 +362,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::day_of_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_day_of_year(&date, context)?.into())
     }
 
     /// 3.3.10 get `Temporal.PlainDate.prototype.weekOfYear`
@@ -374,7 +377,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::week_of_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_week_of_year(&date, context)?.into())
     }
 
     /// 3.3.11 get `Temporal.PlainDate.prototype.yearOfWeek`
@@ -389,7 +392,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::year_of_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_year_of_week(&date, context)?.into())
     }
 
     /// 3.3.12 get `Temporal.PlainDate.prototype.daysInWeek`
@@ -404,7 +407,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::days_in_week(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_days_in_week(&date, context)?.into())
     }
 
     /// 3.3.13 get `Temporal.PlainDate.prototype.daysInMonth`
@@ -423,7 +426,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::days_in_month(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_days_in_month(&date, context)?.into())
     }
 
     /// 3.3.14 get `Temporal.PlainDate.prototype.daysInYear`
@@ -438,7 +441,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::days_in_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_days_in_year(&date, context)?.into())
     }
 
     /// 3.3.15 get `Temporal.PlainDate.prototype.monthsInYear`
@@ -457,7 +460,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::months_in_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_months_in_year(&date, context)?.into())
     }
 
     /// 3.3.16 get `Temporal.PlainDate.prototype.inLeapYear`
@@ -472,7 +475,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(InnerDate::<JsObject>::in_leap_year(&date, context)?.into())
+        Ok(InnerDate::<JsObject>::contextual_in_leap_year(&date, context)?.into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -372,7 +372,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::year(&date, context)?.into())
     }
 
     /// 5.3.5 get `Temporal.PlainDateTime.prototype.month`
@@ -387,7 +387,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_month(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::month(&date, context)?.into())
     }
 
     /// 5.3.6 get Temporal.PlainDateTime.prototype.monthCode
@@ -402,10 +402,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(JsString::from(
-            InnerDateTime::<JsObject>::contextualized_month_code(&date, context)?.as_str(),
-        )
-        .into())
+        Ok(JsString::from(InnerDateTime::<JsObject>::month_code(&date, context)?.as_str()).into())
     }
 
     /// 5.3.7 get `Temporal.PlainDateTime.prototype.day`
@@ -420,7 +417,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_day(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::day(&date, context)?.into())
     }
 
     /// 5.3.8 get `Temporal.PlainDateTime.prototype.hour`
@@ -525,7 +522,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_day_of_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::day_of_week(&date, context)?.into())
     }
 
     /// 5.3.15 get `Temporal.PlainDateTime.prototype.dayOfYear`
@@ -540,7 +537,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_day_of_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::day_of_year(&date, context)?.into())
     }
 
     /// 5.3.16 get `Temporal.PlainDateTime.prototype.weekOfYear`
@@ -555,7 +552,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_week_of_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::week_of_year(&date, context)?.into())
     }
 
     /// 5.3.17 get `Temporal.PlainDateTime.prototype.yearOfWeek`
@@ -570,7 +567,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_year_of_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::year_of_week(&date, context)?.into())
     }
 
     /// 5.3.18 get `Temporal.PlainDateTime.prototype.daysInWeek`
@@ -585,7 +582,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_days_in_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::days_in_week(&date, context)?.into())
     }
 
     /// 5.3.19 get `Temporal.PlainDateTime.prototype.daysInMonth`
@@ -604,7 +601,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_days_in_month(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::days_in_month(&date, context)?.into())
     }
 
     /// 5.3.20 get `Temporal.PlainDateTime.prototype.daysInYear`
@@ -619,7 +616,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_days_in_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::days_in_year(&date, context)?.into())
     }
 
     /// 5.3.21 get `Temporal.PlainDateTime.prototype.monthsInYear`
@@ -638,7 +635,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_months_in_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::months_in_year(&date, context)?.into())
     }
 
     /// 5.3.22 get `Temporal.PlainDateTime.prototype.inLeapYear`
@@ -653,7 +650,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::contextualized_in_leap_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::in_leap_year(&date, context)?.into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -372,7 +372,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_year(&date, context)?.into())
     }
 
     /// 5.3.5 get `Temporal.PlainDateTime.prototype.month`
@@ -387,7 +387,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::month(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_month(&date, context)?.into())
     }
 
     /// 5.3.6 get Temporal.PlainDateTime.prototype.monthCode
@@ -402,7 +402,10 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(JsString::from(InnerDateTime::<JsObject>::month_code(&date, context)?.as_str()).into())
+        Ok(JsString::from(
+            InnerDateTime::<JsObject>::contextual_month_code(&date, context)?.as_str(),
+        )
+        .into())
     }
 
     /// 5.3.7 get `Temporal.PlainDateTime.prototype.day`
@@ -417,7 +420,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::day(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_day(&date, context)?.into())
     }
 
     /// 5.3.8 get `Temporal.PlainDateTime.prototype.hour`
@@ -522,7 +525,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::day_of_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_day_of_week(&date, context)?.into())
     }
 
     /// 5.3.15 get `Temporal.PlainDateTime.prototype.dayOfYear`
@@ -537,7 +540,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::day_of_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_day_of_year(&date, context)?.into())
     }
 
     /// 5.3.16 get `Temporal.PlainDateTime.prototype.weekOfYear`
@@ -552,7 +555,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::week_of_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_week_of_year(&date, context)?.into())
     }
 
     /// 5.3.17 get `Temporal.PlainDateTime.prototype.yearOfWeek`
@@ -567,7 +570,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::year_of_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_year_of_week(&date, context)?.into())
     }
 
     /// 5.3.18 get `Temporal.PlainDateTime.prototype.daysInWeek`
@@ -582,7 +585,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::days_in_week(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_days_in_week(&date, context)?.into())
     }
 
     /// 5.3.19 get `Temporal.PlainDateTime.prototype.daysInMonth`
@@ -601,7 +604,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::days_in_month(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_days_in_month(&date, context)?.into())
     }
 
     /// 5.3.20 get `Temporal.PlainDateTime.prototype.daysInYear`
@@ -616,7 +619,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::days_in_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_days_in_year(&date, context)?.into())
     }
 
     /// 5.3.21 get `Temporal.PlainDateTime.prototype.monthsInYear`
@@ -635,7 +638,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::months_in_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_months_in_year(&date, context)?.into())
     }
 
     /// 5.3.22 get `Temporal.PlainDateTime.prototype.inLeapYear`
@@ -650,7 +653,7 @@ impl PlainDateTime {
                 .into());
         };
 
-        Ok(InnerDateTime::<JsObject>::in_leap_year(&date, context)?.into())
+        Ok(InnerDateTime::<JsObject>::contextual_in_leap_year(&date, context)?.into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/time_zone/custom.rs
+++ b/core/engine/src/builtins/temporal/time_zone/custom.rs
@@ -14,11 +14,8 @@ pub(crate) struct JsCustomTimeZone {
 }
 
 impl TzProtocol for JsCustomTimeZone {
-    fn get_offset_nanos_for(&self, ctx: &mut dyn std::any::Any) -> TemporalResult<BigInt> {
-        let context = ctx
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomTz");
-
+    type Context = Context;
+    fn get_offset_nanos_for(&self, context: &mut Context) -> TemporalResult<BigInt> {
         let method = self
             .tz
             .get(utf16!("getOffsetNanosFor"), context)
@@ -39,23 +36,12 @@ impl TzProtocol for JsCustomTimeZone {
         Ok(bigint.as_inner().clone())
     }
 
-    fn get_possible_instant_for(
-        &self,
-        ctx: &mut dyn std::any::Any,
-    ) -> TemporalResult<Vec<Instant>> {
-        let _context = ctx
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomTz");
-
+    fn get_possible_instant_for(&self, _context: &mut Context) -> TemporalResult<Vec<Instant>> {
         // TODO: Implement once Instant has been migrated to `boa_temporal`'s Instant.
         Err(TemporalError::range().with_message("Not yet implemented."))
     }
 
-    fn id(&self, ctx: &mut dyn std::any::Any) -> TemporalResult<String> {
-        let context = ctx
-            .downcast_mut::<Context>()
-            .expect("Context was not provided for a CustomTz");
-
+    fn id(&self, context: &mut Context) -> TemporalResult<String> {
         let ident = self
             .tz
             .__get__(

--- a/core/temporal/src/components/date.rs
+++ b/core/temporal/src/components/date.rs
@@ -44,7 +44,8 @@ impl<C: CalendarProtocol> Date<C> {
         duration: &Duration,
         context: &mut C::Context,
     ) -> TemporalResult<(Self, f64)> {
-        let new_date = self.add_date(duration, ArithmeticOverflow::Constrain, context)?;
+        let new_date =
+            self.contextual_add_date(duration, ArithmeticOverflow::Constrain, context)?;
         let days = f64::from(self.days_until(&new_date));
         Ok((new_date, days))
     }
@@ -127,84 +128,190 @@ impl<C: CalendarProtocol> Date<C> {
     }
 }
 
+// ==== Calendar-derived Public API ====
+
+impl Date<()> {
+    /// Returns the calendar year value.
+    pub fn year(&self) -> TemporalResult<i32> {
+        self.calendar
+            .year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar month value.
+    pub fn month(&self) -> TemporalResult<u8> {
+        self.calendar
+            .month(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar month code value.
+    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+        self.calendar
+            .month_code(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day value.
+    pub fn day(&self) -> TemporalResult<u8> {
+        self.calendar
+            .day(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day of week value.
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
+        self.calendar
+            .day_of_week(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day of year value.
+    pub fn day_of_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .day_of_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar week of year value.
+    pub fn week_of_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .week_of_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar year of week value.
+    pub fn year_of_week(&self) -> TemporalResult<i32> {
+        self.calendar
+            .year_of_week(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in week value.
+    pub fn days_in_week(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_week(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in month value.
+    pub fn days_in_month(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_month(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in year value.
+    pub fn days_in_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar months in year value.
+    pub fn months_in_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .months_in_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+
+    /// Returns returns whether the date in a leap year for the given calendar.
+    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+        self.calendar
+            .in_leap_year(&CalendarDateLike::Date(self.clone()), &mut ())
+    }
+}
+
 // NOTE(nekevss): The clone below should ideally not change the memory address, but that may
 // not be true across all cases. I.e., it should be fine as long as the clone is simply a
 // reference count increment. Need to test.
 impl<C: CalendarProtocol> Date<C> {
     /// Returns the calendar year value with provided context.
-    pub fn year(this: &C::Date, context: &mut C::Context) -> TemporalResult<i32> {
+    pub fn contextual_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<i32> {
         this.get_calendar()
             .year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar month value with provided context.
-    pub fn month(this: &C::Date, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_month(this: &C::Date, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .month(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar month code value with provided context.
-    pub fn month_code(this: &C::Date, context: &mut C::Context) -> TemporalResult<TinyAsciiStr<4>> {
+    pub fn contextual_month_code(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<TinyAsciiStr<4>> {
         this.get_calendar()
             .month_code(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar day value with provided context.
-    pub fn day(this: &C::Date, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_day(this: &C::Date, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .day(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar day of week value with provided context.
-    pub fn day_of_week(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_day_of_week(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_week(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar day of year value with provided context.
-    pub fn day_of_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_day_of_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar week of year value with provided context.
-    pub fn week_of_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_week_of_year(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .week_of_year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar year of week value with provided context.
-    pub fn year_of_week(this: &C::Date, context: &mut C::Context) -> TemporalResult<i32> {
+    pub fn contextual_year_of_week(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<i32> {
         this.get_calendar()
             .year_of_week(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar days in week value with provided context.
-    pub fn days_in_week(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_week(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_week(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar days in month value with provided context.
-    pub fn days_in_month(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_month(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_month(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar days in year value with provided context.
-    pub fn days_in_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_year(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns the calendar months in year value with provided context.
-    pub fn months_in_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_months_in_year(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .months_in_year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
 
     /// Returns whether the date is in a leap year for the given calendar with provided context.
-    pub fn in_leap_year(this: &C::Date, context: &mut C::Context) -> TemporalResult<bool> {
+    pub fn contextual_in_leap_year(
+        this: &C::Date,
+        context: &mut C::Context,
+    ) -> TemporalResult<bool> {
         this.get_calendar()
             .in_leap_year(&CalendarDateLike::CustomDate(this.clone()), context)
     }
@@ -230,7 +337,7 @@ impl<C: CalendarProtocol> Date<C> {
     ///
     /// Temporal Equivalent: 3.5.13 `AddDate ( calendar, plainDate, duration [ , options [ , dateAdd ] ] )`
     #[inline]
-    pub fn add_date(
+    pub fn contextual_add_date(
         &self,
         duration: &Duration,
         overflow: ArithmeticOverflow,
@@ -273,7 +380,7 @@ impl<C: CalendarProtocol> Date<C> {
     ///
     /// Temporal Equivalent: 3.5.6 `DifferenceDate ( calendar, one, two, options )`
     #[inline]
-    pub fn difference_date(
+    pub fn contextual_difference_date(
         &self,
         other: &Self,
         largest_unit: TemporalUnit,

--- a/core/temporal/src/components/datetime.rs
+++ b/core/temporal/src/components/datetime.rs
@@ -11,10 +11,10 @@ use crate::{
     TemporalError, TemporalResult,
 };
 
-use std::{any::Any, str::FromStr};
+use std::str::FromStr;
 use tinystr::TinyAsciiStr;
 
-use super::calendar::{CalendarDateLike, DateTypes, GetCalendarSlot};
+use super::calendar::{CalendarDateLike, GetCalendarSlot};
 
 /// The native Rust implementation of `Temporal.PlainDateTime`
 #[derive(Debug, Default, Clone)]
@@ -163,203 +163,84 @@ impl<C: CalendarProtocol> DateTime<C> {
     }
 }
 
-// ==== Calendar-derived public API ====
-
-// TODO: Revert to `DateTime<C>`.
-impl DateTime<()> {
-    /// Returns the calendar year value.
-    pub fn year(&self) -> TemporalResult<i32> {
-        self.calendar
-            .year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar month value.
-    pub fn month(&self) -> TemporalResult<u8> {
-        self.calendar
-            .month(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar month code value.
-    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
-        self.calendar
-            .month_code(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar day value.
-    pub fn day(&self) -> TemporalResult<u8> {
-        self.calendar
-            .day(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar day of week value.
-    pub fn day_of_week(&self) -> TemporalResult<u16> {
-        self.calendar
-            .day_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar day of year value.
-    pub fn day_of_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .day_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar week of year value.
-    pub fn week_of_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .week_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar year of week value.
-    pub fn year_of_week(&self) -> TemporalResult<i32> {
-        self.calendar
-            .year_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar days in week value.
-    pub fn days_in_week(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar days in month value.
-    pub fn days_in_month(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_month(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar days in year value.
-    pub fn days_in_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .days_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns the calendar months in year value.
-    pub fn months_in_year(&self) -> TemporalResult<u16> {
-        self.calendar
-            .months_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-
-    /// Returns returns whether the date in a leap year for the given calendar.
-    pub fn in_leap_year(&self) -> TemporalResult<bool> {
-        self.calendar
-            .in_leap_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
-    }
-}
-
 impl<C: CalendarProtocol> DateTime<C> {
     /// Returns the calendar year value with provided context.
-    pub fn contextualized_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<i32> {
+    pub fn year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<i32> {
         this.get_calendar()
             .year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar month value with provided context.
-    pub fn contextualized_month(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u8> {
+    pub fn month(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .month(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar month code value with provided context.
-    pub fn contextualized_month_code(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
+    pub fn month_code(
+        this: &C::DateTime,
+        context: &mut C::Context,
     ) -> TemporalResult<TinyAsciiStr<4>> {
         this.get_calendar()
             .month_code(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar day value with provided context.
-    pub fn contextualized_day(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u8> {
+    pub fn day(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .day(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar day of week value with provided context.
-    pub fn contextualized_day_of_week(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn day_of_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar day of year value with provided context.
-    pub fn contextualized_day_of_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn day_of_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar week of year value with provided context.
-    pub fn contextualized_week_of_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn week_of_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .week_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar year of week value with provided context.
-    pub fn contextualized_year_of_week(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<i32> {
+    pub fn year_of_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<i32> {
         this.get_calendar()
             .year_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in week value with provided context.
-    pub fn contextualized_days_in_week(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn days_in_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in month value with provided context.
-    pub fn contextualized_days_in_month(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn days_in_month(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_month(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in year value with provided context.
-    pub fn contextualized_days_in_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn days_in_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar months in year value with provided context.
-    pub fn contextualized_months_in_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<u16> {
+    pub fn months_in_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
         this.get_calendar()
             .months_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns whether the date is in a leap year for the given calendar with provided context.
-    pub fn contextualized_in_leap_year(
-        this: &<C::DateLikes as DateTypes<C>>::DateTime,
-        context: &mut dyn Any,
-    ) -> TemporalResult<bool> {
+    pub fn in_leap_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<bool> {
         this.get_calendar()
             .in_leap_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }

--- a/core/temporal/src/components/datetime.rs
+++ b/core/temporal/src/components/datetime.rs
@@ -163,21 +163,104 @@ impl<C: CalendarProtocol> DateTime<C> {
     }
 }
 
+// ==== Calendar-derived public API ====
+
+// TODO: Revert to `DateTime<C>`.
+impl DateTime<()> {
+    /// Returns the calendar year value.
+    pub fn year(&self) -> TemporalResult<i32> {
+        self.calendar
+            .year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar month value.
+    pub fn month(&self) -> TemporalResult<u8> {
+        self.calendar
+            .month(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar month code value.
+    pub fn month_code(&self) -> TemporalResult<TinyAsciiStr<4>> {
+        self.calendar
+            .month_code(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day value.
+    pub fn day(&self) -> TemporalResult<u8> {
+        self.calendar
+            .day(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day of week value.
+    pub fn day_of_week(&self) -> TemporalResult<u16> {
+        self.calendar
+            .day_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar day of year value.
+    pub fn day_of_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .day_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar week of year value.
+    pub fn week_of_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .week_of_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar year of week value.
+    pub fn year_of_week(&self) -> TemporalResult<i32> {
+        self.calendar
+            .year_of_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in week value.
+    pub fn days_in_week(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_week(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in month value.
+    pub fn days_in_month(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_month(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar days in year value.
+    pub fn days_in_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .days_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns the calendar months in year value.
+    pub fn months_in_year(&self) -> TemporalResult<u16> {
+        self.calendar
+            .months_in_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+
+    /// Returns returns whether the date in a leap year for the given calendar.
+    pub fn in_leap_year(&self) -> TemporalResult<bool> {
+        self.calendar
+            .in_leap_year(&CalendarDateLike::DateTime(self.clone()), &mut ())
+    }
+}
+
 impl<C: CalendarProtocol> DateTime<C> {
     /// Returns the calendar year value with provided context.
-    pub fn year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<i32> {
+    pub fn contextual_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<i32> {
         this.get_calendar()
             .year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar month value with provided context.
-    pub fn month(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_month(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .month(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar month code value with provided context.
-    pub fn month_code(
+    pub fn contextual_month_code(
         this: &C::DateTime,
         context: &mut C::Context,
     ) -> TemporalResult<TinyAsciiStr<4>> {
@@ -186,61 +269,88 @@ impl<C: CalendarProtocol> DateTime<C> {
     }
 
     /// Returns the calendar day value with provided context.
-    pub fn day(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_day(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u8> {
         this.get_calendar()
             .day(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar day of week value with provided context.
-    pub fn day_of_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_day_of_week(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar day of year value with provided context.
-    pub fn day_of_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_day_of_year(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .day_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar week of year value with provided context.
-    pub fn week_of_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_week_of_year(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .week_of_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar year of week value with provided context.
-    pub fn year_of_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<i32> {
+    pub fn contextual_year_of_week(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<i32> {
         this.get_calendar()
             .year_of_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in week value with provided context.
-    pub fn days_in_week(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_week(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_week(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in month value with provided context.
-    pub fn days_in_month(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_month(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_month(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar days in year value with provided context.
-    pub fn days_in_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_days_in_year(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .days_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns the calendar months in year value with provided context.
-    pub fn months_in_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_months_in_year(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<u16> {
         this.get_calendar()
             .months_in_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }
 
     /// Returns whether the date is in a leap year for the given calendar with provided context.
-    pub fn in_leap_year(this: &C::DateTime, context: &mut C::Context) -> TemporalResult<bool> {
+    pub fn contextual_in_leap_year(
+        this: &C::DateTime,
+        context: &mut C::Context,
+    ) -> TemporalResult<bool> {
         this.get_calendar()
             .in_leap_year(&CalendarDateLike::CustomDateTime(this.clone()), context)
     }

--- a/core/temporal/src/components/duration.rs
+++ b/core/temporal/src/components/duration.rs
@@ -6,7 +6,7 @@ use crate::{
     parser::{duration::parse_duration, Cursor},
     TemporalError, TemporalResult,
 };
-use std::{any::Any, str::FromStr};
+use std::str::FromStr;
 
 use super::{calendar::CalendarProtocol, tz::TzProtocol};
 
@@ -370,7 +370,7 @@ impl Duration {
         &self,
         largest_unit: TemporalUnit,
         plain_relative_to: Option<&Date<C>>,
-        context: &mut dyn Any,
+        context: &mut C::Context,
     ) -> TemporalResult<DateDuration> {
         // 1. Let allZero be false.
         // 2. If years = 0, and months = 0, and weeks = 0, and days = 0, set allZero to true.
@@ -576,7 +576,7 @@ impl Duration {
         &self,
         largest_unit: TemporalUnit,
         plain_relative_to: Option<&Date<C>>,
-        context: &mut dyn Any,
+        context: &mut C::Context,
     ) -> TemporalResult<DateDuration> {
         let mut result = self.date;
 
@@ -816,7 +816,7 @@ impl Duration {
             Option<&ZonedDateTime<C, Z>>,
             Option<&DateTime<C>>,
         ),
-        context: &mut dyn Any,
+        context: &mut C::Context,
     ) -> TemporalResult<(Self, f64)> {
         match unit {
             TemporalUnit::Year | TemporalUnit::Month | TemporalUnit::Week | TemporalUnit::Day => {

--- a/core/temporal/src/components/duration/date.rs
+++ b/core/temporal/src/components/duration/date.rs
@@ -9,8 +9,6 @@ use crate::{
     utils, TemporalError, TemporalResult, NS_PER_DAY,
 };
 
-use std::any::Any;
-
 /// `DateDuration` represents the [date duration record][spec] of the `Duration.`
 ///
 /// These fields are laid out in the [Temporal Proposal][field spec] as 64-bit floating point numbers.
@@ -147,7 +145,7 @@ impl DateDuration {
             Option<&ZonedDateTime<C, Z>>,
             Option<&DateTime<C>>,
         ),
-        context: &mut dyn Any,
+        context: &mut C::Context,
     ) -> TemporalResult<(Self, f64)> {
         // 1. If plainRelativeTo is not present, set plainRelativeTo to undefined.
         let plain_relative_to = relative_targets.0;
@@ -210,7 +208,7 @@ impl DateDuration {
                 // i. Let dateAdd be unused.
 
                 // e. Let yearsLater be ? AddDate(calendar, plainRelativeTo, yearsDuration, undefined, dateAdd).
-                let years_later = plain_relative_to.contextual_add_date(
+                let years_later = plain_relative_to.add_date(
                     &years_duration,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -223,7 +221,7 @@ impl DateDuration {
                 );
 
                 // g. Let yearsMonthsWeeksLater be ? AddDate(calendar, plainRelativeTo, yearsMonthsWeeks, undefined, dateAdd).
-                let years_months_weeks_later = plain_relative_to.contextual_add_date(
+                let years_months_weeks_later = plain_relative_to.add_date(
                     &years_months_weeks,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -250,7 +248,7 @@ impl DateDuration {
                 // m. Let untilOptions be OrdinaryObjectCreate(null).
                 // n. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "year").
                 // o. Let timePassed be ? DifferenceDate(calendar, plainRelativeTo, wholeDaysLater, untilOptions).
-                let time_passed = plain_relative_to.contextual_difference_date(
+                let time_passed = plain_relative_to.difference_date(
                     &whole_days_later,
                     TemporalUnit::Year,
                     context,
@@ -316,7 +314,7 @@ impl DateDuration {
                 // i. Let dateAdd be unused.
 
                 // e. Let yearsMonthsLater be ? AddDate(calendar, plainRelativeTo, yearsMonths, undefined, dateAdd).
-                let years_months_later = plain_relative_to.contextual_add_date(
+                let years_months_later = plain_relative_to.add_date(
                     &years_months,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -331,7 +329,7 @@ impl DateDuration {
                 ));
 
                 // g. Let yearsMonthsWeeksLater be ? AddDate(calendar, plainRelativeTo, yearsMonthsWeeks, undefined, dateAdd).
-                let years_months_weeks_later = plain_relative_to.contextual_add_date(
+                let years_months_weeks_later = plain_relative_to.add_date(
                     &years_months_weeks,
                     ArithmeticOverflow::Constrain,
                     context,

--- a/core/temporal/src/components/duration/date.rs
+++ b/core/temporal/src/components/duration/date.rs
@@ -208,7 +208,7 @@ impl DateDuration {
                 // i. Let dateAdd be unused.
 
                 // e. Let yearsLater be ? AddDate(calendar, plainRelativeTo, yearsDuration, undefined, dateAdd).
-                let years_later = plain_relative_to.add_date(
+                let years_later = plain_relative_to.contextual_add_date(
                     &years_duration,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -221,7 +221,7 @@ impl DateDuration {
                 );
 
                 // g. Let yearsMonthsWeeksLater be ? AddDate(calendar, plainRelativeTo, yearsMonthsWeeks, undefined, dateAdd).
-                let years_months_weeks_later = plain_relative_to.add_date(
+                let years_months_weeks_later = plain_relative_to.contextual_add_date(
                     &years_months_weeks,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -248,7 +248,7 @@ impl DateDuration {
                 // m. Let untilOptions be OrdinaryObjectCreate(null).
                 // n. Perform ! CreateDataPropertyOrThrow(untilOptions, "largestUnit", "year").
                 // o. Let timePassed be ? DifferenceDate(calendar, plainRelativeTo, wholeDaysLater, untilOptions).
-                let time_passed = plain_relative_to.difference_date(
+                let time_passed = plain_relative_to.contextual_difference_date(
                     &whole_days_later,
                     TemporalUnit::Year,
                     context,
@@ -314,7 +314,7 @@ impl DateDuration {
                 // i. Let dateAdd be unused.
 
                 // e. Let yearsMonthsLater be ? AddDate(calendar, plainRelativeTo, yearsMonths, undefined, dateAdd).
-                let years_months_later = plain_relative_to.add_date(
+                let years_months_later = plain_relative_to.contextual_add_date(
                     &years_months,
                     ArithmeticOverflow::Constrain,
                     context,
@@ -329,7 +329,7 @@ impl DateDuration {
                 ));
 
                 // g. Let yearsMonthsWeeksLater be ? AddDate(calendar, plainRelativeTo, yearsMonthsWeeks, undefined, dateAdd).
-                let years_months_weeks_later = plain_relative_to.add_date(
+                let years_months_weeks_later = plain_relative_to.contextual_add_date(
                     &years_months_weeks,
                     ArithmeticOverflow::Constrain,
                     context,

--- a/core/temporal/src/components/zoneddatetime.rs
+++ b/core/temporal/src/components/zoneddatetime.rs
@@ -102,7 +102,7 @@ where
 {
     /// Returns the `year` value for this `ZonedDateTime`.
     #[inline]
-    pub fn year(&self, context: &mut C::Context) -> TemporalResult<i32> {
+    pub fn contextual_year(&self, context: &mut C::Context) -> TemporalResult<i32> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -110,7 +110,7 @@ where
     }
 
     /// Returns the `month` value for this `ZonedDateTime`.
-    pub fn month(&self, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_month(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -119,7 +119,7 @@ where
     }
 
     /// Returns the `monthCode` value for this `ZonedDateTime`.
-    pub fn month_code(&self, context: &mut C::Context) -> TemporalResult<TinyStr4> {
+    pub fn contextual_month_code(&self, context: &mut C::Context) -> TemporalResult<TinyStr4> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -128,7 +128,7 @@ where
     }
 
     /// Returns the `day` value for this `ZonedDateTime`.
-    pub fn day(&self, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_day(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -136,7 +136,7 @@ where
     }
 
     /// Returns the `hour` value for this `ZonedDateTime`.
-    pub fn hour(&self, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_hour(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -144,7 +144,7 @@ where
     }
 
     /// Returns the `minute` value for this `ZonedDateTime`.
-    pub fn minute(&self, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_minute(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -152,7 +152,7 @@ where
     }
 
     /// Returns the `second` value for this `ZonedDateTime`.
-    pub fn second(&self, context: &mut C::Context) -> TemporalResult<u8> {
+    pub fn contextual_second(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -160,7 +160,7 @@ where
     }
 
     /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn millisecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_millisecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -168,7 +168,7 @@ where
     }
 
     /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn microsecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_microsecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -176,7 +176,7 @@ where
     }
 
     /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn nanosecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
+    pub fn contextual_nanosecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -207,12 +207,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(zdt.year(&mut ()).unwrap(), 2023);
-        assert_eq!(zdt.month(&mut ()).unwrap(), 11);
-        assert_eq!(zdt.day(&mut ()).unwrap(), 30);
-        assert_eq!(zdt.hour(&mut ()).unwrap(), 1);
-        assert_eq!(zdt.minute(&mut ()).unwrap(), 49);
-        assert_eq!(zdt.second(&mut ()).unwrap(), 12);
+        assert_eq!(zdt.contextual_year(&mut ()).unwrap(), 2023);
+        assert_eq!(zdt.contextual_month(&mut ()).unwrap(), 11);
+        assert_eq!(zdt.contextual_day(&mut ()).unwrap(), 30);
+        assert_eq!(zdt.contextual_hour(&mut ()).unwrap(), 1);
+        assert_eq!(zdt.contextual_minute(&mut ()).unwrap(), 49);
+        assert_eq!(zdt.contextual_second(&mut ()).unwrap(), 12);
 
         let zdt_minus_five = ZonedDateTime::<(), ()>::new(
             nov_30_2023_utc,
@@ -224,11 +224,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(zdt_minus_five.year(&mut ()).unwrap(), 2023);
-        assert_eq!(zdt_minus_five.month(&mut ()).unwrap(), 11);
-        assert_eq!(zdt_minus_five.day(&mut ()).unwrap(), 29);
-        assert_eq!(zdt_minus_five.hour(&mut ()).unwrap(), 20);
-        assert_eq!(zdt_minus_five.minute(&mut ()).unwrap(), 49);
-        assert_eq!(zdt_minus_five.second(&mut ()).unwrap(), 12);
+        assert_eq!(zdt_minus_five.contextual_year(&mut ()).unwrap(), 2023);
+        assert_eq!(zdt_minus_five.contextual_month(&mut ()).unwrap(), 11);
+        assert_eq!(zdt_minus_five.contextual_day(&mut ()).unwrap(), 29);
+        assert_eq!(zdt_minus_five.contextual_hour(&mut ()).unwrap(), 20);
+        assert_eq!(zdt_minus_five.contextual_minute(&mut ()).unwrap(), 49);
+        assert_eq!(zdt_minus_five.contextual_second(&mut ()).unwrap(), 12);
     }
 }

--- a/core/temporal/src/components/zoneddatetime.rs
+++ b/core/temporal/src/components/zoneddatetime.rs
@@ -12,8 +12,6 @@ use crate::{
     TemporalResult,
 };
 
-use core::any::Any;
-
 use super::tz::TzProtocol;
 
 /// The native Rust implementation of `Temporal.ZonedDateTime`.
@@ -98,24 +96,21 @@ impl<C: CalendarProtocol, Z: TzProtocol> ZonedDateTime<C, Z> {
 
 // ==== Context based API ====
 
-impl<C: CalendarProtocol, Z: TzProtocol> ZonedDateTime<C, Z> {
+impl<C, Z: TzProtocol> ZonedDateTime<C, Z>
+where
+    C: CalendarProtocol<Context = Z::Context>,
+{
     /// Returns the `year` value for this `ZonedDateTime`.
     #[inline]
-    pub fn contextual_year(&self, context: &mut dyn Any) -> TemporalResult<i32> {
+    pub fn year(&self, context: &mut C::Context) -> TemporalResult<i32> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         self.calendar.year(&CalendarDateLike::DateTime(dt), context)
     }
 
-    /// Returns the `year` value for this `ZonedDateTime`.
-    #[inline]
-    pub fn year(&self) -> TemporalResult<i32> {
-        self.contextual_year(&mut ())
-    }
-
     /// Returns the `month` value for this `ZonedDateTime`.
-    pub fn contextual_month(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+    pub fn month(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -123,14 +118,8 @@ impl<C: CalendarProtocol, Z: TzProtocol> ZonedDateTime<C, Z> {
             .month(&CalendarDateLike::DateTime(dt), context)
     }
 
-    /// Returns the `month` value for this `ZonedDateTime`.
-    #[inline]
-    pub fn month(&self) -> TemporalResult<u8> {
-        self.contextual_month(&mut ())
-    }
-
     /// Returns the `monthCode` value for this `ZonedDateTime`.
-    pub fn contextual_month_code(&self, context: &mut dyn Any) -> TemporalResult<TinyStr4> {
+    pub fn month_code(&self, context: &mut C::Context) -> TemporalResult<TinyStr4> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -138,79 +127,40 @@ impl<C: CalendarProtocol, Z: TzProtocol> ZonedDateTime<C, Z> {
             .month_code(&CalendarDateLike::DateTime(dt), context)
     }
 
-    /// Returns the `monthCode` value for this `ZonedDateTime`.
-    #[inline]
-    pub fn month_code(&self) -> TemporalResult<TinyStr4> {
-        self.contextual_month_code(&mut ())
-    }
-
     /// Returns the `day` value for this `ZonedDateTime`.
-    pub fn contextual_day(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+    pub fn day(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         self.calendar.day(&CalendarDateLike::DateTime(dt), context)
     }
 
-    /// Returns the `day` value for this `ZonedDateTime`.
-    pub fn day(&self) -> TemporalResult<u8> {
-        self.contextual_day(&mut ())
-    }
-
     /// Returns the `hour` value for this `ZonedDateTime`.
-    pub fn contextual_hour(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+    pub fn hour(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         Ok(dt.hour())
     }
 
-    /// Returns the `hour` value for this `ZonedDateTime`.
-    pub fn hour(&self) -> TemporalResult<u8> {
-        self.contextual_hour(&mut ())
-    }
-
     /// Returns the `minute` value for this `ZonedDateTime`.
-    pub fn contextual_minute(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+    pub fn minute(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         Ok(dt.minute())
     }
 
-    /// Returns the `minute` value for this `ZonedDateTime`.
-    pub fn minute(&self) -> TemporalResult<u8> {
-        self.contextual_minute(&mut ())
-    }
-
     /// Returns the `second` value for this `ZonedDateTime`.
-    pub fn contextual_second(&self, context: &mut dyn Any) -> TemporalResult<u8> {
+    pub fn second(&self, context: &mut C::Context) -> TemporalResult<u8> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         Ok(dt.second())
     }
 
-    /// Returns the `second` value for this `ZonedDateTime`.
-    pub fn second(&self) -> TemporalResult<u8> {
-        self.contextual_second(&mut ())
-    }
-
     /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn contextual_millisecond(&self, context: &mut dyn Any) -> TemporalResult<u16> {
-        let dt = self
-            .tz
-            .get_datetime_for(&self.instant, &self.calendar, context)?;
-        Ok(dt.millisecond())
-    }
-
-    /// Returns the `millisecond` value for this `ZonedDateTime`.
-    pub fn millisecond(&self) -> TemporalResult<u16> {
-        self.contextual_millisecond(&mut ())
-    }
-
-    /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn contextual_microsecond(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+    pub fn millisecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
@@ -218,21 +168,19 @@ impl<C: CalendarProtocol, Z: TzProtocol> ZonedDateTime<C, Z> {
     }
 
     /// Returns the `microsecond` value for this `ZonedDateTime`.
-    pub fn microsecond(&self) -> TemporalResult<u16> {
-        self.contextual_microsecond(&mut ())
+    pub fn microsecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
+        let dt = self
+            .tz
+            .get_datetime_for(&self.instant, &self.calendar, context)?;
+        Ok(dt.millisecond())
     }
 
     /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn contextual_nanosecond(&self, context: &mut dyn Any) -> TemporalResult<u16> {
+    pub fn nanosecond(&self, context: &mut C::Context) -> TemporalResult<u16> {
         let dt = self
             .tz
             .get_datetime_for(&self.instant, &self.calendar, context)?;
         Ok(dt.nanosecond())
-    }
-
-    /// Returns the `nanosecond` value for this `ZonedDateTime`.
-    pub fn nanosecond(&self) -> TemporalResult<u16> {
-        self.contextual_nanosecond(&mut ())
     }
 }
 
@@ -259,12 +207,12 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(zdt.year().unwrap(), 2023);
-        assert_eq!(zdt.month().unwrap(), 11);
-        assert_eq!(zdt.day().unwrap(), 30);
-        assert_eq!(zdt.hour().unwrap(), 1);
-        assert_eq!(zdt.minute().unwrap(), 49);
-        assert_eq!(zdt.second().unwrap(), 12);
+        assert_eq!(zdt.year(&mut ()).unwrap(), 2023);
+        assert_eq!(zdt.month(&mut ()).unwrap(), 11);
+        assert_eq!(zdt.day(&mut ()).unwrap(), 30);
+        assert_eq!(zdt.hour(&mut ()).unwrap(), 1);
+        assert_eq!(zdt.minute(&mut ()).unwrap(), 49);
+        assert_eq!(zdt.second(&mut ()).unwrap(), 12);
 
         let zdt_minus_five = ZonedDateTime::<(), ()>::new(
             nov_30_2023_utc,
@@ -276,11 +224,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(zdt_minus_five.year().unwrap(), 2023);
-        assert_eq!(zdt_minus_five.month().unwrap(), 11);
-        assert_eq!(zdt_minus_five.day().unwrap(), 29);
-        assert_eq!(zdt_minus_five.hour().unwrap(), 20);
-        assert_eq!(zdt_minus_five.minute().unwrap(), 49);
-        assert_eq!(zdt_minus_five.second().unwrap(), 12);
+        assert_eq!(zdt_minus_five.year(&mut ()).unwrap(), 2023);
+        assert_eq!(zdt_minus_five.month(&mut ()).unwrap(), 11);
+        assert_eq!(zdt_minus_five.day(&mut ()).unwrap(), 29);
+        assert_eq!(zdt_minus_five.hour(&mut ()).unwrap(), 20);
+        assert_eq!(zdt_minus_five.minute(&mut ()).unwrap(), 49);
+        assert_eq!(zdt_minus_five.second(&mut ()).unwrap(), 12);
     }
 }


### PR DESCRIPTION
I'm aware that this mostly undoes some API design decisions @nekevss and I did, but I was experimenting with simplifying the API and I think I prefer the simplicity of having a single contextual low level call for all methods, instead of a contextual and a non-contextual variant. If we do want to offer a protocol free implementation, I think it would be better to just make simple wrappers around the low level types.

On the other hand, this also replaces the `Any`s with an associated type inside `CalendarProtocol` itself. This wasn't possible at the beginning because I'm pretty sure we hadn't introduced the trait when we decided to pass `Any` to all method calls.

@nekevss Let me know what you think of the changes!