### PR TITLE
Consider strict + no-strict tests as a single test

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "f742eb092df835fd07769bbb3537232d3efb61ed"
+commit = "6f7ae1f311a7b01ef2358de7f4f6fd42c3ae3839"
 
 [ignored]
 # Not implemented yet:

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -765,8 +765,6 @@ struct TestResult {
     name: Box<str>,
     #[serde(rename = "v", default)]
     edition: SpecEdition,
-    #[serde(rename = "s", default)]
-    strict: bool,
     #[serde(skip)]
     result_text: Box<str>,
     #[serde(rename = "r")]

--- a/tests/tester/src/results.rs
+++ b/tests/tester/src/results.rs
@@ -461,17 +461,12 @@ fn compute_result_diff(
         if let Some(new_test) = new_result
             .tests
             .iter()
-            .find(|new_test| new_test.strict == base_test.strict && new_test.name == base_test.name)
+            .find(|new_test| new_test.name == base_test.name)
         {
             let test_name = format!(
-                "test/{}/{}.js {}(previously {:?})",
+                "test/{}/{}.js (previously {:?})",
                 base.display(),
                 new_test.name,
-                if base_test.strict {
-                    "[strict mode] "
-                } else {
-                    ""
-                },
                 base_test.result
             )
             .into_boxed_str();


### PR DESCRIPTION
A simplified version of #3364 that only fixes the conformance representation without doing anything else. Thanks to this, it should be completely retrocompatible with previous runs.