### PR TITLE
Preserve `.exe` suffix for Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           os: windows-2019
           rust: stable
           target: x86_64-pc-windows-msvc
-          asset_name: boa-windows-amd64
+          asset_name: boa-windows-amd64.exe
           binary_name: boa.exe
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
In the release workflow we did add the `.exe` suffix for Windows builds, since Windows primarily looks at the extension of the file to know what the file is.

