### PR TITLE
Change `HostEnsureCanCompileStrings` to the new spec

### DIFF
--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -108,10 +108,12 @@ impl Eval {
         // 3. Let evalRealm be the current Realm Record.
         // 4. NOTE: In the case of a direct eval, evalRealm is the realm of both the caller of eval
         // and of the eval function itself.
-        // 5. Perform ? HostEnsureCanCompileStrings(evalRealm).
+        let eval_realm = context.realm().clone();
+
+        // 5. Perform ? HostEnsureCanCompileStrings(evalRealm, « », x, direct).
         context
             .host_hooks()
-            .ensure_can_compile_strings(context.realm().clone(), context)?;
+            .ensure_can_compile_strings(eval_realm, &[], x, direct, context)?;
 
         // 11. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
         //     a. Let script be ParseText(StringToCodePoints(x), Script).

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -25,7 +25,7 @@ use time::util::local_offset;
 /// use boa_engine::{
 ///     context::{Context, ContextBuilder, HostHooks},
 ///     realm::Realm,
-///     JsNativeError, JsResult, Source,
+///     JsNativeError, JsResult, JsString, Source,
 /// };
 ///
 /// struct Hooks;
@@ -34,7 +34,10 @@ use time::util::local_offset;
 ///     fn ensure_can_compile_strings(
 ///         &self,
 ///         _realm: Realm,
-///         context: &mut Context,
+///         _parameters: &[JsString],
+///         _body: &JsString,
+///         _direct: bool,
+///         _context: &mut Context,
 ///     ) -> JsResult<()> {
 ///         Err(JsNativeError::typ()
 ///             .with_message("eval calls not available")

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -4,7 +4,7 @@ use crate::{
     job::JobCallback,
     object::{JsFunction, JsObject},
     realm::Realm,
-    Context, JsResult, JsValue,
+    Context, JsResult, JsString, JsValue,
 };
 use time::{OffsetDateTime, UtcOffset};
 
@@ -106,7 +106,7 @@ pub trait HostHooks {
         // The default implementation of HostPromiseRejectionTracker is to return unused.
     }
 
-    /// [`HostEnsureCanCompileStrings ( calleeRealm )`][spec]
+    /// [`HostEnsureCanCompileStrings ( calleeRealm, parameterStrings, bodyString, direct )`][spec]
     ///
     /// # Requirements
     ///
@@ -114,8 +114,14 @@ pub trait HostHooks {
     /// containing unused. This is already ensured by the return type.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-hostensurecancompilestrings
-    // TODO: Track https://github.com/tc39/ecma262/issues/938
-    fn ensure_can_compile_strings(&self, _realm: Realm, _context: &mut Context) -> JsResult<()> {
+    fn ensure_can_compile_strings(
+        &self,
+        _realm: Realm,
+        _parameters: &[JsString],
+        _body: &JsString,
+        _direct: bool,
+        _context: &mut Context,
+    ) -> JsResult<()> {
         // The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(unused).
         Ok(())
     }

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -230,7 +230,10 @@ impl JsArrayBuffer {
     /// // Get a reference to the data.
     /// let internal_buffer = array_buffer.data();
     ///
-    /// assert_eq!(internal_buffer.as_deref(), Some((0..5).collect::<Vec<u8>>().as_slice()));
+    /// assert_eq!(
+    ///     internal_buffer.as_deref(),
+    ///     Some((0..5).collect::<Vec<u8>>().as_slice())
+    /// );
     /// # Ok(())
     /// # }
     /// ```

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -40,7 +40,6 @@ pub struct CallFrame {
     pub(crate) code_block: Gc<CodeBlock>,
     pub(crate) pc: u32,
     /// The register pointer, points to the first register in the stack.
-    ///
     // TODO: Check if storing the frame pointer instead of argument count and computing the
     //       argument count based on the pointers would be better for accessing the arguments
     //       and the elements before the register pointer.
@@ -124,13 +123,11 @@ impl CallFrame {
     /// │                             callee frame pointer
     /// │
     /// └─────  caller frame pointer
-    ///
     /// ```
     ///
     /// Some questions:
     ///
     /// - Who is responsible for cleaning up the stack after a call? The rust caller.
-    ///
     pub(crate) const FUNCTION_PROLOGUE: u32 = 2;
     pub(crate) const THIS_POSITION: u32 = 2;
     pub(crate) const FUNCTION_POSITION: u32 = 1;


### PR DESCRIPTION
PR https://github.com/tc39/ecma262/pull/3222 introduced a new `HostEnsureCanCompileStrings` that passes the body and parameters of the runtime-compiled function for additional checks.

The regressions are because the test repo hasn't been updated with the new behaviour; on the old spec,
the parameters were converted to strings before the body, which is the opposite of what the new spec states.