### PR TITLE
Implement RegExp `v` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3038,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "regress"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5f39ba4513916c1b2657b72af6ec671f091cd637992f58d0ede5cae4e5dea0"
+checksum = "d06f9a1f7cd8473611ba1a480cf35f9c5cffc2954336ba90a982fdb7e7d7f51e"
 dependencies = [
  "hashbrown 0.14.3",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ once_cell = { version = "1.19.0", default-features = false }
 phf = { version = "0.11.2", default-features = false }
 pollster = "0.3.0"
 regex = "1.10.3"
-regress = { version="0.8.0", features = ["utf16"]}
+regress = { version="0.9.0", features = ["utf16"]}
 rustc-hash = { version = "1.1.0", default-features = false }
 serde_json = "1.0.114"
 serde = "1.0.197"

--- a/core/parser/src/lexer/regex.rs
+++ b/core/parser/src/lexer/regex.rs
@@ -169,6 +169,9 @@ bitflags! {
         /// Whether the regular expression result exposes the start and end indices of
         /// captured substrings.
         const HAS_INDICES = 0b0100_0000;
+
+        /// Whether or not UnicodeSets features are enabled.
+        const UNICODE_SETS = 0b1000_0000;
     }
 }
 
@@ -186,6 +189,7 @@ impl FromStr for RegExpFlags {
                 b'u' => Self::UNICODE,
                 b'y' => Self::STICKY,
                 b'd' => Self::HAS_INDICES,
+                b'v' => Self::UNICODE_SETS,
                 _ => return Err(format!("invalid regular expression flag {}", char::from(c))),
             };
 
@@ -196,6 +200,10 @@ impl FromStr for RegExpFlags {
                 ));
             }
             flags.insert(new_flag);
+        }
+
+        if flags.contains(Self::UNICODE) && flags.contains(Self::UNICODE_SETS) {
+            return Err("cannot use both 'u' and 'v' flags".into());
         }
 
         Ok(flags)
@@ -233,6 +241,9 @@ impl ToString for RegExpFlags {
         if self.contains(Self::STICKY) {
             s.push('y');
         }
+        if self.contains(Self::UNICODE_SETS) {
+            s.push('v');
+        }
         s
     }
 }
@@ -244,6 +255,7 @@ impl From<RegExpFlags> for Flags {
             multiline: value.contains(RegExpFlags::MULTILINE),
             dot_all: value.contains(RegExpFlags::DOT_ALL),
             unicode: value.contains(RegExpFlags::UNICODE),
+            unicode_sets: value.contains(RegExpFlags::UNICODE_SETS),
             ..Self::default()
         }
     }

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -13,7 +13,6 @@ features = [
     "Intl.DisplayNames",
     "Intl.RelativeTimeFormat",
     "Intl-enumeration",
-    "regexp-v-flag",
 
     ### Pending proposals
 


### PR DESCRIPTION
This PR updates `regress` to `v0.9.0`, adding support for the `v` flag.