### PR TITLE
Check that `min <= max` in `clamp_finite`

### DIFF
--- a/core/engine/src/value/integer.rs
+++ b/core/engine/src/value/integer.rs
@@ -22,6 +22,7 @@ impl IntegerOrInfinity {
     /// Panics if `min > max`.
     #[must_use]
     pub fn clamp_finite(self, min: i64, max: i64) -> i64 {
+        assert!(min <= max);
         match self {
             Self::Integer(i) => i.clamp(min, max),
             Self::PositiveInfinity => max,


### PR DESCRIPTION
Fixes #3697.
We should assert that `min <= max` even if `self` is `PositiveInfinity` or `NegativeInfinity`.