### PR TITLE
Add release binary striping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,10 +114,13 @@ incremental = false
 lto = "fat"
 # Makes sure that all code is compiled together, for LTO
 codegen-units = 1
+# Strips debug information and symbols from the binary, reducing its size
+strip = "symbols"
 
 [profile.release-dbg]
 inherits = "release"
 debug = true
+strip = "none"
 
 # The test profile, used for `cargo test`.
 [profile.test]


### PR DESCRIPTION
Our binaries are currently quite big by default. Most of it (around 65%) is due to ICU data. But there are things we can do. Before going for more drastic solutions, such as abort panic, striping the binaries helps slightly.

In this case, striping helps only slightly:

 - `boa` binary: from 26 MB to 25 MB
 - `boa_tester` binary: from 27 MB to 25 MB

I did some further tests by adding `panic = "abort"`, and this reduced sizes even further:

 - `boa` binary: 23MB
 - `boa_tester` binary: 24M

And we would lose panic unwinding, so I don't see too much benefit.