### PR TITLE
Close for-of iterator when the loop body throws

### DIFF
--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -622,7 +622,6 @@ impl CodeBlock {
             | Instruction::IteratorResult
             | Instruction::IteratorDone
             | Instruction::IteratorToArray
-            | Instruction::IteratorPop
             | Instruction::IteratorReturn
             | Instruction::IteratorStackEmpty
             | Instruction::RequireObjectCoercible
@@ -717,7 +716,8 @@ impl CodeBlock {
             | Instruction::Reserved55
             | Instruction::Reserved56
             | Instruction::Reserved57
-            | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved58
+            | Instruction::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -409,7 +409,6 @@ impl CodeBlock {
                 | Instruction::IteratorResult
                 | Instruction::IteratorDone
                 | Instruction::IteratorToArray
-                | Instruction::IteratorPop
                 | Instruction::IteratorReturn
                 | Instruction::IteratorStackEmpty
                 | Instruction::RequireObjectCoercible
@@ -516,7 +515,8 @@ impl CodeBlock {
                 | Instruction::Reserved55
                 | Instruction::Reserved56
                 | Instruction::Reserved57
-                | Instruction::Reserved58 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved58
+                | Instruction::Reserved59 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -1879,12 +1879,6 @@ generate_opcodes! {
     /// Iterator Stack: `iterator` **=>** `iterator`
     IteratorToArray,
 
-    /// Pop an iterator from the call frame close iterator stack.
-    ///
-    /// Iterator Stack:
-    /// - `iterator` **=>**
-    IteratorPop,
-
     /// Pushes `true` to the stack if the iterator stack is empty.
     ///
     /// Stack:
@@ -2222,6 +2216,8 @@ generate_opcodes! {
     Reserved57 => Reserved,
     /// Reserved [`Opcode`].
     Reserved58 => Reserved,
+    /// Reserved [`Opcode`].
+    Reserved59 => Reserved,
 }
 
 /// Specific opcodes for bindings.


### PR DESCRIPTION
Currently the iterator used in a for-of loop is not closed when the loop body throws. This PR fixes that by widening the scope of an exception handler that was already in place for some of the for-of assignment code paths.

To make this work I had to adjust the iterator close opcodes somewhat. The reason is that we may run into a situation when we attempt to close an iterator two times. See the following example:

```javascript
var iterable = {};
iterable[Symbol.iterator] = function() {
  return {
    next: function() {
      return { done: false, value: null };
    },
    return: function() {
      throw "iter-close-error";
    }
  };
};

function f() {
  for (var x of iterable) {
    return;
  }
}
f();
```

In this example we close the iterator when we `return` from `f` inside of the loop body. The iterator close code is injected during the compilation of the `return` statement. The problem is that if the `iterable.return` function throws, like in the example, we start running the exception handler code that also attempts to close the iterator. To avoid this I adjusted the iterator close opcodes.