### PR TITLE
Add default value handling for destructuring property access arrays

### DIFF
--- a/core/ast/src/expression/literal/array.rs
+++ b/core/ast/src/expression/literal/array.rs
@@ -109,6 +109,7 @@ impl ArrayLiteral {
                     AssignTarget::Access(access) => {
                         bindings.push(ArrayPatternElement::PropertyAccess {
                             access: access.clone(),
+                            default_init: Some(assign.rhs().clone()),
                         });
                     }
                     AssignTarget::Pattern(pattern) => match pattern {
@@ -143,6 +144,7 @@ impl ArrayLiteral {
                 Expression::PropertyAccess(access) => {
                     bindings.push(ArrayPatternElement::PropertyAccess {
                         access: access.clone(),
+                        default_init: None,
                     });
                 }
                 _ => return None,


### PR DESCRIPTION
This Pull Request changes the following:

- Add default value handling for destructuring property access arrays
