### PR TITLE
Fix invalid syntax errors for allowed `let` as variable names

### DIFF
--- a/core/parser/src/parser/statement/declaration/lexical.rs
+++ b/core/parser/src/parser/statement/declaration/lexical.rs
@@ -8,7 +8,7 @@
 //! [spec]: https://tc39.es/ecma262/#sec-let-and-const-declarations
 
 use crate::{
-    lexer::{Error as LexError, TokenKind},
+    lexer::{Error as LexError, Token, TokenKind},
     parser::{
         cursor::{Cursor, SemicolonResult},
         expression::Initializer,
@@ -121,6 +121,21 @@ where
 
         Ok(lexical_declaration)
     }
+}
+
+/// Check if the given token is valid after the `let` keyword of a lexical declaration.
+pub(crate) fn allowed_token_after_let(token: Option<&Token>) -> bool {
+    matches!(
+        token.map(Token::kind),
+        Some(
+            TokenKind::IdentifierName(_)
+                | TokenKind::Keyword((
+                    Keyword::Await | Keyword::Yield | Keyword::Let | Keyword::Async,
+                    _
+                ))
+                | TokenKind::Punctuator(Punctuator::OpenBlock | Punctuator::OpenBracket),
+        )
+    )
 }
 
 /// Parses a binding list.

--- a/core/parser/src/parser/statement/declaration/mod.rs
+++ b/core/parser/src/parser/statement/declaration/mod.rs
@@ -20,7 +20,7 @@ pub(in crate::parser) use self::{
         class_decl::ClassTail, ClassDeclaration, FunctionDeclaration, HoistableDeclaration,
     },
     import::ImportDeclaration,
-    lexical::LexicalDeclaration,
+    lexical::{allowed_token_after_let, LexicalDeclaration},
 };
 use crate::{
     lexer::TokenKind,

--- a/core/parser/src/parser/statement/mod.rs
+++ b/core/parser/src/parser/statement/mod.rs
@@ -26,7 +26,7 @@ use self::{
     block::BlockStatement,
     break_stm::BreakStatement,
     continue_stm::ContinueStatement,
-    declaration::{Declaration, ExportDeclaration, ImportDeclaration},
+    declaration::{allowed_token_after_let, Declaration, ExportDeclaration, ImportDeclaration},
     expression::ExpressionStatement,
     if_stm::IfStatement,
     iteration::{DoWhileStatement, ForStatement, WhileStatement},
@@ -412,12 +412,19 @@ where
         let _timer = Profiler::global().start_event("StatementListItem", "Parsing");
         let tok = cursor.peek(0, interner).or_abrupt()?;
 
-        match *tok.kind() {
-            TokenKind::Keyword(
-                (Keyword::Function | Keyword::Class | Keyword::Const, _) | (Keyword::Let, false),
-            ) => Declaration::new(self.allow_yield, self.allow_await)
-                .parse(cursor, interner)
-                .map(ast::StatementListItem::from),
+        match tok.kind().clone() {
+            TokenKind::Keyword((Keyword::Function | Keyword::Class | Keyword::Const, _)) => {
+                Declaration::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)
+                    .map(ast::StatementListItem::from)
+            }
+            TokenKind::Keyword((Keyword::Let, false))
+                if allowed_token_after_let(cursor.peek(1, interner)?) =>
+            {
+                Declaration::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)
+                    .map(ast::StatementListItem::from)
+            }
             TokenKind::Keyword((Keyword::Async, false)) => {
                 let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {
                     2


### PR DESCRIPTION
This allows `let` as a variable name in some more places.