### PR TITLE
Remove array optimization path that prevents usage of setters on prototypes

### DIFF
--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -1,7 +1,5 @@
-use boa_macros::utf16;
-
 use crate::{
-    builtins::{function::set_function_name, Proxy},
+    builtins::function::set_function_name,
     object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
     property::{PropertyDescriptor, PropertyKey},
     vm::{opcode::Operation, CompletionType},
@@ -145,8 +143,6 @@ impl Operation for SetPropertyByValue {
                         break 'fast_path;
                     }
 
-                    let shape = object_borrowed.shape().clone();
-
                     if let Some(dense_elements) = object_borrowed
                         .properties_mut()
                         .dense_indexed_properties_mut()
@@ -155,46 +151,6 @@ impl Operation for SetPropertyByValue {
                         if let Some(element) = dense_elements.get_mut(index) {
                             *element = value;
                             context.vm.push(element.clone());
-                            return Ok(CompletionType::Normal);
-                        } else if dense_elements.len() == index {
-                            // Cannot use fast path if the [[prototype]] is a proxy object,
-                            // because we have to the call prototypes [[set]] on non-existing property,
-                            // and proxy objects can override [[set]].
-                            let prototype = shape.prototype();
-                            if prototype.map_or(false, |x| x.is::<Proxy>()) {
-                                break 'fast_path;
-                            }
-
-                            dense_elements.push(value.clone());
-                            context.vm.push(value);
-
-                            let len = dense_elements.len() as u32;
-                            let length_key = PropertyKey::from(utf16!("length"));
-                            let length = object_borrowed
-                                .properties_mut()
-                                .get(&length_key)
-                                .expect("Arrays must have length property");
-
-                            if length.expect_writable() {
-                                // We have to get the max of previous length and len(dense_elements) + 1,
-                                // this is needed if user spacifies `new Array(n)` then adds properties from 0, 1, etc.
-                                let len = length
-                                    .expect_value()
-                                    .to_u32(context)
-                                    .expect("length should have a u32 value")
-                                    .max(len);
-                                object_borrowed.insert(
-                                    length_key,
-                                    PropertyDescriptor::builder()
-                                        .value(len)
-                                        .writable(true)
-                                        .enumerable(length.expect_enumerable())
-                                        .configurable(false)
-                                        .build(),
-                                );
-                            } else if context.vm.frame().code_block.strict() {
-                                return Err(JsNativeError::typ().with_message("TypeError: Cannot assign to read only property 'length' of array object").into());
-                            }
                             return Ok(CompletionType::Normal);
                         }
                     }


### PR DESCRIPTION
This PR removes an array optimization path in the `SetPropertyByValue` opcode.

The removed code path would insert an indexed property into the dense indexed properties of an array, if the index is the next item in the dense indexed properties.
The problem is that if the prototype of the array contains a setter at the index, this setter is ignored.

For example:
```js
Object.defineProperty(Array.prototype, '1', {
  set: function(param) {
    console.log("setter", param);
  }
});
let a = ["array"][1] = "value";
```
