### PR TITLE
Fix parsing of `async` in for-of loops

### DIFF
--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -141,15 +141,22 @@ where
                     1
                 };
 
+                let peek_1 = cursor.peek(1, interner).or_abrupt()?.kind().clone();
                 if !cursor
                     .peek_is_line_terminator(skip_n, interner)
                     .or_abrupt()?
-                    && matches!(
-                        cursor.peek(1, interner).or_abrupt()?.kind(),
-                        TokenKind::IdentifierName(_)
-                            | TokenKind::Keyword((Keyword::Yield | Keyword::Await, _))
-                            | TokenKind::Punctuator(Punctuator::OpenParen)
-                    )
+                    && (matches!(peek_1, TokenKind::Punctuator(Punctuator::OpenParen))
+                        || (matches!(
+                            peek_1,
+                            TokenKind::IdentifierName(_)
+                                | TokenKind::Keyword((
+                                    Keyword::Yield | Keyword::Await | Keyword::Of,
+                                    _
+                                ))
+                        ) && matches!(
+                            cursor.peek(2, interner).or_abrupt()?.kind(),
+                            TokenKind::Punctuator(Punctuator::Arrow)
+                        )))
                 {
                     return Ok(
                         AsyncArrowFunction::new(self.name, self.allow_in, self.allow_yield)

--- a/core/parser/src/parser/expression/tests.rs
+++ b/core/parser/src/parser/expression/tests.rs
@@ -10,7 +10,8 @@ use boa_ast::{
         },
         Call, Identifier, Parenthesized, RegExpLiteral,
     },
-    Declaration, Expression, Statement,
+    function::{AsyncArrowFunction, FormalParameter, FormalParameterList},
+    Declaration, Expression, Script, Statement,
 };
 use boa_interner::{Interner, Sym};
 use boa_macros::utf16;
@@ -683,6 +684,29 @@ fn check_logical_expressions() {
     check_invalid_script("a && b ?? c");
     check_invalid_script("a ?? b || c");
     check_invalid_script("a || b ?? c");
+}
+
+#[test]
+fn parse_async_arrow_function_named_of() {
+    let interner = &mut Interner::default();
+    check_script_parser(
+        "async of => {}",
+        vec![
+            Statement::Expression(Expression::from(AsyncArrowFunction::new(
+                None,
+                FormalParameterList::from_parameters(vec![FormalParameter::new(
+                    Variable::from_identifier(
+                        Identifier::new(interner.get_or_intern_static("of", utf16!("of"))),
+                        None,
+                    ),
+                    false,
+                )]),
+                Script::default(),
+            )))
+            .into(),
+        ],
+        interner,
+    );
 }
 
 macro_rules! check_non_reserved_identifier {


### PR DESCRIPTION
This PR fixes a syntax error in for-of loops.

Currently the lookahead for the pattern `async of` in a for-of loop errors also in normal for loops. In a normal for loop this pattern might also be an async arrow function. To fix this I also had to fix the parsing of async arrow functions to allow `of` as a binding identifier. I added a test for that, since there seems to be no 262 test.