### PR TITLE
Fix parsing of binding identifier in try catch parameters

### DIFF
--- a/core/parser/src/parser/statement/try_stm/catch.rs
+++ b/core/parser/src/parser/statement/try_stm/catch.rs
@@ -168,16 +168,9 @@ where
                     .parse(cursor, interner)?;
                 Ok(Binding::Pattern(pat.into()))
             }
-            TokenKind::IdentifierName(_) => {
-                let ident = BindingIdentifier::new(self.allow_yield, self.allow_await)
-                    .parse(cursor, interner)?;
-                Ok(Binding::Identifier(ident))
-            }
-            _ => Err(Error::expected(
-                [String::from("pattern"), String::from("binding identifier")],
-                token.to_string(interner),
-                token.span(),
-                "catch parameter",
+            _ => Ok(Binding::Identifier(
+                BindingIdentifier::new(self.allow_yield, self.allow_await)
+                    .parse(cursor, interner)?,
             )),
         }
     }


### PR DESCRIPTION
This Pull Request changes the following:

- Fix parsing of binding identifier in try catch parameters
