### PR TITLE
Add a try_from_js implementation for Vec<T> (accept any Array-like)

### DIFF
--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -76,11 +76,14 @@ where
         let length = object
             .get(js_string!("length"), context)?
             .to_length(context)?;
-        let length = usize::try_from(length).map_err(|e| {
-            JsNativeError::typ()
-                .with_message(format!("could not convert length to usize: {e}"))
-                .into()
-        })?;
+        let length = match usize::try_from(length) {
+            Ok(length) => length,
+            Err(e) => {
+                return Err(JsNativeError::typ()
+                    .with_message(format!("could not convert length to usize: {e}"))
+                    .into());
+            }
+        };
         let mut vec = Vec::with_capacity(length);
         for i in 0..length {
             let value = object.get(i, context)?;

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -307,7 +307,7 @@ fn value_into_vec() {
         "#},
         |value, context| {
             let value = TestStruct::try_from_js(&value, context);
-            eprintln!("{:?}", value);
+
             match value {
                 Ok(value) => {
                     value

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -1,7 +1,8 @@
 //! This module contains the [`TryFromJs`] trait, and conversions to basic Rust types.
 
-use crate::{Context, JsBigInt, JsNativeError, JsResult, JsValue};
 use num_bigint::BigInt;
+
+use crate::{Context, js_string, JsBigInt, JsNativeError, JsResult, JsValue};
 
 /// This trait adds a fallible and efficient conversions from a [`JsValue`] to Rust types.
 pub trait TryFromJs: Sized {
@@ -55,6 +56,33 @@ where
             JsValue::Null | JsValue::Undefined => Ok(None),
             value => Ok(Some(T::try_from_js(value, context)?)),
         }
+    }
+}
+
+impl<T> TryFromJs for Vec<T>
+where
+    T: TryFromJs,
+{
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+        let object = match value {
+            JsValue::Object(o) => o,
+            _ => {
+                return Err(JsNativeError::typ()
+                    .with_message("cannot convert value to a Vec")
+                    .into())
+            }
+        };
+
+        let length = object
+            .get(js_string!("length"), context)?
+            .to_length(context)?;
+        let mut vec = Vec::with_capacity(length as usize);
+        for i in 0..length {
+            let value = object.get(i, context)?;
+            vec.push(T::try_from_js(&value, context)?);
+        }
+
+        Ok(vec)
     }
 }
 
@@ -249,4 +277,43 @@ impl TryFromJs for u128 {
                 .into()),
         }
     }
+}
+
+#[test]
+fn value_into_vec() {
+    use boa_engine::{run_test_actions, TestAction};
+    use indoc::indoc;
+
+    #[derive(Debug, PartialEq, Eq, boa_macros::TryFromJs)]
+    struct TestStruct {
+        inner: bool,
+        my_int: i16,
+        my_vec: Vec<String>,
+    }
+
+    run_test_actions([TestAction::assert_with_op(
+        indoc! {r#"
+            let value = {
+                inner: true,
+                my_int: 11,
+                my_vec: ["a", "b", "c"]
+            };
+            value
+        "#},
+        |value, context| {
+            let value = TestStruct::try_from_js(&value, context);
+            eprintln!("{:?}", value);
+            match value {
+                Ok(value) => {
+                    value
+                        == TestStruct {
+                            inner: true,
+                            my_int: 11,
+                            my_vec: vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                        }
+                }
+                _ => false,
+            }
+        },
+    )]);
 }

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -76,7 +76,12 @@ where
         let length = object
             .get(js_string!("length"), context)?
             .to_length(context)?;
-        let mut vec = Vec::with_capacity(length as usize);
+        let length = usize::try_from(length).map_err(|e| {
+            JsNativeError::typ()
+                .with_message(format!("could not convert length to usize: {e}"))
+                .into()
+        })?;
+        let mut vec = Vec::with_capacity(length);
         for i in 0..length {
             let value = object.get(i, context)?;
             vec.push(T::try_from_js(&value, context)?);

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -2,7 +2,7 @@
 
 use num_bigint::BigInt;
 
-use crate::{Context, js_string, JsBigInt, JsNativeError, JsResult, JsValue};
+use crate::{js_string, Context, JsBigInt, JsNativeError, JsResult, JsValue};
 
 /// This trait adds a fallible and efficient conversions from a [`JsValue`] to Rust types.
 pub trait TryFromJs: Sized {
@@ -64,13 +64,10 @@ where
     T: TryFromJs,
 {
     fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
-        let object = match value {
-            JsValue::Object(o) => o,
-            _ => {
-                return Err(JsNativeError::typ()
-                    .with_message("cannot convert value to a Vec")
-                    .into())
-            }
+        let JsValue::Object(object) = value else {
+            return Err(JsNativeError::typ()
+                .with_message("cannot convert value to a Vec")
+                .into());
         };
 
         let length = object


### PR DESCRIPTION
This PR adds an implementation of `TryFromJs` for `Vec<T: TryFromJs>` to create Rust vectors from Array-like JavaScript objects.

This is useful when using typed arguments to native functions with arrays.