### PR TITLE
Dense array storage variants for `i32` and `f64`

### DIFF
--- a/cli/src/debug/object.rs
+++ b/cli/src/debug/object.rs
@@ -1,6 +1,7 @@
 use boa_engine::{
-    js_string, object::ObjectInitializer, Context, JsNativeError, JsObject, JsResult, JsValue,
-    NativeFunction,
+    js_string,
+    object::{IndexProperties, ObjectInitializer},
+    Context, JsNativeError, JsObject, JsResult, JsValue, NativeFunction,
 };
 
 /// Returns objects pointer in memory.
@@ -21,8 +22,36 @@ fn id(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
     Ok(js_string!(format!("0x{:X}", ptr.cast::<()>() as usize)).into())
 }
 
+/// Returns objects pointer in memory.
+fn indexed_elements_type(_: &JsValue, args: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    let Some(value) = args.first() else {
+        return Err(JsNativeError::typ()
+            .with_message("expected object argument")
+            .into());
+    };
+
+    let Some(object) = value.as_object() else {
+        return Err(JsNativeError::typ()
+            .with_message(format!("expected object, got {}", value.type_of()))
+            .into());
+    };
+
+    let typ = match object.borrow().properties().index_properties() {
+        IndexProperties::DenseI32(_) => "DenseI32",
+        IndexProperties::DenseF64(_) => "DenseF64",
+        IndexProperties::DenseElement(_) => "DenseElement",
+        IndexProperties::Sparse(_) => "SparseElement",
+    };
+    Ok(js_string!(typ).into())
+}
+
 pub(super) fn create_object(context: &mut Context) -> JsObject {
     ObjectInitializer::new(context)
         .function(NativeFunction::from_fn_ptr(id), js_string!("id"), 1)
+        .function(
+            NativeFunction::from_fn_ptr(indexed_elements_type),
+            js_string!("indexedElementsType"),
+            1,
+        )
         .build()
 }

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1225,6 +1225,16 @@ impl Array {
                     return Ok(v.into());
                 }
             }
+            if let IndexedProperties::DenseF64(dense) =
+                &mut o_borrow.properties_mut().indexed_properties
+            {
+                if len <= dense.len() as u64 {
+                    let v = dense.remove(0);
+                    drop(o_borrow);
+                    Self::set_length(&o, len - 1, context)?;
+                    return Ok(v.into());
+                }
+            }
             if let Some(dense) = o_borrow.properties_mut().dense_indexed_properties_mut() {
                 if len <= dense.len() as u64 {
                     let v = dense.remove(0);

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -305,7 +305,7 @@ pub(crate) fn to_integer_if_integral(arg: &JsValue, context: &mut Context) -> Js
     // 1. Let number be ? ToNumber(argument).
     // 2. If IsIntegralNumber(number) is false, throw a RangeError exception.
     // 3. Return ℝ(number).
-    if !arg.is_integer() {
+    if !arg.is_integral_number() {
         return Err(JsNativeError::range()
             .with_message("value to convert is not an integral number.")
             .into());

--- a/core/engine/src/object/property_map.rs
+++ b/core/engine/src/object/property_map.rs
@@ -943,6 +943,7 @@ impl FusedIterator for IndexPropertyKeys<'_> {}
 
 /// An iterator over the index values (`Property`) of an `Object`.
 #[derive(Debug, Clone)]
+#[allow(variant_size_differences)]
 pub enum IndexPropertyValues<'a> {
     /// An iterator over dense, Vec backed indexed property entries of an `Object`.
     DenseI32(std::slice::Iter<'a, i32>),

--- a/core/engine/src/object/shape/shared_shape/template.rs
+++ b/core/engine/src/object/shape/shared_shape/template.rs
@@ -2,7 +2,9 @@ use boa_gc::{Finalize, Trace};
 use thin_vec::ThinVec;
 
 use crate::{
-    object::{shape::slot::SlotAttributes, JsObject, NativeObject, Object, PropertyMap},
+    object::{
+        shape::slot::SlotAttributes, IndexedProperties, JsObject, NativeObject, Object, PropertyMap,
+    },
     property::{Attribute, PropertyKey},
     JsValue,
 };
@@ -110,7 +112,7 @@ impl ObjectTemplate {
         let mut object = Object {
             data,
             extensible: true,
-            properties: PropertyMap::new(self.shape.clone().into(), ThinVec::default()),
+            properties: PropertyMap::new(self.shape.clone().into(), IndexedProperties::default()),
             private_elements: ThinVec::new(),
         };
 
@@ -127,13 +129,13 @@ impl ObjectTemplate {
         &self,
         data: T,
         storage: Vec<JsValue>,
-        elements: ThinVec<JsValue>,
+        indexed_properties: IndexedProperties,
     ) -> JsObject {
         let internal_methods = data.internal_methods();
         let mut object = Object {
             data,
             extensible: true,
-            properties: PropertyMap::new(self.shape.clone().into(), elements),
+            properties: PropertyMap::new(self.shape.clone().into(), indexed_properties),
             private_elements: ThinVec::new(),
         };
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -241,10 +241,15 @@ impl JsValue {
         matches!(self, Self::Rational(_))
     }
 
-    /// Returns true if the value is integer.
+    /// Determines if argument is a finite integral Number value.
+    ///
+    /// More information:
+    /// - [ECMAScript reference][spec]
+    ///
+    /// [spec]: https://tc39.es/ecma262/#sec-isintegralnumber
     #[must_use]
     #[allow(clippy::float_cmp)]
-    pub fn is_integer(&self) -> bool {
+    pub fn is_integral_number(&self) -> bool {
         // If it can fit in a i32 and the truncated version is
         // equal to the original then it is an integer.
         let is_rational_integer = |n: f64| n == f64::from(n as i32);
@@ -253,6 +258,37 @@ impl JsValue {
             Self::Integer(_) => true,
             Self::Rational(n) if is_rational_integer(n) => true,
             _ => false,
+        }
+    }
+
+    /// Returns true if the value can be reprented as an integer.
+    ///
+    /// Similar to [`JsValue::is_integral_number()`] except that it returns `false` for `-0`.
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub fn is_integer(&self) -> bool {
+        // If it can fit in a i32 and the truncated version is
+        // equal to the original then it is an integer.
+        let is_rational_integer = |n: f64| n.to_bits() == f64::from(n as i32).to_bits();
+
+        match *self {
+            Self::Integer(_) => true,
+            Self::Rational(n) if is_rational_integer(n) => true,
+            _ => false,
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn as_integer(&self) -> Option<i32> {
+        // If it can fit in a i32 and the truncated version is
+        // equal to the original then it is an integer.
+        let is_rational_integer = |n: f64| n.to_bits() == f64::from(n as i32).to_bits();
+
+        match *self {
+            Self::Integer(n) => Some(n),
+            Self::Rational(n) if is_rational_integer(n) => Some(n as i32),
+            _ => None,
         }
     }
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -278,20 +278,6 @@ impl JsValue {
         }
     }
 
-    #[must_use]
-    #[allow(clippy::float_cmp)]
-    pub(crate) fn as_integer(&self) -> Option<i32> {
-        // If it can fit in a i32 and the truncated version is
-        // equal to the original then it is an integer.
-        let is_rational_integer = |n: f64| n.to_bits() == f64::from(n as i32).to_bits();
-
-        match *self {
-            Self::Integer(n) => Some(n),
-            Self::Rational(n) if is_rational_integer(n) => Some(n as i32),
-            _ => None,
-        }
-    }
-
     /// Returns true if the value is a number.
     #[inline]
     #[must_use]

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -106,9 +106,8 @@ impl Operation for CallEvalSpread {
         let arguments = arguments_array_object
             .borrow()
             .properties()
-            .dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense")
-            .clone();
+            .to_dense_indexed_properties()
+            .expect("arguments array in call spread function must be dense");
 
         let at = context.vm.stack.len();
         let func = context.vm.stack[at - 1].clone();
@@ -217,9 +216,8 @@ impl Operation for CallSpread {
         let arguments = arguments_array_object
             .borrow()
             .properties()
-            .dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense")
-            .clone();
+            .to_dense_indexed_properties()
+            .expect("arguments array in call spread function must be dense");
 
         let argument_count = arguments.len();
         context.vm.push_values(&arguments);

--- a/core/engine/src/vm/opcode/environment/mod.rs
+++ b/core/engine/src/vm/opcode/environment/mod.rs
@@ -181,9 +181,8 @@ impl Operation for SuperCallSpread {
         let arguments = arguments_array_object
             .borrow()
             .properties()
-            .dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense")
-            .clone();
+            .to_dense_indexed_properties()
+            .expect("arguments array in call spread function must be dense");
 
         let super_constructor = context.vm.pop();
 

--- a/core/engine/src/vm/opcode/get/property.rs
+++ b/core/engine/src/vm/opcode/get/property.rs
@@ -115,12 +115,9 @@ impl Operation for GetPropertyByValue {
         if object.is_array() {
             if let PropertyKey::Index(index) = &key {
                 let object_borrowed = object.borrow();
-                if let Some(element) = object_borrowed
-                    .properties()
-                    .dense_indexed_properties()
-                    .and_then(|vec| vec.get(index.get() as usize))
+                if let Some(element) = object_borrowed.properties().get_dense_property(index.get())
                 {
-                    context.vm.push(element.clone());
+                    context.vm.push(element);
                     return Ok(CompletionType::Normal);
                 }
             }
@@ -162,13 +159,10 @@ impl Operation for GetPropertyByValuePush {
         if object.is_array() {
             if let PropertyKey::Index(index) = &key {
                 let object_borrowed = object.borrow();
-                if let Some(element) = object_borrowed
-                    .properties()
-                    .dense_indexed_properties()
-                    .and_then(|vec| vec.get(index.get() as usize))
+                if let Some(element) = object_borrowed.properties().get_dense_property(index.get())
                 {
                     context.vm.push(key);
-                    context.vm.push(element.clone());
+                    context.vm.push(element);
                     return Ok(CompletionType::Normal);
                 }
             }

--- a/core/engine/src/vm/opcode/new/mod.rs
+++ b/core/engine/src/vm/opcode/new/mod.rs
@@ -70,9 +70,8 @@ impl Operation for NewSpread {
         let arguments = arguments_array_object
             .borrow()
             .properties()
-            .dense_indexed_properties()
-            .expect("arguments array in call spread function must be dense")
-            .clone();
+            .to_dense_indexed_properties()
+            .expect("arguments array in call spread function must be dense");
 
         let func = context.vm.pop();
 

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -1,7 +1,5 @@
-use boa_macros::utf16;
-
 use crate::{
-    builtins::{function::set_function_name, Proxy},
+    builtins::function::set_function_name,
     object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
     property::{PropertyDescriptor, PropertyKey},
     vm::{opcode::Operation, CompletionType},
@@ -145,58 +143,12 @@ impl Operation for SetPropertyByValue {
                         break 'fast_path;
                     }
 
-                    let shape = object_borrowed.shape().clone();
-
-                    if let Some(dense_elements) = object_borrowed
+                    if object_borrowed
                         .properties_mut()
-                        .dense_indexed_properties_mut()
+                        .set_dense_property(index.get(), &value)
                     {
-                        let index = index.get() as usize;
-                        if let Some(element) = dense_elements.get_mut(index) {
-                            *element = value;
-                            context.vm.push(element.clone());
-                            return Ok(CompletionType::Normal);
-                        } else if dense_elements.len() == index {
-                            // Cannot use fast path if the [[prototype]] is a proxy object,
-                            // because we have to the call prototypes [[set]] on non-existing property,
-                            // and proxy objects can override [[set]].
-                            let prototype = shape.prototype();
-                            if prototype.map_or(false, |x| x.is::<Proxy>()) {
-                                break 'fast_path;
-                            }
-
-                            dense_elements.push(value.clone());
-                            context.vm.push(value);
-
-                            let len = dense_elements.len() as u32;
-                            let length_key = PropertyKey::from(utf16!("length"));
-                            let length = object_borrowed
-                                .properties_mut()
-                                .get(&length_key)
-                                .expect("Arrays must have length property");
-
-                            if length.expect_writable() {
-                                // We have to get the max of previous length and len(dense_elements) + 1,
-                                // this is needed if user spacifies `new Array(n)` then adds properties from 0, 1, etc.
-                                let len = length
-                                    .expect_value()
-                                    .to_u32(context)
-                                    .expect("length should have a u32 value")
-                                    .max(len);
-                                object_borrowed.insert(
-                                    length_key,
-                                    PropertyDescriptor::builder()
-                                        .value(len)
-                                        .writable(true)
-                                        .enumerable(length.expect_enumerable())
-                                        .configurable(false)
-                                        .build(),
-                                );
-                            } else if context.vm.frame().code_block.strict() {
-                                return Err(JsNativeError::typ().with_message("TypeError: Cannot assign to read only property 'length' of array object").into());
-                            }
-                            return Ok(CompletionType::Normal);
-                        }
+                        context.vm.push(value);
+                        return Ok(CompletionType::Normal);
                     }
                 }
             }

--- a/docs/boa_object.md
+++ b/docs/boa_object.md
@@ -163,6 +163,30 @@ $boa.object.id(o)    // '0x7F5B3251B718'
 $boa.object.id($boa) // '0x7F5B3251B5D8'
 ```
 
+## Function `$boa.object.indexedStorageType(object)`
+
+This function returns indexed storage type.
+
+Example:
+
+```JavaScript
+let a = [1, 2]
+
+$boa.object.indexedStorageType(a) // 'DenseI32'
+
+a.push(0xdeadbeef)
+$boa.object.indexedStorageType(a) // 'DenseI32'
+
+a.push(0.5)
+$boa.object.indexedStorageType(a) // 'DenseF64'
+
+a.push("Hello")
+$boa.object.indexedStorageType(a) // 'DenseElement'
+
+a[100] = 100 // Make a hole
+$boa.object.indexedStorageType(a) // 'SparseElement'
+```
+
 ## Module `$boa.optimizer`
 
 This modules contains getters and setters for enabling and disabling optimizations.


### PR DESCRIPTION
This PR adds dense variants for array storage (`i32` and `f64`) this is mostly a memory optimization, this optimization is also implemented by v8 (they have even more granular types like sparse `i32` and `f64` variants).

Storing number `i32` numbers in a dense array now takes `6x` less memory and `3x` less memory for `f64` (since `JsValue` is 24 bytes)

This PR also applies the changes in #3744 , because with this PR it complicates that fast path too much. Since the patch introduces a regression for setting new properties in arrays,  this PR amortizes the regression, it's pretty much the same with the current performance in quickjs benchmarks.

Even though I implemented that fast path, I was never happy with it :sweat_smile: (because it has too much duplicate logic), it was a quick way to improve performance, but I think the better option is to improve the internal object methods, which should give overall better performance.