### PR TITLE
Cache `this` value

### DIFF
--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -1054,10 +1054,16 @@ fn function_construct(
         Some(this)
     };
 
-    let frame = CallFrame::new(code.clone(), script_or_module, environments, realm)
+    let mut frame = CallFrame::new(code.clone(), script_or_module, environments, realm)
         .with_argument_count(argument_count as u32)
         .with_env_fp(env_fp)
         .with_flags(CallFrameFlags::CONSTRUCT);
+
+    // We push the `this` below so we can mark this function as having the this value
+    // cached if it's initialized.
+    frame
+        .flags
+        .set(CallFrameFlags::THIS_VALUE_CACHED, this.is_some());
 
     let len = context.vm.stack.len();
 

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -31,6 +31,9 @@ bitflags::bitflags! {
 
         /// Does this [`CallFrame`] need to push registers on [`Vm::push_frame()`].
         const REGISTERS_ALREADY_PUSHED = 0b0000_0100;
+
+        /// If the `this` value has been cached.
+        const THIS_VALUE_CACHED = 0b0000_1000;
     }
 }
 
@@ -322,6 +325,12 @@ impl CallFrame {
     pub(crate) fn registers_already_pushed(&self) -> bool {
         self.flags
             .contains(CallFrameFlags::REGISTERS_ALREADY_PUSHED)
+    }
+    /// Does this [`CallFrame`] have a cached `this` value.
+    ///
+    /// The cached value is placed in the [`CallFrame::THIS_POSITION`] position.
+    pub(crate) fn has_this_value_cached(&self) -> bool {
+        self.flags.contains(CallFrameFlags::THIS_VALUE_CACHED)
     }
 }
 

--- a/core/engine/src/vm/opcode/control_flow/return.rs
+++ b/core/engine/src/vm/opcode/control_flow/return.rs
@@ -54,16 +54,21 @@ impl Operation for CheckReturn {
             );
             return Ok(CompletionType::Throw);
         } else {
-            let realm = context.vm.frame().realm.clone();
-            let this = context.vm.environments.get_this_binding();
+            let frame = context.vm.frame();
+            if frame.has_this_value_cached() {
+                this
+            } else {
+                let realm = frame.realm.clone();
+                let this = context.vm.environments.get_this_binding();
 
-            match this {
-                Err(err) => {
-                    let err = err.inject_realm(realm);
-                    context.vm.pending_exception = Some(err);
-                    return Ok(CompletionType::Throw);
+                match this {
+                    Err(err) => {
+                        let err = err.inject_realm(realm);
+                        context.vm.pending_exception = Some(err);
+                        return Ok(CompletionType::Throw);
+                    }
+                    Ok(this) => this,
                 }
-                Ok(this) => this,
             }
         };
 


### PR DESCRIPTION
The value of `this` when `this` is used in a function does not change after the initial environment chain search, so now we cache this value. This prevents the `this` value from being searched in the environment chain on every `this` usage.

There is a small increase in performance, the functions that use `this` a lot are the ones that benefit from this optimization.

## Benchmarks

### Main

```
PROGRESS Richards
RESULT Richards 58.0
PROGRESS DeltaBlue
RESULT DeltaBlue 63.9
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 69.9
PROGRESS RayTrace
RESULT RayTrace 198
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 181
PROGRESS Splay
RESULT Splay 192
PROGRESS NavierStokes
RESULT NavierStokes 150
SCORE 115
```

### PR

```
PROGRESS Richards
RESULT Richards 60.7
PROGRESS DeltaBlue
RESULT DeltaBlue 65.0
PROGRESS Encrypt
PROGRESS Decrypt
RESULT Crypto 71.3
PROGRESS RayTrace
RESULT RayTrace 200
PROGRESS Earley
PROGRESS Boyer
RESULT EarleyBoyer 183
PROGRESS Splay
RESULT Splay 194
PROGRESS NavierStokes
RESULT NavierStokes 153
SCORE 117
```

