### PR TITLE
don't run test262 on push 

### DIFF
--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -47,10 +47,10 @@ jobs:
 
       # Run the results comparison
       - name: Compare results
+        if: github.event_name == 'pull_request'
         id: compare
         shell: bash
         run: |
-          tree -L 5
           cd boa
           comment="$(./target/release/boa_tester compare ../data/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
           echo "comment<<EOF" >> $GITHUB_OUTPUT
@@ -58,10 +58,12 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get the PR number
+        if: github.event_name == 'pull_request'
         id: pr-number
         uses: kkak10/pr-number-action@v1.3
 
       - name: Find Previous Comment
+        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
         id: previous-comment
         with:
@@ -69,7 +71,7 @@ jobs:
           body-includes: Test262 conformance changes
 
       - name: Update comment
-        if: steps.previous-comment.outputs.comment-id
+        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
         continue-on-error: true
         with:
@@ -81,7 +83,7 @@ jobs:
           edit-mode: replace
 
       - name: Write a new comment
-        if: ${{ !steps.previous-comment.outputs.comment-id }}
+        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
         continue-on-error: true
         with:

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -32,7 +32,12 @@ jobs:
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
 
-      # Run the test suite.
+      - name: Checkout the data repo
+        uses: actions/checkout@v4
+        with:
+          repository: boa-dev/data
+          path: data
+          # Run the test suite.
       - name: Run the test262 test suite
         run: |
           cd boa
@@ -46,7 +51,7 @@ jobs:
         shell: bash
         run: |
           cd boa
-          comment="$(./target/release/boa_tester compare ../gh-pages/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
+          comment="$(./target/release/boa_tester compare ../data/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
           echo "comment<<EOF" >> $GITHUB_OUTPUT
           echo "$comment" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -1,10 +1,5 @@
 name: EcmaScript official test suite (test262)
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
   pull_request:
     branches:
       - main
@@ -37,12 +32,6 @@ jobs:
             ~/.cargo/registry
           key: ${{ runner.os }}-cargo-test262-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Checkout GitHub pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
       # Run the test suite.
       - name: Run the test262 test suite
         run: |
@@ -53,7 +42,6 @@ jobs:
 
       # Run the results comparison
       - name: Compare results
-        if: github.event_name == 'pull_request'
         id: compare
         shell: bash
         run: |
@@ -64,12 +52,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Get the PR number
-        if: github.event_name == 'pull_request'
         id: pr-number
         uses: kkak10/pr-number-action@v1.3
 
       - name: Find Previous Comment
-        if: github.event_name == 'pull_request'
         uses: peter-evans/find-comment@v3
         id: previous-comment
         with:
@@ -77,7 +63,7 @@ jobs:
           body-includes: Test262 conformance changes
 
       - name: Update comment
-        if: github.event_name == 'pull_request' && steps.previous-comment.outputs.comment-id
+        if: steps.previous-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
         continue-on-error: true
         with:
@@ -89,7 +75,7 @@ jobs:
           edit-mode: replace
 
       - name: Write a new comment
-        if: github.event_name == 'pull_request' && !steps.previous-comment.outputs.comment-id
+        if: !steps.previous-comment.outputs.comment-id
         uses: peter-evans/create-or-update-comment@v4
         continue-on-error: true
         with:
@@ -99,27 +85,3 @@ jobs:
 
             ${{ steps.compare.outputs.comment }}
 
-      # Commit changes to GitHub pages.
-      - name: Checkout GitHub pages
-        if: github.event_name == 'push'
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-      - name: Commit files
-        if: github.event_name == 'push'
-        run: |
-          cp -r ./results/test262/* ./gh-pages/test262/
-          cd gh-pages
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add test262
-          git commit -m "Add new test262 results" -a
-          cd ..
-      - name: Upload results
-        if: github.event_name == 'push'
-        uses: ad-m/github-push-action@v0.8.0
-        with:
-          directory: gh-pages
-          branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -50,6 +50,7 @@ jobs:
         id: compare
         shell: bash
         run: |
+          tree -L 5
           cd boa
           comment="$(./target/release/boa_tester compare ../data/test262/refs/heads/main/latest.json ../results/test262/pull/latest.json -m)"
           echo "comment<<EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -75,7 +75,7 @@ jobs:
           edit-mode: replace
 
       - name: Write a new comment
-        if: !steps.previous-comment.outputs.comment-id
+        if: ${{ !steps.previous-comment.outputs.comment-id }}
         uses: peter-evans/create-or-update-comment@v4
         continue-on-error: true
         with:

--- a/tests/tester/src/results.rs
+++ b/tests/tester/src/results.rs
@@ -100,9 +100,6 @@ pub(crate) fn write_json(
         folder
     };
 
-    // We make sure we are using the latest commit information in GitHub pages:
-    update_gh_pages_repo(output_dir.as_path(), verbose);
-
     if verbose != 0 {
         println!("Writing the results to {}...", output_dir.display());
     }
@@ -168,33 +165,6 @@ fn get_test262_commit(test262_path: &Path) -> Result<Box<str>> {
     // Remove newline.
     commit_id.pop();
     Ok(commit_id.into_boxed_str())
-}
-
-/// Updates the GitHub pages repository by pulling latest changes before writing the new things.
-fn update_gh_pages_repo(path: &Path, verbose: u8) {
-    if env::var("GITHUB_REF").is_ok() {
-        use std::process::Command;
-
-        // We run the command to pull the gh-pages branch: git -C ../gh-pages/ pull origin
-        Command::new("git")
-            .args(["-C", "../gh-pages", "pull", "--ff-only"])
-            .output()
-            .expect("could not update GitHub Pages");
-
-        // Copy the full results file
-        let from = Path::new("../gh-pages/test262/refs/heads/main/").join(RESULTS_FILE_NAME);
-        let to = path.join(RESULTS_FILE_NAME);
-
-        if verbose != 0 {
-            println!(
-                "Copying the {} file to {} in order to add the results",
-                from.display(),
-                to.display()
-            );
-        }
-
-        fs::copy(from, to).expect("could not copy the main results file");
-    }
 }
 
 /// Compares the results of two test suite runs.


### PR DESCRIPTION
This PR relies on https://github.com/boa-dev/boa-dev.github.io/pull/145 being merged first.
Essentially this stops adding test262 data to the gh-pages branch on each push to main.

Instead we will rely on the nightly which runs from the data repo instead, this will help remove a lot of data from this repository