### PR TITLE
Add an integration test for relative imports on SimpleModuleLoader

### DIFF
--- a/core/engine/tests/assets/dir1/file1_1.js
+++ b/core/engine/tests/assets/dir1/file1_1.js
@@ -1,0 +1,5 @@
+import {file1_2} from './file1_2.js';
+
+export function file1_1() {
+    return 'file1_1' + '.' + file1_2();
+}

--- a/core/engine/tests/assets/dir1/file1_2.js
+++ b/core/engine/tests/assets/dir1/file1_2.js
@@ -1,0 +1,3 @@
+export function file1_2() {
+    return 'file1_2';
+}

--- a/core/engine/tests/assets/file1.js
+++ b/core/engine/tests/assets/file1.js
@@ -1,0 +1,5 @@
+import {file1_1} from './dir1/file1_1.js';
+
+export function file1() {
+    return 'file1' + '..' + file1_1();
+}

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -3,9 +3,9 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use boa_engine::{Context, js_string, JsValue, Source};
 use boa_engine::builtins::promise::PromiseState;
 use boa_engine::module::SimpleModuleLoader;
+use boa_engine::{js_string, Context, JsValue, Source};
 
 /// Test that relative imports work with the simple module loader.
 #[test]
@@ -27,7 +27,7 @@ fn subdirectories() {
     match result.state() {
         PromiseState::Pending => {}
         PromiseState::Fulfilled(v) => {
-            assert_eq!(v, JsValue::String(js_string!("file1..file1_1.file1_2")))
+            assert_eq!(v, JsValue::String(js_string!("file1..file1_1.file1_2")));
         }
         PromiseState::Rejected(reason) => {
             panic!("Module failed to load: {}", reason.display());

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -1,0 +1,36 @@
+#![allow(unused_crate_dependencies, missing_docs)]
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use boa_engine::{Context, js_string, JsValue, Source};
+use boa_engine::builtins::promise::PromiseState;
+use boa_engine::module::SimpleModuleLoader;
+
+/// Test that relative imports work with the simple module loader.
+#[test]
+fn subdirectories() {
+    let assets_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("tests/assets");
+
+    let loader = Rc::new(SimpleModuleLoader::new(assets_dir).unwrap());
+    let mut context = Context::builder()
+        .module_loader(loader.clone())
+        .build()
+        .unwrap();
+
+    let source = Source::from_bytes(b"import { file1 } from './file1.js'; file1()");
+    let module = boa_engine::Module::parse(source, None, &mut context).unwrap();
+    let result = module.load_link_evaluate(&mut context);
+
+    context.run_jobs();
+    match result.state() {
+        PromiseState::Pending => {}
+        PromiseState::Fulfilled(v) => {
+            assert_eq!(v, JsValue::String(js_string!("file1..file1_1.file1_2")))
+        }
+        PromiseState::Rejected(reason) => {
+            panic!("Module failed to load: {}", reason.display());
+        }
+    }
+}


### PR DESCRIPTION
This PR exposes an issue with the way the module loader trait is designed. There is no way to resolve the specifier relative to the module doing the import.

This test will fail with the following message:

```
running 1 test
test subdirectories ... FAILED

failures:

---- subdirectories stdout ----
thread 'subdirectories' panicked at core/engine/tests/imports.rs:33:13:
Module failed to load: TypeError: could not canonicalize path `./file1_2.js`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I will file an issue separately pointing to this.