### PR TITLE
Add a path to Module (and expose it in Referrer)

### DIFF
--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -5,11 +5,11 @@ use rustc_hash::FxHashMap;
 use boa_gc::GcRefCell;
 use boa_parser::Source;
 
-use crate::{
-    Context, js_string, JsError, JsNativeError, JsResult, JsString, object::JsObject,
-    realm::Realm, vm::ActiveRunnable,
-};
 use crate::script::Script;
+use crate::{
+    js_string, object::JsObject, realm::Realm, vm::ActiveRunnable, Context, JsError, JsNativeError,
+    JsResult, JsString,
+};
 
 use super::Module;
 
@@ -26,6 +26,7 @@ pub enum Referrer {
 
 impl Referrer {
     /// Gets the path of the referrer, if it has one.
+    #[must_use]
     pub fn path(&self) -> Option<&Path> {
         match self {
             Self::Module(module) => module.path(),

--- a/core/engine/src/module/mod.rs
+++ b/core/engine/src/module/mod.rs
@@ -157,7 +157,7 @@ impl Module {
         context: &mut Context,
     ) -> JsResult<Self> {
         let _timer = Profiler::global().start_event("Module parsing", "Main");
-        let path = src.path().map(|p| p.to_path_buf());
+        let path = src.path().map(std::path::Path::to_path_buf);
         let mut parser = Parser::new(src);
         parser.set_identifier(context.next_parser_identifier());
         let module = parser.parse_module(context.interner_mut())?;
@@ -572,6 +572,7 @@ impl Module {
     }
 
     /// Returns the path of the module, if it was created from a file or assigned.
+    #[must_use]
     pub fn path(&self) -> Option<&Path> {
         self.inner.path.as_deref()
     }

--- a/core/engine/tests/assets/dir1/file1_1.js
+++ b/core/engine/tests/assets/dir1/file1_1.js
@@ -1,5 +1,5 @@
-import {file1_2} from './file1_2.js';
+import { file1_2 } from "./file1_2.js";
 
 export function file1_1() {
-    return 'file1_1' + '.' + file1_2();
+  return "file1_1" + "." + file1_2();
 }

--- a/core/engine/tests/assets/dir1/file1_1.js
+++ b/core/engine/tests/assets/dir1/file1_1.js
@@ -1,0 +1,5 @@
+import {file1_2} from './file1_2.js';
+
+export function file1_1() {
+    return 'file1_1' + '.' + file1_2();
+}

--- a/core/engine/tests/assets/dir1/file1_2.js
+++ b/core/engine/tests/assets/dir1/file1_2.js
@@ -1,0 +1,3 @@
+export function file1_2() {
+    return 'file1_2';
+}

--- a/core/engine/tests/assets/dir1/file1_2.js
+++ b/core/engine/tests/assets/dir1/file1_2.js
@@ -1,3 +1,3 @@
 export function file1_2() {
-    return 'file1_2';
+  return "file1_2";
 }

--- a/core/engine/tests/assets/file1.js
+++ b/core/engine/tests/assets/file1.js
@@ -1,0 +1,5 @@
+import {file1_1} from './dir1/file1_1.js';
+
+export function file1() {
+    return 'file1' + '..' + file1_1();
+}

--- a/core/engine/tests/assets/file1.js
+++ b/core/engine/tests/assets/file1.js
@@ -1,5 +1,5 @@
-import {file1_1} from './dir1/file1_1.js';
+import { file1_1 } from "./dir1/file1_1.js";
 
 export function file1() {
-    return 'file1' + '..' + file1_1();
+  return "file1" + ".." + file1_1();
 }

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -3,9 +3,9 @@
 use std::path::PathBuf;
 use std::rc::Rc;
 
-use boa_engine::{Context, js_string, JsValue, Source};
 use boa_engine::builtins::promise::PromiseState;
 use boa_engine::module::SimpleModuleLoader;
+use boa_engine::{js_string, Context, JsValue, Source};
 
 /// Test that relative imports work with the simple module loader.
 #[test]
@@ -29,16 +29,19 @@ fn subdirectories() {
         PromiseState::Fulfilled(v) => {
             assert!(v.is_undefined());
 
-            let foo = module
+            let foo_value = module
                 .namespace(&mut context)
                 .get(js_string!("file1"), &mut context)
-                .unwrap();
-            let v = foo
+                .unwrap()
                 .as_callable()
                 .unwrap()
                 .call(&JsValue::undefined(), &[], &mut context)
                 .unwrap();
-            assert_eq!(v, JsValue::String(js_string!("file1..file1_1.file1_2")));
+
+            assert_eq!(
+                foo_value,
+                JsValue::String(js_string!("file1..file1_1.file1_2"))
+            );
         }
         PromiseState::Rejected(reason) => {
             panic!("Module failed to load: {}", reason.display());

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -1,0 +1,36 @@
+#![allow(unused_crate_dependencies, missing_docs)]
+
+use std::path::PathBuf;
+use std::rc::Rc;
+
+use boa_engine::builtins::promise::PromiseState;
+use boa_engine::module::SimpleModuleLoader;
+use boa_engine::{js_string, Context, JsValue, Source};
+
+/// Test that relative imports work with the simple module loader.
+#[test]
+fn subdirectories() {
+    let assets_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("tests/assets");
+
+    let loader = Rc::new(SimpleModuleLoader::new(assets_dir).unwrap());
+    let mut context = Context::builder()
+        .module_loader(loader.clone())
+        .build()
+        .unwrap();
+
+    let source = Source::from_bytes(b"import { file1 } from './file1.js'; file1()");
+    let module = boa_engine::Module::parse(source, None, &mut context).unwrap();
+    let result = module.load_link_evaluate(&mut context);
+
+    context.run_jobs();
+    match result.state() {
+        PromiseState::Pending => {}
+        PromiseState::Fulfilled(v) => {
+            assert_eq!(v, JsValue::String(js_string!("file1..file1_1.file1_2")));
+        }
+        PromiseState::Rejected(reason) => {
+            panic!("Module failed to load: {}", reason.display());
+        }
+    }
+}

--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -30,6 +30,7 @@ impl<T: IntoIterator<Item = (JsString, NativeFunction)> + Clone> IntoJsModule fo
                 })
             },
             None,
+            None,
             context,
         )
     }

--- a/core/parser/src/source/mod.rs
+++ b/core/parser/src/source/mod.rs
@@ -1,8 +1,5 @@
 //! Boa parser input source types.
 
-mod utf16;
-mod utf8;
-
 use std::{
     fs::File,
     io::{self, BufReader, Read},
@@ -11,6 +8,9 @@ use std::{
 
 pub use utf16::UTF16Input;
 pub use utf8::UTF8Input;
+
+mod utf16;
+mod utf8;
 
 /// A source of ECMAScript code.
 ///
@@ -119,6 +119,13 @@ impl<'path, R: Read> Source<'path, UTF8Input<R>> {
     }
 }
 
+impl<'path, R> Source<'path, R> {
+    /// Returns the path (if any) of this source file.
+    pub fn path(&self) -> Option<&'path Path> {
+        self.path
+    }
+}
+
 /// This trait is used to abstract over the different types of input readers.
 pub trait ReadChar {
     /// Retrieves the next unicode code point. Returns `None` if the end of the input is reached.
@@ -131,8 +138,9 @@ pub trait ReadChar {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::io::Cursor;
+
+    use super::*;
 
     #[test]
     fn from_bytes() {

--- a/examples/src/bin/synthetic.rs
+++ b/examples/src/bin/synthetic.rs
@@ -175,6 +175,7 @@ fn create_operations_module(context: &mut Context) -> Module {
             (sum, sub, mult, div, sqrt),
         ),
         None,
+        None,
         context,
     )
 }


### PR DESCRIPTION
This allows `SimpleModuleLoader` (and other loaders) to resolve relative to the current file (which this commit also does).

Fixes #3782
Closes #3781 