### PR TITLE
Add a new type Convert<> to convert values 

### DIFF
--- a/core/engine/src/value/conversions/coerce.rs
+++ b/core/engine/src/value/conversions/coerce.rs
@@ -2,7 +2,7 @@
 //! converting.
 
 use crate::value::TryFromJs;
-use crate::{Context, JsResult, JsValue};
+use crate::{Context, JsResult, JsString, JsValue};
 use boa_engine::JsNativeError;
 
 /// A wrapper type that allows coercing a `JsValue` to a specific type.
@@ -103,7 +103,7 @@ impl TryFromJs for Coerce<JsString> {
 }
 
 impl TryFromJs for Coerce<bool> {
-    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+    fn try_from_js(value: &JsValue, _context: &mut Context) -> JsResult<Self> {
         Ok(Self(value.to_boolean()))
     }
 }

--- a/core/engine/src/value/conversions/coerce.rs
+++ b/core/engine/src/value/conversions/coerce.rs
@@ -1,0 +1,109 @@
+//! Types and functions for applying Coercing rules to [`JsValue`] when
+//! converting.
+
+use crate::value::TryFromJs;
+use crate::{Context, JsResult, JsValue};
+use boa_engine::JsNativeError;
+
+/// A wrapper type that allows coercing a `JsValue` to a specific type.
+/// This is useful when you want to coerce a `JsValue` to a Rust type.
+///
+/// # Example
+/// ```
+/// # use boa_engine::{Context, js_string, JsValue};
+/// # use boa_engine::value::{Coerce, TryFromJs};
+/// # let mut context = Context::default();
+/// let value = JsValue::from(js_string!("42"));
+/// let Coerce(coerced): Coerce<i32> = Coerce::try_from_js(&value, &mut context).unwrap();
+///
+/// assert_eq!(coerced, 42);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Coerce<T: TryFromJs>(pub T);
+
+impl<T: TryFromJs> From<T> for Coerce<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
+}
+
+macro_rules! decl_coerce_to_int {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFromJs for Coerce<$ty> {
+                fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+                    value.to_numeric_number(context).and_then(|num| {
+                        if num.is_finite() {
+                            if num >= f64::from(<$ty>::MAX) {
+                                Err(JsNativeError::typ()
+                                    .with_message("cannot coerce value to integer, it is too large")
+                                    .into())
+                            } else if num <= f64::from(<$ty>::MIN) {
+                                Err(JsNativeError::typ()
+                                    .with_message("cannot coerce value to integer, it is too small")
+                                    .into())
+                                // Only round if it differs from the next integer by an epsilon
+                            } else if num.abs().fract() >= (1.0 - f64::EPSILON) {
+                                Ok(Coerce(num.round() as $ty))
+                            } else {
+                                Ok(Coerce(num as $ty))
+                            }
+                        } else if num.is_nan() {
+                            Err(JsNativeError::typ()
+                                .with_message("cannot coerce NaN to integer")
+                                .into())
+                        } else if num.is_infinite() {
+                            Err(JsNativeError::typ()
+                                .with_message("cannot coerce Infinity to integer")
+                                .into())
+                        } else {
+                            Err(JsNativeError::typ()
+                                .with_message("cannot coerce non-finite number to integer")
+                                .into())
+                        }
+                    })
+                }
+            }
+        )*
+    };
+}
+
+decl_coerce_to_int!(i8, i16, i32, u8, u16, u32);
+
+macro_rules! decl_coerce_to_float {
+    ($($ty:ty),*) => {
+        $(
+            impl TryFromJs for Coerce<$ty> {
+                fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+                    value.to_numeric_number(context).and_then(|num| Ok(Coerce(<$ty>::try_from(num).map_err(|_| {
+                        JsNativeError::typ()
+                            .with_message("cannot coerce value to float")
+                    })?)))
+                }
+            }
+        )*
+    };
+}
+
+decl_coerce_to_float!(f64);
+
+impl TryFromJs for Coerce<String> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+        value
+            .to_string(context)
+            .and_then(|s| s.to_std_string().map_err(|_| JsNativeError::typ().into()))
+            .map(Coerce)
+    }
+}
+
+impl TryFromJs for Coerce<JsString> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+        value.to_string(context).map(Coerce)
+    }
+}
+
+impl TryFromJs for Coerce<bool> {
+    fn try_from_js(value: &JsValue, context: &mut Context) -> JsResult<Self> {
+        Ok(Self(value.to_boolean()))
+    }
+}

--- a/core/engine/src/value/conversions/convert.rs
+++ b/core/engine/src/value/conversions/convert.rs
@@ -1,5 +1,5 @@
 //! Types and functions for applying JavaScript Convert rules to [`JsValue`] when
-//! converting. See https://262.ecma-international.org/5.1/#sec-9 (Section 9) for
+//! converting. See <https://262.ecma-international.org/5.1/#sec-9> (Section 9) for
 //! conversion rules of JavaScript types.
 //!
 //! Some conversions are not specified in the spec (e.g. integer conversions),
@@ -8,8 +8,8 @@
 
 use boa_engine::JsNativeError;
 
-use crate::{Context, JsResult, JsString, JsValue};
 use crate::value::TryFromJs;
+use crate::{Context, JsResult, JsString, JsValue};
 
 /// A wrapper type that allows converting a `JsValue` to a specific type.
 /// This is useful when you want to convert a `JsValue` to a Rust type.

--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -7,6 +7,8 @@ use super::{JsBigInt, JsObject, JsString, JsSymbol, JsValue, Profiler};
 mod serde_json;
 pub(super) mod try_from_js;
 
+pub(super) mod coerce;
+
 impl From<JsString> for JsValue {
     fn from(value: JsString) -> Self {
         let _timer = Profiler::global().start_event("From<JsString>", "value");

--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -7,7 +7,7 @@ use super::{JsBigInt, JsObject, JsString, JsSymbol, JsValue, Profiler};
 mod serde_json;
 pub(super) mod try_from_js;
 
-pub(super) mod coerce;
+pub(super) mod convert;
 
 impl From<JsString> for JsValue {
     fn from(value: JsString) -> Self {

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -2,7 +2,7 @@
 
 use num_bigint::BigInt;
 
-use crate::{js_string, Context, JsBigInt, JsNativeError, JsResult, JsValue};
+use crate::{js_string, Context, JsBigInt, JsNativeError, JsObject, JsResult, JsString, JsValue};
 
 /// This trait adds a fallible and efficient conversions from a [`JsValue`] to Rust types.
 pub trait TryFromJs: Sized {
@@ -40,6 +40,17 @@ impl TryFromJs for String {
                     .with_message(format!("could not convert JsString to Rust string: {e}"))
                     .into()
             }),
+            _ => Err(JsNativeError::typ()
+                .with_message("cannot convert value to a String")
+                .into()),
+        }
+    }
+}
+
+impl TryFromJs for JsString {
+    fn try_from_js(value: &JsValue, _context: &mut Context) -> JsResult<Self> {
+        match value {
+            JsValue::String(s) => Ok(s.clone()),
             _ => Err(JsNativeError::typ()
                 .with_message("cannot convert value to a String")
                 .into()),
@@ -88,6 +99,17 @@ where
         }
 
         Ok(vec)
+    }
+}
+
+impl TryFromJs for JsObject {
+    fn try_from_js(value: &JsValue, _context: &mut Context) -> JsResult<Self> {
+        match value {
+            JsValue::Object(o) => Ok(o.clone()),
+            _ => Err(JsNativeError::typ()
+                .with_message("cannot convert value to a Object")
+                .into()),
+        }
     }
 }
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -2,16 +2,23 @@
 //!
 //! Javascript values, utility methods and conversion between Javascript values and Rust values.
 
-mod conversions;
-pub(crate) mod display;
-mod equality;
-mod hash;
-mod integer;
-mod operations;
-mod r#type;
+use std::{
+    collections::HashSet,
+    fmt::{self, Display},
+    ops::Sub,
+};
 
-#[cfg(test)]
-mod tests;
+use num_bigint::BigInt;
+use num_integer::Integer;
+use num_traits::{ToPrimitive, Zero};
+use once_cell::sync::Lazy;
+
+use boa_gc::{custom_trace, Finalize, Trace};
+#[doc(inline)]
+pub use boa_macros::TryFromJs;
+use boa_profiler::Profiler;
+#[doc(inline)]
+pub use conversions::coerce::Convert;
 
 use crate::{
     builtins::{
@@ -25,30 +32,24 @@ use crate::{
     symbol::JsSymbol,
     Context, JsBigInt, JsResult, JsString,
 };
-use boa_gc::{custom_trace, Finalize, Trace};
-use boa_profiler::Profiler;
-use num_bigint::BigInt;
-use num_integer::Integer;
-use num_traits::{ToPrimitive, Zero};
-use once_cell::sync::Lazy;
-use std::{
-    collections::HashSet,
-    fmt::{self, Display},
-    ops::Sub,
-};
 
+pub(crate) use self::conversions::IntoOrUndefined;
 #[doc(inline)]
 pub use self::{
     conversions::try_from_js::TryFromJs, display::ValueDisplay, integer::IntegerOrInfinity,
     operations::*, r#type::Type,
 };
-#[doc(inline)]
-pub use boa_macros::TryFromJs;
 
-#[doc(inline)]
-pub use conversions::coerce::Coerce;
+mod conversions;
+pub(crate) mod display;
+mod equality;
+mod hash;
+mod integer;
+mod operations;
+mod r#type;
 
-pub(crate) use self::conversions::IntoOrUndefined;
+#[cfg(test)]
+mod tests;
 
 static TWO_E_64: Lazy<BigInt> = Lazy::new(|| {
     const TWO_E_64: u128 = 2u128.pow(64);

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -25,20 +25,20 @@ use crate::{
         number::{f64_to_int32, f64_to_uint32},
         Number, Promise,
     },
-    Context,
     error::JsNativeError,
     js_string,
-    JsBigInt,
-    JsResult,
-    JsString, object::JsObject, property::{PropertyDescriptor, PropertyKey}, symbol::JsSymbol,
+    object::JsObject,
+    property::{PropertyDescriptor, PropertyKey},
+    symbol::JsSymbol,
+    Context, JsBigInt, JsResult, JsString,
 };
 
+pub(crate) use self::conversions::IntoOrUndefined;
 #[doc(inline)]
 pub use self::{
     conversions::try_from_js::TryFromJs, display::ValueDisplay, integer::IntegerOrInfinity,
     operations::*, r#type::Type,
 };
-pub(crate) use self::conversions::IntoOrUndefined;
 
 mod conversions;
 pub(crate) mod display;

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -18,27 +18,27 @@ use boa_gc::{custom_trace, Finalize, Trace};
 pub use boa_macros::TryFromJs;
 use boa_profiler::Profiler;
 #[doc(inline)]
-pub use conversions::coerce::Convert;
+pub use conversions::convert::Convert;
 
 use crate::{
     builtins::{
         number::{f64_to_int32, f64_to_uint32},
         Number, Promise,
     },
+    Context,
     error::JsNativeError,
     js_string,
-    object::JsObject,
-    property::{PropertyDescriptor, PropertyKey},
-    symbol::JsSymbol,
-    Context, JsBigInt, JsResult, JsString,
+    JsBigInt,
+    JsResult,
+    JsString, object::JsObject, property::{PropertyDescriptor, PropertyKey}, symbol::JsSymbol,
 };
 
-pub(crate) use self::conversions::IntoOrUndefined;
 #[doc(inline)]
 pub use self::{
     conversions::try_from_js::TryFromJs, display::ValueDisplay, integer::IntegerOrInfinity,
     operations::*, r#type::Type,
 };
+pub(crate) use self::conversions::IntoOrUndefined;
 
 mod conversions;
 pub(crate) mod display;

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -45,6 +45,9 @@ pub use self::{
 #[doc(inline)]
 pub use boa_macros::TryFromJs;
 
+#[doc(inline)]
+pub use conversions::coerce::Coerce;
+
 pub(crate) use self::conversions::IntoOrUndefined;
 
 static TWO_E_64: Lazy<BigInt> = Lazy::new(|| {


### PR DESCRIPTION
This can be used to transform values in to converted versions of Rust types by using the type system and `TryFromJs`.

Also added a JsString conversion for `TryFromJs`. These methods are going to be useful when #3773 goes in (but this PR nor that one depend on each others).