### PR TITLE
Properly resolve paths in SimpleModuleLoader and add path to Referrer::Script

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,6 +33,18 @@
       ],
       "sourceLanguages": ["rust"],
       "preLaunchTask": "Cargo Build boa_cli"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Boa (Tester)",
+      "windows": {
+        "program": "${workspaceFolder}/target/debug/boa_tester.exe"
+      },
+      "program": "${workspaceFolder}/target/debug/boa_tester",
+      "args": ["run", "-s", "${input:testPath}", "-vvv"],
+      "sourceLanguages": ["rust"],
+      "preLaunchTask": "Cargo Build boa_tester"
     }
   ],
   "inputs": [
@@ -46,6 +58,11 @@
       "id": "modulePath",
       "description": "Relative path to the module root directory",
       "default": "debug",
+      "type": "promptString"
+    },
+    {
+      "id": "testPath",
+      "description": "Relative path to the test from the test262 directory",
       "type": "promptString"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,6 +25,16 @@
     },
     {
       "type": "process",
+      "label": "Cargo Build boa_tester",
+      "command": "cargo",
+      "args": ["build", "-p", "boa_tester"],
+      "group": "build",
+      "presentation": {
+        "clear": true
+      }
+    },
+    {
+      "type": "process",
       "label": "Run JS file",
       "command": "cargo",
       "args": ["run", "--bin", "boa", "${file}"],

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "sys-locale",
  "tap",
  "temporal_rs",
+ "test-case",
  "textwrap",
  "thin-vec",
  "thiserror",
@@ -3726,6 +3727,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "test-case"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2550dd13afcd286853192af8601920d959b14c401fcece38071d53bf0768a8"
+dependencies = [
+ "test-case-macros",
+]
+
+[[package]]
+name = "test-case-core"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adcb7fd841cd518e279be3d5a3eb0636409487998a4aff22f3de87b81e88384f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+]
+
+[[package]]
+name = "test-case-macros"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.57",
+ "test-case-core",
 ]
 
 [[package]]

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -68,7 +68,7 @@ js = ["dep:web-time"]
 
 [dependencies]
 boa_interner.workspace = true
-boa_gc = { workspace = true, features = [ "thin-vec" ] }
+boa_gc = { workspace = true, features = ["thin-vec"] }
 boa_profiler.workspace = true
 boa_macros.workspace = true
 boa_ast.workspace = true
@@ -106,7 +106,7 @@ time.workspace = true
 hashbrown.workspace = true
 
 # intl deps
-boa_icu_provider = {workspace = true, features = ["std"], optional = true }
+boa_icu_provider = { workspace = true, features = ["std"], optional = true }
 sys-locale = { version = "0.3.1", optional = true }
 icu_provider = { workspace = true, optional = true }
 icu_locid = { workspace = true, features = ["serde"], optional = true }
@@ -116,7 +116,7 @@ icu_calendar = { workspace = true, default-features = false, optional = true }
 icu_collator = { workspace = true, default-features = false, features = ["serde"], optional = true }
 icu_plurals = { workspace = true, default-features = false, features = ["serde", "experimental"], optional = true }
 icu_list = { workspace = true, default-features = false, features = ["serde"], optional = true }
-icu_casemap = { workspace = true, default-features = false, features = ["serde"], optional = true}
+icu_casemap = { workspace = true, default-features = false, features = ["serde"], optional = true }
 icu_segmenter = { workspace = true, default-features = false, features = ["auto", "serde"], optional = true }
 icu_decimal = { workspace = true, default-features = false, features = ["serde"], optional = true }
 writeable = { workspace = true, optional = true }
@@ -137,6 +137,7 @@ float-cmp = "0.9.0"
 indoc.workspace = true
 textwrap.workspace = true
 futures-lite = "2.3.0"
+test-case = "3.3.1"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
 jemallocator = "0.5.4"

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -1,20 +1,17 @@
 //! The ECMAScript context.
 
-mod hooks;
-#[cfg(feature = "intl")]
-pub(crate) mod icu;
-pub mod intrinsics;
-
-use boa_parser::source::ReadChar;
-pub use hooks::{DefaultHooks, HostHooks};
-
-#[cfg(feature = "intl")]
-pub use icu::IcuError;
-
-use intrinsics::Intrinsics;
-
 use std::{cell::Cell, path::Path, rc::Rc};
 
+use boa_ast::StatementList;
+use boa_interner::Interner;
+use boa_parser::source::ReadChar;
+use boa_profiler::Profiler;
+pub use hooks::{DefaultHooks, HostHooks};
+#[cfg(feature = "intl")]
+pub use icu::IcuError;
+use intrinsics::Intrinsics;
+
+use crate::vm::RuntimeLimits;
 use crate::{
     builtins,
     class::{Class, ClassBuilder},
@@ -30,13 +27,13 @@ use crate::{
     vm::{ActiveRunnable, CallFrame, Vm},
     JsNativeError, JsResult, JsString, JsValue, Source,
 };
-use boa_ast::StatementList;
-use boa_interner::Interner;
-use boa_profiler::Profiler;
-
-use crate::vm::RuntimeLimits;
 
 use self::intrinsics::StandardConstructor;
+
+mod hooks;
+#[cfg(feature = "intl")]
+pub(crate) mod icu;
+pub mod intrinsics;
 
 thread_local! {
     static CANNOT_BLOCK_COUNTER: Cell<u64> = const { Cell::new(0) };

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -26,7 +26,18 @@ use super::Module;
 ///
 /// # Examples
 /// ```
-///
+/// # use std::path::Path;
+/// # use boa_engine::{Context, js_string};
+/// # use boa_engine::module::resolve_module_specifier;
+/// assert_eq!(
+///     resolve_module_specifier(
+///         Some(Path::new("/base")),
+///         &js_string!("../a.js"),
+///         Some(Path::new("/base/hello/ref.js")),
+///         &mut Context::default()
+///     ),
+///     Ok("/base/a.js".into())
+/// );
 /// ```
 pub fn resolve_module_specifier(
     base: Option<&Path>,

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -5,11 +5,11 @@ use rustc_hash::FxHashMap;
 use boa_gc::GcRefCell;
 use boa_parser::Source;
 
-use crate::script::Script;
 use crate::{
-    js_string, object::JsObject, realm::Realm, vm::ActiveRunnable, Context, JsError, JsNativeError,
-    JsResult, JsString,
+    Context, js_string, JsError, JsNativeError, JsResult, JsString, object::JsObject,
+    realm::Realm, vm::ActiveRunnable,
 };
+use crate::script::Script;
 
 use super::Module;
 
@@ -26,7 +26,8 @@ use super::Module;
 ///
 /// # Examples
 /// ```
-/// #![cfg(target_family = "unix")]
+/// #[cfg(target_family = "unix")]
+/// # {
 /// # use std::path::Path;
 /// # use boa_engine::{Context, js_string};
 /// # use boa_engine::module::resolve_module_specifier;
@@ -39,6 +40,7 @@ use super::Module;
 ///     ),
 ///     Ok("/base/a.js".into())
 /// );
+/// # }
 /// ```
 pub fn resolve_module_specifier(
     base: Option<&Path>,

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -5,11 +5,11 @@ use rustc_hash::FxHashMap;
 use boa_gc::GcRefCell;
 use boa_parser::Source;
 
-use crate::script::Script;
 use crate::{
-    js_string, object::JsObject, realm::Realm, vm::ActiveRunnable, Context, JsError, JsNativeError,
-    JsResult, JsString,
+    Context, js_string, JsError, JsNativeError, JsResult, JsString, object::JsObject,
+    realm::Realm, vm::ActiveRunnable,
 };
+use crate::script::Script;
 
 use super::Module;
 
@@ -353,12 +353,12 @@ mod tests {
 
     #[rustfmt::skip]
     #[cfg(target_family = "windows")]
-    #[test_case(Some("d:\\hello\\ref.js"),       "a.js",                Ok("a:\\base\\a.js"))]
-    #[test_case(Some("d:\\base\\ref.js"),        ".\\b.js",             Ok("a:\\base\\b.js"))]
-    #[test_case(Some("d:\\base\\other\\ref.js"), ".\\c.js",             Ok("a:\\base\\other\\c.js"))]
-    #[test_case(Some("d:\\base\\other\\ref.js"), "..\\d.js",            Ok("a:\\base\\d.js"))]
-    #[test_case(Some("d:\\base\\ref.js"),        "e.js",                Ok("a:\\base\\e.js"))]
-    #[test_case(Some("d:\\base\\ref.js"),        ".\\f.js",             Ok("a:\\base\\f.js"))]
+    #[test_case(Some("a:\\hello\\ref.js"),       "a.js",                Ok("a:\\base\\a.js"))]
+    #[test_case(Some("a:\\base\\ref.js"),        ".\\b.js",             Ok("a:\\base\\b.js"))]
+    #[test_case(Some("a:\\base\\other\\ref.js"), ".\\c.js",             Ok("a:\\base\\other\\c.js"))]
+    #[test_case(Some("a:\\base\\other\\ref.js"), "..\\d.js",            Ok("a:\\base\\d.js"))]
+    #[test_case(Some("a:\\base\\ref.js"),        "e.js",                Ok("a:\\base\\e.js"))]
+    #[test_case(Some("a:\\base\\ref.js"),        ".\\f.js",             Ok("a:\\base\\f.js"))]
     #[test_case(Some(".\\ref.js"),               ".\\g.js",             Ok("a:\\base\\g.js"))]
     #[test_case(Some(".\\other\\ref.js"),        ".\\other\\h.js",      Ok("a:\\base\\other\\other\\h.js"))]
     #[test_case(Some(".\\other\\ref.js"),        ".\\other\\..\\h1.js", Ok("a:\\base\\other\\h1.js"))]

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -5,11 +5,11 @@ use rustc_hash::FxHashMap;
 use boa_gc::GcRefCell;
 use boa_parser::Source;
 
-use crate::{
-    Context, js_string, JsError, JsNativeError, JsResult, JsString, object::JsObject,
-    realm::Realm, vm::ActiveRunnable,
-};
 use crate::script::Script;
+use crate::{
+    js_string, object::JsObject, realm::Realm, vm::ActiveRunnable, Context, JsError, JsNativeError,
+    JsResult, JsString,
+};
 
 use super::Module;
 

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -26,6 +26,7 @@ use super::Module;
 ///
 /// # Examples
 /// ```
+/// #![cfg(target_family = "unix")]
 /// # use std::path::Path;
 /// # use boa_engine::{Context, js_string};
 /// # use boa_engine::module::resolve_module_specifier;

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -8,10 +8,13 @@
 //! [spec]: https://tc39.es/ecma262/#sec-scripts
 //! [script]: https://tc39.es/ecma262/#sec-script-records
 
+use std::path::{Path, PathBuf};
+
+use rustc_hash::FxHashMap;
+
 use boa_gc::{Finalize, Gc, GcRefCell, Trace};
 use boa_parser::{source::ReadChar, Parser, Source};
 use boa_profiler::Profiler;
-use rustc_hash::FxHashMap;
 
 use crate::{
     bytecompiler::ByteCompiler,
@@ -47,6 +50,7 @@ struct Inner {
     codeblock: GcRefCell<Option<Gc<CodeBlock>>>,
     loaded_modules: GcRefCell<FxHashMap<JsString, Module>>,
     host_defined: HostDefined,
+    path: Option<PathBuf>,
 }
 
 impl Script {
@@ -80,6 +84,7 @@ impl Script {
         context: &mut Context,
     ) -> JsResult<Self> {
         let _timer = Profiler::global().start_event("Script parsing", "Main");
+        let path = src.path().map(std::path::Path::to_path_buf);
         let mut parser = Parser::new(src);
         parser.set_identifier(context.next_parser_identifier());
         if context.is_strict() {
@@ -97,6 +102,7 @@ impl Script {
                 codeblock: GcRefCell::default(),
                 loaded_modules: GcRefCell::default(),
                 host_defined: HostDefined::default(),
+                path,
             }),
         })
     }
@@ -211,5 +217,9 @@ impl Script {
         self.realm().resize_global_env();
 
         Ok(())
+    }
+
+    pub(super) fn path(&self) -> Option<&Path> {
+        self.inner.path.as_deref()
     }
 }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -174,6 +174,12 @@ impl Vm {
             );
         }
 
+        // Keep carrying the last active runnable in case the current callframe
+        // yields.
+        if frame.active_runnable.is_none() {
+            frame.active_runnable = self.frames.last().and_then(|fr| fr.active_runnable.clone());
+        }
+
         self.frames.push(frame);
     }
 

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -19,7 +19,7 @@ fn subdirectories() {
         .build()
         .unwrap();
 
-    let source = Source::from_bytes(b"export { file1 } from './file1.js';");
+    let source = Source::from_bytes(b"export { file1 } from 'file1.js';");
     let module = boa_engine::Module::parse(source, None, &mut context).unwrap();
     let result = module.load_link_evaluate(&mut context);
 

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -9,37 +9,40 @@
     clippy::cast_precision_loss
 )]
 
-mod edition;
-mod exec;
-mod read;
-mod results;
-
-use self::{
-    read::{read_harness, read_suite, read_test, MetaData, Negative, TestFlag},
-    results::{compare_results, write_json},
-};
-use bitflags::bitflags;
-use boa_engine::optimizer::OptimizerOptions;
-use clap::{ArgAction, Parser, ValueHint};
-use color_eyre::{
-    eyre::{bail, eyre, WrapErr},
-    Result,
-};
-use colored::Colorize;
-use edition::SpecEdition;
-use once_cell::sync::Lazy;
-use read::ErrorType;
-use rustc_hash::{FxHashMap, FxHashSet};
-use serde::{
-    de::{Unexpected, Visitor},
-    Deserialize, Deserializer, Serialize,
-};
 use std::{
     ops::{Add, AddAssign},
     path::{Path, PathBuf},
     process::Command,
     time::Instant,
 };
+
+use bitflags::bitflags;
+use clap::{ArgAction, Parser, ValueHint};
+use color_eyre::{
+    eyre::{bail, eyre, WrapErr},
+    Result,
+};
+use colored::Colorize;
+use once_cell::sync::Lazy;
+use rustc_hash::{FxHashMap, FxHashSet};
+use serde::{
+    de::{Unexpected, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+
+use boa_engine::optimizer::OptimizerOptions;
+use edition::SpecEdition;
+use read::ErrorType;
+
+use self::{
+    read::{read_harness, read_suite, read_test, MetaData, Negative, TestFlag},
+    results::{compare_results, write_json},
+};
+
+mod edition;
+mod exec;
+mod read;
+mod results;
 
 static START: Lazy<Instant> = Lazy::new(Instant::now);
 
@@ -225,7 +228,9 @@ fn main() -> Result<()> {
                 clone_test262(test262_commit, verbose)?;
 
                 Path::new(DEFAULT_TEST262_DIRECTORY)
-            };
+            }
+            .canonicalize();
+            let test262_path = &test262_path.wrap_err("could not get the Test262 path")?;
 
             run_test_suite(
                 &config,

--- a/tests/tester/src/read.rs
+++ b/tests/tester/src/read.rs
@@ -1,19 +1,21 @@
 //! Module to read the list of test suites from disk.
 
-use crate::{HarnessFile, Ignored};
+use std::{
+    ffi::OsStr,
+    fs, io,
+    path::{Path, PathBuf},
+};
 
-use super::{Harness, Locale, Phase, Test, TestSuite};
 use color_eyre::{
     eyre::{eyre, WrapErr},
     Result,
 };
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
-use std::{
-    ffi::OsStr,
-    fs, io,
-    path::{Path, PathBuf},
-};
+
+use crate::{HarnessFile, Ignored};
+
+use super::{Harness, Locale, Phase, Test, TestSuite};
 
 /// Representation of the YAML metadata in Test262 tests.
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
We do have the path in parsed `Script` (if the `Source` has it), so use that if we can.

Fixes #3790.