### PR TITLE
Build docs.rs docs with all features enabled

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -39,3 +39,6 @@ path = "src/main.rs"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/ast/Cargo.toml
+++ b/core/ast/Cargo.toml
@@ -26,3 +26,6 @@ indexmap.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -153,3 +153,6 @@ harness = false
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/gc/Cargo.toml
+++ b/core/gc/Cargo.toml
@@ -26,3 +26,6 @@ icu_locid = { workspace = true, optional = true }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/icu_provider/Cargo.toml
+++ b/core/icu_provider/Cargo.toml
@@ -22,3 +22,6 @@ std = ["once_cell/std"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/interner/Cargo.toml
+++ b/core/interner/Cargo.toml
@@ -28,3 +28,6 @@ hashbrown = { workspace = true, default-features = false, features = ["inline-mo
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/interop/Cargo.toml
+++ b/core/interop/Cargo.toml
@@ -17,3 +17,6 @@ rustc-hash = { workspace = true, features = ["std"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -19,3 +19,6 @@ synstructure = "0.13"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/parser/Cargo.toml
+++ b/core/parser/Cargo.toml
@@ -28,3 +28,6 @@ annex-b = []
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/profiler/Cargo.toml
+++ b/core/profiler/Cargo.toml
@@ -20,3 +20,6 @@ rustc-hash = { workspace = true, optional = true }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/core/runtime/Cargo.toml
+++ b/core/runtime/Cargo.toml
@@ -21,3 +21,6 @@ textwrap.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -56,3 +56,6 @@ suspicious = "warn"
 style = "warn"
 complexity = "warn"
 perf = "warn"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -30,3 +30,6 @@ bench = false
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,3 +10,6 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tests/fuzz/Cargo.toml
+++ b/tests/fuzz/Cargo.toml
@@ -40,3 +40,5 @@ name = "bytecompiler-implied"
 path = "fuzz_targets/bytecompiler-implied.rs"
 test = false
 doc = false
+[package.metadata.docs.rs]
+all-features = true

--- a/tests/macros/Cargo.toml
+++ b/tests/macros/Cargo.toml
@@ -16,3 +16,6 @@ boa_engine.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tests/tester/Cargo.toml
+++ b/tests/tester/Cargo.toml
@@ -36,3 +36,6 @@ default = ["boa_engine/intl_bundled", "boa_engine/experimental", "boa_engine/ann
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tools/gen-icu4x-data/Cargo.toml
+++ b/tools/gen-icu4x-data/Cargo.toml
@@ -30,3 +30,6 @@ icu_segmenter = { workspace = true, features = ["datagen"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/tools/scripts/Cargo.toml
+++ b/tools/scripts/Cargo.toml
@@ -12,3 +12,6 @@ simple_logger.workspace = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Currently, the documentation of our crates on docs.rs doesn't show gated items. This PR solves that by adding the corresponding metadata on the Cargo.toml file.