### PR TITLE
Bump ICU4X to 1.5 and cleanup Intl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
- "gimli 0.28.1",
+ "gimli",
 ]
 
 [[package]]
@@ -16,17 +16,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
 
 [[package]]
 name = "ahash"
@@ -150,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "c8828ec6e544c02b0d6691d21ed9f9218d0384a82542855073c2a3f58304aaf0"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -280,15 +269,9 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object 0.32.2",
+ "object",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -312,25 +295,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
-dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
-]
-
-[[package]]
 name = "blocking"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
  "async-channel 2.3.1",
- "async-lock",
  "async-task",
  "futures-io",
  "futures-lite 2.3.0",
@@ -345,7 +315,7 @@ dependencies = [
  "bitflags 2.5.0",
  "boa_interner",
  "boa_macros",
- "indexmap 2.2.6",
+ "indexmap",
  "num-bigint",
  "rustc-hash",
  "serde",
@@ -393,7 +363,7 @@ dependencies = [
  "fixed_decimal",
  "float-cmp",
  "futures-lite 2.3.0",
- "hashbrown 0.14.5",
+ "hashbrown",
  "icu_calendar",
  "icu_casemap",
  "icu_collator",
@@ -406,10 +376,10 @@ dependencies = [
  "icu_plurals",
  "icu_provider",
  "icu_segmenter",
- "indexmap 2.2.6",
+ "indexmap",
  "indoc",
  "intrusive-collections",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "jemallocator",
  "num-bigint",
  "num-integer",
@@ -425,6 +395,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sptr",
+ "static_assertions",
  "sys-locale",
  "tap",
  "temporal_rs",
@@ -432,7 +403,7 @@ dependencies = [
  "textwrap",
  "thin-vec",
  "thiserror",
- "time 0.3.36",
+ "time",
  "tinystr",
  "web-time",
  "writeable",
@@ -453,7 +424,7 @@ dependencies = [
  "futures-util",
  "isahc",
  "smol",
- "time 0.3.36",
+ "time",
 ]
 
 [[package]]
@@ -463,7 +434,7 @@ dependencies = [
  "boa_macros",
  "boa_profiler",
  "boa_string",
- "hashbrown 0.14.5",
+ "hashbrown",
  "icu_locid",
  "thin-vec",
 ]
@@ -485,8 +456,8 @@ dependencies = [
  "arbitrary",
  "boa_gc",
  "boa_macros",
- "hashbrown 0.14.5",
- "indexmap 2.2.6",
+ "hashbrown",
+ "indexmap",
  "once_cell",
  "phf",
  "rustc-hash",
@@ -510,7 +481,7 @@ version = "0.18.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "synstructure",
 ]
 
@@ -591,7 +562,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_yaml",
- "time 0.3.36",
+ "time",
  "toml 0.8.13",
 ]
 
@@ -624,28 +595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive",
- "ptr_meta",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "bytemuck"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,13 +605,13 @@ dependencies = [
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
+checksum = "1ee891b04274a59bd38b412188e24b849617b2e45a0fd8d057deb63e7403761b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -679,9 +628,9 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "calendrical_calculations"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dfe3bc6a50b4667fafdb6d9cf26731c5418c457e317d8166c972014facf9a5d"
+checksum = "cec493b209a1b81fa32312d7ceca1b547d341c7b5f16a3edbf32b1d8b455bbdf"
 dependencies = [
  "core_maths",
  "displaydoc",
@@ -713,7 +662,7 @@ checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.23",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -807,7 +756,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -906,12 +855,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
-
-[[package]]
 name = "core_maths"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,23 +864,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "corosensei"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80128832c58ea9cbd041d2a759ec449224487b2c1e400453d99d244eead87a8e"
-dependencies = [
- "autocfg",
- "cfg-if",
- "libc",
- "scopeguard",
- "windows-sys 0.33.0",
-]
-
-[[package]]
 name = "crc32fast"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58ebf8d6963185c7625d2c3c3962d99eb8936637b1427536d21dc36ae402ebad"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1078,47 +1008,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b2eb4d90d12bdda5ed17de686c2acb4c57914f8f921b8da7e112b5a36f3fe1"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622687fe0bac72a04e5599029151f5796111b90f1baaa9b544d807a5e31cd120"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "733cabb43482b1a1b53eee8583c2b9e8684d592215ea83efd305dd31bc2f0178"
-dependencies = [
- "darling_core",
- "quote",
- "syn 2.0.66",
-]
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.5",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1126,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "databake"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82175d72e69414ceafbe2b49686794d3a8bed846e0d50267355f83ea8fdd953a"
+checksum = "6a04fbfbecca8f0679c8c06fef907594adcc3e2052e11163a6d30535a1a5604d"
 dependencies = [
  "databake-derive",
  "proc-macro2",
@@ -1137,21 +1033,21 @@ dependencies = [
 
 [[package]]
 name = "databake-derive"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377af281d8f23663862a7c84623bc5dcf7f8c44b13c7496a590bdc157f941a43"
+checksum = "4078275de501a61ceb9e759d37bdd3d7210e654dbc167ac1a3678ef4435ed57b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "deduplicating_array"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a636096586ca093a10ac0175bfb384d024089dca0dae54e3e69bc1c1596358e8"
+checksum = "1d579f0dbb23612a78e2d3a483dd1bff5edafa84592d15ba5eb5e3fd689b7d98"
 dependencies = [
  "serde",
 ]
@@ -1173,7 +1069,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -1193,12 +1089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
-
-[[package]]
 name = "displaydoc"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,34 +1096,14 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
-name = "dynasm"
-version = "1.2.3"
+name = "downcast-rs"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm",
- "memmap2 0.5.10",
-]
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
@@ -1263,47 +1133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enum-iterator"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eeac5c5edb79e4e39fe8439ef35207780a11f69c52cbe424ce3dfad4cb78de6"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "enumset"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226c0da7462c13fb57e5cc9e0dc8f0635e7d27f276a3a7fd30054647f669007d"
-dependencies = [
- "enumset_derive",
-]
-
-[[package]]
-name = "enumset_derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08b6c6ab82d70f08844964ba10c7babb716de2ecaeab9be5717918a5177d3af"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn 2.0.66",
 ]
 
 [[package]]
@@ -1396,12 +1225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
-
-[[package]]
 name = "fast-float"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,9 +1247,9 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fixed_decimal"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc7fdec9d7f6671a3ebb3282c969962aba67c49f6abac5311959b65cafabc10"
+checksum = "0febbeb1118a9ecdee6e4520ead6b54882e843dd0592ad233247dbee84c53db8"
 dependencies = [
  "displaydoc",
  "ryu",
@@ -1467,12 +1290,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "funty"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures-core"
@@ -1522,7 +1339,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -1559,20 +1376,9 @@ dependencies = [
  "icu_normalizer",
  "icu_plurals",
  "icu_provider",
- "icu_provider_blob",
  "icu_segmenter",
  "log",
  "simple_logger",
- "winapi",
-]
-
-[[package]]
-name = "generational-arena"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877e94aff08e743b651baaea359664321055749b398adff8740a7399af7796e7"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1586,17 +1392,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator",
- "indexmap 1.9.3",
- "stable_deref_trait",
 ]
 
 [[package]]
@@ -1623,29 +1418,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -1668,15 +1445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "home"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,10 +1456,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_calendar"
-version = "1.4.0"
+name = "icu"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb932a690c92f87955e923106181ee0d5682e688ff37fb5c7b296e1fe806edb"
+checksum = "dff5e3018d703f168b00dcefa540a65f1bbc50754ae32f3f5f0e43fe5ee51502"
+dependencies = [
+ "icu_calendar",
+ "icu_casemap",
+ "icu_collator",
+ "icu_collections",
+ "icu_datetime",
+ "icu_decimal",
+ "icu_experimental",
+ "icu_list",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer",
+ "icu_plurals",
+ "icu_properties",
+ "icu_provider",
+ "icu_segmenter",
+ "icu_timezone",
+]
+
+[[package]]
+name = "icu_calendar"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4231cddf3dcbfc21e04bb52768f18e11a077d2935774eabdf7b239bb83bf3882"
 dependencies = [
  "calendrical_calculations",
  "databake",
@@ -1708,15 +1500,15 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22aec7d032735d9acb256eeef72adcac43c3b7572f19b51576a63d664b524ca2"
+checksum = "8e009b7f0151ee6fb28c40b1283594397e0b7183820793e9ace3dcd13db126d0"
 
 [[package]]
 name = "icu_casemap"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7988d4f2655012592ac5b027722a93fbe12ff2a86d3e0f9ae686aedba0984f5e"
+checksum = "a7701c9ff229dae365623cfb1b24c86552fe3a8e82877f9a75400b95452a9c02"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1731,27 +1523,25 @@ dependencies = [
 
 [[package]]
 name = "icu_codepointtrie_builder"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6030944910d61b4d2832e89b866f5f7961c22c70a73c9aeccffe57eaa3707418"
+checksum = "c41aa8d27817174c88860a3227fa5cc50cf2d915367f626d56f5711dd8a2e22a"
 dependencies = [
  "icu_collections",
- "once_cell",
  "toml 0.5.11",
- "wasmer",
- "wasmer-wasi",
+ "wasmi",
+ "zerovec",
 ]
 
 [[package]]
 name = "icu_collator"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2a45056e541cffde068f5c81ac1c0503b9ee2a4b967546422e509c5c653750"
+checksum = "d370371887d31d56f361c3eaa15743e54f13bc677059c9191c77e099ed6966b2"
 dependencies = [
  "databake",
  "displaydoc",
  "icu_collections",
- "icu_locid",
  "icu_normalizer",
  "icu_properties",
  "icu_provider",
@@ -1764,9 +1554,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137d96353afc8544d437e8a99eceb10ab291352699573b0de5b08bda38c78c60"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1778,13 +1568,15 @@ dependencies = [
 
 [[package]]
 name = "icu_datagen"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a21dec81a41daa5848ed26b230c90656616d4e35557a88a683e311773faa01d"
+checksum = "d1e80c1b833419752592da4d8a37239f6f11dd04dc3c0048f90acc000b17f4a9"
 dependencies = [
+ "calendrical_calculations",
  "displaydoc",
  "either",
  "elsa",
+ "icu",
  "icu_calendar",
  "icu_casemap",
  "icu_codepointtrie_builder",
@@ -1792,21 +1584,29 @@ dependencies = [
  "icu_collections",
  "icu_datetime",
  "icu_decimal",
+ "icu_experimental",
  "icu_list",
  "icu_locid",
  "icu_locid_transform",
  "icu_normalizer",
+ "icu_pattern",
  "icu_plurals",
  "icu_properties",
  "icu_provider",
  "icu_provider_adapters",
+ "icu_provider_blob",
  "icu_segmenter",
  "icu_timezone",
  "itertools 0.10.5",
+ "litemap",
  "log",
  "memchr",
  "ndarray",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
  "once_cell",
+ "rayon",
  "serde",
  "serde-aux",
  "serde_json",
@@ -1822,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "icu_datetime"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1508c7ed627cc0b031c81203eb98f34433e24b32b39d5b2c0238e4962a00957d"
+checksum = "ea57d14f11efa0425216b4e183db61dd23e1bb1357a86009308de18812bb860e"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1846,24 +1646,55 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf994f9ed8061c17bb313f28fba6cffc736f0a16c7fab827efc9b73fd3f7778"
+checksum = "fb8fd98f86ec0448d85e1edf8884e4e318bb2e121bd733ec929a05c0a5e8b0eb"
 dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "icu_locid",
  "icu_provider",
  "serde",
  "writeable",
 ]
 
 [[package]]
-name = "icu_list"
-version = "1.4.0"
+name = "icu_experimental"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6c04ec71ad1bacdbfb47164d4801f80a0533d9340f94f1a880f521eff59f54"
+checksum = "844ad7b682a165c758065d694bc4d74ac67f176da1c499a04d85d492c0f193b7"
+dependencies = [
+ "databake",
+ "displaydoc",
+ "fixed_decimal",
+ "icu_collections",
+ "icu_decimal",
+ "icu_locid",
+ "icu_locid_transform",
+ "icu_normalizer",
+ "icu_pattern",
+ "icu_plurals",
+ "icu_properties",
+ "icu_provider",
+ "litemap",
+ "log",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "serde",
+ "smallvec",
+ "tinystr",
+ "writeable",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_list"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfeda1d7775b6548edd4e8b7562304a559a91ed56ab56e18961a053f367c365"
 dependencies = [
  "databake",
  "deduplicating_array",
@@ -1876,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0aa2536adc14c07e2a521e95512b75ed8ef832f0fdf9299d4a0a45d2be2a9d"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1891,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c17d8f6524fdca4471101dd71f0a132eb6382b5d6d7f2970441cb25f6f435a"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1907,15 +1738,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locid_transform_data"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545c6c3e8bf9580e2dafee8de6f9ec14826aaf359787789c7724f1f85f47d3dc"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
 
 [[package]]
 name = "icu_normalizer"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183072b0ba2f336279c830a3d594a04168494a726c3c94b50c53d788178cf2c2"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1933,20 +1764,34 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22026918a80e6a9a330cb01b60f950e2b4e5284c59528fd0c6150076ef4c8522"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_pattern"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f36aafd098d6717de34e668a8120822275c1fba22b936e757b7de8a2fd7e4"
+dependencies = [
+ "databake",
+ "displaydoc",
+ "either",
+ "serde",
+ "writeable",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "icu_plurals"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d807b123eb2a9ae8f12080fb8cce479f5c8a761fba0bb5ab52da6dd5e31a03"
+checksum = "ba5a70e7c025dbd5c501b0a5c188cd11666a424f0dadcd4f0a95b7dafde3b114"
 dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "icu_locid",
  "icu_provider",
  "serde",
  "zerovec",
@@ -1954,9 +1799,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a89401989d8fdf571b829ce1022801367ec89affc7b1e162b79eff4ae029e69"
+checksum = "1f8ac670d7422d7f76b32e17a5db556510825b29ec9154f235977c9caba61036"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1971,15 +1816,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70a8b51ee5dd4ff8f20ee9b1dd1bc07afc110886a3747b1fec04cc6e5a15815"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba58e782287eb6950247abbf11719f83f5d4e4a5c1f2cd490d30a334bc47c2f4"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "databake",
  "displaydoc",
@@ -1999,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_adapters"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a229f978260da7c3aabb68cb7dc7316589936680570fe55e50fdd3f97711a4dd"
+checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
 dependencies = [
  "icu_locid",
  "icu_locid_transform",
@@ -2013,9 +1858,9 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_blob"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7202cddda672db167c6352719959e9b01cb1ca576d32fa79103f61b5a73601"
+checksum = "c24b98d1365f55d78186c205817631a4acf08d7a45bdf5dc9dcf9c5d54dccf51"
 dependencies = [
  "icu_provider",
  "log",
@@ -2028,20 +1873,20 @@ dependencies = [
 
 [[package]]
 name = "icu_provider_macros"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2abdd3a62551e8337af119c5899e600ca0c88ec8f23a46c60ba216c803dcf1a"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "icu_segmenter"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dc1e8f4ba33a6a4956770ac5c08570f255d6605519fb3a859a0c0a270a2f8f"
+checksum = "a717725612346ffc2d7b42c94b820db6908048f39434504cb130e8b46256b0de"
 dependencies = [
  "core_maths",
  "databake",
@@ -2056,26 +1901,19 @@ dependencies = [
 
 [[package]]
 name = "icu_timezone"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35aabe571a7c653c0f543ff1512b8a1b2ad481cfa24b3d25115298d2ff3b50f"
+checksum = "aa91ba6a585939a020c787235daa8aee856d9bceebd6355e283c0c310bc6de96"
 dependencies = [
  "databake",
  "displaydoc",
  "icu_calendar",
- "icu_locid",
  "icu_provider",
  "serde",
  "tinystr",
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2095,24 +1933,19 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
+
+[[package]]
+name = "indexmap-nostd"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indoc"
@@ -2135,7 +1968,7 @@ version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
 dependencies = [
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -2193,9 +2026,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2242,26 +2075,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "leb128"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libm"
@@ -2281,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.16"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
+checksum = "c15da26e5af7e25c90b37a2d75cdbf940cf4a55316de9d84c679c9b8bfabf82e"
 dependencies = [
  "cc",
  "libc",
@@ -2299,9 +2116,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d642685b028806386b2b6e75685faadd3eb65a85fff7df711ce18446a422da"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 dependencies = [
  "serde",
 ]
@@ -2323,45 +2140,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
-name = "loupe"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
-dependencies = [
- "indexmap 1.9.3",
- "loupe-derive",
- "rustversion",
-]
-
-[[package]]
-name = "loupe-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "matrixmultiply"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,7 +2156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa4a40f09af7aa6faef38285402a78847d0d72bf8827006cd2a332e1e6e4a8d"
 dependencies = [
  "log",
- "memmap2 0.2.3",
+ "memmap2",
  "parking_lot",
  "perf-event-open-sys",
  "rustc-hash",
@@ -2398,24 +2176,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -2447,12 +2207,6 @@ name = "mintex"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
-
-[[package]]
-name = "more-asserts"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "ndarray"
@@ -2516,6 +2270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,7 +2317,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -2562,18 +2327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap 1.9.3",
- "memchr",
 ]
 
 [[package]]
@@ -2633,9 +2386,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2705,7 +2458,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -2734,7 +2487,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -2768,9 +2521,9 @@ checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c224ba00d7cadd4d5c660deaf2098e5e80e07846537c51f9cfa4be50c1fd45"
+checksum = "a15b6eccb8484002195a3e44fe65a4ce8e93a625797a063735536fd59cb01cf3"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2781,15 +2534,15 @@ dependencies = [
 
 [[package]]
 name = "plotters-backend"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e76628b4d3a7581389a35d5b6e2139607ad7c75b17aed325f210aa91f4a9609"
+checksum = "414cec62c6634ae900ea1c56128dfe87cf63e7caece0852ec76aba307cebadb7"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
+checksum = "81b30686a7d9c3e010b84284bdd26a29f2138574f52f5eb6f794fc0ad924e705"
 dependencies = [
  "plotters-backend",
 ]
@@ -2870,62 +2623,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -2936,12 +2639,6 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3054,34 +2751,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
-name = "region"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
- "mach2",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "regress"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eae2a1ebfecc58aff952ef8ccd364329abe627762f5bf09ff42eb9d98522479"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
  "memchr",
-]
-
-[[package]]
-name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck",
 ]
 
 [[package]]
@@ -3100,35 +2776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rkyv"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
-dependencies = [
- "bitvec",
- "bytecheck",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta",
- "rend",
- "rkyv_derive",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3139,15 +2786,6 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
 
 [[package]]
 name = "rustix"
@@ -3227,7 +2865,7 @@ checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3282,21 +2920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3304,12 +2927,6 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -3331,15 +2948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,7 +2955,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3369,7 +2977,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3387,27 +2995,12 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
  "unsafe-libyaml",
 ]
-
-[[package]]
-name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sharded-slab"
@@ -3428,20 +3021,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "simdutf8"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
-
-[[package]]
 name = "simple_logger"
-version = "4.3.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
 dependencies = [
  "colored",
  "log",
- "time 0.3.36",
+ "time",
  "windows-sys 0.48.0",
 ]
 
@@ -3532,68 +3119,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -3617,7 +3146,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3625,17 +3154,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -3656,7 +3174,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3675,28 +3193,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
-
-[[package]]
-name = "tempfile"
-version = "3.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
-dependencies = [
- "cfg-if",
- "fastrand 2.1.0",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "temporal_rs"
 version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460e114a8c5282e7370dff89d53c48f347b3d405cfb8397073eb41a937b189a9"
+source = "git+https://github.com/boa-dev/temporal.git?rev=61a05fbb7c72353deda72a3df0e6887d65b840d2#61a05fbb7c72353deda72a3df0e6887d65b840d2"
 dependencies = [
  "bitflags 2.5.0",
  "icu_calendar",
@@ -3733,7 +3232,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3744,7 +3243,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "test-case-core",
 ]
 
@@ -3782,7 +3281,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -3803,21 +3302,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
@@ -3831,7 +3315,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.18",
+ "time-macros",
 ]
 
 [[package]]
@@ -3839,16 +3323,6 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
-
-[[package]]
-name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
 
 [[package]]
 name = "time-macros"
@@ -3861,23 +3335,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tinystr"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c02bf3c538ab32ba913408224323915f4ef9a6d61c0e85d493f355921c0ece"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "databake",
  "displaydoc",
@@ -3946,7 +3407,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "toml_datetime",
  "winnow 0.5.40",
 ]
@@ -3957,11 +3418,11 @@ version = "0.22.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c127785850e8c20836d49732ae6abfa47616e60bf9d9f57c43c250361a9db96c"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.8",
+ "winnow 0.6.9",
 ]
 
 [[package]]
@@ -3984,7 +3445,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
@@ -4049,6 +3510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
+ "rand",
  "static_assertions",
 ]
 
@@ -4150,12 +3612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "uuid"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
-
-[[package]]
 name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,7 +3672,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -4250,7 +3706,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4283,284 +3739,48 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
-name = "wasmer"
-version = "2.3.0"
+name = "wasmi"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "77a8281d1d660cdf54c76a3efa9ddd0c270cada1383a995db3ccb43d166456c7"
 dependencies = [
- "cfg-if",
- "indexmap 1.9.3",
- "js-sys",
- "loupe",
- "more-asserts",
- "target-lexicon",
- "thiserror",
- "wasm-bindgen",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-compiler-singlepass",
- "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-compiler"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
-dependencies = [
- "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
  "smallvec",
- "target-lexicon",
- "thiserror",
- "wasmer-types",
- "wasmparser",
+ "spin",
+ "wasmi_arena",
+ "wasmi_core",
+ "wasmparser-nostd",
 ]
 
 [[package]]
-name = "wasmer-compiler-singlepass"
-version = "2.3.0"
+name = "wasmi_arena"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ca2a35204d8befa85062bc7aac259a8db8070b801b8a783770ba58231d729e"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
+
+[[package]]
+name = "wasmi_core"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
- "byteorder",
- "dynasm",
- "dynasmrt",
- "gimli 0.26.2",
- "lazy_static",
- "loupe",
- "more-asserts",
- "rayon",
- "smallvec",
- "wasmer-compiler",
- "wasmer-types",
+ "downcast-rs",
+ "libm",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]
-name = "wasmer-derive"
-version = "2.3.0"
+name = "wasmparser-nostd"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "indexmap-nostd",
 ]
-
-[[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2 0.5.10",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if",
- "enum-iterator",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-types"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
-dependencies = [
- "backtrace",
- "enum-iterator",
- "indexmap 1.9.3",
- "loupe",
- "more-asserts",
- "rkyv",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "wasmer-vfs"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9302eae3edc53cb540c2d681e7f16d8274918c1ce207591f04fed351649e97c0"
-dependencies = [
- "slab",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "wasmer-vm"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if",
- "corosensei",
- "enum-iterator",
- "indexmap 1.9.3",
- "lazy_static",
- "libc",
- "loupe",
- "mach",
- "memoffset 0.6.5",
- "more-asserts",
- "region",
- "rkyv",
- "scopeguard",
- "serde",
- "thiserror",
- "wasmer-artifact",
- "wasmer-types",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-wasi"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadbe31e3c1b6f3e398ad172b169152ae1a743ae6efd5f9ffb34019983319d99"
-dependencies = [
- "cfg-if",
- "generational-arena",
- "getrandom",
- "libc",
- "thiserror",
- "tracing",
- "wasm-bindgen",
- "wasmer",
- "wasmer-vfs",
- "wasmer-wasi-types",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-wasi-types"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
-dependencies = [
- "byteorder",
- "time 0.2.27",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
 
 [[package]]
 name = "web-sys"
@@ -4589,18 +3809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
 ]
 
 [[package]]
@@ -4633,19 +3841,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43dbb096663629518eb1dfa72d80243ca5a6aca764cae62a2df70af760a9be75"
-dependencies = [
- "windows_aarch64_msvc 0.33.0",
- "windows_i686_gnu 0.33.0",
- "windows_i686_msvc 0.33.0",
- "windows_x86_64_gnu 0.33.0",
- "windows_x86_64_msvc 0.33.0",
-]
 
 [[package]]
 name = "windows-sys"
@@ -4710,12 +3905,6 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd761fd3eb9ab8cc1ed81e56e567f02dd82c4c837e48ac3b2181b9ffc5060807"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -4725,12 +3914,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab0cf703a96bab2dc0c02c0fa748491294bf9b7feb27e1f4f96340f208ada0e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4752,12 +3935,6 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfdbe89cc9ad7ce618ba34abc34bbb6c36d99e96cae2245b7943cd75ee773d0"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -4767,12 +3944,6 @@ name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4dd9b0c0e9ece7bb22e84d70d01b71c6d6248b81a3c60d11869451b4cb24784"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4800,12 +3971,6 @@ checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1e4aa646495048ec7f3ffddc411e1d829c026a2ec62b39da15c1055e406eaa"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -4827,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "86c949fede1d13936a99f14fafd3e76fd642b556dd2ce96287fbe2e0151bfac6"
 dependencies = [
  "memchr",
 ]
@@ -4842,24 +4007,18 @@ checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad7bb64b8ef9c0aa27b6da38b452b0ee9fd82beaf276a87dd796fb55cbae14e"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 dependencies = [
- "tap",
+ "either",
 ]
 
 [[package]]
 name = "yoke"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e71b2e4f287f467794c671e2b8f8a5f3716b3c829079a1c44740148eff07e4"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4869,13 +4028,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e6936f0cce458098a201c245a11bef556c6a0181129c7034d10d76d1ec3a2b8"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "synstructure",
 ]
 
@@ -4896,41 +4055,41 @@ checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655b0814c5c0b19ade497851070c640773304939a6c0fd5f5fb43da0696d05b7"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6a647510471d372f2e6c2e6b7219e44d8c574d24fdc11c610a61455782f18c3"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerotrie"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0594125a0574fb93059c92c588ab209cc036a23d1baeb3410fa9181bea551a0"
+checksum = "fb594dd55d87335c5f60177cee24f19457a5ec10a065e0a3014722ad252d0a1f"
 dependencies = [
  "databake",
  "displaydoc",
@@ -4943,9 +4102,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff4439ae91fb5c72b8abc12f3f2dbf51bd27e6eadb9f8a5bc8898dddb0e27ea"
+checksum = "bb2cc8827d6c0994478a15c53f374f46fbd41bea663d809b14744bc42e6b109c"
 dependencies = [
  "databake",
  "serde",
@@ -4956,13 +4115,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4e5997cbf58990550ef1f0e5124a05e47e1ebd33a84af25739be6031a62c20"
+checksum = "97cf56601ee5052b4417d90c8755c6683473c926039908196cf35d99f893ebe7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ thin-vec = "0.2.13"
 time = {version = "0.3.36", default-features = false, features = ["local-offset", "large-dates", "wasm-bindgen", "parsing", "formatting", "macros"]}
 tinystr = "0.7.5"
 log = "0.4.21"
-simple_logger = "4.3.3"
+simple_logger = "5.0.0"
 cargo_metadata = "0.18.1"
 trybuild = "1.0.95"
 rayon = "1.10.0"
@@ -107,7 +107,7 @@ tap = "1.0.1"
 thiserror = "1.0.60"
 dashmap = "5.5.3"
 num_enum = "0.7.2"
-itertools = { version = "0.12.1", default-features = false }
+itertools = { version = "0.13.0", default-features = false }
 portable-atomic = "1.6.0"
 bytemuck = { version = "1.15.0", default-features = false }
 arrayvec = "0.7.4"
@@ -115,7 +115,7 @@ intrusive-collections = "0.9.6"
 cfg-if = "1.0.0"
 either = "1.12.0"
 sys-locale = "0.3.1"
-temporal_rs = "0.0.2"
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "61a05fbb7c72353deda72a3df0e6887d65b840d2" }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.9.0"
@@ -125,26 +125,26 @@ winapi = { version = "0.3.9", default-features = false }
 
 # ICU4X
 
-icu_provider = { version = "~1.4.0", default-features = false }
-icu_locid = { version = "~1.4.0", default-features = false }
-icu_locid_transform = { version = "~1.4.0", default-features = false }
-icu_datetime = { version = "~1.4.0", default-features = false }
-icu_calendar = { version = "~1.4.0", default-features = false }
-icu_collator = { version = "~1.4.0", default-features = false }
-icu_plurals = { version = "~1.4.0", default-features = false }
-icu_list = { version = "~1.4.0", default-features = false }
-icu_casemap = { version = "~1.4.0", default-features = false }
-icu_segmenter = { version = "~1.4.0", default-features = false }
-icu_datagen = { version = "~1.4.1", default-features = false }
-icu_provider_adapters = { version = "~1.4.0", default-features = false }
-icu_provider_blob = { version = "~1.4.0", default-features = false }
-icu_properties = { version = "~1.4.1", default-features = true }
-icu_normalizer = { version = "~1.4.2", default-features = false }
-icu_decimal = { version = "~1.4.0", default-features = false }
-writeable = "~0.5.4"
-yoke = "~0.7.3"
-zerofrom = "~0.1.3"
-fixed_decimal = "~0.5.5"
+icu_provider = { version = "~1.5.0", default-features = false }
+icu_locid = { version = "~1.5.0", default-features = false }
+icu_locid_transform = { version = "~1.5.0", default-features = false }
+icu_datetime = { version = "~1.5.0", default-features = false }
+icu_calendar = { version = "~1.5.0", default-features = false }
+icu_collator = { version = "~1.5.0", default-features = false }
+icu_plurals = { version = "~1.5.0", default-features = false }
+icu_list = { version = "~1.5.0", default-features = false }
+icu_casemap = { version = "~1.5.0", default-features = false }
+icu_segmenter = { version = "~1.5.0", default-features = false }
+icu_datagen = { version = "~1.5.0", default-features = false }
+icu_provider_adapters = { version = "~1.5.0", default-features = false }
+icu_provider_blob = { version = "~1.5.0", default-features = false }
+icu_properties = { version = "~1.5.0", default-features = true }
+icu_normalizer = { version = "~1.5.0", default-features = false }
+icu_decimal = { version = "~1.5.0", default-features = false }
+writeable = "~0.5.5"
+yoke = "~0.7.4"
+zerofrom = "~0.1.4"
+fixed_decimal = "~0.5.6"
 
 [workspace.metadata.workspaces]
 allow_branch = "main"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -105,6 +105,7 @@ cfg-if.workspace = true
 time.workspace = true
 hashbrown.workspace = true
 either = { workspace = true, optional = true }
+static_assertions.workspace = true
 
 # intl deps
 boa_icu_provider = { workspace = true, features = ["std"], optional = true }

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use super::{
-    locale::{canonicalize_locale_list, resolve_locale, supported_locales},
+    locale::{canonicalize_locale_list, filter_locales, resolve_locale},
     options::IntlOptions,
     Service,
 };
@@ -122,7 +122,7 @@ impl BuiltInConstructor for ListFormat {
         // 9. Let r be ResolveLocale(%ListFormat%.[[AvailableLocales]], requestedLocales, opt, %ListFormat%.[[RelevantExtensionKeys]], localeData).
         // 10. Set listFormat.[[Locale]] to r.[[locale]].
         let locale = resolve_locale::<Self>(
-            &requested_locales,
+            requested_locales,
             &mut IntlOptions {
                 matcher,
                 ..Default::default()
@@ -204,8 +204,8 @@ impl ListFormat {
         // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
         let requested_locales = canonicalize_locale_list(locales, context)?;
 
-        // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-        supported_locales::<<Self as Service>::LangMarker>(&requested_locales, options, context)
+        // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+        filter_locales::<<Self as Service>::LangMarker>(requested_locales, options, context)
             .map(JsValue::from)
     }
 

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -7,7 +7,7 @@ use icu_locid::{
     extensions::unicode::Value, extensions_unicode_key as key, extensions_unicode_value as value,
 };
 
-#[cfg(test)]
+#[cfg(all(test, feature = "intl_bundled"))]
 mod tests;
 
 mod utils;

--- a/core/engine/src/builtins/intl/locale/tests.rs
+++ b/core/engine/src/builtins/intl/locale/tests.rs
@@ -11,7 +11,7 @@ use icu_provider::{DataLocale, DataProvider, DataRequest, DataRequestMetadata};
 
 use crate::{
     builtins::intl::{
-        locale::{best_locale_for_provider, default_locale, resolve_locale},
+        locale::{default_locale, resolve_locale},
         options::{IntlOptions, LocaleMatcher},
         Service,
     },
@@ -88,7 +88,7 @@ fn locale_resolution() {
             hc: Some(HourCycle::H11),
         },
     };
-    let locale = resolve_locale::<TestService>(&[], &mut options, &provider);
+    let locale = resolve_locale::<TestService>([], &mut options, &provider);
     assert_eq!(locale, default);
 
     // test best fit
@@ -99,15 +99,8 @@ fn locale_resolution() {
         },
     };
 
-    let locale = resolve_locale::<TestService>(&[], &mut options, &provider);
-    let best = best_locale_for_provider::<<TestService as Service>::LangMarker>(
-        default.id.clone(),
-        &provider,
-    )
-    .unwrap();
-    let mut best = Locale::from(best);
-    best.extensions = locale.extensions.clone();
-    assert_eq!(locale, best);
+    let locale = resolve_locale::<TestService>([], &mut options, &provider);
+    assert_eq!(locale, default);
 
     // requested: [es-ES]
     let mut options = IntlOptions {
@@ -115,6 +108,6 @@ fn locale_resolution() {
         service_options: TestOptions { hc: None },
     };
 
-    let locale = resolve_locale::<TestService>(&[locale!("es-AR")], &mut options, &provider);
+    let locale = resolve_locale::<TestService>([locale!("es-AR")], &mut options, &provider);
     assert_eq!(locale, "es-u-hc-h23".parse().unwrap());
 }

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -14,18 +14,13 @@ use crate::{
 };
 
 use boa_macros::js_str;
-use icu_collator::provider::CollationMetadataV1Marker;
 use icu_locid::{
     extensions::unicode::{Key, Value},
     subtags::Variants,
     LanguageIdentifier, Locale,
 };
 use icu_locid_transform::LocaleCanonicalizer;
-use icu_provider::{
-    DataError, DataErrorKind, DataLocale, DataProvider, DataRequest, DataRequestMetadata,
-    KeyedDataMarker,
-};
-use icu_segmenter::provider::WordBreakDataV1Marker;
+use icu_provider::{DataLocale, DataProvider, DataRequest, DataRequestMetadata, KeyedDataMarker};
 use indexmap::IndexSet;
 
 use tap::TapOptional;
@@ -153,212 +148,108 @@ pub(crate) fn canonicalize_locale_list(
     Ok(seen.into_iter().collect())
 }
 
-/// Abstract operation `BestAvailableLocale ( availableLocales, locale )`
+/// Abstract operation [`LookupMatchingLocaleByPrefix ( availableLocales, requestedLocales )`][prefix]
+/// and [`LookupMatchingLocaleByBestFit ( availableLocales, requestedLocales )`][best]
 ///
-/// Compares the provided argument `locale`, which must be a String value with a
-/// structurally valid and canonicalized Unicode BCP 47 locale identifier, against
-/// the locales in `availableLocales` and returns either the longest non-empty prefix
-/// of `locale` that is an element of `availableLocales`, or undefined if there is no
-/// such element.
+/// Compares `requestedLocales`, which must be a `List` as returned by `CanonicalizeLocaleList`,
+/// against the locales in `availableLocales` and determines the best available language to
+/// meet the request.
 ///
-/// We only work with language identifiers, which have the same semantics
-/// but are a bit easier to manipulate.
+/// # Notes
 ///
-/// More information:
-///  - [ECMAScript reference][spec]
+/// - This differs a bit from the spec, since we don't have an `[[AvailableLocales]]`
+/// list to compare with. However, we can do data requests to a [`DataProvider`]
+/// in order to see if a certain [`Locale`] is supported.
 ///
-/// [spec]: https://tc39.es/ecma402/#sec-bestavailablelocale
-pub(crate) fn best_available_locale<M: KeyedDataMarker>(
-    candidate: LanguageIdentifier,
-    provider: &(impl DataProvider<M> + ?Sized),
-) -> Option<LanguageIdentifier> {
-    // 1. Let candidate be locale.
-    let mut candidate = candidate.into();
-    // 2. Repeat
-    loop {
-        // a. If availableLocales contains an element equal to candidate, return candidate.
-        // ICU4X requires doing data requests in order to check if a locale
-        // is part of the set of supported locales.
-        let response = DataProvider::<M>::load(
-            provider,
-            DataRequest {
-                locale: &candidate,
-                metadata: {
-                    let mut metadata = DataRequestMetadata::default();
-                    metadata.silent = true;
-                    metadata
-                },
-            },
-        );
+/// - Calling this function with a singleton `KeyedDataMarker` will always return `None`.
+///
+/// [prefix]: https://tc39.es/ecma402/#sec-lookupmatchinglocalebyprefix
+/// [best]: https://tc39.es/ecma402/#sec-lookupmatchinglocalebybestfit
+pub(crate) fn lookup_matching_locale_by_prefix<M: KeyedDataMarker>(
+    requested_locales: impl IntoIterator<Item = Locale>,
+    provider: &IntlProvider,
+) -> Option<Locale>
+where
+    IntlProvider: DataProvider<M>,
+{
+    // 1. For each element locale of requestedLocales, do
+    for locale in requested_locales {
+        // a. Let extension be empty.
+        // b. If locale contains a Unicode locale extension sequence, then
+        //     i. Set extension to the Unicode locale extension sequence of locale.
+        //     ii. Set locale to the String value that is locale with any Unicode locale extension sequences removed.
+        let mut locale = locale.clone();
+        let id = std::mem::take(&mut locale.id);
+        locale.extensions.transform.clear();
+        locale.extensions.private.clear();
 
-        match response {
-            Ok(req) => {
+        // c. Let prefix be locale.
+        let mut prefix = id.into();
+
+        // d. Repeat, while prefix is not the empty String,
+        // We don't use a `while !prefix.is_und()` because it could be that prefix is und at the start,
+        // so we need to make the request at least once.
+        loop {
+            // i. If availableLocales contains prefix, return the Record { [[locale]]: prefix, [[extension]]: extension }.
+            // ICU4X requires doing data requests in order to check if a locale
+            // is part of the set of supported locales.
+            let response = DataProvider::<M>::load(
+                provider,
+                DataRequest {
+                    locale: &prefix,
+                    metadata: {
+                        let mut metadata = DataRequestMetadata::default();
+                        metadata.silent = true;
+                        metadata
+                    },
+                },
+            );
+
+            if let Ok(req) = response {
                 // `metadata.locale` returns None when the provider doesn't have a fallback mechanism,
                 // but supports the required locale. However, if the provider has a fallback mechanism,
                 // this will return `Some(locale)`, where the locale is the used locale after applying
                 // the fallback algorithm, even if the used locale is exactly the same as the required
                 // locale.
                 match req.metadata.locale {
-                    // TODO: ugly hack to accept locales that fallback to "und" in the collator/segmenter services
-                    Some(loc)
-                        if loc == candidate
-                            || (loc.is_empty()
-                                && [
-                                    CollationMetadataV1Marker::KEY.path(),
-                                    WordBreakDataV1Marker::KEY.path(),
-                                ]
-                                .contains(&M::KEY.path())) =>
-                    {
-                        return Some(candidate.into_locale().id)
+                    Some(loc) if loc.get_langid() == prefix.get_langid() => {
+                        locale.id = loc.into_locale().id;
+                        return Some(locale);
                     }
-                    None => return Some(candidate.into_locale().id),
+                    None => {
+                        locale.id = prefix.into_locale().id;
+                        return Some(locale);
+                    }
                     _ => {}
                 }
             }
-            Err(DataError {
-                kind: DataErrorKind::ExtraneousLocale,
-                ..
-            }) => {
-                // This is essentially the same hack as above but for singleton keys
-                return Some(candidate.into_locale().id);
-            }
-            Err(_) => {}
-        }
 
-        // b. Let pos be the character index of the last occurrence of "-" (U+002D) within candidate. If that character does not occur, return undefined.
-        // c. If pos ≥ 2 and the character "-" occurs at index pos-2 of candidate, decrease pos by 2.
-        // d. Let candidate be the substring of candidate from position 0, inclusive, to position pos, exclusive.
-        //
-        // Since the definition of `LanguageIdentifier` allows us to manipulate it
-        // without using strings, we can replace these steps by a simpler
-        // algorithm.
-
-        if candidate.has_variants() {
-            let mut variants = candidate
-                .clear_variants()
-                .iter()
-                .copied()
-                .collect::<Vec<_>>();
-            variants.pop();
-            candidate.set_variants(Variants::from_vec_unchecked(variants));
-        } else if candidate.region().is_some() {
-            candidate.set_region(None);
-        } else if candidate.script().is_some() {
-            candidate.set_script(None);
-        } else {
-            return None;
-        }
-    }
-}
-
-/// Returns the locale resolved by the `provider` after using the ICU4X fallback
-/// algorithm with `candidate` (if the provider supports this), or None if the locale is not
-/// supported.
-pub(crate) fn best_locale_for_provider<M: KeyedDataMarker>(
-    candidate: LanguageIdentifier,
-    provider: &(impl DataProvider<M> + ?Sized),
-) -> Option<LanguageIdentifier> {
-    // another hack to the list...
-    // This time is because markers like `WordBreakDataV1Marker` throw an error if they receive
-    // a request with a locale, because they don't really need it. In this case, we can
-    // check if the key is one of those kinds and return the candidate as it is.
-    if M::KEY.metadata().singleton {
-        return Some(candidate);
-    }
-
-    let response = DataProvider::<M>::load(
-        provider,
-        DataRequest {
-            locale: &DataLocale::from(&candidate),
-            metadata: {
-                let mut md = DataRequestMetadata::default();
-                md.silent = true;
-                md
-            },
-        },
-    )
-    .ok()?;
-
-    if candidate == LanguageIdentifier::UND {
-        return Some(LanguageIdentifier::UND);
-    }
-
-    response
-        .metadata
-        .locale
-        .map(|dl| {
-            // TODO: ugly hack to accept locales that fallback to "und" in the collator/segmenter services
-            if [
-                CollationMetadataV1Marker::KEY.path(),
-                WordBreakDataV1Marker::KEY.path(),
-            ]
-            .contains(&M::KEY.path())
-                && dl.is_empty()
-            {
-                candidate.clone()
+            // ii. If prefix contains "-" (code unit 0x002D HYPHEN-MINUS), let pos be the index into prefix of the last occurrence of "-"; else let pos be 0.
+            // iii. Repeat, while pos ≥ 2 and the substring of prefix from pos - 2 to pos - 1 is "-",
+            //     1. Set pos to pos - 2.
+            // iv. Set prefix to the substring of prefix from 0 to pos.
+            // Since the definition of `LanguageIdentifier` allows us to manipulate it
+            // without using strings, we can replace these steps by a simpler
+            // algorithm.
+            if prefix.has_variants() {
+                let mut variants = prefix.clear_variants().iter().copied().collect::<Vec<_>>();
+                variants.pop();
+                prefix.set_variants(Variants::from_vec_unchecked(variants));
+            } else if prefix.region().is_some() {
+                prefix.set_region(None);
+            } else if prefix.script().is_some() {
+                prefix.set_script(None);
             } else {
-                dl.into_locale().id
+                break;
             }
-        })
-        .or(Some(candidate))
-        .filter(|loc| loc != &LanguageIdentifier::UND)
-}
-
-/// Abstract operation [`LookupMatcher ( availableLocales, requestedLocales )`][spec]
-///
-/// Compares `requestedLocales`, which must be a `List` as returned by `CanonicalizeLocaleList`,
-/// against the locales in `availableLocales` and determines the best available language to
-/// meet the request.
-///
-/// # Note
-///
-/// This differs a bit from the spec, since we don't have an `[[AvailableLocales]]`
-/// list to compare with. However, we can do data requests to a [`DataProvider`]
-/// in order to see if a certain [`Locale`] is supported.
-///
-/// [spec]: https://tc39.es/ecma402/#sec-lookupmatcher
-fn lookup_matcher<M: KeyedDataMarker>(
-    requested_locales: &[Locale],
-    provider: &IntlProvider,
-) -> Locale
-where
-    IntlProvider: DataProvider<M>,
-{
-    // 1. Let result be a new Record.
-    // 2. For each element locale of requestedLocales, do
-    for locale in requested_locales {
-        // a. Let noExtensionsLocale be the String value that is locale with any Unicode locale
-        //    extension sequences removed.
-        let mut locale = locale.clone();
-        let id = std::mem::take(&mut locale.id);
-        locale.extensions.transform.clear();
-        locale.extensions.private.clear();
-
-        // b. Let availableLocale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
-        let available_locale = best_available_locale::<M>(id, provider);
-
-        // c. If availableLocale is not undefined, then
-        if let Some(available_locale) = available_locale {
-            // i. Set result.[[locale]] to availableLocale.
-            // Assignment deferred. See return statement below.
-            // ii. If locale and noExtensionsLocale are not the same String value, then
-            // 1. Let extension be the String value consisting of the substring of the Unicode
-            //    locale extension sequence within locale.
-            // 2. Set result.[[extension]] to extension.
-            locale.id = available_locale;
-
-            // iii. Return result.
-            return locale;
         }
     }
 
-    // 3. Let defLocale be ! DefaultLocale().
-    // 4. Set result.[[locale]] to defLocale.
-    // 5. Return result.
-    default_locale(provider.locale_canonicalizer())
+    // 2. Return undefined.
+    None
 }
 
-/// Abstract operation [`BestFitMatcher ( availableLocales, requestedLocales )`][spec]
+/// Abstract operation [`LookupMatchingLocaleByBestFit ( availableLocales, requestedLocales )`][spec]
 ///
 /// Compares `requestedLocales`, which must be a `List` as returned by `CanonicalizeLocaleList`,
 /// against the locales in `availableLocales` and determines the best available language to
@@ -367,31 +258,50 @@ where
 /// produced by the `LookupMatcher` abstract operation.
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-bestfitmatcher
-fn best_fit_matcher<M: KeyedDataMarker>(
-    requested_locales: &[Locale],
+fn lookup_matching_locale_by_best_fit<M: KeyedDataMarker>(
+    requested_locales: impl IntoIterator<Item = Locale>,
     provider: &IntlProvider,
-) -> Locale
+) -> Option<Locale>
 where
     IntlProvider: DataProvider<M>,
 {
-    for mut locale in requested_locales
-        .iter()
-        .cloned()
-        .chain(std::iter::once_with(|| {
-            default_locale(provider.locale_canonicalizer())
-        }))
-    {
+    for mut locale in requested_locales {
         let id = std::mem::take(&mut locale.id);
+
+        // Only leave unicode extensions when returning the locale.
         locale.extensions.transform.clear();
         locale.extensions.private.clear();
 
-        if let Some(available) = best_locale_for_provider(id, provider) {
-            locale.id = available;
+        let Ok(response) = DataProvider::<M>::load(
+            provider,
+            DataRequest {
+                locale: &DataLocale::from(&id),
+                metadata: {
+                    let mut md = DataRequestMetadata::default();
+                    md.silent = true;
+                    md
+                },
+            },
+        ) else {
+            continue;
+        };
 
-            return locale;
+        if id == LanguageIdentifier::UND {
+            return Some(locale);
+        }
+
+        if let Some(id) = response
+            .metadata
+            .locale
+            .map(|dl| dl.into_locale().id)
+            .or(Some(id))
+            .filter(|loc| loc != &LanguageIdentifier::UND)
+        {
+            locale.id = id;
+            return Some(locale);
         }
     }
-    Locale::default()
+    None
 }
 
 /// Abstract operation `ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData )`
@@ -406,7 +316,7 @@ where
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-resolvelocale
 pub(in crate::builtins::intl) fn resolve_locale<S>(
-    requested_locales: &[Locale],
+    requested_locales: impl IntoIterator<Item = Locale>,
     options: &mut IntlOptions<S::LocaleOptions>,
     provider: &IntlProvider,
 ) -> Locale
@@ -416,15 +326,16 @@ where
 {
     // 1. Let matcher be options.[[localeMatcher]].
     // 2. If matcher is "lookup", then
-    //    a. Let r be ! LookupMatcher(availableLocales, requestedLocales).
+    //     a. Let r be LookupMatchingLocaleByPrefix(availableLocales, requestedLocales).
     // 3. Else,
-    //    a. Let r be ! BestFitMatcher(availableLocales, requestedLocales).
-    // 4. Let foundLocale be r.[[locale]].
+    //     a. Let r be LookupMatchingLocaleByBestFit(availableLocales, requestedLocales).
+    // 4. If r is undefined, set r to the Record { [[locale]]: DefaultLocale(), [[extension]]: empty }.
     let mut found_locale = if options.matcher == LocaleMatcher::Lookup {
-        lookup_matcher::<S::LangMarker>(requested_locales, provider)
+        lookup_matching_locale_by_prefix::<S::LangMarker>(requested_locales, provider)
     } else {
-        best_fit_matcher::<S::LangMarker>(requested_locales, provider)
-    };
+        lookup_matching_locale_by_best_fit::<S::LangMarker>(requested_locales, provider)
+    }
+    .unwrap_or_else(|| default_locale(provider.locale_canonicalizer()));
 
     // From here, the spec differs significantly from the implementation,
     // since ICU4X allows us to skip some steps and modularize the
@@ -485,62 +396,18 @@ where
     found_locale
 }
 
-/// Abstract operation [`LookupSupportedLocales ( availableLocales, requestedLocales )`][spec]
+/// Abstract operation [`FilterLocales ( availableLocales, requestedLocales, options )`][spec]
 ///
 /// Returns the subset of the provided BCP 47 language priority list requestedLocales for which
-/// `availableLocales` has a matching locale when using the BCP 47 Lookup algorithm. Locales appear
-/// in the same order in the returned list as in `requestedLocales`.
+/// availableLocales has a matching locale.
 ///
 /// # Note
 ///
-/// This differs a bit from the spec, since we don't have an `[[AvailableLocales]]`
-/// list to compare with. However, we can do data requests to a [`DataProvider`]
-/// in order to see if a certain [`Locale`] is supported.
-///
-/// [spec]: https://tc39.es/ecma402/#sec-lookupsupportedlocales
-fn lookup_supported_locales<M: KeyedDataMarker>(
-    requested_locales: &[Locale],
-    provider: &(impl DataProvider<M> + ?Sized),
-) -> Vec<Locale> {
-    // 1. Let subset be a new empty List.
-    // 2. For each element locale of requestedLocales, do
-    //     a. Let noExtensionsLocale be the String value that is locale with any Unicode locale extension sequences removed.
-    //     b. Let availableLocale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
-    //     c. If availableLocale is not undefined, append locale to the end of subset.
-    // 3. Return subset.
-    requested_locales
-        .iter()
-        .filter(|loc| best_available_locale(loc.id.clone(), provider).is_some())
-        .cloned()
-        .collect()
-}
-
-/// Abstract operation [`BestFitSupportedLocales ( availableLocales, requestedLocales )`][spec]
-///
-/// Returns the subset of the provided BCP 47 language priority list `requestedLocales` for which
-/// `availableLocales` has a matching locale when using the Best Fit Matcher algorithm. Locales appear
-/// in the same order in the returned list as in requestedLocales.
-///
-/// [spec]: https://tc39.es/ecma402/#sec-bestfitsupportedlocales
-fn best_fit_supported_locales<M: KeyedDataMarker>(
-    requested_locales: &[Locale],
-    provider: &(impl DataProvider<M> + ?Sized),
-) -> Vec<Locale> {
-    requested_locales
-        .iter()
-        .filter(|loc| best_locale_for_provider(loc.id.clone(), provider).is_some())
-        .cloned()
-        .collect()
-}
-
-/// Abstract operation [`SupportedLocales ( availableLocales, requestedLocales, options )`][spec]
-///
-/// Returns the subset of the provided BCP 47 language priority list requestedLocales for which
-/// availableLocales has a matching locale
+/// Calling this function with a singleton `KeyedDataMarker` will always return `None`.
 ///
 /// [spec]: https://tc39.es/ecma402/#sec-supportedlocales
-pub(in crate::builtins::intl) fn supported_locales<M: KeyedDataMarker>(
-    requested_locales: &[Locale],
+pub(in crate::builtins::intl) fn filter_locales<M: KeyedDataMarker>(
+    requested_locales: Vec<Locale>,
     options: &JsValue,
     context: &mut Context,
 ) -> JsResult<JsObject>
@@ -553,22 +420,36 @@ where
     // 2. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
     let matcher = get_option(&options, js_str!("localeMatcher"), context)?.unwrap_or_default();
 
-    let elements = match matcher {
-        // 4. Else,
-        //     a. Let supportedLocales be LookupSupportedLocales(availableLocales, requestedLocales).
-        LocaleMatcher::Lookup => {
-            lookup_supported_locales(requested_locales, context.intl_provider())
-        }
-        // 3. If matcher is "best fit", then
-        //     a. Let supportedLocales be BestFitSupportedLocales(availableLocales, requestedLocales).
-        LocaleMatcher::BestFit => {
-            best_fit_supported_locales(requested_locales, context.intl_provider())
-        }
-    };
+    // 3. Let subset be a new empty List.
+    let mut subset = Vec::with_capacity(requested_locales.len());
 
-    // 5. Return CreateArrayFromList(supportedLocales).
+    // 4. For each element locale of requestedLocales, do
+    for locale in requested_locales {
+        // a. Let noExtensionsLocale be the String value that is locale with any Unicode locale extension sequences removed.
+        let mut no_ext_loc = locale.clone();
+        no_ext_loc.extensions.unicode.clear();
+        let loc_match = match matcher {
+            // b. If matcher is "lookup", then
+            //     i. Let match be LookupMatchingLocaleByPrefix(availableLocales, noExtensionsLocale).
+            LocaleMatcher::Lookup => {
+                lookup_matching_locale_by_prefix([no_ext_loc], context.intl_provider())
+            }
+            // c. Else,
+            //     i. Let match be LookupMatchingLocaleByBestFit(availableLocales, noExtensionsLocale).
+            LocaleMatcher::BestFit => {
+                lookup_matching_locale_by_best_fit([no_ext_loc], context.intl_provider())
+            }
+        };
+
+        // d. If match is not undefined, append locale to subset.
+        if loc_match.is_some() {
+            subset.push(locale);
+        }
+    }
+
+    // 5. Return CreateArrayFromList(subset).
     Ok(Array::create_array_from_list(
-        elements
+        subset
             .into_iter()
             .map(|loc| js_string!(loc.to_string()).into()),
         context,
@@ -577,6 +458,10 @@ where
 
 /// Validates that the unicode extension `key` with `value` is a valid extension value for the
 /// `language`.
+///
+/// # Note
+///
+/// Calling this function with a singleton `KeyedDataMarker` will always return `None`.
 pub(in crate::builtins::intl) fn validate_extension<M: KeyedDataMarker>(
     language: LanguageIdentifier,
     key: Key,
@@ -597,54 +482,47 @@ pub(in crate::builtins::intl) fn validate_extension<M: KeyedDataMarker>(
         .is_some()
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "intl_bundled"))]
 mod tests {
     use icu_locid::{langid, locale, Locale};
     use icu_plurals::provider::CardinalV1Marker;
-    use icu_provider::AsDeserializingBufferProvider;
 
     use crate::{
         builtins::intl::locale::utils::{
-            best_available_locale, best_fit_matcher, default_locale, lookup_matcher,
+            lookup_matching_locale_by_best_fit, lookup_matching_locale_by_prefix,
         },
         context::icu::IntlProvider,
     };
 
     #[test]
-    fn best_avail_loc() {
-        let provider = boa_icu_provider::buffer();
-        let provider = provider.as_deserializing();
+    fn best_fit() {
+        let icu = &IntlProvider::try_new_with_buffer_provider(boa_icu_provider::buffer()).unwrap();
 
         assert_eq!(
-            best_available_locale::<CardinalV1Marker>(langid!("en"), &provider),
-            Some(langid!("en"))
+            lookup_matching_locale_by_best_fit::<CardinalV1Marker>([locale!("en")], icu),
+            Some(locale!("en"))
         );
 
         assert_eq!(
-            best_available_locale::<CardinalV1Marker>(langid!("es-ES"), &provider),
-            Some(langid!("es"))
+            lookup_matching_locale_by_best_fit::<CardinalV1Marker>([locale!("es-ES")], icu),
+            Some(locale!("es"))
         );
 
         assert_eq!(
-            best_available_locale::<CardinalV1Marker>(langid!("kr"), &provider),
+            lookup_matching_locale_by_best_fit::<CardinalV1Marker>([locale!("kr")], icu),
             None
         );
     }
 
     #[test]
     fn lookup_match() {
-        let icu = IntlProvider::try_new_with_buffer_provider(boa_icu_provider::buffer()).unwrap();
-
-        // requested: []
-
-        let res = lookup_matcher::<CardinalV1Marker>(&[], &icu);
-        assert_eq!(res, default_locale(icu.locale_canonicalizer()));
-        assert!(res.extensions.is_empty());
+        let icu = &IntlProvider::try_new_with_buffer_provider(boa_icu_provider::buffer()).unwrap();
 
         // requested: [fr-FR-u-hc-h12]
         let requested: Locale = "fr-FR-u-hc-h12".parse().unwrap();
 
-        let result = lookup_matcher::<CardinalV1Marker>(&[requested.clone()], &icu);
+        let result =
+            lookup_matching_locale_by_prefix::<CardinalV1Marker>([requested.clone()], icu).unwrap();
         assert_eq!(result.id, langid!("fr"));
         assert_eq!(result.extensions, requested.extensions);
 
@@ -655,7 +533,7 @@ mod tests {
         let uz = locale!("uz-Cyrl");
         let requested = vec![kr, gr, es.clone(), uz];
 
-        let res = best_fit_matcher::<CardinalV1Marker>(&requested, &icu);
+        let res = lookup_matching_locale_by_best_fit::<CardinalV1Marker>(requested, icu).unwrap();
         assert_eq!(res.id, langid!("es"));
         assert_eq!(res.extensions, es.extensions);
     }

--- a/core/engine/src/builtins/intl/mod.rs
+++ b/core/engine/src/builtins/intl/mod.rs
@@ -28,6 +28,7 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 use icu_provider::KeyedDataMarker;
+use static_assertions::const_assert;
 
 pub(crate) mod collator;
 pub(crate) mod date_time_format;
@@ -43,6 +44,15 @@ pub(crate) use self::{
 };
 
 mod options;
+
+// No singletons are allowed as lang markers.
+// Hopefully, we'll be able to migrate this to the definition of `Service` in the future
+// (https://github.com/rust-lang/rust/issues/76560)
+const_assert! {!<Collator as Service>::LangMarker::KEY.metadata().singleton}
+const_assert! {!<ListFormat as Service>::LangMarker::KEY.metadata().singleton}
+const_assert! {!<NumberFormat as Service>::LangMarker::KEY.metadata().singleton}
+const_assert! {!<PluralRules as Service>::LangMarker::KEY.metadata().singleton}
+const_assert! {!<Segmenter as Service>::LangMarker::KEY.metadata().singleton}
 
 /// JavaScript `Intl` object.
 #[derive(Debug, Clone, Trace, Finalize, JsData)]

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 
 use super::{
-    locale::{canonicalize_locale_list, resolve_locale, supported_locales, validate_extension},
+    locale::{canonicalize_locale_list, filter_locales, resolve_locale, validate_extension},
     options::{coerce_options_to_object, IntlOptions},
     Service,
 };
@@ -237,7 +237,7 @@ impl BuiltInConstructor for NumberFormat {
         // 9. Let localeData be %Intl.NumberFormat%.[[LocaleData]].
         // 10. Let r be ResolveLocale(%Intl.NumberFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.NumberFormat%.[[RelevantExtensionKeys]], localeData).
         let locale = resolve_locale::<Self>(
-            &requested_locales,
+            requested_locales,
             &mut intl_options,
             context.intl_provider(),
         );
@@ -465,8 +465,8 @@ impl NumberFormat {
         // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
         let requested_locales = canonicalize_locale_list(locales, context)?;
 
-        // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-        supported_locales::<<Self as Service>::LangMarker>(&requested_locales, options, context)
+        // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+        filter_locales::<<Self as Service>::LangMarker>(requested_locales, options, context)
             .map(JsValue::from)
     }
 

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 use super::{
-    locale::{canonicalize_locale_list, resolve_locale, supported_locales},
+    locale::{canonicalize_locale_list, filter_locales, resolve_locale},
     number_format::{DigitFormatOptions, Extrema, NotationKind},
     options::{coerce_options_to_object, IntlOptions},
     Service,
@@ -136,7 +136,7 @@ impl BuiltInConstructor for PluralRules {
         // 10. Let r be ResolveLocale(%PluralRules%.[[AvailableLocales]], requestedLocales, opt, %PluralRules%.[[RelevantExtensionKeys]], localeData).
         // 11. Set pluralRules.[[Locale]] to r.[[locale]].
         let locale = resolve_locale::<Self>(
-            &requested_locales,
+            requested_locales,
             &mut IntlOptions {
                 matcher,
                 ..Default::default()
@@ -292,8 +292,8 @@ impl PluralRules {
         // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
         let requested_locales = canonicalize_locale_list(locales, context)?;
 
-        // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-        supported_locales::<<Self as Service>::LangMarker>(&requested_locales, options, context)
+        // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+        filter_locales::<<Self as Service>::LangMarker>(requested_locales, options, context)
             .map(JsValue::from)
     }
 

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -940,6 +940,14 @@ impl ContextBuilder {
     ///
     /// This function is only available if the `intl` feature is enabled.
     ///
+    /// # Additional considerations
+    ///
+    /// If the data was generated using `icu_datagen`, make sure that the deduplication strategy is
+    /// not set to [`Maximal`]. Otherwise, `icu_datagen` will delete base locales such as "en" from
+    /// the list of supported locales if the required data for "en" is the same as "und".
+    /// We recommend [`RetainBaseLanguages`] as a nice default, which will only deduplicate locales
+    /// if the deduplication target is not "und".
+    ///
     /// # Errors
     ///
     /// This returns `Err` if the provided provider doesn't have the required locale information
@@ -947,6 +955,9 @@ impl ContextBuilder {
     /// mean that the provider will successfully construct all `Intl` services; that check is made
     /// until the creation of an instance of a service.
     ///
+    /// [`Maximal`]: https://docs.rs/icu_datagen/latest/icu_datagen/enum.DeduplicationStrategy.html#variant.Maximal
+    /// [`RetainBaseLanguages`]: https://docs.rs/icu_datagen/latest/icu_datagen/enum.DeduplicationStrategy.html#variant.RetainBaseLanguages
+    /// [`ResolveLocale`]: https://tc39.es/ecma402/#sec-resolvelocale
     /// [`LocaleCanonicalizer`]: icu_locid_transform::LocaleCanonicalizer
     /// [`LocaleExpander`]: icu_locid_transform::LocaleExpander
     /// [`BufferProvider`]: icu_provider::BufferProvider
@@ -963,6 +974,14 @@ impl ContextBuilder {
     ///
     /// This function is only available if the `intl` feature is enabled.
     ///
+    /// # Additional considerations
+    ///
+    /// If the data was generated using `icu_datagen`, make sure that the deduplication strategy is
+    /// not set to [`Maximal`]. Otherwise, `icu_datagen` will delete base locales such as "en" from
+    /// the list of supported locales if the required data for "en" is the same as "und".
+    /// We recommend [`RetainBaseLanguages`] as a nice default, which will only deduplicate locales
+    /// if the deduplication target is not "und".
+    ///
     /// # Errors
     ///
     /// This returns `Err` if the provided provider doesn't have the required locale information
@@ -970,6 +989,9 @@ impl ContextBuilder {
     /// mean that the provider will successfully construct all `Intl` services; that check is made
     /// until the creation of an instance of a service.
     ///
+    /// [`Maximal`]: https://docs.rs/icu_datagen/latest/icu_datagen/enum.DeduplicationStrategy.html#variant.Maximal
+    /// [`RetainBaseLanguages`]: https://docs.rs/icu_datagen/latest/icu_datagen/enum.DeduplicationStrategy.html#variant.RetainBaseLanguages
+    /// [`ResolveLocale`]: https://tc39.es/ecma402/#sec-resolvelocale
     /// [`LocaleCanonicalizer`]: icu_locid_transform::LocaleCanonicalizer
     /// [`LocaleExpander`]: icu_locid_transform::LocaleExpander
     /// [`AnyProvider`]: icu_provider::AnyProvider

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "b73f7d662d51584bfee6d3ed274b676d313b646a"
+commit = "c00830acef42bdb0e917b5fdec76ed9d399c0eea"
 
 [ignored]
 # Not implemented yet:

--- a/tests/tester/src/edition.rs
+++ b/tests/tester/src/edition.rs
@@ -81,6 +81,10 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-iterator-helpers
     "iterator-helpers" => SpecEdition::ESNext,
 
+    // Promise.try
+    // https://github.com/tc39/proposal-promise-try
+    "promise-try" => SpecEdition::ESNext,
+
     // Set methods
     // https://github.com/tc39/proposal-set-methods
     "set-methods" => SpecEdition::ESNext,

--- a/tools/gen-icu4x-data/Cargo.toml
+++ b/tools/gen-icu4x-data/Cargo.toml
@@ -10,9 +10,15 @@ license.workspace = true
 description.workspace = true
 
 [dependencies]
-icu_provider = { workspace = true, features = ["datagen"] }
-icu_provider_blob = { workspace = true, features = ["export"] }
-icu_datagen = { workspace = true, features = ["networking", "use_wasm"] }
+icu_provider.workspace = true
+icu_datagen = { workspace = true, features = [
+    "networking",
+    "use_wasm",
+    "provider",
+    "blob_exporter",
+    "experimental_components",
+    "rayon",
+] }
 log.workspace = true
 simple_logger.workspace = true
 
@@ -27,12 +33,6 @@ icu_locid_transform = { workspace = true, features = ["datagen"] }
 icu_normalizer = { workspace = true, features = ["datagen"] }
 icu_plurals = { workspace = true, features = ["datagen", "experimental"] }
 icu_segmenter = { workspace = true, features = ["datagen"] }
-
-[target.'cfg(windows)'.dependencies]
-# wasmer-wasi apparently has a wrong deps config...
-# This dep patches that.
-winapi = { workspace = true, features = ["sysinfoapi"] }
-
 
 [lints]
 workspace = true


### PR DESCRIPTION
Some additional cleanups were made to the `Intl` services, since the ECMA-402 spec had editorial changes that hadn't been implemented.

Had to pin `temporal_rs` to the git repo until we publish a new version, but it would be better to fix the panics before doing so.

Removed some hacks that we had in place for locale resolution. We still have a small hack for `Segmenter`, but that will possibly be resolved in the future with locale-aware segmenters.
