### PR TITLE
Add a js_class to implement the Class trait without boilerplate

### DIFF
--- a/core/engine/src/object/mod.rs
+++ b/core/engine/src/object/mod.rs
@@ -247,6 +247,13 @@ impl<T: ?Sized> Object<T> {
         &self.data
     }
 
+    /// Returns the data of the object.
+    #[inline]
+    #[must_use]
+    pub fn data_mut(&mut self) -> &mut T {
+        &mut self.data
+    }
+
     /// Gets the prototype instance of this object.
     #[inline]
     #[must_use]

--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -353,6 +353,7 @@ impl<T: NativeObject> JsClass<T> {
     ///
     /// This does not panic if the type is wrong, as the type is checked
     /// during the construction of the `JsClass` instance.
+    #[must_use]
     pub fn borrow(&self) -> Ref<'_, T> {
         self.inner.downcast_ref::<T>().unwrap()
     }
@@ -362,6 +363,7 @@ impl<T: NativeObject> JsClass<T> {
     /// # Panics
     ///
     /// Panics if the object is currently mutably borrowed.
+    #[must_use]
     pub fn borrow_mut(&self) -> Option<RefMut<'_, ErasedObject, T>> {
         self.inner.downcast_mut::<T>()
     }
@@ -378,7 +380,7 @@ impl<'a, T: NativeObject + 'static> TryFromJsArgument<'a> for JsClass<T> {
                 return Ok((
                     JsClass {
                         inner: object.clone(),
-                        _ty: Default::default(),
+                        _ty: PhantomData,
                     },
                     rest,
                 ));
@@ -607,6 +609,7 @@ fn class() {
     }
 
     impl Test {
+        #[allow(clippy::needless_pass_by_value)]
         fn get_value(this: JsClass<Test>) -> i32 {
             this.borrow().value
         }

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -13,11 +13,7 @@
 /// Here's an example using the animal class declared in [`boa_engine::class`]:
 /// # Example
 /// ```
-/// # use boa_engine::{
-/// #    Context, JsResult, JsValue, JsString,
-/// #    Source, js_str, js_string,
-/// #    JsData,
-/// # };
+/// # use boa_engine::{JsString, JsData, js_string};
 /// # use boa_gc::{Finalize, Trace};
 /// use boa_interop::{js_class, Ignore, JsClass};
 ///
@@ -65,6 +61,8 @@
 /// }
 ///
 /// fn main() {
+///#    use boa_engine::{Context, JsString, Source, js_str};
+///
 ///     let mut context = Context::default();
 ///
 ///     context.register_global_class::<Animal>().unwrap();
@@ -161,7 +159,7 @@ macro_rules! js_class {
 
                     instance.set(
                         $crate::boa_engine::JsString::from(stringify!($field_name)),
-                        function.call(&JsValue::undefined(), args, context)?,
+                        function.call(&$crate::boa_engine::JsValue::undefined(), args, context)?,
                         false,
                         context
                     );

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -96,7 +96,7 @@ macro_rules! js_class {
 
         $(
             $(#[$method_attr: meta])*
-            fn $method_name: ident
+            fn $method_name: ident $( as $method_js_name: literal )?
                 ( $( $fn_arg: ident: $fn_arg_type: ty ),* )
                 $(-> $result_type: ty)?
                 $method_body: block
@@ -120,8 +120,10 @@ macro_rules! js_class {
                         class.context(),
                     );
 
+                    let function_name = $crate::__js_class_name!($method_name, $($method_js_name)?);
+
                     class.method(
-                        $crate::boa_engine::JsString::from(stringify!($method_name)),
+                        $crate::boa_engine::JsString::from(function_name),
                         $crate::__count!($( $fn_arg )*),
                         function,
                     );

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -14,12 +14,9 @@
 /// # Example
 /// ```
 /// # use boa_engine::{
-/// #    NativeFunction,
-/// #    property::Attribute,
-/// #    class::{Class, ClassBuilder},
 /// #    Context, JsResult, JsValue, JsString,
-/// #    JsArgs, Source, JsObject, js_str, js_string,
-/// #    JsNativeError, JsData,
+/// #    Source, js_str, js_string,
+/// #    JsData,
 /// # };
 /// # use boa_gc::{Finalize, Trace};
 /// use boa_interop::{js_class, Ignore, JsClass};
@@ -114,7 +111,7 @@ macro_rules! js_class {
 
             const LENGTH: usize = $crate::__count!( $( $ctor_arg )* );
 
-            fn init(class: &mut ClassBuilder<'_>) -> $crate::boa_engine::JsResult<()> {
+            fn init(class: &mut $crate::boa_engine::class::ClassBuilder<'_>) -> $crate::boa_engine::JsResult<()> {
                 // Add all methods to the class.
                 $(
                     fn $method_name ( $($fn_arg: $fn_arg_type),* ) -> $( $result_type )?

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -126,7 +126,7 @@ macro_rules! js_class {
                     );
 
                     class.method(
-                        js_string!(stringify!($method_name)),
+                        $crate::boa_engine::JsString::from(stringify!($method_name)),
                         $crate::__count!($( $fn_arg )*),
                         function,
                     );
@@ -163,7 +163,7 @@ macro_rules! js_class {
                     );
 
                     instance.set(
-                        js_string!(stringify!($field_name)),
+                        $crate::boa_engine::JsString::from(stringify!($field_name)),
                         function.call(&JsValue::undefined(), args, context)?,
                         false,
                         context

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -1,0 +1,198 @@
+//! Module declaring interop macro rules.
+
+/// Declare a JavaScript class, in a simpler way.
+///
+/// This can make declaration of JavaScript classes easier by using an hybrid
+/// declarative approach. The class itself follows a closer syntax to JavaScript
+/// while the method arguments/results and bodies are written in Rust.
+///
+/// This only declares the Boa interop parts of the class. The actual type must
+/// be declared separately as a Rust type, along with necessary derives and
+/// traits.
+///
+/// Here's an example using the animal class declared in [`boa_engine::class`]:
+/// # Example
+/// ```
+/// # use boa_engine::{
+/// #    NativeFunction,
+/// #    property::Attribute,
+/// #    class::{Class, ClassBuilder},
+/// #    Context, JsResult, JsValue, JsString,
+/// #    JsArgs, Source, JsObject, js_str, js_string,
+/// #    JsNativeError, JsData,
+/// # };
+/// # use boa_gc::{Finalize, Trace};
+/// use boa_interop::{js_class, Ignore, JsClass};
+///
+/// #[derive(Clone, Trace, Finalize, JsData)]
+/// pub enum Animal {
+///     Cat,
+///     Dog,
+///     Other,
+/// }
+///
+/// js_class! {
+///     // Implement [`Class`] trait for the `Animal` enum.
+///     class Animal {
+///         // This sets a field on the JavaScript object. The arguments to
+///         // `init` are the arguments passed to the constructor. This
+///         // function MUST return the value to be set on the field. If this
+///         // returns a `JsResult`, it will be unwrapped and error out during
+///         // construction of the object.
+///         public age(_name: Ignore, age: i32) -> i32 {
+///             age
+///         }
+///
+///         // This is called when a new instance of the class is created in
+///         // JavaScript, e.g. `new Animal("cat")`.
+///         // This method is mandatory and MUST return `JsResult<Self>`.
+///         constructor(name: String) {
+///             match name.as_str() {
+///                 "cat" => Ok(Animal::Cat),
+///                 "dog" => Ok(Animal::Dog),
+///                 _ => Ok(Animal::Other),
+///             }
+///         }
+///
+///         // Declare a function on the class itself.
+///         // There is a current limitation using `self` in methods, so the
+///         // instance must be accessed using an actual argument.
+///         fn speak(this: JsClass<Animal>) -> JsString {
+///             match *this.borrow() {
+///                 Animal::Cat => js_string!("meow"),
+///                 Animal::Dog => js_string!("woof"),
+///                 Animal::Other => js_string!(r"¯\_(ツ)_/¯"),
+///             }
+///         }
+///     }
+/// }
+///
+/// fn main() {
+///     let mut context = Context::default();
+///
+///     context.register_global_class::<Animal>().unwrap();
+///
+///     let result = context.eval(Source::from_bytes(r#"
+///         let pet = new Animal("dog", 3);
+///
+///         `My pet is ${pet.age} years old. Right, buddy? - ${pet.speak()}!`
+///     "#)).expect("Could not evaluate script");
+///
+///     assert_eq!(
+///         result.as_string().unwrap(),
+///         &js_str!("My pet is 3 years old. Right, buddy? - woof!")
+///     );
+/// }
+/// ```
+#[macro_export]
+macro_rules! js_class {
+    (
+    class $class_name: ident $(as $class_js_name: literal)? {
+        $(
+            $(#[$field_attr: meta])*
+            public $field_name: ident
+                ( $( $field_arg: ident: $field_arg_type: ty ),* ) -> $field_ty: ty
+                $field_body: block
+        )*
+
+        $(#[$constructor_attr: meta])*
+        constructor( $( $ctor_arg: ident: $ctor_arg_ty: ty ),* )
+            $constructor_body: block
+
+        $(
+            $(#[$method_attr: meta])*
+            fn $method_name: ident
+                ( $( $fn_arg: ident: $fn_arg_type: ty ),* )
+                $(-> $result_type: ty)?
+                $method_body: block
+        )*
+    }
+    ) => {
+        impl $crate::boa_engine::class::Class for $class_name {
+
+            const NAME: &'static str = $crate::__js_class_name!($class_name, $($class_js_name)?);
+
+            const LENGTH: usize = $crate::__count!( $( $ctor_arg )* );
+
+            fn init(class: &mut ClassBuilder<'_>) -> $crate::boa_engine::JsResult<()> {
+                // Add all methods to the class.
+                $(
+                    fn $method_name ( $($fn_arg: $fn_arg_type),* ) -> $( $result_type )?
+                        $method_body
+
+                    let function = $crate::IntoJsFunctionCopied::into_js_function_copied(
+                        $method_name,
+                        class.context(),
+                    );
+
+                    class.method(
+                        js_string!(stringify!($method_name)),
+                        $crate::__count!($( $fn_arg )*),
+                        function,
+                    );
+                )*
+
+                Ok(())
+            }
+
+            fn data_constructor(
+                new_target: &$crate::boa_engine::JsValue,
+                args: &[$crate::boa_engine::JsValue],
+                context: &mut $crate::boa_engine::Context,
+            ) -> $crate::boa_engine::JsResult<$class_name> {
+                let rest = args;
+                $(
+                    let ($ctor_arg, rest) : ($ctor_arg_ty, _) = $crate::TryFromJsArgument::try_from_js_argument(new_target, rest, context)?;
+                )*
+
+                $constructor_body
+            }
+
+            fn object_constructor(
+                instance: &$crate::boa_engine::JsObject,
+                args: &[$crate::boa_engine::JsValue],
+                context: &mut $crate::boa_engine::Context
+            ) -> $crate::boa_engine::JsResult<()> {
+                $(
+                    fn $field_name ( $($field_arg: $field_arg_type),* ) -> $field_ty
+                        $field_body
+
+                    let function = $crate::IntoJsFunctionCopied::into_js_function_copied(
+                        $field_name,
+                        context,
+                    );
+
+                    instance.set(
+                        js_string!(stringify!($field_name)),
+                        function.call(&JsValue::undefined(), args, context)?,
+                        false,
+                        context
+                    );
+                )*
+
+                Ok(())
+            }
+
+        }
+    }
+}
+
+/// Internal macro to get the JavaScript class name.
+#[macro_export]
+macro_rules! __js_class_name {
+    ($class_name: ident, $class_js_name: literal) => {
+        $class_js_name
+    };
+    ($class_name: ident,) => {
+        stringify!($class_name)
+    };
+}
+
+/// Internal macro to get the JavaScript class length.
+#[macro_export]
+macro_rules! __count {
+    () => (0);
+    ($_: ident $($rest: ident)*) => {
+        1 + $crate::__count!($($rest)*)
+    };
+}


### PR DESCRIPTION
This also adds a JsInstance that verifies that `this` is of the proper class, and an `Ignore` that ignore arguments.

The syntax is a bit special because of limitations of macro_rules. For example, the way fields are defined. It was impossible to keep both assignments (e.g. `public field = 123;`) and dynamic fields.

This reduces significantly the boilerplate for declaring classes. The example in class.rs is more than twice as long (if you remove comments) than the macro is.
