### PR TITLE
Fix boa cli history

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fd-lock"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "fixed_decimal"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2857,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "clipboard-win",
+ "fd-lock",
  "libc",
  "log",
  "memchr",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,7 +16,7 @@ boa_engine = { workspace = true, features = ["deser", "flowgraph", "trace"] }
 boa_parser.workspace = true
 boa_gc.workspace = true
 boa_runtime.workspace = true
-rustyline = { workspace = true, features = ["derive"]}
+rustyline = { workspace = true, features = ["derive", "with-file-history"] }
 clap = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 colored.workspace = true

--- a/tests/fuzz/fuzz_targets/common.rs
+++ b/tests/fuzz/fuzz_targets/common.rs
@@ -74,6 +74,7 @@ impl Debug for FuzzData {
     }
 }
 
+#[allow(dead_code)]
 pub struct FuzzSource {
     pub interner: Interner,
     pub source: String,


### PR DESCRIPTION
This Pull Request changes the following:

- Fix the history of the boa cli. We accidentally turned off the file history default feature in #3863

