### PR TITLE
Fix hashbang comments by using proper goal symbols

### DIFF
--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -11,7 +11,7 @@ mod tests;
 
 use crate::{
     error::ParseResult,
-    lexer::Error as LexError,
+    lexer::{Error as LexError, InputElement},
     parser::{
         cursor::Cursor,
         function::{FormalParameters, FunctionStatementList},
@@ -140,6 +140,7 @@ impl<'a, R: ReadChar> Parser<'a, R> {
     ///
     /// [spec]: https://tc39.es/ecma262/#prod-Script
     pub fn parse_script(&mut self, interner: &mut Interner) -> ParseResult<boa_ast::Script> {
+        self.cursor.set_goal(InputElement::HashbangOrRegExp);
         ScriptParser::new(false).parse(&mut self.cursor, interner)
     }
 
@@ -155,6 +156,7 @@ impl<'a, R: ReadChar> Parser<'a, R> {
     where
         R: ReadChar,
     {
+        self.cursor.set_goal(InputElement::HashbangOrRegExp);
         ModuleParser.parse(&mut self.cursor, interner)
     }
 
@@ -172,6 +174,7 @@ impl<'a, R: ReadChar> Parser<'a, R> {
         direct: bool,
         interner: &mut Interner,
     ) -> ParseResult<boa_ast::Script> {
+        self.cursor.set_goal(InputElement::HashbangOrRegExp);
         ScriptParser::new(direct).parse(&mut self.cursor, interner)
     }
 


### PR DESCRIPTION
This Pull Request changes the following:

- Add a lexer goal symbol for hashbang comments and regexes. This goal is only used for the first lexical token of a `Script` or `Module` parse goal.
