### PR TITLE
Remove `FormalParameterList` from `CodeBlock`

### DIFF
--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -1182,6 +1182,7 @@ impl ByteCompiler<'_> {
                 //          default value initializers, or any destructured parameters.
                 // ii. Let ao be CreateMappedArgumentsObject(func, formals, argumentsList, env).
                 self.emit_opcode(Opcode::CreateMappedArgumentsObject);
+                self.emitted_mapped_arguments_object_opcode = true;
             }
 
             // c. If strict is true, then

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -12,7 +12,6 @@ use crate::{
     Context, JsBigInt, JsString, JsValue,
 };
 use bitflags::bitflags;
-use boa_ast::function::FormalParameterList;
 use boa_gc::{empty_trace, Finalize, Gc, Trace};
 use boa_profiler::Profiler;
 use std::{cell::Cell, fmt::Display, mem::size_of, rc::Rc};
@@ -137,14 +136,16 @@ pub struct CodeBlock {
     /// The number of arguments expected.
     pub(crate) length: u32,
 
+    pub(crate) parameter_length: u32,
+
     pub(crate) register_count: u32,
 
     /// `[[ThisMode]]`
     pub(crate) this_mode: ThisMode,
 
-    /// Parameters passed to this function.
+    /// Used for constructing a `MappedArguments` object.
     #[unsafe_ignore_trace]
-    pub(crate) params: FormalParameterList,
+    pub(crate) mapped_arguments_binding_indices: ThinVec<Option<u32>>,
 
     /// Bytecode
     #[unsafe_ignore_trace]
@@ -180,7 +181,8 @@ impl CodeBlock {
             length,
             register_count: 0,
             this_mode: ThisMode::Global,
-            params: FormalParameterList::default(),
+            mapped_arguments_binding_indices: ThinVec::new(),
+            parameter_length: 0,
             handlers: ThinVec::default(),
             ic: Box::default(),
         }

--- a/core/engine/src/vm/opcode/arguments.rs
+++ b/core/engine/src/vm/opcode/arguments.rs
@@ -31,7 +31,7 @@ impl Operation for CreateMappedArgumentsObject {
         let env = context.vm.environments.current();
         let arguments = MappedArguments::new(
             &function_object,
-            &code.params,
+            &code.mapped_arguments_binding_indices,
             &args,
             env.declarative_expect(),
             context,

--- a/core/engine/src/vm/opcode/rest_parameter/mod.rs
+++ b/core/engine/src/vm/opcode/rest_parameter/mod.rs
@@ -17,12 +17,12 @@ impl Operation for RestParameterInit {
     const COST: u8 = 6;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let argument_count = context.vm.frame().argument_count as usize;
-        let param_count = context.vm.frame().code_block().params.as_ref().len();
+        let argument_count = context.vm.frame().argument_count;
+        let param_count = context.vm.frame().code_block().parameter_length;
 
         let array = if argument_count >= param_count {
             let rest_count = argument_count - param_count + 1;
-            let args = context.vm.pop_n_values(rest_count);
+            let args = context.vm.pop_n_values(rest_count as usize);
             Array::create_array_from_list(args, context)
         } else {
             Array::array_create(0, None, context).expect("could not create an empty array")


### PR DESCRIPTION
This is a simple change that removes the formal parameter list from codeblock which was only needed in non-strict mode and compute the required binding indices when needed during compilation, instead of every function call. This also reduces the `CodeBlock` size by 16 bytes.