### PR TITLE
Combine `HasProperty` and `Get` operations when possible

### DIFF
--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -210,11 +210,9 @@ impl Error {
         context: &mut Context,
     ) -> JsResult<()> {
         // 1. If Type(options) is Object and ? HasProperty(options, "cause") is true, then
+        // 1.a. Let cause be ? Get(options, "cause").
         if let Some(options) = options.as_object() {
-            if options.has_property(js_str!("cause"), context)? {
-                // a. Let cause be ? Get(options, "cause").
-                let cause = options.get(js_str!("cause"), context)?;
-
+            if let Some(cause) = options.try_get(js_str!("cause"), context)? {
                 // b. Perform CreateNonEnumerableDataPropertyOrThrow(O, "cause", cause).
                 o.create_non_enumerable_data_property_or_throw(js_str!("cause"), cause, context);
             }

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -93,12 +93,9 @@ pub(crate) fn canonicalize_locale_list(
     for k in 0..len {
         // a. Let Pk be ToString(k).
         // b. Let kPresent be ? HasProperty(O, Pk).
-        let k_present = o.has_property(k, context)?;
         // c. If kPresent is true, then
-        if k_present {
-            // i. Let kValue be ? Get(O, Pk).
-            let k_value = o.get(k, context)?;
-
+        // c.i. Let kValue be ? Get(O, Pk).
+        if let Some(k_value) = o.try_get(k, context)? {
             // ii. If Type(kValue) is not String or Object, throw a TypeError exception.
             if !(k_value.is_object() || k_value.is_string()) {
                 return Err(JsNativeError::typ()

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -1155,15 +1155,9 @@ impl BuiltinTypedArray {
         let ta = ta.upcast();
         for k in k..len {
             // a. Let kPresent be ! HasProperty(O, ! ToString(𝔽(k))).
-            let k_present = ta
-                .has_property(k, context)
-                .expect("HasProperty cannot fail here");
-
             // b. If kPresent is true, then
-            if k_present {
-                // i. Let elementK be ! Get(O, ! ToString(𝔽(k))).
-                let element_k = ta.get(k, context).expect("Get cannot fail here");
-
+            // b.i. Let elementK be ! Get(O, ! ToString(𝔽(k))).
+            if let Some(element_k) = ta.try_get(k, context).expect("Get cannot fail here") {
                 // ii. Let same be IsStrictlyEqual(searchElement, elementK).
                 // iii. If same is true, return 𝔽(k).
                 if args.get_or_undefined(0).strict_equals(&element_k) {
@@ -1296,15 +1290,9 @@ impl BuiltinTypedArray {
         let ta = ta.upcast();
         for k in (0..k).rev() {
             // a. Let kPresent be ! HasProperty(O, ! ToString(𝔽(k))).
-            let k_present = ta
-                .has_property(k, context)
-                .expect("HasProperty cannot fail here");
-
             // b. If kPresent is true, then
-            if k_present {
-                // i. Let elementK be ! Get(O, ! ToString(𝔽(k))).
-                let element_k = ta.get(k, context).expect("Get cannot fail here");
-
+            // b.i. Let elementK be ! Get(O, ! ToString(𝔽(k))).
+            if let Some(element_k) = ta.try_get(k, context).expect("Get cannot fail here") {
                 // ii. Let same be IsStrictlyEqual(searchElement, elementK).
                 // iii. If same is true, return 𝔽(k).
                 if args.get_or_undefined(0).strict_equals(&element_k) {

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -621,11 +621,7 @@ impl Context {
         if locator.global {
             let global = self.global_object();
             let key = locator.name().clone();
-            if global.has_property(key.clone(), self)? {
-                global.get(key, self).map(Some)
-            } else {
-                Ok(None)
-            }
+            global.try_get(key, self)
         } else {
             match self.environment_expect(locator.environment_index) {
                 Environment::Declarative(env) => Ok(env.get(locator.binding_index)),

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -233,13 +233,7 @@ impl JsError {
                     .ok_or_else(|| TryNativeError::NotAnErrorObject(val.clone()))?;
 
                 let try_get_property = |key: JsString, name, context: &mut Context| {
-                    obj.has_property(key.clone(), context)
-                        .map_err(|e| TryNativeError::InaccessibleProperty {
-                            property: name,
-                            source: e,
-                        })?
-                        .then(|| obj.get(key, context))
-                        .transpose()
+                    obj.try_get(key, context)
                         .map_err(|e| TryNativeError::InaccessibleProperty {
                             property: name,
                             source: e,

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -379,41 +379,40 @@ impl JsObject {
 
         // 3. Let hasEnumerable be ? HasProperty(Obj, "enumerable").
         // 4. If hasEnumerable is true, then ...
-        if self.has_property(js_str!("enumerable"), context)? {
+        if let Some(enumerable) = self.try_get(js_str!("enumerable"), context)? {
             // a. Let enumerable be ! ToBoolean(? Get(Obj, "enumerable")).
             // b. Set desc.[[Enumerable]] to enumerable.
-            desc = desc.enumerable(self.get(js_str!("enumerable"), context)?.to_boolean());
+            desc = desc.enumerable(enumerable.to_boolean());
         }
 
         // 5. Let hasConfigurable be ? HasProperty(Obj, "configurable").
         // 6. If hasConfigurable is true, then ...
-        if self.has_property(js_str!("configurable"), context)? {
+        if let Some(configurable) = self.try_get(js_str!("configurable"), context)? {
             // a. Let configurable be ! ToBoolean(? Get(Obj, "configurable")).
             // b. Set desc.[[Configurable]] to configurable.
-            desc = desc.configurable(self.get(js_str!("configurable"), context)?.to_boolean());
+            desc = desc.configurable(configurable.to_boolean());
         }
 
         // 7. Let hasValue be ? HasProperty(Obj, "value").
         // 8. If hasValue is true, then ...
-        if self.has_property(js_str!("value"), context)? {
+        if let Some(value) = self.try_get(js_str!("value"), context)? {
             // a. Let value be ? Get(Obj, "value").
             // b. Set desc.[[Value]] to value.
-            desc = desc.value(self.get(js_str!("value"), context)?);
+            desc = desc.value(value);
         }
 
         // 9. Let hasWritable be ? HasProperty(Obj, ).
         // 10. If hasWritable is true, then ...
-        if self.has_property(js_str!("writable"), context)? {
+        if let Some(writable) = self.try_get(js_str!("writable"), context)? {
             // a. Let writable be ! ToBoolean(? Get(Obj, "writable")).
             // b. Set desc.[[Writable]] to writable.
-            desc = desc.writable(self.get(js_str!("writable"), context)?.to_boolean());
+            desc = desc.writable(writable.to_boolean());
         }
 
         // 11. Let hasGet be ? HasProperty(Obj, "get").
         // 12. If hasGet is true, then
-        let get = if self.has_property(js_str!("get"), context)? {
-            // a. Let getter be ? Get(Obj, "get").
-            let getter = self.get(js_str!("get"), context)?;
+        // 12.a. Let getter be ? Get(Obj, "get").
+        let get = if let Some(getter) = self.try_get(js_str!("get"), context)? {
             // b. If IsCallable(getter) is false and getter is not undefined, throw a TypeError exception.
             // todo: extract IsCallable to be callable from Value
             if !getter.is_undefined() && getter.as_object().map_or(true, |o| !o.is_callable()) {
@@ -429,9 +428,8 @@ impl JsObject {
 
         // 13. Let hasSet be ? HasProperty(Obj, "set").
         // 14. If hasSet is true, then
-        let set = if self.has_property(js_str!("set"), context)? {
-            // 14.a. Let setter be ? Get(Obj, "set").
-            let setter = self.get(js_str!("set"), context)?;
+        // 14.a. Let setter be ? Get(Obj, "set").
+        let set = if let Some(setter) = self.try_get(js_str!("set"), context)? {
             // 14.b. If IsCallable(setter) is false and setter is not undefined, throw a TypeError exception.
             // todo: extract IsCallable to be callable from Value
             if !setter.is_undefined() && setter.as_object().map_or(true, |o| !o.is_callable()) {

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -323,6 +323,28 @@ impl JsObject {
         self.__has_property__(&key.into(), &mut InternalMethodContext::new(context))
     }
 
+    /// Abstract optimization operation.
+    ///
+    /// Check if an object has a property and get it if it exists.
+    /// This operation combines the abstract operations `HasProperty` and `Get`.
+    ///
+    /// More information:
+    ///  - [ECMAScript reference HasProperty][spec0]
+    ///  - [ECMAScript reference Get][spec1]
+    ///
+    /// [spec0]: https://tc39.es/ecma262/#sec-hasproperty
+    /// [spec1]: https://tc39.es/ecma262/#sec-get-o-p
+    pub(crate) fn try_get<K>(&self, key: K, context: &mut Context) -> JsResult<Option<JsValue>>
+    where
+        K: Into<PropertyKey>,
+    {
+        self.__try_get__(
+            &key.into(),
+            self.clone().into(),
+            &mut InternalMethodContext::new(context),
+        )
+    }
+
     /// Check if object has an own property.
     ///
     /// More information:


### PR DESCRIPTION
This PR creates a new object operation that combines the `HasProperty` and `Get` operations.

In some cases in the spec `HasProperty` and `Get` are called on an object, with the same arguments, directly following each other. Both operations boil down to (in most cases) `[[GetOwnProperty]]`, just that `HasProperty` does not return the value. To avoid duplicating the exact same operations we can combine both operations.

I have some Flame Graphs from a `GetName` operation to visualize the benefit:

Before:
![image](https://github.com/boa-dev/boa/assets/32105367/a3aa4926-74f0-4c59-9ba3-9e9a69ced8c9)
After:
![image](https://github.com/boa-dev/boa/assets/32105367/3c40335f-bd4e-4944-abd4-947db741fcb3)

I also ran the benchmarks:

Before:
```txt
RESULT Richards 54.3
RESULT DeltaBlue 58.2
RESULT Crypto 68.4
RESULT RayTrace 186
RESULT EarleyBoyer 170
RESULT RegExp 58.6
RESULT Splay 195
RESULT NavierStokes 159
SCORE 103
```
After:
```txt
RESULT Richards 55.1
RESULT DeltaBlue 59.6
RESULT Crypto 68.1
RESULT RayTrace 187
RESULT EarleyBoyer 176
RESULT RegExp 58.5
RESULT Splay 195
RESULT NavierStokes 160
SCORE 104
```