### PR TITLE
Refactor call frame access to avoid panic checks

### DIFF
--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -96,8 +96,9 @@ impl GeneratorContext {
         let rp = frame.rp;
         context.vm.push_frame(frame);
 
-        context.vm.frame_mut().rp = rp;
-        context.vm.frame_mut().set_exit_early(true);
+        let frame = context.vm.frame_mut();
+        frame.rp = rp;
+        frame.set_exit_early(true);
 
         if let Some(value) = value {
             context.vm.push(value);

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -828,6 +828,10 @@ impl Context {
         // 1. If the execution context stack is empty, return null.
         // 2. Let ec be the topmost execution context on the execution context stack whose ScriptOrModule component is not null.
         // 3. If no such execution context exists, return null. Otherwise, return ec's ScriptOrModule.
+        if let Some(active_runnable) = &self.vm.frame.active_runnable {
+            return Some(active_runnable.clone());
+        }
+
         self.vm
             .frames
             .iter()
@@ -846,11 +850,7 @@ impl Context {
             return self.vm.native_active_function.clone();
         }
 
-        if let Some(frame) = self.vm.frames.last() {
-            return frame.function(&self.vm);
-        }
-
-        None
+        self.vm.frame.function(&self.vm)
     }
 }
 

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -1772,9 +1772,7 @@ impl SourceTextModule {
 
         context
             .vm
-            .frames
-            .last()
-            .expect("there should be a frame")
+            .frame
             .set_promise_capability(&mut context.vm.stack, capability);
 
         // 9. If module.[[HasTLA]] is false, then

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -411,7 +411,11 @@ impl JsObject {
             return Ok(context.vm.pop());
         }
 
-        context.vm.frames[frame_index].set_exit_early(true);
+        if frame_index + 1 == context.vm.frames.len() {
+            context.vm.frame.set_exit_early(true);
+        } else {
+            context.vm.frames[frame_index + 1].set_exit_early(true);
+        }
 
         let result = context.run().consume();
 
@@ -461,7 +465,11 @@ impl JsObject {
                 .clone());
         }
 
-        context.vm.frames[frame_index].set_exit_early(true);
+        if frame_index + 1 == context.vm.frames.len() {
+            context.vm.frame.set_exit_early(true);
+        } else {
+            context.vm.frames[frame_index + 1].set_exit_early(true);
+        }
 
         let result = context.run().consume();
 

--- a/core/engine/src/vm/opcode/arguments.rs
+++ b/core/engine/src/vm/opcode/arguments.rs
@@ -19,14 +19,13 @@ impl Operation for CreateMappedArgumentsObject {
     const COST: u8 = 8;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let function_object = context
-            .vm
-            .frame()
+        let frame = context.vm.frame();
+        let function_object = frame
             .function(&context.vm)
             .clone()
             .expect("there should be a function object");
-        let code = context.vm.frame().code_block().clone();
-        let args = context.vm.frame().arguments(&context.vm).to_vec();
+        let code = frame.code_block().clone();
+        let args = frame.arguments(&context.vm).to_vec();
 
         let env = context.vm.environments.current_ref();
         let arguments = MappedArguments::new(

--- a/core/engine/src/vm/opcode/await/mod.rs
+++ b/core/engine/src/vm/opcode/await/mod.rs
@@ -183,9 +183,7 @@ impl Operation for CreatePromiseCapability {
 
         context
             .vm
-            .frames
-            .last()
-            .expect("there should be a frame")
+            .frame
             .set_promise_capability(&mut context.vm.stack, Some(&promise_capability));
         Ok(CompletionType::Normal)
     }

--- a/core/engine/src/vm/opcode/control_flow/return.rs
+++ b/core/engine/src/vm/opcode/control_flow/return.rs
@@ -33,10 +33,10 @@ impl Operation for CheckReturn {
     const COST: u8 = 3;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        if !context.vm.frame().construct() {
+        let frame = context.vm.frame();
+        if !frame.construct() {
             return Ok(CompletionType::Normal);
         }
-        let frame = context.vm.frame();
         let this = frame.this(&context.vm);
         let result = context.vm.take_return_value();
 

--- a/core/engine/src/vm/opcode/define/mod.rs
+++ b/core/engine/src/vm/opcode/define/mod.rs
@@ -62,13 +62,11 @@ pub(crate) struct DefInitVar;
 impl DefInitVar {
     fn operation(context: &mut Context, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
-        let mut binding_locator = context.vm.frame().code_block.bindings[index].clone();
+        let frame = context.vm.frame();
+        let strict = frame.code_block.strict();
+        let mut binding_locator = frame.code_block.bindings[index].clone();
         context.find_runtime_binding(&mut binding_locator)?;
-        context.set_binding(
-            &binding_locator,
-            value,
-            context.vm.frame().code_block.strict(),
-        )?;
+        context.set_binding(&binding_locator, value, strict)?;
 
         Ok(CompletionType::Normal)
     }

--- a/core/engine/src/vm/opcode/delete/mod.rs
+++ b/core/engine/src/vm/opcode/delete/mod.rs
@@ -16,15 +16,12 @@ impl DeletePropertyByName {
     fn operation(context: &mut Context, index: usize) -> JsResult<CompletionType> {
         let value = context.vm.pop();
         let object = value.to_object(context)?;
-        let key = context
-            .vm
-            .frame()
-            .code_block()
-            .constant_string(index)
-            .into();
+        let code_block = context.vm.frame().code_block();
+        let key = code_block.constant_string(index).into();
+        let strict = code_block.strict();
 
         let result = object.__delete__(&key, &mut InternalMethodContext::new(context))?;
-        if !result && context.vm.frame().code_block().strict() {
+        if !result && strict {
             return Err(JsNativeError::typ()
                 .with_message("Cannot delete property")
                 .into());

--- a/core/engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/core/engine/src/vm/opcode/iteration/loop_ops.rs
@@ -17,16 +17,17 @@ impl Operation for IncrementLoopIteration {
     const COST: u8 = 3;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let previous_iteration_count = context.vm.frame_mut().loop_iteration_count;
-
         let max = context.vm.runtime_limits.loop_iteration_limit();
+        let frame = context.vm.frame_mut();
+        let previous_iteration_count = frame.loop_iteration_count;
+
         if previous_iteration_count > max {
             return Err(JsNativeError::runtime_limit()
                 .with_message(format!("Maximum loop iteration limit {max} exceeded"))
                 .into());
         }
 
-        context.vm.frame_mut().loop_iteration_count = previous_iteration_count.wrapping_add(1);
+        frame.loop_iteration_count = previous_iteration_count.wrapping_add(1);
         Ok(CompletionType::Normal)
     }
 }

--- a/core/engine/src/vm/opcode/push/literal.rs
+++ b/core/engine/src/vm/opcode/push/literal.rs
@@ -59,12 +59,9 @@ impl PushRegExp {
         pattern_index: usize,
         flags_index: usize,
     ) -> JsResult<CompletionType> {
-        let pattern = context
-            .vm
-            .frame()
-            .code_block()
-            .constant_string(pattern_index);
-        let flags = context.vm.frame().code_block().constant_string(flags_index);
+        let code_block = context.vm.frame().code_block();
+        let pattern = code_block.constant_string(pattern_index);
+        let flags = code_block.constant_string(flags_index);
 
         let regexp = JsRegExp::new(pattern, flags, context)?;
         context.vm.push(regexp);

--- a/core/engine/src/vm/opcode/rest_parameter/mod.rs
+++ b/core/engine/src/vm/opcode/rest_parameter/mod.rs
@@ -17,8 +17,9 @@ impl Operation for RestParameterInit {
     const COST: u8 = 6;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let argument_count = context.vm.frame().argument_count;
-        let param_count = context.vm.frame().code_block().parameter_length;
+        let frame = context.vm.frame();
+        let argument_count = frame.argument_count;
+        let param_count = frame.code_block().parameter_length;
 
         let array = if argument_count >= param_count {
             let rest_count = argument_count - param_count + 1;

--- a/core/engine/src/vm/opcode/set/name.rs
+++ b/core/engine/src/vm/opcode/set/name.rs
@@ -54,18 +54,16 @@ pub(crate) struct SetName;
 
 impl SetName {
     fn operation(context: &mut Context, index: usize) -> JsResult<CompletionType> {
-        let mut binding_locator = context.vm.frame().code_block.bindings[index].clone();
+        let code_block = context.vm.frame().code_block();
+        let mut binding_locator = code_block.bindings[index].clone();
+        let strict = code_block.strict();
         let value = context.vm.pop();
 
         context.find_runtime_binding(&mut binding_locator)?;
 
         verify_initialized(&binding_locator, context)?;
 
-        context.set_binding(
-            &binding_locator,
-            value,
-            context.vm.frame().code_block.strict(),
-        )?;
+        context.set_binding(&binding_locator, value, strict)?;
 
         Ok(CompletionType::Normal)
     }
@@ -105,9 +103,9 @@ impl Operation for SetNameByLocator {
     const COST: u8 = 4;
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
-        let binding_locator = context
-            .vm
-            .frame_mut()
+        let frame = context.vm.frame_mut();
+        let strict = frame.code_block.strict();
+        let binding_locator = frame
             .binding_stack
             .pop()
             .expect("locator should have been popped before");
@@ -115,11 +113,7 @@ impl Operation for SetNameByLocator {
 
         verify_initialized(&binding_locator, context)?;
 
-        context.set_binding(
-            &binding_locator,
-            value,
-            context.vm.frame().code_block.strict(),
-        )?;
+        context.set_binding(&binding_locator, value, strict)?;
 
         Ok(CompletionType::Normal)
     }


### PR DESCRIPTION
This PR slightly changes how we store and access call frames in the vm. In addition to the `frames` stack, there is now a `frame` field that always holds the current call frame. The main reason for this is, so that we can avoid panic checks in critical paths.

I also removed some duplicate calls to `Vm::frame` and `Vm::fram_mut` and grouped them where possible. This should not be that relevant anymore, since now it's just a field access.

Here two graphs to visualize the change. These are running in `dev` profile so functions are visible. Here the bigger impact seems to actually be the deref of the `frames` vec, but I'm not sure if the actual cost in `release` looks different.

Before:
![image](https://github.com/boa-dev/boa/assets/32105367/79ab0e53-a205-4a73-a2c2-e5dc2833d5a9)

After:
![image](https://github.com/boa-dev/boa/assets/32105367/74a00cba-bf1d-4402-be9d-5210b5689d2d)

And here some benchmarks. I did not run them multiple times, the impact seems a bit high to me:

Before:
```txt
RESULT Richards 55.7
RESULT DeltaBlue 57.8
RESULT Crypto 67.7
RESULT RayTrace 187
RESULT EarleyBoyer 174
RESULT RegExp 60.4
RESULT Splay 192
RESULT NavierStokes 155
SCORE 103
```

After:
```txt
RESULT Richards 59.1
RESULT DeltaBlue 59.7
RESULT Crypto 72.5
RESULT RayTrace 197
RESULT EarleyBoyer 182
RESULT RegExp 60.0
RESULT Splay 189
RESULT NavierStokes 172
SCORE 108
```