### PR TITLE
Patch regression from change to to-relative-to-object

### DIFF
--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -252,6 +252,7 @@ pub(crate) fn to_relative_temporal_object(
     let plain_date = match relative_to {
         JsValue::String(relative_to_str) => JsValue::from(relative_to_str),
         JsValue::Object(relative_to_obj) => JsValue::from(relative_to_obj),
+        JsValue::Undefined => return Ok((None, None)),
         _ => {
             return Err(JsNativeError::typ()
                 .with_message("Invalid type for converting to relativeTo object")

--- a/core/engine/src/builtins/temporal/options.rs
+++ b/core/engine/src/builtins/temporal/options.rs
@@ -53,12 +53,12 @@ pub(crate) fn get_difference_settings(
     context: &mut Context,
 ) -> JsResult<DifferenceSettings> {
     let mut settings = DifferenceSettings::default();
-    settings.rounding_mode =
-        get_option::<TemporalRoundingMode>(options, js_str!("roundingMode"), context)?;
+    settings.largest_unit = get_option::<TemporalUnit>(options, js_str!("largestUnit"), context)?;
     settings.increment =
         get_option::<RoundingIncrement>(options, js_str!("roundingIncrement"), context)?;
+    settings.rounding_mode =
+        get_option::<TemporalRoundingMode>(options, js_str!("roundingMode"), context)?;
     settings.smallest_unit = get_option::<TemporalUnit>(options, js_str!("smallestUnit"), context)?;
-    settings.largest_unit = get_option::<TemporalUnit>(options, js_str!("largestUnit"), context)?;
     Ok(settings)
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This fixes a regression on the tests from changes to the `to_relative_to_object` function.

The function was early returning an error on `relativeTo` being undefined, which is incorrect.

There's also a small update to the order that we fetch `DiffferenceSettings` to be more in line with the order in the specification.
