### PR TITLE
bump gc threshold

### DIFF
--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -65,7 +65,7 @@ struct GcConfig {
 impl Default for GcConfig {
     fn default() -> Self {
         Self {
-            // Start at 1MB, the nursary for V8 is ~1-8MB and SM can be up to 16MB, so we have room to increase if needed.
+            // Start at 1MB, the nursary size for V8 is ~1-8MB and SM can be up to 16MB
             threshold: 1_000_000,
             used_space_percentage: 70,
         }

--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -65,6 +65,7 @@ struct GcConfig {
 impl Default for GcConfig {
     fn default() -> Self {
         Self {
+            // Start at 1MB, the nursary for V8 is ~1-8MB and SM can be up to 16MB, so we have room to increase if needed.
             threshold: 1_000_000,
             used_space_percentage: 70,
         }

--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -66,7 +66,7 @@ impl Default for GcConfig {
     fn default() -> Self {
         Self {
             // Start at 1MB, the nursary size for V8 is ~1-8MB and SM can be up to 16MB
-            threshold: 1_000_000,
+            threshold: 1_048_576,
             used_space_percentage: 70,
         }
     }

--- a/core/gc/src/lib.rs
+++ b/core/gc/src/lib.rs
@@ -53,7 +53,9 @@ thread_local!(static BOA_GC: RefCell<BoaGc> = RefCell::new( BoaGc {
 
 #[derive(Debug, Clone, Copy)]
 struct GcConfig {
+    /// The threshold at which the garbage collector will trigger a collection.
     threshold: usize,
+    /// The percentage of used space at which the garbage collector will trigger a collection.
     used_space_percentage: usize,
 }
 
@@ -63,7 +65,7 @@ struct GcConfig {
 impl Default for GcConfig {
     fn default() -> Self {
         Self {
-            threshold: 1024,
+            threshold: 1_000_000,
             used_space_percentage: 70,
         }
     }
@@ -191,6 +193,8 @@ impl Allocator {
         if gc.runtime.bytes_allocated > gc.config.threshold {
             Collector::collect(gc);
 
+            // Post collection check
+            // If the allocated bytes are still above the threshold, increase the threshold.
             if gc.runtime.bytes_allocated
                 > gc.config.threshold / 100 * gc.config.used_space_percentage
             {


### PR DESCRIPTION
As mentioned in https://github.com/boa-dev/boa/issues/3896, Boa's GC threshold is set too low. This was causing too many GC collections before the interpreter even started running.

We see an improvement to the 2.

```
Benchmark main: ./target/release/boa
  Time (mean ± σ): 2.2 ms ± 0.2 ms [User: 0.6 ms, System: 0.1 ms]
  Range (min … max): 2.0 ms … 3.4 ms 827 runs
```

```
Benchmark PR: ./target/release/boa
  Time (mean ± σ):       2.1 ms ±   0.1 ms    [User: 0.6 ms, System: 0.1 ms]
  Range (min … max):     1.9 ms …   2.8 ms    924 runs
```

Looking at the traces:

Before:
![image](https://github.com/boa-dev/boa/assets/936006/e2d80abc-da1e-4f7e-807c-48cd73ede886)

After (there are no GC collections in this trace)
![image](https://github.com/boa-dev/boa/assets/936006/c9c4e2a3-1208-4691-80dc-8123a83d045a)

1MB seems like a good start, we can always bump it higher or adjust after this, V8's nursery size before GC kicks in seems to be between 1-8MB,

