### PR TITLE
Cleanup README.md and contributor documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Discord channel
-    url: https://discord.gg/tUFFk9Y
+  - name: Matrix space
+    url: https://matrix.to/#/#boa:matrix.org
     about: Please ask and answer questions here.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,8 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[discord](https://discord.gg/tUFFk9Y) by contacting anyone in the _@boa_dev_
-group (check the yellow usernames).
+[Matrix](https://matrix.to/#/#boa:matrix.org) by contacting any of the admins in the space.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,8 +111,8 @@ cargo doc --all-features --document-private-items --workspace --no-deps
 
 ## Communication
 
-We have a Discord server, feel free to ask questions here:
-<https://discord.gg/tUFFk9Y>
+We have a Matrix space, feel free to ask questions here:
+<https://matrix.to/#/#boa:matrix.org>
 
 [issues]: https://github.com/boa-dev/boa/issues
 [rustup]: https://rustup.rs/

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Boa currently publishes and actively maintains the following crates:
 - **`boa_profiler`** - Boa's code profiler
 - **`boa_icu_provider`** - Boa's ICU4X data provider
 - **`boa_runtime`** - Boa's WebAPI features
+- **`boa_string`** - Boa's ECMAScript string implementation.
 
-Please note: the `Boa` and `boa_unicode` crate are deprecated.
+Please note: the `Boa` and `boa_unicode` crates are deprecated.
 
 ## Boa Engine Example
 
@@ -54,7 +55,7 @@ Add the below dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-boa_engine = "0.17.3"
+boa_engine = "0.19.0"
 ```
 
 Then in `main.rs`, copy the below:
@@ -178,8 +179,9 @@ See [CHANGELOG.md](./CHANGELOG.md).
 
 ## Communication
 
-Feel free to contact us on [Discord](https://discord.gg/tUFFk9Y) for any questions or issues. The general
-contributor chat for Boa occurs on [Matrix](https://matrix.to/#/#boa:matrix.org) if you're interested in contributing.
+Feel free to contact us on [Matrix](https://matrix.to/#/#boa:matrix.org) if you have any questions.
+Contributor discussions take place on the same Matrix Space if you're interested in contributing.
+We also have a [Discord](https://discord.gg/tUFFk9Y) for any questions or issues.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,6 +11,6 @@ on [crates.io][crate].
 
 ## Reporting a Vulnerability
 
-If you find any potential vulnerability, join our [discord](https://discord.gg/tUFFk9Y) channel
-and contact anyone in the _@boa_dev_ group (check the yellow usernames). Explain how to trigger
-the vulnerability, where can it be found and any recommendation you might have to fix it.
+If you find any potential vulnerability, join our [Matrix](https://matrix.to/#/#boa:matrix.org) space
+and contact anyone who is an admin. Explain how to trigger the vulnerability, where can it be found
+and any recommendation you might have to fix it.


### PR DESCRIPTION
Mainly replaced the Discord links with the new Matrix space, and set the new Boa version in the tutorial.
