### PR TITLE
Add `JsStringBuilder` to build `JsString`

### DIFF
--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -1389,7 +1389,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
         self.len() == 0
     }
 
-    /// build `JsString` from JsStringBuilder
+    /// build `JsString` from `JsStringBuilder`
     #[must_use]
     pub fn build(mut self) -> JsString {
         if self.is_empty() {

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -1145,7 +1145,7 @@ impl ToStringEscaped for [u16] {
             .collect()
     }
 }
-/// Inner elements represented for [`RawJsString`].
+/// Inner elements represented for `RawJsString`.
 pub trait JsStringData: std::fmt::Display {}
 
 impl JsStringData for u8 {}
@@ -1194,7 +1194,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
         Self::NEW
     }
 
-    /// Returns the number of elements in the inner [`RawJsString`], also referred to
+    /// Returns the number of elements in the inner `RawJsString`, also referred to
     #[inline]
     #[must_use]
     pub fn len(&self) -> usize {
@@ -1205,7 +1205,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
     ///
     /// # Safety
     ///
-    /// - `new_len` must be less than or equal to [`capacity()`].
+    /// - `new_len` must be less than or equal to `capacity()`.
     /// - The elements at `old_len..new_len` must be initialized.
     ///
     #[inline]
@@ -1215,7 +1215,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
         self.len = new_len;
     }
 
-    /// Returns the total number of elements the inner [`RawJsString`] can hold without reallocating
+    /// Returns the total number of elements the inner `RawJsString` can hold without reallocating
     #[inline]
     #[must_use]
     pub fn capacity(&self) -> usize {

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -1151,15 +1151,16 @@ pub trait JsStringData: std::fmt::Display {}
 impl JsStringData for u8 {}
 impl JsStringData for u16 {}
 
-/// A mutable builder to create instance of JsString.
+/// A mutable builder to create instance of `JsString`.
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
+/// use boa_string::JsStringBuilder;
 /// let mut s = JsStringBuilder::new();
-/// s.push(ch);
-/// s.extend_from_slice(slice);
-/// s.extend(iter);
+/// s.push(b'x');
+/// s.extend_from_slice(&[b'1', b'2', b'3']);
+/// s.extend([b'1', b'2', b'3']);
 /// let js_string = s.build();
 /// ```
 #[derive(Debug)]
@@ -1190,6 +1191,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
 
     /// Create a new `JsStringBuilder` with capacity of zero.
     #[inline]
+    #[must_use]
     pub const fn new() -> Self {
         Self::NEW
     }
@@ -1223,6 +1225,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
     }
 
     /// create a new `JsStringBuilder` with specific capacity
+    #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
         let layout = Self::new_layout(cap);
         #[allow(clippy::cast_ptr_alignment)]
@@ -1245,6 +1248,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
         self.inner == NonNull::dangling()
     }
 
+    #[allow(clippy::cast_ptr_alignment)]
     fn reserve(&mut self, new_layout: Layout) {
         // SAFETY:
         // The layout size of `RawJsString` is never zero, since it has to store
@@ -1379,13 +1383,14 @@ impl<T: JsStringData> JsStringBuilder<T> {
         }
     }
 
-    /// Returns true if this JsStringBuilder has a length of zero, and false otherwise.
+    /// Returns true if this `JsStringBuilder` has a length of zero, and false otherwise.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
 
     /// build `JsString` from JsStringBuilder
+    #[must_use]
     pub fn build(mut self) -> JsString {
         if self.is_empty() {
             return JsString::default();
@@ -1421,7 +1426,7 @@ impl<T: JsStringData> JsStringBuilder<T> {
 }
 
 impl<T: JsStringData> Drop for JsStringBuilder<T> {
-    /// Set cold since [`JsStringBuilder`] should be created to build JsString
+    /// Set cold since [`JsStringBuilder`] should be created to build `JsString`
     #[cold]
     fn drop(&mut self) {
         if self.is_dangling() {

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -1170,9 +1170,17 @@ pub struct JsStringBuilder<T: JsStringData> {
     phantom_data: PhantomData<T>,
 }
 
+impl<T: JsStringData> Default for JsStringBuilder<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<T: JsStringData> JsStringBuilder<T> {
     const DATA_SIZE: usize = std::mem::size_of::<T>();
     const IS_LATIN: bool = Self::DATA_SIZE == std::mem::size_of::<u8>();
+
+    /// Constant default for [`JsStringBuilder`]
     pub const NEW: Self = Self {
         cap: 0,
         len: 0,

--- a/core/string/src/tests.rs
+++ b/core/string/src/tests.rs
@@ -2,7 +2,7 @@
 
 use std::hash::{BuildHasher, BuildHasherDefault, Hash};
 
-use crate::{JsStr, JsString, StaticJsStrings};
+use crate::{JsStr, JsString, JsStringBuilder, StaticJsStrings};
 
 use boa_macros::utf16;
 use rustc_hash::FxHasher;
@@ -163,4 +163,53 @@ fn conversion_to_known_static_js_string() {
 
     assert!(string.is_some());
     assert!(string.unwrap().as_str().is_latin1());
+}
+
+#[test]
+fn js_string_builder() {
+    let _s_utf16 = utf16!("2024年5月21日").repeat(10);
+    let s_utf16 = _s_utf16.as_slice();
+    let s_utf8 = &b"Lorem ipsum dolor sit amet"[..];
+
+    // utf8 -- test
+    let s_js_string = JsString::from(JsStr::latin1(s_utf8));
+
+    // push
+    let mut builder: JsStringBuilder<u8> = JsStringBuilder::new();
+    for &code in s_utf8 {
+        builder.push(code);
+    }
+    let s_builder = builder.build();
+    assert_eq!(s_js_string, s_builder);
+
+    // from_iter
+    let s_builder = JsStringBuilder::from_iter(s_utf8.iter().copied()).build();
+    assert_eq!(s_js_string, s_builder);
+
+    // extend_from_slice
+    let mut builder = JsStringBuilder::new();
+    builder.extend_from_slice(s_utf8);
+    let s_builder = builder.build();
+    assert_eq!(s_js_string, s_builder);
+
+    // utf16 -- test
+    let s_js_string = JsString::from(s_utf16);
+
+    // push
+    let mut builder = JsStringBuilder::new();
+    for &code in s_utf16 {
+        builder.push(code);
+    }
+    let s_builder = builder.build();
+    assert_eq!(s_js_string, s_builder);
+
+    // from_iter
+    let s_builder = JsStringBuilder::from_iter(s_utf16.iter().copied()).build();
+    assert_eq!(s_js_string, s_builder);
+
+    // extend_from_slice
+    let mut builder = JsStringBuilder::new();
+    builder.extend_from_slice(s_utf16);
+    let s_builder = builder.build();
+    assert_eq!(s_js_string, s_builder);
 }

--- a/core/string/src/tests.rs
+++ b/core/string/src/tests.rs
@@ -183,7 +183,11 @@ fn js_string_builder() {
     assert_eq!(s_js_string, s_builder);
 
     // from_iter
-    let s_builder = JsStringBuilder::from_iter(s_utf8.iter().copied()).build();
+    let s_builder = s_utf8
+        .iter()
+        .copied()
+        .collect::<JsStringBuilder<_>>()
+        .build();
     assert_eq!(s_js_string, s_builder);
 
     // extend_from_slice
@@ -204,7 +208,11 @@ fn js_string_builder() {
     assert_eq!(s_js_string, s_builder);
 
     // from_iter
-    let s_builder = JsStringBuilder::from_iter(s_utf16.iter().copied()).build();
+    let s_builder = s_utf8
+        .iter()
+        .copied()
+        .collect::<JsStringBuilder<_>>()
+        .build();
     assert_eq!(s_js_string, s_builder);
 
     // extend_from_slice

--- a/core/string/src/tests.rs
+++ b/core/string/src/tests.rs
@@ -208,7 +208,7 @@ fn js_string_builder() {
     assert_eq!(s_js_string, s_builder);
 
     // from_iter
-    let s_builder = s_utf8
+    let s_builder = s_utf16
         .iter()
         .copied()
         .collect::<JsStringBuilder<_>>()

--- a/core/string/src/tests.rs
+++ b/core/string/src/tests.rs
@@ -167,8 +167,8 @@ fn conversion_to_known_static_js_string() {
 
 #[test]
 fn js_string_builder() {
-    let _s_utf16 = utf16!("2024年5月21日").repeat(10);
-    let s_utf16 = _s_utf16.as_slice();
+    let utf16 = "2024年5月21日".encode_utf16().collect::<Vec<_>>();
+    let s_utf16 = utf16.as_slice();
     let s_utf8 = &b"Lorem ipsum dolor sit amet"[..];
 
     // utf8 -- test


### PR DESCRIPTION
There are many places where `Vec` is used as a builder to create `JsString`. This adds a more natural `JsStringBuilder` as an alternative choice.