### PR TITLE
Add a js_error! macro to create opaque errors

### DIFF
--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -17,7 +17,7 @@ use thiserror::Error;
 /// Create an opaque error object from a value. This can be a literal or any
 /// value that can be converted to a `JsValue`.
 ///
-/// Can be used with an expression that converts into JsValue or a format
+/// Can be used with an expression that converts into `JsValue` or a format
 /// string with arguments.
 ///
 /// # Examples

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -14,6 +14,43 @@ use boa_gc::{custom_trace, Finalize, Trace};
 use boa_macros::js_str;
 use thiserror::Error;
 
+/// Create an opaque error object from a value. This can be a literal or any
+/// value that can be converted to a `JsValue`.
+///
+/// Can be used with an expression that converts into JsValue or a format
+/// string with arguments.
+///
+/// # Examples
+///
+/// ```
+/// # use boa_engine::{js_str, Context, JsValue};
+/// use boa_engine::{js_error};
+/// let context = &mut Context::default();
+///
+/// let error = js_error!("error!");
+/// assert!(error.as_opaque().is_some());
+/// assert_eq!(error.as_opaque().unwrap().to_string(context).unwrap(), "error!");
+///
+/// let error = js_error!("error: {}", 5);
+/// assert_eq!(error.as_opaque().unwrap().to_string(context).unwrap(), "error: 5");
+///
+/// let error = js_error!(true);
+/// assert_eq!(error.as_opaque().unwrap(), &JsValue::from(true));
+/// ```
+#[macro_export]
+macro_rules! js_error {
+    ($value: expr) => {
+        $crate::JsError::from_opaque(
+            $crate::JsValue::from($value)
+        )
+    };
+    ($value: literal $(, $args: tt)* $(,)?) => {
+        $crate::JsError::from_opaque($crate::JsValue::from(
+            $crate::JsString::from(format!($value $(, $args)*))
+        ))
+    };
+}
+
 /// The error type returned by all operations related
 /// to the execution of Javascript code.
 ///
@@ -352,7 +389,7 @@ impl JsError {
     ///
     /// assert!(error.as_native().is_some());
     ///
-    /// let error = JsError::from_opaque(JsValue::undefined().into());
+    /// let error = JsError::from_opaque(JsValue::undefined());
     ///
     /// assert!(error.as_native().is_none());
     /// ```

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -14,8 +14,7 @@ use boa_gc::{custom_trace, Finalize, Trace};
 use boa_macros::js_str;
 use thiserror::Error;
 
-/// Create an opaque error object from a value. This can be a literal or any
-/// value that can be converted to a `JsValue`.
+/// Create an opaque error object from a value or string literal.
 ///
 /// Can be used with an expression that converts into `JsValue` or a format
 /// string with arguments.
@@ -34,11 +33,17 @@ use thiserror::Error;
 /// let error = js_error!("error: {}", 5);
 /// assert_eq!(error.as_opaque().unwrap().to_string(context).unwrap(), "error: 5");
 ///
-/// let error = js_error!(true);
+/// // Non-string literals must be used as an expression.
+/// let error = js_error!({ true });
 /// assert_eq!(error.as_opaque().unwrap(), &JsValue::from(true));
 /// ```
 #[macro_export]
 macro_rules! js_error {
+    ($value: literal) => {
+        $crate::JsError::from_opaque($crate::JsValue::from(
+            $crate::js_string!($value)
+        ))
+    };
     ($value: expr) => {
         $crate::JsError::from_opaque(
             $crate::JsValue::from($value)

--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -39,24 +39,6 @@ impl From<char> for JsValue {
     }
 }
 
-impl From<&str> for JsValue {
-    #[inline]
-    fn from(value: &str) -> Self {
-        let _timer = Profiler::global().start_event("From<&str>", "value");
-
-        Self::from(js_string!(value))
-    }
-}
-
-impl From<String> for JsValue {
-    #[inline]
-    fn from(value: String) -> Self {
-        let _timer = Profiler::global().start_event("From<&str>", "value");
-
-        Self::from(JsString::from(value))
-    }
-}
-
 impl From<JsSymbol> for JsValue {
     #[inline]
     fn from(value: JsSymbol) -> Self {

--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -39,6 +39,24 @@ impl From<char> for JsValue {
     }
 }
 
+impl From<&str> for JsValue {
+    #[inline]
+    fn from(value: &str) -> Self {
+        let _timer = Profiler::global().start_event("From<&str>", "value");
+
+        Self::from(js_string!(value))
+    }
+}
+
+impl From<String> for JsValue {
+    #[inline]
+    fn from(value: String) -> Self {
+        let _timer = Profiler::global().start_event("From<&str>", "value");
+
+        Self::from(JsString::from(value))
+    }
+}
+
 impl From<JsSymbol> for JsValue {
     #[inline]
     fn from(value: JsSymbol) -> Self {

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -1073,19 +1073,14 @@ impl<const N: usize> PartialEq<[u16; N]> for JsString {
 impl PartialEq<str> for JsString {
     #[inline]
     fn eq(&self, other: &str) -> bool {
-        let utf16 = self.code_points();
-        let mut utf8 = other.chars();
+        self.as_str() == other
+    }
+}
 
-        for lhs in utf16 {
-            if let Some(rhs) = utf8.next() {
-                match lhs {
-                    CodePoint::Unicode(lhs) if lhs == rhs => continue,
-                    _ => return false,
-                }
-            }
-            return false;
-        }
-        utf8.next().is_none()
+impl PartialEq<&str> for JsString {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
     }
 }
 

--- a/core/string/src/str.rs
+++ b/core/string/src/str.rs
@@ -291,6 +291,16 @@ impl PartialEq for JsStr<'_> {
     }
 }
 
+impl PartialEq<&str> for JsStr<'_> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        match self.variant() {
+            JsStrVariant::Latin1(v) => v == other.as_bytes(),
+            JsStrVariant::Utf16(v) => other.encode_utf16().zip(v).all(|(a, b)| a == *b),
+        }
+    }
+}
+
 impl<'a> PartialEq<JsStr<'a>> for [u16] {
     #[inline]
     fn eq(&self, other: &JsStr<'a>) -> bool {

--- a/core/string/src/str.rs
+++ b/core/string/src/str.rs
@@ -291,13 +291,20 @@ impl PartialEq for JsStr<'_> {
     }
 }
 
-impl PartialEq<&str> for JsStr<'_> {
+impl PartialEq<str> for JsStr<'_> {
     #[inline]
-    fn eq(&self, other: &&str) -> bool {
+    fn eq(&self, other: &str) -> bool {
         match self.variant() {
             JsStrVariant::Latin1(v) => v == other.as_bytes(),
             JsStrVariant::Utf16(v) => other.encode_utf16().zip(v).all(|(a, b)| a == *b),
         }
+    }
+}
+
+impl PartialEq<&str> for JsStr<'_> {
+    #[inline]
+    fn eq(&self, other: &&str) -> bool {
+        self == *other
     }
 }
 


### PR DESCRIPTION
And as a bonus since I needed it, simplify comparison of strings and add PartialEq<&str> for JsString.
