### PR TITLE
Fix destructuring assignment evaluation order

### DIFF
--- a/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
+++ b/core/engine/src/bytecompiler/declaration/declaration_pattern.rs
@@ -119,6 +119,7 @@ impl ByteCompiler<'_> {
                             self.emit_opcode(Opcode::Dup);
                             if let PropertyName::Computed(node) = &name {
                                 self.compile_expr(node, true);
+                                self.emit_opcode(Opcode::ToPropertyKey);
                                 self.emit_opcode(Opcode::Swap);
                             }
 

--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -587,7 +587,7 @@ impl ByteCompiler<'_> {
                 .r#async(r#async)
                 .strict(self.strict())
                 .in_with(self.in_with)
-                .binding_identifier(Some(name.sym().to_js_string(self.interner())))
+                .binding_identifier(None)
                 .compile(
                     parameters,
                     body,

--- a/core/engine/src/vm/opcode/iteration/iterator.rs
+++ b/core/engine/src/vm/opcode/iteration/iterator.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{iterable::create_iter_result_object, Array},
     js_str,
     vm::{opcode::Operation, CompletionType, GeneratorResumeKind},
-    Context, JsResult,
+    Context, JsResult, JsValue,
 };
 
 /// `IteratorNext` implements the Opcode Operation for `Opcode::IteratorNext`
@@ -184,7 +184,12 @@ impl Operation for IteratorValueWithoutPop {
             .pop()
             .expect("iterator on the call frame must exist");
 
-        let value = iterator.value(context);
+        let value = if iterator.done() {
+            Ok(JsValue::undefined())
+        } else {
+            iterator.value(context)
+        };
+
         context.vm.frame_mut().iterators.push(iterator);
 
         context.vm.push(value?);


### PR DESCRIPTION
This PR changes the following:

- Fix evaluation of computed property names in declaration patterns
- Fix invalid value getter in iterator opcode
- Fix invalid setting of function binding identifier in `global_declaration_instantiation`
