### PR TITLE
Add a Source::with_path method to set the path on a Source

### DIFF
--- a/core/parser/src/source/mod.rs
+++ b/core/parser/src/source/mod.rs
@@ -121,10 +121,10 @@ impl<'path, R: Read> Source<'path, UTF8Input<R>> {
 
 impl<'path, R> Source<'path, R> {
     /// Add a path to the current [`Source`] instance.
-    pub fn with_path<'path2>(self, new_path: &'path2 Path) -> Self<'path2, R> {
-        Self {
+    pub fn with_path(self, new_path: &Path) -> Source<'_, R> {
+        Source {
             reader: self.reader,
-            path: new_path,
+            path: Some(new_path),
         }
     }
 

--- a/core/parser/src/source/mod.rs
+++ b/core/parser/src/source/mod.rs
@@ -120,6 +120,14 @@ impl<'path, R: Read> Source<'path, UTF8Input<R>> {
 }
 
 impl<'path, R> Source<'path, R> {
+    /// Add a path to the current [`Source`] instance.
+    pub fn with_path<'path2>(self, new_path: &'path2 Path) -> Self<'path2, R> {
+        Self {
+            reader: self.reader,
+            path: new_path,
+        }
+    }
+
     /// Returns the path (if any) of this source file.
     pub fn path(&self) -> Option<&'path Path> {
         self.path

--- a/core/parser/src/source/mod.rs
+++ b/core/parser/src/source/mod.rs
@@ -120,7 +120,7 @@ impl<'path, R: Read> Source<'path, UTF8Input<R>> {
 }
 
 impl<'path, R> Source<'path, R> {
-    /// Add a path to the current [`Source`] instance.
+    /// Sets the path of this [`Source`].
     pub fn with_path(self, new_path: &Path) -> Source<'_, R> {
         Source {
             reader: self.reader,


### PR DESCRIPTION
This should allow any path to be added to a Source, even when using `from_bytes` or `from_reader`.