### PR TITLE
Allow a custom Logger to be used as the backend for boa_runtime::Console

### DIFF
--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -54,10 +54,7 @@
 mod console;
 
 #[doc(inline)]
-pub use console::Console;
-
-#[doc(inline)]
-pub use console::Logger;
+pub use console::{Console, Logger};
 
 #[cfg(test)]
 pub(crate) mod test {

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -56,6 +56,9 @@ mod console;
 #[doc(inline)]
 pub use console::Console;
 
+#[doc(inline)]
+pub use console::Logger;
+
 #[cfg(test)]
 pub(crate) mod test {
     use boa_engine::{builtins, Context, JsResult, JsValue, Source};


### PR DESCRIPTION
There are some cleanup that could be done in the number of lines of codes, but this was the smallest change I could do to make the change.

This comes from a need to implement `Console` with using `tracing` as the backend. Please note that there is an issue here where multiple logs in the same function (e.g. `console.trace()`) would output into multiple log entries. This should probably be fixed in a following PR (as this one is already large enough).