### PR TITLE
lazy builtins

### DIFF
--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -203,7 +203,7 @@ impl Realm {
         ForInIterator::init(self);
         Math::init(self);
         Json::init(self);
-        Array::init(self);
+        // Array::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);
         ArrayBuffer::init(self);

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use crate::{
+    builtins::{Array, IntrinsicObject},
     environments::CompileTimeEnvironment,
     object::{JsObject, PrivateName},
     Context, JsResult, JsString, JsSymbol, JsValue,
@@ -641,6 +642,9 @@ impl Context {
         match locator.environment() {
             BindingLocatorEnvironment::GlobalObject => {
                 let key = locator.name().clone();
+                if key.as_str() == "Array" {
+                    Array::init(self.realm());
+                }
                 let obj = self.global_object();
                 obj.try_get(key, self)
             }

--- a/core/engine/src/realm.rs
+++ b/core/engine/src/realm.rs
@@ -60,7 +60,6 @@ struct Inner {
     template_map: GcRefCell<FxHashMap<u64, JsObject>>,
     loaded_modules: GcRefCell<FxHashMap<JsString, Module>>,
     host_classes: GcRefCell<FxHashMap<TypeId, StandardConstructor>>,
-
     host_defined: GcRefCell<HostDefined>,
 }
 

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -110,6 +110,7 @@ unsafe impl Trace for ActiveRunnable {
 impl Vm {
     /// Creates a new virtual machine.
     pub(crate) fn new(realm: Realm) -> Self {
+        let _timer = Profiler::global().start_event("Vm:new", "vm");
         Self {
             frames: Vec::with_capacity(16),
             frame: CallFrame::new(


### PR DESCRIPTION
I just did this to experiment if lazy loading builtins would work and tryed it out with Array for now.

Using the js input

```js
console.log(Array);
```

Before:
![image](https://github.com/user-attachments/assets/31740581-54f3-4795-b287-d204f7f5a096)

After:
![image](https://github.com/user-attachments/assets/54650fcd-0010-4bb2-9338-fdfdb4829249)

@jedel1043 do you have any pointers on how is best to structure this, and is the `GetName` operation `BindingLocatorEnvironment::GlobalObject` going to be a safe assumption for global builtin access?