### PR TITLE
Build out partial record functionality, property bag construction, and `with` methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,7 +3220,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "temporal_rs"
 version = "0.0.3"
-source = "git+https://github.com/boa-dev/temporal.git?rev=51bc30aa288b08b44daf6b73372a7335e5a54446#51bc30aa288b08b44daf6b73372a7335e5a54446"
+source = "git+https://github.com/boa-dev/temporal.git?rev=1e7901d07a83211e62373ab94284a7d1ada4c913#1e7901d07a83211e62373ab94284a7d1ada4c913"
 dependencies = [
  "bitflags 2.6.0",
  "icu_calendar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3220,7 +3220,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "temporal_rs"
 version = "0.0.3"
-source = "git+https://github.com/boa-dev/temporal.git?rev=af94bbc31d409a2bfdce473e667e08e16c677149#af94bbc31d409a2bfdce473e667e08e16c677149"
+source = "git+https://github.com/boa-dev/temporal.git?rev=51bc30aa288b08b44daf6b73372a7335e5a54446#51bc30aa288b08b44daf6b73372a7335e5a54446"
 dependencies = [
  "bitflags 2.6.0",
  "icu_calendar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ intrusive-collections = "0.9.6"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.1"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "af94bbc31d409a2bfdce473e667e08e16c677149" }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "51bc30aa288b08b44daf6b73372a7335e5a54446" }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,7 +116,7 @@ intrusive-collections = "0.9.6"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.1"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "51bc30aa288b08b44daf6b73372a7335e5a54446" }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "1e7901d07a83211e62373ab94284a7d1ada4c913" }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.9.0"

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -279,16 +279,15 @@ pub(crate) fn is_partial_temporal_object<'value>(
     value: &'value JsValue,
     context: &mut Context,
 ) -> JsResult<Option<&'value JsObject>> {
-    // 2. If value has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]],
-    // [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]],
-    // [[InitializedTemporalYearMonth]], or
-    // [[InitializedTemporalZonedDateTime]] internal slot, return false.
-
     // 1. If value is not an Object, return false.
     let Some(obj) = value.as_object() else {
         return Ok(None);
     };
 
+    // 2. If value has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]],
+    // [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]],
+    // [[InitializedTemporalYearMonth]], or
+    // [[InitializedTemporalZonedDateTime]] internal slot, return false.
     if obj.is::<PlainDate>()
         || obj.is::<PlainDateTime>()
         || obj.is::<PlainMonthDay>()

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -274,6 +274,47 @@ pub(crate) fn to_relative_temporal_object(
 // 13.26 `GetUnsignedRoundingMode ( roundingMode, isNegative )`
 // Implemented on RoundingMode in builtins/options.rs
 
+// 13.26 IsPartialTemporalObject ( object )
+pub(crate) fn is_partial_temporal_object<'value>(
+    value: &'value JsValue,
+    context: &mut Context,
+) -> JsResult<Option<&'value JsObject>> {
+    // 2. If value has an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]],
+    // [[InitializedTemporalMonthDay]], [[InitializedTemporalTime]],
+    // [[InitializedTemporalYearMonth]], or
+    // [[InitializedTemporalZonedDateTime]] internal slot, return false.
+
+    // 1. If value is not an Object, return false.
+    let Some(obj) = value.as_object() else {
+        return Ok(None);
+    };
+
+    if obj.is::<PlainDate>()
+        || obj.is::<PlainDateTime>()
+        || obj.is::<PlainMonthDay>()
+        || obj.is::<PlainYearMonth>()
+        || obj.is::<PlainTime>()
+        || obj.is::<ZonedDateTime>()
+    {
+        return Ok(None);
+    }
+
+    // 3. Let calendarProperty be ? Get(value, "calendar").
+    let calendar_property = obj.get(js_str!("calendar"), context)?;
+    // 4. If calendarProperty is not undefined, return false.
+    if !calendar_property.is_undefined() {
+        return Ok(None);
+    }
+    // 5. Let timeZoneProperty be ? Get(value, "timeZone").
+    let time_zone_property = obj.get(js_str!("timeZone"), context)?;
+    // 6. If timeZoneProperty is not undefined, return false.
+    if !time_zone_property.is_undefined() {
+        return Ok(None);
+    }
+    // 7. Return true.
+    Ok(Some(obj))
+}
+
 // 13.27 `ApplyUnsignedRoundingMode ( x, r1, r2, unsignedRoundingMode )`
 // Migrated to `temporal_rs`
 

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -29,9 +29,8 @@ use temporal_rs::{
     },
     iso::IsoDateSlots,
     options::ArithmeticOverflow,
-    TemporalFields,
+    TemporalFields, TinyAsciiStr,
 };
-use tinystr::TinyAsciiStr;
 
 use super::{
     calendar::{get_temporal_calendar_slot_value_with_default, to_temporal_calendar_slot_value},

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -639,13 +639,13 @@ impl PlainDate {
         };
         let options = get_options_object(args.get_or_undefined(1))?;
 
+        // SKIP: Steps 4-9 are handled by the with method of temporal_rs's Date
         // 4. Let resolvedOptions be ? SnapshotOwnProperties(? GetOptionsObject(options), null).
         // 5. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-from-fields, fields, merge-fields »).
         // 6. Let fieldsResult be ? PrepareCalendarFieldsAndFieldNames(calendarRec, temporalDate, « "day", "month", "monthCode", "year" »).
         // 7. Let partialDate be ? PrepareTemporalFields(temporalDateLike, fieldsResult.[[FieldNames]], partial).
         // 8. Let fields be ? CalendarMergeFields(calendarRec, fieldsResult.[[Fields]], partialDate).
         // 9. Set fields to ? PrepareTemporalFields(fields, fieldsResult.[[FieldNames]], «»).
-
         let overflow = get_option::<ArithmeticOverflow>(&options, js_str!("overflow"), context)?;
         let partial = to_partial_date_record(partial_object, context)?;
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 use temporal_rs::{
     components::{
         calendar::{Calendar, GetTemporalCalendar},
-        DateTime as InnerDateTime, Time,
+        DateTime as InnerDateTime, PartialDateTime, Time,
     },
     iso::{IsoDate, IsoDateSlots},
     options::{ArithmeticOverflow, RoundingIncrement, RoundingOptions, TemporalRoundingMode},
@@ -702,10 +702,12 @@ impl PlainDateTime {
         let date = to_partial_date_record(partial_object, context)?;
         let time = to_partial_time_record(partial_object, context)?;
 
-        // TODO: PartialDateTime pub fields.
-        Err(JsNativeError::range()
-            .with_message("not yet implemented.")
-            .into())
+        let partial_dt = PartialDateTime { date, time };
+
+        let overflow = get_option::<ArithmeticOverflow>(&options, js_str!("overflow"), context)?;
+
+        create_temporal_datetime(dt.inner.with(partial_dt, overflow)?, None, context)
+            .map(Into::into)
     }
 
     /// 5.3.26 Temporal.PlainDateTime.prototype.withPlainTime ( `[ plainTimeLike ]` )

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -1020,6 +1020,40 @@ impl JsValue {
         .into()
     }
 
+    /// Maps a `JsValue` into a `Option<T>` where T is the result of an
+    /// operation on a defined value. If the value is `JsValue::undefined`,
+    /// then `JsValue::map` will return None.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use boa_engine::{JsValue, Context};
+    ///
+    /// let mut context = Context::default();
+    ///
+    /// let defined_value = JsValue::from(5);
+    /// let undefined = JsValue::undefined();
+    ///
+    /// let defined_result = defined_value.map(|v| v.add(&JsValue::from(5), &mut context)).transpose().unwrap();
+    /// let undefined_result = undefined.map(|v| v.add(&JsValue::from(5), &mut context)).transpose().unwrap();
+    ///
+    /// assert_eq!(defined_result, Some(JsValue::Integer(10)));
+    /// assert_eq!(undefined_result, None);
+    ///
+    /// ```
+    ///
+    #[inline]
+    #[must_use]
+    pub fn map<T, F>(&self, f: F) -> Option<T>
+    where
+        F: FnOnce(&JsValue) -> T,
+    {
+        if self.is_undefined() {
+            return None;
+        }
+        Some(f(self))
+    }
+
     /// Abstract operation `IsArray ( argument )`
     ///
     /// Check if a value is an array.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This PR is related to the ongoing work for temporal, specifically in relation to the `with` methods and partial records.

It changes the following:

- Implements `map` on `JsValue`
- Implements `to_partial_date_record` and `to_partial_time_record`
- Builds out the `with` methods on `Time` and `Date` along with the property bags portions of `to_date` and `to_time` abstract methods

I totally blanked on making the fields of `PartialDateTime` public :sweat_smile: So that will hopefully still be coming after a patch I submitted is merged.