### PR TITLE
Latin1 is the wrong optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
 name = "boa_macros"
 version = "0.19.0"
 dependencies = [
+ "boa_engine",
  "proc-macro2",
  "quote",
  "syn",

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -17,6 +17,9 @@ syn = { workspace = true, features = ["full"] }
 proc-macro2.workspace = true
 synstructure.workspace = true
 
+[dev-dependencies]
+boa_engine.workspace = true
+
 [lints]
 workspace = true
 

--- a/core/macros/tests/tests.rs
+++ b/core/macros/tests/tests.rs
@@ -1,6 +1,7 @@
 #![allow(unused_crate_dependencies)]
 
-use boa_macros::utf16;
+use boa_engine::{JsStr, JsString};
+use boa_macros::{js_str, utf16};
 
 #[test]
 fn literal() {
@@ -14,4 +15,16 @@ fn utf16() {
     let utf16 = utf16!("hello!😁😁😁");
     let manual = "hello!😁😁😁".encode_utf16().collect::<Vec<_>>();
     assert_eq!(manual, utf16);
+}
+
+#[test]
+fn latin1_is_wrong() {
+    const NON_UTF8_LATIN1: JsStr<'_> = js_str!("Hello é World!");
+    assert!(NON_UTF8_LATIN1.is_latin1());
+
+    let js_string = JsString::from(NON_UTF8_LATIN1);
+    assert_eq!(
+        format!("{}", js_string.to_std_string_escaped()),
+        "Hello é World!"
+    );
 }


### PR DESCRIPTION
This is a PR showing a new test that breaks Latin1. The first `assert!` will pass, but the `assert_eq!` will fail.

The right optimization would be to use `u8::MAX >> 1` and make it ASCII only.