### PR TITLE
use with_capacity to reduce re-allocations fixes #3896

### DIFF
--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -105,7 +105,7 @@ impl IntrinsicObject for Array {
 
         let unscopables_object = Self::unscopables_object();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 41, 5>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             // Static Methods
             .static_method(Self::from, js_string!("from"), 1)
             .static_method(Self::is_array, js_string!("isArray"), 1)
@@ -190,6 +190,9 @@ impl BuiltInObject for Array {
 }
 
 impl BuiltInConstructor for Array {
+    const P: usize = 41;
+    const SP: usize = 5;
+
     const LENGTH: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -105,7 +105,7 @@ impl IntrinsicObject for Array {
 
         let unscopables_object = Self::unscopables_object();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 41, 5)
             // Static Methods
             .static_method(Self::from, js_string!("from"), 1)
             .static_method(Self::is_array, js_string!("isArray"), 1)

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -105,7 +105,7 @@ impl IntrinsicObject for Array {
 
         let unscopables_object = Self::unscopables_object();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 41, 5)
+        BuiltInBuilder::from_standard_constructor::<Self, 41, 5>(realm)
             // Static Methods
             .static_method(Self::from, js_string!("from"), 1)
             .static_method(Self::is_array, js_string!("isArray"), 1)

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -312,7 +312,7 @@ impl IntrinsicObject for ArrayBuffer {
             .name(js_string!("get detached"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, 9, 2)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self, 9, 2>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -312,7 +312,7 @@ impl IntrinsicObject for ArrayBuffer {
             .name(js_string!("get detached"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, 9, 2)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -312,7 +312,7 @@ impl IntrinsicObject for ArrayBuffer {
             .name(js_string!("get detached"))
             .build();
 
-        let builder = BuiltInBuilder::from_standard_constructor::<Self, 9, 2>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -374,6 +374,8 @@ impl BuiltInObject for ArrayBuffer {
 }
 
 impl BuiltInConstructor for ArrayBuffer {
+    const P: usize = 9;
+    const SP: usize = 2;
     const LENGTH: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for SharedArrayBuffer {
             .name(js_string!("get maxByteLength"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 6, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 6, 1>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for SharedArrayBuffer {
             .name(js_string!("get maxByteLength"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 6, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -155,6 +155,8 @@ impl BuiltInObject for SharedArrayBuffer {
 
 impl BuiltInConstructor for SharedArrayBuffer {
     const LENGTH: usize = 1;
+    const P: usize = 6;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::shared_array_buffer;

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for SharedArrayBuffer {
             .name(js_string!("get maxByteLength"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 6, 1)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/async_function/mod.rs
+++ b/core/engine/src/builtins/async_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 1, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().function().constructor())
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
@@ -52,6 +52,8 @@ impl BuiltInObject for AsyncFunction {
 
 impl BuiltInConstructor for AsyncFunction {
     const LENGTH: usize = 1;
+    const P: usize = 1;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::async_function;

--- a/core/engine/src/builtins/async_function/mod.rs
+++ b/core/engine/src/builtins/async_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 1, 0>(realm)
             .prototype(realm.intrinsics().constructors().function().constructor())
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),

--- a/core/engine/src/builtins/async_function/mod.rs
+++ b/core/engine/src/builtins/async_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 0)
             .prototype(realm.intrinsics().constructors().function().constructor())
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),

--- a/core/engine/src/builtins/async_generator_function/mod.rs
+++ b/core/engine/src/builtins/async_generator_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncGeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))
@@ -57,6 +57,8 @@ impl BuiltInObject for AsyncGeneratorFunction {
 
 impl BuiltInConstructor for AsyncGeneratorFunction {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::async_generator_function;

--- a/core/engine/src/builtins/async_generator_function/mod.rs
+++ b/core/engine/src/builtins/async_generator_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncGeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/async_generator_function/mod.rs
+++ b/core/engine/src/builtins/async_generator_function/mod.rs
@@ -28,7 +28,7 @@ impl IntrinsicObject for AsyncGeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for BigInt {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 2)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .static_method(Self::as_int_n, js_string!("asIntN"), 2)

--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for BigInt {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 3, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .static_method(Self::as_int_n, js_string!("asIntN"), 2)
@@ -65,6 +65,8 @@ impl BuiltInObject for BigInt {
 
 impl BuiltInConstructor for BigInt {
     const LENGTH: usize = 1;
+    const P: usize = 3;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::bigint;

--- a/core/engine/src/builtins/bigint/mod.rs
+++ b/core/engine/src/builtins/bigint/mod.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for BigInt {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 3, 2>(realm)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .static_method(Self::as_int_n, js_string!("asIntN"), 2)

--- a/core/engine/src/builtins/boolean/mod.rs
+++ b/core/engine/src/builtins/boolean/mod.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for Boolean {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();

--- a/core/engine/src/builtins/boolean/mod.rs
+++ b/core/engine/src/builtins/boolean/mod.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for Boolean {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();

--- a/core/engine/src/builtins/boolean/mod.rs
+++ b/core/engine/src/builtins/boolean/mod.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for Boolean {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -51,6 +51,8 @@ impl BuiltInObject for Boolean {
 
 impl BuiltInConstructor for Boolean {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::boolean;

--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -532,13 +532,7 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
 
 impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
     /// Create a new builder for a constructor function setting the properties ahead of time for optimizations (less reallocations)
-    /// Const Generic `P` is the minimum storage capacity for the prototype's Property table.
-    /// Const Generic `SP` is the minimum storage capacity for the object's Static Property table.
-    pub(crate) fn from_standard_constructor<
-        SC: BuiltInConstructor,
-        const P: usize,
-        const SP: usize,
-    >(
+    pub(crate) fn from_standard_constructor<SC: BuiltInConstructor>(
         realm: &'ctx Realm,
     ) -> BuiltInConstructorWithPrototype<'ctx> {
         let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
@@ -547,11 +541,11 @@ impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
             function: SC::constructor,
             name: js_string!(SC::NAME),
             length: SC::LENGTH,
-            object_property_table: PropertyTableInner::with_capacity(SP + OWN_PROPS),
-            object_storage: Vec::with_capacity(SP + OWN_PROPS),
+            object_property_table: PropertyTableInner::with_capacity(SC::SP + OWN_PROPS),
+            object_storage: Vec::with_capacity(SC::SP + OWN_PROPS),
             object: constructor.constructor(),
-            prototype_property_table: PropertyTableInner::with_capacity(P),
-            prototype_storage: Vec::with_capacity(P),
+            prototype_property_table: PropertyTableInner::with_capacity(SC::P),
+            prototype_storage: Vec::with_capacity(SC::P),
             prototype: constructor.prototype(),
             __proto__: Some(realm.intrinsics().constructors().function().prototype()),
             inherits: Some(realm.intrinsics().constructors().object().prototype()),

--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -135,6 +135,9 @@ impl ApplyToObject for OrdinaryObject {
     fn apply_to(self, _: &JsObject) {}
 }
 
+// The number of properties that are always present in a standard constructor. See build method
+const OWN_PROPS: usize = 3;
+
 /// Builder for creating built-in objects, like `Array`.
 ///
 /// The marker `ObjectType` restricts the methods that can be called depending on the
@@ -538,8 +541,6 @@ impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
     >(
         realm: &'ctx Realm,
     ) -> BuiltInConstructorWithPrototype<'ctx> {
-        // The number of properties that are always present in a standard constructor. See build method
-        const OWN_PROPS: usize = 3;
         let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
         BuiltInConstructorWithPrototype {
             realm,

--- a/core/engine/src/builtins/builder.rs
+++ b/core/engine/src/builtins/builder.rs
@@ -528,8 +528,13 @@ impl<'ctx> BuiltInBuilder<'ctx, OrdinaryObject> {
 }
 
 impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
+    /// Create a new builder for a constructor function setting the properties ahead of time for optimizations (less reallocations)
     pub(crate) fn from_standard_constructor<SC: BuiltInConstructor>(
         realm: &'ctx Realm,
+        // Sets the minimum storage capacity for the prototype's property table.
+        num_prototype_properties: usize,
+        // Sets the minimum storage capacity for the object's property table.
+        num_own_properties: usize,
     ) -> BuiltInConstructorWithPrototype<'ctx> {
         let constructor = SC::STANDARD_CONSTRUCTOR(realm.intrinsics().constructors());
         BuiltInConstructorWithPrototype {
@@ -537,11 +542,11 @@ impl<'ctx> BuiltInBuilder<'ctx, Callable<Constructor>> {
             function: SC::constructor,
             name: js_string!(SC::NAME),
             length: SC::LENGTH,
-            object_property_table: PropertyTableInner::default(),
-            object_storage: Vec::default(),
+            object_property_table: PropertyTableInner::with_capacity(num_own_properties),
+            object_storage: Vec::with_capacity(num_own_properties),
             object: constructor.constructor(),
-            prototype_property_table: PropertyTableInner::default(),
-            prototype_storage: Vec::default(),
+            prototype_property_table: PropertyTableInner::with_capacity(num_prototype_properties),
+            prototype_storage: Vec::with_capacity(num_prototype_properties),
             prototype: constructor.prototype(),
             __proto__: Some(realm.intrinsics().constructors().function().prototype()),
             inherits: Some(realm.intrinsics().constructors().object().prototype()),

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for DataView {
             .name(js_string!("get byteOffset"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 24, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 24, 0>(realm)
             .accessor(
                 js_string!("buffer"),
                 Some(get_buffer),

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for DataView {
             .name(js_string!("get byteOffset"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 24, 0)
             .accessor(
                 js_string!("buffer"),
                 Some(get_buffer),

--- a/core/engine/src/builtins/dataview/mod.rs
+++ b/core/engine/src/builtins/dataview/mod.rs
@@ -109,7 +109,7 @@ impl IntrinsicObject for DataView {
             .name(js_string!("get byteOffset"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 24, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .accessor(
                 js_string!("buffer"),
                 Some(get_buffer),
@@ -167,6 +167,8 @@ impl BuiltInObject for DataView {
 
 impl BuiltInConstructor for DataView {
     const LENGTH: usize = 1;
+    const P: usize = 24;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::data_view;

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -72,7 +72,7 @@ impl IntrinsicObject for Date {
             .length(1)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 47, 3>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::now, js_string!("now"), 0)
             .static_method(Self::parse, js_string!("parse"), 1)
             .static_method(Self::utc, js_string!("UTC"), 7)
@@ -185,6 +185,8 @@ impl BuiltInObject for Date {
 
 impl BuiltInConstructor for Date {
     const LENGTH: usize = 7;
+    const P: usize = 47;
+    const SP: usize = 3;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::date;

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -72,7 +72,7 @@ impl IntrinsicObject for Date {
             .length(1)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 47, 3)
+        BuiltInBuilder::from_standard_constructor::<Self, 47, 3>(realm)
             .static_method(Self::now, js_string!("now"), 0)
             .static_method(Self::parse, js_string!("parse"), 1)
             .static_method(Self::utc, js_string!("UTC"), 7)

--- a/core/engine/src/builtins/date/mod.rs
+++ b/core/engine/src/builtins/date/mod.rs
@@ -72,7 +72,7 @@ impl IntrinsicObject for Date {
             .length(1)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 47, 3)
             .static_method(Self::now, js_string!("now"), 0)
             .static_method(Self::parse, js_string!("parse"), 1)
             .static_method(Self::utc, js_string!("UTC"), 7)

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for AggregateError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for AggregateError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -52,6 +52,8 @@ impl BuiltInObject for AggregateError {
 
 impl BuiltInConstructor for AggregateError {
     const LENGTH: usize = 2;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::aggregate_error;

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for AggregateError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for EvalError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for EvalError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/eval.rs
+++ b/core/engine/src/builtins/error/eval.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for EvalError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -54,6 +54,8 @@ impl BuiltInObject for EvalError {
 
 impl BuiltInConstructor for EvalError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::eval_error;

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -136,7 +136,7 @@ impl IntrinsicObject for Error {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .property(js_string!("name"), Self::NAME, attribute)
             .property(js_string!("message"), js_string!(), attribute)
             .method(Self::to_string, js_string!("toString"), 0)

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -136,7 +136,7 @@ impl IntrinsicObject for Error {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(js_string!("name"), Self::NAME, attribute)
             .property(js_string!("message"), js_string!(), attribute)
             .method(Self::to_string, js_string!("toString"), 0)
@@ -154,6 +154,8 @@ impl BuiltInObject for Error {
 
 impl BuiltInConstructor for Error {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::error;

--- a/core/engine/src/builtins/error/mod.rs
+++ b/core/engine/src/builtins/error/mod.rs
@@ -136,7 +136,7 @@ impl IntrinsicObject for Error {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .property(js_string!("name"), Self::NAME, attribute)
             .property(js_string!("message"), js_string!(), attribute)
             .method(Self::to_string, js_string!("toString"), 0)

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for RangeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for RangeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/range.rs
+++ b/core/engine/src/builtins/error/range.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for RangeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -52,6 +52,8 @@ impl BuiltInObject for RangeError {
 
 impl BuiltInConstructor for RangeError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::range_error;

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -32,7 +32,7 @@ impl IntrinsicObject for ReferenceError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -32,7 +32,7 @@ impl IntrinsicObject for ReferenceError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -51,6 +51,8 @@ impl BuiltInObject for ReferenceError {
 
 impl BuiltInConstructor for ReferenceError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::reference_error;

--- a/core/engine/src/builtins/error/reference.rs
+++ b/core/engine/src/builtins/error/reference.rs
@@ -32,7 +32,7 @@ impl IntrinsicObject for ReferenceError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for SyntaxError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for SyntaxError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/syntax.rs
+++ b/core/engine/src/builtins/error/syntax.rs
@@ -35,7 +35,7 @@ impl IntrinsicObject for SyntaxError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -54,6 +54,8 @@ impl BuiltInObject for SyntaxError {
 
 impl BuiltInConstructor for SyntaxError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::syntax_error;

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for TypeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -60,6 +60,8 @@ impl BuiltInObject for TypeError {
 
 impl BuiltInConstructor for TypeError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::type_error;

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for TypeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/type.rs
+++ b/core/engine/src/builtins/error/type.rs
@@ -41,7 +41,7 @@ impl IntrinsicObject for TypeError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for UriError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)
@@ -53,6 +53,8 @@ impl BuiltInObject for UriError {
 
 impl BuiltInConstructor for UriError {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::uri_error;

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for UriError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/error/uri.rs
+++ b/core/engine/src/builtins/error/uri.rs
@@ -34,7 +34,7 @@ impl IntrinsicObject for UriError {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
         let attribute = Attribute::WRITABLE | Attribute::NON_ENUMERABLE | Attribute::CONFIGURABLE;
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .prototype(realm.intrinsics().constructors().error().constructor())
             .inherits(Some(realm.intrinsics().constructors().error().prototype()))
             .property(js_str!("name"), Self::NAME, attribute)

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -315,7 +315,7 @@ impl IntrinsicObject for BuiltInFunctionObject {
 
         let throw_type_error = realm.intrinsics().objects().throw_type_error();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 7, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .method(Self::apply, js_string!("apply"), 2)
             .method(Self::bind, js_string!("bind"), 1)
             .method(Self::call, js_string!("call"), 1)
@@ -356,6 +356,8 @@ impl BuiltInObject for BuiltInFunctionObject {
 
 impl BuiltInConstructor for BuiltInFunctionObject {
     const LENGTH: usize = 1;
+    const P: usize = 7;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::function;

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -315,7 +315,7 @@ impl IntrinsicObject for BuiltInFunctionObject {
 
         let throw_type_error = realm.intrinsics().objects().throw_type_error();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 7, 0)
             .method(Self::apply, js_string!("apply"), 2)
             .method(Self::bind, js_string!("bind"), 1)
             .method(Self::call, js_string!("call"), 1)

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -315,7 +315,7 @@ impl IntrinsicObject for BuiltInFunctionObject {
 
         let throw_type_error = realm.intrinsics().objects().throw_type_error();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 7, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 7, 0>(realm)
             .method(Self::apply, js_string!("apply"), 2)
             .method(Self::bind, js_string!("bind"), 1)
             .method(Self::call, js_string!("call"), 1)

--- a/core/engine/src/builtins/generator_function/mod.rs
+++ b/core/engine/src/builtins/generator_function/mod.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for GeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/generator_function/mod.rs
+++ b/core/engine/src/builtins/generator_function/mod.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for GeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))

--- a/core/engine/src/builtins/generator_function/mod.rs
+++ b/core/engine/src/builtins/generator_function/mod.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for GeneratorFunction {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .inherits(Some(
                 realm.intrinsics().constructors().function().prototype(),
             ))
@@ -62,6 +62,8 @@ impl BuiltInObject for GeneratorFunction {
 
 impl BuiltInConstructor for GeneratorFunction {
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::generator_function;

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for Collator {
             .name(js_string!("get compare"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -188,6 +188,8 @@ impl BuiltInObject for Collator {
 
 impl BuiltInConstructor for Collator {
     const LENGTH: usize = 0;
+    const P: usize = 3;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::collator;

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for Collator {
             .name(js_string!("get compare"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/collator/mod.rs
+++ b/core/engine/src/builtins/intl/collator/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for Collator {
             .name(js_string!("get compare"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/date_time_format.rs
+++ b/core/engine/src/builtins/intl/date_time_format.rs
@@ -68,7 +68,7 @@ impl IntrinsicObject for DateTimeFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm).build();
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 0, 0).build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {

--- a/core/engine/src/builtins/intl/date_time_format.rs
+++ b/core/engine/src/builtins/intl/date_time_format.rs
@@ -68,7 +68,7 @@ impl IntrinsicObject for DateTimeFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 0, 0>(realm).build();
+        BuiltInBuilder::from_standard_constructor::<Self>(realm).build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {
@@ -82,6 +82,8 @@ impl BuiltInObject for DateTimeFormat {
 
 impl BuiltInConstructor for DateTimeFormat {
     const LENGTH: usize = 0;
+    const P: usize = 0;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::date_time_format;

--- a/core/engine/src/builtins/intl/date_time_format.rs
+++ b/core/engine/src/builtins/intl/date_time_format.rs
@@ -68,7 +68,7 @@ impl IntrinsicObject for DateTimeFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 0, 0).build();
+        BuiltInBuilder::from_standard_constructor::<Self, 0, 0>(realm).build();
     }
 
     fn get(intrinsics: &Intrinsics) -> JsObject {

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for ListFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 1)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for ListFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 4, 1>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/list_format/mod.rs
+++ b/core/engine/src/builtins/intl/list_format/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for ListFormat {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 4, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -83,6 +83,8 @@ impl BuiltInObject for ListFormat {
 
 impl BuiltInConstructor for ListFormat {
     const LENGTH: usize = 0;
+    const P: usize = 4;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::list_format;

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -74,7 +74,7 @@ impl IntrinsicObject for Locale {
             .name(js_string!("get region"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 14, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 14, 0>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("Intl.Locale"),

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -74,7 +74,7 @@ impl IntrinsicObject for Locale {
             .name(js_string!("get region"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 14, 0)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("Intl.Locale"),

--- a/core/engine/src/builtins/intl/locale/mod.rs
+++ b/core/engine/src/builtins/intl/locale/mod.rs
@@ -74,7 +74,7 @@ impl IntrinsicObject for Locale {
             .name(js_string!("get region"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 14, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("Intl.Locale"),
@@ -157,6 +157,8 @@ impl BuiltInObject for Locale {
 
 impl BuiltInConstructor for Locale {
     const LENGTH: usize = 1;
+    const P: usize = 14;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::locale;

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -141,7 +141,7 @@ impl IntrinsicObject for NumberFormat {
             .name(js_string!("get format"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -141,7 +141,7 @@ impl IntrinsicObject for NumberFormat {
             .name(js_string!("get format"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -141,7 +141,7 @@ impl IntrinsicObject for NumberFormat {
             .name(js_string!("get format"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -173,6 +173,8 @@ impl BuiltInObject for NumberFormat {
 
 impl BuiltInConstructor for NumberFormat {
     const LENGTH: usize = 0;
+    const P: usize = 3;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::number_format;

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for PluralRules {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 4, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -83,6 +83,8 @@ impl BuiltInObject for PluralRules {
 
 impl BuiltInConstructor for PluralRules {
     const LENGTH: usize = 0;
+    const P: usize = 4;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plural_rules;

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for PluralRules {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 4, 1>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/plural_rules/mod.rs
+++ b/core/engine/src/builtins/intl/plural_rules/mod.rs
@@ -55,7 +55,7 @@ impl IntrinsicObject for PluralRules {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 1)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -92,7 +92,7 @@ impl IntrinsicObject for Segmenter {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -92,7 +92,7 @@ impl IntrinsicObject for Segmenter {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 3, 1)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),

--- a/core/engine/src/builtins/intl/segmenter/mod.rs
+++ b/core/engine/src/builtins/intl/segmenter/mod.rs
@@ -92,7 +92,7 @@ impl IntrinsicObject for Segmenter {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 3, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(
                 Self::supported_locales_of,
                 js_string!("supportedLocalesOf"),
@@ -119,6 +119,8 @@ impl BuiltInObject for Segmenter {
 
 impl BuiltInConstructor for Segmenter {
     const LENGTH: usize = 0;
+    const P: usize = 3;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::segmenter;

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -57,7 +57,7 @@ impl IntrinsicObject for Map {
             .name(js_string!("entries"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 11, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::group_by, js_string!("groupBy"), 2)
             .static_accessor(
                 JsSymbol::species(),
@@ -108,6 +108,8 @@ impl BuiltInObject for Map {
 
 impl BuiltInConstructor for Map {
     const LENGTH: usize = 0;
+    const P: usize = 11;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::map;

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -57,7 +57,7 @@ impl IntrinsicObject for Map {
             .name(js_string!("entries"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 2)
             .static_method(Self::group_by, js_string!("groupBy"), 2)
             .static_accessor(
                 JsSymbol::species(),

--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -57,7 +57,7 @@ impl IntrinsicObject for Map {
             .name(js_string!("entries"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 11, 2>(realm)
             .static_method(Self::group_by, js_string!("groupBy"), 2)
             .static_accessor(
                 JsSymbol::species(),

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -158,6 +158,10 @@ pub(crate) trait BuiltInObject: IntrinsicObject {
 ///
 /// [built-in object]: https://tc39.es/ecma262/#sec-built-in-object
 pub(crate) trait BuiltInConstructor: BuiltInObject {
+    /// Const Generic `P` is the minimum storage capacity for the prototype's Property table.
+    const P: usize;
+    /// Const Generic `SP` is the minimum storage capacity for the object's Static Property table.
+    const SP: usize;
     /// The amount of arguments this function object takes.
     const LENGTH: usize;
 

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -37,6 +37,7 @@ pub mod weak_set;
 mod builder;
 
 use boa_macros::js_str;
+use boa_profiler::Profiler;
 use builder::BuiltInBuilder;
 
 #[cfg(feature = "annex-b")]
@@ -304,6 +305,8 @@ impl Realm {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-setdefaultglobalbindings
 pub(crate) fn set_default_global_bindings(context: &mut Context) -> JsResult<()> {
+    let _timer =
+        Profiler::global().start_event("Builtins::set_default_global_bindings", "Builtins");
     let global_object = context.global_object();
 
     global_object.define_property_or_throw(

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -53,7 +53,7 @@ impl IntrinsicObject for Number {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 6, 14)
+        BuiltInBuilder::from_standard_constructor::<Self, 6, 14>(realm)
             .static_property(js_string!("EPSILON"), f64::EPSILON, attribute)
             .static_property(
                 js_string!("MAX_SAFE_INTEGER"),

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -53,7 +53,7 @@ impl IntrinsicObject for Number {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 6, 14)
             .static_property(js_string!("EPSILON"), f64::EPSILON, attribute)
             .static_property(
                 js_string!("MAX_SAFE_INTEGER"),

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -53,7 +53,7 @@ impl IntrinsicObject for Number {
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
 
-        BuiltInBuilder::from_standard_constructor::<Self, 6, 14>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_property(js_string!("EPSILON"), f64::EPSILON, attribute)
             .static_property(
                 js_string!("MAX_SAFE_INTEGER"),
@@ -108,6 +108,8 @@ impl BuiltInObject for Number {
 
 impl BuiltInConstructor for Number {
     const LENGTH: usize = 1;
+    const P: usize = 6;
+    const SP: usize = 14;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::number;

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -59,7 +59,7 @@ impl IntrinsicObject for OrdinaryObject {
             .name(js_string!("set __proto__"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 11, 23>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .inherits(None)
             .accessor(
                 js_string!("__proto__"),
@@ -150,6 +150,8 @@ impl BuiltInObject for OrdinaryObject {
 
 impl BuiltInConstructor for OrdinaryObject {
     const LENGTH: usize = 1;
+    const P: usize = 11;
+    const SP: usize = 23;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::object;

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -59,7 +59,7 @@ impl IntrinsicObject for OrdinaryObject {
             .name(js_string!("set __proto__"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 23)
             .inherits(None)
             .accessor(
                 js_string!("__proto__"),

--- a/core/engine/src/builtins/object/mod.rs
+++ b/core/engine/src/builtins/object/mod.rs
@@ -59,7 +59,7 @@ impl IntrinsicObject for OrdinaryObject {
             .name(js_string!("set __proto__"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 23)
+        BuiltInBuilder::from_standard_constructor::<Self, 11, 23>(realm)
             .inherits(None)
             .accessor(
                 js_string!("__proto__"),

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -343,7 +343,7 @@ impl IntrinsicObject for Promise {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 4, 9>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::all, js_string!("all"), 1)
             .static_method(Self::all_settled, js_string!("allSettled"), 1)
             .static_method(Self::any, js_string!("any"), 1)
@@ -381,6 +381,8 @@ impl BuiltInObject for Promise {
 
 impl BuiltInConstructor for Promise {
     const LENGTH: usize = 1;
+    const P: usize = 4;
+    const SP: usize = 9;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::promise;

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -343,7 +343,7 @@ impl IntrinsicObject for Promise {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 9)
             .static_method(Self::all, js_string!("all"), 1)
             .static_method(Self::all_settled, js_string!("allSettled"), 1)
             .static_method(Self::any, js_string!("any"), 1)

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -343,7 +343,7 @@ impl IntrinsicObject for Promise {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 9)
+        BuiltInBuilder::from_standard_constructor::<Self, 4, 9>(realm)
             .static_method(Self::all, js_string!("all"), 1)
             .static_method(Self::all_settled, js_string!("allSettled"), 1)
             .static_method(Self::any, js_string!("any"), 1)

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -90,7 +90,7 @@ impl IntrinsicObject for Proxy {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 0, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 0, 1>(realm)
             .static_method(Self::revocable, js_string!("revocable"), 2)
             .build_without_prototype();
     }

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -90,7 +90,7 @@ impl IntrinsicObject for Proxy {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 0, 1)
             .static_method(Self::revocable, js_string!("revocable"), 2)
             .build_without_prototype();
     }

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -90,7 +90,7 @@ impl IntrinsicObject for Proxy {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 0, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::revocable, js_string!("revocable"), 2)
             .build_without_prototype();
     }
@@ -106,6 +106,8 @@ impl BuiltInObject for Proxy {
 
 impl BuiltInConstructor for Proxy {
     const LENGTH: usize = 2;
+    const P: usize = 0;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::proxy;

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -88,7 +88,7 @@ impl IntrinsicObject for RegExp {
         let get_source = BuiltInBuilder::callable(realm, Self::get_source)
             .name(js_string!("get source"))
             .build();
-        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm, 19, 1)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -88,7 +88,7 @@ impl IntrinsicObject for RegExp {
         let get_source = BuiltInBuilder::callable(realm, Self::get_source)
             .name(js_string!("get source"))
             .build();
-        let regexp = BuiltInBuilder::from_standard_constructor::<Self, 19, 1>(realm)
+        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -177,6 +177,8 @@ impl BuiltInObject for RegExp {
 
 impl BuiltInConstructor for RegExp {
     const LENGTH: usize = 2;
+    const P: usize = 19;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::regexp;

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -88,7 +88,7 @@ impl IntrinsicObject for RegExp {
         let get_source = BuiltInBuilder::callable(realm, Self::get_source)
             .name(js_string!("get source"))
             .build();
-        let regexp = BuiltInBuilder::from_standard_constructor::<Self>(realm, 19, 1)
+        let regexp = BuiltInBuilder::from_standard_constructor::<Self, 19, 1>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -60,7 +60,7 @@ impl IntrinsicObject for Set {
             .name(js_string!("values"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 11, 1>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -60,7 +60,7 @@ impl IntrinsicObject for Set {
             .name(js_string!("values"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 11, 1)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -60,7 +60,7 @@ impl IntrinsicObject for Set {
             .name(js_string!("values"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 11, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -109,6 +109,8 @@ impl BuiltInObject for Set {
 
 impl BuiltInConstructor for Set {
     const LENGTH: usize = 0;
+    const P: usize = 11;
+    const SP: usize = 1;
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::set;
 

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -98,7 +98,7 @@ impl IntrinsicObject for String {
         let trim_right = trim_end.clone();
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, 36, 3)
             .property(js_string!("length"), 0, attribute)
             .property(
                 js_string!("trimStart"),

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -98,7 +98,7 @@ impl IntrinsicObject for String {
         let trim_right = trim_end.clone();
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm, 36, 3)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self, 36, 3>(realm)
             .property(js_string!("length"), 0, attribute)
             .property(
                 js_string!("trimStart"),

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -98,7 +98,7 @@ impl IntrinsicObject for String {
         let trim_right = trim_end.clone();
 
         let attribute = Attribute::READONLY | Attribute::NON_ENUMERABLE | Attribute::PERMANENT;
-        let builder = BuiltInBuilder::from_standard_constructor::<Self, 36, 3>(realm)
+        let builder = BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(js_string!("length"), 0, attribute)
             .property(
                 js_string!("trimStart"),
@@ -198,6 +198,8 @@ impl BuiltInObject for String {
 
 impl BuiltInConstructor for String {
     const LENGTH: usize = 1;
+    const P: usize = 36;
+    const SP: usize = 3;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::string;

--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -122,7 +122,7 @@ impl IntrinsicObject for Symbol {
             .name(js_string!("get description"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 15)
             .static_method(Self::for_, js_string!("for"), 1)
             .static_method(Self::key_for, js_string!("keyFor"), 1)
             .static_property(

--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -122,7 +122,7 @@ impl IntrinsicObject for Symbol {
             .name(js_string!("get description"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 15)
+        BuiltInBuilder::from_standard_constructor::<Self, 5, 15>(realm)
             .static_method(Self::for_, js_string!("for"), 1)
             .static_method(Self::key_for, js_string!("keyFor"), 1)
             .static_property(

--- a/core/engine/src/builtins/symbol/mod.rs
+++ b/core/engine/src/builtins/symbol/mod.rs
@@ -122,7 +122,7 @@ impl IntrinsicObject for Symbol {
             .name(js_string!("get description"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 5, 15>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_method(Self::for_, js_string!("for"), 1)
             .static_method(Self::key_for, js_string!("keyFor"), 1)
             .static_property(
@@ -186,6 +186,8 @@ impl BuiltInObject for Symbol {
 
 impl BuiltInConstructor for Symbol {
     const LENGTH: usize = 0;
+    const P: usize = 5;
+    const SP: usize = 15;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::symbol;

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -103,7 +103,7 @@ impl IntrinsicObject for Duration {
             .name(js_string!("get blank"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 22, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 22, 1>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::DURATION_TAG,

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -103,7 +103,7 @@ impl IntrinsicObject for Duration {
             .name(js_string!("get blank"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 22, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::DURATION_TAG,
@@ -201,6 +201,8 @@ impl IntrinsicObject for Duration {
 
 impl BuiltInConstructor for Duration {
     const LENGTH: usize = 0;
+    const P: usize = 22;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::duration;

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -103,7 +103,7 @@ impl IntrinsicObject for Duration {
             .name(js_string!("get blank"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 22, 1)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::DURATION_TAG,

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -63,7 +63,7 @@ impl IntrinsicObject for Instant {
             .name(js_string!("get epochNanoseconds"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 13, 4>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::INSTANT_TAG,
@@ -127,6 +127,8 @@ impl IntrinsicObject for Instant {
 
 impl BuiltInConstructor for Instant {
     const LENGTH: usize = 1;
+    const P: usize = 13;
+    const SP: usize = 4;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::instant;

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -63,7 +63,7 @@ impl IntrinsicObject for Instant {
             .name(js_string!("get epochNanoseconds"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 13, 4)
+        BuiltInBuilder::from_standard_constructor::<Self, 13, 4>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::INSTANT_TAG,

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -63,7 +63,7 @@ impl IntrinsicObject for Instant {
             .name(js_string!("get epochNanoseconds"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 13, 4)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::INSTANT_TAG,

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -128,7 +128,7 @@ impl IntrinsicObject for PlainDate {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 26, 2)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATE_TAG,

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -128,7 +128,7 @@ impl IntrinsicObject for PlainDate {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 26, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATE_TAG,
@@ -241,6 +241,8 @@ impl IntrinsicObject for PlainDate {
 
 impl BuiltInConstructor for PlainDate {
     const LENGTH: usize = 3;
+    const P: usize = 26;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plain_date;

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -128,7 +128,7 @@ impl IntrinsicObject for PlainDate {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 26, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 26, 2>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATE_TAG,

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for PlainDateTime {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 29, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATETIME_TAG,
@@ -298,6 +298,8 @@ impl IntrinsicObject for PlainDateTime {
 
 impl BuiltInConstructor for PlainDateTime {
     const LENGTH: usize = 3;
+    const P: usize = 29;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plain_date_time;

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for PlainDateTime {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 29, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 29, 2>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATETIME_TAG,

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -156,7 +156,7 @@ impl IntrinsicObject for PlainDateTime {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 29, 2)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_DATETIME_TAG,

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -149,7 +149,7 @@ impl IntrinsicObject for PlainMonthDay {
             .name(js_string!("get calendarId"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 5, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_MD_TAG,
@@ -185,6 +185,8 @@ impl IntrinsicObject for PlainMonthDay {
 
 impl BuiltInConstructor for PlainMonthDay {
     const LENGTH: usize = 2;
+    const P: usize = 5;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plain_month_day;

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -149,7 +149,7 @@ impl IntrinsicObject for PlainMonthDay {
             .name(js_string!("get calendarId"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 5, 1>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_MD_TAG,

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -149,7 +149,7 @@ impl IntrinsicObject for PlainMonthDay {
             .name(js_string!("get calendarId"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 1)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_MD_TAG,

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -66,7 +66,7 @@ impl IntrinsicObject for PlainTime {
             .name(js_string!("get nanosecond"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 15, 2)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_TIME_TAG,

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -66,7 +66,7 @@ impl IntrinsicObject for PlainTime {
             .name(js_string!("get nanosecond"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 15, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 15, 2>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_TIME_TAG,

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -66,7 +66,7 @@ impl IntrinsicObject for PlainTime {
             .name(js_string!("get nanosecond"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 15, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_TIME_TAG,
@@ -129,6 +129,8 @@ impl IntrinsicObject for PlainTime {
 
 impl BuiltInConstructor for PlainTime {
     const LENGTH: usize = 0;
+    const P: usize = 15;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plain_time;

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -95,7 +95,7 @@ impl IntrinsicObject for PlainYearMonth {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 16, 1)
+        BuiltInBuilder::from_standard_constructor::<Self, 16, 1>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_YM_TAG,

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -95,7 +95,7 @@ impl IntrinsicObject for PlainYearMonth {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 16, 1)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_YM_TAG,

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -95,7 +95,7 @@ impl IntrinsicObject for PlainYearMonth {
             .name(js_string!("get inLeapYear"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 16, 1>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::PLAIN_YM_TAG,
@@ -167,6 +167,8 @@ impl IntrinsicObject for PlainYearMonth {
 
 impl BuiltInConstructor for PlainYearMonth {
     const LENGTH: usize = 2;
+    const P: usize = 16;
+    const SP: usize = 1;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::plain_year_month;

--- a/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
@@ -26,7 +26,7 @@ impl IntrinsicObject for ZonedDateTime {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 1, 0>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::ZONED_DT_TAG,

--- a/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
@@ -26,7 +26,7 @@ impl IntrinsicObject for ZonedDateTime {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self, 1, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::ZONED_DT_TAG,
@@ -42,6 +42,8 @@ impl IntrinsicObject for ZonedDateTime {
 
 impl BuiltInConstructor for ZonedDateTime {
     const LENGTH: usize = 2;
+    const P: usize = 1;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::zoned_date_time;

--- a/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/zoned_date_time/mod.rs
@@ -26,7 +26,7 @@ impl IntrinsicObject for ZonedDateTime {
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 0)
             .property(
                 JsSymbol::to_string_tag(),
                 StaticJsStrings::ZONED_DT_TAG,

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -65,7 +65,7 @@ impl IntrinsicObject for BuiltinTypedArray {
             .length(0)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 37, 3>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),
@@ -165,6 +165,8 @@ impl BuiltInObject for BuiltinTypedArray {
 
 impl BuiltInConstructor for BuiltinTypedArray {
     const LENGTH: usize = 0;
+    const P: usize = 37;
+    const SP: usize = 3;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::typed_array;

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -65,7 +65,7 @@ impl IntrinsicObject for BuiltinTypedArray {
             .length(0)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 37, 3)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -65,7 +65,7 @@ impl IntrinsicObject for BuiltinTypedArray {
             .length(0)
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 37, 3)
+        BuiltInBuilder::from_standard_constructor::<Self, 37, 3>(realm)
             .static_accessor(
                 JsSymbol::species(),
                 Some(get_species),

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -54,7 +54,7 @@ impl<T: TypedArrayMarker> IntrinsicObject for T {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 2)
             .prototype(
                 realm
                     .intrinsics()

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -54,7 +54,7 @@ impl<T: TypedArrayMarker> IntrinsicObject for T {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self, 1, 2>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .prototype(
                 realm
                     .intrinsics()
@@ -94,6 +94,8 @@ impl<T: TypedArrayMarker> BuiltInObject for T {
 
 impl<T: TypedArrayMarker> BuiltInConstructor for T {
     const LENGTH: usize = 3;
+    const P: usize = 1;
+    const SP: usize = 2;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         <Self as TypedArrayMarker>::ERASED.standard_constructor();

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -54,7 +54,7 @@ impl<T: TypedArrayMarker> IntrinsicObject for T {
             .name(js_string!("get [Symbol.species]"))
             .build();
 
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 1, 2)
+        BuiltInBuilder::from_standard_constructor::<Self, 1, 2>(realm)
             .prototype(
                 realm
                     .intrinsics()

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for WeakRef {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("WeakRef"),
@@ -53,6 +53,8 @@ impl BuiltInObject for WeakRef {
 impl BuiltInConstructor for WeakRef {
     /// The amount of arguments the `WeakRef` constructor takes.
     const LENGTH: usize = 1;
+    const P: usize = 2;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::weak_ref;

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for WeakRef {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 2, 0>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("WeakRef"),

--- a/core/engine/src/builtins/weak/weak_ref.rs
+++ b/core/engine/src/builtins/weak/weak_ref.rs
@@ -33,7 +33,7 @@ impl IntrinsicObject for WeakRef {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 2, 0)
             .property(
                 JsSymbol::to_string_tag(),
                 js_string!("WeakRef"),

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -37,7 +37,7 @@ impl IntrinsicObject for WeakMap {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 5, 0>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -37,7 +37,7 @@ impl IntrinsicObject for WeakMap {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 5, 0)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -37,7 +37,7 @@ impl IntrinsicObject for WeakMap {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self, 5, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -60,6 +60,8 @@ impl BuiltInObject for WeakMap {
 impl BuiltInConstructor for WeakMap {
     /// The amount of arguments the `WeakMap` constructor takes.
     const LENGTH: usize = 0;
+    const P: usize = 5;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::weak_map;

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -36,7 +36,7 @@ impl IntrinsicObject for WeakSet {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 0)
+        BuiltInBuilder::from_standard_constructor::<Self, 4, 0>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -36,7 +36,7 @@ impl IntrinsicObject for WeakSet {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self, 4, 0>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,
@@ -58,6 +58,8 @@ impl BuiltInObject for WeakSet {
 impl BuiltInConstructor for WeakSet {
     /// The amount of arguments the `WeakSet` constructor takes.
     const LENGTH: usize = 0;
+    const P: usize = 4;
+    const SP: usize = 0;
 
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::weak_set;

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -36,7 +36,7 @@ impl IntrinsicObject for WeakSet {
 
     fn init(realm: &Realm) {
         let _timer = Profiler::global().start_event(std::any::type_name::<Self>(), "init");
-        BuiltInBuilder::from_standard_constructor::<Self>(realm)
+        BuiltInBuilder::from_standard_constructor::<Self>(realm, 4, 0)
             .property(
                 JsSymbol::to_string_tag(),
                 Self::NAME,

--- a/core/engine/src/context/icu.rs
+++ b/core/engine/src/context/icu.rs
@@ -1,5 +1,6 @@
 use std::{cell::OnceCell, fmt::Debug};
 
+use boa_profiler::Profiler;
 use icu_casemap::CaseMapper;
 use icu_locid_transform::{LocaleCanonicalizer, LocaleExpander, LocaleTransformError};
 use icu_normalizer::{ComposingNormalizer, DecomposingNormalizer, NormalizerError};
@@ -89,6 +90,7 @@ impl IntlProvider {
     pub(crate) fn try_new_with_buffer_provider(
         provider: (impl BufferProvider + 'static),
     ) -> IntlProvider {
+        let _timer = Profiler::global().start_event("ICU::try_new_with_buffer_provider", "ICU");
         Self {
             locale_canonicalizer: OnceCell::new(),
             locale_expander: OnceCell::new(),
@@ -106,6 +108,7 @@ impl IntlProvider {
     pub(crate) fn try_new_with_any_provider(
         provider: (impl AnyProvider + 'static),
     ) -> IntlProvider {
+        let _timer = Profiler::global().start_event("ICU::try_new_with_any_provider", "ICU");
         Self {
             locale_canonicalizer: OnceCell::new(),
             locale_expander: OnceCell::new(),

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -1052,6 +1052,7 @@ impl ContextBuilder {
     // TODO: try to use a custom error here, since most of the `JsError` APIs
     // require having a `Context` in the first place.
     pub fn build(self) -> JsResult<Context> {
+        let _timer = Profiler::global().start_event("Ctx::build", "context");
         if self.can_block {
             if CANNOT_BLOCK_COUNTER.get() > 0 {
                 return Err(JsNativeError::typ()

--- a/core/engine/src/module/loader.rs
+++ b/core/engine/src/module/loader.rs
@@ -1,5 +1,6 @@
 use std::path::{Component, Path, PathBuf};
 
+use boa_profiler::Profiler;
 use rustc_hash::FxHashMap;
 
 use boa_gc::GcRefCell;
@@ -251,6 +252,7 @@ pub struct SimpleModuleLoader {
 impl SimpleModuleLoader {
     /// Creates a new `SimpleModuleLoader` from a root module path.
     pub fn new<P: AsRef<Path>>(root: P) -> JsResult<Self> {
+        let _timer = Profiler::global().start_event("Loader::new", "Loader");
         if cfg!(target_family = "wasm") {
             return Err(JsNativeError::typ()
                 .with_message("cannot resolve a relative path in WASM targets")

--- a/core/engine/src/object/shape/property_table.rs
+++ b/core/engine/src/object/shape/property_table.rs
@@ -80,6 +80,13 @@ pub(crate) struct PropertyTable {
 }
 
 impl PropertyTable {
+    /// Creates a new `PropertyTable` with the specified capacity.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Rc::new(RefCell::new(PropertyTableInner::with_capacity(capacity))),
+        }
+    }
+
     /// Returns the inner representation of a [`PropertyTable`].
     pub(super) fn inner(&self) -> &RefCell<PropertyTableInner> {
         &self.inner

--- a/core/engine/src/object/shape/property_table.rs
+++ b/core/engine/src/object/shape/property_table.rs
@@ -1,11 +1,9 @@
-use std::{cell::RefCell, rc::Rc};
-
-use rustc_hash::FxHashMap;
-
 use crate::{
     object::shape::slot::{Slot, SlotAttributes},
     property::PropertyKey,
 };
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use std::{cell::RefCell, rc::Rc};
 
 /// The internal representation of [`PropertyTable`].
 #[derive(Default, Debug, Clone)]
@@ -15,6 +13,14 @@ pub(crate) struct PropertyTableInner {
 }
 
 impl PropertyTableInner {
+    /// Returns a new table with a given minimum capacity.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            map: FxHashMap::with_capacity_and_hasher(capacity, FxBuildHasher),
+            keys: Vec::with_capacity(capacity),
+        }
+    }
+
     /// Returns all the keys, in insertion order.
     pub(crate) fn keys(&self) -> Vec<PropertyKey> {
         self.keys_cloned_n(self.keys.len() as u32)

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -186,6 +186,7 @@ impl SharedShape {
             forward_transitions: ForwardTransition::default(),
             prototype: None,
             property_count: 0,
+            // Most of the time the root shape initiates with between 1-4 properties.
             property_table: PropertyTable::with_capacity(4),
             previous: None,
             flags: ShapeFlags::default(),

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -186,7 +186,7 @@ impl SharedShape {
             forward_transitions: ForwardTransition::default(),
             prototype: None,
             property_count: 0,
-            property_table: PropertyTable::default(),
+            property_table: PropertyTable::with_capacity(4),
             previous: None,
             flags: ShapeFlags::default(),
             transition_count: 0,

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -110,6 +110,7 @@ unsafe impl Trace for ActiveRunnable {
 impl Vm {
     /// Creates a new virtual machine.
     pub(crate) fn new(realm: Realm) -> Self {
+        let _timer = Profiler::global().start_event("VM::new", "VM");
         Self {
             frames: Vec::with_capacity(16),
             frame: CallFrame::new(


### PR DESCRIPTION
This PR attempts to address https://github.com/boa-dev/boa/issues/3896

We already raised the threshold, but it would be good to not re-allocate the hashmaps and vectors as we will up the property storage during startup. 

It doesn't seem to have much noticeable affect in the performance profiler but DHAT shows less `grow_one` calls from `boa_engine::object::shape::property_table::PropertyTableInner::insert (object/shape/property_table.rs:70:9)`, there are still some, we may be able to find these by checking `.len() == .capacity()` and tracing back where these are coming from