### PR TITLE
Refactor iterator APIs to be on parity with the latest spec

### DIFF
--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -15,10 +15,7 @@ use boa_profiler::Profiler;
 use thin_vec::ThinVec;
 
 use crate::{
-    builtins::{
-        iterable::{if_abrupt_close_iterator, IteratorHint},
-        BuiltInObject, Number,
-    },
+    builtins::{iterable::if_abrupt_close_iterator, BuiltInObject, Number},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
     js_string,
@@ -610,44 +607,41 @@ impl Array {
             _ => Self::array_create(0, None, context)?,
         };
 
-        // c. Let iteratorRecord be ? GetIterator(items, sync, usingIterator).
-        let mut iterator_record =
-            items.get_iterator(context, Some(IteratorHint::Sync), Some(using_iterator))?;
+        // c. Let iteratorRecord be ? GetIteratorFromMethod(items, usingIterator).
+        let mut iterator_record = items.get_iterator_from_method(&using_iterator, context)?;
 
         // d. Let k be 0.
         // e. Repeat,
         //     i. If k ≥ 2^53 - 1 (MAX_SAFE_INTEGER), then
         //     ...
-        //     x. Set k to k + 1.
+        //     ix. Set k to k + 1.
         for k in 0..9_007_199_254_740_991_u64 {
-            // iii. Let next be ? IteratorStep(iteratorRecord).
-            if iterator_record.step(context)? {
-                // 1. Perform ? Set(A, "length", 𝔽(k), true).
+            // iii. Let next be ? IteratorStepValue(iteratorRecord).
+            let Some(next) = iterator_record.step_value(context)? else {
+                // iv. If next is done, then
+                //     1. Perform ? Set(A, "length", 𝔽(k), true).
                 a.set(StaticJsStrings::LENGTH, k, true, context)?;
-                // 2. Return A.
+                //     2. Return A.
                 return Ok(a.into());
-            }
+            };
 
-            // iv. If next is false, then
-            // v. Let nextValue be ? IteratorValue(next).
-            let next_value = iterator_record.value(context)?;
-
-            // vi. If mapping is true, then
+            // v. If mapping is true, then
             let mapped_value = if let Some(mapfn) = mapping {
-                // 1. Let mappedValue be Call(mapfn, thisArg, « nextValue, 𝔽(k) »).
-                let mapped_value = mapfn.call(this_arg, &[next_value, k.into()], context);
+                // 1. Let mappedValue be Completion(Call(mapper, thisArg, « next, 𝔽(k) »)).
+                let mapped_value = mapfn.call(this_arg, &[next, k.into()], context);
 
                 // 2. IfAbruptCloseIterator(mappedValue, iteratorRecord).
                 if_abrupt_close_iterator!(mapped_value, iterator_record, context)
             } else {
-                // vii. Else, let mappedValue be nextValue.
-                next_value
+                // vi. Else,
+                //     1. Let mappedValue be next.
+                next
             };
 
-            // viii. Let defineStatus be CreateDataPropertyOrThrow(A, Pk, mappedValue).
+            // vii. Let defineStatus be Completion(CreateDataPropertyOrThrow(A, Pk, mappedValue)).
             let define_status = a.create_data_property_or_throw(k, mapped_value, context);
 
-            // ix. IfAbruptCloseIterator(defineStatus, iteratorRecord).
+            // viii. IfAbruptCloseIterator(defineStatus, iteratorRecord).
             if_abrupt_close_iterator!(define_status, iterator_record, context);
         }
 

--- a/core/engine/src/builtins/error/aggregate.rs
+++ b/core/engine/src/builtins/error/aggregate.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     builtins::{
-        iterable::iterable_to_list, Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject,
+        iterable::IteratorHint, Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject,
         IntrinsicObject,
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
@@ -56,7 +56,11 @@ impl BuiltInConstructor for AggregateError {
     const STANDARD_CONSTRUCTOR: fn(&StandardConstructors) -> &StandardConstructor =
         StandardConstructors::aggregate_error;
 
-    /// Create a new aggregate error object.
+    /// [`AggregateError ( errors, message [ , options ] )`][spec]
+    ///
+    /// Creates a new aggregate error object.
+    ///
+    /// [spec]: AggregateError ( errors, message [ , options ] )
     fn constructor(
         new_target: &JsValue,
         args: &[JsValue],
@@ -102,9 +106,12 @@ impl BuiltInConstructor for AggregateError {
         // 4. Perform ? InstallErrorCause(O, options).
         Error::install_error_cause(&o, args.get_or_undefined(2), context)?;
 
-        // 5. Let errorsList be ? IterableToList(errors).
+        // 5. Let errorsList be ? IteratorToList(? GetIterator(errors, sync)).
         let errors = args.get_or_undefined(0);
-        let errors_list = iterable_to_list(context, errors, None)?;
+        let errors_list = errors
+            .get_iterator(IteratorHint::Sync, context)?
+            .into_list(context)?;
+
         // 6. Perform ! DefinePropertyOrThrow(O, "errors",
         //    PropertyDescriptor {
         //      [[Configurable]]: true,

--- a/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
+++ b/core/engine/src/builtins/iterable/async_from_sync_iterator.rs
@@ -98,7 +98,7 @@ impl AsyncFromSyncIterator {
         // 1. Let O be the this value.
         // 2. Assert: O is an Object that has a [[SyncIteratorRecord]] internal slot.
         // 4. Let syncIteratorRecord be O.[[SyncIteratorRecord]].
-        let sync_iterator_record = this
+        let mut sync_iterator_record = this
             .as_object()
             .and_then(JsObject::downcast_ref::<Self>)
             .expect("async from sync iterator prototype must be object")
@@ -113,18 +113,10 @@ impl AsyncFromSyncIterator {
         .expect("cannot fail with promise constructor");
 
         // 5. If value is present, then
-        // a. Let result be Completion(IteratorNext(syncIteratorRecord, value)).
+        //     a. Let result be Completion(IteratorNext(syncIteratorRecord, value)).
         // 6. Else,
-        // a. Let result be Completion(IteratorNext(syncIteratorRecord)).
-        let iterator = sync_iterator_record.iterator().clone();
-        let next = sync_iterator_record.next_method();
-        let result = next
-            .call(
-                &iterator.into(),
-                args.first().map_or(&[], std::slice::from_ref),
-                context,
-            )
-            .and_then(IteratorResult::from_value);
+        //     a. Let result be Completion(IteratorNext(syncIteratorRecord)).
+        let result = sync_iterator_record.next(args.first(), context);
 
         // 7. IfAbruptRejectPromise(result, promiseCapability).
         let result = if_abrupt_reject_promise!(result, promise_capability, context);

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1301,7 +1301,7 @@ impl Promise {
         remaining_elements_count.set(remaining_elements_count.get() - 1);
         //         ii. If remainingElementsCount.[[Value]] = 0, then
         if remaining_elements_count.get() == 0 {
-            //             1. Let error be a newly created AggregateError object.
+            // 1. Let error be a newly created AggregateError object.
             let error = JsNativeError::aggregate(
                 errors
                     .borrow()
@@ -1312,8 +1312,8 @@ impl Promise {
             )
             .with_message("no promise in Promise.any was fulfilled.");
 
-            //             2. Perform ! DefinePropertyOrThrow(error, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errors) }).
-            //             3. Return ThrowCompletion(error).
+            // 2. Perform ! DefinePropertyOrThrow(error, "errors", PropertyDescriptor { [[Configurable]]: true, [[Enumerable]]: false, [[Writable]]: true, [[Value]]: CreateArrayFromList(errors) }).
+            // 3. Return ThrowCompletion(error).
             return Err(error.into());
         }
 

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1078,11 +1078,11 @@ impl Promise {
 
         //     ii. If remainingElementsCount.[[Value]] = 0, then
         if remaining_elements_count.get() == 0 {
-            //         1. Let valuesArray be CreateArrayFromList(values).
+            // 1. Let valuesArray be CreateArrayFromList(values).
             let values_array =
                 Array::create_array_from_list(values.borrow().as_slice().iter().cloned(), context);
 
-            //         2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
+            // 2. Perform ? Call(resultCapability.[[Resolve]], undefined, « valuesArray »).
             result_capability.functions.resolve.call(
                 &JsValue::undefined(),
                 &[values_array.into()],

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -189,28 +189,26 @@ pub(crate) fn _iterator_to_list_of_types(
     // 1. Let values be a new empty List.
     let mut values = Vec::new();
 
-    // 2. Let next be true.
-    // 3. Repeat, while next is not false,
-    // a. Set next to ? IteratorStep(iteratorRecord).
-    // b. If next is not false, then
-    while iterator.step(context)? {
-        // i. Let nextValue be ? IteratorValue(next).
-        let next_value = iterator.value(context)?;
-        // ii. If Type(nextValue) is not an element of elementTypes, then
-        if element_types.contains(&next_value.get_type()) {
-            // 1. Let completion be ThrowCompletion(a newly created TypeError object).
+    // 2. Repeat,
+    //     a. Let next be ? IteratorStepValue(iteratorRecord).
+    while let Some(next) = iterator.step_value(context)? {
+        // c. If Type(next) is not an element of elementTypes, then
+
+        if element_types.contains(&next.get_type()) {
+            //     i. Let completion be ThrowCompletion(a newly created TypeError object).
             let completion = JsNativeError::typ()
                 .with_message("IteratorNext is not within allowed type values.");
 
-            // NOTE: The below should return as we are forcing a ThrowCompletion.
-            // 2. Return ? IteratorClose(iteratorRecord, completion).
+            //     ii. Return ? IteratorClose(iteratorRecord, completion).
             let _never = iterator.close(Err(completion.into()), context)?;
         }
-        // iii. Append nextValue to the end of the List values.
-        values.push(next_value);
+
+        // d. Append next to the end of the List values.
+        values.push(next);
     }
 
-    // 4. Return values.
+    // b. If next is done, then
+    //     i. Return values.
     Ok(values)
 }
 

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -16,7 +16,6 @@ use crate::{
             utils::{memcpy, memmove, SliceRefMut},
             ArrayBuffer, BufferObject,
         },
-        iterable::iterable_to_list,
         Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
@@ -228,7 +227,9 @@ impl BuiltinTypedArray {
         // 6. If usingIterator is not undefined, then
         if let Some(using_iterator) = using_iterator {
             // a. Let values be ? IterableToList(source, usingIterator).
-            let values = iterable_to_list(context, source, Some(using_iterator))?;
+            let values = source
+                .get_iterator_from_method(&using_iterator, context)?
+                .into_list(context)?;
 
             // b. Let len be the number of elements in values.
             // c. Let targetObj be ? TypedArrayCreate(C, « 𝔽(len) »).

--- a/core/engine/src/builtins/weak_map/mod.rs
+++ b/core/engine/src/builtins/weak_map/mod.rs
@@ -101,14 +101,11 @@ impl BuiltInConstructor for WeakMap {
         }
 
         // 5. Let adder be ? Get(map, "set").
-        let adder = map.get(js_str!("set"), context)?;
-
         // 6. If IsCallable(adder) is false, throw a TypeError exception.
-        if !adder.is_callable() {
-            return Err(JsNativeError::typ()
-                .with_message("WeakMap: 'add' is not a function")
-                .into());
-        }
+        let adder = map
+            .get(js_str!("set"), context)?
+            .as_function()
+            .ok_or_else(|| JsNativeError::typ().with_message("WeakMap: 'add' is not a function"))?;
 
         // 7. Return ? AddEntriesFromIterable(map, iterable, adder).
         add_entries_from_iterable(&map, iterable, &adder, context)

--- a/core/engine/src/builtins/weak_set/mod.rs
+++ b/core/engine/src/builtins/weak_set/mod.rs
@@ -22,6 +22,8 @@ use boa_gc::{Finalize, Trace};
 use boa_macros::js_str;
 use boa_profiler::Profiler;
 
+use super::iterable::IteratorHint;
+
 type NativeWeakSet = boa_gc::WeakMap<ErasedVTableObject, ()>;
 
 #[derive(Debug, Trace, Finalize)]
@@ -104,23 +106,20 @@ impl BuiltInConstructor for WeakSet {
             .as_callable()
             .ok_or_else(|| JsNativeError::typ().with_message("WeakSet: 'add' is not a function"))?;
 
-        // 7. Let iteratorRecord be ? GetIterator(iterable).
-        let mut iterator_record = iterable.clone().get_iterator(context, None, None)?;
+        // 7. Let iteratorRecord be ? GetIterator(iterable, sync).
+        let mut iterator_record = iterable.clone().get_iterator(IteratorHint::Sync, context)?;
 
         // 8. Repeat,
-        // a. Let next be ? IteratorStep(iteratorRecord).
-        while !iterator_record.step(context)? {
-            // c. Let nextValue be ? IteratorValue(next).
-            let next = iterator_record.value(context)?;
-
-            // d. Let status be Completion(Call(adder, set, « nextValue »)).
-            // e. IfAbruptCloseIterator(status, iteratorRecord).
+        //     a. Let next be ? IteratorStepValue(iteratorRecord).
+        while let Some(next) = iterator_record.step_value(context)? {
+            //     c. Let status be Completion(Call(adder, set, « next »)).
             if let Err(status) = adder.call(&weak_set.clone().into(), &[next], context) {
+                //     d. IfAbruptCloseIterator(status, iteratorRecord).
                 return iterator_record.close(Err(status), context);
             }
         }
 
-        // b. If next is false, return set.
+        //     b. If next is done, return set.
         Ok(weak_set.into())
     }
 }

--- a/core/engine/src/object/builtins/jsset.rs
+++ b/core/engine/src/object/builtins/jsset.rs
@@ -4,7 +4,7 @@ use std::ops::Deref;
 use boa_gc::{Finalize, Trace};
 
 use crate::{
-    builtins::{set::ordered_set::OrderedSet, Set},
+    builtins::{iterable::IteratorHint, set::ordered_set::OrderedSet, Set},
     error::JsNativeError,
     object::{JsFunction, JsObject, JsSetIterator},
     value::TryFromJs,
@@ -104,7 +104,7 @@ impl JsSet {
     #[inline]
     pub fn values(&self, context: &mut Context) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
-            .get_iterator(context, None, None)?;
+            .get_iterator(IteratorHint::Sync, context)?;
 
         JsSetIterator::from_object(iterator_object.iterator().clone())
     }
@@ -117,7 +117,7 @@ impl JsSet {
     #[inline]
     pub fn keys(&self, context: &mut Context) -> JsResult<JsSetIterator> {
         let iterator_object = Set::values(&self.inner.clone().into(), &[JsValue::Null], context)?
-            .get_iterator(context, None, None)?;
+            .get_iterator(IteratorHint::Sync, context)?;
 
         JsSetIterator::from_object(iterator_object.iterator().clone())
     }

--- a/core/engine/src/vm/opcode/iteration/get.rs
+++ b/core/engine/src/vm/opcode/iteration/get.rs
@@ -18,7 +18,7 @@ impl Operation for GetIterator {
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
         let object = context.vm.pop();
-        let iterator = object.get_iterator(context, None, None)?;
+        let iterator = object.get_iterator(IteratorHint::Sync, context)?;
         context.vm.frame_mut().iterators.push(iterator);
         Ok(CompletionType::Normal)
     }
@@ -38,7 +38,7 @@ impl Operation for GetAsyncIterator {
 
     fn execute(context: &mut Context) -> JsResult<CompletionType> {
         let object = context.vm.pop();
-        let iterator = object.get_iterator(context, Some(IteratorHint::Async), None)?;
+        let iterator = object.get_iterator(IteratorHint::Async, context)?;
         context.vm.frame_mut().iterators.push(iterator);
         Ok(CompletionType::Normal)
     }

--- a/core/engine/src/vm/opcode/push/array.rs
+++ b/core/engine/src/vm/opcode/push/array.rs
@@ -101,8 +101,7 @@ impl Operation for PushIteratorToArray {
             .expect("iterator stack should have at least an iterator");
         let array = context.vm.pop();
 
-        while !iterator.step(context)? {
-            let next = iterator.value(context)?;
+        while let Some(next) = iterator.step_value(context)? {
             Array::push(&array, &[next], context)?;
         }
 

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "12307f5c20a4c4211e69823939fd1872212894c5"
+commit = "dde3050bdbfb8f425084077b6293563932d57ebc"
 
 [ignored]
 # Not implemented yet:


### PR DESCRIPTION
Alternative name: The Great Refactoring Of Iterators

This pulls the latest changes from the spec around iterators, which both makes the code easier in some parts and also future-proofs for any new spec additions that use iterator APIs.
