### PR TITLE
Rename as_promise to as_promise_object and add as_promise -> JsPromise

### DIFF
--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1559,7 +1559,7 @@ impl Promise {
         context: &mut Context,
     ) -> JsResult<JsObject> {
         // 1. If IsPromise(x) is true, then
-        if let Some(x) = x.as_promise() {
+        if let Some(x) = x.as_promise_object() {
             // a. Let xConstructor be ? Get(x, "constructor").
             let x_constructor = x.get(CONSTRUCTOR, context)?;
             // b. If SameValue(xConstructor, C) is true, return x.
@@ -1808,7 +1808,7 @@ impl Promise {
         let promise = this;
 
         // 2. If IsPromise(promise) is false, throw a TypeError exception.
-        let promise = promise.as_promise().ok_or_else(|| {
+        let promise = promise.as_promise_object().ok_or_else(|| {
             JsNativeError::typ().with_message("Promise.prototype.then: this is not a promise")
         })?;
 

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -21,7 +21,7 @@ use boa_profiler::Profiler;
 #[doc(inline)]
 pub use conversions::convert::Convert;
 
-use crate::object::JsFunction;
+use crate::object::{JsFunction, JsPromise};
 use crate::{
     builtins::{
         number::{f64_to_int32, f64_to_uint32},
@@ -205,11 +205,20 @@ impl JsValue {
         matches!(self, Self::Object(obj) if obj.is::<Promise>())
     }
 
-    /// Returns the promise if the value is a promise, otherwise `None`.
+    /// Returns the value as an object if the value is a promise, otherwise `None`.
     #[inline]
     #[must_use]
-    pub fn as_promise(&self) -> Option<&JsObject> {
+    pub(crate) fn as_promise_object(&self) -> Option<&JsObject> {
         self.as_object().filter(|obj| obj.is::<Promise>())
+    }
+
+    /// Returns the value as a promise if the value is a promise, otherwise `None`.
+    #[inline]
+    #[must_use]
+    pub fn as_promise(&self) -> Option<JsPromise> {
+        self.as_promise_object()
+            .cloned()
+            .and_then(|o| JsPromise::from_object(o).ok())
     }
 
     /// Returns true if the value is a symbol.


### PR DESCRIPTION
This aligns the API with other methods (e.g. `as_function()`) and makes it more intuitive.

# BREAKING CHANGE

This is a breaking change as the `JsValue::as_promise()` API returns a different value. It is now more align to the rest of the API though with `as_*` returning the expected type.