### PR TITLE
Add a clone_inner method to allow cloning of inner data

### DIFF
--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -394,7 +394,7 @@ impl<T: NativeObject + Clone> JsClass<T> {
     /// Clones the inner class instance.
     #[must_use]
     pub fn clone_inner(&self) -> T {
-        self.inner.data().clone()
+        self.inner.borrow().data().clone()
     }
 }
 

--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -392,6 +392,10 @@ impl<T: NativeObject> JsClass<T> {
 
 impl<T: NativeObject + Clone> JsClass<T> {
     /// Clones the inner class instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the inner object is currently borrowed mutably.
     #[must_use]
     pub fn clone_inner(&self) -> T {
         self.inner.borrow().data().clone()

--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -390,6 +390,14 @@ impl<T: NativeObject> JsClass<T> {
     }
 }
 
+impl<T: NativeObject + Clone> JsClass<T> {
+    /// Clones the inner class instance.
+    #[must_use]
+    pub fn clone_inner(&self) -> T {
+        self.inner.data().clone()
+    }
+}
+
 impl<'a, T: NativeObject + 'static> TryFromJsArgument<'a> for JsClass<T> {
     fn try_from_js_argument(
         this: &'a JsValue,


### PR DESCRIPTION
The issue I'm looking to solve is that I'm passing back the same object into JavaScript (think callbacks). The object is reentrant safe, but I'm ending up doing a lot of `this.borrow().clone()`. This would make it a bit easier to manage.

The JS code looks like that:

```js
const someValue = new ApiClass();
someValue.doSomethingAndCallback(() => {
  // Using a naive but straightforward borrow_mut(), Boa would fail here as
  // the `doSomethingElse` method would need to borrow_mut() again.
  someValue.doSomethingElse();
});
```