### PR TITLE
Add a way for js_error! macro to create native errors with message

### DIFF
--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -23,8 +23,8 @@ use thiserror::Error;
 /// # Native Errors
 ///
 /// The only native error that is not buildable using this macro is
-/// [`crate::JsNativeErrorKind::AggregateError`], which requires multiple
-/// error objects available at construction.
+/// `AggregateError`, which requires multiple error objects available at
+/// construction.
 ///
 /// [`InternalError`][mdn] is non-standard and unsupported in Boa.
 ///


### PR DESCRIPTION
I assume this will have a fair bit of bikeshedding on the interface.

This only supports text errors since it only adds the message (which is text only). Supports syntax similar to `format!()`, e.g. `js_error!(TypeError: "the number {} should be even", odd_number)`.

## Other Considerations and Explanation

I considered another option for the API: having a separate macro per type (like `js_typ_error!()`, `js_syntax_error!()`, etc). I decided to dismiss this and went the way of this PR instead as the code looks closer to what the message will be, since it's normally prefixed with the error. It also declutters the `use` statements as there's only one macro.

For example, the following code:

```rust
js_error!(TypeError: "not a day of the week")
```

would show the following message when printed on the console:

```text
TypeError: not a day of the week
```

Tested with boa_cli: 
<img width="547" alt="CleanShot 2024-08-26 at 16 37 00@2x" src="https://github.com/user-attachments/assets/a87496b5-b7c4-4d9f-80cd-d42befcebedb">