### PR TITLE
lazy builtins

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,7 +37,7 @@
       "type": "process",
       "label": "Run JS file",
       "command": "cargo",
-      "args": ["run", "--bin", "boa", "${file}"],
+      "args": ["run", "--bin", "boa", "${workspaceFolder}/debug/script.js"],
       "group": {
         "kind": "build",
         "isDefault": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## What's Changed
 
-# [0.20.0 (2024-09-11)](https://github.com/boa-dev/boa/compare/v0.19.1...v0.20.0)
+# [0.20.0 (2024-12-5)](https://github.com/boa-dev/boa/compare/v0.19.1...v0.20.0)
 
 ### Feature Enhancements
 
@@ -61,6 +61,7 @@
 - Update night build's rename binary step by @nekevss in https://github.com/boa-dev/boa/pull/4032
 - Use upload-rust-binary-action for nightly release by @nekevss in https://github.com/boa-dev/boa/pull/4040
 - Fix `ref` value in nightly and add target to nightly release by @nekevss in https://github.com/boa-dev/boa/pull/4042
+- Reduce environment allocations by @raskad in https://github.com/boa-dev/boa/pull/4002
 
 ### Other Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "boa_ast"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arbitrary",
  "bitflags 2.6.0",
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "boa_cli"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "boa_engine"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.6.0",
@@ -419,7 +419,7 @@ dependencies = [
 
 [[package]]
 name = "boa_examples"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_ast",
  "boa_engine",
@@ -435,7 +435,7 @@ dependencies = [
 
 [[package]]
 name = "boa_gc"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_macros",
  "boa_profiler",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "boa_icu_provider"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "icu_casemap",
  "icu_collator",
@@ -467,7 +467,7 @@ dependencies = [
 
 [[package]]
 name = "boa_interner"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arbitrary",
  "boa_gc",
@@ -483,7 +483,7 @@ dependencies = [
 
 [[package]]
 name = "boa_interop"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -493,7 +493,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -503,7 +503,7 @@ dependencies = [
 
 [[package]]
 name = "boa_macros_tests"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_engine",
  "trybuild",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "boa_parser"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bitflags 2.6.0",
  "boa_ast",
@@ -528,7 +528,7 @@ dependencies = [
 
 [[package]]
 name = "boa_profiler"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "measureme",
  "once_cell",
@@ -537,7 +537,7 @@ dependencies = [
 
 [[package]]
 name = "boa_runtime"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_engine",
  "boa_gc",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "boa_string"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "fast-float2",
  "paste",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "boa_tester"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bitflags 2.6.0",
  "boa_engine",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "boa_wasm"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "boa_engine",
  "console_error_panic_hook",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "gen-icu4x-data"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "icu_casemap",
  "icu_collator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 
 [workspace.package]
 edition = "2021"
-version = "0.19.0"
+version = "0.20.0"
 rust-version = "1.82.0"
 authors = ["boa-dev"]
 repository = "https://github.com/boa-dev/boa"
@@ -33,17 +33,17 @@ description = "Boa is a Javascript lexer, parser and compiler written in Rust. C
 [workspace.dependencies]
 
 # Repo Crates
-boa_ast = { version = "~0.19.0", path = "core/ast" }
-boa_engine = { version = "~0.19.0", path = "core/engine" }
-boa_gc = { version = "~0.19.0", path = "core/gc" }
-boa_icu_provider = { version = "~0.19.0", path = "core/icu_provider" }
-boa_interner = { version = "~0.19.0", path = "core/interner" }
-boa_interop = { version = "~0.19.0", path = "core/interop" }
-boa_macros = { version = "~0.19.0", path = "core/macros" }
-boa_parser = { version = "~0.19.0", path = "core/parser" }
-boa_profiler = { version = "~0.19.0", path = "core/profiler" }
-boa_runtime = { version = "~0.19.0", path = "core/runtime" }
-boa_string = { version = "~0.19.0", path = "core/string" }
+boa_ast = { version = "~0.20.0", path = "core/ast" }
+boa_engine = { version = "~0.20.0", path = "core/engine" }
+boa_gc = { version = "~0.20.0", path = "core/gc" }
+boa_icu_provider = { version = "~0.20.0", path = "core/icu_provider" }
+boa_interner = { version = "~0.20.0", path = "core/interner" }
+boa_interop = { version = "~0.20.0", path = "core/interop" }
+boa_macros = { version = "~0.20.0", path = "core/macros" }
+boa_parser = { version = "~0.20.0", path = "core/parser" }
+boa_profiler = { version = "~0.20.0", path = "core/profiler" }
+boa_runtime = { version = "~0.20.0", path = "core/runtime" }
+boa_string = { version = "~0.20.0", path = "core/string" }
 
 # Shared deps
 arbitrary = "1"

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1009,7 +1009,7 @@ impl Array {
             // b. Let element be ? Get(O, ! ToString(𝔽(k))).
             let element = o.get(k, context)?;
             // c. If element is undefined, null or the array itself, let next be the empty String; otherwise, let next be ? ToString(element).
-            let next: JsString = if element.is_null_or_undefined() || &element == this {
+            let next = if element.is_null_or_undefined() || &element == this {
                 js_string!()
             } else {
                 element.to_string(context)?

--- a/core/engine/src/builtins/array/mod.rs
+++ b/core/engine/src/builtins/array/mod.rs
@@ -1009,7 +1009,7 @@ impl Array {
             // b. Let element be ? Get(O, ! ToString(𝔽(k))).
             let element = o.get(k, context)?;
             // c. If element is undefined, null or the array itself, let next be the empty String; otherwise, let next be ? ToString(element).
-            let next = if element.is_null_or_undefined() || &element == this {
+            let next: JsString = if element.is_null_or_undefined() || &element == this {
                 js_string!()
             } else {
                 element.to_string(context)?

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -26,7 +26,7 @@ use crate::{
             get_prototype_from_constructor, CallValue, InternalObjectMethods,
             ORDINARY_INTERNAL_METHODS,
         },
-        JsData, JsFunction, JsObject, PrivateElement, PrivateName,
+        JsData, JsFunction, JsObject, LazyBuiltIn, PrivateElement, PrivateName,
     },
     property::{Attribute, PropertyDescriptor, PropertyKey},
     realm::Realm,
@@ -845,8 +845,7 @@ impl BuiltInFunctionObject {
             return Err(JsNativeError::typ().with_message("not a function").into());
         };
 
-        let object_borrow = object.borrow();
-        if object_borrow.is::<NativeFunctionObject>() {
+        if object.is::<NativeFunctionObject>() || object.is::<LazyBuiltIn>() {
             let name = {
                 // Is there a case here where if there is no name field on a value
                 // name should default to None? Do all functions have names set?
@@ -860,10 +859,11 @@ impl BuiltInFunctionObject {
             return Ok(
                 js_string!(js_str!("function "), &name, js_str!("() { [native code] }")).into(),
             );
-        } else if object_borrow.is::<Proxy>() || object_borrow.is::<BoundFunction>() {
+        } else if object.is::<Proxy>() || object.is::<BoundFunction>() {
             return Ok(js_string!("function () { [native code] }").into());
         }
 
+        let object_borrow = object.borrow();
         let function = object_borrow
             .downcast_ref::<OrdinaryFunction>()
             .ok_or_else(|| JsNativeError::typ().with_message("not a function"))?;

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -206,16 +206,15 @@ impl Realm {
         AsyncIterator::init(self);
         AsyncFromSyncIterator::init(self);
         ForInIterator::init(self);
-        Math::init(self);
+        // Math::init(self);
         Json::init(self);
-        Array::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);
         ArrayBuffer::init(self);
         SharedArrayBuffer::init(self);
         BigInt::init(self);
         Boolean::init(self);
-        Date::init(self);
+        // Date::init(self);
         DataView::init(self);
         Map::init(self);
         MapIterator::init(self);

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -206,7 +206,6 @@ impl Realm {
         AsyncIterator::init(self);
         AsyncFromSyncIterator::init(self);
         ForInIterator::init(self);
-        Math::init(self);
         Json::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -206,12 +206,15 @@ impl Realm {
         AsyncIterator::init(self);
         AsyncFromSyncIterator::init(self);
         ForInIterator::init(self);
+        Math::init(self);
+        Json::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);
         ArrayBuffer::init(self);
         SharedArrayBuffer::init(self);
         BigInt::init(self);
         Boolean::init(self);
+        Date::init(self);
         DataView::init(self);
         Map::init(self);
         MapIterator::init(self);
@@ -223,7 +226,9 @@ impl Realm {
         Eval::init(self);
         Set::init(self);
         SetIterator::init(self);
+        String::init(self);
         StringIterator::init(self);
+        RegExp::init(self);
         RegExpStringIterator::init(self);
         BuiltinTypedArray::init(self);
         Int8Array::init(self);

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -206,7 +206,7 @@ impl Realm {
         AsyncIterator::init(self);
         AsyncFromSyncIterator::init(self);
         ForInIterator::init(self);
-        // Math::init(self);
+        Math::init(self);
         Json::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);
@@ -214,7 +214,6 @@ impl Realm {
         SharedArrayBuffer::init(self);
         BigInt::init(self);
         Boolean::init(self);
-        // Date::init(self);
         DataView::init(self);
         Map::init(self);
         MapIterator::init(self);

--- a/core/engine/src/builtins/mod.rs
+++ b/core/engine/src/builtins/mod.rs
@@ -206,7 +206,6 @@ impl Realm {
         AsyncIterator::init(self);
         AsyncFromSyncIterator::init(self);
         ForInIterator::init(self);
-        Json::init(self);
         ArrayIterator::init(self);
         Proxy::init(self);
         ArrayBuffer::init(self);
@@ -224,9 +223,7 @@ impl Realm {
         Eval::init(self);
         Set::init(self);
         SetIterator::init(self);
-        String::init(self);
         StringIterator::init(self);
-        RegExp::init(self);
         RegExpStringIterator::init(self);
         BuiltinTypedArray::init(self);
         Int8Array::init(self);

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -1,18 +1,22 @@
 //! Data structures that contain intrinsic objects and constructors.
 
-use boa_gc::{Finalize, Trace};
-
 use crate::{
-    builtins::{iterable::IteratorPrototypes, uri::UriFunctions, Array, OrdinaryObject},
+    builtins::{
+        function::ConstructorKind, iterable::IteratorPrototypes, uri::UriFunctions, Array, Date,
+        IntrinsicObject, OrdinaryObject,
+    },
     js_string,
+    native_function::NativeFunctionObject,
     object::{
         internal_methods::immutable_prototype::IMMUTABLE_PROTOTYPE_EXOTIC_INTERNAL_METHODS,
         shape::{shared_shape::template::ObjectTemplate, RootShape},
-        JsFunction, JsObject, Object, CONSTRUCTOR, PROTOTYPE,
+        BuiltinKind, JsFunction, JsObject, LazyBuiltIn, Object, CONSTRUCTOR, PROTOTYPE,
     },
     property::{Attribute, PropertyKey},
-    JsSymbol,
+    realm::{Realm, RealmInner},
+    JsSymbol, JsValue, NativeFunction,
 };
+use boa_gc::{Finalize, Trace, WeakGc};
 
 #[cfg(feature = "intl")]
 use crate::builtins::intl::Intl;
@@ -39,13 +43,13 @@ impl Intrinsics {
     /// To initialize all the intrinsics with their spec properties, see [`Realm::initialize`].
     ///
     /// [`Realm::initialize`]: crate::realm::Realm::initialize
-    pub(crate) fn uninit(root_shape: &RootShape) -> Option<Self> {
-        let constructors = StandardConstructors::default();
+    pub(crate) fn uninit(root_shape: &RootShape, realm_inner: &WeakGc<RealmInner>) -> Option<Self> {
+        let constructors = StandardConstructors::new(realm_inner);
         let templates = ObjectTemplates::new(root_shape, &constructors);
 
         Some(Self {
             constructors,
-            objects: IntrinsicObjects::uninit()?,
+            objects: IntrinsicObjects::uninit(realm_inner)?,
             templates,
         })
     }
@@ -91,6 +95,46 @@ impl StandardConstructor {
         Self {
             constructor,
             prototype,
+        }
+    }
+
+    /// Build a constructor that is lazily initialized.
+    /// Both the constructor and the prototype are lazily initialized.
+    ///
+    /// For example: Both the initiation of the `Array` and accessing its prototype will fire `init` once.
+    /// This means that the actual creation of the array and the retrieval of its
+    /// prototype are deferred until they are actually needed.
+    ///
+    /// ## Example
+    ///
+    /// ```javascript
+    /// // Lazy initiation of the Array
+    /// let array = new Array(10); // Creates an array with 10 empty slots
+    ///
+    /// // Lazy access to the prototype
+    /// let prototype = Object.getPrototypeOf(array);
+    ///
+    /// // Accessing an index in the array
+    /// array[0] = 42; // Sets the first element to 42
+    /// console.log(array[0]); // Logs 42
+    /// ```
+    fn lazy(init: fn(&Realm) -> (), realm_inner: &WeakGc<RealmInner>) -> Self {
+        let obj: JsObject<LazyBuiltIn> = JsObject::new_unique(
+            None,
+            LazyBuiltIn {
+                init_and_realm: Some((init, realm_inner.clone())),
+                kind: BuiltinKind::Function(NativeFunctionObject {
+                    f: NativeFunction::from_fn_ptr(|_, _, _| Ok(JsValue::undefined())),
+                    constructor: Some(ConstructorKind::Base),
+                    realm: None,
+                }),
+            },
+        );
+        let constructor = JsFunction::from_object_unchecked(obj.clone().upcast());
+
+        Self {
+            constructor: constructor.clone(),
+            prototype: JsObject::lazy_prototype(obj),
         }
     }
 
@@ -202,8 +246,8 @@ pub struct StandardConstructors {
     calendar: StandardConstructor,
 }
 
-impl Default for StandardConstructors {
-    fn default() -> Self {
+impl StandardConstructors {
+    fn new(realm_inner: &WeakGc<RealmInner>) -> Self {
         Self {
             object: StandardConstructor::with_prototype(JsObject::from_object_and_vtable(
                 Object::<OrdinaryObject>::default(),
@@ -211,14 +255,14 @@ impl Default for StandardConstructors {
             )),
             async_generator_function: StandardConstructor::default(),
             proxy: StandardConstructor::default(),
-            date: StandardConstructor::default(),
+            date: StandardConstructor::lazy(Date::init, realm_inner),
             function: StandardConstructor {
                 constructor: JsFunction::empty_intrinsic_function(true),
                 prototype: JsFunction::empty_intrinsic_function(false).into(),
             },
             async_function: StandardConstructor::default(),
             generator_function: StandardConstructor::default(),
-            array: StandardConstructor::with_prototype(JsObject::from_proto_and_data(None, Array)),
+            array: StandardConstructor::lazy(Array::init, realm_inner),
             bigint: StandardConstructor::default(),
             number: StandardConstructor::with_prototype(JsObject::from_proto_and_data(None, 0.0)),
             boolean: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
@@ -1119,7 +1163,7 @@ impl IntrinsicObjects {
     ///
     /// [`Realm::initialize`]: crate::realm::Realm::initialize
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn uninit() -> Option<Self> {
+    pub(crate) fn uninit(realm_inner: &WeakGc<RealmInner>) -> Option<Self> {
         Some(Self {
             reflect: JsObject::default(),
             math: JsObject::default(),

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     builtins::{
-        function::ConstructorKind, iterable::IteratorPrototypes, uri::UriFunctions, Array, Date,
-        IntrinsicObject, Json, Math, OrdinaryObject, RegExp, String,
+        function::ConstructorKind, iterable::IteratorPrototypes, uri::UriFunctions, Array,
+        IntrinsicObject, OrdinaryObject,
     },
     js_string,
     native_function::NativeFunctionObject,
@@ -49,7 +49,7 @@ impl Intrinsics {
 
         Some(Self {
             constructors,
-            objects: IntrinsicObjects::uninit(realm_inner)?,
+            objects: IntrinsicObjects::uninit()?,
             templates,
         })
     }
@@ -118,7 +118,7 @@ impl StandardConstructor {
     /// array[0] = 42; // Sets the first element to 42
     /// console.log(array[0]); // Logs 42
     /// ```
-    fn lazy(init: fn(&Realm) -> (), realm_inner: &WeakGc<RealmInner>) -> Self {
+    fn lazy_array(init: fn(&Realm) -> (), realm_inner: &WeakGc<RealmInner>) -> Self {
         let obj: JsObject<LazyBuiltIn> = JsObject::new_unique(
             None,
             LazyBuiltIn {
@@ -134,7 +134,7 @@ impl StandardConstructor {
 
         Self {
             constructor: constructor.clone(),
-            prototype: JsObject::lazy_prototype(obj),
+            prototype: JsObject::lazy_array_prototype(obj),
         }
     }
 
@@ -262,7 +262,7 @@ impl StandardConstructors {
             },
             async_function: StandardConstructor::default(),
             generator_function: StandardConstructor::default(),
-            array: StandardConstructor::lazy(Array::init, realm_inner),
+            array: StandardConstructor::lazy_array(Array::init, realm_inner),
             bigint: StandardConstructor::default(),
             number: StandardConstructor::with_prototype(JsObject::from_proto_and_data(None, 0.0)),
             boolean: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
@@ -1163,7 +1163,7 @@ impl IntrinsicObjects {
     ///
     /// [`Realm::initialize`]: crate::realm::Realm::initialize
     #[allow(clippy::unnecessary_wraps)]
-    pub(crate) fn uninit(realm_inner: &WeakGc<RealmInner>) -> Option<Self> {
+    pub(crate) fn uninit() -> Option<Self> {
         Some(Self {
             reflect: JsObject::default(),
             math: JsObject::default(),

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -3,7 +3,7 @@
 use crate::{
     builtins::{
         function::ConstructorKind, iterable::IteratorPrototypes, uri::UriFunctions, Array, Date,
-        IntrinsicObject, Math, OrdinaryObject,
+        IntrinsicObject, Json, Math, OrdinaryObject, RegExp, String,
     },
     js_string,
     native_function::NativeFunctionObject,
@@ -268,11 +268,8 @@ impl StandardConstructors {
             boolean: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
                 None, false,
             )),
-            string: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
-                None,
-                js_string!(),
-            )),
-            regexp: StandardConstructor::default(),
+            string: StandardConstructor::lazy(String::init, realm_inner),
+            regexp: StandardConstructor::lazy(RegExp::init, realm_inner),
             symbol: StandardConstructor::default(),
             error: StandardConstructor::default(),
             type_error: StandardConstructor::default(),
@@ -1167,7 +1164,7 @@ impl IntrinsicObjects {
         Some(Self {
             reflect: JsObject::default(),
             math: JsObject::lazy(Math::init, realm_inner),
-            json: JsObject::default(),
+            json: JsObject::lazy(Json::init, realm_inner),
             throw_type_error: JsFunction::empty_intrinsic_function(false),
             array_prototype_values: JsFunction::empty_intrinsic_function(false),
             array_prototype_to_string: JsFunction::empty_intrinsic_function(false),

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -255,7 +255,7 @@ impl StandardConstructors {
             )),
             async_generator_function: StandardConstructor::default(),
             proxy: StandardConstructor::default(),
-            date: StandardConstructor::lazy(Date::init, realm_inner),
+            date: StandardConstructor::default(),
             function: StandardConstructor {
                 constructor: JsFunction::empty_intrinsic_function(true),
                 prototype: JsFunction::empty_intrinsic_function(false).into(),
@@ -268,8 +268,11 @@ impl StandardConstructors {
             boolean: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
                 None, false,
             )),
-            string: StandardConstructor::lazy(String::init, realm_inner),
-            regexp: StandardConstructor::lazy(RegExp::init, realm_inner),
+            string: StandardConstructor::with_prototype(JsObject::from_proto_and_data(
+                None,
+                js_string!(),
+            )),
+            regexp: StandardConstructor::default(),
             symbol: StandardConstructor::default(),
             error: StandardConstructor::default(),
             type_error: StandardConstructor::default(),
@@ -1163,8 +1166,8 @@ impl IntrinsicObjects {
     pub(crate) fn uninit(realm_inner: &WeakGc<RealmInner>) -> Option<Self> {
         Some(Self {
             reflect: JsObject::default(),
-            math: JsObject::lazy(Math::init, realm_inner),
-            json: JsObject::lazy(Json::init, realm_inner),
+            math: JsObject::default(),
+            json: JsObject::default(),
             throw_type_error: JsFunction::empty_intrinsic_function(false),
             array_prototype_values: JsFunction::empty_intrinsic_function(false),
             array_prototype_to_string: JsFunction::empty_intrinsic_function(false),

--- a/core/engine/src/context/intrinsics.rs
+++ b/core/engine/src/context/intrinsics.rs
@@ -3,7 +3,7 @@
 use crate::{
     builtins::{
         function::ConstructorKind, iterable::IteratorPrototypes, uri::UriFunctions, Array, Date,
-        IntrinsicObject, OrdinaryObject,
+        IntrinsicObject, Math, OrdinaryObject,
     },
     js_string,
     native_function::NativeFunctionObject,
@@ -1166,7 +1166,7 @@ impl IntrinsicObjects {
     pub(crate) fn uninit(realm_inner: &WeakGc<RealmInner>) -> Option<Self> {
         Some(Self {
             reflect: JsObject::default(),
-            math: JsObject::default(),
+            math: JsObject::lazy(Math::init, realm_inner),
             json: JsObject::default(),
             throw_type_error: JsFunction::empty_intrinsic_function(false),
             array_prototype_values: JsFunction::empty_intrinsic_function(false),

--- a/core/engine/src/native_function.rs
+++ b/core/engine/src/native_function.rs
@@ -343,14 +343,14 @@ pub(crate) fn native_function_call(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
-    native_function_call_inner(
-        obj,
-        &obj.downcast_ref::<NativeFunctionObject>()
-            .expect("the object should be a native function object")
-            .clone(),
-        argument_count,
-        context,
-    )
+    let native_function = &obj
+        .clone()
+        .downcast::<NativeFunctionObject>()
+        .expect("the object should be a native function object")
+        .borrow_mut()
+        .data
+        .clone();
+    native_function_call_inner(obj, native_function, argument_count, context)
 }
 
 /// Call this object.

--- a/core/engine/src/native_function.rs
+++ b/core/engine/src/native_function.rs
@@ -392,19 +392,31 @@ fn native_function_construct(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
+    native_function_construct_inner(
+        &obj.downcast_ref::<NativeFunctionObject>()
+            .expect("the object should be a native function object")
+            .clone(),
+        obj.clone(),
+        argument_count,
+        context,
+    )
+}
+
+pub(crate) fn native_function_construct_inner(
+    native_function: &NativeFunctionObject,
+    this_function_object: JsObject,
+    argument_count: usize,
+    context: &mut Context,
+) -> JsResult<CallValue> {
     // We technically don't need this since native functions don't push any new frames to the
     // vm, but we'll eventually have to combine the native stack with the vm stack.
     context.check_runtime_limits()?;
-    let this_function_object = obj.clone();
 
     let NativeFunctionObject {
         f: function,
         constructor,
         realm,
-    } = obj
-        .downcast_ref::<NativeFunctionObject>()
-        .expect("the object should be a native function object")
-        .clone();
+    } = native_function.clone();
 
     let mut realm = realm.unwrap_or_else(|| context.realm().clone());
 

--- a/core/engine/src/native_function.rs
+++ b/core/engine/src/native_function.rs
@@ -359,6 +359,7 @@ pub(crate) fn native_function_call(
 ///
 /// Panics if the object is currently mutably borrowed.
 // <https://tc39.es/ecma262/#sec-built-in-function-objects-call-thisargument-argumentslist>
+#[inline]
 pub(crate) fn native_function_call_inner(
     obj: &JsObject,
     native_function: &NativeFunctionObject,
@@ -420,6 +421,7 @@ fn native_function_construct(
     )
 }
 
+#[inline]
 pub(crate) fn native_function_construct_inner(
     native_function: &NativeFunctionObject,
     this_function_object: JsObject,

--- a/core/engine/src/object/builtins/lazy_array_prototype.rs
+++ b/core/engine/src/object/builtins/lazy_array_prototype.rs
@@ -1,0 +1,226 @@
+use crate::{
+    object::{
+        internal_methods::{
+            non_existant_call, non_existant_construct, ordinary_define_own_property,
+            ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of,
+            ordinary_has_property, ordinary_is_extensible, ordinary_own_property_keys,
+            ordinary_prevent_extensions, ordinary_set, ordinary_set_prototype_of, ordinary_try_get,
+            InternalMethodContext, InternalObjectMethods,
+        },
+        JsPrototype,
+    },
+    property::{PropertyDescriptor, PropertyKey},
+    Context, JsData, JsObject, JsResult, JsValue,
+};
+use boa_gc::{Finalize, Trace};
+
+use super::LazyBuiltIn;
+
+/// The `LazyArrayPrototype` struct is responsible for ensuring that the prototype
+/// of a constructor is lazily initialized. In JavaScript, constructors have a
+/// `prototype` property that points to an object which is used as the prototype
+/// for instances created by that constructor.
+///
+/// The `LazyArrayPrototype` struct is used within `JsObject` (e.g., `JsObject<LazyPrototype>`)
+/// to defer the creation of the prototype object until it is actually needed.
+/// This lazy initialization helps improve performance by avoiding the creation
+/// of the prototype object until it is necessary.
+///
+/// Each `LazyArrayPrototype` instance points to the constructor's `lazyBuiltin` (via its
+/// object) and triggers the initialization of the prototype if any methods on
+/// the prototype are called.
+
+#[derive(Clone, Trace, Finalize, Debug)]
+#[allow(clippy::type_complexity)]
+pub struct LazyArrayPrototype {
+    pub(crate) constructor: JsObject<LazyBuiltIn>,
+}
+
+// Implement the trait for JsData by overriding all internal_methods by calling init on the LazyBuiltIn associated with this prototype
+impl JsData for LazyArrayPrototype {
+    fn internal_methods(&self) -> &'static InternalObjectMethods {
+        &LAZY_INTERNAL_METHODS
+    }
+}
+
+pub(crate) static LAZY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMethods {
+    __get_prototype_of__: lazy_get_prototype_of,
+    __set_prototype_of__: lazy_set_prototype_of,
+    __is_extensible__: lazy_is_extensible,
+    __prevent_extensions__: lazy_prevent_extensions,
+    __get_own_property__: lazy_get_own_property,
+    __define_own_property__: lazy_define_own_property,
+    __has_property__: lazy_has_property,
+    __try_get__: lazy_try_get,
+    __get__: lazy_get,
+    __set__: lazy_set,
+    __delete__: lazy_delete,
+    __own_property_keys__: lazy_own_property_keys,
+    __call__: non_existant_call,
+    __construct__: non_existant_construct,
+};
+
+pub(crate) fn lazy_get_prototype_of(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<JsPrototype> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get_prototype_of(obj, context)
+}
+
+pub(crate) fn lazy_set_prototype_of(
+    obj: &JsObject,
+    prototype: JsPrototype,
+    context: &mut Context,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_set_prototype_of(obj, prototype, context)
+}
+pub(crate) fn lazy_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_is_extensible(obj, context)
+}
+
+pub(crate) fn lazy_prevent_extensions(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_prevent_extensions(obj, context)
+}
+
+pub(crate) fn lazy_get_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<PropertyDescriptor>> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get_own_property(obj, key, context)
+}
+
+pub(crate) fn lazy_define_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    desc: PropertyDescriptor,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_define_own_property(obj, key, desc, context)
+}
+
+pub(crate) fn lazy_has_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_has_property(obj, key, context)
+}
+
+pub(crate) fn lazy_try_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<JsValue>> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_try_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<JsValue> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_set(
+    obj: &JsObject,
+    key: PropertyKey,
+    value: JsValue,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_set(obj, key, value, receiver, context)
+}
+
+pub(crate) fn lazy_delete(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_delete(obj, key, context)
+}
+
+pub(crate) fn lazy_own_property_keys(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<Vec<PropertyKey>> {
+    let lazy_prototype: JsObject<LazyArrayPrototype> = obj
+        .clone()
+        .downcast::<LazyArrayPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_own_property_keys(obj, context)
+}

--- a/core/engine/src/object/builtins/lazy_builtin.rs
+++ b/core/engine/src/object/builtins/lazy_builtin.rs
@@ -1,7 +1,9 @@
 use crate::{
     builtins::function::ConstructorKind,
     gc::custom_trace,
-    native_function::{native_function_construct_inner, NativeFunctionObject},
+    native_function::{
+        native_function_call_inner, native_function_construct_inner, NativeFunctionObject,
+    },
     object::{
         internal_methods::{
             non_existant_call, non_existant_construct, ordinary_define_own_property,
@@ -248,10 +250,9 @@ pub(crate) fn lazy_call(
             .with_realm(context.realm().clone())
             .into()),
         BuiltinKind::Function(function) => {
-            let call = function.internal_methods().__call__;
             // builtin needs to be dropped before calling the constructor to avoid a double borrow
             drop(builtin);
-            Ok(call(obj, argument_count, context)?)
+            native_function_call_inner(obj, function, argument_count, context)
         }
     }
 }

--- a/core/engine/src/object/builtins/lazy_builtin.rs
+++ b/core/engine/src/object/builtins/lazy_builtin.rs
@@ -23,6 +23,7 @@ use boa_gc::{Finalize, Trace, WeakGc};
 #[derive(Debug, Clone, Trace, Finalize)]
 pub(crate) enum BuiltinKind {
     Function(NativeFunctionObject),
+    #[allow(dead_code)]
     Ordinary,
 }
 

--- a/core/engine/src/object/builtins/lazy_builtin.rs
+++ b/core/engine/src/object/builtins/lazy_builtin.rs
@@ -1,0 +1,257 @@
+use crate::{
+    builtins::function::ConstructorKind,
+    gc::custom_trace,
+    native_function::{native_function_construct_inner, NativeFunctionObject},
+    object::{
+        internal_methods::{
+            non_existant_call, non_existant_construct, ordinary_define_own_property,
+            ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of,
+            ordinary_has_property, ordinary_is_extensible, ordinary_own_property_keys,
+            ordinary_prevent_extensions, ordinary_set, ordinary_set_prototype_of, ordinary_try_get,
+            CallValue, InternalMethodContext, InternalObjectMethods,
+        },
+        JsPrototype,
+    },
+    property::{PropertyDescriptor, PropertyKey},
+    realm::{Realm, RealmInner},
+    Context, JsData, JsNativeError, JsObject, JsResult, JsValue, NativeFunction,
+};
+use boa_gc::{Finalize, Trace, WeakGc};
+
+#[derive(Debug, Clone, Trace, Finalize)]
+pub(crate) enum BuiltinKind {
+    Function(NativeFunctionObject),
+    Ordinary,
+}
+
+/// A Lazy Built-in data structure. Used for lazy initialization of builtins.
+#[derive(Clone, Finalize, Debug)]
+#[allow(clippy::type_complexity)]
+pub struct LazyBuiltIn {
+    pub(crate) init_and_realm: Option<(fn(&Realm), WeakGc<RealmInner>)>,
+    pub(crate) kind: BuiltinKind,
+}
+
+impl LazyBuiltIn {
+    pub(crate) fn set_constructor(&mut self, function: NativeFunction, realm: Realm) {
+        if let BuiltinKind::Function(ref mut native_function) = self.kind {
+            native_function.f = function;
+            native_function.constructor = Some(ConstructorKind::Base);
+            native_function.realm = Some(realm);
+        } else {
+            panic!("Expected BuiltinKind::Function");
+        }
+    }
+
+    pub(crate) fn ensure_init(built_in: &JsObject<LazyBuiltIn>) {
+        let borrowed_built_in = built_in.borrow_mut().data.init_and_realm.take();
+        if let Some((init, realm_inner)) = borrowed_built_in {
+            let realm = &Realm {
+                inner: realm_inner.upgrade().expect("realm_inner not set"),
+            };
+            init(realm);
+        }
+    }
+}
+
+// SAFETY: Temporary, TODO move back to derived Trace when possible
+unsafe impl Trace for LazyBuiltIn {
+    custom_trace!(this, mark, {
+        mark(&this.kind);
+    });
+}
+
+// Implement the trait for JsData by overriding all internal_methods by calling init before calling into the underlying internel_method
+impl JsData for LazyBuiltIn {
+    fn internal_methods(&self) -> &'static InternalObjectMethods {
+        static FUNCTION: InternalObjectMethods = InternalObjectMethods {
+            __construct__: lazy_construct,
+            __call__: lazy_call,
+            ..LAZY_INTERNAL_METHODS
+        };
+
+        if let BuiltinKind::Function(_) = self.kind {
+            return &FUNCTION;
+        }
+
+        &LAZY_INTERNAL_METHODS
+    }
+}
+
+pub(crate) static LAZY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMethods {
+    __get_prototype_of__: lazy_get_prototype_of,
+    __set_prototype_of__: lazy_set_prototype_of,
+    __is_extensible__: lazy_is_extensible,
+    __prevent_extensions__: lazy_prevent_extensions,
+    __get_own_property__: lazy_get_own_property,
+    __define_own_property__: lazy_define_own_property,
+    __has_property__: lazy_has_property,
+    __try_get__: lazy_try_get,
+    __get__: lazy_get,
+    __set__: lazy_set,
+    __delete__: lazy_delete,
+    __own_property_keys__: lazy_own_property_keys,
+    __call__: non_existant_call,
+    __construct__: non_existant_construct,
+};
+
+pub(crate) fn lazy_get_prototype_of(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<JsPrototype> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_get_prototype_of(obj, context)
+}
+
+pub(crate) fn lazy_set_prototype_of(
+    obj: &JsObject,
+    prototype: JsPrototype,
+    context: &mut Context,
+) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_set_prototype_of(obj, prototype, context)
+}
+pub(crate) fn lazy_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_is_extensible(obj, context)
+}
+
+pub(crate) fn lazy_prevent_extensions(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_prevent_extensions(obj, context)
+}
+
+pub(crate) fn lazy_get_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<PropertyDescriptor>> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_get_own_property(obj, key, context)
+}
+
+pub(crate) fn lazy_define_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    desc: PropertyDescriptor,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+
+    ordinary_define_own_property(obj, key, desc, context)
+}
+
+pub(crate) fn lazy_has_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_has_property(obj, key, context)
+}
+
+pub(crate) fn lazy_try_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<JsValue>> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+
+    ordinary_try_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<JsValue> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_set(
+    obj: &JsObject,
+    key: PropertyKey,
+    value: JsValue,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_set(obj, key, value, receiver, context)
+}
+
+pub(crate) fn lazy_delete(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    ordinary_delete(obj, key, context)
+}
+
+pub(crate) fn lazy_own_property_keys(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<Vec<PropertyKey>> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+
+    ordinary_own_property_keys(obj, context)
+}
+
+pub(crate) fn lazy_construct(
+    obj: &JsObject,
+    argument_count: usize,
+    context: &mut Context,
+) -> JsResult<CallValue> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    let kind = &builtin.borrow().data.kind.clone();
+
+    match kind {
+        BuiltinKind::Ordinary => Err(JsNativeError::typ()
+            .with_message("not a constructor")
+            .with_realm(context.realm().clone())
+            .into()),
+        BuiltinKind::Function(cons) => {
+            // builtin needs to be dropped before calling the constructor to avoid a double borrow
+            drop(builtin);
+            native_function_construct_inner(cons, obj.clone(), argument_count, context)
+        }
+    }
+}
+
+pub(crate) fn lazy_call(
+    obj: &JsObject,
+    argument_count: usize,
+    context: &mut Context,
+) -> JsResult<CallValue> {
+    let builtin: JsObject<LazyBuiltIn> = obj.clone().downcast().expect("obj is not a Builtin");
+    LazyBuiltIn::ensure_init(&builtin);
+    let kind = &builtin.borrow().data.kind.clone();
+    match kind {
+        BuiltinKind::Ordinary => Err(JsNativeError::typ()
+            .with_message("not a constructor")
+            .with_realm(context.realm().clone())
+            .into()),
+        BuiltinKind::Function(function) => {
+            let call = function.internal_methods().__call__;
+            // builtin needs to be dropped before calling the constructor to avoid a double borrow
+            drop(builtin);
+            Ok(call(obj, argument_count, context)?)
+        }
+    }
+}

--- a/core/engine/src/object/builtins/lazy_prototype.rs
+++ b/core/engine/src/object/builtins/lazy_prototype.rs
@@ -1,0 +1,226 @@
+use crate::{
+    object::{
+        internal_methods::{
+            non_existant_call, non_existant_construct, ordinary_define_own_property,
+            ordinary_delete, ordinary_get, ordinary_get_own_property, ordinary_get_prototype_of,
+            ordinary_has_property, ordinary_is_extensible, ordinary_own_property_keys,
+            ordinary_prevent_extensions, ordinary_set, ordinary_set_prototype_of, ordinary_try_get,
+            InternalMethodContext, InternalObjectMethods,
+        },
+        JsPrototype,
+    },
+    property::{PropertyDescriptor, PropertyKey},
+    Context, JsData, JsObject, JsResult, JsValue,
+};
+use boa_gc::{Finalize, Trace};
+
+use super::LazyBuiltIn;
+
+/// The `LazyPrototype` struct is responsible for ensuring that the prototype
+/// of a constructor is lazily initialized. In JavaScript, constructors have a
+/// `prototype` property that points to an object which is used as the prototype
+/// for instances created by that constructor.
+///
+/// The `LazyPrototype` struct is used within `JsObject` (e.g., `JsObject<LazyPrototype>`)
+/// to defer the creation of the prototype object until it is actually needed.
+/// This lazy initialization helps improve performance by avoiding the creation
+/// of the prototype object until it is necessary.
+///
+/// Each `LazyPrototype` instance points to the constructor's `lazyBuiltin` (via its
+/// object) and triggers the initialization of the prototype if any methods on
+/// the prototype are called.
+
+#[derive(Clone, Trace, Finalize, Debug)]
+#[allow(clippy::type_complexity)]
+pub struct LazyPrototype {
+    pub(crate) constructor: JsObject<LazyBuiltIn>,
+}
+
+// Implement the trait for JsData by overriding all internal_methods by calling init on the LazyBuiltIn associated with this prototype
+impl JsData for LazyPrototype {
+    fn internal_methods(&self) -> &'static InternalObjectMethods {
+        &LAZY_INTERNAL_METHODS
+    }
+}
+
+pub(crate) static LAZY_INTERNAL_METHODS: InternalObjectMethods = InternalObjectMethods {
+    __get_prototype_of__: lazy_get_prototype_of,
+    __set_prototype_of__: lazy_set_prototype_of,
+    __is_extensible__: lazy_is_extensible,
+    __prevent_extensions__: lazy_prevent_extensions,
+    __get_own_property__: lazy_get_own_property,
+    __define_own_property__: lazy_define_own_property,
+    __has_property__: lazy_has_property,
+    __try_get__: lazy_try_get,
+    __get__: lazy_get,
+    __set__: lazy_set,
+    __delete__: lazy_delete,
+    __own_property_keys__: lazy_own_property_keys,
+    __call__: non_existant_call,
+    __construct__: non_existant_construct,
+};
+
+pub(crate) fn lazy_get_prototype_of(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<JsPrototype> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get_prototype_of(obj, context)
+}
+
+pub(crate) fn lazy_set_prototype_of(
+    obj: &JsObject,
+    prototype: JsPrototype,
+    context: &mut Context,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_set_prototype_of(obj, prototype, context)
+}
+pub(crate) fn lazy_is_extensible(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_is_extensible(obj, context)
+}
+
+pub(crate) fn lazy_prevent_extensions(obj: &JsObject, context: &mut Context) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_prevent_extensions(obj, context)
+}
+
+pub(crate) fn lazy_get_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<PropertyDescriptor>> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get_own_property(obj, key, context)
+}
+
+pub(crate) fn lazy_define_own_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    desc: PropertyDescriptor,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_define_own_property(obj, key, desc, context)
+}
+
+pub(crate) fn lazy_has_property(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_has_property(obj, key, context)
+}
+
+pub(crate) fn lazy_try_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<Option<JsValue>> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_try_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_get(
+    obj: &JsObject,
+    key: &PropertyKey,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<JsValue> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_get(obj, key, receiver, context)
+}
+
+pub(crate) fn lazy_set(
+    obj: &JsObject,
+    key: PropertyKey,
+    value: JsValue,
+    receiver: JsValue,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_set(obj, key, value, receiver, context)
+}
+
+pub(crate) fn lazy_delete(
+    obj: &JsObject,
+    key: &PropertyKey,
+    context: &mut InternalMethodContext<'_>,
+) -> JsResult<bool> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+    ordinary_delete(obj, key, context)
+}
+
+pub(crate) fn lazy_own_property_keys(
+    obj: &JsObject,
+    context: &mut Context,
+) -> JsResult<Vec<PropertyKey>> {
+    let lazy_prototype: JsObject<LazyPrototype> = obj
+        .clone()
+        .downcast::<LazyPrototype>()
+        .expect("obj is not a Builtin");
+    let lazy_built_in = &lazy_prototype.borrow_mut().data.constructor.clone();
+    LazyBuiltIn::ensure_init(lazy_built_in);
+
+    ordinary_own_property_keys(obj, context)
+}

--- a/core/engine/src/object/builtins/mod.rs
+++ b/core/engine/src/object/builtins/mod.rs
@@ -17,6 +17,7 @@ mod jsset;
 mod jsset_iterator;
 mod jssharedarraybuffer;
 mod jstypedarray;
+mod lazy_array_prototype;
 mod lazy_builtin;
 mod lazy_prototype;
 
@@ -35,5 +36,6 @@ pub use jsset::*;
 pub use jsset_iterator::*;
 pub use jssharedarraybuffer::*;
 pub use jstypedarray::*;
+pub use lazy_array_prototype::*;
 pub use lazy_builtin::*;
 pub use lazy_prototype::*;

--- a/core/engine/src/object/builtins/mod.rs
+++ b/core/engine/src/object/builtins/mod.rs
@@ -17,6 +17,8 @@ mod jsset;
 mod jsset_iterator;
 mod jssharedarraybuffer;
 mod jstypedarray;
+mod lazy_builtin;
+mod lazy_prototype;
 
 pub use jsarray::*;
 pub use jsarraybuffer::*;
@@ -33,3 +35,5 @@ pub use jsset::*;
 pub use jsset_iterator::*;
 pub use jssharedarraybuffer::*;
 pub use jstypedarray::*;
+pub use lazy_builtin::*;
+pub use lazy_prototype::*;

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -1117,7 +1117,7 @@ where
     Ok(default(realm.intrinsics().constructors()).prototype())
 }
 
-fn non_existant_call(
+pub(crate) fn non_existant_call(
     _obj: &JsObject,
     _argument_count: usize,
     context: &mut Context,
@@ -1128,7 +1128,7 @@ fn non_existant_call(
         .into())
 }
 
-fn non_existant_construct(
+pub(crate) fn non_existant_construct(
     _obj: &JsObject,
     _argument_count: usize,
     context: &mut Context,

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -5,7 +5,7 @@
 use super::{
     internal_methods::{InternalMethodContext, InternalObjectMethods, ORDINARY_INTERNAL_METHODS},
     shape::RootShape,
-    JsPrototype, NativeObject, Object, PrivateName, PropertyMap,
+    JsPrototype, LazyBuiltIn, LazyPrototype, NativeObject, Object, PrivateName, PropertyMap,
 };
 use crate::{
     builtins::{
@@ -90,6 +90,11 @@ impl JsObject {
         Self {
             inner: coerce_gc(gc),
         }
+    }
+    /// Creates a new lazy `JsObject` from its inner object and its vtable.
+    /// This is used for built-in objects that are lazily initialized.
+    pub(crate) fn lazy_prototype(constructor: JsObject<LazyBuiltIn>) -> Self {
+        Self::from_proto_and_data(None, LazyPrototype { constructor })
     }
 
     /// Creates a new ordinary object with its prototype set to the `Object` prototype.

--- a/core/engine/src/object/jsobject.rs
+++ b/core/engine/src/object/jsobject.rs
@@ -95,7 +95,7 @@ impl JsObject {
     }
 
     /// Creates a new lazy `JsObject` from its inner object and its vtable.
-    /// This object will call init([realm]) when it's first accessed
+    /// This object will call `init(realm)` when it's first accessed
     pub(crate) fn lazy(init: fn(&Realm) -> (), realm_inner: &WeakGc<RealmInner>) -> Self {
         let data = LazyBuiltIn {
             init_and_realm: Some((init, realm_inner.clone())),

--- a/core/gc/src/cell.rs
+++ b/core/gc/src/cell.rs
@@ -16,7 +16,7 @@ use std::{
 /// `BorrowFlag` represent the internal state of a `GcCell` and
 /// keeps track of the amount of current borrows.
 #[derive(Copy, Clone)]
-struct BorrowFlag(usize);
+pub struct BorrowFlag(usize);
 
 /// `BorrowState` represents the various states of a `BorrowFlag`
 ///
@@ -91,7 +91,8 @@ impl Debug for BorrowFlag {
 ///
 /// This object is a `RefCell` that can be used inside of a `Gc<T>`.
 pub struct GcRefCell<T: ?Sized + 'static> {
-    flags: Cell<BorrowFlag>,
+    /// The current state of the `GcCell`.
+    pub flags: Cell<BorrowFlag>,
     cell: UnsafeCell<T>,
 }
 


### PR DESCRIPTION
## Lazy Builtins

So, this creates 2 new data structs which are used inside of JS Objects. `LazyBuiltIn` and `LazyPrototype`.
Instead of calling [initialize](https://github.com/boa-dev/boa/blob/main/core/engine/src/builtins/mod.rs#L211) on array for example, we will setup array with a constructor that has a LazyBuiltin object and a prototype which lazy a LazyPrototype. If any properties or the constructor itself is called then we will call `init` at that point. 

For now I've started with:
- Array

I also updated the VSCode task to always choose the `debug/script.js` path, as it makes debugging much faster

Closes #2307