### PR TITLE
fix: ignore `debugger` statement

### DIFF
--- a/core/ast/src/expression/mod.rs
+++ b/core/ast/src/expression/mod.rs
@@ -175,6 +175,9 @@ pub enum Expression {
     /// It is not a valid expression node.
     #[doc(hidden)]
     FormalParameterList(FormalParameterList),
+
+    #[doc(hidden)]
+    Debugger,
 }
 
 impl Expression {
@@ -220,6 +223,7 @@ impl Expression {
             Self::Parenthesized(expr) => expr.to_interned_string(interner),
             Self::RegExpLiteral(regexp) => regexp.to_interned_string(interner),
             Self::FormalParameterList(_) => unreachable!(),
+            Self::Debugger => "debugger".to_owned(),
         }
     }
 
@@ -326,7 +330,7 @@ impl VisitWith for Expression {
             Self::Yield(y) => visitor.visit_yield(y),
             Self::Parenthesized(e) => visitor.visit_parenthesized(e),
             Self::FormalParameterList(fpl) => visitor.visit_formal_parameter_list(fpl),
-            Self::This | Self::NewTarget | Self::ImportMeta => {
+            Self::This | Self::NewTarget | Self::ImportMeta | Self::Debugger => {
                 // do nothing; can be handled as special case by visitor
                 ControlFlow::Continue(())
             }
@@ -369,7 +373,7 @@ impl VisitWith for Expression {
             Self::Yield(y) => visitor.visit_yield_mut(y),
             Self::Parenthesized(e) => visitor.visit_parenthesized_mut(e),
             Self::FormalParameterList(fpl) => visitor.visit_formal_parameter_list_mut(fpl),
-            Self::This | Self::NewTarget | Self::ImportMeta => {
+            Self::This | Self::NewTarget | Self::ImportMeta | Self::Debugger => {
                 // do nothing; can be handled as special case by visitor
                 ControlFlow::Continue(())
             }

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -363,6 +363,7 @@ impl ByteCompiler<'_> {
             }
             // TODO: try to remove this variant somehow
             Expression::FormalParameterList(_) => unreachable!(),
+            Expression::Debugger => (),
         }
     }
 }

--- a/core/parser/src/parser/expression/primary/mod.rs
+++ b/core/parser/src/parser/expression/primary/mod.rs
@@ -133,6 +133,10 @@ where
                     .parse(cursor, interner)
                     .map(Into::into)
             }
+            TokenKind::Keyword((Keyword::Debugger, _)) => {
+                cursor.advance(interner);
+                Ok(ast::Expression::Debugger)
+            }
             TokenKind::Keyword((Keyword::Async, contain_escaped_char)) => {
                 let contain_escaped_char = *contain_escaped_char;
                 let skip_n = if cursor.peek_is_line_terminator(0, interner).or_abrupt()? {


### PR DESCRIPTION
Right now, if I try to run js code with a `debugger` statement in it, I got the error:
`SyntaxError: unexpected token 'debugger', primary expression at line 14, col 645`.

In this PR, I’m simply ignoring the `debugger` statement. I know it’s not a definitive solution, but at least it allows the code to run.