### PR TITLE
Enable CI for release branches

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - releases/**
 
 jobs:
   runBenchmark:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,9 +4,11 @@ on:
   pull_request:
     branches:
       - main
+      - releases/**
   push:
     branches:
       - main
+      - releases/**
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - releases/**
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -2,9 +2,11 @@ on:
   pull_request:
     branches:
       - main
+      - releases/**
   push:
     branches:
       - main
+      - releases/**
   merge_group:
     types: [checks_requested]
 


### PR DESCRIPTION
Just to have some checks in place before backporting fixes to old releases.
