### PR TITLE
chore: bump intrusive collections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1962,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "intrusive-collections"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b694dc9f70c3bda874626d2aed13b780f137aab435f4e9814121955cf706122e"
+checksum = "189d0897e4cbe8c75efedf3502c18c887b05046e59d28404d4d8e46cbc4d1e86"
 dependencies = [
  "memoffset",
 ]


### PR DESCRIPTION
with the newest intrusive-collections release this is currently causing issues

https://github.com/Amanieu/intrusive-rs/commit/5c1cf180639ae3653ea023c59ff7b21a217e99cf

>  /Users/Matthias/.cargo/registry/src/index.crates.io-6f17d22bba15001f/boa_engine-0.19.0/src/builtins/atomics/futex.rs:161:37
    |
161 | pub(crate) static CRITICAL_SECTION: Mutex<FutexWaiters> = Mutex::new(FutexWaiters {
    |                                     ^^^^^^^^^^^^^^^^^^^ `Cell<std::option::Option<NonNull<LinkedListLink>>>` cannot be shared between threads safely
    |
    = help: within `FutexWaiter`, the trait `Sync` is not implemented for `Cell<std::option::Option<NonNull<LinkedListLink>>>`, which is required by `Mutex<FutexWaiters>: Sync`
    = note: if you want to do aliasing and mutation between multiple threads, use `std::sync::RwLock`


but it looks like this is no longer an issue on main because it looks like this is compiling
ref #3984