### PR TITLE
Limit actions runs to 1 per branch and fix macos release

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,6 +6,10 @@ on:
       - main
       - releases/**
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   runBenchmark:
     if: contains(github.event.pull_request.labels.*.name, 'run-benchmark')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          targets: ${{ matrix.target }}
 
       - name: Build
         run: cargo build --target ${{ matrix.target }} --verbose --release --locked --bin boa

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,15 +12,19 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
-  RUSTFLAGS: ${{ github.ref == 'refs/heads/main' && '-D warnings' || '' }}
+  RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
 
 jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' || github.base_ref == 'main' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -152,7 +156,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      RUSTDOCFLAGS: ${{ github.ref == 'refs/heads/main' && '-D warnings' || '' }}
+      RUSTDOCFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-D warnings' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test262.yml
+++ b/.github/workflows/test262.yml
@@ -7,6 +7,10 @@ on:
   merge_group:
     types: [checks_requested]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run_test262:
     name: Run the test262 test suite

--- a/.github/workflows/webassembly.yml
+++ b/.github/workflows/webassembly.yml
@@ -1,3 +1,5 @@
+name: Webassembly demo
+
 on:
   pull_request:
     branches:
@@ -10,7 +12,9 @@ on:
   merge_group:
     types: [checks_requested]
 
-name: Webassembly demo
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check_style:
@@ -29,7 +33,7 @@ jobs:
     timeout-minutes: 60
     env:
       WASM_PACK_PATH: ~/.cargo/bin/wasm-pack
-      RUSTFLAGS: ${{ github.ref == 'refs/heads/main' && '-Dwarnings' || '' }}
+      RUSTFLAGS: ${{ (github.ref == 'refs/heads/main' || github.base_ref == 'main') && '-Dwarnings' || '' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the macos release binary action.
Also limits the amount of actions running per PR/protected branch to 1, to avoid running the actions multiple times when pushing multiple times to the same PR/branch.
