### PR TITLE
`TryFromJs` from `JsMap` for `HashMap` & `BtreeMap`

### DIFF
--- a/core/engine/src/builtins/map/mod.rs
+++ b/core/engine/src/builtins/map/mod.rs
@@ -509,7 +509,7 @@ impl Map {
     /// 2. Perform ? RequireInternalSlot(M, [[MapData]]).
     /// 3. If IsCallable(callbackfn) is false, throw a TypeError exception.
     /// ```
-    pub(crate) fn rust_for_each<F>(this: &JsValue, mut f: F) -> JsResult<()>
+    pub(crate) fn for_each_native<F>(this: &JsValue, mut f: F) -> JsResult<()>
     where
         F: FnMut(JsValue, JsValue) -> JsResult<()>,
     {

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -406,7 +406,7 @@ impl JsMap {
     #[inline]
     pub fn rust_for_each<F>(&self, f: F) -> JsResult<()>
     where
-        F: FnMut(&JsValue, &JsValue) -> JsResult<()>,
+        F: FnMut(JsValue, JsValue) -> JsResult<()>,
     {
         let this = self.inner.clone().into();
         Map::rust_for_each(&this, f)

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -404,12 +404,12 @@ impl JsMap {
 
     /// Executes the provided callback function for each key-value pair within the [`JsMap`].
     #[inline]
-    pub fn rust_for_each<F>(&self, f: F) -> JsResult<()>
+    pub fn for_each_native<F>(&self, f: F) -> JsResult<()>
     where
         F: FnMut(JsValue, JsValue) -> JsResult<()>,
     {
         let this = self.inner.clone().into();
-        Map::rust_for_each(&this, f)
+        Map::for_each_native(&this, f)
     }
 
     /// Returns a new [`JsMapIterator`] object that yields the `value` for each element within the [`JsMap`] in insertion order.

--- a/core/engine/src/object/builtins/jsmap.rs
+++ b/core/engine/src/object/builtins/jsmap.rs
@@ -402,6 +402,16 @@ impl JsMap {
         )
     }
 
+    /// Executes the provided callback function for each key-value pair within the [`JsMap`].
+    #[inline]
+    pub fn rust_for_each<F>(&self, f: F) -> JsResult<()>
+    where
+        F: FnMut(&JsValue, &JsValue) -> JsResult<()>,
+    {
+        let this = self.inner.clone().into();
+        Map::rust_for_each(&this, f)
+    }
+
     /// Returns a new [`JsMapIterator`] object that yields the `value` for each element within the [`JsMap`] in insertion order.
     #[inline]
     pub fn values(&self, context: &mut Context) -> JsResult<JsMapIterator> {

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -573,7 +573,7 @@ fn js_map_into_rust_map() -> JsResult<()> {
     let hash_map = HashMap::<String, i32>::try_from_js(&js_value, &mut context)?;
     let btree_map = BTreeMap::<String, i32>::try_from_js(&js_value, &mut context)?;
 
-    let expect = vec![("a".into(), 1), ("aboba".into(), 42024), ("b".into(), 3)];
+    let expect = [("a".into(), 1), ("aboba".into(), 42024), ("b".into(), 3)];
 
     let expected_hash_map: HashMap<String, _> = expect.iter().cloned().collect();
     assert_eq!(expected_hash_map, hash_map);

--- a/core/engine/src/value/conversions/try_from_js.rs
+++ b/core/engine/src/value/conversions/try_from_js.rs
@@ -559,3 +559,26 @@ fn value_into_map() {
         }),
     ]);
 }
+
+#[test]
+fn js_map_into_rust_map() -> JsResult<()> {
+    use boa_engine::Source;
+    use std::collections::{BTreeMap, HashMap};
+
+    let js_code = "new Map([['a', 1], ['b', 3], ['aboba', 42024]])";
+    let mut context = Context::default();
+
+    let js_value = context.eval(Source::from_bytes(js_code))?;
+
+    let hash_map = HashMap::<String, i32>::try_from_js(&js_value, &mut context)?;
+    let btree_map = BTreeMap::<String, i32>::try_from_js(&js_value, &mut context)?;
+
+    let expect = vec![("a".into(), 1), ("aboba".into(), 42024), ("b".into(), 3)];
+
+    let expected_hash_map: HashMap<String, _> = expect.iter().cloned().collect();
+    assert_eq!(expected_hash_map, hash_map);
+
+    let expected_btree_map: BTreeMap<String, _> = expect.iter().cloned().collect();
+    assert_eq!(expected_btree_map, btree_map);
+    Ok(())
+}

--- a/core/engine/src/value/conversions/try_from_js/collections.rs
+++ b/core/engine/src/value/conversions/try_from_js/collections.rs
@@ -31,7 +31,7 @@ where
                 );
                 Ok(())
             };
-            for_each_elem_in_js_map(js_map, f, context)?;
+            for_each_elem_in_js_map(&js_map, f, context)?;
             return Ok(map);
         }
 
@@ -75,7 +75,7 @@ where
                 );
                 Ok(())
             };
-            for_each_elem_in_js_map(js_map, f, context)?;
+            for_each_elem_in_js_map(&js_map, f, context)?;
             return Ok(map);
         }
 
@@ -96,7 +96,7 @@ where
     }
 }
 
-fn for_each_elem_in_js_map<F>(js_map: JsMap, mut f: F, context: &mut Context) -> JsResult<()>
+fn for_each_elem_in_js_map<F>(js_map: &JsMap, mut f: F, context: &mut Context) -> JsResult<()>
 where
     F: FnMut(JsValue, JsValue, &mut Context) -> JsResult<()>,
 {

--- a/core/engine/src/value/conversions/try_from_js/collections.rs
+++ b/core/engine/src/value/conversions/try_from_js/collections.rs
@@ -22,7 +22,7 @@ where
         // JsMap case
         if let Ok(js_map) = JsMap::from_object(object.clone()) {
             let mut map = Self::default();
-            js_map.rust_for_each(|key, value| {
+            js_map.for_each_native(|key, value| {
                 map.insert(
                     K::try_from_js(&key, context)?,
                     V::try_from_js(&value, context)?,
@@ -65,7 +65,7 @@ where
         // JsMap case
         if let Ok(js_map) = JsMap::from_object(object.clone()) {
             let mut map = Self::default();
-            js_map.rust_for_each(|key, value| {
+            js_map.for_each_native(|key, value| {
                 map.insert(
                     K::try_from_js(&key, context)?,
                     V::try_from_js(&value, context)?,

--- a/core/engine/src/value/conversions/try_from_js/collections.rs
+++ b/core/engine/src/value/conversions/try_from_js/collections.rs
@@ -24,8 +24,8 @@ where
             let mut map = Self::default();
             js_map.rust_for_each(|key, value| {
                 map.insert(
-                    K::try_from_js(key, context)?,
-                    V::try_from_js(value, context)?,
+                    K::try_from_js(&key, context)?,
+                    V::try_from_js(&value, context)?,
                 );
                 Ok(())
             })?;
@@ -67,8 +67,8 @@ where
             let mut map = Self::default();
             js_map.rust_for_each(|key, value| {
                 map.insert(
-                    K::try_from_js(key, context)?,
-                    V::try_from_js(value, context)?,
+                    K::try_from_js(&key, context)?,
+                    V::try_from_js(&value, context)?,
                 );
                 Ok(())
             })?;

--- a/core/engine/src/value/conversions/try_from_js/collections.rs
+++ b/core/engine/src/value/conversions/try_from_js/collections.rs
@@ -3,6 +3,9 @@
 use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 
+use boa_macros::js_str;
+
+use crate::object::{JsArray, JsMap};
 use crate::value::TryFromJs;
 use crate::{Context, JsNativeError, JsResult, JsValue};
 
@@ -18,6 +21,21 @@ where
                 .into());
         };
 
+        // JsMap case
+        if let Ok(js_map) = JsMap::from_object(object.clone()) {
+            let mut map = Self::default();
+            let f = |key, value, context: &mut _| {
+                map.insert(
+                    K::try_from_js(&key, context)?,
+                    V::try_from_js(&value, context)?,
+                );
+                Ok(())
+            };
+            for_each_elem_in_js_map(js_map, f, context)?;
+            return Ok(map);
+        }
+
+        // key-valued JsObject case:
         let keys = object.__own_property_keys__(context)?;
 
         keys.into_iter()
@@ -47,6 +65,21 @@ where
                 .into());
         };
 
+        // JsMap case
+        if let Ok(js_map) = JsMap::from_object(object.clone()) {
+            let mut map = Self::default();
+            let f = |key, value, context: &mut _| {
+                map.insert(
+                    K::try_from_js(&key, context)?,
+                    V::try_from_js(&value, context)?,
+                );
+                Ok(())
+            };
+            for_each_elem_in_js_map(js_map, f, context)?;
+            return Ok(map);
+        }
+
+        // key-valued JsObject case:
         let keys = object.__own_property_keys__(context)?;
 
         keys.into_iter()
@@ -61,4 +94,45 @@ where
             })
             .collect()
     }
+}
+
+fn for_each_elem_in_js_map<F>(js_map: JsMap, mut f: F, context: &mut Context) -> JsResult<()>
+where
+    F: FnMut(JsValue, JsValue, &mut Context) -> JsResult<()>,
+{
+    let unexp_obj_err = || {
+        JsResult::Err(
+            JsNativeError::typ()
+                .with_message("MapIterator return unexpected object")
+                .into(),
+        )
+    };
+
+    let iter = js_map.entries(context)?;
+    loop {
+        let next = iter.next(context)?;
+        let Some(iter_obj) = next.as_object() else {
+            return unexp_obj_err();
+        };
+
+        let done = iter_obj.get(js_str!("done"), context)?;
+        let Some(done) = done.as_boolean() else {
+            return unexp_obj_err();
+        };
+        if done {
+            break;
+        }
+
+        let value = iter_obj.get(js_str!("value"), context)?;
+        let Some(js_obj) = value.as_object() else {
+            return unexp_obj_err();
+        };
+        let arr = JsArray::from_object(js_obj.clone())?;
+
+        let key = arr.at(0, context)?;
+        let value = arr.at(1, context)?;
+
+        f(key, value, context)?;
+    }
+    Ok(())
 }

--- a/core/engine/src/value/conversions/try_from_js/collections.rs
+++ b/core/engine/src/value/conversions/try_from_js/collections.rs
@@ -5,6 +5,7 @@ use std::hash::Hash;
 
 use boa_macros::js_str;
 
+use crate::builtins::iterable::IteratorResult;
 use crate::object::{JsArray, JsMap};
 use crate::value::TryFromJs;
 use crate::{Context, JsNativeError, JsResult, JsValue};
@@ -110,10 +111,8 @@ where
 
     let iter = js_map.entries(context)?;
     loop {
-        let next = iter.next(context)?;
-        let Some(iter_obj) = next.as_object() else {
-            return unexp_obj_err();
-        };
+        let next = iter.next(context).and_then(IteratorResult::from_value)?;
+        let iter_obj = next.object();
 
         let done = iter_obj.get(js_str!("done"), context)?;
         let Some(done) = done.as_boolean() else {


### PR DESCRIPTION
Seems like `TryFromJs` didn't convert correctly from `JsMap` into `HashMap` / `BtreeMap`

This PR fix it

**Example**  
Next code
```Rust
use boa_engine::{value::TryFromJs, Context, JsResult, Source};
use std::collections::HashMap;

fn main() -> JsResult<()> {
    let js_code = "new Map([['a', 2], ['b', 3]])";
    let mut context = Context::default();

    let js_value = context.eval(Source::from_bytes(js_code))?;
    println!("{}", js_value.display());

    let map = HashMap::<String, i32>::try_from_js(&js_value, &mut context)?;
    println!("{map:?}");
    Ok(())
}
```
before this changes will return:
```
Map { "a" → 2, "b" → 3 }
{}
```
and after changes returns:
```
Map { "a" → 2, "b" → 3 }
{"a": 2, "b": 3}
```

**Notes**  
I don't find more fast way(than the one used in `for_each_elem_in_js_map`) to get `(key, value)`'s from `JsMap`.
Maybe there is a way?
Or maybe I should write it (for example by function like [next](https://github.com/boa-dev/boa/blob/main/core/engine/src/builtins/map/map_iterator.rs#L110-L133) but that just return `Option<(JsValue, JsValue)>`)?