### PR TITLE
`TryIntoJs` trait and derive macro for it

### DIFF
--- a/core/engine/src/value/conversions/mod.rs
+++ b/core/engine/src/value/conversions/mod.rs
@@ -7,6 +7,7 @@ use super::{JsBigInt, JsObject, JsString, JsSymbol, JsValue, Profiler};
 mod either;
 mod serde_json;
 pub(super) mod try_from_js;
+pub(super) mod try_into_js;
 
 pub(super) mod convert;
 

--- a/core/engine/src/value/conversions/try_into_js.rs
+++ b/core/engine/src/value/conversions/try_into_js.rs
@@ -211,27 +211,26 @@ mod try_into_js_tests {
     use crate::{Context, JsResult};
 
     #[test]
-    fn big_int_err() -> JsResult<()> {
-        let mut context = Context::default();
-        let context = &mut context;
-
-        fn assert<T: TryIntoJs>(int: T, context: &mut Context) {
+    fn big_int_err() {
+        fn assert<T: TryIntoJs>(int: &T, context: &mut Context) {
             let expect_err = int.try_into_js(context);
             assert!(expect_err.is_err());
         }
+
+        let mut context = Context::default();
+        let context = &mut context;
+
         let int = (1 << 55) + 17i64;
-        assert(int, context);
+        assert(&int, context);
 
         let int = (1 << 55) + 17u64;
-        assert(int, context);
+        assert(&int, context);
 
         let int = (1 << 55) + 17u128;
-        assert(int, context);
+        assert(&int, context);
 
         let int = (1 << 55) + 17i128;
-        assert(int, context);
-
-        Ok(())
+        assert(&int, context);
     }
 
     #[test]
@@ -254,7 +253,7 @@ mod try_into_js_tests {
 
         // it will rewrite without reading, so it's just for auto type resolving.
         #[allow(unused_assignments)]
-        let mut tuple_after_transform = tuple_initial.clone();
+        let mut tuple_after_transform = tuple_initial;
 
         let js_value = tuple_initial.try_into_js(context)?;
         tuple_after_transform = TryFromJs::try_from_js(&js_value, context)?;
@@ -287,8 +286,4 @@ mod try_into_js_tests {
         assert_eq!(vec_init, vec);
         Ok(())
     }
-
-    // TODO: try_from_js don't convert JsMap into HashMap, is it ok?
-    //       but still not sure about convertion into js type:
-    //       HashMap --> Map([...])   OR   HashMap --> [k1: v1, ..., k2: v2]
 }

--- a/core/engine/src/value/conversions/try_into_js.rs
+++ b/core/engine/src/value/conversions/try_into_js.rs
@@ -9,10 +9,7 @@ pub trait TryIntoJs: Sized {
 
 impl TryIntoJs for bool {
     fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
-        JsResult::Ok(match *self {
-            true => JsValue::Boolean(true),
-            false => JsValue::Boolean(false),
-        })
+        JsResult::Ok(JsValue::Boolean(*self))
     }
 }
 
@@ -82,6 +79,7 @@ fn convert_safe_i64(value: i64) -> JsValue {
 impl TryIntoJs for i64 {
     fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
         let value = *self;
+        #[allow(clippy::manual_range_contains)]
         if value < MIN_SAFE_INTEGER_I64 || MAX_SAFE_INTEGER_I64 < value {
             JsResult::Err(err_outside_safe_range())
         } else {
@@ -102,7 +100,7 @@ impl TryIntoJs for u64 {
 impl TryIntoJs for i128 {
     fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
         let value = *self;
-        if value < (MIN_SAFE_INTEGER_I64 as i128) || (MAX_SAFE_INTEGER_I64 as i128) < value {
+        if value < i128::from(MIN_SAFE_INTEGER_I64) || i128::from(MAX_SAFE_INTEGER_I64) < value {
             JsResult::Err(err_outside_safe_range())
         } else {
             JsResult::Ok(convert_safe_i64(value as i64))

--- a/core/engine/src/value/conversions/try_into_js.rs
+++ b/core/engine/src/value/conversions/try_into_js.rs
@@ -1,0 +1,208 @@
+use crate::{Context, JsNativeError, JsResult, JsValue};
+use boa_string::JsString;
+
+/// This trait adds a conversions from a Rust Type into [`JsValue`].
+pub trait TryIntoJs: Sized {
+    /// This function tries to convert a `Self` into [`JsValue`].
+    fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue>;
+}
+
+impl TryIntoJs for bool {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        JsResult::Ok(match *self {
+            true => JsValue::Boolean(true),
+            false => JsValue::Boolean(false),
+        })
+    }
+}
+
+impl TryIntoJs for &str {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        JsResult::Ok(JsValue::String(JsString::from(*self)))
+    }
+}
+impl TryIntoJs for String {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        JsResult::Ok(JsValue::String(JsString::from(self.as_str())))
+    }
+}
+
+macro_rules! impl_try_into_js_by_from {
+    ($t:ty) => {
+        impl TryIntoJs for $t {
+            fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+                JsResult::Ok(JsValue::from(self.clone()))
+            }
+        }
+    };
+    [$($ts:ty),+] => {
+        $(impl_try_into_js_by_from!($ts);)+
+    }
+}
+impl_try_into_js_by_from![i8, u8, i16, u16, i32, u32, f32, f64];
+impl_try_into_js_by_from![
+    JsValue,
+    JsString,
+    crate::JsBigInt,
+    crate::JsObject,
+    crate::JsSymbol,
+    crate::object::JsArray,
+    crate::object::JsArrayBuffer,
+    crate::object::JsDataView,
+    crate::object::JsDate,
+    crate::object::JsFunction,
+    crate::object::JsGenerator,
+    crate::object::JsMapIterator,
+    crate::object::JsMap,
+    crate::object::JsSetIterator,
+    crate::object::JsSet,
+    crate::object::JsSharedArrayBuffer,
+    crate::object::JsInt8Array,
+    crate::object::JsInt16Array,
+    crate::object::JsInt32Array,
+    crate::object::JsUint8Array,
+    crate::object::JsUint16Array,
+    crate::object::JsUint32Array,
+    crate::object::JsFloat32Array,
+    crate::object::JsFloat64Array
+];
+
+const MAX_SAFE_INTEGER_I64: i64 = (1 << 53) - 1;
+const MIN_SAFE_INTEGER_I64: i64 = -MAX_SAFE_INTEGER_I64;
+
+fn err_outside_safe_range() -> crate::JsError {
+    JsNativeError::typ()
+        .with_message("cannot convert value into JsValue: the value is outside the safe range")
+        .into()
+}
+fn convert_safe_i64(value: i64) -> JsValue {
+    i32::try_from(value).map_or(JsValue::Rational(value as f64), JsValue::Integer)
+}
+
+impl TryIntoJs for i64 {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        let value = *self;
+        if value < MIN_SAFE_INTEGER_I64 || MAX_SAFE_INTEGER_I64 < value {
+            JsResult::Err(err_outside_safe_range())
+        } else {
+            JsResult::Ok(convert_safe_i64(value))
+        }
+    }
+}
+impl TryIntoJs for u64 {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        let value = *self;
+        if (MAX_SAFE_INTEGER_I64 as u64) < value {
+            JsResult::Err(err_outside_safe_range())
+        } else {
+            JsResult::Ok(convert_safe_i64(value as i64))
+        }
+    }
+}
+impl TryIntoJs for i128 {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        let value = *self;
+        if value < (MIN_SAFE_INTEGER_I64 as i128) || (MAX_SAFE_INTEGER_I64 as i128) < value {
+            JsResult::Err(err_outside_safe_range())
+        } else {
+            JsResult::Ok(convert_safe_i64(value as i64))
+        }
+    }
+}
+impl TryIntoJs for u128 {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        let value = *self;
+        if (MAX_SAFE_INTEGER_I64 as u128) < value {
+            JsResult::Err(err_outside_safe_range())
+        } else {
+            JsResult::Ok(convert_safe_i64(value as i64))
+        }
+    }
+}
+
+impl<T> TryIntoJs for Option<T>
+where
+    T: TryIntoJs,
+{
+    fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue> {
+        match self {
+            Some(x) => x.try_into_js(context),
+            None => JsResult::Ok(JsValue::Null),
+        }
+    }
+}
+
+impl<T> TryIntoJs for Vec<T>
+where
+    T: TryIntoJs,
+{
+    fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue> {
+        let arr = crate::object::JsArray::new(context);
+        for value in self {
+            let value = value.try_into_js(context)?;
+            arr.push(value, context)?;
+        }
+        JsResult::Ok(arr.into())
+    }
+}
+
+macro_rules! impl_try_into_js_for_tuples {
+    ($($names:ident : $ts:ident),+) => {
+        impl<$($ts: TryIntoJs,)+> TryIntoJs for ($($ts,)+) {
+            fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue> {
+                let ($($names,)+) = self;
+                let arr = crate::object::JsArray::new(context);
+                $(arr.push($names.try_into_js(context)?, context)?;)+
+                JsResult::Ok(arr.into())
+            }
+        }
+    };
+}
+
+impl_try_into_js_for_tuples!(a: A);
+impl_try_into_js_for_tuples!(a: A, b: B);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F, g: G);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J);
+impl_try_into_js_for_tuples!(a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J, k: K);
+
+impl TryIntoJs for () {
+    fn try_into_js(&self, _context: &mut Context) -> JsResult<JsValue> {
+        JsResult::Ok(JsValue::Null)
+    }
+}
+
+impl<T, S> TryIntoJs for std::collections::HashSet<T, S>
+where
+    T: TryIntoJs,
+{
+    fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue> {
+        let set = crate::object::JsSet::new(context);
+        for value in self {
+            let value = value.try_into_js(context)?;
+            set.add(value, context)?;
+        }
+        JsResult::Ok(set.into())
+    }
+}
+
+impl<K, V, S> TryIntoJs for std::collections::HashMap<K, V, S>
+where
+    K: TryIntoJs,
+    V: TryIntoJs,
+{
+    fn try_into_js(&self, context: &mut Context) -> JsResult<JsValue> {
+        let map = crate::object::JsMap::new(context);
+        for (key, value) in self {
+            let key = key.try_into_js(context)?;
+            let value = value.try_into_js(context)?;
+            map.set(key, value, context)?;
+        }
+        JsResult::Ok(map.into())
+    }
+}

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -24,8 +24,8 @@ pub use conversions::convert::Convert;
 pub(crate) use self::conversions::IntoOrUndefined;
 #[doc(inline)]
 pub use self::{
-    conversions::try_from_js::TryFromJs, display::ValueDisplay, integer::IntegerOrInfinity,
-    operations::*, r#type::Type,
+    conversions::try_from_js::TryFromJs, conversions::try_into_js::TryIntoJs,
+    display::ValueDisplay, integer::IntegerOrInfinity, operations::*, r#type::Type,
 };
 use crate::builtins::RegExp;
 use crate::object::{JsFunction, JsPromise, JsRegExp};

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -17,6 +17,7 @@ use once_cell::sync::Lazy;
 use boa_gc::{custom_trace, Finalize, Trace};
 #[doc(inline)]
 pub use boa_macros::TryFromJs;
+pub use boa_macros::TryIntoJs;
 use boa_profiler::Profiler;
 #[doc(inline)]
 pub use conversions::convert::Convert;

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -527,9 +527,9 @@ pub fn derive_try_into_js(input: TokenStream) -> TokenStream {
     let expanded = quote! {
         impl ::boa_engine::value::TryIntoJs for #type_name {
             fn try_into_js(&self, context: &mut boa_engine::Context) -> boa_engine::JsResult<boa_engine::JsValue> {
-                let obj = JsObject::default();
+                let obj = boa_engine::JsObject::default();
                 #props
-                JsResult::Ok(obj.into())
+                boa_engine::JsResult::Ok(obj.into())
             }
         }
     };
@@ -595,10 +595,10 @@ fn generate_obj_properties(fields: FieldsNamed) -> Result<proc_macro2::TokenStre
             let into_js_with = Ident::new(&into_js_with.value(), into_js_with.span());
             quote! { #into_js_with(&self.#name, context)? }
         } else {
-            quote! { self.#name.try_into_js(context)? }
+            quote! { boa_engine::value::TryIntoJs::try_into_js(&self.#name, context)? }
         };
         prop_ctors.push(quote! {
-            obj.create_data_property_or_throw(js_str!(#prop_key), #value, context)?;
+            obj.create_data_property_or_throw(boa_engine::js_str!(#prop_key), #value, context)?;
         });
     }
 

--- a/examples/src/bin/try_into_js_derive.rs
+++ b/examples/src/bin/try_into_js_derive.rs
@@ -1,7 +1,7 @@
 use boa_engine::{
-    js_str, js_string,
+    js_string,
     value::{TryFromJs, TryIntoJs},
-    Context, JsObject, JsResult, JsValue, Source,
+    Context, JsResult, JsValue, Source,
 };
 
 #[derive(TryIntoJs)]

--- a/examples/src/bin/try_into_js_derive.rs
+++ b/examples/src/bin/try_into_js_derive.rs
@@ -1,0 +1,96 @@
+use boa_engine::{
+    js_str, js_string,
+    value::{TryFromJs, TryIntoJs},
+    Context, JsObject, JsResult, JsValue, Source,
+};
+
+#[derive(TryIntoJs)]
+struct Test {
+    x: i32,
+    #[boa(rename = "y")]
+    y_point: i32,
+    #[allow(unused)]
+    #[boa(skip)]
+    tuple: (i32, u8, String),
+    #[boa(rename = "isReadable")]
+    #[boa(into_js_with = "readable_into_js")]
+    is_readable: i8,
+}
+
+#[derive(TryFromJs, Debug, PartialEq, Eq)]
+struct ResultVerifier {
+    x: i32,
+    y: i32,
+    #[boa(rename = "isReadable")]
+    is_readable: bool,
+}
+
+fn main() -> JsResult<()> {
+    let js_code = r#"
+    function pointShift(pointA, pointB) {
+        if (pointA.isReadable === true && pointB.isReadable === true) {
+            return {
+                x: pointA.x + pointB.x,
+                y: pointA.y + pointB.y,
+                isReadable: true,
+            }
+        }
+        return undefined
+    }
+    "#;
+
+    let mut context = Context::default();
+    let context = &mut context;
+
+    context.eval(Source::from_bytes(js_code))?;
+
+    let point_shift = context
+        .global_object()
+        .get(js_string!("pointShift"), context)?;
+    let point_shift = point_shift.as_callable().unwrap();
+
+    let a = Test {
+        x: 10,
+        y_point: 20,
+        tuple: (30, 40, "no matter".into()),
+        is_readable: 1,
+    };
+    let b = Test {
+        x: 2,
+        y_point: 1,
+        tuple: (30, 40, "no matter".into()),
+        is_readable: 2,
+    };
+    let c = Test {
+        x: 2,
+        y_point: 1,
+        tuple: (30, 40, "no matter".into()),
+        is_readable: 0,
+    };
+
+    let result = point_shift.call(
+        &JsValue::Undefined,
+        &[a.try_into_js(context)?, b.try_into_js(context)?],
+        context,
+    )?;
+    let verifier = ResultVerifier::try_from_js(&result, context)?;
+    let expect = ResultVerifier {
+        x: 10 + 2,
+        y: 20 + 1,
+        is_readable: true,
+    };
+    assert_eq!(verifier, expect);
+
+    let result = point_shift.call(
+        &JsValue::Undefined,
+        &[a.try_into_js(context)?, c.try_into_js(context)?],
+        context,
+    )?;
+    assert!(result.is_undefined());
+
+    Ok(())
+}
+
+fn readable_into_js(value: &i8, _context: &mut Context) -> JsResult<JsValue> {
+    Ok(JsValue::Boolean(*value != 0))
+}


### PR DESCRIPTION
This Pull Request closes #3874 

**Notes**
* I don't sure about conversion of `HashMap` into `JsObject`.
Should it be converted into `JsMap` or  into ordinary object `{ k1: v1, ..., kN: vN }`?
Or maybe I need to add a macro attribute to allow choose a way of conversion of `Map` types?