### PR TITLE
Reduce environment allocations

### DIFF
--- a/core/ast/src/expression/literal/object.rs
+++ b/core/ast/src/expression/literal/object.rs
@@ -469,6 +469,13 @@ impl ObjectMethodDefinition {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the object method definition contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for ObjectMethodDefinition {

--- a/core/ast/src/function/arrow_function.rs
+++ b/core/ast/src/function/arrow_function.rs
@@ -86,6 +86,13 @@ impl ArrowFunction {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the arrow function contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for ArrowFunction {

--- a/core/ast/src/function/async_arrow_function.rs
+++ b/core/ast/src/function/async_arrow_function.rs
@@ -86,6 +86,13 @@ impl AsyncArrowFunction {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the function declaration contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for AsyncArrowFunction {

--- a/core/ast/src/function/async_function.rs
+++ b/core/ast/src/function/async_function.rs
@@ -78,6 +78,13 @@ impl AsyncFunctionDeclaration {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the async function declaration contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for AsyncFunctionDeclaration {
@@ -206,6 +213,13 @@ impl AsyncFunctionExpression {
     #[must_use]
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
+    }
+
+    /// Returns `true` if the async function expression contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
     }
 }
 

--- a/core/ast/src/function/async_generator.rs
+++ b/core/ast/src/function/async_generator.rs
@@ -77,6 +77,13 @@ impl AsyncGeneratorDeclaration {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the async generator declaration contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for AsyncGeneratorDeclaration {
@@ -205,6 +212,13 @@ impl AsyncGeneratorExpression {
     #[must_use]
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
+    }
+
+    /// Returns `true` if the async generator expression contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
     }
 }
 

--- a/core/ast/src/function/class.rs
+++ b/core/ast/src/function/class.rs
@@ -748,6 +748,13 @@ impl ClassMethodDefinition {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the class method definition contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for ClassMethodDefinition {

--- a/core/ast/src/function/generator.rs
+++ b/core/ast/src/function/generator.rs
@@ -76,6 +76,13 @@ impl GeneratorDeclaration {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the generator declaration contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for GeneratorDeclaration {
@@ -204,6 +211,13 @@ impl GeneratorExpression {
     #[must_use]
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
+    }
+
+    /// Returns `true` if the generator expression contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
     }
 }
 

--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -77,6 +77,13 @@ impl FunctionDeclaration {
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
     }
+
+    /// Returns `true` if the function declaration contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
+    }
 }
 
 impl ToIndentedString for FunctionDeclaration {
@@ -205,6 +212,13 @@ impl FunctionExpression {
     #[must_use]
     pub const fn scopes(&self) -> &FunctionScopes {
         &self.scopes
+    }
+
+    /// Returns `true` if the function expression contains a direct call to `eval`.
+    #[inline]
+    #[must_use]
+    pub const fn contains_direct_eval(&self) -> bool {
+        self.contains_direct_eval
     }
 
     /// Analyze the scope of the function expression.

--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -105,6 +105,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         try_break!(self.visit_statement_list_mut(&mut node.statements));
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
@@ -125,6 +126,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         }
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
@@ -140,6 +142,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         std::mem::swap(&mut self.scope, &mut node.scope);
         try_break!(self.visit_statement_mut(&mut node.statement));
         std::mem::swap(&mut self.scope, &mut node.scope);
+        node.scope.reorder_binding_indices();
         self.with = with;
         ControlFlow::Continue(())
     }
@@ -156,6 +159,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         }
         try_break!(self.visit_block_mut(&mut node.block));
         std::mem::swap(&mut self.scope, &mut node.scope);
+        node.scope.reorder_binding_indices();
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
     }
@@ -181,6 +185,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         try_break!(self.visit_statement_mut(&mut node.inner.body));
         if let Some(ForLoopInitializer::Lexical(decl)) = &mut node.inner.init {
             std::mem::swap(&mut self.scope, &mut decl.scope);
+            decl.scope.reorder_binding_indices();
         }
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
@@ -199,6 +204,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         if let Some(scope) = &mut node.target_scope {
             self.direct_eval = direct_eval_old;
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         if let Some(scope) = &mut node.scope {
             self.direct_eval = node.contains_direct_eval || self.direct_eval;
@@ -211,6 +217,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         try_break!(self.visit_statement_mut(&mut node.body));
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
@@ -229,6 +236,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         if let Some(scope) = &mut node.iterable_scope {
             self.direct_eval = direct_eval_old;
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         if let Some(scope) = &mut node.scope {
             self.direct_eval = node.contains_direct_eval || self.direct_eval;
@@ -241,6 +249,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         try_break!(self.visit_statement_mut(&mut node.body));
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
+            scope.reorder_binding_indices();
         }
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
@@ -253,7 +262,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -265,7 +274,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -277,7 +286,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -289,7 +298,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -301,7 +310,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -313,7 +322,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -325,7 +334,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -337,7 +346,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -349,7 +358,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -361,7 +370,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -382,6 +391,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             try_break!(self.visit_class_element_mut(element));
         }
         std::mem::swap(&mut self.scope, &mut node.name_scope);
+        node.name_scope.reorder_binding_indices();
         ControlFlow::Continue(())
     }
 
@@ -407,6 +417,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         }
         if let Some(name_scope) = &mut node.name_scope {
             std::mem::swap(&mut self.scope, name_scope);
+            name_scope.reorder_binding_indices();
         }
         ControlFlow::Continue(())
     }
@@ -415,15 +426,41 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         &mut self,
         node: &'ast mut ClassElement,
     ) -> ControlFlow<Self::BreakTy> {
-        if let ClassElement::MethodDefinition(node) = node {
-            self.visit_function_like(
+        match node {
+            ClassElement::MethodDefinition(node) => self.visit_function_like(
                 &mut node.parameters,
                 &mut node.body,
-                &node.scopes,
+                &mut node.scopes,
                 node.contains_direct_eval,
-            )
-        } else {
-            ControlFlow::Continue(())
+            ),
+            ClassElement::FieldDefinition(field) | ClassElement::StaticFieldDefinition(field) => {
+                try_break!(self.visit_property_name_mut(&mut field.name));
+                if let Some(e) = &mut field.field {
+                    try_break!(self.visit_expression_mut(e));
+                }
+                ControlFlow::Continue(())
+            }
+            ClassElement::PrivateFieldDefinition(field) => {
+                if let Some(e) = &mut field.field {
+                    try_break!(self.visit_expression_mut(e));
+                }
+                ControlFlow::Continue(())
+            }
+            ClassElement::PrivateStaticFieldDefinition(_, e) => {
+                if let Some(e) = e {
+                    try_break!(self.visit_expression_mut(e));
+                }
+                ControlFlow::Continue(())
+            }
+            ClassElement::StaticBlock(node) => {
+                let contains_direct_eval = contains(node.statements(), ContainsSymbol::DirectEval);
+                self.visit_function_like(
+                    &mut FormalParameterList::default(),
+                    &mut node.body,
+                    &mut node.scopes,
+                    contains_direct_eval,
+                )
+            }
         }
     }
 
@@ -435,7 +472,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
-            &node.scopes,
+            &mut node.scopes,
             node.contains_direct_eval,
         )
     }
@@ -485,6 +522,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         std::mem::swap(&mut self.scope, &mut scope);
         try_break!(self.visit_module_item_list_mut(&mut node.items));
         std::mem::swap(&mut self.scope, &mut scope);
+        scope.reorder_binding_indices();
         ControlFlow::Continue(())
     }
 }
@@ -494,7 +532,7 @@ impl BindingEscapeAnalyzer<'_> {
         &mut self,
         parameters: &mut FormalParameterList,
         body: &mut FunctionBody,
-        scopes: &FunctionScopes,
+        scopes: &mut FunctionScopes,
         contains_direct_eval: bool,
     ) -> ControlFlow<&'static str> {
         let direct_eval_old = self.direct_eval;
@@ -510,6 +548,7 @@ impl BindingEscapeAnalyzer<'_> {
         std::mem::swap(&mut self.scope, &mut scope);
         try_break!(self.visit_function_body_mut(body));
         std::mem::swap(&mut self.scope, &mut scope);
+        scopes.reorder_binding_indices();
         self.direct_eval = direct_eval_old;
         ControlFlow::Continue(())
     }

--- a/core/ast/src/source.rs
+++ b/core/ast/src/source.rs
@@ -7,7 +7,7 @@ use crate::{
     scope::Scope,
     scope_analyzer::{
         analyze_binding_escapes, collect_bindings, eval_declaration_instantiation_scope,
-        EvalDeclarationBindings,
+        optimize_scope_indicies, EvalDeclarationBindings,
     },
     visitor::{VisitWith, Visitor, VisitorMut},
     ModuleItemList, StatementList,
@@ -56,7 +56,11 @@ impl Script {
         if !collect_bindings(self, self.strict(), false, scope, interner) {
             return false;
         }
-        analyze_binding_escapes(self, false, scope.clone(), interner)
+        if !analyze_binding_escapes(self, false, scope.clone(), interner) {
+            return false;
+        }
+        optimize_scope_indicies(self, scope);
+        true
     }
 
     /// Analyze the scope of the script in eval mode.
@@ -84,10 +88,10 @@ impl Script {
         if !collect_bindings(self, strict, true, lexical_scope, interner) {
             return Err(String::from("Failed to analyze scope"));
         }
-
         if !analyze_binding_escapes(self, true, lexical_scope.clone(), interner) {
             return Err(String::from("Failed to analyze scope"));
         }
+        optimize_scope_indicies(self, lexical_scope);
 
         Ok(bindings)
     }
@@ -158,7 +162,11 @@ impl Module {
         if !collect_bindings(self, true, false, scope, interner) {
             return false;
         }
-        analyze_binding_escapes(self, false, scope.clone(), interner)
+        if !analyze_binding_escapes(self, false, scope.clone(), interner) {
+            return false;
+        }
+        optimize_scope_indicies(self, &self.scope.clone());
+        true
     }
 }
 

--- a/core/ast/src/source.rs
+++ b/core/ast/src/source.rs
@@ -91,6 +91,10 @@ impl Script {
         if !analyze_binding_escapes(self, true, lexical_scope.clone(), interner) {
             return Err(String::from("Failed to analyze scope"));
         }
+        variable_scope.escape_all_bindings();
+        lexical_scope.escape_all_bindings();
+        variable_scope.reorder_binding_indices();
+        lexical_scope.reorder_binding_indices();
         optimize_scope_indicies(self, lexical_scope);
 
         Ok(bindings)

--- a/core/engine/src/builtins/function/mod.rs
+++ b/core/engine/src/builtins/function/mod.rs
@@ -657,6 +657,7 @@ impl BuiltInFunctionObject {
                 context.realm().scope().clone(),
                 context.realm().scope().clone(),
                 function.scopes(),
+                function.contains_direct_eval(),
                 context.interner_mut(),
             );
 
@@ -1028,10 +1029,12 @@ pub(crate) fn function_call(
         last_env += 1;
     }
 
-    context.vm.environments.push_function(
-        code.constant_scope(last_env),
-        FunctionSlots::new(this, function_object.clone(), None),
-    );
+    if code.has_function_scope() {
+        context.vm.environments.push_function(
+            code.constant_scope(last_env),
+            FunctionSlots::new(this, function_object.clone(), None),
+        );
+    }
 
     Ok(CallValue::Ready)
 }

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -101,6 +101,7 @@ impl ByteCompiler<'_> {
 
             compiler.length = expr.parameters().length();
             compiler.params = expr.parameters().clone();
+            compiler.parameter_scope = expr.scopes().parameter_scope();
 
             compiler.function_declaration_instantiation(
                 expr.body(),

--- a/core/engine/src/bytecompiler/class.rs
+++ b/core/engine/src/bytecompiler/class.rs
@@ -96,6 +96,7 @@ impl ByteCompiler<'_> {
         compiler.code_block_flags |= CodeBlockFlags::IS_CLASS_CONSTRUCTOR;
 
         if let Some(expr) = &class.constructor {
+            compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
             let _ = compiler.push_scope(expr.scopes().function_scope());
 
             compiler.length = expr.parameters().length();
@@ -115,11 +116,13 @@ impl ByteCompiler<'_> {
             compiler.emit_opcode(Opcode::PushUndefined);
         } else if class.super_ref.is_some() {
             // We push an empty, unused function scope since the compiler expects a function scope.
+            compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
             let _ = compiler.push_scope(&Scope::new(compiler.lexical_scope.clone(), true));
             compiler.emit_opcode(Opcode::SuperCallDerived);
             compiler.emit_opcode(Opcode::BindThisValue);
         } else {
             // We push an empty, unused function scope since the compiler expects a function scope.
+            compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
             let _ = compiler.push_scope(&Scope::new(compiler.lexical_scope.clone(), true));
             compiler.emit_opcode(Opcode::PushUndefined);
         }
@@ -288,6 +291,7 @@ impl ByteCompiler<'_> {
                     );
 
                     // Function environment
+                    field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
                     let is_anonymous_function = if let Some(node) = &field.field() {
                         field_compiler.compile_expr(node, true);
@@ -322,6 +326,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                     );
+                    field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
                     if let Some(node) = field.field() {
                         field_compiler.compile_expr(node, true);
@@ -363,6 +368,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                     );
+                    field_compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = field_compiler.push_scope(field.scope());
                     let is_anonymous_function = if let Some(node) = &field.field() {
                         field_compiler.compile_expr(node, true);
@@ -406,6 +412,7 @@ impl ByteCompiler<'_> {
                         self.interner,
                         self.in_with,
                     );
+                    compiler.code_block_flags |= CodeBlockFlags::HAS_FUNCTION_SCOPE;
                     let _ = compiler.push_scope(block.scopes().function_scope());
 
                     compiler.function_declaration_instantiation(

--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -963,10 +963,7 @@ impl ByteCompiler<'_> {
         }
 
         // 19-20
-        if let Some(scope) = scopes.parameters_eval_scope() {
-            let scope_index = self.push_scope(scope);
-            self.emit_with_varying_operand(Opcode::PushScope, scope_index);
-        }
+        drop(self.push_declarative_scope(scopes.parameters_eval_scope()));
 
         let scope = self.lexical_scope.clone();
 
@@ -1057,8 +1054,7 @@ impl ByteCompiler<'_> {
                 //          visibility of declarations in the function body.
                 // b. Let varEnv be NewDeclarativeEnvironment(env).
                 // c. Set the VariableEnvironment of calleeContext to varEnv.
-                let scope_index = self.push_scope(scope);
-                self.emit_with_varying_operand(Opcode::PushScope, scope_index);
+                drop(self.push_declarative_scope(Some(scope)));
 
                 let mut variable_scope = self.lexical_scope.clone();
 
@@ -1177,10 +1173,7 @@ impl ByteCompiler<'_> {
         }
 
         // 30-31
-        if let Some(scope) = scopes.lexical_scope() {
-            let scope_index = self.push_scope(scope);
-            self.emit_with_varying_operand(Opcode::PushScope, scope_index);
-        }
+        drop(self.push_declarative_scope(scopes.lexical_scope()));
 
         // 35. Let privateEnv be the PrivateEnvironment of calleeContext.
         // 36. For each Parse Node f of functionsToInitialize, do

--- a/core/engine/src/bytecompiler/declarations.rs
+++ b/core/engine/src/bytecompiler/declarations.rs
@@ -479,41 +479,46 @@ impl ByteCompiler<'_> {
         // 16. For each Parse Node f of functionsToInitialize, do
         for function in functions_to_initialize {
             // a. Let fn be the sole element of the BoundNames of f.
-            let (name, generator, r#async, parameters, body, scopes) = match &function {
-                VarScopedDeclaration::FunctionDeclaration(f) => (
-                    f.name(),
-                    false,
-                    false,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::GeneratorDeclaration(f) => (
-                    f.name(),
-                    true,
-                    false,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::AsyncFunctionDeclaration(f) => (
-                    f.name(),
-                    false,
-                    true,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::AsyncGeneratorDeclaration(f) => (
-                    f.name(),
-                    true,
-                    true,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::VariableDeclaration(_) => continue,
-            };
+            let (name, generator, r#async, parameters, body, scopes, contains_direct_eval) =
+                match &function {
+                    VarScopedDeclaration::FunctionDeclaration(f) => (
+                        f.name(),
+                        false,
+                        false,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::GeneratorDeclaration(f) => (
+                        f.name(),
+                        true,
+                        false,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::AsyncFunctionDeclaration(f) => (
+                        f.name(),
+                        false,
+                        true,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::AsyncGeneratorDeclaration(f) => (
+                        f.name(),
+                        true,
+                        true,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::VariableDeclaration(_) => continue,
+                };
 
             let code = FunctionCompiler::new()
                 .name(name.sym().to_js_string(self.interner()))
@@ -527,6 +532,7 @@ impl ByteCompiler<'_> {
                     self.variable_scope.clone(),
                     self.lexical_scope.clone(),
                     &scopes,
+                    contains_direct_eval,
                     self.interner,
                 );
 
@@ -737,43 +743,48 @@ impl ByteCompiler<'_> {
         // 17. For each Parse Node f of functionsToInitialize, do
         for function in functions_to_initialize {
             // a. Let fn be the sole element of the BoundNames of f.
-            let (name, generator, r#async, parameters, body, scopes) = match &function {
-                VarScopedDeclaration::FunctionDeclaration(f) => (
-                    f.name(),
-                    false,
-                    false,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::GeneratorDeclaration(f) => (
-                    f.name(),
-                    true,
-                    false,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::AsyncFunctionDeclaration(f) => (
-                    f.name(),
-                    false,
-                    true,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::AsyncGeneratorDeclaration(f) => (
-                    f.name(),
-                    true,
-                    true,
-                    f.parameters(),
-                    f.body(),
-                    f.scopes().clone(),
-                ),
-                VarScopedDeclaration::VariableDeclaration(_) => {
-                    continue;
-                }
-            };
+            let (name, generator, r#async, parameters, body, scopes, contains_direct_eval) =
+                match &function {
+                    VarScopedDeclaration::FunctionDeclaration(f) => (
+                        f.name(),
+                        false,
+                        false,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::GeneratorDeclaration(f) => (
+                        f.name(),
+                        true,
+                        false,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::AsyncFunctionDeclaration(f) => (
+                        f.name(),
+                        false,
+                        true,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::AsyncGeneratorDeclaration(f) => (
+                        f.name(),
+                        true,
+                        true,
+                        f.parameters(),
+                        f.body(),
+                        f.scopes().clone(),
+                        f.contains_direct_eval(),
+                    ),
+                    VarScopedDeclaration::VariableDeclaration(_) => {
+                        continue;
+                    }
+                };
 
             let code = FunctionCompiler::new()
                 .name(name.sym().to_js_string(self.interner()))
@@ -788,6 +799,7 @@ impl ByteCompiler<'_> {
                     self.variable_scope.clone(),
                     self.lexical_scope.clone(),
                     &scopes,
+                    contains_direct_eval,
                     self.interner,
                 );
 

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -129,8 +129,10 @@ impl FunctionCompiler {
         }
 
         if let Some(scope) = self.name_scope {
-            compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
-            let _ = compiler.push_scope(&scope);
+            if !scope.all_bindings_local() {
+                compiler.code_block_flags |= CodeBlockFlags::HAS_BINDING_IDENTIFIER;
+                let _ = compiler.push_scope(&scope);
+            }
         }
         // Function environment
         let _ = compiler.push_scope(scopes.function_scope());

--- a/core/engine/src/bytecompiler/function.rs
+++ b/core/engine/src/bytecompiler/function.rs
@@ -195,6 +195,7 @@ impl FunctionCompiler {
         compiler.compile_statement_list(body.statement_list(), false, false);
 
         compiler.params = parameters.clone();
+        compiler.parameter_scope = scopes.parameter_scope();
 
         let code = compiler.finish();
 

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -122,6 +122,7 @@ pub(crate) struct FunctionSpec<'a> {
     body: &'a FunctionBody,
     pub(crate) scopes: &'a FunctionScopes,
     pub(crate) name_scope: Option<&'a Scope>,
+    pub(crate) contains_direct_eval: bool,
 }
 
 impl<'a> From<&'a FunctionDeclaration> for FunctionSpec<'a> {
@@ -133,6 +134,7 @@ impl<'a> From<&'a FunctionDeclaration> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -146,6 +148,7 @@ impl<'a> From<&'a GeneratorDeclaration> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -159,6 +162,7 @@ impl<'a> From<&'a AsyncFunctionDeclaration> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -172,6 +176,7 @@ impl<'a> From<&'a AsyncGeneratorDeclaration> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -185,6 +190,7 @@ impl<'a> From<&'a FunctionExpression> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: function.name_scope(),
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -198,6 +204,7 @@ impl<'a> From<&'a ArrowFunction> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -211,6 +218,7 @@ impl<'a> From<&'a AsyncArrowFunction> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: None,
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -224,6 +232,7 @@ impl<'a> From<&'a AsyncFunctionExpression> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: function.name_scope(),
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -237,6 +246,7 @@ impl<'a> From<&'a GeneratorExpression> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: function.name_scope(),
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -250,6 +260,7 @@ impl<'a> From<&'a AsyncGeneratorExpression> for FunctionSpec<'a> {
             body: function.body(),
             scopes: function.scopes(),
             name_scope: function.name_scope(),
+            contains_direct_eval: function.contains_direct_eval(),
         }
     }
 }
@@ -270,6 +281,7 @@ impl<'a> From<&'a ClassMethodDefinition> for FunctionSpec<'a> {
             body: method.body(),
             scopes: method.scopes(),
             name_scope: None,
+            contains_direct_eval: method.contains_direct_eval(),
         }
     }
 }
@@ -290,6 +302,7 @@ impl<'a> From<&'a ObjectMethodDefinition> for FunctionSpec<'a> {
             body: method.body(),
             scopes: method.scopes(),
             name_scope: None,
+            contains_direct_eval: method.contains_direct_eval(),
         }
     }
 }
@@ -1518,6 +1531,7 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.variable_scope.clone(),
                 self.lexical_scope.clone(),
                 scopes,
+                function.contains_direct_eval,
                 self.interner,
             );
 
@@ -1595,6 +1609,7 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.variable_scope.clone(),
                 self.lexical_scope.clone(),
                 scopes,
+                function.contains_direct_eval,
                 self.interner,
             );
 
@@ -1638,6 +1653,7 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.variable_scope.clone(),
                 self.lexical_scope.clone(),
                 scopes,
+                function.contains_direct_eval,
                 self.interner,
             );
 

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -401,6 +401,9 @@ pub struct ByteCompiler<'ctx> {
     /// Parameters passed to this function.
     pub(crate) params: FormalParameterList,
 
+    /// Scope of the function parameters.
+    pub(crate) parameter_scope: Scope,
+
     /// Bytecode
     pub(crate) bytecode: Vec<u8>,
 
@@ -513,6 +516,7 @@ impl<'ctx> ByteCompiler<'ctx> {
             local_binding_registers: FxHashMap::default(),
             this_mode: ThisMode::Global,
             params: FormalParameterList::default(),
+            parameter_scope: Scope::default(),
             current_open_environments_count: 0,
 
             register_allocator,
@@ -1772,7 +1776,9 @@ impl<'ctx> ByteCompiler<'ctx> {
 
         let mapped_arguments_binding_indices = self
             .emitted_mapped_arguments_object_opcode
-            .then(|| MappedArguments::binding_indices(&self.params))
+            .then(|| {
+                MappedArguments::binding_indices(&self.params, &self.parameter_scope, self.interner)
+            })
             .unwrap_or_default();
 
         let max_local_binding_register_index =

--- a/core/engine/src/bytecompiler/statement/block.rs
+++ b/core/engine/src/bytecompiler/statement/block.rs
@@ -1,25 +1,12 @@
-use crate::{bytecompiler::ByteCompiler, vm::Opcode};
+use crate::bytecompiler::ByteCompiler;
 use boa_ast::statement::Block;
 
 impl ByteCompiler<'_> {
     /// Compile a [`Block`] `boa_ast` node
     pub(crate) fn compile_block(&mut self, block: &Block, use_expr: bool) {
-        let outer_scope = if let Some(scope) = block.scope() {
-            let outer_scope = self.lexical_scope.clone();
-            let scope_index = self.push_scope(scope);
-            self.emit_with_varying_operand(Opcode::PushScope, scope_index);
-            Some(outer_scope)
-        } else {
-            None
-        };
-
+        let scope = self.push_declarative_scope(block.scope());
         self.block_declaration_instantiation(block);
         self.compile_statement_list(block.statement_list(), use_expr, true);
-
-        if let Some(outer_scope) = outer_scope {
-            self.pop_scope();
-            self.lexical_scope = outer_scope;
-            self.emit_opcode(Opcode::PopEnvironment);
-        }
+        self.pop_declarative_scope(scope);
     }
 }

--- a/core/engine/src/bytecompiler/statement/switch.rs
+++ b/core/engine/src/bytecompiler/statement/switch.rs
@@ -5,15 +5,7 @@ impl ByteCompiler<'_> {
     /// Compile a [`Switch`] `boa_ast` node
     pub(crate) fn compile_switch(&mut self, switch: &Switch, use_expr: bool) {
         self.compile_expr(switch.val(), true);
-
-        let outer_scope = if let Some(scope) = switch.scope() {
-            let outer_scope = self.lexical_scope.clone();
-            let scope_index = self.push_scope(scope);
-            self.emit_with_varying_operand(Opcode::PushScope, scope_index);
-            Some(outer_scope)
-        } else {
-            None
-        };
+        let outer_scope = self.push_declarative_scope(switch.scope());
 
         self.block_declaration_instantiation(switch);
 
@@ -55,11 +47,6 @@ impl ByteCompiler<'_> {
         }
 
         self.pop_switch_control_info();
-
-        if let Some(outer_scope) = outer_scope {
-            self.pop_scope();
-            self.lexical_scope = outer_scope;
-            self.emit_opcode(Opcode::PopEnvironment);
-        }
+        self.pop_declarative_scope(outer_scope);
     }
 }

--- a/core/engine/src/bytecompiler/statement/try.rs
+++ b/core/engine/src/bytecompiler/statement/try.rs
@@ -108,11 +108,7 @@ impl ByteCompiler<'_> {
     }
 
     pub(crate) fn compile_catch_stmt(&mut self, catch: &Catch, _has_finally: bool, use_expr: bool) {
-        // stack: exception
-
-        let outer_scope = self.lexical_scope.clone();
-        let scope_index = self.push_scope(catch.scope());
-        self.emit_with_varying_operand(Opcode::PushScope, scope_index);
+        let outer_scope = self.push_declarative_scope(Some(catch.scope()));
 
         if let Some(binding) = catch.parameter() {
             match binding {
@@ -130,9 +126,7 @@ impl ByteCompiler<'_> {
 
         self.compile_catch_finally_block(catch.block(), use_expr);
 
-        self.pop_scope();
-        self.lexical_scope = outer_scope;
-        self.emit_opcode(Opcode::PopEnvironment);
+        self.pop_declarative_scope(outer_scope);
     }
 
     pub(crate) fn compile_finally_stmt(&mut self, finally: &Finally, has_catch: bool) {

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -186,7 +186,7 @@ impl EnvironmentStack {
 
     /// Push a function environment on the environments stack.
     pub(crate) fn push_function(&mut self, scope: Scope, function_slots: FunctionSlots) {
-        let num_bindings = scope.num_bindings();
+        let num_bindings = scope.num_bindings_non_local();
 
         let (poisoned, with) = {
             // Check if the outer environment is a declarative environment.
@@ -214,7 +214,7 @@ impl EnvironmentStack {
 
     /// Push a module environment on the environments stack.
     pub(crate) fn push_module(&mut self, scope: Scope) {
-        let num_bindings = scope.num_bindings();
+        let num_bindings = scope.num_bindings_non_local();
         self.stack.push(Environment::Declarative(Gc::new(
             DeclarativeEnvironment::new(DeclarativeEnvironmentKind::Module(
                 ModuleEnvironment::new(num_bindings, scope),

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -307,6 +307,8 @@ impl SyntheticModule {
             })
             .collect::<Vec<_>>();
 
+        module_scope.escape_all_bindings();
+
         let cb = Gc::new(compiler.finish());
 
         let mut envs = EnvironmentStack::new(global_env);

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -66,6 +66,9 @@ bitflags! {
         /// Arrow and method functions don't have `"prototype"` property.
         const HAS_PROTOTYPE_PROPERTY = 0b1000_0000;
 
+        /// If the function requires a function scope.
+        const HAS_FUNCTION_SCOPE = 0b1_0000_0000;
+
         /// Trace instruction execution to `stdout`.
         #[cfg(feature = "trace")]
         const TRACEABLE = 0b1000_0000_0000_0000;
@@ -269,6 +272,13 @@ impl CodeBlock {
         self.flags
             .get()
             .contains(CodeBlockFlags::HAS_PROTOTYPE_PROPERTY)
+    }
+
+    /// Returns true if this function requires a function scope.
+    pub(crate) fn has_function_scope(&self) -> bool {
+        self.flags
+            .get()
+            .contains(CodeBlockFlags::HAS_FUNCTION_SCOPE)
     }
 
     /// Find exception [`Handler`] in the code block given the current program counter (`pc`).

--- a/core/engine/src/vm/opcode/push/environment.rs
+++ b/core/engine/src/vm/opcode/push/environment.rs
@@ -17,7 +17,10 @@ impl PushScope {
     #[allow(clippy::unnecessary_wraps)]
     fn operation(context: &mut Context, index: usize) -> JsResult<CompletionType> {
         let scope = context.vm.frame().code_block().constant_scope(index);
-        context.vm.environments.push_lexical(scope.num_bindings());
+        context
+            .vm
+            .environments
+            .push_lexical(scope.num_bindings_non_local());
         Ok(CompletionType::Normal)
     }
 }


### PR DESCRIPTION
This PR builds on #3988 and removes runtime environment allocations when possible.
All three commits can be reviewd independently. I just put them all together here, because they depend on each other anyways.

Running the benchmarks did not show a big reduction in execution time, but this should reduce memory usage since we can skip and reduce size of allocations.

- Skip environment creation when all bindings in the scope are local
- Skip environment creation when possible for arrow functions
- Do not allocate space for local bindings in runtime environments
