### PR TITLE
Add context to the console `Logger` trait

### DIFF
--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -1,4 +1,4 @@
-use super::{formatter, Console};
+use super::{formatter, Console, ConsoleState};
 use crate::test::{run_test_actions, run_test_actions_with, TestAction};
 use crate::Logger;
 use boa_engine::{js_string, property::Attribute, Context, JsError, JsResult, JsValue};
@@ -120,22 +120,22 @@ struct RecordingLogger {
 }
 
 impl Logger for RecordingLogger {
-    fn log(&self, msg: String, state: &Console) -> JsResult<()> {
+    fn log(&self, msg: String, state: &ConsoleState, _: &mut Context) -> JsResult<()> {
         use std::fmt::Write;
-        let indent = 2 * state.groups.len();
+        let indent = state.indent();
         writeln!(self.log.borrow_mut(), "{msg:>indent$}").map_err(JsError::from_rust)
     }
 
-    fn info(&self, msg: String, state: &Console) -> JsResult<()> {
-        self.log(msg, state)
+    fn info(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)
     }
 
-    fn warn(&self, msg: String, state: &Console) -> JsResult<()> {
-        self.log(msg, state)
+    fn warn(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)
     }
 
-    fn error(&self, msg: String, state: &Console) -> JsResult<()> {
-        self.log(msg, state)
+    fn error(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)
     }
 }
 

--- a/core/runtime/src/lib.rs
+++ b/core/runtime/src/lib.rs
@@ -54,7 +54,7 @@
 mod console;
 
 #[doc(inline)]
-pub use console::{Console, Logger};
+pub use console::{Console, ConsoleState, Logger};
 
 mod text;
 


### PR DESCRIPTION
This is not backward compatible but should have minimal impact. This is also more future proof by passing the ConsoleState which is more opaque and allows us to update the way the console object is constructed and passed.
