### PR TITLE
Some optimizations on `Error`

### DIFF
--- a/core/engine/src/builtins/temporal/error.rs
+++ b/core/engine/src/builtins/temporal/error.rs
@@ -5,10 +5,10 @@ use crate::{JsError, JsNativeError};
 impl From<TemporalError> for JsNativeError {
     fn from(value: TemporalError) -> Self {
         match value.kind() {
-            ErrorKind::Range => JsNativeError::range().with_message(value.message()),
-            ErrorKind::Type => JsNativeError::typ().with_message(value.message()),
-            ErrorKind::Generic => JsNativeError::error().with_message(value.message()),
-            ErrorKind::Syntax => JsNativeError::syntax().with_message(value.message()),
+            ErrorKind::Range => JsNativeError::range().with_message(value.message().to_owned()),
+            ErrorKind::Type => JsNativeError::typ().with_message(value.message().to_owned()),
+            ErrorKind::Generic => JsNativeError::error().with_message(value.message().to_owned()),
+            ErrorKind::Syntax => JsNativeError::syntax().with_message(value.message().to_owned()),
             ErrorKind::Assert => JsNativeError::error().with_message("internal engine error"),
         }
     }

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -734,7 +734,7 @@ impl JsNativeError {
     pub const URI: Self = Self::uri();
     #[cfg(feature = "fuzz")]
     /// Default `NoInstructionsRemain` kind `JsNativeError`.
-    pub const IS_NO_INSTRUCTIONS_REMAIN: Self = Self::is_no_instructions_remain();
+    pub const NO_INSTRUCTIONS_REMAIN: Self = Self::no_instructions_remain();
     /// Default `error` kind `JsNativeError`.
     pub const RUNTIME_LIMIT: Self = Self::runtime_limit();
 

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -716,6 +716,28 @@ const fn new_str() -> Box<str> {
 }
 
 impl JsNativeError {
+    /// Default `AggregateError` kind `JsNativeError`.
+    pub const AGGREGATE: Self = Self::aggregate(Vec::new());
+    /// Default `Error` kind `JsNativeError`.
+    pub const ERROR: Self = Self::error();
+    /// Default `EvalError` kind `JsNativeError`.
+    pub const EVAL: Self = Self::eval();
+    /// Default `RangeError` kind `JsNativeError`.
+    pub const RANGE: Self = Self::range();
+    /// Default `ReferenceError` kind `JsNativeError`.
+    pub const REFERENCE: Self = Self::reference();
+    /// Default `SyntaxError` kind `JsNativeError`.
+    pub const SYNTAX: Self = Self::syntax();
+    /// Default `error` kind `JsNativeError`.
+    pub const TYP: Self = Self::typ();
+    /// Default `UriError` kind `JsNativeError`.
+    pub const URI: Self = Self::uri();
+    #[cfg(feature = "fuzz")]
+    /// Default `NoInstructionsRemain` kind `JsNativeError`.
+    pub const IS_NO_INSTRUCTIONS_REMAIN: Self = Self::is_no_instructions_remain();
+    /// Default `error` kind `JsNativeError`.
+    pub const RUNTIME_LIMIT: Self = Self::runtime_limit();
+
     /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally) its `cause`.
     const fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<Box<JsError>>) -> Self {
         Self {

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -59,80 +59,80 @@ use thiserror::Error;
 macro_rules! js_error {
     (Error: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::error().with_message($value)
+            $crate::JsNativeError::ERROR.with_message($value)
         )
     };
     (Error: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::error()
+            $crate::JsNativeError::ERROR
                 .with_message(format!($value $(, $args)*))
         )
     };
 
     (TypeError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::typ().with_message($value)
+            $crate::JsNativeError::TYP.with_message($value)
         )
     };
     (TypeError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::typ()
+            $crate::JsNativeError::TYP
                 .with_message(format!($value $(, $args)*))
         )
     };
 
     (SyntaxError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::syntax().with_message($value)
+            $crate::JsNativeError::SYNTAX.with_message($value)
         )
     };
     (SyntaxError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::syntax().with_message(format!($value $(, $args)*))
+            $crate::JsNativeError::SYNTAX.with_message(format!($value $(, $args)*))
         )
     };
 
     (RangeError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::range().with_message($value)
+            $crate::JsNativeError::RANGE.with_message($value)
         )
     };
     (RangeError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::range().with_message(format!($value $(, $args)*))
+            $crate::JsNativeError::RANGE.with_message(format!($value $(, $args)*))
         )
     };
 
     (EvalError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::eval().with_message($value)
+            $crate::JsNativeError::EVAL.with_message($value)
         )
     };
     (EvalError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::eval().with_message(format!($value $(, $args)*))
+            $crate::JsNativeError::EVAL.with_message(format!($value $(, $args)*))
         )
     };
 
     (ReferenceError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::reference().with_message($value)
+            $crate::JsNativeError::REFERENCE.with_message($value)
         )
     };
     (ReferenceError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::reference().with_message(format!($value $(, $args)*))
+            $crate::JsNativeError::REFERENCE.with_message(format!($value $(, $args)*))
         )
     };
 
     (URIError: $value: literal) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::uri().with_message($value)
+            $crate::JsNativeError::URI.with_message($value)
         )
     };
     (URIError: $value: literal $(, $args: expr)* $(,)?) => {
         $crate::JsError::from_native(
-            $crate::JsNativeError::uri().with_message(format!($value $(, $args)*))
+            $crate::JsNativeError::URI.with_message(format!($value $(, $args)*))
         )
     };
 

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -709,9 +709,15 @@ impl fmt::Debug for JsNativeError {
     }
 }
 
+// FIXME(const-hack): replaced with Box::default once it is `const`
+const fn new_str() -> Box<str> {
+    // SAFETY: miri safe and works in stable
+    unsafe { std::mem::transmute("") }
+}
+
 impl JsNativeError {
     /// Creates a new `JsNativeError` from its `kind`, `message` and (optionally) its `cause`.
-    fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<Box<JsError>>) -> Self {
+    const fn new(kind: JsNativeErrorKind, message: Box<str>, cause: Option<Box<JsError>>) -> Self {
         Self {
             kind,
             message,
@@ -740,8 +746,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn aggregate(errors: Vec<JsError>) -> Self {
-        Self::new(JsNativeErrorKind::Aggregate(errors), Box::default(), None)
+    pub const fn aggregate(errors: Vec<JsError>) -> Self {
+        Self::new(JsNativeErrorKind::Aggregate(errors), new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Aggregate`].
@@ -763,8 +769,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn error() -> Self {
-        Self::new(JsNativeErrorKind::Error, Box::default(), None)
+    pub const fn error() -> Self {
+        Self::new(JsNativeErrorKind::Error, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Error`].
@@ -786,8 +792,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn eval() -> Self {
-        Self::new(JsNativeErrorKind::Eval, Box::default(), None)
+    pub const fn eval() -> Self {
+        Self::new(JsNativeErrorKind::Eval, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Eval`].
@@ -809,8 +815,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn range() -> Self {
-        Self::new(JsNativeErrorKind::Range, Box::default(), None)
+    pub const fn range() -> Self {
+        Self::new(JsNativeErrorKind::Range, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Range`].
@@ -832,8 +838,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn reference() -> Self {
-        Self::new(JsNativeErrorKind::Reference, Box::default(), None)
+    pub const fn reference() -> Self {
+        Self::new(JsNativeErrorKind::Reference, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Reference`].
@@ -855,8 +861,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn syntax() -> Self {
-        Self::new(JsNativeErrorKind::Syntax, Box::default(), None)
+    pub const fn syntax() -> Self {
+        Self::new(JsNativeErrorKind::Syntax, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Syntax`].
@@ -878,8 +884,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn typ() -> Self {
-        Self::new(JsNativeErrorKind::Type, Box::default(), None)
+    pub const fn typ() -> Self {
+        Self::new(JsNativeErrorKind::Type, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Type`].
@@ -901,8 +907,8 @@ impl JsNativeError {
     /// ```
     #[must_use]
     #[inline]
-    pub fn uri() -> Self {
-        Self::new(JsNativeErrorKind::Uri, Box::default(), None)
+    pub const fn uri() -> Self {
+        Self::new(JsNativeErrorKind::Uri, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::Uri`].
@@ -916,12 +922,8 @@ impl JsNativeError {
     /// is only used in a fuzzing context.
     #[cfg(feature = "fuzz")]
     #[must_use]
-    pub fn no_instructions_remain() -> Self {
-        Self::new(
-            JsNativeErrorKind::NoInstructionsRemain,
-            Box::default(),
-            None,
-        )
+    pub const fn no_instructions_remain() -> Self {
+        Self::new(JsNativeErrorKind::NoInstructionsRemain, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::NoInstructionsRemain`].
@@ -935,8 +937,8 @@ impl JsNativeError {
     /// Creates a new `JsNativeError` that indicates that the context exceeded the runtime limits.
     #[must_use]
     #[inline]
-    pub fn runtime_limit() -> Self {
-        Self::new(JsNativeErrorKind::RuntimeLimit, Box::default(), None)
+    pub const fn runtime_limit() -> Self {
+        Self::new(JsNativeErrorKind::RuntimeLimit, new_str(), None)
     }
 
     /// Check if it's a [`JsNativeErrorKind::RuntimeLimit`].

--- a/core/gc/src/trace.rs
+++ b/core/gc/src/trace.rs
@@ -179,7 +179,7 @@ simple_empty_finalize_trace![
     char,
     TypeId,
     String,
-    Box<str>,
+    str,
     Rc<str>,
     Path,
     PathBuf,

--- a/core/parser/src/lexer/number.rs
+++ b/core/parser/src/lexer/number.rs
@@ -367,19 +367,15 @@ impl<R> Tokenizer<R> for NumberLiteral {
 
                     // The non-digit character at this point must be an 'e' or 'E' to indicate an Exponent Part.
                     // Another '.' or 'n' is not allowed.
-                    match cursor.peek_char()? {
-                        Some(0x0065 /*e */ | 0x0045 /* E */) => {
-                            // Consume the ExponentIndicator.
-                            cursor.next_char()?.expect("e or E token vanished");
+                    if let Some(0x0065 /*e */ | 0x0045 /* E */) = cursor.peek_char()? {
+                        // Consume the ExponentIndicator.
+                        cursor.next_char()?.expect("e or E token vanished");
 
-                            buf.push(b'E');
+                        buf.push(b'E');
 
-                            take_signed_integer(&mut buf, cursor, kind)?;
-                        }
-                        Some(_) | None => {
-                            // Finished lexing.
-                        }
+                        take_signed_integer(&mut buf, cursor, kind)?;
                     }
+                    // Finished lexing.
                 }
             }
             Some(0x0065 /*e */ | 0x0045 /* E */) => {


### PR DESCRIPTION
This brings some optimizations:
- use constant to reduce binary size(https://godbolt.org/z/YEq4hW49n)
- change `message`'s type to `Cow<'static, str>` to reduce allocations