### PR TITLE
Use upload-rust-binary-action for nightly release

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,4 +1,6 @@
 name: Nightly Build
+permisions:
+  "contents": "write"
 
 # Schedule this workflow to run at midnight every day
 on:
@@ -8,40 +10,25 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Check out the repository
       uses: actions/checkout@v4
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
-      with:
-          toolchain: stable
-
-    - name: Install Dependencies
-      run: |
-        cargo fetch
-
-    - name: Build Project
-      run: |
-        cargo build --release
-
-    - name: Set File Name
-      id: vars
-      run: |
-        DATE=$(date +'%Y%m%d')
-        COMMIT_HASH=$(git rev-parse --short HEAD)
-        echo "FILE_NAME=boa-nightly-linux-${DATE}-${COMMIT_HASH}" >> $GITHUB_ENV
-
-    - name: Rename binary to file name
-      run: |
-        echo "Renaming binary to $FILE_NAME"
-        mv target/release/boa "target/release/$FILE_NAME"
-
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v2
+      uses: taiki-e/upload-rust-binary-action@v1
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/release/$FILE_NAME
-        asset_name: ${{ env.FILE_NAME }}
-        tag: nightly
-        overwrite: true
+        bin: boa
+        # We may be able to provide a custom archive name, but
+        # currently just going with the example default.
+        archive: $bin-$tag-$target
+        ref: nightly
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

So this should hopefully fix the nightly release. I've been playing around with a new release action in [practice repo](https://github.com/nekevss/dummy-release-test), and I've had some positive output so far (from what I can tell)! 😄 
