### PR TITLE
Fix misspelled permissions in nightly build action

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,5 +1,5 @@
 name: Nightly Build
-permisions:
+permissions:
   "contents": "write"
 
 # Schedule this workflow to run at midnight every day


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Apparently forgot how to properly spell, so this should fix the current error.

Reminds me that it may be worth looking into adding [Typos](https://github.com/crate-ci/typos) into our CI.
