### PR TITLE
Fix `ref` value in nightly and add target to nightly release

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -29,6 +29,7 @@ jobs:
         bin: boa
         # We may be able to provide a custom archive name, but
         # currently just going with the example default.
+        target: ${{ matrix.target }}
         archive: $bin-$tag-$target
-        ref: nightly
+        ref: refs/tags/nightly
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This should hopefully be the final PR to get nightly working. I tested this workflow out [here](https://github.com/nekevss/dummy-release-test/actions/workflows/nightly.yml), and it does appear to be working fine.

`ref: refs/tags/nightly` fixes the current error and `target: ${{ matrix.target }}` addresses a warning that is given without the target field.
