### PR TITLE
bug fix: ops that stay strictly at the EOF after assigns ops are ignored

### DIFF
--- a/core/engine/src/tests/operators.rs
+++ b/core/engine/src/tests/operators.rs
@@ -600,6 +600,44 @@ fn delete_in_strict_function_returned() {
     )]);
 }
 
+#[test]
+fn ops_at_the_end() {
+    let msg = "abrupt end";
+
+    let mut actions = vec![TestAction::assert_eq("var a, b=3; a = b ++", 3)];
+
+    let abrupt_op_sources = [
+        // there was a bug with different behavior with and without space at the end;
+        // so few lines are almost the same except for ending space
+        "var a, b=3; a = b **",
+        "var a, b=3; a = b ** ",
+        "var a, b=3; a = b *",
+        "var a, b=3; a = b * ",
+        "var a, b=3; a /= b *",
+        "var a, b=3; a /= b * ",
+        "var a, b=3; a = b /",
+        "var a, b=3; a = b / ",
+        "var a, b=3; a = b +",
+        "var a, b=3; a = b -",
+        "var a, b=3; a = b ||",
+        "var a, b=3; a = b || ",
+        "var a, b=3; a = b ==",
+        "var a, b=3; a = b ===",
+    ];
+
+    for source in abrupt_op_sources {
+        actions.push(TestAction::assert_native_error(
+            source,
+            JsNativeErrorKind::Syntax,
+            msg,
+        ));
+    }
+
+    actions.push(TestAction::assert_eq("var a, b=3; a = b --", 3));
+
+    run_test_actions(actions);
+}
+
 mod in_operator {
     use super::*;
 

--- a/core/parser/src/lexer/mod.rs
+++ b/core/parser/src/lexer/mod.rs
@@ -169,9 +169,9 @@ impl<R> Lexer<R> {
                 }
             }
         } else {
-            Err(Error::syntax(
-                "Abrupt end: Expecting Token /,*,= or regex",
-                start,
+            Ok(Token::new(
+                Punctuator::Div.into(),
+                Span::new(start, self.cursor.pos()),
             ))
         }
     }

--- a/core/parser/src/lexer/operator.rs
+++ b/core/parser/src/lexer/operator.rs
@@ -20,8 +20,6 @@ macro_rules! vop {
                 $assign_op
             }
             Some(_) => $op,
-            #[allow(unreachable_patterns)]
-            _ => Err(Error::syntax("must be unreachable: need to auto type inference", $cursor.pos())),
         }
     });
     ($cursor:ident, $assign_op:expr, $op:expr, {$($case:pat => $block:expr), +}) => ({
@@ -36,8 +34,6 @@ macro_rules! vop {
                 $block
             })+,
             Some(_) => $op,
-            #[allow(unreachable_patterns)]
-            _ => Err(Error::syntax("must be unreachable: need to auto type inference", $cursor.pos())),
         }
     });
 }
@@ -45,17 +41,17 @@ macro_rules! vop {
 /// The `op` macro handles binary operations or assignment operations and converts them into tokens.
 macro_rules! op {
     ($cursor:ident, $start_pos:expr, $assign_op:expr, $op:expr) => ({
-        Ok(Token::new(
-            vop!($cursor, $assign_op, $op)?.into(),
+        Token::new(
+            vop!($cursor, $assign_op, $op).into(),
             Span::new($start_pos, $cursor.pos()),
-        ))
+        )
     });
     ($cursor:ident, $start_pos:expr, $assign_op:expr, $op:expr, {$($case:pat => $block:expr),+}) => ({
-        let punc: Punctuator = vop!($cursor, $assign_op, $op, {$($case => $block),+})?;
-        Ok(Token::new(
+        let punc: Punctuator = vop!($cursor, $assign_op, $op, {$($case => $block),+});
+        Token::new(
             punc.into(),
             Span::new($start_pos, $cursor.pos()),
-        ))
+        )
     });
 }
 
@@ -93,29 +89,22 @@ impl<R> Tokenizer<R> for Operator {
     {
         let _timer = Profiler::global().start_event("Operator", "Lexing");
 
-        match self.init {
-            b'*' => op!(cursor, start_pos, Ok(Punctuator::AssignMul), Ok(Punctuator::Mul), {
-                Some(0x2A /* * */) => vop!(cursor, Ok(Punctuator::AssignPow), Ok(Punctuator::Exp))
+        Ok(match self.init {
+            b'*' => op!(cursor, start_pos, Punctuator::AssignMul, Punctuator::Mul, {
+                Some(0x2A /* * */) => vop!(cursor, Punctuator::AssignPow, Punctuator::Exp)
             }),
-            b'+' => op!(cursor, start_pos, Ok(Punctuator::AssignAdd), Ok(Punctuator::Add), {
-                Some(0x2B /* + */) => Ok(Punctuator::Inc)
+            b'+' => op!(cursor, start_pos, Punctuator::AssignAdd, Punctuator::Add, {
+                Some(0x2B /* + */) => Punctuator::Inc
             }),
-            b'-' => op!(cursor, start_pos, Ok(Punctuator::AssignSub), Ok(Punctuator::Sub), {
-                Some(0x2D /* - */) => {
-                    Ok(Punctuator::Dec)
-                }
+            b'-' => op!(cursor, start_pos, Punctuator::AssignSub, Punctuator::Sub, {
+                Some(0x2D /* - */) => Punctuator::Dec
             }),
-            b'%' => op!(
-                cursor,
-                start_pos,
-                Ok(Punctuator::AssignMod),
-                Ok(Punctuator::Mod)
-            ),
-            b'|' => op!(cursor, start_pos, Ok(Punctuator::AssignOr), Ok(Punctuator::Or), {
-                Some(0x7C /* | */) => vop!(cursor, Ok(Punctuator::AssignBoolOr), Ok(Punctuator::BoolOr))
+            b'%' => op!(cursor, start_pos, Punctuator::AssignMod, Punctuator::Mod),
+            b'|' => op!(cursor, start_pos, Punctuator::AssignOr, Punctuator::Or, {
+                Some(0x7C /* | */) => vop!(cursor, Punctuator::AssignBoolOr, Punctuator::BoolOr)
             }),
-            b'&' => op!(cursor, start_pos, Ok(Punctuator::AssignAnd), Ok(Punctuator::And), {
-                Some(0x26 /* & */) => vop!(cursor, Ok(Punctuator::AssignBoolAnd), Ok(Punctuator::BoolAnd))
+            b'&' => op!(cursor, start_pos, Punctuator::AssignAnd, Punctuator::And, {
+                Some(0x26 /* & */) => vop!(cursor, Punctuator::AssignBoolAnd, Punctuator::BoolAnd)
             }),
             b'?' => {
                 let (first, second) = (cursor.peek_char()?, cursor.peek_n(2)?[1]);
@@ -125,62 +114,54 @@ impl<R> Tokenizer<R> for Operator {
                         op!(
                             cursor,
                             start_pos,
-                            Ok(Punctuator::AssignCoalesce),
-                            Ok(Punctuator::Coalesce)
+                            Punctuator::AssignCoalesce,
+                            Punctuator::Coalesce
                         )
                     }
                     Some(0x2E /* . */) if !matches!(second, Some(second) if (0x30..=0x39 /* 0..=9 */).contains(&second)) =>
                     {
                         cursor.next_char()?.expect(". vanished");
-                        Ok(Token::new(
+                        Token::new(
                             TokenKind::Punctuator(Punctuator::Optional),
                             Span::new(start_pos, cursor.pos()),
-                        ))
+                        )
                     }
-                    _ => Ok(Token::new(
+                    _ => Token::new(
                         TokenKind::Punctuator(Punctuator::Question),
                         Span::new(start_pos, cursor.pos()),
-                    )),
+                    ),
                 }
             }
-            b'^' => op!(
-                cursor,
-                start_pos,
-                Ok(Punctuator::AssignXor),
-                Ok(Punctuator::Xor)
-            ),
+            b'^' => op!(cursor, start_pos, Punctuator::AssignXor, Punctuator::Xor),
             b'=' => op!(cursor, start_pos, if cursor.next_if(0x3D /* = */)? {
-                Ok(Punctuator::StrictEq)
+                Punctuator::StrictEq
             } else {
-                Ok(Punctuator::Eq)
-            }, Ok(Punctuator::Assign), {
+                Punctuator::Eq
+            }, Punctuator::Assign, {
                 Some(0x3E /* > */) => {
-                    Ok(Punctuator::Arrow)
+                    Punctuator::Arrow
                 }
             }),
             b'<' => {
-                op!(cursor, start_pos, Ok(Punctuator::LessThanOrEq), Ok(Punctuator::LessThan), {
-                    Some(0x3C /* < */) => vop!(cursor, Ok(Punctuator::AssignLeftSh), Ok(Punctuator::LeftSh))
+                op!(cursor, start_pos, Punctuator::LessThanOrEq, Punctuator::LessThan, {
+                    Some(0x3C /* < */) => vop!(cursor, Punctuator::AssignLeftSh, Punctuator::LeftSh)
                 })
             }
             b'>' => {
-                op!(cursor, start_pos, Ok(Punctuator::GreaterThanOrEq), Ok(Punctuator::GreaterThan), {
-                    Some(0x3E /* > */) => vop!(cursor, Ok(Punctuator::AssignRightSh), Ok(Punctuator::RightSh), {
-                        Some(0x3E /* > */) => vop!(cursor, Ok(Punctuator::AssignURightSh), Ok(Punctuator::URightSh))
+                op!(cursor, start_pos, Punctuator::GreaterThanOrEq, Punctuator::GreaterThan, {
+                    Some(0x3E /* > */) => vop!(cursor, Punctuator::AssignRightSh, Punctuator::RightSh, {
+                        Some(0x3E /* > */) => vop!(cursor, Punctuator::AssignURightSh, Punctuator::URightSh)
                     })
                 })
             }
             b'!' => op!(
                 cursor,
                 start_pos,
-                vop!(cursor, Ok(Punctuator::StrictNotEq), Ok(Punctuator::NotEq)),
-                Ok(Punctuator::Not)
+                vop!(cursor, Punctuator::StrictNotEq, Punctuator::NotEq),
+                Punctuator::Not
             ),
-            b'~' => Ok(Token::new(
-                Punctuator::Neg.into(),
-                Span::new(start_pos, cursor.pos()),
-            )),
+            b'~' => Token::new(Punctuator::Neg.into(), Span::new(start_pos, cursor.pos())),
             op => unimplemented!("operator {}", op),
-        }
+        })
     }
 }

--- a/core/parser/src/lexer/tests.rs
+++ b/core/parser/src/lexer/tests.rs
@@ -254,6 +254,86 @@ fn check_punctuators() {
 }
 
 #[test]
+fn check_punctuator_at_the_end() {
+    //TODO: maybe just use `strum` (`EnumIter`)?
+    //    * it is already in dependencies
+    let last_expected = [
+        Punctuator::Add,
+        Punctuator::And,
+        Punctuator::Arrow,
+        Punctuator::AssignAdd,
+        Punctuator::AssignAnd,
+        Punctuator::AssignBoolAnd,
+        Punctuator::AssignBoolOr,
+        Punctuator::AssignCoalesce,
+        // Punctuator::AssignDiv, : is unclosed regular expr
+        Punctuator::AssignLeftSh,
+        Punctuator::AssignMod,
+        Punctuator::AssignMul,
+        Punctuator::AssignOr,
+        Punctuator::AssignPow,
+        Punctuator::AssignRightSh,
+        Punctuator::AssignSub,
+        Punctuator::AssignURightSh,
+        Punctuator::AssignXor,
+        Punctuator::BoolAnd,
+        Punctuator::BoolOr,
+        Punctuator::Coalesce,
+        Punctuator::CloseBlock,
+        Punctuator::CloseBracket,
+        Punctuator::CloseParen,
+        Punctuator::Colon,
+        Punctuator::Comma,
+        Punctuator::Dec,
+        Punctuator::Div,
+        Punctuator::Dot,
+        Punctuator::Eq,
+        Punctuator::GreaterThan,
+        Punctuator::GreaterThanOrEq,
+        Punctuator::Inc,
+        Punctuator::LeftSh,
+        Punctuator::LessThan,
+        Punctuator::LessThanOrEq,
+        Punctuator::Mod,
+        Punctuator::Mul,
+        Punctuator::Neg,
+        Punctuator::Not,
+        Punctuator::NotEq,
+        Punctuator::OpenBlock,
+        Punctuator::OpenBracket,
+        Punctuator::OpenParen,
+        Punctuator::Optional,
+        Punctuator::Or,
+        Punctuator::Exp,
+        Punctuator::Question,
+        Punctuator::RightSh,
+        Punctuator::Semicolon,
+        Punctuator::Spread,
+        Punctuator::StrictEq,
+        Punctuator::StrictNotEq,
+        Punctuator::Sub,
+        Punctuator::URightSh,
+        Punctuator::Xor,
+    ];
+
+    for last in last_expected {
+        let s = format!("var a = b {}", last.as_str());
+        let mut lexer = Lexer::from(s.as_bytes());
+        let interner = &mut Interner::default();
+
+        let expected = [
+            TokenKind::Keyword((Keyword::Var, false)),
+            TokenKind::identifier(interner.get_or_intern_static("a", utf16!("a"))),
+            TokenKind::Punctuator(Punctuator::Assign),
+            TokenKind::identifier(interner.get_or_intern_static("b", utf16!("b"))),
+            TokenKind::Punctuator(last),
+        ];
+
+        expect_tokens(&mut lexer, &expected, interner);
+    }
+}
+
+#[test]
 fn check_keywords() {
     // https://tc39.es/ecma262/#sec-keywords
     let s = "await break case catch class const continue debugger default delete \

--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -107,7 +107,7 @@ where
                 } else {
                     1
                 };
-                if let Some(tok) = cursor.peek(skip_n, interner)? {
+                if let Some(tok) = cursor.peek_no_skip_line_term(skip_n, interner)? {
                     if tok.kind() == &TokenKind::Punctuator(Punctuator::Arrow) {
                         return ArrowFunction::new(
                             self.allow_in,

--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -107,9 +107,7 @@ where
                 } else {
                     1
                 };
-                if let Ok(tok) =
-                    cursor.peek_expect_no_lineterminator(skip_n, "assignment expression", interner)
-                {
+                if let Some(tok) = cursor.peek(skip_n, interner)? {
                     if tok.kind() == &TokenKind::Punctuator(Punctuator::Arrow) {
                         return ArrowFunction::new(
                             self.allow_in,


### PR DESCRIPTION
This Pull Request closes #3330 

The reason of the bug was that lexer decides next Token sequence {`...`, `OP`, `EOF`} as invalid and return an error. Yes, it's invalid, but in the same time lexer cannot know that {`...`, `OP`, `SPACE`, `EOF`} is also invalid and therefore there was two different logic to catch first case.

So, for me it seems more logically correct to delegate the catching of invalid ops at the end to the parser

-----

Should I:
* remove all `Ok(...)` from `core/parser/src/lexer/operator.rs` (now there exist only pseudo `Err(..)` that needs only for type inference)?
* use strum::EnumIter to remove enumeration of almost all `Punctuator`  in `core/parser/src/lexer/tests.rs`?

-----

Hmm... now I understand that I don't know the place where errors from lexer don't propagate upwards before, seems like somewhere not used `?`
Do I need to investigate where the place?