### PR TITLE
Fix #4051, parse Arguments should expect  `)` not `}`

### DIFF
--- a/core/parser/src/parser/expression/left_hand_side/arguments.rs
+++ b/core/parser/src/parser/expression/left_hand_side/arguments.rs
@@ -87,7 +87,7 @@ where
                 _ => {
                     if !args.is_empty() {
                         return Err(Error::expected(
-                            [",".to_owned(), "}".to_owned()],
+                            [",".to_owned(), ")".to_owned()],
                             next_token.to_string(interner),
                             next_token.span(),
                             "argument list",


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request close #4051 .

