### PR TITLE
Add inline cache for getting bindings from the global object

### DIFF
--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -450,6 +450,12 @@ impl IdentifierReference {
         self.locator.scope > 0 && !self.escapes
     }
 
+    /// Returns if the binding is on the global object.
+    #[must_use]
+    pub fn is_global_object(&self) -> bool {
+        self.locator.scope == 0
+    }
+
     /// Check if this identifier reference is lexical.
     #[must_use]
     pub fn is_lexical(&self) -> bool {

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -738,7 +738,7 @@ impl CodeBlock {
             | Instruction::Reserved45
             | Instruction::Reserved46
             | Instruction::Reserved47
-            | Instruction::Reserved48  => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved48 => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -472,6 +472,7 @@ impl CodeBlock {
             | Instruction::DefInitVar { index }
             | Instruction::PutLexicalValue { index }
             | Instruction::GetName { index }
+            | Instruction::GetNameGlobal { index, .. }
             | Instruction::GetLocator { index }
             | Instruction::GetNameAndLocator { index }
             | Instruction::GetNameOrUndefined { index }
@@ -737,8 +738,7 @@ impl CodeBlock {
             | Instruction::Reserved45
             | Instruction::Reserved46
             | Instruction::Reserved47
-            | Instruction::Reserved48
-            | Instruction::Reserved49 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved48  => unreachable!("Reserved opcodes are unrechable"),
         }
     }
 }

--- a/core/engine/src/vm/code_block.rs
+++ b/core/engine/src/vm/code_block.rs
@@ -738,7 +738,7 @@ impl CodeBlock {
             | Instruction::Reserved45
             | Instruction::Reserved46
             | Instruction::Reserved47
-            | Instruction::Reserved48 => unreachable!("Reserved opcodes are unrechable"),
+            | Instruction::Reserved48 => unreachable!("Reserved opcodes are unreachable"),
         }
     }
 }

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -516,7 +516,7 @@ impl CodeBlock {
                 | Instruction::Reserved45
                 | Instruction::Reserved46
                 | Instruction::Reserved47
-                | Instruction::Reserved48 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved48 => unreachable!("Reserved opcodes are unreachable"),
             }
         }
 

--- a/core/engine/src/vm/flowgraph/mod.rs
+++ b/core/engine/src/vm/flowgraph/mod.rs
@@ -250,6 +250,7 @@ impl CodeBlock {
                 | Instruction::DefInitVar { .. }
                 | Instruction::PutLexicalValue { .. }
                 | Instruction::GetName { .. }
+                | Instruction::GetNameGlobal { .. }
                 | Instruction::GetLocator { .. }
                 | Instruction::GetNameAndLocator { .. }
                 | Instruction::GetNameOrUndefined { .. }
@@ -515,8 +516,7 @@ impl CodeBlock {
                 | Instruction::Reserved45
                 | Instruction::Reserved46
                 | Instruction::Reserved47
-                | Instruction::Reserved48
-                | Instruction::Reserved49 => unreachable!("Reserved opcodes are unrechable"),
+                | Instruction::Reserved48 => unreachable!("Reserved opcodes are unrechable"),
             }
         }
 

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -1117,7 +1117,7 @@ generate_opcodes! {
 
     /// Find a binding in the global object and push its value.
     ///
-    /// Operands: index: `u32`
+    /// Operands: index: `VaryingOperand`, ic_index: `VaryingOperand`,
     ///
     /// Stack: **=>** value
     GetNameGlobal { index: VaryingOperand, ic_index: VaryingOperand },

--- a/core/engine/src/vm/opcode/mod.rs
+++ b/core/engine/src/vm/opcode/mod.rs
@@ -1115,6 +1115,13 @@ generate_opcodes! {
     /// Stack: **=>** value
     GetName { index: VaryingOperand },
 
+    /// Find a binding in the global object and push its value.
+    ///
+    /// Operands: index: `u32`
+    ///
+    /// Stack: **=>** value
+    GetNameGlobal { index: VaryingOperand, ic_index: VaryingOperand },
+
     /// Find a binding on the environment and set the `current_binding` of the current frame.
     ///
     /// Operands: index: `u32`
@@ -2280,8 +2287,6 @@ generate_opcodes! {
     Reserved47 => Reserved,
     /// Reserved [`Opcode`].
     Reserved48 => Reserved,
-    /// Reserved [`Opcode`].
-    Reserved49 => Reserved,
 }
 
 /// Specific opcodes for bindings.


### PR DESCRIPTION
It changes the following:

- Add inline cache for getting bindings from the global object

I saw a small performance increase when running the benchmarks for this patch.