### PR TITLE
Add valueOf methods to the Temporal builtins

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -798,7 +798,7 @@ impl Duration {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -191,6 +191,7 @@ impl IntrinsicObject for Duration {
             .method(Self::total, js_string!("total"), 1)
             .method(Self::to_string, js_string!("toString"), 1)
             .method(Self::to_json, js_string!("toJSON"), 0)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
     }
 
@@ -792,6 +793,12 @@ impl Duration {
     pub(crate) fn to_json(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::error()
             .with_message("not yet implemented.")
+            .into())
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -797,7 +797,7 @@ impl Duration {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -477,7 +477,7 @@ impl Instant {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -91,6 +91,7 @@ impl IntrinsicObject for Instant {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_zoned_date_time, js_string!("toZonedDateTime"), 1)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .method(
                 Self::to_zoned_date_time_iso,
                 js_string!("toZonedDateTimeISO"),
@@ -472,6 +473,12 @@ impl Instant {
         // TODO Complete
         Err(JsNativeError::error()
             .with_message("not yet implemented.")
+            .into())
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -478,7 +478,7 @@ impl Instant {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -786,7 +786,7 @@ impl PlainDate {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -787,7 +787,7 @@ impl PlainDate {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -216,6 +216,7 @@ impl IntrinsicObject for PlainDate {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_plain_datetime, js_string!("toPlainDateTime"), 0)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
     }
 
@@ -782,6 +783,12 @@ impl PlainDate {
             .transpose()?;
         // 4. Return ? CreateTemporalDateTime(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]], temporalTime.[[ISOHour]], temporalTime.[[ISOMinute]], temporalTime.[[ISOSecond]], temporalTime.[[ISOMillisecond]], temporalTime.[[ISOMicrosecond]], temporalTime.[[ISONanosecond]], temporalDate.[[Calendar]]).
         create_temporal_datetime(date.inner.to_date_time(time)?, None, context).map(Into::into)
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -277,6 +277,7 @@ impl IntrinsicObject for PlainDateTime {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
     }
 
@@ -903,6 +904,12 @@ impl PlainDateTime {
         // 5. If result is not 0, return false.
         // 6. Return ? CalendarEquals(dateTime.[[Calendar]], other.[[Calendar]]).
         Ok((dt.inner == other).into())
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -907,7 +907,7 @@ impl PlainDateTime {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -908,7 +908,7 @@ impl PlainDateTime {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -121,7 +121,7 @@ impl PlainMonthDay {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -118,6 +118,12 @@ impl PlainMonthDay {
 
         Ok(month_day_to_string(inner, show_calendar))
     }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .into())
+    }
 }
 
 impl BuiltInObject for PlainMonthDay {
@@ -164,6 +170,7 @@ impl IntrinsicObject for PlainMonthDay {
                 Attribute::CONFIGURABLE,
             )
             .method(Self::to_string, js_string!("toString"), 1)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .static_method(Self::from, js_string!("from"), 2)
             .build();
     }

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -120,7 +120,7 @@ impl PlainMonthDay {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -569,7 +569,7 @@ impl PlainTime {
     fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -566,10 +566,10 @@ impl PlainTime {
     }
 
     /// 4.3.22 Temporal.PlainTime.prototype.valueOf ( )
-    fn value_of(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
-        Err(JsNativeError::typ()
-            .with_message("valueOf cannot be called on PlainTime.")
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -566,9 +566,9 @@ impl PlainTime {
     }
 
     /// 4.3.22 Temporal.PlainTime.prototype.valueOf ( )
-    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Throw a TypeError exception.
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -140,6 +140,7 @@ impl IntrinsicObject for PlainYearMonth {
             .method(Self::since, js_string!("since"), 2)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 1)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
     }
 
@@ -405,6 +406,12 @@ impl PlainYearMonth {
                 .unwrap_or(CalendarName::Auto);
 
         Ok(year_month_to_string(inner, show_calendar))
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::error()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -409,7 +409,7 @@ impl PlainYearMonth {
     }
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
+        Err(JsNativeError::typ()
             .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
             .into())
     }

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -410,7 +410,7 @@ impl PlainYearMonth {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -319,6 +319,7 @@ impl IntrinsicObject for ZonedDateTime {
             .static_method(Self::from, js_string!("from"), 1)
             .method(Self::add, js_string!("add"), 1)
             .method(Self::subtract, js_string!("subtract"), 1)
+            .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
     }
 
@@ -837,6 +838,12 @@ impl ZonedDateTime {
             context,
         )
         .map(Into::into)
+    }
+
+    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        Err(JsNativeError::typ()
+            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -842,7 +842,7 @@ impl ZonedDateTime {
 
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
-            .with_message("valueOf not implemented for Temporal objects. See 'compare', 'equals', or `toString`")
+            .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
     }
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the general work on #1804

It changes the following:

- Adds or adjusts the error message for the `prototype.valueOf` method implementation to the Temporal builtins