### PR TITLE
Update Temporal ToIntegerIfIntegral, ToIntegerWithTruncation, and ToPositiveIntegerWithTruncation implementation 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3467,7 +3467,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=c25c4475810b7549febb7a5fe4404f17581e8010#c25c4475810b7549febb7a5fe4404f17581e8010"
+source = "git+https://github.com/boa-dev/temporal.git?rev=4498edf4efa52f0cdec0bbed8bf49cae7e543e74#4498edf4efa52f0cdec0bbed8bf49cae7e543e74"
 dependencies = [
  "bitflags 2.6.0",
  "combine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
  "float-cmp",
  "futures-lite 2.5.0",
  "hashbrown 0.15.2",
- "icu_calendar",
+ "icu_calendar 1.5.2",
  "icu_casemap",
  "icu_collator",
  "icu_datetime",
@@ -389,7 +389,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_normalizer",
  "icu_plurals",
- "icu_provider",
+ "icu_provider 1.5.0",
  "icu_segmenter",
  "indexmap",
  "indoc",
@@ -419,9 +419,9 @@ dependencies = [
  "thin-vec",
  "thiserror",
  "time",
- "tinystr",
+ "tinystr 0.7.6",
  "web-time",
- "writeable",
+ "writeable 0.5.5",
  "yoke",
  "zerofrom",
 ]
@@ -466,7 +466,7 @@ dependencies = [
  "icu_locid_transform",
  "icu_normalizer",
  "icu_plurals",
- "icu_provider",
+ "icu_provider 1.5.0",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_segmenter",
@@ -1297,7 +1297,7 @@ dependencies = [
  "displaydoc",
  "ryu",
  "smallvec",
- "writeable",
+ "writeable 0.5.5",
 ]
 
 [[package]]
@@ -1543,10 +1543,10 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff5e3018d703f168b00dcefa540a65f1bbc50754ae32f3f5f0e43fe5ee51502"
 dependencies = [
- "icu_calendar",
+ "icu_calendar 1.5.2",
  "icu_casemap",
  "icu_collator",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_datetime",
  "icu_decimal",
  "icu_experimental",
@@ -1556,7 +1556,7 @@ dependencies = [
  "icu_normalizer",
  "icu_plurals",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "icu_segmenter",
  "icu_timezone",
 ]
@@ -1570,21 +1570,39 @@ dependencies = [
  "calendrical_calculations",
  "databake",
  "displaydoc",
- "icu_calendar_data",
  "icu_locid",
- "icu_locid_transform",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_calendar"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3689f3f720936703584298dce9711d8c68b7aecef258d0e1e2677ec3d9567ff6"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_calendar_data",
+ "icu_locale_core",
+ "icu_provider 2.0.0-beta1",
+ "tinystr 0.8.0",
+ "writeable 0.6.0",
+ "zerovec 0.11.0",
 ]
 
 [[package]]
 name = "icu_calendar_data"
-version = "1.5.0"
+version = "2.0.0-beta1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e009b7f0151ee6fb28c40b1283594397e0b7183820793e9ace3dcd13db126d0"
+checksum = "a113bfe4a5f0a4f9ab2f4ec5baac9f5cfab7c5ada910abf4b9ed4cfd066881cd"
+dependencies = [
+ "icu_locale",
+ "icu_provider_baked",
+]
 
 [[package]]
 name = "icu_casemap"
@@ -1594,13 +1612,13 @@ checksum = "9ff0c8ae9f8d31b12e27fc385ff9ab1f3cd9b17417c665c49e4ec958c37da75f"
 dependencies = [
  "databake",
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "writeable",
- "zerovec",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1609,10 +1627,10 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41aa8d27817174c88860a3227fa5cc50cf2d915367f626d56f5711dd8a2e22a"
 dependencies = [
- "icu_collections",
+ "icu_collections 1.5.0",
  "toml 0.5.11",
  "wasmi",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1623,15 +1641,15 @@ checksum = "d370371887d31d56f361c3eaa15743e54f13bc677059c9191c77e099ed6966b2"
 dependencies = [
  "databake",
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_normalizer",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1645,7 +1663,20 @@ dependencies = [
  "serde",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547ceba155a760830b848d9ae28183bc6bddf1b714ffc27bee1c7144f07229db"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec 0.11.0",
 ]
 
 [[package]]
@@ -1659,11 +1690,11 @@ dependencies = [
  "either",
  "elsa",
  "icu",
- "icu_calendar",
+ "icu_calendar 1.5.2",
  "icu_casemap",
  "icu_codepointtrie_builder",
  "icu_collator",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_datetime",
  "icu_decimal",
  "icu_experimental",
@@ -1674,7 +1705,7 @@ dependencies = [
  "icu_pattern",
  "icu_plurals",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "icu_provider_adapters",
  "icu_provider_blob",
  "icu_segmenter",
@@ -1692,13 +1723,13 @@ dependencies = [
  "serde",
  "serde-aux",
  "serde_json",
- "tinystr",
+ "tinystr 0.7.6",
  "toml 0.5.11",
  "twox-hash",
  "ureq",
- "writeable",
- "zerotrie",
- "zerovec",
+ "writeable 0.5.5",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
  "zip",
 ]
 
@@ -1712,18 +1743,18 @@ dependencies = [
  "displaydoc",
  "either",
  "fixed_decimal",
- "icu_calendar",
+ "icu_calendar 1.5.2",
  "icu_decimal",
  "icu_locid",
  "icu_plurals",
- "icu_provider",
+ "icu_provider 1.5.0",
  "icu_timezone",
  "litemap",
  "serde",
  "smallvec",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1735,9 +1766,9 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "writeable",
+ "writeable 0.5.5",
 ]
 
 [[package]]
@@ -1749,7 +1780,7 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_decimal",
  "icu_locid",
  "icu_locid_transform",
@@ -1757,7 +1788,7 @@ dependencies = [
  "icu_pattern",
  "icu_plurals",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "litemap",
  "log",
  "num-bigint",
@@ -1765,11 +1796,11 @@ dependencies = [
  "num-traits",
  "serde",
  "smallvec",
- "tinystr",
- "writeable",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
  "zerofrom",
- "zerotrie",
- "zerovec",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1781,10 +1812,48 @@ dependencies = [
  "databake",
  "deduplicating_array",
  "displaydoc",
- "icu_provider",
+ "icu_provider 1.5.0",
  "regex-automata 0.2.0",
  "serde",
- "writeable",
+ "writeable 0.5.5",
+]
+
+[[package]]
+name = "icu_locale"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49d3c7f2dae0cd50d8b681a258e761eb714c9924f8222b7042118c0fb410649"
+dependencies = [
+ "displaydoc",
+ "icu_collections 2.0.0-beta1",
+ "icu_locale_core",
+ "icu_locale_data",
+ "icu_provider 2.0.0-beta1",
+ "potential_utf",
+ "tinystr 0.8.0",
+ "zerovec 0.11.0",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36332a8c93574b07598351bb479425282022341528ff521238fd4a48d143162"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr 0.8.0",
+ "writeable 0.6.0",
+ "zerovec 0.11.0",
+]
+
+[[package]]
+name = "icu_locale_data"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222f29513408cc4572fce10bcadd05505c61ca1e30412416661e2fd464821c80"
+dependencies = [
+ "icu_provider_baked",
 ]
 
 [[package]]
@@ -1797,9 +1866,9 @@ dependencies = [
  "displaydoc",
  "litemap",
  "serde",
- "tinystr",
- "writeable",
- "zerovec",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1812,10 +1881,10 @@ dependencies = [
  "displaydoc",
  "icu_locid",
  "icu_locid_transform_data",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1832,16 +1901,16 @@ checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
 dependencies = [
  "databake",
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_normalizer_data",
  "icu_properties",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
  "smallvec",
  "utf16_iter",
  "utf8_iter",
  "write16",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1860,7 +1929,7 @@ dependencies = [
  "displaydoc",
  "either",
  "serde",
- "writeable",
+ "writeable 0.5.5",
  "yoke",
  "zerofrom",
 ]
@@ -1874,9 +1943,9 @@ dependencies = [
  "databake",
  "displaydoc",
  "fixed_decimal",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1887,13 +1956,13 @@ checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
  "databake",
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid_transform",
  "icu_properties_data",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1912,16 +1981,33 @@ dependencies = [
  "displaydoc",
  "erased-serde",
  "icu_locid",
- "icu_provider_macros",
+ "icu_provider_macros 1.5.0",
  "log",
  "postcard",
  "serde",
  "stable_deref_trait",
- "tinystr",
- "writeable",
+ "tinystr 0.7.6",
+ "writeable 0.5.5",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "201d2b3bc0bd9a7ad78a00af62374365dd53ee6916942c645cd9e28778c238a5"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "icu_provider_macros 2.0.0-beta1",
+ "stable_deref_trait",
+ "tinystr 0.8.0",
+ "writeable 0.6.0",
+ "yoke",
+ "zerofrom",
+ "zerovec 0.11.0",
 ]
 
 [[package]]
@@ -1932,10 +2018,21 @@ checksum = "d6324dfd08348a8e0374a447ebd334044d766b1839bb8d5ccf2482a99a77c0bc"
 dependencies = [
  "icu_locid",
  "icu_locid_transform",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
- "tinystr",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "icu_provider_baked"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c6494d25b75593ad56dcd9bde1040ef7e22e9c70b24c1de8920d9a919118893"
+dependencies = [
+ "icu_provider 2.0.0-beta1",
+ "writeable 0.6.0",
+ "zerotrie 0.2.0",
 ]
 
 [[package]]
@@ -1944,13 +2041,13 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c24b98d1365f55d78186c205817631a4acf08d7a45bdf5dc9dcf9c5d54dccf51"
 dependencies = [
- "icu_provider",
+ "icu_provider 1.5.0",
  "log",
  "postcard",
  "serde",
- "writeable",
- "zerotrie",
- "zerovec",
+ "writeable 0.5.5",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1958,6 +2055,17 @@ name = "icu_provider_macros"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "2.0.0-beta1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba0c1a4c9cca68c00053013b9ad7dc7d2e69aefed59dd9e38cb63347c28299b0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1973,12 +2081,12 @@ dependencies = [
  "core_maths",
  "databake",
  "displaydoc",
- "icu_collections",
+ "icu_collections 1.5.0",
  "icu_locid",
- "icu_provider",
+ "icu_provider 1.5.0",
  "serde",
  "utf8_iter",
- "zerovec",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -1989,12 +2097,12 @@ checksum = "aa91ba6a585939a020c787235daa8aee856d9bceebd6355e283c0c310bc6de96"
 dependencies = [
  "databake",
  "displaydoc",
- "icu_calendar",
- "icu_provider",
+ "icu_calendar 1.5.2",
+ "icu_provider 1.5.0",
  "serde",
- "tinystr",
- "zerotrie",
- "zerovec",
+ "tinystr 0.7.6",
+ "zerotrie 0.1.3",
+ "zerovec 0.10.4",
 ]
 
 [[package]]
@@ -2134,11 +2242,12 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "ixdtf"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2123305f927452a9502fc05c33800280d90127c95c50eb45ec6b3c50346afbf3"
+checksum = "fb6cd1080e64f68b07c577e3c687f4a894b3d1bd6093cb36b55c7bd07675aa3a"
 dependencies = [
  "displaydoc",
+ "utf8_iter",
 ]
 
 [[package]]
@@ -2728,6 +2837,16 @@ dependencies = [
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
  "serde",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2a1d6d1132e166768a82805efecd7c326eb8dc70ad4a586da697836b44eb970"
+dependencies = [
+ "serde",
+ "zerovec 0.11.0",
 ]
 
 [[package]]
@@ -3348,17 +3467,17 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=016bc31d2ce5484973b71ccdb0faeb33c00a9ae6#016bc31d2ce5484973b71ccdb0faeb33c00a9ae6"
+source = "git+https://github.com/boa-dev/temporal.git?rev=c25c4475810b7549febb7a5fe4404f17581e8010#c25c4475810b7549febb7a5fe4404f17581e8010"
 dependencies = [
  "bitflags 2.6.0",
  "combine",
  "iana-time-zone",
- "icu_calendar",
+ "icu_calendar 2.0.0-beta1",
  "ixdtf",
  "jiff-tzdb",
  "num-traits",
  "rustc-hash 2.1.0",
- "tinystr",
+ "tinystr 0.8.0",
  "tzif",
  "web-time",
 ]
@@ -3501,7 +3620,17 @@ dependencies = [
  "databake",
  "displaydoc",
  "serde",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b56a820bb70060f096338fcc02edb78cb3f8fb21c5078503f48588cfcaf494"
+dependencies = [
+ "displaydoc",
+ "zerovec 0.11.0",
 ]
 
 [[package]]
@@ -3649,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "tzif"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b8eb18929606c6f3eea7ef096a91dd5c26dbbde2a20a343c4a409b851666fd"
+checksum = "5cecffbab91858408738280e7bb6aac788f59a522dda961cd6b15542f0c08559"
 dependencies = [
  "combine",
 ]
@@ -4159,6 +4288,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74b3b5b7c6114bf7253093603034e102d479ecc8501deca33b6c1c816418b6d2"
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4242,7 +4377,16 @@ dependencies = [
  "serde",
  "yoke",
  "zerofrom",
- "zerovec",
+ "zerovec 0.10.4",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa766b97d68da210d29cc0bc8d072d87de9359cb998e4bc30ab4982a1c795d47"
+dependencies = [
+ "displaydoc",
 ]
 
 [[package]]
@@ -4255,7 +4399,18 @@ dependencies = [
  "serde",
  "yoke",
  "zerofrom",
- "zerovec-derive",
+ "zerovec-derive 0.10.3",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b622856b789971a6fe0442b69f3a2d7ac949005c4c8586b2c4ef09cc5182f2b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive 0.11.0",
 ]
 
 [[package]]
@@ -4263,6 +4418,17 @@ name = "zerovec-derive"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "996c67268f00e216986ac140d8de9f47968c330b96aeefcae9ed296f23934448"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "c25c4475810b7549febb7a5fe4404f17581e8010", features = ["tzdb", "now"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "4498edf4efa52f0cdec0bbed8bf49cae7e543e74", features = ["tzdb", "now"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "016bc31d2ce5484973b71ccdb0faeb33c00a9ae6", features = ["tzdb", "now"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "c25c4475810b7549febb7a5fe4404f17581e8010", features = ["tzdb", "now"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -23,7 +23,6 @@ use boa_profiler::Profiler;
 use temporal_rs::{
     options::{RelativeTo, RoundingIncrement, RoundingOptions, TemporalRoundingMode, TemporalUnit},
     partial::PartialDuration,
-    primitive::FiniteF64,
     Duration as InnerDuration,
 };
 
@@ -221,6 +220,7 @@ impl BuiltInConstructor for Duration {
                 .into());
         }
 
+        // TOOD: Support conversion to i64
         // 2. If years is undefined, let y be 0; else let y be ? ToIntegerIfIntegral(years).
         let years = args
             .get_or_undefined(0)
@@ -929,119 +929,112 @@ pub(crate) fn to_temporal_partial_duration(
     };
 
     // 2. Let result be a new partial Duration Record with each field set to undefined.
-    let mut result = PartialDuration::default();
-
     // 3. NOTE: The following steps read properties and perform independent validation in alphabetical order.
     // 4. Let days be ? Get(temporalDurationLike, "days").
-    let days = unknown_object.get(js_string!("days"), context)?;
-    if !days.is_undefined() {
-        // 5. If days is not undefined, set result.[[Days]] to ? ToIntegerIfIntegral(days).
-        let _ = result
-            .days
-            .insert(FiniteF64::from(to_integer_if_integral(&days, context)?));
-    }
+    // 5. If days is not undefined, set result.[[Days]] to ? ToIntegerIfIntegral(days).
+    // TODO: Increase to i64
+    let days = unknown_object
+        .get(js_string!("days"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 6. Let hours be ? Get(temporalDurationLike, "hours").
-    let hours = unknown_object.get(js_string!("hours"), context)?;
     // 7. If hours is not undefined, set result.[[Hours]] to ? ToIntegerIfIntegral(hours).
-    if !hours.is_undefined() {
-        let _ = result
-            .hours
-            .insert(FiniteF64::from(to_integer_if_integral(&hours, context)?));
-    }
+    let hours = unknown_object
+        .get(js_string!("hours"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 8. Let microseconds be ? Get(temporalDurationLike, "microseconds").
-    let microseconds = unknown_object.get(js_string!("microseconds"), context)?;
     // 9. If microseconds is not undefined, set result.[[Microseconds]] to ? ToIntegerIfIntegral(microseconds).
-    if !microseconds.is_undefined() {
-        let _ = result
-            .microseconds
-            .insert(FiniteF64::from(to_integer_if_integral(
-                &microseconds,
-                context,
-            )?));
-    }
+    let microseconds = unknown_object
+        .get(js_string!("microseconds"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 10. Let milliseconds be ? Get(temporalDurationLike, "milliseconds").
-    let milliseconds = unknown_object.get(js_string!("milliseconds"), context)?;
     // 11. If milliseconds is not undefined, set result.[[Milliseconds]] to ? ToIntegerIfIntegral(milliseconds).
-    if !milliseconds.is_undefined() {
-        let _ = result
-            .milliseconds
-            .insert(FiniteF64::from(to_integer_if_integral(
-                &milliseconds,
-                context,
-            )?));
-    }
+    let milliseconds = unknown_object
+        .get(js_string!("milliseconds"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 12. Let minutes be ? Get(temporalDurationLike, "minutes").
-    let minutes = unknown_object.get(js_string!("minutes"), context)?;
     // 13. If minutes is not undefined, set result.[[Minutes]] to ? ToIntegerIfIntegral(minutes).
-    if !minutes.is_undefined() {
-        let _ = result
-            .minutes
-            .insert(FiniteF64::from(to_integer_if_integral(&minutes, context)?));
-    }
+    let minutes = unknown_object
+        .get(js_string!("minutes"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 14. Let months be ? Get(temporalDurationLike, "months").
-    let months = unknown_object.get(js_string!("months"), context)?;
     // 15. If months is not undefined, set result.[[Months]] to ? ToIntegerIfIntegral(months).
-    if !months.is_undefined() {
-        let _ = result
-            .months
-            .insert(FiniteF64::from(to_integer_if_integral(&months, context)?));
-    }
+    let months = unknown_object
+        .get(js_string!("months"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 16. Let nanoseconds be ? Get(temporalDurationLike, "nanoseconds").
-    let nanoseconds = unknown_object.get(js_string!("nanoseconds"), context)?;
     // 17. If nanoseconds is not undefined, set result.[[Nanoseconds]] to ? ToIntegerIfIntegral(nanoseconds).
-    if !nanoseconds.is_undefined() {
-        let _ = result
-            .nanoseconds
-            .insert(FiniteF64::from(to_integer_if_integral(
-                &nanoseconds,
-                context,
-            )?));
-    }
+    let nanoseconds = unknown_object
+        .get(js_string!("nanoseconds"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 18. Let seconds be ? Get(temporalDurationLike, "seconds").
-    let seconds = unknown_object.get(js_string!("seconds"), context)?;
     // 19. If seconds is not undefined, set result.[[Seconds]] to ? ToIntegerIfIntegral(seconds).
-    if !seconds.is_undefined() {
-        let _ = result
-            .seconds
-            .insert(FiniteF64::from(to_integer_if_integral(&seconds, context)?));
-    }
+    let seconds = unknown_object
+        .get(js_string!("seconds"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 20. Let weeks be ? Get(temporalDurationLike, "weeks").
-    let weeks = unknown_object.get(js_string!("weeks"), context)?;
     // 21. If weeks is not undefined, set result.[[Weeks]] to ? ToIntegerIfIntegral(weeks).
-    if !weeks.is_undefined() {
-        let _ = result
-            .weeks
-            .insert(FiniteF64::from(to_integer_if_integral(&weeks, context)?));
-    }
+    let weeks = unknown_object
+        .get(js_string!("weeks"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
 
     // 22. Let years be ? Get(temporalDurationLike, "years").
-    let years = unknown_object.get(js_string!("years"), context)?;
     // 23. If years is not undefined, set result.[[Years]] to ? ToIntegerIfIntegral(years).
-    if !years.is_undefined() {
-        let _ = result
-            .years
-            .insert(FiniteF64::from(to_integer_if_integral(&years, context)?));
-    }
+    let years = unknown_object
+        .get(js_string!("years"), context)?
+        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
+        .transpose()?
+        .map(Into::into);
+
+    let partial = PartialDuration {
+        years,
+        months,
+        weeks,
+        days,
+        hours,
+        minutes,
+        seconds,
+        milliseconds,
+        microseconds,
+        nanoseconds,
+    };
 
     // TODO: Implement this functionality better in `temporal_rs`.
     // 24. If years is undefined, and months is undefined, and weeks is undefined, and days
     // is undefined, and hours is undefined, and minutes is undefined, and seconds is
     // undefined, and milliseconds is undefined, and microseconds is undefined, and
     // nanoseconds is undefined, throw a TypeError exception.
-    if result.is_empty() {
+    if partial.is_empty() {
         return Err(JsNativeError::typ()
             .with_message("PartialDurationRecord must have a defined field.")
             .into());
     }
 
     // 25. Return result.
-    Ok(result)
+    Ok(partial)
 }

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -2,7 +2,7 @@
 
 use super::{
     options::{get_temporal_unit, TemporalUnitGroup},
-    to_integer_if_integral, DateTimeValues,
+    DateTimeValues,
 };
 use crate::value::JsVariant;
 use crate::{
@@ -16,7 +16,8 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsArgs, JsData, JsError, JsNativeError, JsObject, JsResult, JsString, JsSymbol,
+    JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
@@ -222,66 +223,96 @@ impl BuiltInConstructor for Duration {
 
         // TOOD: Support conversion to i64
         // 2. If years is undefined, let y be 0; else let y be ? ToIntegerIfIntegral(years).
-        let years = args
-            .get_or_undefined(0)
-            .map_or(Ok(0), |y| to_integer_if_integral(y, context))?;
+        let years = args.get_or_undefined(0).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 3. If months is undefined, let mo be 0; else let mo be ? ToIntegerIfIntegral(months).
-        let months = args
-            .get_or_undefined(1)
-            .map_or(Ok(0), |mo| to_integer_if_integral(mo, context))?;
+        let months = args.get_or_undefined(1).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 4. If weeks is undefined, let w be 0; else let w be ? ToIntegerIfIntegral(weeks).
-        let weeks = args
-            .get_or_undefined(2)
-            .map_or(Ok(0), |wk| to_integer_if_integral(wk, context))?;
+        let weeks = args.get_or_undefined(2).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 5. If days is undefined, let d be 0; else let d be ? ToIntegerIfIntegral(days).
-        let days = args
-            .get_or_undefined(3)
-            .map_or(Ok(0), |d| to_integer_if_integral(d, context))?;
+        let days = args.get_or_undefined(3).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 6. If hours is undefined, let h be 0; else let h be ? ToIntegerIfIntegral(hours).
-        let hours = args
-            .get_or_undefined(4)
-            .map_or(Ok(0), |h| to_integer_if_integral(h, context))?;
+        let hours = args.get_or_undefined(4).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 7. If minutes is undefined, let m be 0; else let m be ? ToIntegerIfIntegral(minutes).
-        let minutes = args
-            .get_or_undefined(5)
-            .map_or(Ok(0), |m| to_integer_if_integral(m, context))?;
+        let minutes = args.get_or_undefined(5).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 8. If seconds is undefined, let s be 0; else let s be ? ToIntegerIfIntegral(seconds).
-        let seconds = args
-            .get_or_undefined(6)
-            .map_or(Ok(0), |s| to_integer_if_integral(s, context))?;
+        let seconds = args.get_or_undefined(6).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 9. If milliseconds is undefined, let ms be 0; else let ms be ? ToIntegerIfIntegral(milliseconds).
-        let milliseconds = args
-            .get_or_undefined(7)
-            .map_or(Ok(0), |ms| to_integer_if_integral(ms, context))?;
+        let milliseconds = args.get_or_undefined(7).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 10. If microseconds is undefined, let mis be 0; else let mis be ? ToIntegerIfIntegral(microseconds).
-        let microseconds = args
-            .get_or_undefined(8)
-            .map_or(Ok(0), |mis| to_integer_if_integral(mis, context))?;
+        let microseconds = args.get_or_undefined(8).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         // 11. If nanoseconds is undefined, let ns be 0; else let ns be ? ToIntegerIfIntegral(nanoseconds).
-        let nanoseconds = args
-            .get_or_undefined(9)
-            .map_or(Ok(0), |ns| to_integer_if_integral(ns, context))?;
+        let nanoseconds = args.get_or_undefined(9).map_or(Ok(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)
+        })?;
 
         let record = InnerDuration::new(
-            years.into(),
-            months.into(),
-            weeks.into(),
-            days.into(),
-            hours.into(),
-            minutes.into(),
-            seconds.into(),
-            milliseconds.into(),
-            microseconds.into(),
-            nanoseconds.into(),
+            years.try_into()?,
+            months.try_into()?,
+            weeks.try_into()?,
+            days.try_into()?,
+            hours.try_into()?,
+            minutes.try_into()?,
+            seconds.try_into()?,
+            milliseconds.try_into()?,
+            microseconds.try_into()?,
+            nanoseconds.try_into()?,
         )?;
 
         // 12. Return ? CreateTemporalDuration(y, mo, w, d, h, m, s, ms, mis, ns, NewTarget).
@@ -935,81 +966,131 @@ pub(crate) fn to_temporal_partial_duration(
     // TODO: Increase to i64
     let days = unknown_object
         .get(js_string!("days"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 6. Let hours be ? Get(temporalDurationLike, "hours").
     // 7. If hours is not undefined, set result.[[Hours]] to ? ToIntegerIfIntegral(hours).
     let hours = unknown_object
         .get(js_string!("hours"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 8. Let microseconds be ? Get(temporalDurationLike, "microseconds").
     // 9. If microseconds is not undefined, set result.[[Microseconds]] to ? ToIntegerIfIntegral(microseconds).
     let microseconds = unknown_object
         .get(js_string!("microseconds"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 10. Let milliseconds be ? Get(temporalDurationLike, "milliseconds").
     // 11. If milliseconds is not undefined, set result.[[Milliseconds]] to ? ToIntegerIfIntegral(milliseconds).
     let milliseconds = unknown_object
         .get(js_string!("milliseconds"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 12. Let minutes be ? Get(temporalDurationLike, "minutes").
     // 13. If minutes is not undefined, set result.[[Minutes]] to ? ToIntegerIfIntegral(minutes).
     let minutes = unknown_object
         .get(js_string!("minutes"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 14. Let months be ? Get(temporalDurationLike, "months").
     // 15. If months is not undefined, set result.[[Months]] to ? ToIntegerIfIntegral(months).
     let months = unknown_object
         .get(js_string!("months"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 16. Let nanoseconds be ? Get(temporalDurationLike, "nanoseconds").
     // 17. If nanoseconds is not undefined, set result.[[Nanoseconds]] to ? ToIntegerIfIntegral(nanoseconds).
     let nanoseconds = unknown_object
         .get(js_string!("nanoseconds"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 18. Let seconds be ? Get(temporalDurationLike, "seconds").
     // 19. If seconds is not undefined, set result.[[Seconds]] to ? ToIntegerIfIntegral(seconds).
     let seconds = unknown_object
         .get(js_string!("seconds"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 20. Let weeks be ? Get(temporalDurationLike, "weeks").
     // 21. If weeks is not undefined, set result.[[Weeks]] to ? ToIntegerIfIntegral(weeks).
     let weeks = unknown_object
         .get(js_string!("weeks"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     // 22. Let years be ? Get(temporalDurationLike, "years").
     // 23. If years is not undefined, set result.[[Years]] to ? ToIntegerIfIntegral(years).
     let years = unknown_object
         .get(js_string!("years"), context)?
-        .map_or(None, |v| Some(to_integer_if_integral::<i32>(v, context)))
-        .transpose()?
-        .map(Into::into);
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            let integral_int = finite
+                .as_integer_if_integral::<i64>()
+                .map_err(JsError::from)?;
+            integral_int.try_into().map_err(JsError::from)
+        })
+        .transpose()?;
 
     let partial = PartialDuration {
         years,

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -221,7 +221,6 @@ impl BuiltInConstructor for Duration {
                 .into());
         }
 
-        // TOOD: Support conversion to i64
         // 2. If years is undefined, let y be 0; else let y be ? ToIntegerIfIntegral(years).
         let years = args.get_or_undefined(0).map_or(Ok(0), |v| {
             let finite = v.to_finitef64(context)?;
@@ -963,7 +962,6 @@ pub(crate) fn to_temporal_partial_duration(
     // 3. NOTE: The following steps read properties and perform independent validation in alphabetical order.
     // 4. Let days be ? Get(temporalDurationLike, "days").
     // 5. If days is not undefined, set result.[[Days]] to ? ToIntegerIfIntegral(days).
-    // TODO: Increase to i64
     let days = unknown_object
         .get(js_string!("days"), context)?
         .map(|v| {
@@ -1105,7 +1103,6 @@ pub(crate) fn to_temporal_partial_duration(
         nanoseconds,
     };
 
-    // TODO: Implement this functionality better in `temporal_rs`.
     // 24. If years is undefined, and months is undefined, and weeks is undefined, and days
     // is undefined, and hours is undefined, and minutes is undefined, and seconds is
     // undefined, and milliseconds is undefined, and microseconds is undefined, and

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -530,7 +530,7 @@ fn to_temporal_instant(item: &JsValue, context: &mut Context) -> JsResult<InnerI
         // c. NOTE: This use of ToPrimitive allows Instant-like objects to be converted.
         // d. Set item to ? ToPrimitive(item, string).
         if let Some(instant) = obj.downcast_ref::<Instant>() {
-            return Ok(instant.inner.clone());
+            return Ok(instant.inner);
         } else if let Some(_zdt) = obj.downcast_ref::<ZonedDateTime>() {
             return Err(JsNativeError::error()
                 .with_message("Not yet implemented.")

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -31,7 +31,7 @@ use temporal_rs::{
 };
 
 /// The `Temporal.Instant` object.
-#[derive(Debug, Clone, Trace, Finalize, JsData)]
+#[derive(Debug, Clone, Copy, Trace, Finalize, JsData)]
 // SAFETY: Instant does not contain any traceable values.
 #[boa_gc(unsafe_empty_trace)]
 pub struct Instant {

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -913,7 +913,7 @@ pub(crate) fn to_partial_date_record(
                     .into());
             };
 
-            TinyAsciiStr::<4>::from_str(&month_code.to_std_string_escaped())
+            TinyAsciiStr::<4>::try_from_str(&month_code.to_std_string_escaped())
                 .map_err(|e| JsError::from(JsNativeError::typ().with_message(e.to_string())))
         })
         .transpose()?;
@@ -938,7 +938,7 @@ pub(crate) fn to_partial_date_record(
                 ));
             };
             // TODO: double check if an invalid monthCode is a range or type error.
-            TinyAsciiStr::<19>::from_str(&era.to_std_string_escaped())
+            TinyAsciiStr::<19>::try_from_str(&era.to_std_string_escaped())
                 .map_err(|e| JsError::from(JsNativeError::range().with_message(e.to_string())))
         })
         .transpose()?;

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -21,15 +21,15 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 use temporal_rs::{
-    options::ArithmeticOverflow, partial::PartialDate, Calendar, PlainDate as InnerDate,
-    TinyAsciiStr,
+    options::ArithmeticOverflow, partial::PartialDate, PlainDate as InnerDate, TinyAsciiStr,
 };
 
 use super::{
     calendar::{get_temporal_calendar_slot_value_with_default, to_temporal_calendar_slot_value},
     create_temporal_datetime, create_temporal_duration,
     options::get_difference_settings,
-    to_temporal_duration_record, to_temporal_time, PlainDateTime, ZonedDateTime,
+    to_finite_number, to_temporal_duration_record, to_temporal_time, truncate,
+    truncate_as_positive, PlainDateTime, ZonedDateTime,
 };
 
 #[cfg(feature = "temporal")]
@@ -244,20 +244,14 @@ impl BuiltInConstructor for PlainDate {
                 .into());
         };
 
-        let iso_year = super::to_integer_with_truncation(args.get_or_undefined(0), context)?;
-        let iso_month = super::to_integer_with_truncation(args.get_or_undefined(1), context)?;
-        let iso_day = super::to_integer_with_truncation(args.get_or_undefined(2), context)?;
+        let year = truncate::<i32>(to_finite_number(args.get_or_undefined(0), context)?);
+        let month = truncate::<u8>(to_finite_number(args.get_or_undefined(1), context)?);
+        let day = truncate::<u8>(to_finite_number(args.get_or_undefined(2), context)?);
         let calendar_slot = to_temporal_calendar_slot_value(args.get_or_undefined(3))?;
 
-        Ok(create_temporal_date(
-            iso_year,
-            iso_month,
-            iso_day,
-            calendar_slot,
-            Some(new_target),
-            context,
-        )?
-        .into())
+        let inner = InnerDate::try_new(year, month.into(), day.into(), calendar_slot)?;
+
+        Ok(create_temporal_date(inner, Some(new_target), context)?.into())
     }
 }
 
@@ -491,27 +485,11 @@ impl PlainDate {
         if let Some(date) = item.as_object().and_then(JsObject::downcast_ref::<Self>) {
             let options = get_options_object(options.unwrap_or(&JsValue::undefined()))?;
             let _ = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
-            return create_temporal_date(
-                date.inner.iso_year(),
-                date.inner.iso_month().into(),
-                date.inner.iso_day().into(),
-                date.inner.calendar().clone(),
-                None,
-                context,
-            )
-            .map(Into::into);
+            return create_temporal_date(date.inner.clone(), None, context).map(Into::into);
         }
 
         let resolved_date = to_temporal_date(item, options.cloned(), context)?;
-        create_temporal_date(
-            resolved_date.iso_year(),
-            resolved_date.iso_month().into(),
-            resolved_date.iso_day().into(),
-            resolved_date.calendar().clone(),
-            None,
-            context,
-        )
-        .map(Into::into)
+        create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
     /// 3.2.3 Temporal.PlainDate.compare ( one, two )
@@ -600,15 +578,7 @@ impl PlainDate {
         // 5. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 6. Return ? AddDate(calendarRec, temporalDate, duration, options).
         let resolved_date = date.inner.add(&duration, overflow)?;
-        create_temporal_date(
-            resolved_date.iso_year(),
-            resolved_date.iso_month().into(),
-            resolved_date.iso_day().into(),
-            resolved_date.calendar().clone(),
-            None,
-            context,
-        )
-        .map(Into::into)
+        create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
     fn subtract(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -632,15 +602,7 @@ impl PlainDate {
         // 6. Let calendarRec be ? CreateCalendarMethodsRecord(temporalDate.[[Calendar]], « date-add »).
         // 7. Return ? AddDate(calendarRec, temporalDate, negatedDuration, options).
         let resolved_date = date.inner.subtract(&duration, overflow)?;
-        create_temporal_date(
-            resolved_date.iso_year(),
-            resolved_date.iso_month().into(),
-            resolved_date.iso_day().into(),
-            resolved_date.calendar().clone(),
-            None,
-            context,
-        )
-        .map(Into::into)
+        create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
     // 3.3.24 Temporal.PlainDate.prototype.with ( temporalDateLike [ , options ] )
@@ -677,15 +639,7 @@ impl PlainDate {
 
         // 10. Return ? CalendarDateFromFields(calendarRec, fields, resolvedOptions).
         let resolved_date = date.inner.with(partial, overflow)?;
-        create_temporal_date(
-            resolved_date.iso_year(),
-            resolved_date.iso_month().into(),
-            resolved_date.iso_day().into(),
-            resolved_date.calendar().clone(),
-            None,
-            context,
-        )
-        .map(Into::into)
+        create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
     /// 3.3.26 Temporal.PlainDate.prototype.withCalendar ( calendarLike )
@@ -699,15 +653,7 @@ impl PlainDate {
 
         let calendar = to_temporal_calendar_slot_value(args.get_or_undefined(0))?;
         let resolved_date = date.inner.with_calendar(calendar)?;
-        create_temporal_date(
-            resolved_date.iso_year(),
-            resolved_date.iso_month().into(),
-            resolved_date.iso_day().into(),
-            resolved_date.calendar().clone(),
-            None,
-            context,
-        )
-        .map(Into::into)
+        create_temporal_date(resolved_date, None, context).map(Into::into)
     }
 
     fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -797,14 +743,7 @@ impl PlainDate {
 impl PlainDate {
     /// Utitily function for translating a `Temporal.PlainDate` into a `JsObject`.
     pub(crate) fn as_object(&self, context: &mut Context) -> JsResult<JsObject> {
-        create_temporal_date(
-            self.inner.iso_year(),
-            self.inner.iso_month().into(),
-            self.inner.iso_day().into(),
-            self.inner.calendar().clone(),
-            None,
-            context,
-        )
+        create_temporal_date(self.inner.clone(), None, context)
     }
 }
 
@@ -813,16 +752,12 @@ impl PlainDate {
 
 /// 3.5.3 `CreateTemporalDate ( isoYear, isoMonth, isoDay, calendar [ , newTarget ] )`
 pub(crate) fn create_temporal_date(
-    iso_year: i32,
-    iso_month: i32,
-    iso_day: i32,
-    calendar_slot: Calendar,
+    inner: InnerDate,
     new_target: Option<&JsValue>,
     context: &mut Context,
 ) -> JsResult<JsObject> {
     // 1. If IsValidISODate(isoYear, isoMonth, isoDay) is false, throw a RangeError exception.
     // 2. If ISODateTimeWithinLimits(isoYear, isoMonth, isoDay, 12, 0, 0, 0, 0, 0) is false, throw a RangeError exception.
-    let inner = InnerDate::try_new(iso_year, iso_month, iso_day, calendar_slot)?;
 
     // 3. If newTarget is not present, set newTarget to %Temporal.PlainDate%.
     let new_target = if let Some(new_target) = new_target {
@@ -958,11 +893,15 @@ pub(crate) fn to_partial_date_record(
     // TODO: Most likely need to use an iterator to handle.
     let day = partial_object
         .get(js_string!("day"), context)?
-        .map(|v| super::to_positive_integer_with_trunc(v, context))
+        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .transpose()?
+        .map(truncate_as_positive)
         .transpose()?;
     let month = partial_object
         .get(js_string!("month"), context)?
-        .map(|v| super::to_positive_integer_with_trunc(v, context))
+        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .transpose()?
+        .map(truncate_as_positive)
         .transpose()?;
     let month_code = partial_object
         .get(js_string!("monthCode"), context)?
@@ -973,18 +912,21 @@ pub(crate) fn to_partial_date_record(
                     .with_message("The monthCode field value must be a string.")
                     .into());
             };
+
             TinyAsciiStr::<4>::from_str(&month_code.to_std_string_escaped())
                 .map_err(|e| JsError::from(JsNativeError::typ().with_message(e.to_string())))
         })
         .transpose()?;
     let year = partial_object
         .get(js_string!("year"), context)?
-        .map(|v| super::to_integer_if_integral(v, context))
-        .transpose()?;
+        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .transpose()?
+        .map(truncate);
     let era_year = partial_object
         .get(js_string!("eraYear"), context)?
-        .map(|v| super::to_integer_if_integral(v, context))
-        .transpose()?;
+        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .transpose()?
+        .map(truncate);
     let era = partial_object
         .get(js_string!("era"), context)?
         .map(|v| {

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -4,7 +4,7 @@
 use crate::{
     builtins::{
         options::{get_option, get_options_object},
-        temporal::{to_integer_with_truncation, to_partial_date_record, to_partial_time_record},
+        temporal::{to_partial_date_record, to_partial_time_record},
         BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject,
     },
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
@@ -22,18 +22,21 @@ use boa_profiler::Profiler;
 #[cfg(test)]
 mod tests;
 
+use temporal_rs::{
+    options::{ArithmeticOverflow, RoundingIncrement, RoundingOptions, TemporalRoundingMode},
+    partial::PartialDateTime,
+    primitive::FiniteF64,
+    PlainDateTime as InnerDateTime, PlainTime,
+};
+
 use super::{
     calendar::{get_temporal_calendar_slot_value_with_default, to_temporal_calendar_slot_value},
     create_temporal_duration,
     options::{get_difference_settings, get_temporal_unit, TemporalUnitGroup},
-    to_temporal_duration_record, to_temporal_time, PlainDate, ZonedDateTime,
+    to_finite_number, to_temporal_duration_record, to_temporal_time, truncate, PlainDate,
+    ZonedDateTime,
 };
 use crate::value::JsVariant;
-use temporal_rs::{
-    options::{ArithmeticOverflow, RoundingIncrement, RoundingOptions, TemporalRoundingMode},
-    partial::PartialDateTime,
-    PlainDateTime as InnerDateTime, PlainTime,
-};
 
 /// The `Temporal.PlainDateTime` object.
 #[derive(Debug, Clone, Trace, Finalize, JsData)]
@@ -308,48 +311,58 @@ impl BuiltInConstructor for PlainDateTime {
         };
 
         // 2. Set isoYear to ? ToIntegerWithTruncation(isoYear).
-        let iso_year = to_integer_with_truncation(args.get_or_undefined(0), context)?;
+        let iso_year = truncate::<i32>(to_finite_number(args.get_or_undefined(0), context)?);
         // 3. Set isoMonth to ? ToIntegerWithTruncation(isoMonth).
-        let iso_month = to_integer_with_truncation(args.get_or_undefined(1), context)?;
+        let iso_month = truncate::<u8>(to_finite_number(args.get_or_undefined(1), context)?);
         // 4. Set isoDay to ? ToIntegerWithTruncation(isoDay).
-        let iso_day = to_integer_with_truncation(args.get_or_undefined(2), context)?;
+        let iso_day = truncate::<u8>(to_finite_number(args.get_or_undefined(2), context)?);
         // 5. If hour is undefined, set hour to 0; else set hour to ? ToIntegerWithTruncation(hour).
         let hour = args
             .get_or_undefined(3)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u8>)?;
         // 6. If minute is undefined, set minute to 0; else set minute to ? ToIntegerWithTruncation(minute).
         let minute = args
             .get_or_undefined(4)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u8>)?;
+
         // 7. If second is undefined, set second to 0; else set second to ? ToIntegerWithTruncation(second).
         let second = args
             .get_or_undefined(5)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u8>)?;
+
         // 8. If millisecond is undefined, set millisecond to 0; else set millisecond to ? ToIntegerWithTruncation(millisecond).
         let millisecond = args
             .get_or_undefined(6)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u16>)?;
+
         // 9. If microsecond is undefined, set microsecond to 0; else set microsecond to ? ToIntegerWithTruncation(microsecond).
         let microsecond = args
             .get_or_undefined(7)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u16>)?;
+
         // 10. If nanosecond is undefined, set nanosecond to 0; else set nanosecond to ? ToIntegerWithTruncation(nanosecond).
         let nanosecond = args
             .get_or_undefined(8)
-            .map_or(Ok(0), |v| to_integer_with_truncation(v, context))?;
-        // 11. Let calendar be ? ToTemporalCalendarSlotValue(calendarLike, "iso8601").
+            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
+            .map(truncate::<u16>)?;
+
         let calendar_slot = to_temporal_calendar_slot_value(args.get_or_undefined(9))?;
 
         let dt = InnerDateTime::new(
             iso_year,
-            iso_month,
-            iso_day,
-            hour,
-            minute,
-            second,
-            millisecond,
-            microsecond,
-            nanosecond,
+            iso_month.into(),
+            iso_day.into(),
+            hour.into(),
+            minute.into(),
+            second.into(),
+            millisecond.into(),
+            microsecond.into(),
+            nanosecond.into(),
             calendar_slot,
         )?;
 

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -3,7 +3,7 @@
 use super::{
     create_temporal_duration,
     options::{get_difference_settings, get_temporal_unit, TemporalUnitGroup},
-    to_temporal_duration_record, PlainDateTime, ZonedDateTime, truncate, to_finite_number,
+    to_temporal_duration_record, PlainDateTime, ZonedDateTime,
 };
 use crate::value::JsVariant;
 use crate::{
@@ -17,14 +17,14 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    Context, JsArgs, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsArgs, JsData, JsError, JsNativeError, JsObject, JsResult, JsString, JsSymbol,
+    JsValue,
 };
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 use temporal_rs::{
     options::{ArithmeticOverflow, TemporalRoundingMode},
     partial::PartialTime,
-    primitive::FiniteF64,
     PlainTime as PlainTimeInner,
 };
 
@@ -150,38 +150,44 @@ impl BuiltInConstructor for PlainTime {
         }
 
         // 2. If hour is undefined, set hour to 0; else set hour to ? ToIntegerWithTruncation(hour).
-        let hour = args
-            .get_or_undefined(0)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u8>)?;
+        let hour = args.get_or_undefined(0).map_or(Ok::<u8, JsError>(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            Ok(finite.as_integer_with_truncation::<u8>())
+        })?;
         // 3. If minute is undefined, set minute to 0; else set minute to ? ToIntegerWithTruncation(minute).
-        let minute = args
-            .get_or_undefined(1)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u8>)?;
+        let minute = args.get_or_undefined(1).map_or(Ok::<u8, JsError>(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            Ok(finite.as_integer_with_truncation::<u8>())
+        })?;
         // 4. If second is undefined, set second to 0; else set second to ? ToIntegerWithTruncation(second).
-        let second = args
-            .get_or_undefined(2)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u8>)?;
+        let second = args.get_or_undefined(2).map_or(Ok::<u8, JsError>(0), |v| {
+            let finite = v.to_finitef64(context)?;
+            Ok(finite.as_integer_with_truncation::<u8>())
+        })?;
 
         // 5. If millisecond is undefined, set millisecond to 0; else set millisecond to ? ToIntegerWithTruncation(millisecond).
         let millisecond = args
             .get_or_undefined(3)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u16>)?;
+            .map_or(Ok::<u16, JsError>(0), |v| {
+                let finite = v.to_finitef64(context)?;
+                Ok(finite.as_integer_with_truncation::<u16>())
+            })?;
 
         // 6. If microsecond is undefined, set microsecond to 0; else set microsecond to ? ToIntegerWithTruncation(microsecond).
         let microsecond = args
             .get_or_undefined(4)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u16>)?;
+            .map_or(Ok::<u16, JsError>(0), |v| {
+                let finite = v.to_finitef64(context)?;
+                Ok(finite.as_integer_with_truncation::<u16>())
+            })?;
 
         // 7. If nanosecond is undefined, set nanosecond to 0; else set nanosecond to ? ToIntegerWithTruncation(nanosecond).
         let nanosecond = args
             .get_or_undefined(5)
-            .map_or(Ok(FiniteF64::from(0)), |v| to_finite_number(v, context))
-            .map(truncate::<u16>)?;
+            .map_or(Ok::<u16, JsError>(0), |v| {
+                let finite = v.to_finitef64(context)?;
+                Ok(finite.as_integer_with_truncation::<u16>())
+            })?;
 
         let inner = PlainTimeInner::new(
             hour.into(),
@@ -717,44 +723,56 @@ pub(crate) fn to_partial_time_record(
 ) -> JsResult<PartialTime> {
     let hour = partial_object
         .get(js_string!("hour"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+        })
         .transpose()?
-        .map(truncate::<u8>)
         .map(Into::into);
 
     let minute = partial_object
         .get(js_string!("minute"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+        })
         .transpose()?
-        .map(truncate::<u8>)
         .map(Into::into);
 
     let second = partial_object
         .get(js_string!("second"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+        })
         .transpose()?
-        .map(truncate::<u8>)
         .map(Into::into);
 
     let millisecond = partial_object
         .get(js_string!("millisecond"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
+        })
         .transpose()?
-        .map(truncate::<u16>)
         .map(Into::into);
 
     let microsecond = partial_object
         .get(js_string!("microsecond"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
+        })
         .transpose()?
-        .map(truncate::<u16>)
         .map(Into::into);
 
     let nanosecond = partial_object
         .get(js_string!("nanosecond"), context)?
-        .map_or(None, |v| Some(to_finite_number(v, context)))
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
+        })
         .transpose()?
-        .map(truncate::<u16>)
         .map(Into::into);
 
     Ok(PartialTime {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

Posting this as a draft to hopefully get comments.

TLDR: I'm convinced the way we currently handle converting JsValue to integers in the Temporal implementation is wrong and this is a way to update it.

## Baseline issue

Currently, we are using `to_integer_with_truncation`, `to_positive_integer_with_truncation` and `to_integer_if_integral` to convert values into `i32`. These methods are still hold over from the initial prototype of Temporal prior to `temporal_rs` being split off. At the time, I think it was ultimately an optimistic approach, but I'm now fairly certain it's wrong long term and should probably addressed (hence the draft PR)  ASAP.

Also, every argument being truncated to `i32` negatively impacts `temporal_rs`'s API by forcing us to keep the values at `i32`. This change would allow us to change `temporal_rs`'s API, and move it away from only `i32`.

## General approach / Order of Operations

So the general approach of this PR is to first get the value and transform it to a `FiniteF64` by calling `ToNumber()` and checking that it's finite, which was essentially all the previous functions were doing anyways besides the truncation.

Once the values are made `FiniteF64`s, we then get the options object and determine the `ArithmeticOverflow` from the options object. This is needed for the observability tests which may check for the finite check throwing prior to a wrong options object throwing.

After the options object, we then truncate the value into the integer type that is expected by `temporal_rs` with the user defined `ArithmeticOverflow`. If ArithmeticOverflow::Reject and the value is not contained within T::MIN and T::MAX, we throw an early far exceeds range RangeError. If ArithemeticOverflow::Constrain, then we clamp the value to T::MAX or T::MIN.

There is also an argument to just always silently constrain the value to T::MAX or T::MIN and let `temporal_rs` handle the error. I think I may like this option more, because it does allow us to truncate early without `ArithmeticOverflow` and deferring truncation to after reading options.

Anyways, general thoughts would be appreciated. Technically, this is probably more of a `temporal_rs` leaning PR as I think the current `truncate` function in this PR should live in `temporal_rs`, but it does handle specifically the Boa's glue code to the library.