### PR TITLE
Replace all u64/i64 for length, index or offsets into usize/isize

### DIFF
--- a/cli/src/debug/limits.rs
+++ b/cli/src/debug/limits.rs
@@ -2,7 +2,7 @@ use boa_engine::{
     js_string,
     object::{FunctionObjectBuilder, ObjectInitializer},
     property::Attribute,
-    Context, JsArgs, JsNativeError, JsObject, JsResult, JsValue, NativeFunction,
+    Context, JsArgs, JsObject, JsResult, JsValue, NativeFunction,
 };
 
 fn get_loop(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -12,7 +12,9 @@ fn get_loop(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsVal
 
 fn set_loop(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
-    context.runtime_limits_mut().set_loop_iteration_limit(value);
+    context
+        .runtime_limits_mut()
+        .set_loop_iteration_limit(value as u64);
     Ok(JsValue::undefined())
 }
 
@@ -23,11 +25,6 @@ fn get_stack(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsVa
 
 fn set_stack(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
-    let Ok(value) = value.try_into() else {
-        return Err(JsNativeError::range()
-            .with_message(format!("Argument {value} greater than usize::MAX"))
-            .into());
-    };
     context.runtime_limits_mut().set_stack_size_limit(value);
     Ok(JsValue::undefined())
 }
@@ -39,11 +36,6 @@ fn get_recursion(_: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<
 
 fn set_recursion(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
     let value = args.get_or_undefined(0).to_length(context)?;
-    let Ok(value) = value.try_into() else {
-        return Err(JsNativeError::range()
-            .with_message(format!("Argument {value} greater than usize::MAX"))
-            .into());
-    };
     context.runtime_limits_mut().set_recursion_limit(value);
     Ok(JsValue::undefined())
 }

--- a/core/engine/src/builtins/array/array_iterator.rs
+++ b/core/engine/src/builtins/array/array_iterator.rs
@@ -31,7 +31,7 @@ use boa_profiler::Profiler;
 #[derive(Debug, Clone, Finalize, Trace, JsData)]
 pub(crate) struct ArrayIterator {
     array: JsObject,
-    next_index: u64,
+    next_index: usize,
     #[unsafe_ignore_trace]
     kind: PropertyNameKind,
     done: bool,

--- a/core/engine/src/builtins/array/tests.rs
+++ b/core/engine/src/builtins/array/tests.rs
@@ -874,7 +874,7 @@ fn array_spread_non_iterable() {
 #[test]
 fn get_relative_start() {
     #[track_caller]
-    fn assert(context: &mut Context, arg: Option<&JsValue>, len: u64, expected: u64) {
+    fn assert(context: &mut Context, arg: Option<&JsValue>, len: usize, expected: usize) {
         let arg = arg.unwrap_or(&JsValue::Undefined);
         assert_eq!(
             Array::get_relative_start(context, arg, len).unwrap(),
@@ -901,7 +901,7 @@ fn get_relative_start() {
 #[test]
 fn get_relative_end() {
     #[track_caller]
-    fn assert(context: &mut Context, arg: Option<&JsValue>, len: u64, expected: u64) {
+    fn assert(context: &mut Context, arg: Option<&JsValue>, len: usize, expected: usize) {
         let arg = arg.unwrap_or(&JsValue::Undefined);
         assert_eq!(
             Array::get_relative_end(context, arg, len).unwrap(),

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -228,7 +228,7 @@ impl SharedArrayBuffer {
             })?;
 
         // 4. Let length be ArrayBufferByteLength(O, seq-cst).
-        let len = buf.bytes(Ordering::SeqCst).len() as u64;
+        let len = buf.bytes(Ordering::SeqCst).len();
 
         // 5. Return 𝔽(length).
         Ok(len.into())
@@ -329,14 +329,14 @@ impl SharedArrayBuffer {
         // d. If newByteLength < currentByteLength or newByteLength > O.[[ArrayBufferMaxByteLength]], throw a RangeError exception.
         // Extracting this condition outside the CAS since throwing early doesn't affect the correct
         // behaviour of the loop.
-        if new_byte_len > buf.data.buffer.len() as u64 {
+        if new_byte_len > buf.data.buffer.len() {
             return Err(JsNativeError::range()
                 .with_message(
                     "SharedArrayBuffer.grow: new length cannot be bigger than `maxByteLength`",
                 )
                 .into());
         }
-        let new_byte_len = new_byte_len as usize;
+        let new_byte_len = new_byte_len;
 
         // If we used let-else above to avoid the expect, we would carry a borrow through the `to_index`
         // call, which could mutably borrow. Another alternative would be to clone the whole
@@ -404,13 +404,13 @@ impl SharedArrayBuffer {
         // 6. If relativeStart = -∞, let first be 0.
         // 7. Else if relativeStart < 0, let first be max(len + relativeStart, 0).
         // 8. Else, let first be min(relativeStart, len).
-        let first = Array::get_relative_start(context, args.get_or_undefined(0), len as u64)?;
+        let first = Array::get_relative_start(context, args.get_or_undefined(0), len)?;
 
         // 9. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
         // 10. If relativeEnd = -∞, let final be 0.
         // 11. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
         // 12. Else, let final be min(relativeEnd, len).
-        let final_ = Array::get_relative_end(context, args.get_or_undefined(1), len as u64)?;
+        let final_ = Array::get_relative_end(context, args.get_or_undefined(1), len)?;
 
         // 13. Let newLen be max(final - first, 0).
         let new_len = final_.saturating_sub(first);
@@ -442,14 +442,13 @@ impl SharedArrayBuffer {
             }
 
             // 19. If ArrayBufferByteLength(new, seq-cst) < newLen, throw a TypeError exception.
-            if (new.len(Ordering::SeqCst) as u64) < new_len {
+            if (new.len(Ordering::SeqCst)) < new_len {
                 return Err(JsNativeError::typ()
                     .with_message("invalid size of constructed SharedArrayBuffer")
                     .into());
             }
 
-            let first = first as usize;
-            let new_len = new_len as usize;
+            let new_len = new_len;
 
             // 20. Let fromBuf be O.[[ArrayBufferData]].
             let from_buf = &buf.bytes_with_len(len)[first..];
@@ -480,8 +479,8 @@ impl SharedArrayBuffer {
     /// [spec]: https://tc39.es/ecma262/#sec-allocatesharedarraybuffer
     pub(crate) fn allocate(
         constructor: &JsValue,
-        byte_len: u64,
-        max_byte_len: Option<u64>,
+        byte_len: usize,
+        max_byte_len: Option<usize>,
         context: &mut Context,
     ) -> JsResult<JsObject<SharedArrayBuffer>> {
         // 1. Let slots be « [[ArrayBufferData]] ».
@@ -523,7 +522,7 @@ impl SharedArrayBuffer {
         // c. Perform SetValueInBuffer(byteLengthBlock, 0, biguint64, ℤ(byteLength), true, seq-cst).
         // d. Set obj.[[ArrayBufferByteLengthData]] to byteLengthBlock.
         // e. Set obj.[[ArrayBufferMaxByteLength]] to maxByteLength.
-        let current_len = max_byte_len.map(|_| AtomicUsize::new(byte_len as usize));
+        let current_len = max_byte_len.map(|_| AtomicUsize::new(byte_len));
 
         // 10. Else,
         //     a. Set obj.[[ArrayBufferByteLength]] to byteLength.
@@ -551,7 +550,7 @@ impl SharedArrayBuffer {
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-createsharedbytedatablock
 pub(crate) fn create_shared_byte_data_block(
-    size: u64,
+    size: usize,
     context: &mut Context,
 ) -> JsResult<Box<[AtomicU8]>> {
     if size > context.host_hooks().max_buffer_size(context) {

--- a/core/engine/src/builtins/array_buffer/tests.rs
+++ b/core/engine/src/builtins/array_buffer/tests.rs
@@ -7,7 +7,7 @@ fn create_byte_data_block() {
     assert!(super::create_byte_data_block(100, None, context).is_ok());
 
     // Rainy day
-    assert!(super::create_byte_data_block(u64::MAX, None, context).is_err());
+    assert!(super::create_byte_data_block(usize::MAX, None, context).is_err());
 }
 
 #[test]
@@ -17,5 +17,5 @@ fn create_shared_byte_data_block() {
     assert!(super::shared::create_shared_byte_data_block(100, context).is_ok());
 
     // Rainy day
-    assert!(super::shared::create_shared_byte_data_block(u64::MAX, context).is_err());
+    assert!(super::shared::create_shared_byte_data_block(usize::MAX, context).is_err());
 }

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -151,7 +151,7 @@ impl SliceRef<'_> {
                 .array_buffer()
                 .constructor()
                 .into(),
-            self.len() as u64,
+            self.len(),
             None,
             context,
         )?;

--- a/core/engine/src/builtins/atomics/mod.rs
+++ b/core/engine/src/builtins/atomics/mod.rs
@@ -644,9 +644,6 @@ fn validate_atomic_access(
     }
 
     // 8. Return (accessIndex × elementSize) + offset.
-    let offset = ((access_index * kind.element_size()) + offset) as usize;
-    Ok(AtomicAccess {
-        byte_offset: offset,
-        kind,
-    })
+    let byte_offset = (access_index * kind.element_size()) + offset;
+    Ok(AtomicAccess { byte_offset, kind })
 }

--- a/core/engine/src/builtins/regexp/mod.rs
+++ b/core/engine/src/builtins/regexp/mod.rs
@@ -847,7 +847,7 @@ impl RegExp {
         let arg_str = args.get_or_undefined(0).to_string(context)?;
 
         // 4. Return ? RegExpBuiltinExec(R, S).
-        (Self::abstract_builtin_exec(obj, &arg_str, context)?)
+        Self::abstract_builtin_exec(obj, &arg_str, context)?
             .map_or_else(|| Ok(JsValue::null()), |v| Ok(v.into()))
     }
 
@@ -915,7 +915,7 @@ impl RegExp {
             })?;
 
         // 1. Let length be the length of S.
-        let length = input.len() as u64;
+        let length = input.len();
 
         // 2. Let lastIndex be ℝ(? ToLength(? Get(R, "lastIndex"))).
         let mut last_index = this
@@ -972,14 +972,10 @@ impl RegExp {
                 let input = input.to_vec();
 
                 // NOTE: We can use the faster ucs2 variant since there will never be two byte unicode.
-                matcher.find_from_ucs2(&input, last_index as usize).next()
+                matcher.find_from_ucs2(&input, last_index).next()
             }
-            (true, JsStrVariant::Utf16(input)) => {
-                matcher.find_from_utf16(input, last_index as usize).next()
-            }
-            (false, JsStrVariant::Utf16(input)) => {
-                matcher.find_from_ucs2(input, last_index as usize).next()
-            }
+            (true, JsStrVariant::Utf16(input)) => matcher.find_from_utf16(input, last_index).next(),
+            (false, JsStrVariant::Utf16(input)) => matcher.find_from_ucs2(input, last_index).next(),
         };
 
         let Some(match_value) = r else {
@@ -1007,7 +1003,7 @@ impl RegExp {
         // SKIP: ii. Set matchSucceeded to true.
 
         // NOTE: regress currently doesn't support the sticky flag so we have to emulate it.
-        if sticky && match_value.start() != last_index as usize {
+        if sticky && match_value.start() != last_index {
             // 1. Perform ? Set(R, "lastIndex", +0𝔽, true).
             this.set(js_string!("lastIndex"), 0, true, context)?;
 
@@ -1017,7 +1013,7 @@ impl RegExp {
 
         // 13.d.ii. Set lastIndex to AdvanceStringIndex(S, lastIndex, fullUnicode).
         // NOTE: Calculation of last_index is done in regress.
-        last_index = match_value.start() as u64;
+        last_index = match_value.start();
 
         // 14. Let e be r's endIndex value.
         // 15. If fullUnicode is true, set e to GetStringIndex(S, e).
@@ -1031,10 +1027,10 @@ impl RegExp {
         }
 
         // 17. Let n be the number of elements in r's captures List.
-        let n = match_value.captures.len() as u64;
+        let n = match_value.captures.len();
         // 18. Assert: n = R.[[RegExpRecord]].[[CapturingGroupsCount]].
         // 19. Assert: n < 232 - 1.
-        debug_assert!(n < 23u64.pow(2) - 1);
+        debug_assert!(n < u32::MAX as usize);
 
         // 20. Let A be ! ArrayCreate(n + 1).
         // 21. Assert: The mathematical value of A's "length" property is n + 1.
@@ -1066,7 +1062,7 @@ impl RegExp {
             .expect("this CreateDataPropertyOrThrow call must not fail");
 
         // 28. Let matchedSubstr be GetMatchString(S, match).
-        let matched_substr = input.get_expect((last_index as usize)..(e));
+        let matched_substr = input.get_expect(last_index..e);
 
         // 29. Perform ! CreateDataPropertyOrThrow(A, "0", matchedSubstr).
         a.create_data_property_or_throw(0, matched_substr, context)
@@ -1151,7 +1147,7 @@ impl RegExp {
         // 27. For each integer i such that i ≥ 1 and i ≤ n, in ascending order, do
         for i in 1..=n {
             // a. Let captureI be ith element of r's captures List.
-            let capture = match_value.group(i as usize);
+            let capture = match_value.group(i);
 
             // b. If captureI is undefined, let capturedValue be undefined.
             // c. Else if fullUnicode is true, then
@@ -1226,7 +1222,7 @@ impl RegExp {
         // 5. If flags does not contain "g", then
         if !flags.contains(b'g') {
             // a. Return ? RegExpExec(rx, S).
-            return (Self::abstract_exec(rx, arg_str, context)?)
+            return Self::abstract_exec(rx, arg_str, context)?
                 .map_or_else(|| Ok(JsValue::null()), |v| Ok(v.into()));
         }
 
@@ -1767,7 +1763,7 @@ impl RegExp {
         }
 
         // 15. Let size be the length of S.
-        let size = arg_str.len() as u64;
+        let size = arg_str.len();
 
         // 16. If size is 0, then
         if size == 0 {
@@ -1817,7 +1813,7 @@ impl RegExp {
                     q = advance_string_index(&arg_str, q, unicode);
                 } else {
                     // 1. Let T be the substring of S from p to q.
-                    let arg_str_substring = arg_str.get_expect(p as usize..q as usize);
+                    let arg_str_substring = arg_str.get_expect(p..q);
 
                     // 2. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
                     a.create_data_property_or_throw(length_a, arg_str_substring, context)
@@ -1868,7 +1864,7 @@ impl RegExp {
         }
 
         // 20. Let T be the substring of S from p to size.
-        let arg_str_substring = arg_str.get_expect(p as usize..size as usize);
+        let arg_str_substring = arg_str.get_expect(p..size);
 
         // 21. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(lengthA)), T).
         a.create_data_property_or_throw(length_a, arg_str_substring, context)
@@ -1941,7 +1937,7 @@ impl RegExp {
 ///  - [ECMAScript reference][spec]
 ///
 /// [spec]: https://tc39.es/ecma262/#sec-advancestringindex
-fn advance_string_index(s: &JsString, index: u64, unicode: bool) -> u64 {
+fn advance_string_index(s: &JsString, index: usize, unicode: bool) -> usize {
     // Regress only works with utf8, so this function differs from the spec.
 
     // 1. Assert: index ≤ 2^53 - 1.
@@ -1952,7 +1948,7 @@ fn advance_string_index(s: &JsString, index: u64, unicode: bool) -> u64 {
     }
 
     // 3. Let length be the number of code units in S.
-    let length = s.len() as u64;
+    let length = s.len();
 
     // 4. If index + 1 ≥ length, return index + 1.
     if index + 1 > length {
@@ -1960,7 +1956,7 @@ fn advance_string_index(s: &JsString, index: u64, unicode: bool) -> u64 {
     }
 
     // 5. Let cp be ! CodePointAt(S, index).
-    let code_point = s.code_point_at(index as usize);
+    let code_point = s.code_point_at(index);
 
-    index + code_point.code_unit_count() as u64
+    index + code_point.code_unit_count()
 }

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -382,7 +382,7 @@ impl String {
         let substitutions = args.get(1..).unwrap_or_default();
 
         // 1. Let numberOfSubstitutions be the number of elements in substitutions.
-        let number_of_substitutions = substitutions.len() as u64;
+        let number_of_substitutions = substitutions.len();
 
         // 2. Let cooked be ? ToObject(template).
         let cooked = args.get_or_undefined(0).to_object(context)?;
@@ -424,7 +424,7 @@ impl String {
 
             // e. If nextIndex < numberOfSubstitutions, let next be substitutions[nextIndex].
             let next = if next_index < number_of_substitutions {
-                substitutions.get_or_undefined(next_index as usize).clone()
+                substitutions.get_or_undefined(next_index).clone()
 
             // f. Else, let next be the empty String.
             } else {
@@ -1524,7 +1524,7 @@ impl String {
         let int_max_length = max_length.to_length(context)?;
 
         // 3. Let stringLength be the length of S.
-        let string_length = string.len() as u64;
+        let string_length = string.len();
 
         // 4. If intMaxLength ≤ stringLength, return S.
         if int_max_length <= string_length {
@@ -1546,7 +1546,7 @@ impl String {
 
         // 8. Let fillLen be intMaxLength - stringLength.
         let fill_len = int_max_length - string_length;
-        let filler_len = filler.len() as u64;
+        let filler_len = filler.len();
 
         // 9. Let truncatedStringFiller be the String value consisting of repeated
         // concatenations of filler truncated to length fillLen.
@@ -1560,8 +1560,8 @@ impl String {
             }
         };
 
-        let truncated_string_filler = filler.to_vec().repeat(repetitions as usize);
-        let truncated_string_filler = JsString::from(&truncated_string_filler[..fill_len as usize]);
+        let truncated_string_filler = filler.to_vec().repeat(repetitions);
+        let truncated_string_filler = JsString::from(&truncated_string_filler[..fill_len]);
 
         // 10. If placement is start, return the string-concatenation of truncatedStringFiller and S.
         if placement == Placement::Start {

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -303,7 +303,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-typedarray-create-same-type
     fn from_kind_and_length(
         kind: TypedArrayKind,
-        length: u64,
+        length: usize,
         context: &mut Context,
     ) -> JsResult<JsObject> {
         let constructor =
@@ -557,16 +557,16 @@ impl BuiltinTypedArray {
             let byte_offset = ta.byte_offset();
 
             // h. Let bufferByteLimit be (len × elementSize) + byteOffset.
-            let buffer_byte_limit = ((len * element_size) + byte_offset) as usize;
+            let buffer_byte_limit = (len * element_size) + byte_offset;
 
             // i. Let toByteIndex be (targetIndex × elementSize) + byteOffset.
-            let to_byte_index = (to * element_size + byte_offset) as usize;
+            let to_byte_index = to * element_size + byte_offset;
 
             // j. Let fromByteIndex be (startIndex × elementSize) + byteOffset.
-            let from_byte_index = (from * element_size + byte_offset) as usize;
+            let from_byte_index = from * element_size + byte_offset;
 
             // k. Let countBytes be count × elementSize.
-            let mut count_bytes = (count * element_size) as usize;
+            let mut count_bytes = count * element_size;
 
             // Readjust considering the buffer_byte_limit. A resize could
             // have readjusted the buffer size, which could put `count_bytes`
@@ -1076,13 +1076,15 @@ impl BuiltinTypedArray {
             IntegerOrInfinity::PositiveInfinity => return Ok(false.into()),
             // 8. Else if n is -∞, set n to 0.
             IntegerOrInfinity::NegativeInfinity => 0,
-            IntegerOrInfinity::Integer(i) => i,
+            IntegerOrInfinity::Integer(i) if i >= isize::MAX as i64 => isize::MAX,
+            IntegerOrInfinity::Integer(i) if i < isize::MIN as i64 => isize::MIN,
+            IntegerOrInfinity::Integer(i) => i as isize,
         };
 
         // 9. If n ≥ 0, then
         let k = if n >= 0 {
             // a. Let k be n.
-            n as u64
+            n as usize
         } else {
             // 10. Else,
             // a. Let k be len + n.
@@ -1140,13 +1142,15 @@ impl BuiltinTypedArray {
             IntegerOrInfinity::PositiveInfinity => return Ok((-1).into()),
             // 8. Else if n is -∞, set n to 0.
             IntegerOrInfinity::NegativeInfinity => 0,
-            IntegerOrInfinity::Integer(i) => i,
+            IntegerOrInfinity::Integer(i) if i >= isize::MAX as i64 => isize::MAX,
+            IntegerOrInfinity::Integer(i) if i < isize::MIN as i64 => isize::MIN,
+            IntegerOrInfinity::Integer(i) => i as isize,
         };
 
         // 9. If n ≥ 0, then
         let k = if n >= 0 {
             // a. Let k be n.
-            n as u64
+            n as usize
         // 10. Else,
         } else {
             // a. Let k be len + n.
@@ -1280,11 +1284,18 @@ impl BuiltinTypedArray {
                     IntegerOrInfinity::NegativeInfinity => return Ok((-1).into()),
                     // 7. If n ≥ 0, then
                     // a. Let k be min(n, len - 1).
-                    IntegerOrInfinity::Integer(i) if i >= 0 => min(i as u64 + 1, len),
+                    IntegerOrInfinity::Integer(i) if i >= 0 => {
+                        if i < usize::MAX as i64 {
+                            min(i as usize + 1, len)
+                        } else {
+                            len
+                        }
+                    }
                     IntegerOrInfinity::PositiveInfinity => len,
                     // 8. Else,
                     // a. Let k be len + n.
-                    IntegerOrInfinity::Integer(i) => len.saturating_add_signed(i + 1),
+                    IntegerOrInfinity::Integer(i) if i < isize::MIN as i64 => 0,
+                    IntegerOrInfinity::Integer(i) => len.saturating_add_signed(i as isize + 1),
                 }
             }
         };
@@ -1679,8 +1690,8 @@ impl BuiltinTypedArray {
                     .with_message("TypedArray.set called with negative offset")
                     .into())
             }
-            IntegerOrInfinity::PositiveInfinity => U64OrPositiveInfinity::PositiveInfinity,
-            IntegerOrInfinity::Integer(i) => U64OrPositiveInfinity::U64(i as u64),
+            IntegerOrInfinity::PositiveInfinity => UsizeOrPositiveInfinity::PositiveInfinity,
+            IntegerOrInfinity::Integer(i) => UsizeOrPositiveInfinity::Usize(i as usize),
         };
 
         // 6. If source is an Object that has a [[TypedArrayName]] internal slot, then
@@ -1710,7 +1721,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromtypedarray
     fn set_typed_array_from_typed_array(
         target: &JsObject<TypedArray>,
-        target_offset: &U64OrPositiveInfinity,
+        target_offset: &UsizeOrPositiveInfinity,
         source: &JsObject<TypedArray>,
         context: &mut Context,
     ) -> JsResult<()> {
@@ -1777,7 +1788,7 @@ impl BuiltinTypedArray {
         drop(src_array);
 
         // 15. If targetOffset = +∞, throw a RangeError exception.
-        let U64OrPositiveInfinity::U64(target_offset) = target_offset else {
+        let UsizeOrPositiveInfinity::Usize(target_offset) = target_offset else {
             return Err(JsNativeError::range()
                 .with_message("Target offset cannot be Infinity")
                 .into());
@@ -1805,8 +1816,8 @@ impl BuiltinTypedArray {
         // 19. If SameValue(srcBuffer, targetBuffer) is true or sameSharedArrayBuffer is true, then
         let src_byte_index = if BufferObject::equals(&src_buf_obj, &target_buf_obj) {
             // a. Let srcByteLength be source.[[ByteLength]].
-            let src_byte_offset = src_byte_offset as usize;
-            let src_byte_length = src_byte_length as usize;
+            let src_byte_offset = src_byte_offset;
+            let src_byte_length = src_byte_length;
 
             let s = {
                 let slice = src_buf_obj.as_buffer();
@@ -1848,9 +1859,9 @@ impl BuiltinTypedArray {
 
         // 24. If srcType is the same as targetType, then
         if src_type == target_type {
-            let src_byte_index = src_byte_index as usize;
-            let target_byte_index = target_byte_index as usize;
-            let byte_count = (target_element_size * src_length) as usize;
+            let src_byte_index = src_byte_index;
+            let target_byte_index = target_byte_index;
+            let byte_count = target_element_size * src_length;
 
             // a. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
             // b. Repeat, while targetByteIndex < limit,
@@ -1875,10 +1886,10 @@ impl BuiltinTypedArray {
         // 25. Else,
         else {
             // 23. Let limit be targetByteIndex + targetElementSize × srcLength.
-            let limit = (target_byte_index + target_element_size * src_length) as usize;
+            let limit = target_byte_index + target_element_size * src_length;
 
-            let mut src_byte_index = src_byte_index as usize;
-            let mut target_byte_index = target_byte_index as usize;
+            let mut src_byte_index = src_byte_index;
+            let mut target_byte_index = target_byte_index;
 
             // a. Repeat, while targetByteIndex < limit,
             while target_byte_index < limit {
@@ -1905,10 +1916,10 @@ impl BuiltinTypedArray {
                 }
 
                 // iii. Set srcByteIndex to srcByteIndex + srcElementSize.
-                src_byte_index += src_element_size as usize;
+                src_byte_index += src_element_size;
 
                 // iv. Set targetByteIndex to targetByteIndex + targetElementSize.
-                target_byte_index += target_element_size as usize;
+                target_byte_index += target_element_size;
             }
         }
 
@@ -1923,7 +1934,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-settypedarrayfromarraylike
     fn set_typed_array_from_array_like(
         target: &JsObject<TypedArray>,
-        target_offset: &U64OrPositiveInfinity,
+        target_offset: &UsizeOrPositiveInfinity,
         source: &JsValue,
         context: &mut Context,
     ) -> JsResult<()> {
@@ -1958,8 +1969,8 @@ impl BuiltinTypedArray {
 
         // 6. If targetOffset = +∞, throw a RangeError exception.
         let target_offset = match target_offset {
-            U64OrPositiveInfinity::U64(target_offset) => target_offset,
-            U64OrPositiveInfinity::PositiveInfinity => {
+            UsizeOrPositiveInfinity::Usize(target_offset) => target_offset,
+            UsizeOrPositiveInfinity::PositiveInfinity => {
                 return Err(JsNativeError::range()
                     .with_message("Target offset cannot be positive infinity")
                     .into())
@@ -2063,7 +2074,7 @@ impl BuiltinTypedArray {
         let end_index = min(end_index, src_borrow.data.array_length(src_buf.len()));
 
         // d. Set countBytes to max(endIndex - startIndex, 0).
-        let count = end_index.saturating_sub(start_index) as usize;
+        let count = end_index.saturating_sub(start_index);
 
         // f. Let targetType be TypedArrayElementType(A).
         let target_type = target_borrow.data.kind();
@@ -2071,7 +2082,7 @@ impl BuiltinTypedArray {
         // g. If srcType is targetType, then
         if src_type == target_type {
             {
-                let byte_count = count * src_type.element_size() as usize;
+                let byte_count = count * src_type.element_size();
 
                 // i. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
                 // ii. Let srcBuffer be O.[[ViewedArrayBuffer]].
@@ -2089,10 +2100,10 @@ impl BuiltinTypedArray {
                 let src_byte_offset = src_borrow.data.byte_offset();
 
                 // vi. Let srcByteIndex be (startIndex × elementSize) + srcByteOffset.
-                let src_byte_index = (start_index * element_size + src_byte_offset) as usize;
+                let src_byte_index = start_index * element_size + src_byte_offset;
 
                 // vii. Let targetByteIndex be A.[[ByteOffset]].
-                let target_byte_index = target_borrow.data.byte_offset() as usize;
+                let target_byte_index = target_borrow.data.byte_offset();
 
                 // viii. Let endByteIndex be targetByteIndex + (countBytes × elementSize).
                 // Not needed by the impl.
@@ -2555,9 +2566,9 @@ impl BuiltinTypedArray {
                 .with_message("invalid integer index for TypedArray operation")
                 .into());
         };
-        let actual_index = u64::try_from(relative_index) // should succeed if `relative_index >= 0`
+        let actual_index = usize::try_from(relative_index) // should succeed if `relative_index >= 0`
             .ok()
-            .or_else(|| len.checked_add_signed(relative_index))
+            .or_else(|| len.checked_add_signed(relative_index as isize))
             // TODO: Replace with `is_valid_integer_index_u64` or equivalent.
             .filter(|&rel| is_valid_integer_index(&ta.clone().upcast(), rel as f64))
             .ok_or_else(|| {
@@ -2696,7 +2707,7 @@ impl BuiltinTypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-allocatetypedarraybuffer
     fn allocate_buffer<T: TypedArrayMarker>(
-        length: u64,
+        length: usize,
         context: &mut Context,
     ) -> JsResult<TypedArray> {
         // 1. Assert: O.[[ViewedArrayBuffer]] is undefined.
@@ -2706,7 +2717,7 @@ impl BuiltinTypedArray {
         let element_size = T::ERASED.element_size();
 
         // 4. Let byteLength be elementSize × length.
-        let byte_length = element_size * length;
+        let byte_length = length.saturating_mul(element_size);
 
         // 5. Let data be ? AllocateArrayBuffer(%ArrayBuffer%, byteLength).
         let data = ArrayBuffer::allocate(
@@ -2742,7 +2753,7 @@ impl BuiltinTypedArray {
         context: &mut Context,
     ) -> JsResult<JsObject> {
         // 1. Let len be the number of elements in values.
-        let len = values.len() as u64;
+        let len = values.len();
         // 2. Perform ? AllocateTypedArrayBuffer(O, len).
         let buf = Self::allocate_buffer::<T>(len, context)?;
         let obj = JsObject::from_proto_and_data_with_shared_shape(context.root_shape(), proto, buf);
@@ -2774,7 +2785,7 @@ impl BuiltinTypedArray {
     /// [spec]: https://tc39.es/ecma262/#sec-allocatetypedarray
     pub(super) fn allocate<T: TypedArrayMarker>(
         new_target: &JsValue,
-        length: u64,
+        length: usize,
         context: &mut Context,
     ) -> JsResult<JsObject> {
         // 1. Let proto be ? GetPrototypeFromConstructor(newTarget, defaultProto).
@@ -2850,8 +2861,8 @@ impl BuiltinTypedArray {
         // 11. If elementType is srcType, then
 
         let new_buffer = if element_type == src_type {
-            let start = src_byte_offset as usize;
-            let count = byte_length as usize;
+            let start = src_byte_offset;
+            let count = byte_length;
             // a. Let data be ? CloneArrayBuffer(srcData, srcByteOffset, byteLength).
             src_data.subslice(start..start + count).clone(context)?
         } else {
@@ -2884,11 +2895,11 @@ impl BuiltinTypedArray {
                         .into());
                 }
 
-                let src_element_size = src_element_size as usize;
-                let target_element_size = element_size as usize;
+                let src_element_size = src_element_size;
+                let target_element_size = element_size;
 
                 // c. Let srcByteIndex be srcByteOffset.
-                let mut src_byte_index = src_byte_offset as usize;
+                let mut src_byte_index = src_byte_offset;
 
                 // d. Let targetByteIndex be 0.
                 let mut target_byte_index = 0;
@@ -3001,7 +3012,7 @@ impl BuiltinTypedArray {
             };
 
             // 7. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
-            data.len() as u64
+            data.len()
         };
 
         let (byte_length, array_length) = if let Some(new_length) = new_length {
@@ -3100,8 +3111,8 @@ impl BuiltinTypedArray {
 }
 
 #[derive(Debug)]
-enum U64OrPositiveInfinity {
-    U64(u64),
+enum UsizeOrPositiveInfinity {
+    Usize(usize),
     PositiveInfinity,
 }
 

--- a/core/engine/src/builtins/typed_array/mod.rs
+++ b/core/engine/src/builtins/typed_array/mod.rs
@@ -433,17 +433,17 @@ impl TypedArrayKind {
     }
 
     /// Gets the size of the type of element of this `TypedArrayKind`.
-    pub(crate) const fn element_size(self) -> u64 {
+    pub(crate) const fn element_size(self) -> usize {
         match self {
             TypedArrayKind::Int8 | TypedArrayKind::Uint8 | TypedArrayKind::Uint8Clamped => {
-                size_of::<u8>() as u64
+                size_of::<u8>()
             }
-            TypedArrayKind::Int16 | TypedArrayKind::Uint16 => size_of::<u16>() as u64,
+            TypedArrayKind::Int16 | TypedArrayKind::Uint16 => size_of::<u16>(),
             TypedArrayKind::Int32 | TypedArrayKind::Uint32 | TypedArrayKind::Float32 => {
-                size_of::<u32>() as u64
+                size_of::<u32>()
             }
             TypedArrayKind::BigInt64 | TypedArrayKind::BigUint64 | TypedArrayKind::Float64 => {
-                size_of::<u64>() as u64
+                size_of::<u64>()
             }
         }
     }

--- a/core/engine/src/builtins/typed_array/object.rs
+++ b/core/engine/src/builtins/typed_array/object.rs
@@ -31,9 +31,9 @@ use super::{is_valid_integer_index, TypedArrayKind};
 pub struct TypedArray {
     viewed_array_buffer: BufferObject,
     kind: TypedArrayKind,
-    byte_offset: u64,
-    byte_length: Option<u64>,
-    array_length: Option<u64>,
+    byte_offset: usize,
+    byte_length: Option<usize>,
+    array_length: Option<usize>,
 }
 
 impl JsData for TypedArray {
@@ -58,9 +58,9 @@ impl TypedArray {
     pub(crate) const fn new(
         viewed_array_buffer: BufferObject,
         kind: TypedArrayKind,
-        byte_offset: u64,
-        byte_length: Option<u64>,
-        array_length: Option<u64>,
+        byte_offset: usize,
+        byte_length: Option<usize>,
+        array_length: Option<usize>,
     ) -> Self {
         Self {
             viewed_array_buffer,
@@ -80,9 +80,6 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/sec-istypedarrayoutofbounds
     pub(crate) fn is_out_of_bounds(&self, buf_byte_len: usize) -> bool {
-        // Checks when allocating the buffer ensure the length fits inside an `u64`.
-        let buf_byte_len = buf_byte_len as u64;
-
         // 1. Let O be taRecord.[[Object]].
         // 2. Let bufferByteLength be taRecord.[[CachedBufferByteLength]].
         // 3. Assert: IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true if and only if bufferByteLength is detached.
@@ -111,7 +108,7 @@ impl TypedArray {
 
     /// Get the `TypedArray` object's byte offset.
     #[must_use]
-    pub const fn byte_offset(&self) -> u64 {
+    pub const fn byte_offset(&self) -> usize {
         self.byte_offset
     }
 
@@ -132,7 +129,7 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarraybytelength
     #[must_use]
-    pub fn byte_length(&self, buf_byte_len: usize) -> u64 {
+    pub fn byte_length(&self, buf_byte_len: usize) -> usize {
         // 1. If IsTypedArrayOutOfBounds(taRecord) is true, return 0.
         if self.is_out_of_bounds(buf_byte_len) {
             return 0;
@@ -166,10 +163,9 @@ impl TypedArray {
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-typedarraylength
     #[must_use]
-    pub fn array_length(&self, buf_byte_len: usize) -> u64 {
+    pub fn array_length(&self, buf_byte_len: usize) -> usize {
         // 1. Assert: IsTypedArrayOutOfBounds(taRecord) is false.
         debug_assert!(!self.is_out_of_bounds(buf_byte_len));
-        let buf_byte_len = buf_byte_len as u64;
 
         // 2. Let O be taRecord.[[Object]].
 
@@ -227,7 +223,7 @@ impl TypedArray {
     ///
     /// Note: if this is only used for bounds checking, it is recommended to use
     /// the `Ordering::Relaxed` ordering to get the buffer slice.
-    pub(crate) fn validate_index(&self, index: f64, buf_len: usize) -> Option<u64> {
+    pub(crate) fn validate_index(&self, index: f64, buf_len: usize) -> Option<usize> {
         // 2. If IsIntegralNumber(index) is false, return false.
         if index.is_nan() || index.is_infinite() || index.fract() != 0.0 {
             return None;
@@ -252,7 +248,7 @@ impl TypedArray {
         }
 
         // 9. Return true.
-        Some(index as u64)
+        Some(index as usize)
     }
 }
 
@@ -627,7 +623,7 @@ fn typed_array_get_element(obj: &JsObject, index: f64) -> Option<JsValue> {
     let size = inner.kind.element_size();
 
     // 4. Let byteIndexInBuffer be (ℝ(index) × elementSize) + offset.
-    let byte_index = ((index * size) + offset) as usize;
+    let byte_index = (index * size) + offset;
 
     // 5. Let elementType be TypedArrayElementType(O).
     let elem_type = inner.kind();
@@ -686,7 +682,7 @@ pub(crate) fn typed_array_set_element(
     let size = elem_type.element_size();
 
     //     c. Let byteIndexInBuffer be (ℝ(index) × elementSize) + offset.
-    let byte_index = ((index * size) + offset) as usize;
+    let byte_index = (index * size) + offset;
 
     //     e. Perform SetValueInBuffer(O.[[ViewedArrayBuffer]], byteIndexInBuffer, elementType, numValue, true, unordered).
     // SAFETY: The TypedArray object guarantees that the buffer is aligned.

--- a/core/engine/src/context/hooks.rs
+++ b/core/engine/src/context/hooks.rs
@@ -209,7 +209,7 @@ pub trait HostHooks {
     ///
     ///
     /// [specification]: https://tc39.es/ecma262/#sec-resizable-arraybuffer-guidelines
-    fn max_buffer_size(&self, _context: &mut Context) -> u64 {
+    fn max_buffer_size(&self, _context: &mut Context) -> usize {
         1_610_612_736 // 1.5 GiB
     }
 }

--- a/core/engine/src/error.rs
+++ b/core/engine/src/error.rs
@@ -239,7 +239,7 @@ pub enum TryNativeError {
     #[error("could not get element `{index}` of property `errors`")]
     InvalidErrorsIndex {
         /// The index of the error that could not be accessed.
-        index: u64,
+        index: usize,
 
         /// The source error.
         source: JsError,

--- a/core/engine/src/object/builtins/jsarray.rs
+++ b/core/engine/src/object/builtins/jsarray.rs
@@ -53,7 +53,7 @@ impl JsArray {
     ///
     /// Same as `array.length` in JavaScript.
     #[inline]
-    pub fn length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn length(&self, context: &mut Context) -> JsResult<usize> {
         self.inner.length_of_array_like(context)
     }
 
@@ -402,7 +402,7 @@ impl JsArray {
 
     /// Calls `Array.prototype.with`.
     #[inline]
-    pub fn with(&self, index: u64, value: JsValue, context: &mut Context) -> JsResult<Self> {
+    pub fn with(&self, index: usize, value: JsValue, context: &mut Context) -> JsResult<Self> {
         let array = Array::with(&self.inner.clone().into(), &[index.into(), value], context)?;
 
         Ok(Self {

--- a/core/engine/src/object/builtins/jsarraybuffer.rs
+++ b/core/engine/src/object/builtins/jsarraybuffer.rs
@@ -60,7 +60,7 @@ impl JsArrayBuffer {
                 .array_buffer()
                 .constructor()
                 .into(),
-            byte_length as u64,
+            byte_length,
             None,
             context,
         )?;

--- a/core/engine/src/object/builtins/jsdataview.rs
+++ b/core/engine/src/object/builtins/jsdataview.rs
@@ -52,8 +52,8 @@ impl JsDataView {
     /// Create a new `JsDataView` object from an existing `JsArrayBuffer`.
     pub fn from_js_array_buffer(
         buffer: JsArrayBuffer,
-        offset: Option<u64>,
-        byte_len: Option<u64>,
+        offset: Option<usize>,
+        byte_len: Option<usize>,
         context: &mut Context,
     ) -> JsResult<Self> {
         let offset = offset.unwrap_or_default();
@@ -70,7 +70,7 @@ impl JsDataView {
             };
 
             // 5. Let bufferByteLength be ArrayBufferByteLength(buffer, seq-cst).
-            let buf_len = slice.len() as u64;
+            let buf_len = slice.len();
 
             // 6. If offset > bufferByteLength, throw a RangeError exception.
             if offset > buf_len {
@@ -109,7 +109,7 @@ impl JsDataView {
 
         // 11. If IsDetachedBuffer(buffer) is true, throw a TypeError exception.
         // 12. Set bufferByteLength to ArrayBufferByteLength(buffer, seq-cst).
-        let Some(buf_byte_len) = buffer.borrow().data.bytes().map(|s| s.len() as u64) else {
+        let Some(buf_byte_len) = buffer.borrow().data.bytes().map(|s| s.len()) else {
             return Err(JsNativeError::typ()
                 .with_message("ArrayBuffer is detached")
                 .into());
@@ -168,18 +168,18 @@ impl JsDataView {
         DataView::get_buffer(&self.inner.clone().upcast().into(), &[], context)
     }
 
-    /// Returns the `byte_length` property of [`JsDataView`] as a u64 integer
+    /// Returns the `byte_length` property of [`JsDataView`] as a usize integer
     #[inline]
-    pub fn byte_length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn byte_length(&self, context: &mut Context) -> JsResult<usize> {
         DataView::get_byte_length(&self.inner.clone().upcast().into(), &[], context)
-            .map(|v| v.as_number().expect("value should be a number") as u64)
+            .map(|v| v.as_number().expect("value should be a number") as usize)
     }
 
-    /// Returns the `byte_offset` field property of [`JsDataView`] as a u64 integer
+    /// Returns the `byte_offset` field property of [`JsDataView`] as a usize integer
     #[inline]
-    pub fn byte_offset(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn byte_offset(&self, context: &mut Context) -> JsResult<usize> {
         DataView::get_byte_offset(&self.inner.clone().upcast().into(), &[], context)
-            .map(|v| v.as_number().expect("byte_offset value must be a number") as u64)
+            .map(|v| v.as_number().expect("byte_offset value must be a number") as usize)
     }
 
     /// Returns a signed 64-bit integer at the specified offset from the start of the [`JsDataView`]

--- a/core/engine/src/object/builtins/jssharedarraybuffer.rs
+++ b/core/engine/src/object/builtins/jssharedarraybuffer.rs
@@ -38,7 +38,7 @@ impl JsSharedArrayBuffer {
                 .shared_array_buffer()
                 .constructor()
                 .into(),
-            byte_length as u64,
+            byte_length,
             None,
             context,
         )?;

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -603,7 +603,7 @@ impl JsObject {
     /// Returns the value of the "length" property of an array-like object.
     ///
     /// [spec]: https://tc39.es/ecma262/#sec-lengthofarraylike
-    pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<u64> {
+    pub(crate) fn length_of_array_like(&self, context: &mut Context) -> JsResult<usize> {
         // 1. Assert: Type(obj) is Object.
 
         // NOTE: This is an optimization, most of the cases that `LengthOfArrayLike` will be called
@@ -614,7 +614,7 @@ impl JsObject {
             //       since arrays are limited to [0, 2^32 - 1] range.
             return borrowed_object.properties().storage[0]
                 .to_u32(context)
-                .map(u64::from);
+                .map(|l| l as usize);
         }
 
         // 2. Return ℝ(? ToLength(? Get(obj, "length"))).
@@ -1267,7 +1267,7 @@ impl JsValue {
         let len = obj.length_of_array_like(context)?;
 
         // 4. Let list be a new empty List.
-        let mut list = Vec::with_capacity(len as usize);
+        let mut list = Vec::with_capacity(len);
 
         // 5. Let index be 0.
         // 6. Repeat, while index < len,

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -134,7 +134,7 @@ impl JsValue {
 
                 if obj.is_array() {
                     let len = obj.length_of_array_like(context)?;
-                    let mut arr = Vec::with_capacity(len as usize);
+                    let mut arr = Vec::with_capacity(len);
 
                     for k in 0..len as u32 {
                         let val = value_by_prop_key(k.into(), context)?;

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -865,7 +865,7 @@ impl JsValue {
     /// Converts a value to a non-negative integer if it is a valid integer index value.
     ///
     /// See: <https://tc39.es/ecma262/#sec-toindex>
-    pub fn to_index(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn to_index(&self, context: &mut Context) -> JsResult<usize> {
         // 1. If value is undefined, then
         if self.is_undefined() {
             // a. Return 0.
@@ -890,19 +890,19 @@ impl JsValue {
         debug_assert!(0 <= clamped && clamped <= Number::MAX_SAFE_INTEGER as i64);
 
         // e. Return integer.
-        Ok(clamped as u64)
+        Ok(clamped as usize)
     }
 
     /// Converts argument to an integer suitable for use as the length of an array-like object.
     ///
     /// See: <https://tc39.es/ecma262/#sec-tolength>
-    pub fn to_length(&self, context: &mut Context) -> JsResult<u64> {
+    pub fn to_length(&self, context: &mut Context) -> JsResult<usize> {
         // 1. Let len be ? ToInteger(argument).
         // 2. If len ≤ +0, return +0.
         // 3. Return min(len, 2^53 - 1).
         Ok(self
             .to_integer_or_infinity(context)?
-            .clamp_finite(0, Number::MAX_SAFE_INTEGER as i64) as u64)
+            .clamp_finite(0, Number::MAX_SAFE_INTEGER as i64) as usize)
     }
 
     /// Abstract operation `ToIntegerOrInfinity ( argument )`

--- a/core/engine/src/value/tests.rs
+++ b/core/engine/src/value/tests.rs
@@ -553,7 +553,7 @@ fn to_length() {
         assert_eq!(JsValue::new(f64::NEG_INFINITY).to_length(ctx).unwrap(), 0);
         assert_eq!(
             JsValue::new(f64::INFINITY).to_length(ctx).unwrap(),
-            Number::MAX_SAFE_INTEGER as u64
+            Number::MAX_SAFE_INTEGER as usize
         );
         assert_eq!(JsValue::new(0.0).to_length(ctx).unwrap(), 0);
         assert_eq!(JsValue::new(-0.0).to_length(ctx).unwrap(), 0);

--- a/core/engine/src/vm/opcode/templates/mod.rs
+++ b/core/engine/src/vm/opcode/templates/mod.rs
@@ -43,9 +43,9 @@ impl TemplateCreate {
     #[allow(clippy::unnecessary_wraps)]
     fn operation(context: &mut Context, count: u32, site: u64) -> JsResult<CompletionType> {
         let template =
-            Array::array_create(count.into(), None, context).expect("cannot fail per spec");
+            Array::array_create(count as usize, None, context).expect("cannot fail per spec");
         let raw_obj =
-            Array::array_create(count.into(), None, context).expect("cannot fail per spec");
+            Array::array_create(count as usize, None, context).expect("cannot fail per spec");
 
         for index in (0..count).rev() {
             let raw_value = context.vm.pop();

--- a/examples/src/bin/jsarraybuffer.rs
+++ b/examples/src/bin/jsarraybuffer.rs
@@ -41,7 +41,7 @@ fn main() -> JsResult<()> {
 
     // We can create a Dataview from a JsArrayBuffer
     let dataview =
-        JsDataView::from_js_array_buffer(array_buffer.clone(), None, Some(100_u64), context)?;
+        JsDataView::from_js_array_buffer(array_buffer.clone(), None, Some(100), context)?;
 
     let dataview_length = dataview.byte_length(context)?;
 


### PR DESCRIPTION
On platforms that are 32-bits (or 128?) this should make array and iterations faster in general. On platforms that are 64-bits, this will have no effect.
