### PR TITLE
Some string cleanups

### DIFF
--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -9,7 +9,7 @@ use std::{
     marker::PhantomData,
     mem::ManuallyDrop,
     ops::{Add, AddAssign},
-    ptr::{self, addr_of_mut, NonNull},
+    ptr::{self, NonNull},
     str::{self},
 };
 
@@ -143,7 +143,7 @@ impl<D: Copy> JsStringBuilder<D> {
     unsafe fn data(&self) -> *mut D {
         // SAFETY:
         // Caller should ensure that the inner is allocated.
-        unsafe { addr_of_mut!((*self.inner.as_ptr()).data).cast() }
+        unsafe { (&raw mut (*self.inner.as_ptr()).data).cast() }
     }
 
     /// Allocates when there is not sufficient capacity.

--- a/core/string/src/builder.rs
+++ b/core/string/src/builder.rs
@@ -60,7 +60,7 @@ impl<D: Copy> JsStringBuilder<D> {
     /// - The elements at `old_len..new_len` must be initialized.
     ///
     #[inline]
-    pub unsafe fn set_len(&mut self, new_len: usize) {
+    pub const unsafe fn set_len(&mut self, new_len: usize) {
         debug_assert!(new_len <= self.capacity());
 
         self.len = new_len;
@@ -140,7 +140,7 @@ impl<D: Copy> JsStringBuilder<D> {
     ///
     /// Caller should ensure that the inner is allocated.
     #[must_use]
-    unsafe fn data(&self) -> *mut D {
+    const unsafe fn data(&self) -> *mut D {
         // SAFETY:
         // Caller should ensure that the inner is allocated.
         unsafe { (&raw mut (*self.inner.as_ptr()).data).cast() }
@@ -205,7 +205,7 @@ impl<D: Copy> JsStringBuilder<D> {
     ///
     /// Caller should ensure the capacity is large enough to hold elements.
     #[inline]
-    pub unsafe fn extend_from_slice_unchecked(&mut self, v: &[D]) {
+    pub const unsafe fn extend_from_slice_unchecked(&mut self, v: &[D]) {
         // SAFETY: Caller should ensure the capacity is large enough to hold elements.
         unsafe {
             ptr::copy_nonoverlapping(v.as_ptr(), self.data().add(self.len()), v.len());
@@ -294,7 +294,7 @@ impl<D: Copy> JsStringBuilder<D> {
     ///
     /// Caller should ensure the capacity is large enough to hold elements.
     #[inline]
-    pub unsafe fn push_unchecked(&mut self, v: D) {
+    pub const unsafe fn push_unchecked(&mut self, v: D) {
         // SAFETY: Caller should ensure the capacity is large enough to hold elements.
         unsafe {
             self.data().add(self.len()).write(v);

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -321,6 +321,7 @@ impl JsString {
     /// Obtains the underlying [`&[u16]`][slice] slice of a [`JsString`]
     #[inline]
     #[must_use]
+    #[allow(clippy::cast_ptr_alignment)]
     pub fn as_str(&self) -> JsStr<'_> {
         match self.ptr.unwrap() {
             UnwrappedTagged::Ptr(h) => {

--- a/core/string/src/lib.rs
+++ b/core/string/src/lib.rs
@@ -45,7 +45,7 @@ use std::{
     iter::Peekable,
     mem::ManuallyDrop,
     process::abort,
-    ptr::{self, addr_of, addr_of_mut, NonNull},
+    ptr::{self, NonNull},
     str::FromStr,
 };
 
@@ -347,9 +347,9 @@ impl JsString {
                     let ptr = if (*h).refcount.read_only == 0 {
                         let h = h.cast::<StaticJsString>();
                         (*h).ptr
-                        } else {
+                    } else {
                         (&raw const (*h).data).cast::<u8>()
-                        };
+                    };
 
                     if is_latin1 {
                         JsStr::latin1(std::slice::from_raw_parts(ptr, len))
@@ -394,7 +394,7 @@ impl JsString {
 
         let string = {
             // SAFETY: `allocate_inner` guarantees that `ptr` is a valid pointer.
-            let mut data = unsafe { addr_of_mut!((*ptr.as_ptr()).data).cast::<u8>() };
+            let mut data = unsafe { (&raw mut (*ptr.as_ptr()).data).cast::<u8>() };
             for &string in strings {
                 // SAFETY:
                 // The sum of all `count` for each `string` equals `full_count`, and since we're
@@ -801,7 +801,7 @@ impl JsString {
         let ptr = Self::allocate_inner(count, string.is_latin1());
 
         // SAFETY: `allocate_inner` guarantees that `ptr` is a valid pointer.
-        let data = unsafe { addr_of_mut!((*ptr.as_ptr()).data).cast::<u8>() };
+        let data = unsafe { (&raw mut (*ptr.as_ptr()).data).cast::<u8>() };
 
         // SAFETY:
         // - We read `count = data.len()` elements from `data`, which is within the bounds of the slice.


### PR DESCRIPTION
- Simplify `JsString::as_str` (miri passed,  decrease the size of `cli` executable by ~5kb under release mode (28,680kb => 28,675kb) )
- Replace soft deprecated `addr_of*` macro with `& [const|mut] raw`
- Mark some `&mut self` tagged methods const