### PR TITLE
Allow local parameters if mapped arguments object is not used

### DIFF
--- a/core/ast/src/position.rs
+++ b/core/ast/src/position.rs
@@ -176,7 +176,7 @@ impl fmt::Display for Span {
 /// Note that linear spans are of the form [start, end) i.e. that the
 /// start position is inclusive and the end position is exclusive.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LinearSpan {
     start: LinearPosition,
     end: LinearPosition,

--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -584,6 +584,7 @@ pub struct FunctionScopes {
     pub(crate) parameters_eval_scope: Option<Scope>,
     pub(crate) parameters_scope: Option<Scope>,
     pub(crate) lexical_scope: Option<Scope>,
+    pub(crate) mapped_arguments_object: bool,
 }
 
 impl FunctionScopes {
@@ -701,6 +702,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FunctionScopes {
             parameters_eval_scope: None,
             parameters_scope: None,
             lexical_scope: None,
+            mapped_arguments_object: false,
         })
     }
 }

--- a/core/ast/tests/scope.rs
+++ b/core/ast/tests/scope.rs
@@ -1,0 +1,239 @@
+//! Tests for the scope analysis of the AST.
+
+#![allow(unused_crate_dependencies)]
+
+use boa_ast::{
+    declaration::{LexicalDeclaration, Variable},
+    expression::Identifier,
+    function::{FormalParameter, FormalParameterList, FunctionBody, FunctionDeclaration},
+    scope::Scope,
+    statement::Block,
+    Declaration, Expression, Script, Statement, StatementList, StatementListItem,
+};
+use boa_interner::Interner;
+use boa_string::JsString;
+
+#[test]
+fn empty_script_is_ok() {
+    let scope = &Scope::new_global();
+    let mut script = Script::default();
+    let ok = script.analyze_scope(scope, &Interner::new());
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+}
+
+#[test]
+fn script_global_let() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::Lexical(LexicalDeclaration::Let(
+            vec![Variable::from_identifier(a.into(), None)]
+                .try_into()
+                .unwrap(),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+}
+
+#[test]
+fn script_global_const() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::Lexical(LexicalDeclaration::Const(
+            vec![Variable::from_identifier(a.into(), None)]
+                .try_into()
+                .unwrap(),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+}
+
+#[test]
+fn script_block_let() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Statement::Block(Block::from(vec![Declaration::Lexical(
+            LexicalDeclaration::Let(
+                vec![Variable::from_identifier(a.into(), None)]
+                    .try_into()
+                    .unwrap(),
+            ),
+        )
+        .into()]))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Statement(Statement::Block(block)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    let scope = block.scope().unwrap();
+    assert_eq!(scope.num_bindings(), 1);
+    let a = scope.get_binding_reference(&JsString::from("a")).unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}
+
+#[test]
+fn script_function_mapped_arguments_not_accessed() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let f = interner.get_or_intern("f");
+    let a = interner.get_or_intern("a");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::FunctionDeclaration(FunctionDeclaration::new(
+            f.into(),
+            FormalParameterList::from_parameters(vec![FormalParameter::new(
+                Variable::from_identifier(a.into(), None),
+                false,
+            )]),
+            FunctionBody::new(
+                [Declaration::Lexical(LexicalDeclaration::Let(
+                    vec![Variable::from_identifier(a.into(), None)]
+                        .try_into()
+                        .unwrap(),
+                ))
+                .into()],
+                false,
+            ),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Declaration(Declaration::FunctionDeclaration(f)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    assert_eq!(f.scopes().function_scope().num_bindings(), 2);
+    assert_eq!(f.scopes().parameters_eval_scope(), None);
+    assert_eq!(f.scopes().parameters_scope(), None);
+    assert_eq!(f.scopes().lexical_scope().unwrap().num_bindings(), 1);
+    let arguments = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("arguments"))
+        .unwrap();
+    assert!(!f.scopes().arguments_object_accessed());
+    assert!(!arguments.is_global_object());
+    assert!(arguments.is_lexical());
+    assert!(arguments.local());
+    let a = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+    let a = f
+        .scopes()
+        .lexical_scope()
+        .unwrap()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}
+
+#[test]
+fn script_function_mapped_arguments_accessed() {
+    let scope = Scope::new_global();
+    let mut interner = Interner::new();
+    let f = interner.get_or_intern("f");
+    let a = interner.get_or_intern("a");
+    let arguments = interner.get_or_intern("arguments");
+    let mut script = Script::new(StatementList::new(
+        [Declaration::FunctionDeclaration(FunctionDeclaration::new(
+            f.into(),
+            FormalParameterList::from_parameters(vec![FormalParameter::new(
+                Variable::from_identifier(a.into(), None),
+                false,
+            )]),
+            FunctionBody::new(
+                [
+                    Declaration::Lexical(LexicalDeclaration::Let(
+                        vec![Variable::from_identifier(a.into(), None)]
+                            .try_into()
+                            .unwrap(),
+                    ))
+                    .into(),
+                    Statement::Expression(Expression::Identifier(Identifier::new(arguments)))
+                        .into(),
+                ],
+                false,
+            ),
+        ))
+        .into()],
+        false,
+    ));
+    let ok = script.analyze_scope(&scope, &interner);
+    assert!(ok);
+    assert_eq!(scope.num_bindings(), 0);
+    let StatementListItem::Declaration(Declaration::FunctionDeclaration(f)) =
+        script.statements().first().unwrap()
+    else {
+        panic!("Expected a block statement");
+    };
+    assert!(f.scopes().arguments_object_accessed());
+    assert_eq!(f.scopes().function_scope().num_bindings(), 2);
+    assert_eq!(f.scopes().parameters_eval_scope(), None);
+    assert_eq!(f.scopes().parameters_scope(), None);
+    assert_eq!(f.scopes().lexical_scope().unwrap().num_bindings(), 1);
+    let arguments = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("arguments"))
+        .unwrap();
+    assert!(!arguments.is_global_object());
+    assert!(arguments.is_lexical());
+    assert!(arguments.local());
+    let a = f
+        .scopes()
+        .function_scope()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(!a.local());
+    let a = f
+        .scopes()
+        .lexical_scope()
+        .unwrap()
+        .get_binding_reference(&JsString::from("a"))
+        .unwrap();
+    assert!(!a.is_global_object());
+    assert!(a.is_lexical());
+    assert!(a.local());
+}

--- a/core/ast/tests/scope.rs
+++ b/core/ast/tests/scope.rs
@@ -8,7 +8,8 @@ use boa_ast::{
     function::{FormalParameter, FormalParameterList, FunctionBody, FunctionDeclaration},
     scope::Scope,
     statement::Block,
-    Declaration, Expression, Script, Statement, StatementList, StatementListItem,
+    Declaration, Expression, LinearPosition, LinearSpan, Script, Statement, StatementList,
+    StatementListItem,
 };
 use boa_interner::Interner;
 use boa_string::JsString;
@@ -34,6 +35,7 @@ fn script_global_let() {
                 .unwrap(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -57,6 +59,7 @@ fn script_global_const() {
                 .unwrap(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -74,15 +77,17 @@ fn script_block_let() {
     let mut interner = Interner::new();
     let a = interner.get_or_intern("a");
     let mut script = Script::new(StatementList::new(
-        [Statement::Block(Block::from(vec![Declaration::Lexical(
-            LexicalDeclaration::Let(
+        [Statement::Block(Block::from((
+            vec![Declaration::Lexical(LexicalDeclaration::Let(
                 vec![Variable::from_identifier(a.into(), None)]
                     .try_into()
                     .unwrap(),
-            ),
-        )
-        .into()]))
+            ))
+            .into()],
+            LinearPosition::default(),
+        )))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -121,10 +126,13 @@ fn script_function_mapped_arguments_not_accessed() {
                         .unwrap(),
                 ))
                 .into()],
+                LinearPosition::default(),
                 false,
             ),
+            LinearSpan::default(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);
@@ -192,10 +200,13 @@ fn script_function_mapped_arguments_accessed() {
                     Statement::Expression(Expression::Identifier(Identifier::new(arguments)))
                         .into(),
                 ],
+                LinearPosition::default(),
                 false,
             ),
+            LinearSpan::default(),
         ))
         .into()],
+        LinearPosition::default(),
         false,
     ));
     let ok = script.analyze_scope(&scope, &interner);


### PR DESCRIPTION
This Pull Request changes the following:

- Allow local parmeters if mapped arguments object is not used
- Add tests for scopes in `boa_ast`
