### PR TITLE
fix very minor typo shift -> unshift

### DIFF
--- a/core/engine/src/object/builtins/jsarray.rs
+++ b/core/engine/src/object/builtins/jsarray.rs
@@ -100,7 +100,7 @@ impl JsArray {
     /// Calls `Array.prototype.unshift()`.
     #[inline]
     pub fn unshift(&self, items: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        Array::shift(&self.inner.clone().into(), items, context)
+        Array::unshift(&self.inner.clone().into(), items, context)
     }
 
     /// Calls `Array.prototype.reverse()`.


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes a very minor type in its rust jsArray api

It changes the following:

- just rename shift into unshift in jsarray::unshfit 
