### PR TITLE
Bump test262 commit and changes to `boa_tester` to support sm changes

### DIFF
--- a/test262_config.toml
+++ b/test262_config.toml
@@ -78,4 +78,4 @@ features = [
     "caller",
 ]
 
-tests = []
+tests = ["sm"]

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -1,4 +1,4 @@
-commit = "dad2774b2eab2119cc8390ae65db4a5016de2dfe"
+commit = "8296db887368bbffa3379f995a1e628ddbe8421f"
 
 [ignored]
 # Not implemented yet:
@@ -34,6 +34,9 @@ features = [
 
     # https://tc39.es/proposal-defer-import-eval
     "import-defer",
+
+    # https://github.com/tc39/proposal-iterator-sequencing
+    "iterator-sequencing",
 
     # https://github.com/tc39/proposal-json-modules
     "json-modules",

--- a/tests/tester/src/edition.rs
+++ b/tests/tester/src/edition.rs
@@ -45,6 +45,10 @@ static FEATURE_EDITION: phf::Map<&'static str, SpecEdition> = phf::phf_map! {
     // https://github.com/tc39/proposal-import-assertions/
     "import-assertions"  => SpecEdition::ESNext,
 
+    // Iterator sequencing
+    // https://github.com/tc39/proposal-iterator-sequencing
+    "iterator-sequencing" => SpecEdition::ESNext,
+
     // JSON modules
     // https://github.com/tc39/proposal-json-modules
     "json-modules"  => SpecEdition::ESNext,


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request bumps the test262 commit version.

There are also some changes made to support the new SpiderMonkey harness files and tests. Although, I did end up ignoring the SpiderMonkey tests in general as some of the tests seemed implementation specific. There were some tests that looked like they may not be engine specific, but maybe those will be moved out of the sm tests over time?
