### PR TITLE
Fix bugs on ephemeron and TypedArray.prototype.slice

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,7 +42,7 @@
         "program": "${workspaceFolder}/target/debug/boa_tester.exe"
       },
       "program": "${workspaceFolder}/target/debug/boa_tester",
-      "args": ["run", "-s", "${input:testPath}", "-vvv"],
+      "args": ["run", "-s", "${input:testPath}", "-vvv", "-d"],
       "sourceLanguages": ["rust"],
       "preLaunchTask": "Cargo Build boa_tester"
     }

--- a/core/engine/src/builtins/array_buffer/mod.rs
+++ b/core/engine/src/builtins/array_buffer/mod.rs
@@ -158,6 +158,7 @@ impl BufferObject {
 
     /// Gets the mutable buffer data of the object
     #[inline]
+    #[track_caller]
     pub(crate) fn as_buffer_mut(
         &self,
     ) -> BufferRefMut<

--- a/core/engine/src/builtins/typed_array/builtin.rs
+++ b/core/engine/src/builtins/typed_array/builtin.rs
@@ -9,7 +9,7 @@ use num_traits::Zero;
 use super::{
     object::typed_array_set_element, ContentType, TypedArray, TypedArrayKind, TypedArrayMarker,
 };
-use crate::value::JsVariant;
+use crate::{builtins::array_buffer::utils::memmove_naive, value::JsVariant};
 use crate::{
     builtins::{
         array::{find_via_predicate, ArrayIterator, Direction},
@@ -2048,8 +2048,8 @@ impl BuiltinTypedArray {
 
         // a. Set taRecord to MakeTypedArrayWithBufferWitnessRecord(O, seq-cst).
         // b. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
-        let src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer();
-        let Some(src_buf) = src_buf_borrow
+        let mut src_buf_borrow = src_borrow.data.viewed_array_buffer().as_buffer_mut();
+        let Some(mut src_buf) = src_buf_borrow
             .bytes(Ordering::SeqCst)
             .filter(|s| !src_borrow.data.is_out_of_bounds(s.len()))
         else {
@@ -2067,61 +2067,7 @@ impl BuiltinTypedArray {
         // f. Let targetType be TypedArrayElementType(A).
         let target_type = target_borrow.data.kind();
 
-        // g. If srcType is targetType, then
-        if src_type == target_type {
-            {
-                let byte_count = count * src_type.element_size() as usize;
-
-                // i. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
-                // ii. Let srcBuffer be O.[[ViewedArrayBuffer]].
-                // iii. Let targetBuffer be A.[[ViewedArrayBuffer]].
-                let target_borrow = target_borrow;
-                let mut target_buf = target_borrow.data.viewed_array_buffer().as_buffer_mut();
-                let mut target_buf = target_buf
-                    .bytes_with_len(byte_count)
-                    .expect("newly created array cannot be detached");
-
-                // iv. Let elementSize be TypedArrayElementSize(O).
-                let element_size = src_type.element_size();
-
-                // v. Let srcByteOffset be O.[[ByteOffset]].
-                let src_byte_offset = src_borrow.data.byte_offset();
-
-                // vi. Let srcByteIndex be (startIndex × elementSize) + srcByteOffset.
-                let src_byte_index = (start_index * element_size + src_byte_offset) as usize;
-
-                // vii. Let targetByteIndex be A.[[ByteOffset]].
-                let target_byte_index = target_borrow.data.byte_offset() as usize;
-
-                // viii. Let endByteIndex be targetByteIndex + (countBytes × elementSize).
-                // Not needed by the impl.
-
-                // ix. Repeat, while targetByteIndex < endByteIndex,
-                //     1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, uint8, true, unordered).
-                //     2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, uint8, value, true, unordered).
-                //     3. Set srcByteIndex to srcByteIndex + 1.
-                //     4. Set targetByteIndex to targetByteIndex + 1.
-
-                let src = src_buf.subslice(src_byte_index..);
-                let mut target = target_buf.subslice_mut(target_byte_index..);
-
-                #[cfg(debug_assertions)]
-                {
-                    assert!(src.len() >= byte_count);
-                    assert!(target.len() >= byte_count);
-                }
-
-                // SAFETY: All previous checks put the indices at least within the bounds of `src_buffer`.
-                // Also, `target_buffer` is precisely allocated to fit all sliced elements from
-                // `src_buffer`, making this operation safe.
-                unsafe {
-                    memcpy(src.as_ptr(), target.as_ptr(), byte_count);
-                }
-            }
-
-            // 15. Return A.
-            Ok(target.upcast().into())
-        } else {
+        if src_type != target_type {
             // h. Else,
             drop(src_buf_borrow);
             drop((src_borrow, target_borrow));
@@ -2146,8 +2092,84 @@ impl BuiltinTypedArray {
             }
 
             // 15. Return A.
-            Ok(target.into())
+            return Ok(target.into());
         }
+
+        // g. If srcType is targetType, then
+        {
+            let byte_count = count * src_type.element_size() as usize;
+
+            // i. NOTE: The transfer must be performed in a manner that preserves the bit-level encoding of the source data.
+            // ii. Let srcBuffer be O.[[ViewedArrayBuffer]].
+            // iii. Let targetBuffer be A.[[ViewedArrayBuffer]].
+
+            // iv. Let elementSize be TypedArrayElementSize(O).
+            let element_size = src_type.element_size();
+
+            // v. Let srcByteOffset be O.[[ByteOffset]].
+            let src_byte_offset = src_borrow.data.byte_offset();
+
+            // vi. Let srcByteIndex be (startIndex × elementSize) + srcByteOffset.
+            let src_byte_index = (start_index * element_size + src_byte_offset) as usize;
+
+            // vii. Let targetByteIndex be A.[[ByteOffset]].
+            let target_byte_index = target_borrow.data.byte_offset() as usize;
+
+            // viii. Let endByteIndex be targetByteIndex + (countBytes × elementSize).
+            // Not needed by the impl.
+
+            // ix. Repeat, while targetByteIndex < endByteIndex,
+            //     1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, uint8, true, unordered).
+            //     2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, uint8, value, true, unordered).
+            //     3. Set srcByteIndex to srcByteIndex + 1.
+            //     4. Set targetByteIndex to targetByteIndex + 1.
+            if BufferObject::equals(
+                src_borrow.data.viewed_array_buffer(),
+                target_borrow.data.viewed_array_buffer(),
+            ) {
+                // cannot borrow the target mutably (overlapping bytes), but we can move the data instead.
+
+                #[cfg(debug_assertions)]
+                {
+                    assert!(src_buf.subslice_mut(src_byte_index..).len() >= byte_count);
+                    assert!(src_buf.subslice_mut(target_byte_index..).len() >= byte_count);
+                }
+
+                // SAFETY: All previous checks put the copied bytes at least within the bounds of `src_buf`.
+                unsafe {
+                    memmove_naive(
+                        src_buf.as_ptr(),
+                        src_byte_index,
+                        target_byte_index,
+                        byte_count,
+                    );
+                }
+            } else {
+                let mut target_buf = target_borrow.data.viewed_array_buffer().as_buffer_mut();
+                let mut target_buf = target_buf
+                    .bytes(Ordering::SeqCst)
+                    .expect("newly created array cannot be detached");
+                let src = src_buf.subslice(src_byte_index..);
+                let mut target = target_buf.subslice_mut(target_byte_index..);
+
+                #[cfg(debug_assertions)]
+                {
+                    assert!(src.len() >= byte_count);
+                    assert!(target.len() >= byte_count);
+                }
+
+                // SAFETY: All previous checks put the indices at least within the bounds of `src_buffer`.
+                // Also, `target_buffer` is precisely allocated to fit all sliced elements from
+                // `src_buffer`, making this operation safe.
+                unsafe {
+                    memcpy(src.as_ptr(), target.as_ptr(), byte_count);
+                }
+            }
+        }
+
+        drop(target_borrow);
+        // 15. Return A.
+        Ok(target.upcast().into())
     }
 
     /// `%TypedArray%.prototype.some ( callbackfn [ , thisArg ] )`

--- a/core/engine/src/environments/runtime/mod.rs
+++ b/core/engine/src/environments/runtime/mod.rs
@@ -506,6 +506,7 @@ impl Context {
     /// # Panics
     ///
     /// Panics if the environment or binding index are out of range.
+    #[track_caller]
     pub(crate) fn get_binding(&mut self, locator: &BindingLocator) -> JsResult<Option<JsValue>> {
         match locator.scope() {
             BindingLocatorScope::GlobalObject => {

--- a/core/gc/src/trace.rs
+++ b/core/gc/src/trace.rs
@@ -34,8 +34,24 @@ impl Tracer {
         self.queue.push_back(node);
     }
 
-    pub(crate) fn next(&mut self) -> Option<GcErasedPointer> {
-        self.queue.pop_front()
+    /// Traces through all the queued nodes until the queue is empty.
+    ///
+    /// # Safety
+    ///
+    /// All the pointers inside of the queue must point to valid memory.
+    pub(crate) unsafe fn trace_until_empty(&mut self) {
+        while let Some(node) = self.queue.pop_front() {
+            let node_ref = unsafe { node.as_ref() };
+            if node_ref.is_marked() {
+                continue;
+            }
+            node_ref.header.mark();
+            let trace_fn = node_ref.trace_fn();
+
+            // SAFETY: The function pointer is appropriate for this node type because we extract it from it's VTable.
+            // Additionally, the node pointer is valid per the caller's guarantee.
+            unsafe { trace_fn(node, self) }
+        }
     }
 
     pub(crate) fn is_empty(&mut self) -> bool {

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -78,4 +78,13 @@ features = [
     "caller",
 ]
 
-tests = ["sm"]
+tests = [
+    # Should throw an OOM error instead of filling the whole RAM.
+    "test/staging/sm/String/replace-math.js",
+    # Panics
+    "test/staging/sm/expressions/optional-chain-first-expression.js",
+    "test/staging/sm/regress/regress-554955-2.js",
+    "test/staging/sm/class/fields-static-class-name-binding-eval.js",
+    "test/staging/sm/regress/regress-554955-1.js",
+    "test/staging/sm/regress/regress-554955-3.js"
+]

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -82,10 +82,15 @@ struct Ignored {
 }
 
 impl Ignored {
-    /// Checks if the ignore list contains the given test name in the list of
+    /// Checks if the ignore list contains the given test in the list of
     /// tests to ignore.
-    pub(crate) fn contains_test(&self, test: &str) -> bool {
-        self.tests.contains(test)
+    pub(crate) fn contains_test(&self, test_path: &Path) -> bool {
+        let Some(test_path) = test_path.to_str() else {
+            return false;
+        };
+        self.tests
+            .iter()
+            .any(|ignored| test_path.contains(&**ignored))
     }
 
     /// Checks if the ignore list contains the given feature name in the list


### PR DESCRIPTION
This allows enabling the sm test suite which was throwing a SIGSEGV on memory usage.
Also, ignores a couple of tests that cause panics.
