### PR TITLE
Remove `try_break` macro in favour of question mark operator

### DIFF
--- a/core/ast/src/declaration/export.rs
+++ b/core/ast/src/declaration/export.rs
@@ -16,7 +16,6 @@ use crate::{
         AsyncFunctionDeclaration, AsyncGeneratorDeclaration, ClassDeclaration, FunctionDeclaration,
         GeneratorDeclaration,
     },
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Declaration, Expression,
 };
@@ -50,7 +49,7 @@ impl VisitWith for ReExportKind {
             Self::Namespaced { name: None } => ControlFlow::Continue(()),
             Self::Named { names } => {
                 for name in &**names {
-                    try_break!(visitor.visit_export_specifier(name));
+                    visitor.visit_export_specifier(name)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -66,7 +65,7 @@ impl VisitWith for ReExportKind {
             Self::Namespaced { name: None } => ControlFlow::Continue(()),
             Self::Named { names } => {
                 for name in &mut **names {
-                    try_break!(visitor.visit_export_specifier_mut(name));
+                    visitor.visit_export_specifier_mut(name)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -117,12 +116,12 @@ impl VisitWith for ExportDeclaration {
     {
         match self {
             Self::ReExport { specifier, kind } => {
-                try_break!(visitor.visit_module_specifier(specifier));
+                visitor.visit_module_specifier(specifier)?;
                 visitor.visit_re_export_kind(kind)
             }
             Self::List(list) => {
                 for item in &**list {
-                    try_break!(visitor.visit_export_specifier(item));
+                    visitor.visit_export_specifier(item)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -147,12 +146,12 @@ impl VisitWith for ExportDeclaration {
     {
         match self {
             Self::ReExport { specifier, kind } => {
-                try_break!(visitor.visit_module_specifier_mut(specifier));
+                visitor.visit_module_specifier_mut(specifier)?;
                 visitor.visit_re_export_kind_mut(kind)
             }
             Self::List(list) => {
                 for item in &mut **list {
-                    try_break!(visitor.visit_export_specifier_mut(item));
+                    visitor.visit_export_specifier_mut(item)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -226,7 +225,7 @@ impl VisitWith for ExportSpecifier {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_sym(&self.alias));
+        visitor.visit_sym(&self.alias)?;
         visitor.visit_sym(&self.private_name)
     }
 
@@ -234,7 +233,7 @@ impl VisitWith for ExportSpecifier {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_sym_mut(&mut self.alias));
+        visitor.visit_sym_mut(&mut self.alias)?;
         visitor.visit_sym_mut(&mut self.private_name)
     }
 }

--- a/core/ast/src/declaration/import.rs
+++ b/core/ast/src/declaration/import.rs
@@ -13,7 +13,6 @@ use std::ops::ControlFlow;
 
 use crate::{
     expression::Identifier,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::Sym;
@@ -49,7 +48,7 @@ impl VisitWith for ImportKind {
             Self::Namespaced { binding } => visitor.visit_identifier(binding),
             Self::Named { names } => {
                 for name in &**names {
-                    try_break!(visitor.visit_import_specifier(name));
+                    visitor.visit_import_specifier(name)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -65,7 +64,7 @@ impl VisitWith for ImportKind {
             Self::Namespaced { binding } => visitor.visit_identifier_mut(binding),
             Self::Named { names } => {
                 for name in &mut **names {
-                    try_break!(visitor.visit_import_specifier_mut(name));
+                    visitor.visit_import_specifier_mut(name)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -134,9 +133,9 @@ impl VisitWith for ImportDeclaration {
         V: Visitor<'a>,
     {
         if let Some(default) = &self.default {
-            try_break!(visitor.visit_identifier(default));
+            visitor.visit_identifier(default)?;
         }
-        try_break!(visitor.visit_import_kind(&self.kind));
+        visitor.visit_import_kind(&self.kind)?;
         visitor.visit_module_specifier(&self.specifier)
     }
 
@@ -145,9 +144,9 @@ impl VisitWith for ImportDeclaration {
         V: VisitorMut<'a>,
     {
         if let Some(default) = &mut self.default {
-            try_break!(visitor.visit_identifier_mut(default));
+            visitor.visit_identifier_mut(default)?;
         }
-        try_break!(visitor.visit_import_kind_mut(&mut self.kind));
+        visitor.visit_import_kind_mut(&mut self.kind)?;
         visitor.visit_module_specifier_mut(&mut self.specifier)
     }
 }
@@ -197,7 +196,7 @@ impl VisitWith for ImportSpecifier {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.binding));
+        visitor.visit_identifier(&self.binding)?;
         visitor.visit_sym(&self.export_name)
     }
 
@@ -205,7 +204,7 @@ impl VisitWith for ImportSpecifier {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.binding));
+        visitor.visit_identifier_mut(&mut self.binding)?;
         visitor.visit_sym_mut(&mut self.export_name)
     }
 }

--- a/core/ast/src/declaration/variable.rs
+++ b/core/ast/src/declaration/variable.rs
@@ -5,7 +5,6 @@ use crate::{
     expression::{Expression, Identifier},
     join_nodes,
     pattern::Pattern,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Statement,
 };
@@ -197,7 +196,7 @@ impl VisitWith for VariableList {
         V: Visitor<'a>,
     {
         for variable in &*self.list {
-            try_break!(visitor.visit_variable(variable));
+            visitor.visit_variable(variable)?;
         }
         ControlFlow::Continue(())
     }
@@ -207,7 +206,7 @@ impl VisitWith for VariableList {
         V: VisitorMut<'a>,
     {
         for variable in &mut *self.list {
-            try_break!(visitor.visit_variable_mut(variable));
+            visitor.visit_variable_mut(variable)?;
         }
         ControlFlow::Continue(())
     }
@@ -309,9 +308,9 @@ impl VisitWith for Variable {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_binding(&self.binding));
+        visitor.visit_binding(&self.binding)?;
         if let Some(init) = &self.init {
-            try_break!(visitor.visit_expression(init));
+            visitor.visit_expression(init)?;
         }
         ControlFlow::Continue(())
     }
@@ -320,9 +319,9 @@ impl VisitWith for Variable {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_binding_mut(&mut self.binding));
+        visitor.visit_binding_mut(&mut self.binding)?;
         if let Some(init) = &mut self.init {
-            try_break!(visitor.visit_expression_mut(init));
+            visitor.visit_expression_mut(init)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/expression/access.rs
+++ b/core/ast/src/expression/access.rs
@@ -16,7 +16,6 @@
 
 use crate::expression::Expression;
 use crate::function::PrivateName;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use boa_interner::{Interner, Sym, ToInternedString};
 use core::ops::ControlFlow;
@@ -188,7 +187,7 @@ impl VisitWith for SimplePropertyAccess {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.target));
+        visitor.visit_expression(&self.target)?;
         visitor.visit_property_access_field(&self.field)
     }
 
@@ -196,7 +195,7 @@ impl VisitWith for SimplePropertyAccess {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.target));
+        visitor.visit_expression_mut(&mut self.target)?;
         visitor.visit_property_access_field_mut(&mut self.field)
     }
 }
@@ -268,7 +267,7 @@ impl VisitWith for PrivatePropertyAccess {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.target));
+        visitor.visit_expression(&self.target)?;
         visitor.visit_private_name(&self.field)
     }
 
@@ -276,7 +275,7 @@ impl VisitWith for PrivatePropertyAccess {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.target));
+        visitor.visit_expression_mut(&mut self.target)?;
         visitor.visit_private_name_mut(&mut self.field)
     }
 }

--- a/core/ast/src/expression/call.rs
+++ b/core/ast/src/expression/call.rs
@@ -1,5 +1,4 @@
 use crate::join_nodes;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use boa_interner::{Interner, ToInternedString};
 use core::ops::ControlFlow;
@@ -77,9 +76,9 @@ impl VisitWith for Call {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.function));
+        visitor.visit_expression(&self.function)?;
         for expr in &*self.args {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         ControlFlow::Continue(())
     }
@@ -88,9 +87,9 @@ impl VisitWith for Call {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.function));
+        visitor.visit_expression_mut(&mut self.function)?;
         for expr in &mut *self.args {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         ControlFlow::Continue(())
     }
@@ -147,7 +146,7 @@ impl VisitWith for SuperCall {
         V: Visitor<'a>,
     {
         for expr in &*self.args {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         ControlFlow::Continue(())
     }
@@ -157,7 +156,7 @@ impl VisitWith for SuperCall {
         V: VisitorMut<'a>,
     {
         for expr in &mut *self.args {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/expression/literal/array.rs
+++ b/core/ast/src/expression/literal/array.rs
@@ -3,7 +3,6 @@
 use crate::expression::operator::assign::{AssignOp, AssignTarget};
 use crate::expression::Expression;
 use crate::pattern::{ArrayPattern, ArrayPatternElement, Pattern};
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use boa_interner::{Interner, Sym, ToInternedString};
 use core::ops::ControlFlow;
@@ -223,7 +222,7 @@ impl VisitWith for ArrayLiteral {
         V: Visitor<'a>,
     {
         for expr in self.arr.iter().flatten() {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         ControlFlow::Continue(())
     }
@@ -233,7 +232,7 @@ impl VisitWith for ArrayLiteral {
         V: VisitorMut<'a>,
     {
         for expr in self.arr.iter_mut().flatten() {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/expression/literal/object.rs
+++ b/core/ast/src/expression/literal/object.rs
@@ -12,7 +12,6 @@ use crate::{
     pattern::{ObjectPattern, ObjectPatternElement},
     property::{MethodDefinitionKind, PropertyName},
     scope::FunctionScopes,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, Sym, ToIndentedString, ToInternedString};
@@ -266,7 +265,7 @@ impl VisitWith for ObjectLiteral {
         V: Visitor<'a>,
     {
         for pd in &*self.properties {
-            try_break!(visitor.visit_property_definition(pd));
+            visitor.visit_property_definition(pd)?;
         }
         ControlFlow::Continue(())
     }
@@ -276,7 +275,7 @@ impl VisitWith for ObjectLiteral {
         V: VisitorMut<'a>,
     {
         for pd in &mut *self.properties {
-            try_break!(visitor.visit_property_definition_mut(pd));
+            visitor.visit_property_definition_mut(pd)?;
         }
         ControlFlow::Continue(())
     }
@@ -359,13 +358,13 @@ impl VisitWith for PropertyDefinition {
         match self {
             Self::IdentifierReference(id) => visitor.visit_identifier(id),
             Self::Property(pn, expr) => {
-                try_break!(visitor.visit_property_name(pn));
+                visitor.visit_property_name(pn)?;
                 visitor.visit_expression(expr)
             }
             Self::MethodDefinition(m) => visitor.visit_object_method_definition(m),
             Self::SpreadObject(expr) => visitor.visit_expression(expr),
             Self::CoverInitializedName(id, expr) => {
-                try_break!(visitor.visit_identifier(id));
+                visitor.visit_identifier(id)?;
                 visitor.visit_expression(expr)
             }
         }
@@ -378,13 +377,13 @@ impl VisitWith for PropertyDefinition {
         match self {
             Self::IdentifierReference(id) => visitor.visit_identifier_mut(id),
             Self::Property(pn, expr) => {
-                try_break!(visitor.visit_property_name_mut(pn));
+                visitor.visit_property_name_mut(pn)?;
                 visitor.visit_expression_mut(expr)
             }
             Self::MethodDefinition(m) => visitor.visit_object_method_definition_mut(m),
             Self::SpreadObject(expr) => visitor.visit_expression_mut(expr),
             Self::CoverInitializedName(id, expr) => {
-                try_break!(visitor.visit_identifier_mut(id));
+                visitor.visit_identifier_mut(id)?;
                 visitor.visit_expression_mut(expr)
             }
         }
@@ -501,8 +500,8 @@ impl VisitWith for ObjectMethodDefinition {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_property_name(&self.name));
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_property_name(&self.name)?;
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -510,8 +509,8 @@ impl VisitWith for ObjectMethodDefinition {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_property_name_mut(&mut self.name));
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_property_name_mut(&mut self.name)?;
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/expression/literal/template.rs
+++ b/core/ast/src/expression/literal/template.rs
@@ -2,7 +2,6 @@
 
 use crate::{
     expression::Expression,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, Sym, ToInternedString};
@@ -108,7 +107,7 @@ impl VisitWith for TemplateLiteral {
         V: Visitor<'a>,
     {
         for element in &*self.elements {
-            try_break!(visitor.visit_template_element(element));
+            visitor.visit_template_element(element)?;
         }
         ControlFlow::Continue(())
     }
@@ -118,7 +117,7 @@ impl VisitWith for TemplateLiteral {
         V: VisitorMut<'a>,
     {
         for element in &mut *self.elements {
-            try_break!(visitor.visit_template_element_mut(element));
+            visitor.visit_template_element_mut(element)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/expression/operator/assign/mod.rs
+++ b/core/ast/src/expression/operator/assign/mod.rs
@@ -22,7 +22,6 @@ use boa_interner::{Interner, Sym, ToInternedString};
 use crate::{
     expression::{access::PropertyAccess, identifier::Identifier, Expression},
     pattern::Pattern,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 
@@ -96,7 +95,7 @@ impl VisitWith for Assign {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_assign_target(&self.lhs));
+        visitor.visit_assign_target(&self.lhs)?;
         visitor.visit_expression(&self.rhs)
     }
 
@@ -104,7 +103,7 @@ impl VisitWith for Assign {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_assign_target_mut(&mut self.lhs));
+        visitor.visit_assign_target_mut(&mut self.lhs)?;
         visitor.visit_expression_mut(&mut self.rhs)
     }
 }

--- a/core/ast/src/expression/operator/binary/mod.rs
+++ b/core/ast/src/expression/operator/binary/mod.rs
@@ -19,7 +19,6 @@ mod op;
 use crate::{
     expression::Expression,
     function::PrivateName,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToInternedString};
@@ -111,7 +110,7 @@ impl VisitWith for Binary {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.lhs));
+        visitor.visit_expression(&self.lhs)?;
         visitor.visit_expression(&self.rhs)
     }
 
@@ -119,7 +118,7 @@ impl VisitWith for Binary {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.lhs));
+        visitor.visit_expression_mut(&mut self.lhs)?;
         visitor.visit_expression_mut(&mut self.rhs)
     }
 }
@@ -186,7 +185,7 @@ impl VisitWith for BinaryInPrivate {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_private_name(&self.lhs));
+        visitor.visit_private_name(&self.lhs)?;
         visitor.visit_expression(&self.rhs)
     }
 
@@ -194,7 +193,7 @@ impl VisitWith for BinaryInPrivate {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_private_name_mut(&mut self.lhs));
+        visitor.visit_private_name_mut(&mut self.lhs)?;
         visitor.visit_expression_mut(&mut self.rhs)
     }
 }

--- a/core/ast/src/expression/operator/conditional.rs
+++ b/core/ast/src/expression/operator/conditional.rs
@@ -1,6 +1,5 @@
 use crate::{
     expression::Expression,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToInternedString};
@@ -87,8 +86,8 @@ impl VisitWith for Conditional {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.condition));
-        try_break!(visitor.visit_expression(&self.if_true));
+        visitor.visit_expression(&self.condition)?;
+        visitor.visit_expression(&self.if_true)?;
         visitor.visit_expression(&self.if_false)
     }
 
@@ -96,8 +95,8 @@ impl VisitWith for Conditional {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.condition));
-        try_break!(visitor.visit_expression_mut(&mut self.if_true));
+        visitor.visit_expression_mut(&mut self.condition)?;
+        visitor.visit_expression_mut(&mut self.if_true)?;
         visitor.visit_expression_mut(&mut self.if_false)
     }
 }

--- a/core/ast/src/expression/optional.rs
+++ b/core/ast/src/expression/optional.rs
@@ -1,7 +1,7 @@
 use super::{access::PropertyAccessField, Expression};
 use crate::{
     function::PrivateName,
-    join_nodes, try_break,
+    join_nodes,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToInternedString};
@@ -39,7 +39,7 @@ impl VisitWith for OptionalOperationKind {
             Self::PrivatePropertyAccess { field } => visitor.visit_private_name(field),
             Self::Call { args } => {
                 for arg in args {
-                    try_break!(visitor.visit_expression(arg));
+                    visitor.visit_expression(arg)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -55,7 +55,7 @@ impl VisitWith for OptionalOperationKind {
             Self::PrivatePropertyAccess { field } => visitor.visit_private_name_mut(field),
             Self::Call { args } => {
                 for arg in args.iter_mut() {
-                    try_break!(visitor.visit_expression_mut(arg));
+                    visitor.visit_expression_mut(arg)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -185,9 +185,9 @@ impl VisitWith for Optional {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.target));
+        visitor.visit_expression(&self.target)?;
         for op in &*self.chain {
-            try_break!(visitor.visit_optional_operation(op));
+            visitor.visit_optional_operation(op)?;
         }
         ControlFlow::Continue(())
     }
@@ -196,9 +196,9 @@ impl VisitWith for Optional {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.target));
+        visitor.visit_expression_mut(&mut self.target)?;
         for op in &mut *self.chain {
-            try_break!(visitor.visit_optional_operation_mut(op));
+            visitor.visit_optional_operation_mut(op)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/expression/regexp.rs
+++ b/core/ast/src/expression/regexp.rs
@@ -11,10 +11,7 @@ use std::ops::ControlFlow;
 
 use boa_interner::{Interner, Sym, ToInternedString};
 
-use crate::{
-    try_break,
-    visitor::{VisitWith, Visitor, VisitorMut},
-};
+use crate::visitor::{VisitWith, Visitor, VisitorMut};
 
 use super::Expression;
 
@@ -79,7 +76,7 @@ impl VisitWith for RegExpLiteral {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_sym(&self.pattern));
+        visitor.visit_sym(&self.pattern)?;
         visitor.visit_sym(&self.flags)
     }
 
@@ -88,7 +85,7 @@ impl VisitWith for RegExpLiteral {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_sym_mut(&mut self.pattern));
+        visitor.visit_sym_mut(&mut self.pattern)?;
         visitor.visit_sym_mut(&mut self.flags)
     }
 }

--- a/core/ast/src/expression/tagged_template.rs
+++ b/core/ast/src/expression/tagged_template.rs
@@ -1,7 +1,6 @@
 use boa_interner::{Interner, Sym, ToInternedString};
 use core::ops::ControlFlow;
 
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 
 use super::Expression;
@@ -111,15 +110,15 @@ impl VisitWith for TaggedTemplate {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.tag));
+        visitor.visit_expression(&self.tag)?;
         for raw in &*self.raws {
-            try_break!(visitor.visit_sym(raw));
+            visitor.visit_sym(raw)?;
         }
         for cooked in self.cookeds.iter().flatten() {
-            try_break!(visitor.visit_sym(cooked));
+            visitor.visit_sym(cooked)?;
         }
         for expr in &*self.exprs {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         ControlFlow::Continue(())
     }
@@ -128,15 +127,15 @@ impl VisitWith for TaggedTemplate {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.tag));
+        visitor.visit_expression_mut(&mut self.tag)?;
         for raw in &mut *self.raws {
-            try_break!(visitor.visit_sym_mut(raw));
+            visitor.visit_sym_mut(raw)?;
         }
         for cooked in self.cookeds.iter_mut().flatten() {
-            try_break!(visitor.visit_sym_mut(cooked));
+            visitor.visit_sym_mut(cooked)?;
         }
         for expr in &mut *self.exprs {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/function/arrow_function.rs
+++ b/core/ast/src/function/arrow_function.rs
@@ -1,6 +1,5 @@
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::FunctionScopes;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::{Expression, Identifier},
@@ -123,9 +122,9 @@ impl VisitWith for ArrowFunction {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -134,9 +133,9 @@ impl VisitWith for ArrowFunction {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/async_arrow_function.rs
+++ b/core/ast/src/function/async_arrow_function.rs
@@ -3,7 +3,6 @@ use std::ops::ControlFlow;
 use super::{FormalParameterList, FunctionBody};
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::FunctionScopes;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::{Expression, Identifier},
@@ -123,9 +122,9 @@ impl VisitWith for AsyncArrowFunction {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -134,9 +133,9 @@ impl VisitWith for AsyncArrowFunction {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/async_function.rs
+++ b/core/ast/src/function/async_function.rs
@@ -7,7 +7,6 @@ use crate::{
     join_nodes,
     operations::{contains, ContainsSymbol},
     scope::{FunctionScopes, Scope},
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Declaration,
 };
@@ -103,8 +102,8 @@ impl VisitWith for AsyncFunctionDeclaration {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.name));
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_identifier(&self.name)?;
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -112,8 +111,8 @@ impl VisitWith for AsyncFunctionDeclaration {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.name));
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_identifier_mut(&mut self.name)?;
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }
@@ -261,9 +260,9 @@ impl VisitWith for AsyncFunctionExpression {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -272,9 +271,9 @@ impl VisitWith for AsyncFunctionExpression {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/async_generator.rs
+++ b/core/ast/src/function/async_generator.rs
@@ -1,7 +1,6 @@
 //! Async Generator Expression
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::{FunctionScopes, Scope};
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     block_to_string,
@@ -102,8 +101,8 @@ impl VisitWith for AsyncGeneratorDeclaration {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.name));
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_identifier(&self.name)?;
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -111,8 +110,8 @@ impl VisitWith for AsyncGeneratorDeclaration {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.name));
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_identifier_mut(&mut self.name)?;
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }
@@ -253,9 +252,9 @@ impl VisitWith for AsyncGeneratorExpression {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -264,9 +263,9 @@ impl VisitWith for AsyncGeneratorExpression {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/class.rs
+++ b/core/ast/src/function/class.rs
@@ -6,7 +6,6 @@ use crate::{
     operations::{contains, ContainsSymbol},
     property::{MethodDefinitionKind, PropertyName},
     scope::{FunctionScopes, Scope},
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Declaration,
 };
@@ -125,15 +124,15 @@ impl VisitWith for ClassDeclaration {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.name));
+        visitor.visit_identifier(&self.name)?;
         if let Some(expr) = &self.super_ref {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         if let Some(func) = &self.constructor {
-            try_break!(visitor.visit_function_expression(func));
+            visitor.visit_function_expression(func)?;
         }
         for elem in &*self.elements {
-            try_break!(visitor.visit_class_element(elem));
+            visitor.visit_class_element(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -142,15 +141,15 @@ impl VisitWith for ClassDeclaration {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.name));
+        visitor.visit_identifier_mut(&mut self.name)?;
         if let Some(expr) = &mut self.super_ref {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         if let Some(func) = &mut self.constructor {
-            try_break!(visitor.visit_function_expression_mut(func));
+            visitor.visit_function_expression_mut(func)?;
         }
         for elem in &mut *self.elements {
-            try_break!(visitor.visit_class_element_mut(elem));
+            visitor.visit_class_element_mut(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -291,16 +290,16 @@ impl VisitWith for ClassExpression {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
         if let Some(expr) = &self.super_ref {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         if let Some(func) = &self.constructor {
-            try_break!(visitor.visit_function_expression(func));
+            visitor.visit_function_expression(func)?;
         }
         for elem in &*self.elements {
-            try_break!(visitor.visit_class_element(elem));
+            visitor.visit_class_element(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -310,16 +309,16 @@ impl VisitWith for ClassExpression {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
         if let Some(expr) = &mut self.super_ref {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         if let Some(func) = &mut self.constructor {
-            try_break!(visitor.visit_function_expression_mut(func));
+            visitor.visit_function_expression_mut(func)?;
         }
         for elem in &mut *self.elements {
-            try_break!(visitor.visit_class_element_mut(elem));
+            visitor.visit_class_element_mut(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -583,17 +582,17 @@ impl VisitWith for ClassElement {
             Self::MethodDefinition(m) => {
                 match &m.name {
                     ClassElementName::PropertyName(pn) => {
-                        try_break!(visitor.visit_property_name(pn));
+                        visitor.visit_property_name(pn)?;
                     }
                     ClassElementName::PrivateName(pn) => {
-                        try_break!(visitor.visit_private_name(pn));
+                        visitor.visit_private_name(pn)?;
                     }
                 }
-                try_break!(visitor.visit_formal_parameter_list(&m.parameters));
+                visitor.visit_formal_parameter_list(&m.parameters)?;
                 visitor.visit_function_body(&m.body)
             }
             Self::FieldDefinition(field) | Self::StaticFieldDefinition(field) => {
-                try_break!(visitor.visit_property_name(&field.name));
+                visitor.visit_property_name(&field.name)?;
                 if let Some(expr) = &field.field {
                     visitor.visit_expression(expr)
                 } else {
@@ -602,7 +601,7 @@ impl VisitWith for ClassElement {
             }
             Self::PrivateFieldDefinition(PrivateFieldDefinition { name, field, .. })
             | Self::PrivateStaticFieldDefinition(name, field) => {
-                try_break!(visitor.visit_private_name(name));
+                visitor.visit_private_name(name)?;
                 if let Some(expr) = field {
                     visitor.visit_expression(expr)
                 } else {
@@ -621,17 +620,17 @@ impl VisitWith for ClassElement {
             Self::MethodDefinition(m) => {
                 match m.name {
                     ClassElementName::PropertyName(ref mut pn) => {
-                        try_break!(visitor.visit_property_name_mut(pn));
+                        visitor.visit_property_name_mut(pn)?;
                     }
                     ClassElementName::PrivateName(ref mut pn) => {
-                        try_break!(visitor.visit_private_name_mut(pn));
+                        visitor.visit_private_name_mut(pn)?;
                     }
                 }
-                try_break!(visitor.visit_formal_parameter_list_mut(&mut m.parameters));
+                visitor.visit_formal_parameter_list_mut(&mut m.parameters)?;
                 visitor.visit_function_body_mut(&mut m.body)
             }
             Self::FieldDefinition(field) | Self::StaticFieldDefinition(field) => {
-                try_break!(visitor.visit_property_name_mut(&mut field.name));
+                visitor.visit_property_name_mut(&mut field.name)?;
                 if let Some(expr) = &mut field.field {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -640,7 +639,7 @@ impl VisitWith for ClassElement {
             }
             Self::PrivateFieldDefinition(PrivateFieldDefinition { name, field, .. })
             | Self::PrivateStaticFieldDefinition(name, field) => {
-                try_break!(visitor.visit_private_name_mut(name));
+                visitor.visit_private_name_mut(name)?;
                 if let Some(expr) = field {
                     visitor.visit_expression_mut(expr)
                 } else {

--- a/core/ast/src/function/generator.rs
+++ b/core/ast/src/function/generator.rs
@@ -5,7 +5,6 @@ use crate::{
     join_nodes,
     operations::{contains, ContainsSymbol},
     scope::{FunctionScopes, Scope},
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Declaration,
 };
@@ -101,8 +100,8 @@ impl VisitWith for GeneratorDeclaration {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.name));
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_identifier(&self.name)?;
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -110,8 +109,8 @@ impl VisitWith for GeneratorDeclaration {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.name));
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_identifier_mut(&mut self.name)?;
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }
@@ -252,9 +251,9 @@ impl VisitWith for GeneratorExpression {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -263,9 +262,9 @@ impl VisitWith for GeneratorExpression {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/mod.rs
+++ b/core/ast/src/function/mod.rs
@@ -48,7 +48,6 @@ pub use ordinary_function::{FunctionDeclaration, FunctionExpression};
 pub use parameters::{FormalParameter, FormalParameterList, FormalParameterListFlags};
 
 use crate::{
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     StatementList, StatementListItem,
 };
@@ -121,7 +120,7 @@ impl VisitWith for FunctionBody {
         V: Visitor<'a>,
     {
         for statement in &*self.statements {
-            try_break!(visitor.visit_statement_list_item(statement));
+            visitor.visit_statement_list_item(statement)?;
         }
         ControlFlow::Continue(())
     }
@@ -131,7 +130,7 @@ impl VisitWith for FunctionBody {
         V: VisitorMut<'a>,
     {
         for statement in &mut *self.statements.statements {
-            try_break!(visitor.visit_statement_list_item_mut(statement));
+            visitor.visit_statement_list_item_mut(statement)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -6,7 +6,6 @@ use crate::{
     operations::{contains, ContainsSymbol},
     scope::{FunctionScopes, Scope},
     scope_analyzer::{analyze_binding_escapes, collect_bindings},
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Declaration,
 };
@@ -102,8 +101,8 @@ impl VisitWith for FunctionDeclaration {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_identifier(&self.name));
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_identifier(&self.name)?;
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -111,8 +110,8 @@ impl VisitWith for FunctionDeclaration {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_identifier_mut(&mut self.name));
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_identifier_mut(&mut self.name)?;
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }
@@ -261,9 +260,9 @@ impl VisitWith for FunctionExpression {
         V: Visitor<'a>,
     {
         if let Some(ident) = &self.name {
-            try_break!(visitor.visit_identifier(ident));
+            visitor.visit_identifier(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list(&self.parameters));
+        visitor.visit_formal_parameter_list(&self.parameters)?;
         visitor.visit_function_body(&self.body)
     }
 
@@ -272,9 +271,9 @@ impl VisitWith for FunctionExpression {
         V: VisitorMut<'a>,
     {
         if let Some(ident) = &mut self.name {
-            try_break!(visitor.visit_identifier_mut(ident));
+            visitor.visit_identifier_mut(ident)?;
         }
-        try_break!(visitor.visit_formal_parameter_list_mut(&mut self.parameters));
+        visitor.visit_formal_parameter_list_mut(&mut self.parameters)?;
         visitor.visit_function_body_mut(&mut self.body)
     }
 }

--- a/core/ast/src/function/parameters.rs
+++ b/core/ast/src/function/parameters.rs
@@ -2,7 +2,6 @@ use crate::{
     declaration::{Binding, Variable},
     expression::Expression,
     operations::bound_names,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use bitflags::bitflags;
@@ -149,7 +148,7 @@ impl VisitWith for FormalParameterList {
         V: Visitor<'a>,
     {
         for parameter in &*self.parameters {
-            try_break!(visitor.visit_formal_parameter(parameter));
+            visitor.visit_formal_parameter(parameter)?;
         }
 
         ControlFlow::Continue(())
@@ -160,7 +159,7 @@ impl VisitWith for FormalParameterList {
         V: VisitorMut<'a>,
     {
         for parameter in &mut *self.parameters {
-            try_break!(visitor.visit_formal_parameter_mut(parameter));
+            visitor.visit_formal_parameter_mut(parameter)?;
         }
 
         // TODO recompute flags

--- a/core/ast/src/module_item_list/mod.rs
+++ b/core/ast/src/module_item_list/mod.rs
@@ -13,7 +13,6 @@ use crate::{
     },
     expression::Identifier,
     operations::{bound_names, BoundNamesVisitor},
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     StatementListItem,
 };
@@ -86,7 +85,7 @@ impl ModuleItemList {
                             ReExportKind::Namespaced { name: None } => {}
                             ReExportKind::Named { names } => {
                                 for specifier in &**names {
-                                    try_break!(self.visit_export_specifier(specifier));
+                                    self.visit_export_specifier(specifier)?;
                                 }
                             }
                         }
@@ -94,7 +93,7 @@ impl ModuleItemList {
                     }
                     ExportDeclaration::List(list) => {
                         for specifier in &**list {
-                            try_break!(self.visit_export_specifier(specifier));
+                            self.visit_export_specifier(specifier)?;
                         }
                         ControlFlow::Continue(())
                     }
@@ -163,7 +162,7 @@ impl ModuleItemList {
                     ExportDeclaration::ReExport { .. } => return ControlFlow::Continue(()),
                     ExportDeclaration::List(list) => {
                         for specifier in &**list {
-                            try_break!(self.visit_export_specifier(specifier));
+                            self.visit_export_specifier(specifier)?;
                         }
                         return ControlFlow::Continue(());
                     }
@@ -428,7 +427,7 @@ impl VisitWith for ModuleItemList {
         V: Visitor<'a>,
     {
         for item in &*self.items {
-            try_break!(visitor.visit_module_item(item));
+            visitor.visit_module_item(item)?;
         }
 
         ControlFlow::Continue(())
@@ -439,7 +438,7 @@ impl VisitWith for ModuleItemList {
         V: VisitorMut<'a>,
     {
         for item in &mut *self.items {
-            try_break!(visitor.visit_module_item_mut(item));
+            visitor.visit_module_item_mut(item)?;
         }
 
         ControlFlow::Continue(())

--- a/core/ast/src/pattern.rs
+++ b/core/ast/src/pattern.rs
@@ -25,7 +25,6 @@
 use crate::{
     expression::{access::PropertyAccess, Identifier},
     property::PropertyName,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Expression,
 };
@@ -172,7 +171,7 @@ impl VisitWith for ObjectPattern {
         V: Visitor<'a>,
     {
         for elem in &*self.0 {
-            try_break!(visitor.visit_object_pattern_element(elem));
+            visitor.visit_object_pattern_element(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -182,7 +181,7 @@ impl VisitWith for ObjectPattern {
         V: VisitorMut<'a>,
     {
         for elem in &mut *self.0 {
-            try_break!(visitor.visit_object_pattern_element_mut(elem));
+            visitor.visit_object_pattern_element_mut(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -250,7 +249,7 @@ impl VisitWith for ArrayPattern {
         V: Visitor<'a>,
     {
         for elem in &*self.0 {
-            try_break!(visitor.visit_array_pattern_element(elem));
+            visitor.visit_array_pattern_element(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -260,7 +259,7 @@ impl VisitWith for ArrayPattern {
         V: VisitorMut<'a>,
     {
         for elem in &mut *self.0 {
-            try_break!(visitor.visit_array_pattern_element_mut(elem));
+            visitor.visit_array_pattern_element_mut(elem)?;
         }
         ControlFlow::Continue(())
     }
@@ -466,8 +465,8 @@ impl VisitWith for ObjectPatternElement {
                 ident,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name(name));
-                try_break!(visitor.visit_identifier(ident));
+                visitor.visit_property_name(name)?;
+                visitor.visit_identifier(ident)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -480,8 +479,8 @@ impl VisitWith for ObjectPatternElement {
                 access,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name(name));
-                try_break!(visitor.visit_property_access(access));
+                visitor.visit_property_name(name)?;
+                visitor.visit_property_access(access)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -496,8 +495,8 @@ impl VisitWith for ObjectPatternElement {
                 pattern,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name(name));
-                try_break!(visitor.visit_pattern(pattern));
+                visitor.visit_property_name(name)?;
+                visitor.visit_pattern(pattern)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -517,8 +516,8 @@ impl VisitWith for ObjectPatternElement {
                 ident,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name_mut(name));
-                try_break!(visitor.visit_identifier_mut(ident));
+                visitor.visit_property_name_mut(name)?;
+                visitor.visit_identifier_mut(ident)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -531,8 +530,8 @@ impl VisitWith for ObjectPatternElement {
                 access,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name_mut(name));
-                try_break!(visitor.visit_property_access_mut(access));
+                visitor.visit_property_name_mut(name)?;
+                visitor.visit_property_access_mut(access)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -547,8 +546,8 @@ impl VisitWith for ObjectPatternElement {
                 pattern,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_name_mut(name));
-                try_break!(visitor.visit_pattern_mut(pattern));
+                visitor.visit_property_name_mut(name)?;
+                visitor.visit_pattern_mut(pattern)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -718,7 +717,7 @@ impl VisitWith for ArrayPatternElement {
                 ident,
                 default_init,
             } => {
-                try_break!(visitor.visit_identifier(ident));
+                visitor.visit_identifier(ident)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -729,7 +728,7 @@ impl VisitWith for ArrayPatternElement {
                 access,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_access(access));
+                visitor.visit_property_access(access)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -741,7 +740,7 @@ impl VisitWith for ArrayPatternElement {
                 pattern,
                 default_init,
             } => {
-                try_break!(visitor.visit_pattern(pattern));
+                visitor.visit_pattern(pattern)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression(expr)
                 } else {
@@ -766,7 +765,7 @@ impl VisitWith for ArrayPatternElement {
                 ident,
                 default_init,
             } => {
-                try_break!(visitor.visit_identifier_mut(ident));
+                visitor.visit_identifier_mut(ident)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -777,7 +776,7 @@ impl VisitWith for ArrayPatternElement {
                 access,
                 default_init,
             } => {
-                try_break!(visitor.visit_property_access_mut(access));
+                visitor.visit_property_access_mut(access)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {
@@ -789,7 +788,7 @@ impl VisitWith for ArrayPatternElement {
                 pattern,
                 default_init,
             } => {
-                try_break!(visitor.visit_pattern_mut(pattern));
+                visitor.visit_pattern_mut(pattern)?;
                 if let Some(expr) = default_init {
                     visitor.visit_expression_mut(expr)
                 } else {

--- a/core/ast/src/scope_analyzer.rs
+++ b/core/ast/src/scope_analyzer.rs
@@ -26,7 +26,6 @@ use crate::{
         iteration::{ForLoopInitializer, IterableLoopInitializer},
         Block, Catch, ForInLoop, ForLoop, ForOfLoop, Switch, With,
     },
-    try_break,
     visitor::{NodeRef, NodeRefMut, VisitorMut},
     Declaration, Module, Script, StatementListItem, ToJsString,
 };
@@ -102,7 +101,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             std::mem::swap(&mut self.scope, scope);
         }
 
-        try_break!(self.visit_statement_list_mut(&mut node.statements));
+        self.visit_statement_list_mut(&mut node.statements)?;
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
             scope.reorder_binding_indices();
@@ -112,7 +111,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
     }
 
     fn visit_switch_mut(&mut self, node: &'ast mut Switch) -> ControlFlow<Self::BreakTy> {
-        try_break!(self.visit_expression_mut(&mut node.val));
+        self.visit_expression_mut(&mut node.val)?;
         let direct_eval_old = self.direct_eval;
         self.direct_eval = node.contains_direct_eval || self.direct_eval;
         if let Some(scope) = &mut node.scope {
@@ -122,7 +121,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             std::mem::swap(&mut self.scope, scope);
         }
         for case in &mut node.cases {
-            try_break!(self.visit_case_mut(case));
+            self.visit_case_mut(case)?;
         }
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
@@ -138,9 +137,9 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         if self.direct_eval {
             node.scope.escape_all_bindings();
         }
-        try_break!(self.visit_expression_mut(&mut node.expression));
+        self.visit_expression_mut(&mut node.expression)?;
         std::mem::swap(&mut self.scope, &mut node.scope);
-        try_break!(self.visit_statement_mut(&mut node.statement));
+        self.visit_statement_mut(&mut node.statement)?;
         std::mem::swap(&mut self.scope, &mut node.scope);
         node.scope.reorder_binding_indices();
         self.with = with;
@@ -155,9 +154,9 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         }
         std::mem::swap(&mut self.scope, &mut node.scope);
         if let Some(binding) = &mut node.parameter {
-            try_break!(self.visit_binding_mut(binding));
+            self.visit_binding_mut(binding)?;
         }
-        try_break!(self.visit_block_mut(&mut node.block));
+        self.visit_block_mut(&mut node.block)?;
         std::mem::swap(&mut self.scope, &mut node.scope);
         node.scope.reorder_binding_indices();
         self.direct_eval = direct_eval_old;
@@ -174,15 +173,15 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             std::mem::swap(&mut self.scope, &mut decl.scope);
         }
         if let Some(init) = &mut node.inner.init {
-            try_break!(self.visit_for_loop_initializer_mut(init));
+            self.visit_for_loop_initializer_mut(init)?;
         }
         if let Some(condition) = &mut node.inner.condition {
-            try_break!(self.visit_expression_mut(condition));
+            self.visit_expression_mut(condition)?;
         }
         if let Some(final_expr) = &mut node.inner.final_expr {
-            try_break!(self.visit_expression_mut(final_expr));
+            self.visit_expression_mut(final_expr)?;
         }
-        try_break!(self.visit_statement_mut(&mut node.inner.body));
+        self.visit_statement_mut(&mut node.inner.body)?;
         if let Some(ForLoopInitializer::Lexical(decl)) = &mut node.inner.init {
             std::mem::swap(&mut self.scope, &mut decl.scope);
             decl.scope.reorder_binding_indices();
@@ -200,7 +199,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             }
             std::mem::swap(&mut self.scope, scope);
         }
-        try_break!(self.visit_expression_mut(&mut node.target));
+        self.visit_expression_mut(&mut node.target)?;
         if let Some(scope) = &mut node.target_scope {
             self.direct_eval = direct_eval_old;
             std::mem::swap(&mut self.scope, scope);
@@ -213,8 +212,8 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             }
             std::mem::swap(&mut self.scope, scope);
         }
-        try_break!(self.visit_iterable_loop_initializer_mut(&mut node.initializer));
-        try_break!(self.visit_statement_mut(&mut node.body));
+        self.visit_iterable_loop_initializer_mut(&mut node.initializer)?;
+        self.visit_statement_mut(&mut node.body)?;
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
             scope.reorder_binding_indices();
@@ -232,7 +231,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             }
             std::mem::swap(&mut self.scope, scope);
         }
-        try_break!(self.visit_expression_mut(&mut node.iterable));
+        self.visit_expression_mut(&mut node.iterable)?;
         if let Some(scope) = &mut node.iterable_scope {
             self.direct_eval = direct_eval_old;
             std::mem::swap(&mut self.scope, scope);
@@ -245,8 +244,8 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             }
             std::mem::swap(&mut self.scope, scope);
         }
-        try_break!(self.visit_iterable_loop_initializer_mut(&mut node.init));
-        try_break!(self.visit_statement_mut(&mut node.body));
+        self.visit_iterable_loop_initializer_mut(&mut node.init)?;
+        self.visit_statement_mut(&mut node.body)?;
         if let Some(scope) = &mut node.scope {
             std::mem::swap(&mut self.scope, scope);
             scope.reorder_binding_indices();
@@ -382,13 +381,13 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         node.name_scope.escape_all_bindings();
         std::mem::swap(&mut self.scope, &mut node.name_scope);
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         std::mem::swap(&mut self.scope, &mut node.name_scope);
         node.name_scope.reorder_binding_indices();
@@ -407,13 +406,13 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
             std::mem::swap(&mut self.scope, name_scope);
         }
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         if let Some(name_scope) = &mut node.name_scope {
             std::mem::swap(&mut self.scope, name_scope);
@@ -434,21 +433,21 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
                 node.contains_direct_eval,
             ),
             ClassElement::FieldDefinition(field) | ClassElement::StaticFieldDefinition(field) => {
-                try_break!(self.visit_property_name_mut(&mut field.name));
+                self.visit_property_name_mut(&mut field.name)?;
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 ControlFlow::Continue(())
             }
             ClassElement::PrivateFieldDefinition(field) => {
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 ControlFlow::Continue(())
             }
             ClassElement::PrivateStaticFieldDefinition(_, e) => {
                 if let Some(e) = e {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -468,7 +467,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         &mut self,
         node: &'ast mut ObjectMethodDefinition,
     ) -> ControlFlow<Self::BreakTy> {
-        try_break!(self.visit_property_name_mut(&mut node.name));
+        self.visit_property_name_mut(&mut node.name)?;
         self.visit_function_like(
             &mut node.parameters,
             &mut node.body,
@@ -483,12 +482,12 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
     ) -> ControlFlow<Self::BreakTy> {
         match node {
             ExportDeclaration::ReExport { specifier, kind } => {
-                try_break!(self.visit_module_specifier_mut(specifier));
+                self.visit_module_specifier_mut(specifier)?;
                 self.visit_re_export_kind_mut(kind)
             }
             ExportDeclaration::List(list) => {
                 for item in &mut **list {
-                    try_break!(self.visit_export_specifier_mut(item));
+                    self.visit_export_specifier_mut(item)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -520,7 +519,7 @@ impl<'ast> VisitorMut<'ast> for BindingEscapeAnalyzer<'_> {
         let mut scope = node.scope.clone();
         scope.escape_all_bindings();
         std::mem::swap(&mut self.scope, &mut scope);
-        try_break!(self.visit_module_item_list_mut(&mut node.items));
+        self.visit_module_item_list_mut(&mut node.items)?;
         std::mem::swap(&mut self.scope, &mut scope);
         scope.reorder_binding_indices();
         ControlFlow::Continue(())
@@ -542,11 +541,11 @@ impl BindingEscapeAnalyzer<'_> {
         }
         let mut scope = scopes.parameter_scope();
         std::mem::swap(&mut self.scope, &mut scope);
-        try_break!(self.visit_formal_parameter_list_mut(parameters));
+        self.visit_formal_parameter_list_mut(parameters)?;
         std::mem::swap(&mut self.scope, &mut scope);
         scope = scopes.body_scope();
         std::mem::swap(&mut self.scope, &mut scope);
-        try_break!(self.visit_function_body_mut(body));
+        self.visit_function_body_mut(body)?;
         std::mem::swap(&mut self.scope, &mut scope);
         scopes.reorder_binding_indices();
         self.direct_eval = direct_eval_old;
@@ -753,13 +752,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         name_scope.create_immutable_binding(name, true);
         std::mem::swap(&mut self.scope, &mut name_scope);
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         std::mem::swap(&mut self.scope, &mut name_scope);
         node.name_scope = name_scope;
@@ -782,13 +781,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
             }
         }
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         if let Some(mut scope) = name_scope {
             std::mem::swap(&mut self.scope, &mut scope);
@@ -814,11 +813,11 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
                 )
             }
             ClassElement::FieldDefinition(field) | ClassElement::StaticFieldDefinition(field) => {
-                try_break!(self.visit_property_name_mut(&mut field.name));
+                self.visit_property_name_mut(&mut field.name)?;
                 let mut scope = Scope::new(self.scope.clone(), true);
                 std::mem::swap(&mut self.scope, &mut scope);
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 std::mem::swap(&mut self.scope, &mut scope);
                 field.scope = scope;
@@ -828,7 +827,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
                 let mut scope = Scope::new(self.scope.clone(), true);
                 std::mem::swap(&mut self.scope, &mut scope);
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 std::mem::swap(&mut self.scope, &mut scope);
                 field.scope = scope;
@@ -836,7 +835,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
             }
             ClassElement::PrivateStaticFieldDefinition(_, e) => {
                 if let Some(e) = e {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -862,7 +861,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         match &mut node.name {
             PropertyName::Literal(_) => {}
             PropertyName::Computed(name) => {
-                try_break!(self.visit_expression_mut(name));
+                self.visit_expression_mut(name)?;
             }
         }
         let strict = node.body.strict();
@@ -882,7 +881,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         if let Some(scope) = &mut scope {
             std::mem::swap(&mut self.scope, scope);
         }
-        try_break!(self.visit_statement_list_mut(&mut node.statements));
+        self.visit_statement_list_mut(&mut node.statements)?;
         if let Some(scope) = &mut scope {
             std::mem::swap(&mut self.scope, scope);
         }
@@ -891,13 +890,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
     }
 
     fn visit_switch_mut(&mut self, node: &'ast mut Switch) -> ControlFlow<Self::BreakTy> {
-        try_break!(self.visit_expression_mut(&mut node.val));
+        self.visit_expression_mut(&mut node.val)?;
         let mut scope = block_declaration_instantiation(node, self.scope.clone(), self.interner);
         if let Some(scope) = &mut scope {
             std::mem::swap(&mut self.scope, scope);
         }
         for case in &mut *node.cases {
-            try_break!(self.visit_case_mut(case));
+            self.visit_case_mut(case)?;
         }
         if let Some(scope) = &mut scope {
             std::mem::swap(&mut self.scope, scope);
@@ -907,10 +906,10 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
     }
 
     fn visit_with_mut(&mut self, node: &'ast mut With) -> ControlFlow<Self::BreakTy> {
-        try_break!(self.visit_expression_mut(&mut node.expression));
+        self.visit_expression_mut(&mut node.expression)?;
         let mut scope = Scope::new(self.scope.clone(), false);
         std::mem::swap(&mut self.scope, &mut scope);
-        try_break!(self.visit_statement_mut(&mut node.statement));
+        self.visit_statement_mut(&mut node.statement)?;
         std::mem::swap(&mut self.scope, &mut scope);
         node.scope = scope;
         ControlFlow::Continue(())
@@ -934,9 +933,9 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         }
         std::mem::swap(&mut self.scope, &mut scope);
         if let Some(binding) = &mut node.parameter {
-            try_break!(self.visit_binding_mut(binding));
+            self.visit_binding_mut(binding)?;
         }
-        try_break!(self.visit_block_mut(&mut node.block));
+        self.visit_block_mut(&mut node.block)?;
         std::mem::swap(&mut self.scope, &mut scope);
         node.scope = scope;
         ControlFlow::Continue(())
@@ -965,13 +964,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
             _ => None,
         };
         if let Some(fli) = &mut node.inner.init {
-            try_break!(self.visit_for_loop_initializer_mut(fli));
+            self.visit_for_loop_initializer_mut(fli)?;
         }
         if let Some(expr) = &mut node.inner.condition {
-            try_break!(self.visit_expression_mut(expr));
+            self.visit_expression_mut(expr)?;
         }
         if let Some(expr) = &mut node.inner.final_expr {
-            try_break!(self.visit_expression_mut(expr));
+            self.visit_expression_mut(expr)?;
         }
         self.visit_statement_mut(&mut node.inner.body);
         if let Some(mut scope) = scope {
@@ -987,7 +986,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
             _ => Vec::new(),
         };
         if initializer_bound_names.is_empty() {
-            try_break!(self.visit_expression_mut(&mut node.target));
+            self.visit_expression_mut(&mut node.target)?;
         } else {
             let mut scope = Scope::new(self.scope.clone(), false);
             for name in &initializer_bound_names {
@@ -995,7 +994,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
                 drop(scope.create_mutable_binding(name, false));
             }
             std::mem::swap(&mut self.scope, &mut scope);
-            try_break!(self.visit_expression_mut(&mut node.target));
+            self.visit_expression_mut(&mut node.target)?;
             std::mem::swap(&mut self.scope, &mut scope);
             node.target_scope = Some(scope);
         }
@@ -1036,13 +1035,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         };
         if let Some(mut scope) = scope {
             std::mem::swap(&mut self.scope, &mut scope);
-            try_break!(self.visit_iterable_loop_initializer_mut(&mut node.initializer));
-            try_break!(self.visit_statement_mut(&mut node.body));
+            self.visit_iterable_loop_initializer_mut(&mut node.initializer)?;
+            self.visit_statement_mut(&mut node.body)?;
             std::mem::swap(&mut self.scope, &mut scope);
             node.scope = Some(scope);
         } else {
-            try_break!(self.visit_iterable_loop_initializer_mut(&mut node.initializer));
-            try_break!(self.visit_statement_mut(&mut node.body));
+            self.visit_iterable_loop_initializer_mut(&mut node.initializer)?;
+            self.visit_statement_mut(&mut node.body)?;
         }
         ControlFlow::Continue(())
     }
@@ -1054,7 +1053,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
             _ => Vec::new(),
         };
         if initializer_bound_names.is_empty() {
-            try_break!(self.visit_expression_mut(&mut node.iterable));
+            self.visit_expression_mut(&mut node.iterable)?;
         } else {
             let mut scope = Scope::new(self.scope.clone(), false);
             for name in &initializer_bound_names {
@@ -1062,7 +1061,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
                 drop(scope.create_mutable_binding(name, false));
             }
             std::mem::swap(&mut self.scope, &mut scope);
-            try_break!(self.visit_expression_mut(&mut node.iterable));
+            self.visit_expression_mut(&mut node.iterable)?;
             std::mem::swap(&mut self.scope, &mut scope);
             node.iterable_scope = Some(scope);
         }
@@ -1103,13 +1102,13 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         };
         if let Some(mut scope) = scope {
             std::mem::swap(&mut self.scope, &mut scope);
-            try_break!(self.visit_iterable_loop_initializer_mut(&mut node.init));
-            try_break!(self.visit_statement_mut(&mut node.body));
+            self.visit_iterable_loop_initializer_mut(&mut node.init)?;
+            self.visit_statement_mut(&mut node.body)?;
             std::mem::swap(&mut self.scope, &mut scope);
             node.scope = Some(scope);
         } else {
-            try_break!(self.visit_iterable_loop_initializer_mut(&mut node.init));
-            try_break!(self.visit_statement_mut(&mut node.body));
+            self.visit_iterable_loop_initializer_mut(&mut node.init)?;
+            self.visit_statement_mut(&mut node.body)?;
         }
         ControlFlow::Continue(())
     }
@@ -1118,7 +1117,7 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
         let mut scope = Scope::new(self.scope.clone(), true);
         module_instantiation(node, &scope, self.interner);
         std::mem::swap(&mut self.scope, &mut scope);
-        try_break!(self.visit_module_item_list_mut(&mut node.items));
+        self.visit_module_item_list_mut(&mut node.items)?;
         std::mem::swap(&mut self.scope, &mut scope);
         node.scope = scope;
         ControlFlow::Continue(())
@@ -1126,11 +1125,11 @@ impl<'ast> VisitorMut<'ast> for BindingCollectorVisitor<'_> {
 
     fn visit_script_mut(&mut self, node: &'ast mut Script) -> ControlFlow<Self::BreakTy> {
         if self.eval {
-            try_break!(self.visit_statement_list_mut(node.statements_mut()));
+            self.visit_statement_list_mut(node.statements_mut())?;
         } else {
             match global_declaration_instantiation(node, &self.scope, self.interner) {
                 Ok(()) => {
-                    try_break!(self.visit_statement_list_mut(node.statements_mut()));
+                    self.visit_statement_list_mut(node.statements_mut())?;
                 }
                 Err(e) => return ControlFlow::Break(e),
             }
@@ -1176,11 +1175,11 @@ impl BindingCollectorVisitor<'_> {
         let mut body_scope = function_scopes.body_scope();
 
         std::mem::swap(&mut self.scope, &mut params_scope);
-        try_break!(self.visit_formal_parameter_list_mut(parameters));
+        self.visit_formal_parameter_list_mut(parameters)?;
         std::mem::swap(&mut self.scope, &mut params_scope);
 
         std::mem::swap(&mut self.scope, &mut body_scope);
-        try_break!(self.visit_function_body_mut(body));
+        self.visit_function_body_mut(body)?;
         std::mem::swap(&mut self.scope, &mut body_scope);
 
         *scopes = function_scopes;
@@ -1367,13 +1366,13 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
         }
         node.name_scope.set_index(self.index);
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         self.index = index;
         ControlFlow::Continue(())
@@ -1391,13 +1390,13 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             scope.set_index(self.index);
         }
         if let Some(super_ref) = &mut node.super_ref {
-            try_break!(self.visit_expression_mut(super_ref));
+            self.visit_expression_mut(super_ref)?;
         }
         if let Some(constructor) = &mut node.constructor {
-            try_break!(self.visit_function_expression_mut(constructor));
+            self.visit_function_expression_mut(constructor)?;
         }
         for element in &mut *node.elements {
-            try_break!(self.visit_class_element_mut(element));
+            self.visit_class_element_mut(element)?;
         }
         self.index = index;
         ControlFlow::Continue(())
@@ -1420,12 +1419,12 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
                 )
             }
             ClassElement::FieldDefinition(field) | ClassElement::StaticFieldDefinition(field) => {
-                try_break!(self.visit_property_name_mut(&mut field.name));
+                self.visit_property_name_mut(&mut field.name)?;
                 let index = self.index;
                 self.index += 1;
                 field.scope.set_index(self.index);
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 self.index = index;
                 ControlFlow::Continue(())
@@ -1435,14 +1434,14 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
                 self.index += 1;
                 field.scope.set_index(self.index);
                 if let Some(e) = &mut field.field {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 self.index = index;
                 ControlFlow::Continue(())
             }
             ClassElement::PrivateStaticFieldDefinition(_, e) => {
                 if let Some(e) = e {
-                    try_break!(self.visit_expression_mut(e));
+                    self.visit_expression_mut(e)?;
                 }
                 ControlFlow::Continue(())
             }
@@ -1467,7 +1466,7 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
         match &mut node.name {
             PropertyName::Literal(_) => {}
             PropertyName::Computed(name) => {
-                try_break!(self.visit_expression_mut(name));
+                self.visit_expression_mut(name)?;
             }
         }
         let contains_direct_eval = node.contains_direct_eval();
@@ -1489,14 +1488,14 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             }
             scope.set_index(self.index);
         }
-        try_break!(self.visit_statement_list_mut(&mut node.statements));
+        self.visit_statement_list_mut(&mut node.statements)?;
         self.index = index;
         ControlFlow::Continue(())
     }
 
     fn visit_switch_mut(&mut self, node: &'ast mut Switch) -> ControlFlow<Self::BreakTy> {
         let index = self.index;
-        try_break!(self.visit_expression_mut(&mut node.val));
+        self.visit_expression_mut(&mut node.val)?;
         if let Some(scope) = &node.scope {
             if !scope.all_bindings_local() {
                 self.index += 1;
@@ -1504,7 +1503,7 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             scope.set_index(self.index);
         }
         for case in &mut *node.cases {
-            try_break!(self.visit_case_mut(case));
+            self.visit_case_mut(case)?;
         }
         self.index = index;
         ControlFlow::Continue(())
@@ -1512,10 +1511,10 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
 
     fn visit_with_mut(&mut self, node: &'ast mut With) -> ControlFlow<Self::BreakTy> {
         let index = self.index;
-        try_break!(self.visit_expression_mut(&mut node.expression));
+        self.visit_expression_mut(&mut node.expression)?;
         self.index += 1;
         node.scope.set_index(self.index);
-        try_break!(self.visit_statement_mut(&mut node.statement));
+        self.visit_statement_mut(&mut node.statement)?;
         self.index = index;
         ControlFlow::Continue(())
     }
@@ -1527,9 +1526,9 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
         }
         node.scope.set_index(self.index);
         if let Some(binding) = &mut node.parameter {
-            try_break!(self.visit_binding_mut(binding));
+            self.visit_binding_mut(binding)?;
         }
-        try_break!(self.visit_block_mut(&mut node.block));
+        self.visit_block_mut(&mut node.block)?;
         self.index = index;
         ControlFlow::Continue(())
     }
@@ -1543,13 +1542,13 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             decl.scope.set_index(self.index);
         }
         if let Some(fli) = &mut node.inner.init {
-            try_break!(self.visit_for_loop_initializer_mut(fli));
+            self.visit_for_loop_initializer_mut(fli)?;
         }
         if let Some(expr) = &mut node.inner.condition {
-            try_break!(self.visit_expression_mut(expr));
+            self.visit_expression_mut(expr)?;
         }
         if let Some(expr) = &mut node.inner.final_expr {
-            try_break!(self.visit_expression_mut(expr));
+            self.visit_expression_mut(expr)?;
         }
         self.visit_statement_mut(&mut node.inner.body);
         self.index = index;
@@ -1565,7 +1564,7 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
                 }
                 scope.set_index(self.index);
             }
-            try_break!(self.visit_expression_mut(&mut node.target));
+            self.visit_expression_mut(&mut node.target)?;
             self.index = index;
         }
         let index = self.index;
@@ -1575,8 +1574,8 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             }
             scope.set_index(self.index);
         }
-        try_break!(self.visit_iterable_loop_initializer_mut(&mut node.initializer));
-        try_break!(self.visit_statement_mut(&mut node.body));
+        self.visit_iterable_loop_initializer_mut(&mut node.initializer)?;
+        self.visit_statement_mut(&mut node.body)?;
         self.index = index;
         ControlFlow::Continue(())
     }
@@ -1590,7 +1589,7 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
                 }
                 scope.set_index(self.index);
             }
-            try_break!(self.visit_expression_mut(&mut node.iterable));
+            self.visit_expression_mut(&mut node.iterable)?;
             self.index = index;
         }
         let index = self.index;
@@ -1600,8 +1599,8 @@ impl<'ast> VisitorMut<'ast> for ScopeIndexVisitor {
             }
             scope.set_index(self.index);
         }
-        try_break!(self.visit_iterable_loop_initializer_mut(&mut node.init));
-        try_break!(self.visit_statement_mut(&mut node.body));
+        self.visit_iterable_loop_initializer_mut(&mut node.init)?;
+        self.visit_statement_mut(&mut node.body)?;
         self.index = index;
         ControlFlow::Continue(())
     }
@@ -1634,7 +1633,7 @@ impl ScopeIndexVisitor {
             }
             scope.set_index(self.index);
         }
-        try_break!(self.visit_formal_parameter_list_mut(parameters));
+        self.visit_formal_parameter_list_mut(parameters)?;
         if let Some(scope) = &scopes.parameters_scope {
             if !scope.all_bindings_local() {
                 self.index += 1;
@@ -1647,7 +1646,7 @@ impl ScopeIndexVisitor {
             }
             scope.set_index(self.index);
         }
-        try_break!(self.visit_function_body_mut(body));
+        self.visit_function_body_mut(body)?;
         self.index = index;
         ControlFlow::Continue(())
     }

--- a/core/ast/src/statement/if.rs
+++ b/core/ast/src/statement/if.rs
@@ -3,7 +3,6 @@
 use crate::{
     expression::Expression,
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
@@ -97,10 +96,10 @@ impl VisitWith for If {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.condition));
-        try_break!(visitor.visit_statement(&self.body));
+        visitor.visit_expression(&self.condition)?;
+        visitor.visit_statement(&self.body)?;
         if let Some(stmt) = &self.else_node {
-            try_break!(visitor.visit_statement(stmt));
+            visitor.visit_statement(stmt)?;
         }
         ControlFlow::Continue(())
     }
@@ -109,10 +108,10 @@ impl VisitWith for If {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.condition));
-        try_break!(visitor.visit_statement_mut(&mut self.body));
+        visitor.visit_expression_mut(&mut self.condition)?;
+        visitor.visit_statement_mut(&mut self.body)?;
         if let Some(stmt) = &mut self.else_node {
-            try_break!(visitor.visit_statement_mut(stmt));
+            visitor.visit_statement_mut(stmt)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/statement/iteration/do_while_loop.rs
+++ b/core/ast/src/statement/iteration/do_while_loop.rs
@@ -1,7 +1,6 @@
 use crate::{
     expression::Expression,
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
@@ -73,7 +72,7 @@ impl VisitWith for DoWhileLoop {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_statement(&self.body));
+        visitor.visit_statement(&self.body)?;
         visitor.visit_expression(&self.condition)
     }
 
@@ -81,7 +80,7 @@ impl VisitWith for DoWhileLoop {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_statement_mut(&mut self.body));
+        visitor.visit_statement_mut(&mut self.body)?;
         visitor.visit_expression_mut(&mut self.condition)
     }
 }

--- a/core/ast/src/statement/iteration/for_in_loop.rs
+++ b/core/ast/src/statement/iteration/for_in_loop.rs
@@ -1,6 +1,5 @@
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::Scope;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::Expression,
@@ -113,8 +112,8 @@ impl VisitWith for ForInLoop {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_iterable_loop_initializer(&self.initializer));
-        try_break!(visitor.visit_expression(&self.target));
+        visitor.visit_iterable_loop_initializer(&self.initializer)?;
+        visitor.visit_expression(&self.target)?;
         visitor.visit_statement(&self.body)
     }
 
@@ -122,8 +121,8 @@ impl VisitWith for ForInLoop {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_iterable_loop_initializer_mut(&mut self.initializer));
-        try_break!(visitor.visit_expression_mut(&mut self.target));
+        visitor.visit_iterable_loop_initializer_mut(&mut self.initializer)?;
+        visitor.visit_expression_mut(&mut self.target)?;
         visitor.visit_statement_mut(&mut self.body)
     }
 }

--- a/core/ast/src/statement/iteration/for_loop.rs
+++ b/core/ast/src/statement/iteration/for_loop.rs
@@ -1,6 +1,5 @@
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::Scope;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     declaration::{LexicalDeclaration, VarDeclaration},
@@ -108,13 +107,13 @@ impl VisitWith for ForLoop {
         V: Visitor<'a>,
     {
         if let Some(fli) = &self.inner.init {
-            try_break!(visitor.visit_for_loop_initializer(fli));
+            visitor.visit_for_loop_initializer(fli)?;
         }
         if let Some(expr) = &self.inner.condition {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         if let Some(expr) = &self.inner.final_expr {
-            try_break!(visitor.visit_expression(expr));
+            visitor.visit_expression(expr)?;
         }
         visitor.visit_statement(&self.inner.body)
     }
@@ -124,13 +123,13 @@ impl VisitWith for ForLoop {
         V: VisitorMut<'a>,
     {
         if let Some(fli) = &mut self.inner.init {
-            try_break!(visitor.visit_for_loop_initializer_mut(fli));
+            visitor.visit_for_loop_initializer_mut(fli)?;
         }
         if let Some(expr) = &mut self.inner.condition {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         if let Some(expr) = &mut self.inner.final_expr {
-            try_break!(visitor.visit_expression_mut(expr));
+            visitor.visit_expression_mut(expr)?;
         }
         visitor.visit_statement_mut(&mut self.inner.body)
     }

--- a/core/ast/src/statement/iteration/for_of_loop.rs
+++ b/core/ast/src/statement/iteration/for_of_loop.rs
@@ -1,6 +1,5 @@
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::Scope;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     expression::Expression,
@@ -130,8 +129,8 @@ impl VisitWith for ForOfLoop {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_iterable_loop_initializer(&self.init));
-        try_break!(visitor.visit_expression(&self.iterable));
+        visitor.visit_iterable_loop_initializer(&self.init)?;
+        visitor.visit_expression(&self.iterable)?;
         visitor.visit_statement(&self.body)
     }
 
@@ -139,8 +138,8 @@ impl VisitWith for ForOfLoop {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_iterable_loop_initializer_mut(&mut self.init));
-        try_break!(visitor.visit_expression_mut(&mut self.iterable));
+        visitor.visit_iterable_loop_initializer_mut(&mut self.init)?;
+        visitor.visit_expression_mut(&mut self.iterable)?;
         visitor.visit_statement_mut(&mut self.body)
     }
 }

--- a/core/ast/src/statement/iteration/while_loop.rs
+++ b/core/ast/src/statement/iteration/while_loop.rs
@@ -1,7 +1,6 @@
 use crate::{
     expression::Expression,
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
@@ -74,7 +73,7 @@ impl VisitWith for WhileLoop {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.condition));
+        visitor.visit_expression(&self.condition)?;
         visitor.visit_statement(&self.body)
     }
 
@@ -82,7 +81,7 @@ impl VisitWith for WhileLoop {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.condition));
+        visitor.visit_expression_mut(&mut self.condition)?;
         visitor.visit_statement_mut(&mut self.body)
     }
 }

--- a/core/ast/src/statement/labelled.rs
+++ b/core/ast/src/statement/labelled.rs
@@ -1,6 +1,5 @@
 use crate::{
     function::FunctionDeclaration,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     Statement,
 };
@@ -141,7 +140,7 @@ impl VisitWith for Labelled {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_labelled_item(&self.item));
+        visitor.visit_labelled_item(&self.item)?;
         visitor.visit_sym(&self.label)
     }
 
@@ -149,7 +148,7 @@ impl VisitWith for Labelled {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_labelled_item_mut(&mut self.item));
+        visitor.visit_labelled_item_mut(&mut self.item)?;
         visitor.visit_sym_mut(&mut self.label)
     }
 }

--- a/core/ast/src/statement/switch.rs
+++ b/core/ast/src/statement/switch.rs
@@ -4,7 +4,6 @@ use crate::{
     operations::{contains, ContainsSymbol},
     scope::Scope,
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
     StatementList,
 };
@@ -79,7 +78,7 @@ impl VisitWith for Case {
         V: Visitor<'a>,
     {
         if let Some(condition) = &self.condition {
-            try_break!(visitor.visit_expression(condition));
+            visitor.visit_expression(condition)?;
         }
 
         visitor.visit_statement_list(&self.body)
@@ -90,7 +89,7 @@ impl VisitWith for Case {
         V: VisitorMut<'a>,
     {
         if let Some(condition) = &mut self.condition {
-            try_break!(visitor.visit_expression_mut(condition));
+            visitor.visit_expression_mut(condition)?;
         }
         visitor.visit_statement_list_mut(&mut self.body)
     }
@@ -212,9 +211,9 @@ impl VisitWith for Switch {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.val));
+        visitor.visit_expression(&self.val)?;
         for case in &*self.cases {
-            try_break!(visitor.visit_case(case));
+            visitor.visit_case(case)?;
         }
         ControlFlow::Continue(())
     }
@@ -223,9 +222,9 @@ impl VisitWith for Switch {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.val));
+        visitor.visit_expression_mut(&mut self.val)?;
         for case in &mut *self.cases {
-            try_break!(visitor.visit_case_mut(case));
+            visitor.visit_case_mut(case)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/statement/try.rs
+++ b/core/ast/src/statement/try.rs
@@ -2,7 +2,6 @@
 
 use crate::operations::{contains, ContainsSymbol};
 use crate::scope::Scope;
-use crate::try_break;
 use crate::visitor::{VisitWith, Visitor, VisitorMut};
 use crate::{
     declaration::Binding,
@@ -112,12 +111,12 @@ impl VisitWith for Try {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_block(&self.block));
+        visitor.visit_block(&self.block)?;
         if let Some(catch) = &self.catch() {
-            try_break!(visitor.visit_catch(catch));
+            visitor.visit_catch(catch)?;
         }
         if let Some(finally) = &self.finally() {
-            try_break!(visitor.visit_finally(finally));
+            visitor.visit_finally(finally)?;
         }
         ControlFlow::Continue(())
     }
@@ -126,13 +125,13 @@ impl VisitWith for Try {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_block_mut(&mut self.block));
+        visitor.visit_block_mut(&mut self.block)?;
         match &mut self.handler {
-            ErrorHandler::Catch(c) => try_break!(visitor.visit_catch_mut(c)),
-            ErrorHandler::Finally(f) => try_break!(visitor.visit_finally_mut(f)),
+            ErrorHandler::Catch(c) => visitor.visit_catch_mut(c)?,
+            ErrorHandler::Finally(f) => visitor.visit_finally_mut(f)?,
             ErrorHandler::Full(c, f) => {
-                try_break!(visitor.visit_catch_mut(c));
-                try_break!(visitor.visit_finally_mut(f));
+                visitor.visit_catch_mut(c)?;
+                visitor.visit_finally_mut(f)?;
             }
         }
         ControlFlow::Continue(())
@@ -212,7 +211,7 @@ impl VisitWith for Catch {
         V: Visitor<'a>,
     {
         if let Some(binding) = &self.parameter {
-            try_break!(visitor.visit_binding(binding));
+            visitor.visit_binding(binding)?;
         }
         visitor.visit_block(&self.block)
     }
@@ -222,7 +221,7 @@ impl VisitWith for Catch {
         V: VisitorMut<'a>,
     {
         if let Some(binding) = &mut self.parameter {
-            try_break!(visitor.visit_binding_mut(binding));
+            visitor.visit_binding_mut(binding)?;
         }
         visitor.visit_block_mut(&mut self.block)
     }

--- a/core/ast/src/statement/with.rs
+++ b/core/ast/src/statement/with.rs
@@ -2,7 +2,6 @@ use crate::{
     expression::Expression,
     scope::Scope,
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToIndentedString, ToInternedString};
@@ -78,7 +77,7 @@ impl VisitWith for With {
     where
         V: Visitor<'a>,
     {
-        try_break!(visitor.visit_expression(&self.expression));
+        visitor.visit_expression(&self.expression)?;
         visitor.visit_statement(&self.statement)
     }
 
@@ -86,7 +85,7 @@ impl VisitWith for With {
     where
         V: VisitorMut<'a>,
     {
-        try_break!(visitor.visit_expression_mut(&mut self.expression));
+        visitor.visit_expression_mut(&mut self.expression)?;
         visitor.visit_statement_mut(&mut self.statement)
     }
 }

--- a/core/ast/src/statement_list.rs
+++ b/core/ast/src/statement_list.rs
@@ -3,7 +3,6 @@
 use super::Declaration;
 use crate::{
     statement::Statement,
-    try_break,
     visitor::{VisitWith, Visitor, VisitorMut},
 };
 use boa_interner::{Interner, ToIndentedString};
@@ -178,7 +177,7 @@ impl VisitWith for StatementList {
         V: Visitor<'a>,
     {
         for statement in &*self.statements {
-            try_break!(visitor.visit_statement_list_item(statement));
+            visitor.visit_statement_list_item(statement)?;
         }
         ControlFlow::Continue(())
     }
@@ -188,7 +187,7 @@ impl VisitWith for StatementList {
         V: VisitorMut<'a>,
     {
         for statement in &mut *self.statements {
-            try_break!(visitor.visit_statement_list_item_mut(statement));
+            visitor.visit_statement_list_item_mut(statement)?;
         }
         ControlFlow::Continue(())
     }

--- a/core/ast/src/visitor.rs
+++ b/core/ast/src/visitor.rs
@@ -48,17 +48,6 @@ use crate::{
 };
 use boa_interner::Sym;
 
-/// `Try`-like conditional unwrapping of `ControlFlow`.
-#[macro_export]
-macro_rules! try_break {
-    ($expr:expr) => {
-        match $expr {
-            core::ops::ControlFlow::Continue(c) => c,
-            core::ops::ControlFlow::Break(b) => return core::ops::ControlFlow::Break(b),
-        }
-    };
-}
-
 /// Creates the default visit function implementation for a particular type
 macro_rules! define_visit {
     ($fn_name:ident, $type_name:ident) => {


### PR DESCRIPTION
`ControlFlow` now implements `Try`, so we don't need to use a macro anymore.
