### PR TITLE
Fix CI with the latest linter errors introduced in 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,6 +94,7 @@ syn = { version = "2.0.95", default-features = false }
 proc-macro2 = "1.0"
 synstructure = "0.13"
 measureme = "12.0.0"
+# TODO: when moving past 1.84, remove dependency to sptr and use `.addr()` directly.
 sptr = "0.3.2"
 paste = "1.0"
 rand = "0.8.5"
@@ -117,7 +118,6 @@ criterion = "0.5.1"
 float-cmp = "0.10.0"
 futures-lite = "2.5.0"
 test-case = "3.3.1"
-winapi = { version = "0.3.9", default-features = false }
 url = "2.5.4"
 tokio = { version = "1.42.0", default-features = false }
 futures-concurrency = "7.6.2"

--- a/core/ast/src/scope.rs
+++ b/core/ast/src/scope.rs
@@ -118,7 +118,7 @@ impl Scope {
             .borrow()
             .iter()
             .find(|b| &b.name == name)
-            .map_or(false, |binding| binding.lex)
+            .is_some_and(|binding| binding.lex)
     }
 
     /// Check if the scope has a binding with the given name.

--- a/core/engine/src/bigint.rs
+++ b/core/engine/src/bigint.rs
@@ -489,7 +489,7 @@ impl PartialEq<f64> for JsBigInt {
     #[inline]
     fn eq(&self, other: &f64) -> bool {
         other.fract().is_zero()
-            && RawBigInt::from_f64(*other).map_or(false, |bigint| self.inner.as_ref() == &bigint)
+            && RawBigInt::from_f64(*other).is_some_and(|bigint| self.inner.as_ref() == &bigint)
     }
 }
 
@@ -497,6 +497,6 @@ impl PartialEq<JsBigInt> for f64 {
     #[inline]
     fn eq(&self, other: &JsBigInt) -> bool {
         self.fract().is_zero()
-            && RawBigInt::from_f64(*self).map_or(false, |bigint| other.inner.as_ref() == &bigint)
+            && RawBigInt::from_f64(*self).is_some_and(|bigint| other.inner.as_ref() == &bigint)
     }
 }

--- a/core/engine/src/builtins/array_buffer/shared.rs
+++ b/core/engine/src/builtins/array_buffer/shared.rs
@@ -9,7 +9,6 @@ use boa_profiler::Profiler;
 use portable_atomic::{AtomicU8, AtomicUsize};
 
 use boa_gc::{Finalize, Trace};
-use sptr::Strict;
 
 use crate::{
     builtins::{Array, BuiltInBuilder, BuiltInConstructor, BuiltInObject, IntrinsicObject},
@@ -611,7 +610,7 @@ pub(crate) fn create_shared_byte_data_block(
     // This could be replaced with a custom `Box` implementation, but most architectures
     // already align pointers to 8 bytes, so it's a lot of work for such a small
     // compatibility improvement.
-    assert_eq!(buffer.as_ptr().addr() % align_of::<u64>(), 0);
+    assert_eq!(sptr::Strict::addr(buffer.as_ptr()) % align_of::<u64>(), 0);
 
     // 3. Return db.
     Ok(buffer)

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -88,8 +88,11 @@ impl SliceRef<'_> {
 
             // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
             // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.
-            debug_assert!(buffer.len() >= size_of::<T>());
-            debug_assert_eq!(buffer.addr() % align_of::<T>(), 0);
+            #[cfg(debug_assertions)]
+            {
+                assert!(buffer.len() >= size_of::<T>());
+                assert_eq!(buffer.addr() % align_of::<T>(), 0);
+            }
 
             // 3. Let block be arrayBuffer.[[ArrayBufferData]].
             // 4. Let elementSize be the Element Size value specified in Table 70 for Element Type type.

--- a/core/engine/src/builtins/array_buffer/utils.rs
+++ b/core/engine/src/builtins/array_buffer/utils.rs
@@ -54,10 +54,9 @@ impl SliceRef<'_> {
     /// Gets the starting address of this `SliceRef`.
     #[cfg(debug_assertions)]
     pub(crate) fn addr(&self) -> usize {
-        use sptr::Strict;
         match self {
-            Self::Slice(buf) => buf.as_ptr().addr(),
-            Self::AtomicSlice(buf) => buf.as_ptr().addr(),
+            Self::Slice(buf) => sptr::Strict::addr(buf.as_ptr()),
+            Self::AtomicSlice(buf) => sptr::Strict::addr(buf.as_ptr()),
         }
     }
 
@@ -89,11 +88,8 @@ impl SliceRef<'_> {
 
             // 1. Assert: IsDetachedBuffer(arrayBuffer) is false.
             // 2. Assert: There are sufficient bytes in arrayBuffer starting at byteIndex to represent a value of type.
-            #[cfg(debug_assertions)]
-            {
-                assert!(buffer.len() >= size_of::<T>());
-                assert_eq!(buffer.addr() % align_of::<T>(), 0);
-            }
+            debug_assert!(buffer.len() >= size_of::<T>());
+            debug_assert_eq!(buffer.addr() % align_of::<T>(), 0);
 
             // 3. Let block be arrayBuffer.[[ArrayBufferData]].
             // 4. Let elementSize be the Element Size value specified in Table 70 for Element Type type.
@@ -242,10 +238,9 @@ impl SliceRefMut<'_> {
     /// Gets the starting address of this `SliceRefMut`.
     #[cfg(debug_assertions)]
     pub(crate) fn addr(&self) -> usize {
-        use sptr::Strict;
         match self {
-            Self::Slice(buf) => buf.as_ptr().addr(),
-            Self::AtomicSlice(buf) => buf.as_ptr().addr(),
+            Self::Slice(buf) => sptr::Strict::addr(buf.as_ptr()),
+            Self::AtomicSlice(buf) => sptr::Strict::addr(buf.as_ptr()),
         }
     }
 

--- a/core/engine/src/builtins/atomics/futex.rs
+++ b/core/engine/src/builtins/atomics/futex.rs
@@ -141,8 +141,6 @@
 
 use std::{cell::UnsafeCell, sync::atomic::Ordering};
 
-use sptr::Strict;
-
 use crate::{
     builtins::{
         array_buffer::{utils::SliceRef, SharedArrayBuffer},
@@ -328,7 +326,7 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
 
     // SAFETY: waiter is valid and we call `remove_node` below.
     unsafe {
-        waiters.add_waiter(waiter_ptr, buffer.as_ptr().addr());
+        waiters.add_waiter(waiter_ptr, sptr::Strict::addr(buffer.as_ptr()));
     }
 
     // 18. Let notified be SuspendAgent(WL, W, t).
@@ -397,7 +395,7 @@ pub(super) unsafe fn wait<E: Element + PartialEq>(
 
 /// Notifies at most `count` agents waiting on the memory address pointed to by `buffer[offset..]`.
 pub(super) fn notify(buffer: &SharedArrayBuffer, offset: usize, count: u64) -> JsResult<u64> {
-    let addr = buffer.as_ptr().addr() + offset;
+    let addr = sptr::Strict::addr(buffer.as_ptr()) + offset;
 
     // 7. Let WL be GetWaiterList(block, indexedPosition).
     // 8. Perform EnterCriticalSection(WL).

--- a/core/engine/src/builtins/boolean/mod.rs
+++ b/core/engine/src/builtins/boolean/mod.rs
@@ -66,7 +66,7 @@ impl BuiltInConstructor for Boolean {
         context: &mut Context,
     ) -> JsResult<JsValue> {
         // Get the argument, if any
-        let data = args.first().map_or(false, JsValue::to_boolean);
+        let data = args.first().is_some_and(JsValue::to_boolean);
         if new_target.is_undefined() {
             return Ok(JsValue::new(data));
         }

--- a/core/engine/src/builtins/intl/locale/utils.rs
+++ b/core/engine/src/builtins/intl/locale/utils.rs
@@ -74,7 +74,7 @@ pub(crate) fn canonicalize_locale_list(
     let o = if locales.is_string()
         || locales
             .as_object()
-            .map_or(false, |o| o.borrow().is::<Locale>())
+            .is_some_and(|o| o.borrow().is::<Locale>())
     {
         // a. Let O be CreateArrayFromList(« locales »).
         Array::create_array_from_list([locales.clone()], context)

--- a/core/engine/src/builtins/number/mod.rs
+++ b/core/engine/src/builtins/number/mod.rs
@@ -744,8 +744,7 @@ impl Number {
         // 1. If number is not a Number, return false.
         // 2. If number is not finite, return false.
         // 3. Otherwise, return true.
-        Ok(JsValue::new(args.first().map_or(
-            false,
+        Ok(JsValue::new(args.first().is_some_and(
             |val| match val.variant() {
                 JsVariant::Integer32(_) => true,
                 JsVariant::Float64(number) => number.is_finite(),
@@ -770,7 +769,7 @@ impl Number {
         args: &[JsValue],
         _ctx: &mut Context,
     ) -> JsResult<JsValue> {
-        Ok(args.first().map_or(false, Self::is_integer).into())
+        Ok(args.first().is_some_and(Self::is_integer).into())
     }
 
     /// `Number.isNaN( number )`

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1522,7 +1522,7 @@ impl Promise {
             // b. If SameValue(xConstructor, C) is true, return x.
             if x_constructor
                 .as_object()
-                .map_or(false, |o| JsObject::equals(o, c))
+                .is_some_and(|o| JsObject::equals(o, c))
             {
                 return Ok(x.clone());
             }

--- a/core/engine/src/builtins/string/mod.rs
+++ b/core/engine/src/builtins/string/mod.rs
@@ -2661,7 +2661,7 @@ pub(crate) fn get_substitution(
             let second_is_digit = second
                 .and_then(CodePoint::as_char)
                 .as_ref()
-                .map_or(false, char::is_ascii_digit);
+                .is_some_and(char::is_ascii_digit);
 
             match second {
                 // $$

--- a/core/engine/src/builtins/temporal/time_zone/mod.rs
+++ b/core/engine/src/builtins/temporal/time_zone/mod.rs
@@ -96,7 +96,7 @@ fn canonicalize_time_zone_name(time_zone: &str) -> String {
     // do not include local political rules for any time zones performs the following steps when
     // called:
     // 1. Assert: timeZone is an ASCII-case-insensitive match for "UTC".
-    assert!(time_zone.to_ascii_uppercase() == "UTC");
+    assert_eq!(time_zone.to_ascii_uppercase(), "UTC");
     // 2. Return "UTC".
     "UTC".to_owned()
 }

--- a/core/engine/src/object/shape/shared_shape/mod.rs
+++ b/core/engine/src/object/shape/shared_shape/mod.rs
@@ -166,10 +166,7 @@ impl SharedShape {
     /// Check if the shape has the given prototype.
     #[must_use]
     pub fn has_prototype(&self, prototype: &JsObject) -> bool {
-        self.inner
-            .prototype
-            .as_ref()
-            .map_or(false, |this| this == prototype)
+        self.inner.prototype.as_ref() == Some(prototype)
     }
 
     /// Create a new [`SharedShape`].

--- a/core/engine/src/small_map/mod.rs
+++ b/core/engine/src/small_map/mod.rs
@@ -572,7 +572,7 @@ impl<K: PartialEq + Ord, V: PartialEq, const LHS_SIZE: usize, const RHS_SIZE: us
         }
 
         self.iter()
-            .all(|(key, value)| other.get(key).map_or(false, |v| *value == *v))
+            .all(|(key, value)| other.get(key).is_some_and(|v| *value == *v))
     }
 }
 

--- a/core/engine/src/tagged.rs
+++ b/core/engine/src/tagged.rs
@@ -3,7 +3,6 @@
 // the same names from the unstable functions of the `std::ptr` module.
 #![allow(unstable_name_collisions)]
 
-use sptr::Strict;
 use std::ptr::NonNull;
 
 /// A pointer that can be tagged with an `usize`.
@@ -81,7 +80,7 @@ impl<T> Tagged<T> {
 
     /// Unwraps the `Tagged` pointer.
     pub(crate) fn unwrap(self) -> UnwrappedTagged<T> {
-        let addr = self.0.as_ptr().addr();
+        let addr = sptr::Strict::addr(self.0.as_ptr());
         if addr & 1 == 0 {
             UnwrappedTagged::Ptr(self.0)
         } else {
@@ -92,13 +91,13 @@ impl<T> Tagged<T> {
     /// Gets the address of the inner pointer.
     #[allow(unused)]
     pub(crate) fn addr(self) -> usize {
-        self.0.as_ptr().addr()
+        sptr::Strict::addr(self.0.as_ptr())
     }
 
     /// Returns `true` if `self ` is a tagged pointer.
     #[allow(unused)]
     pub(crate) fn is_tagged(self) -> bool {
-        self.0.as_ptr().addr() & 1 > 0
+        sptr::Strict::addr(self.0.as_ptr()) & 1 > 0
     }
 }
 

--- a/core/engine/src/value/equality.rs
+++ b/core/engine/src/value/equality.rs
@@ -69,14 +69,14 @@ impl JsValue {
             //    a. Let n be ! StringToBigInt(y).
             //    b. If n is NaN, return false.
             //    c. Return the result of the comparison x == n.
-            (InnerValue::BigInt(ref a), InnerValue::String(ref b)) => JsBigInt::from_js_string(b)
-                .as_ref()
-                .map_or(false, |b| a == b),
+            (InnerValue::BigInt(ref a), InnerValue::String(ref b)) => {
+                JsBigInt::from_js_string(b).as_ref() == Some(a)
+            }
 
             // 7. If Type(x) is String and Type(y) is BigInt, return the result of the comparison y == x.
-            (InnerValue::String(ref a), InnerValue::BigInt(ref b)) => JsBigInt::from_js_string(a)
-                .as_ref()
-                .map_or(false, |a| a == b),
+            (InnerValue::String(ref a), InnerValue::BigInt(ref b)) => {
+                JsBigInt::from_js_string(a).as_ref() == Some(b)
+            }
 
             // 8. If Type(x) is Boolean, return the result of the comparison ! ToNumber(x) == y.
             (InnerValue::Boolean(x), _) => {

--- a/core/parser/src/lexer/mod.rs
+++ b/core/parser/src/lexer/mod.rs
@@ -192,7 +192,7 @@ impl<R> Lexer<R> {
             return Ok(());
         }
 
-        while self.cursor.peek_char()?.map_or(false, is_whitespace) {
+        while self.cursor.peek_char()?.is_some_and(is_whitespace) {
             let _next = self.cursor.next_char();
         }
 

--- a/core/parser/src/parser/function/mod.rs
+++ b/core/parser/src/parser/function/mod.rs
@@ -384,9 +384,10 @@ where
                 _ => {
                     let ident = BindingIdentifier::new(self.allow_yield, self.allow_await)
                         .parse(cursor, interner)?;
-                    let init = if cursor.peek(0, interner)?.map_or(false, |tok| {
-                        tok.kind() == &TokenKind::Punctuator(Punctuator::Assign)
-                    }) {
+                    let init = if cursor
+                        .peek(0, interner)?
+                        .is_some_and(|tok| tok.kind() == &TokenKind::Punctuator(Punctuator::Assign))
+                    {
                         Some(
                             Initializer::new(true, self.allow_yield, self.allow_await)
                                 .parse(cursor, interner)?,

--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -421,7 +421,7 @@ impl Console {
         logger: &impl Logger,
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        let assertion = args.first().map_or(false, JsValue::to_boolean);
+        let assertion = args.first().is_some_and(JsValue::to_boolean);
 
         if !assertion {
             let mut args: Vec<JsValue> = args.iter().skip(1).cloned().collect();

--- a/core/string/src/tagged.rs
+++ b/core/string/src/tagged.rs
@@ -3,7 +3,6 @@
 // the same names from the unstable functions of the `std::ptr` module.
 #![allow(unstable_name_collisions)]
 
-use sptr::Strict;
 use std::ptr::NonNull;
 
 /// A pointer that can be tagged with an `usize`.
@@ -80,7 +79,7 @@ impl<T> Tagged<T> {
 
     /// Unwraps the `Tagged` pointer.
     pub(crate) fn unwrap(self) -> UnwrappedTagged<T> {
-        let addr = self.0.as_ptr().addr();
+        let addr = sptr::Strict::addr(self.0.as_ptr());
         if addr & 1 == 0 {
             UnwrappedTagged::Ptr(self.0)
         } else {
@@ -91,13 +90,13 @@ impl<T> Tagged<T> {
     /// Gets the address of the inner pointer.
     #[allow(unused)]
     pub(crate) fn addr(self) -> usize {
-        self.0.as_ptr().addr()
+        sptr::Strict::addr(self.0.as_ptr())
     }
 
     /// Returns `true` if `self ` is a tagged pointer.
     #[allow(unused)]
     pub(crate) fn is_tagged(self) -> bool {
-        self.0.as_ptr().addr() & 1 > 0
+        sptr::Strict::addr(self.0.as_ptr()) & 1 > 0
     }
 }
 


### PR DESCRIPTION
To maintain backward compatibility, we had to move to using caller style calls (`sptr::Strict::addr(...)`) as clippy was erroneously triggering those as unused (and `.addr()` is not stabilized in 1.82).
