### PR TITLE
Revamp `JobQueue` into `JobExecutor` and introduce `NativeAsyncJob` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "boa_parser",
  "boa_runtime",
  "futures-concurrency",
+ "futures-lite 2.5.0",
  "isahc",
  "smol",
  "time",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -13,7 +13,7 @@ mod helper;
 use boa_engine::{
     builtins::promise::PromiseState,
     context::ContextBuilder,
-    job::{FutureJob, JobQueue, NativeJob},
+    job::{BoxedFuture, JobQueue, NativeJob},
     module::{Module, SimpleModuleLoader},
     optimizer::OptimizerOptions,
     script::Script,
@@ -456,7 +456,7 @@ fn add_runtime(context: &mut Context) {
 struct Jobs(RefCell<VecDeque<NativeJob>>);
 
 impl JobQueue for Jobs {
-    fn enqueue_promise_job(&self, job: NativeJob, _: &mut Context) {
+    fn enqueue_job(&self, job: NativeJob, _: &mut Context) {
         self.0.borrow_mut().push_back(job);
     }
 
@@ -474,7 +474,7 @@ impl JobQueue for Jobs {
         }
     }
 
-    fn enqueue_future_job(&self, future: FutureJob, _: &mut Context) {
+    fn enqueue_async_job(&self, future: BoxedFuture, _: &mut Context) {
         let job = pollster::block_on(future);
         self.0.borrow_mut().push_back(job);
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -472,6 +472,14 @@ impl JobExecutor for Executor {
             if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
                 return;
             }
+
+            let jobs = std::mem::take(&mut *self.promise_jobs.borrow_mut());
+            for job in jobs {
+                if let Err(e) = job.call(context) {
+                    eprintln!("Uncaught {e}");
+                }
+            }
+
             let async_jobs = std::mem::take(&mut *self.async_jobs.borrow_mut());
             for async_job in async_jobs {
                 if let Err(err) = pollster::block_on(async_job.call(&RefCell::new(context))) {

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     builtins::{Array, BuiltInObject},
     context::intrinsics::{Intrinsics, StandardConstructor, StandardConstructors},
     error::JsNativeError,
-    job::{JobCallback, NativeJob},
+    job::{JobCallback, PromiseJob},
     js_string,
     native_function::NativeFunction,
     object::{
@@ -1887,7 +1887,9 @@ impl Promise {
                     new_promise_reaction_job(fulfill_reaction, value.clone(), context);
 
                 //   c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
-                context.job_queue().enqueue_job(fulfill_job, context);
+                context
+                    .job_executor()
+                    .enqueue_job(fulfill_job.into(), context);
             }
 
             // 11. Else,
@@ -1907,7 +1909,9 @@ impl Promise {
                 let reject_job = new_promise_reaction_job(reject_reaction, reason.clone(), context);
 
                 //   e. Perform HostEnqueuePromiseJob(rejectJob.[[Job]], rejectJob.[[Realm]]).
-                context.job_queue().enqueue_job(reject_job, context);
+                context
+                    .job_executor()
+                    .enqueue_job(reject_job.into(), context);
 
                 // 12. Set promise.[[PromiseIsHandled]] to true.
                 promise
@@ -1983,7 +1987,7 @@ impl Promise {
                 let job = new_promise_reaction_job(reaction, argument.clone(), context);
 
                 // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                context.job_queue().enqueue_job(job, context);
+                context.job_executor().enqueue_job(job.into(), context);
             }
             // 2. Return unused.
         }
@@ -2176,7 +2180,7 @@ impl Promise {
                     );
 
                     // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                    context.job_queue().enqueue_job(job, context);
+                    context.job_executor().enqueue_job(job.into(), context);
 
                     // 16. Return undefined.
                     Ok(JsValue::undefined())
@@ -2237,7 +2241,7 @@ fn new_promise_reaction_job(
     mut reaction: ReactionRecord,
     argument: JsValue,
     context: &mut Context,
-) -> NativeJob {
+) -> PromiseJob {
     // Inverting order since `job` captures `reaction` by value.
 
     // 2. Let handlerRealm be null.
@@ -2318,7 +2322,7 @@ fn new_promise_reaction_job(
     };
 
     // 4. Return the Record { [[Job]]: job, [[Realm]]: handlerRealm }.
-    NativeJob::with_realm(job, realm, context)
+    PromiseJob::with_realm(job, realm, context)
 }
 
 /// More information:
@@ -2330,7 +2334,7 @@ fn new_promise_resolve_thenable_job(
     thenable: JsValue,
     then: JobCallback,
     context: &mut Context,
-) -> NativeJob {
+) -> PromiseJob {
     // Inverting order since `job` captures variables by value.
 
     // 2. Let getThenRealmResult be Completion(GetFunctionRealm(then.[[Callback]])).
@@ -2372,5 +2376,5 @@ fn new_promise_resolve_thenable_job(
     };
 
     // 6. Return the Record { [[Job]]: job, [[Realm]]: thenRealm }.
-    NativeJob::with_realm(job, realm, context)
+    PromiseJob::with_realm(job, realm, context)
 }

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1889,7 +1889,7 @@ impl Promise {
                 //   c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
                 context
                     .job_queue()
-                    .enqueue_promise_job(fulfill_job, context);
+                    .enqueue_job(fulfill_job, context);
             }
 
             // 11. Else,
@@ -1909,7 +1909,7 @@ impl Promise {
                 let reject_job = new_promise_reaction_job(reject_reaction, reason.clone(), context);
 
                 //   e. Perform HostEnqueuePromiseJob(rejectJob.[[Job]], rejectJob.[[Realm]]).
-                context.job_queue().enqueue_promise_job(reject_job, context);
+                context.job_queue().enqueue_job(reject_job, context);
 
                 // 12. Set promise.[[PromiseIsHandled]] to true.
                 promise
@@ -1985,7 +1985,7 @@ impl Promise {
                 let job = new_promise_reaction_job(reaction, argument.clone(), context);
 
                 // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                context.job_queue().enqueue_promise_job(job, context);
+                context.job_queue().enqueue_job(job, context);
             }
             // 2. Return unused.
         }
@@ -2178,7 +2178,7 @@ impl Promise {
                     );
 
                     // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-                    context.job_queue().enqueue_promise_job(job, context);
+                    context.job_queue().enqueue_job(job, context);
 
                     // 16. Return undefined.
                     Ok(JsValue::undefined())

--- a/core/engine/src/builtins/promise/mod.rs
+++ b/core/engine/src/builtins/promise/mod.rs
@@ -1887,9 +1887,7 @@ impl Promise {
                     new_promise_reaction_job(fulfill_reaction, value.clone(), context);
 
                 //   c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
-                context
-                    .job_queue()
-                    .enqueue_job(fulfill_job, context);
+                context.job_queue().enqueue_job(fulfill_job, context);
             }
 
             // 11. Else,

--- a/core/engine/src/builtins/promise/tests.rs
+++ b/core/engine/src/builtins/promise/tests.rs
@@ -13,8 +13,7 @@ fn promise() {
                     count += 1;
                 "#}),
         TestAction::assert_eq("count", 2),
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert_eq("count", 3),
     ]);
 }

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -477,9 +477,10 @@ impl Context {
 
     /// Runs all the jobs with the provided job executor.
     #[inline]
-    pub fn run_jobs(&mut self) {
-        self.job_executor().run_jobs(self);
+    pub fn run_jobs(&mut self) -> JsResult<()> {
+        let result = self.job_executor().run_jobs(self);
         self.clear_kept_objects();
+        result
     }
 
     /// Asynchronously runs all the jobs with the provided job executor.
@@ -490,11 +491,13 @@ impl Context {
     /// specific handling of each [`JobExecutor`]. If you want to execute jobs concurrently, you must
     /// provide a custom implementatin of `JobExecutor` to the context.
     #[allow(clippy::future_not_send)]
-    pub async fn run_jobs_async(&mut self) {
-        self.job_executor()
+    pub async fn run_jobs_async(&mut self) -> JsResult<()> {
+        let result = self
+            .job_executor()
             .run_jobs_async(&RefCell::new(self))
             .await;
         self.clear_kept_objects();
+        result
     }
 
     /// Abstract operation [`ClearKeptObjects`][clear].

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -130,7 +130,7 @@ impl NativeJob {
     }
 }
 
-/// The [`Future`] job passed to the [`JobQueue::enqueue_future_job`] operation.
+/// The [`Future`] job returned by a [`NativeAsyncJob`] operation.
 pub type BoxedFuture<'a> = Pin<Box<dyn Future<Output = JsResult<JsValue>> + 'a>>;
 
 /// An ECMAScript [Job] that can be run asynchronously.

--- a/core/engine/src/job.rs
+++ b/core/engine/src/job.rs
@@ -146,6 +146,7 @@ pub type BoxedFuture<'a> = Pin<Box<dyn Future<Output = JsResult<JsValue>> + 'a>>
 ///
 /// [Job]: https://tc39.es/ecma262/#sec-jobs
 /// [`NativeFunction`]: crate::native_function::NativeFunction
+#[allow(clippy::type_complexity)]
 pub struct NativeAsyncJob {
     f: Box<dyn for<'a> FnOnce(&'a RefCell<&mut Context>) -> BoxedFuture<'a>>,
     realm: Option<Realm>,
@@ -171,7 +172,7 @@ impl NativeAsyncJob {
         }
     }
 
-    /// Creates a new `NativeJob` from a closure and an execution realm.
+    /// Creates a new `NativeAsyncJob` from a closure and an execution realm.
     pub fn with_realm<F>(f: F, realm: Realm) -> Self
     where
         F: for<'a> FnOnce(&'a RefCell<&mut Context>) -> BoxedFuture<'a> + 'static,
@@ -188,11 +189,11 @@ impl NativeAsyncJob {
         self.realm.as_ref()
     }
 
-    /// Calls the native job with the specified [`Context`].
+    /// Calls the native async job with the specified [`Context`].
     ///
     /// # Note
     ///
-    /// If the native job has an execution realm defined, this sets the running execution
+    /// If the native async job has an execution realm defined, this sets the running execution
     /// context to the realm's before calling the inner closure, and resets it after execution.
     pub fn call<'a>(
         self,
@@ -300,7 +301,7 @@ pub trait JobQueue {
     /// Enqueues a new [`NativeAsyncJob`] job on the job queue.
     ///
     /// Calling `future` returns a Rust [`Future`] that can be sent to a runtime for concurrent computation.
-    fn enqueue_async_job(&self, future: NativeAsyncJob, context: &mut Context);
+    fn enqueue_async_job(&self, async_job: NativeAsyncJob, context: &mut Context);
 
     /// Runs all jobs in the queue.
     ///

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -1143,14 +1143,14 @@ impl JsPromise {
     /// // Uncommenting the following line would panic.
     /// // context.run_jobs();
     /// ```
-    pub fn await_blocking(&self, context: &mut Context) -> Result<JsValue, JsValue> {
+    pub fn await_blocking(&self, context: &mut Context) -> Result<JsValue, JsError> {
         loop {
             match self.state() {
                 PromiseState::Pending => {
-                    context.run_jobs();
+                    context.run_jobs()?;
                 }
                 PromiseState::Fulfilled(f) => break Ok(f),
-                PromiseState::Rejected(r) => break Err(r),
+                PromiseState::Rejected(r) => break Err(JsError::from_opaque(r)),
             }
         }
     }

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -292,7 +292,7 @@ impl JsPromise {
     {
         let (promise, resolvers) = Self::new_pending(context);
 
-        context.job_queue().enqueue_async_job(
+        context.enqueue_job(
             NativeAsyncJob::new(move |context| {
                 Box::pin(async move {
                     let result = future.await;
@@ -306,8 +306,8 @@ impl JsPromise {
                         }
                     }
                 })
-            }),
-            context,
+            })
+            .into(),
         );
 
         promise
@@ -1085,7 +1085,7 @@ impl JsPromise {
 
     /// Run jobs until this promise is resolved or rejected. This could
     /// result in an infinite loop if the promise is never resolved or
-    /// rejected (e.g. with a [`boa_engine::job::JobQueue`] that does
+    /// rejected (e.g. with a [`boa_engine::job::JobExecutor`] that does
     /// not prioritize properly). If you need more control over how
     /// the promise handles timing out, consider using
     /// [`Context::run_jobs`] directly.

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -160,9 +160,9 @@ impl Script {
     /// Evaluates this script and returns its result.
     ///
     /// Note that this won't run any scheduled promise jobs; you need to call [`Context::run_jobs`]
-    /// on the context or [`JobQueue::run_jobs`] on the provided queue to run them.
+    /// on the context or [`JobExecutor::run_jobs`] on the provided queue to run them.
     ///
-    /// [`JobQueue::run_jobs`]: crate::job::JobQueue::run_jobs
+    /// [`JobExecutor::run_jobs`]: crate::job::JobExecutor::run_jobs
     pub fn evaluate(&self, context: &mut Context) -> JsResult<JsValue> {
         let _timer = Profiler::global().start_event("Execution", "Main");
 

--- a/core/engine/src/tests/async_generator.rs
+++ b/core/engine/src/tests/async_generator.rs
@@ -47,7 +47,7 @@ fn return_on_then_infinite_loop() {
             });
             g.return();
         "#}),
-        TestAction::inspect_context(Context::run_jobs),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert_eq("count", 100),
     ]);
 }
@@ -71,7 +71,7 @@ fn return_on_then_single() {
             });
             let ret = g.return()
         "#}),
-        TestAction::inspect_context(Context::run_jobs),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert_eq("first", false),
         TestAction::assert_with_op("ret", |ret, context| {
             assert_promise_iter_value(&ret, &JsValue::undefined(), true, context);
@@ -104,7 +104,7 @@ fn return_on_then_queue() {
             let second = g.next();
             let ret = g.return();
         "#}),
-        TestAction::inspect_context(Context::run_jobs),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert_with_op("first", |first, context| {
             assert_promise_iter_value(&first, &JsValue::from(1), false, context);
             true

--- a/core/engine/src/tests/iterators.rs
+++ b/core/engine/src/tests/iterators.rs
@@ -46,8 +46,7 @@ fn iterator_close_in_continue_before_jobs() {
                 actual.push("async fn end");
             }();
         "#}),
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,
@@ -110,8 +109,7 @@ fn async_iterator_close_in_continue_is_awaited() {
                 actual.push("async fn end");
             }();
         "#}),
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,
@@ -198,8 +196,7 @@ fn mixed_iterators_close_in_continue() {
                 actual.push("async fn end");
             }();
         "#}),
-        #[allow(clippy::redundant_closure_for_method_calls)]
-        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert(indoc! {r#"
             arrayEquals(
                 actual,

--- a/core/engine/src/tests/promise.rs
+++ b/core/engine/src/tests/promise.rs
@@ -31,7 +31,7 @@ fn issue_2658() {
                     genTwo.next().then(v => { result2 = v; });
                 "#
         }),
-        TestAction::inspect_context(|ctx| ctx.run_jobs()),
+        TestAction::inspect_context(|ctx| ctx.run_jobs().unwrap()),
         TestAction::assert("!result1.done"),
         TestAction::assert_eq("result1.value", 5),
         TestAction::assert("!result2.done"),

--- a/core/engine/tests/imports.rs
+++ b/core/engine/tests/imports.rs
@@ -23,7 +23,7 @@ fn subdirectories() {
     let module = boa_engine::Module::parse(source, None, &mut context).unwrap();
     let result = module.load_link_evaluate(&mut context);
 
-    context.run_jobs();
+    context.run_jobs().unwrap();
     match result.state() {
         PromiseState::Pending => {}
         PromiseState::Fulfilled(v) => {

--- a/core/engine/tests/module.rs
+++ b/core/engine/tests/module.rs
@@ -41,7 +41,7 @@ fn test_json_module_from_str() {
 
     let module = Module::parse(source, None, &mut context).unwrap();
     let promise = module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     match promise.state() {
         PromiseState::Pending => {}

--- a/core/interop/src/lib.rs
+++ b/core/interop/src/lib.rs
@@ -565,7 +565,7 @@ fn into_js_module() {
     let root_module = Module::parse(source, None, &mut context).unwrap();
 
     let promise_result = root_module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     // Checking if the final promise didn't return an error.
     assert!(
@@ -617,7 +617,7 @@ fn can_throw_exception() {
     let root_module = Module::parse(source, None, &mut context).unwrap();
 
     let promise_result = root_module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     // Checking if the final promise didn't return an error.
     assert_eq!(
@@ -721,7 +721,7 @@ fn class() {
     let root_module = Module::parse(source, None, &mut context).unwrap();
 
     let promise_result = root_module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     // Checking if the final promise didn't return an error.
     assert!(

--- a/core/interop/src/macros.rs
+++ b/core/interop/src/macros.rs
@@ -525,7 +525,7 @@ fn js_class_test() {
     let root_module = Module::parse(source, None, &mut context).unwrap();
 
     let promise_result = root_module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     // Checking if the final promise didn't return an error.
     assert!(

--- a/core/interop/tests/embedded.rs
+++ b/core/interop/tests/embedded.rs
@@ -35,7 +35,7 @@ fn simple() {
     )
     .expect("failed to parse module");
     let promise = module.load_link_evaluate(&mut context);
-    context.run_jobs();
+    context.run_jobs().unwrap();
 
     match promise.state() {
         PromiseState::Fulfilled(value) => {

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -19,6 +19,7 @@ boa_runtime.workspace = true
 time.workspace = true
 smol.workspace = true
 futures-concurrency.workspace = true
+futures-lite.workspace = true
 isahc.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "time", "macros"] }
 

--- a/examples/src/bin/module_fetch_async.rs
+++ b/examples/src/bin/module_fetch_async.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::VecDeque, future::Future, pin::Pin, rc::Rc
 
 use boa_engine::{
     builtins::promise::PromiseState,
-    job::{BoxedFuture, JobQueue, NativeJob},
+    job::{JobQueue, NativeAsyncJob, NativeJob},
     js_string,
     module::ModuleLoader,
     Context, JsNativeError, JsResult, JsString, JsValue, Module,
@@ -28,60 +28,59 @@ impl ModuleLoader for HttpModuleLoader {
     ) {
         let url = specifier.to_std_string_escaped();
 
-        let fetch = async move {
-            // Adding some prints to show the non-deterministic nature of the async fetches.
-            // Try to run the example several times to see how sometimes the fetches start in order
-            // but finish in disorder.
-            println!("Fetching `{url}`...");
-            // This could also retry fetching in case there's an error while requesting the module.
-            let body: Result<_, isahc::Error> = async {
-                let mut response = Request::get(&url)
-                    .redirect_policy(RedirectPolicy::Limit(5))
-                    .body(())?
-                    .send_async()
-                    .await?;
-
-                Ok(response.text().await?)
-            }
-            .await;
-            println!("Finished fetching `{url}`");
-
-            // Since the async context cannot take the `context` by ref, we have to continue
-            // parsing inside a new `NativeJob` that will be enqueued into the promise job queue.
-            NativeJob::new(move |context| -> JsResult<JsValue> {
-                let body = match body {
-                    Ok(body) => body,
-                    Err(err) => {
-                        // On error we always call `finish_load` to notify the load promise about the
-                        // error.
-                        finish_load(
-                            Err(JsNativeError::typ().with_message(err.to_string()).into()),
-                            context,
-                        );
-
-                        // Just returns anything to comply with `NativeJob::new`'s signature.
-                        return Ok(JsValue::undefined());
-                    }
-                };
-
-                // Could also add a path if needed.
-                let source = Source::from_bytes(body.as_bytes());
-
-                let module = Module::parse(source, None, context);
-
-                // We don't do any error handling, `finish_load` takes care of that for us.
-                finish_load(module, context);
-
-                // Also needed to match `NativeJob::new`.
-                Ok(JsValue::undefined())
-            })
-        };
-
         // Just enqueue the future for now. We'll advance all the enqueued futures inside our custom
         // `JobQueue`.
-        context
-            .job_queue()
-            .enqueue_async_job(Box::pin(fetch), context)
+        context.enqueue_async_job(NativeAsyncJob::with_realm(
+            move |context| {
+                Box::pin(async move {
+                    // Adding some prints to show the non-deterministic nature of the async fetches.
+                    // Try to run the example several times to see how sometimes the fetches start in order
+                    // but finish in disorder.
+                    println!("Fetching `{url}`...");
+
+                    // This could also retry fetching in case there's an error while requesting the module.
+                    let body: Result<_, isahc::Error> = async {
+                        let mut response = Request::get(&url)
+                            .redirect_policy(RedirectPolicy::Limit(5))
+                            .body(())?
+                            .send_async()
+                            .await?;
+
+                        Ok(response.text().await?)
+                    }
+                    .await;
+
+                    println!("Finished fetching `{url}`");
+
+                    let body = match body {
+                        Ok(body) => body,
+                        Err(err) => {
+                            // On error we always call `finish_load` to notify the load promise about the
+                            // error.
+                            finish_load(
+                                Err(JsNativeError::typ().with_message(err.to_string()).into()),
+                                &mut context.borrow_mut(),
+                            );
+
+                            // Just returns anything to comply with `NativeAsyncJob::new`'s signature.
+                            return Ok(JsValue::undefined());
+                        }
+                    };
+
+                    // Could also add a path if needed.
+                    let source = Source::from_bytes(body.as_bytes());
+
+                    let module = Module::parse(source, None, &mut context.borrow_mut());
+
+                    // We don't do any error handling, `finish_load` takes care of that for us.
+                    finish_load(module, &mut context.borrow_mut());
+
+                    // Also needed to match `NativeAsyncJob::new`.
+                    Ok(JsValue::undefined())
+                })
+            },
+            context.realm().clone(),
+        ));
     }
 }
 
@@ -170,14 +169,14 @@ fn main() -> JsResult<()> {
 // Taken from the `smol_event_loop.rs` example.
 /// An event queue using smol to drive futures to completion.
 struct Queue {
-    futures: RefCell<Vec<FutureJob>>,
+    async_jobs: RefCell<Vec<NativeAsyncJob>>,
     jobs: RefCell<VecDeque<NativeJob>>,
 }
 
 impl Queue {
     fn new() -> Self {
         Self {
-            futures: RefCell::default(),
+            async_jobs: RefCell::default(),
             jobs: RefCell::default(),
         }
     }
@@ -193,66 +192,66 @@ impl Queue {
 }
 
 impl JobQueue for Queue {
-    fn enqueue_promise_job(&self, job: NativeJob, _context: &mut Context) {
+    fn enqueue_job(&self, job: NativeJob, _context: &mut Context) {
         self.jobs.borrow_mut().push_back(job);
     }
 
-    fn enqueue_future_job(&self, future: FutureJob, _context: &mut Context) {
-        self.futures.borrow_mut().push(future);
+    fn enqueue_async_job(&self, async_job: NativeAsyncJob, _context: &mut Context) {
+        self.async_jobs.borrow_mut().push(async_job);
     }
 
     // While the sync flavor of `run_jobs` will block the current thread until all the jobs have finished...
     fn run_jobs(&self, context: &mut Context) {
-        smol::block_on(smol::LocalExecutor::new().run(self.run_jobs_async(context)));
+        smol::block_on(smol::LocalExecutor::new().run(self.run_jobs_async(&RefCell::new(context))));
     }
 
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
-    fn run_jobs_async<'a, 'ctx, 'fut>(
+    fn run_jobs_async<'a, 'b, 'fut>(
         &'a self,
-        context: &'ctx mut Context,
+        context: &'b RefCell<&mut Context>,
     ) -> Pin<Box<dyn Future<Output = ()> + 'fut>>
     where
         'a: 'fut,
-        'ctx: 'fut,
+        'b: 'fut,
     {
         Box::pin(async move {
             // Early return in case there were no jobs scheduled.
-            if self.jobs.borrow().is_empty() && self.futures.borrow().is_empty() {
+            if self.jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
                 return;
             }
             let mut group = FutureGroup::new();
             loop {
-                group.extend(std::mem::take(&mut *self.futures.borrow_mut()));
+                for job in std::mem::take(&mut *self.async_jobs.borrow_mut()) {
+                    group.insert(job.call(context));
+                }
 
                 if self.jobs.borrow().is_empty() {
-                    let Some(job) = group.next().await else {
+                    let Some(result) = group.next().await else {
                         // Both queues are empty. We can exit.
                         return;
                     };
 
-                    // Important to schedule the returned `job` into the job queue, since that's
-                    // what allows updating the `Promise` seen by ECMAScript for when the future
-                    // completes.
-                    self.enqueue_promise_job(job, context);
+                    if let Err(err) = result {
+                        eprintln!("Uncaught {err}");
+                    }
                     continue;
                 }
 
                 // We have some jobs pending on the microtask queue. Try to poll the pending
                 // tasks once to see if any of them finished, and run the pending microtasks
                 // otherwise.
-                let Some(job) = future::poll_once(group.next()).await.flatten() else {
+                let Some(result) = future::poll_once(group.next()).await.flatten() else {
                     // No completed jobs. Run the microtask queue once.
-                    self.drain_jobs(context);
+                    self.drain_jobs(&mut context.borrow_mut());
                     continue;
                 };
 
-                // Important to schedule the returned `job` into the job queue, since that's
-                // what allows updating the `Promise` seen by ECMAScript for when the future
-                // completes.
-                self.enqueue_promise_job(job, context);
+                if let Err(err) = result {
+                    eprintln!("Uncaught {err}");
+                }
 
                 // Only one macrotask can be executed before the next drain of the microtask queue.
-                self.drain_jobs(context);
+                self.drain_jobs(&mut context.borrow_mut());
             }
         })
     }

--- a/examples/src/bin/module_fetch_async.rs
+++ b/examples/src/bin/module_fetch_async.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, collections::VecDeque, future::Future, pin::Pin, rc::Rc
 
 use boa_engine::{
     builtins::promise::PromiseState,
-    job::{FutureJob, JobQueue, NativeJob},
+    job::{BoxedFuture, JobQueue, NativeJob},
     js_string,
     module::ModuleLoader,
     Context, JsNativeError, JsResult, JsString, JsValue, Module,
@@ -81,7 +81,7 @@ impl ModuleLoader for HttpModuleLoader {
         // `JobQueue`.
         context
             .job_queue()
-            .enqueue_future_job(Box::pin(fetch), context)
+            .enqueue_async_job(Box::pin(fetch), context)
     }
 }
 

--- a/examples/src/bin/modules.rs
+++ b/examples/src/bin/modules.rs
@@ -87,7 +87,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
 
     // Very important to push forward the job queue after queueing promises.
-    context.run_jobs();
+    context.run_jobs()?;
 
     // Checking if the final promise didn't return an error.
     match promise_result.state() {

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -9,7 +9,7 @@ use std::{
 
 use boa_engine::{
     context::ContextBuilder,
-    job::{JobQueue, NativeAsyncJob, NativeJob},
+    job::{Job, JobExecutor, NativeAsyncJob, PromiseJob},
     js_string,
     native_function::NativeFunction,
     property::Attribute,
@@ -35,19 +35,19 @@ fn main() {
 /// An event queue using smol to drive futures to completion.
 struct Queue {
     async_jobs: RefCell<VecDeque<NativeAsyncJob>>,
-    jobs: RefCell<VecDeque<NativeJob>>,
+    promise_jobs: RefCell<VecDeque<PromiseJob>>,
 }
 
 impl Queue {
     fn new() -> Self {
         Self {
             async_jobs: RefCell::default(),
-            jobs: RefCell::default(),
+            promise_jobs: RefCell::default(),
         }
     }
 
     fn drain_jobs(&self, context: &mut Context) {
-        let jobs = std::mem::take(&mut *self.jobs.borrow_mut());
+        let jobs = std::mem::take(&mut *self.promise_jobs.borrow_mut());
         for job in jobs {
             if let Err(e) = job.call(context) {
                 eprintln!("Uncaught {e}");
@@ -56,13 +56,13 @@ impl Queue {
     }
 }
 
-impl JobQueue for Queue {
-    fn enqueue_job(&self, job: NativeJob, _context: &mut Context) {
-        self.jobs.borrow_mut().push_back(job);
-    }
-
-    fn enqueue_async_job(&self, async_job: NativeAsyncJob, _context: &mut Context) {
-        self.async_jobs.borrow_mut().push_back(async_job);
+impl JobExecutor for Queue {
+    fn enqueue_job(&self, job: Job, _context: &mut Context) {
+        match job {
+            Job::PromiseJob(job) => self.promise_jobs.borrow_mut().push_back(job),
+            Job::AsyncJob(job) => self.async_jobs.borrow_mut().push_back(job),
+            _ => panic!("unsupported job type"),
+        }
     }
 
     // While the sync flavor of `run_jobs` will block the current thread until all the jobs have finished...
@@ -81,7 +81,7 @@ impl JobQueue for Queue {
     {
         Box::pin(async move {
             // Early return in case there were no jobs scheduled.
-            if self.jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
+            if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
                 return;
             }
             let mut group = FutureGroup::new();
@@ -90,7 +90,7 @@ impl JobQueue for Queue {
                     group.insert(job.call(context));
                 }
 
-                if self.jobs.borrow().is_empty() {
+                if self.promise_jobs.borrow().is_empty() {
                     let Some(result) = group.next().await else {
                         // Both queues are empty. We can exit.
                         return;
@@ -153,21 +153,24 @@ fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult
     let delay = args.get_or_undefined(1).to_u32(context)?;
     let args = args.get(2..).unwrap_or_default().to_vec();
 
-    context.enqueue_async_job(NativeAsyncJob::with_realm(
-        move |context| {
-            Box::pin(async move {
-                let mut timer = smol::Timer::interval(Duration::from_millis(u64::from(delay)));
-                for _ in 0..10 {
-                    timer.next().await;
-                    if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
-                        eprintln!("Uncaught {err}");
+    context.enqueue_job(
+        NativeAsyncJob::with_realm(
+            move |context| {
+                Box::pin(async move {
+                    let mut timer = smol::Timer::interval(Duration::from_millis(u64::from(delay)));
+                    for _ in 0..10 {
+                        timer.next().await;
+                        if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
+                            eprintln!("Uncaught {err}");
+                        }
                     }
-                }
-                Ok(JsValue::undefined())
-            })
-        },
-        context.realm().clone(),
-    ));
+                    Ok(JsValue::undefined())
+                })
+            },
+            context.realm().clone(),
+        )
+        .into(),
+    );
 
     Ok(JsValue::undefined())
 }
@@ -233,7 +236,7 @@ fn internally_async_event_loop() {
     // Initialize the queue and the context
     let queue = Queue::new();
     let context = &mut ContextBuilder::new()
-        .job_queue(Rc::new(queue))
+        .job_executor(Rc::new(queue))
         .build()
         .unwrap();
 
@@ -262,7 +265,7 @@ fn externally_async_event_loop() {
         // Initialize the queue and the context
         let queue = Queue::new();
         let context = &mut ContextBuilder::new()
-            .job_queue(Rc::new(queue))
+            .job_executor(Rc::new(queue))
             .build()
             .unwrap();
 

--- a/examples/src/bin/smol_event_loop.rs
+++ b/examples/src/bin/smol_event_loop.rs
@@ -192,7 +192,7 @@ fn add_runtime(context: &mut Context) {
     // Finally, bind the defined async job to the ECMAScript function "interval".
     context
         .register_global_builtin_callable(
-            js_string!("timeout"),
+            js_string!("interval"),
             1,
             NativeFunction::from_fn_ptr(interval),
         )
@@ -217,7 +217,7 @@ const SCRIPT: &str = r"
         i += 1;
     }
 
-    timeout(counter, 100);
+    interval(counter, 100);
 
     for(let i = 0; i <= 100000; i++) {
         // Emulate a long-running evaluation of a script.

--- a/examples/src/bin/synthetic.rs
+++ b/examples/src/bin/synthetic.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let promise_result = module.load_link_evaluate(context);
 
     // Very important to push forward the job queue after queueing promises.
-    context.run_jobs();
+    context.run_jobs()?;
 
     // Checking if the final promise didn't return an error.
     match promise_result.state() {

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -22,14 +22,14 @@ use tokio::{task, time};
 
 // This example shows how to create an event loop using the tokio runtime.
 // The example contains two "flavors" of event loops:
-fn main() {
+fn main() -> JsResult<()> {
     // An internally async event loop. This event loop blocks the execution of the thread
     // while executing tasks, but internally uses async to run its tasks.
-    internally_async_event_loop();
+    internally_async_event_loop()?;
 
     // An externally async event loop. This event loop can yield to the runtime to concurrently
     // run tasks with it.
-    externally_async_event_loop();
+    externally_async_event_loop()
 }
 
 /// An event queue using tokio to drive futures to completion.
@@ -66,20 +66,20 @@ impl JobExecutor for Queue {
     }
 
     // While the sync flavor of `run_jobs` will block the current thread until all the jobs have finished...
-    fn run_jobs(&self, context: &mut Context) {
+    fn run_jobs(&self, context: &mut Context) -> JsResult<()> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_time()
             .build()
             .unwrap();
 
-        task::LocalSet::default().block_on(&runtime, self.run_jobs_async(&RefCell::new(context)));
+        task::LocalSet::default().block_on(&runtime, self.run_jobs_async(&RefCell::new(context)))
     }
 
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
     fn run_jobs_async<'a, 'b, 'fut>(
         &'a self,
         context: &'b RefCell<&mut Context>,
-    ) -> Pin<Box<dyn Future<Output = ()> + 'fut>>
+    ) -> Pin<Box<dyn Future<Output = JsResult<()>> + 'fut>>
     where
         'a: 'fut,
         'b: 'fut,
@@ -87,7 +87,7 @@ impl JobExecutor for Queue {
         Box::pin(async move {
             // Early return in case there were no jobs scheduled.
             if self.promise_jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
-                return;
+                return Ok(());
             }
             let mut group = FutureGroup::new();
             loop {
@@ -98,7 +98,7 @@ impl JobExecutor for Queue {
                 if self.promise_jobs.borrow().is_empty() {
                     let Some(result) = group.next().await else {
                         // Both queues are empty. We can exit.
-                        return;
+                        return Ok(());
                     };
 
                     if let Err(err) = result {
@@ -238,7 +238,7 @@ const SCRIPT: &str = r"
 // This flavor is most recommended when you have an application that:
 //  - Needs to wait until the engine finishes executing; depends on the execution result to continue.
 //  - Delegates the execution of the application to the engine's event loop.
-fn internally_async_event_loop() {
+fn internally_async_event_loop() -> JsResult<()> {
     println!("====== Internally async event loop. ======");
 
     // Initialize the queue and the context
@@ -257,16 +257,18 @@ fn internally_async_event_loop() {
 
     // Important to run this after evaluating, since this is what triggers to run the enqueued jobs.
     println!("Running jobs...");
-    context.run_jobs();
+    context.run_jobs()?;
 
     println!("Total elapsed time: {:?}\n", now.elapsed());
+
+    Ok(())
 }
 
 // This flavor is most recommended when you have an application that:
 //  - Cannot afford to block until the engine finishes executing.
 //  - Needs to process IO requests between executions that will be consumed by the engine.
 #[tokio::main]
-async fn externally_async_event_loop() {
+async fn externally_async_event_loop() -> JsResult<()> {
     println!("====== Externally async event loop. ======");
     // Initialize the queue and the context
     let queue = Queue::new();
@@ -281,15 +283,19 @@ async fn externally_async_event_loop() {
     let now = Instant::now();
 
     // Example of an asynchronous workload that must be run alongside the engine.
-    let counter = tokio::spawn(async {
-        let mut interval = time::interval(Duration::from_millis(100));
-        println!("Starting tokio interval job...");
-        for i in 0..10 {
-            interval.tick().await;
-            println!("Executed interval tick {i}");
-        }
-        println!("Finished tokio interval job...")
-    });
+    let counter = async {
+        tokio::spawn(async {
+            let mut interval = time::interval(Duration::from_millis(100));
+            println!("Starting tokio interval job...");
+            for i in 0..10 {
+                interval.tick().await;
+                println!("Executed interval tick {i}");
+            }
+            println!("Finished tokio interval job...")
+        })
+        .await
+        .map_err(|err| JsNativeError::typ().with_message(err.to_string()).into())
+    };
 
     let local_set = &mut task::LocalSet::default();
     let engine = local_set.run_until(async {
@@ -302,11 +308,12 @@ async fn externally_async_event_loop() {
 
         // Run the jobs asynchronously, which avoids blocking the main thread.
         println!("Running jobs...");
-        context.run_jobs_async().await;
-        Ok(())
+        context.run_jobs_async().await
     });
 
-    tokio::try_join!(counter, engine).unwrap();
+    tokio::try_join!(counter, engine)?;
 
     println!("Total elapsed time: {:?}\n", now.elapsed());
+
+    Ok(())
 }

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -9,13 +9,15 @@ use std::{
 
 use boa_engine::{
     context::ContextBuilder,
-    job::{FutureJob, JobQueue, NativeJob},
+    job::{JobQueue, NativeAsyncJob, NativeJob},
     js_string,
     native_function::NativeFunction,
     property::Attribute,
-    Context, JsArgs, JsResult, JsValue, Script, Source,
+    Context, JsArgs, JsNativeError, JsResult, JsValue, Script, Source,
 };
 use boa_runtime::Console;
+use futures_concurrency::future::FutureGroup;
+use futures_lite::{future, StreamExt};
 use tokio::{task, time};
 
 // This example shows how to create an event loop using the tokio runtime.
@@ -32,14 +34,14 @@ fn main() {
 
 /// An event queue using tokio to drive futures to completion.
 struct Queue {
-    futures: RefCell<Vec<FutureJob>>,
+    async_jobs: RefCell<VecDeque<NativeAsyncJob>>,
     jobs: RefCell<VecDeque<NativeJob>>,
 }
 
 impl Queue {
     fn new() -> Self {
         Self {
-            futures: RefCell::default(),
+            async_jobs: RefCell::default(),
             jobs: RefCell::default(),
         }
     }
@@ -55,12 +57,12 @@ impl Queue {
 }
 
 impl JobQueue for Queue {
-    fn enqueue_promise_job(&self, job: NativeJob, _context: &mut Context) {
+    fn enqueue_job(&self, job: NativeJob, _context: &mut Context) {
         self.jobs.borrow_mut().push_back(job);
     }
 
-    fn enqueue_future_job(&self, future: FutureJob, _context: &mut Context) {
-        self.futures.borrow_mut().push(future);
+    fn enqueue_async_job(&self, async_job: NativeAsyncJob, _context: &mut Context) {
+        self.async_jobs.borrow_mut().push_back(async_job);
     }
 
     // While the sync flavor of `run_jobs` will block the current thread until all the jobs have finished...
@@ -70,41 +72,37 @@ impl JobQueue for Queue {
             .build()
             .unwrap();
 
-        task::LocalSet::default().block_on(&runtime, self.run_jobs_async(context));
+        task::LocalSet::default().block_on(&runtime, self.run_jobs_async(&RefCell::new(context)));
     }
 
     // ...the async flavor won't, which allows concurrent execution with external async tasks.
-    fn run_jobs_async<'a, 'ctx, 'fut>(
+    fn run_jobs_async<'a, 'b, 'fut>(
         &'a self,
-        context: &'ctx mut Context,
+        context: &'b RefCell<&mut Context>,
     ) -> Pin<Box<dyn Future<Output = ()> + 'fut>>
     where
         'a: 'fut,
-        'ctx: 'fut,
+        'b: 'fut,
     {
         Box::pin(async move {
             // Early return in case there were no jobs scheduled.
-            if self.jobs.borrow().is_empty() && self.futures.borrow().is_empty() {
+            if self.jobs.borrow().is_empty() && self.async_jobs.borrow().is_empty() {
                 return;
             }
-            let mut join_set = task::JoinSet::new();
+            let mut group = FutureGroup::new();
             loop {
-                for future in std::mem::take(&mut *self.futures.borrow_mut()) {
-                    join_set.spawn_local(future);
+                for job in std::mem::take(&mut *self.async_jobs.borrow_mut()) {
+                    group.insert(job.call(context));
                 }
 
                 if self.jobs.borrow().is_empty() {
-                    let Some(job) = join_set.join_next().await else {
+                    let Some(result) = group.next().await else {
                         // Both queues are empty. We can exit.
                         return;
                     };
 
-                    // Important to schedule the returned `job` into the job queue, since that's
-                    // what allows updating the `Promise` seen by ECMAScript for when the future
-                    // completes.
-                    match job {
-                        Ok(job) => self.enqueue_promise_job(job, context),
-                        Err(e) => eprintln!("{e}"),
+                    if let Err(err) = result {
+                        eprintln!("Uncaught {err}");
                     }
 
                     continue;
@@ -113,24 +111,20 @@ impl JobQueue for Queue {
                 // We have some jobs pending on the microtask queue. Try to poll the pending
                 // tasks once to see if any of them finished, and run the pending microtasks
                 // otherwise.
-                let Some(job) = join_set.try_join_next() else {
+                let Some(result) = future::poll_once(group.next()).await.flatten() else {
                     // No completed jobs. Run the microtask queue once.
-                    self.drain_jobs(context);
+                    self.drain_jobs(&mut context.borrow_mut());
 
                     task::yield_now().await;
                     continue;
                 };
 
-                // Important to schedule the returned `job` into the job queue, since that's
-                // what allows updating the `Promise` seen by ECMAScript for when the future
-                // completes.
-                match job {
-                    Ok(job) => self.enqueue_promise_job(job, context),
-                    Err(e) => eprintln!("{e}"),
+                if let Err(err) = result {
+                    eprintln!("Uncaught {err}");
                 }
 
                 // Only one macrotask can be executed before the next drain of the microtask queue.
-                self.drain_jobs(context);
+                self.drain_jobs(&mut context.borrow_mut());
             }
         })
     }
@@ -154,6 +148,38 @@ fn delay(
     }
 }
 
+// Example interval function. We cannot use a function returning async in this case since it would
+// borrow the context for too long, but using a `NativeAsyncJob` we can!
+fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    let Some(function) = args.get_or_undefined(0).as_callable().cloned() else {
+        return Err(JsNativeError::typ()
+            .with_message("arg must be a callable")
+            .into());
+    };
+
+    let this = this.clone();
+    let delay = args.get_or_undefined(1).to_u32(context)?;
+    let args = args.get(2..).unwrap_or_default().to_vec();
+
+    context.enqueue_async_job(NativeAsyncJob::with_realm(
+        move |context| {
+            Box::pin(async move {
+                let mut timer = time::interval(Duration::from_millis(u64::from(delay)));
+                for _ in 0..10 {
+                    timer.tick().await;
+                    if let Err(err) = function.call(&this, &args, &mut context.borrow_mut()) {
+                        eprintln!("Uncaught {err}");
+                    }
+                }
+                Ok(JsValue::undefined())
+            })
+        },
+        context.realm().clone(),
+    ));
+
+    Ok(JsValue::undefined())
+}
+
 /// Adds the custom runtime to the context.
 fn add_runtime(context: &mut Context) {
     // First add the `console` object, to be able to call `console.log()`.
@@ -170,18 +196,36 @@ fn add_runtime(context: &mut Context) {
             NativeFunction::from_async_fn(delay),
         )
         .expect("the delay builtin shouldn't exist");
+
+    // Finally, bind the defined async job to the ECMAScript function "interval".
+    context
+        .register_global_builtin_callable(
+            js_string!("timeout"),
+            1,
+            NativeFunction::from_fn_ptr(interval),
+        )
+        .expect("the delay builtin shouldn't exist");
 }
 
 // Script that does multiple calls to multiple async timers.
 const SCRIPT: &str = r"
     function print(elapsed) {
-        console.log(`Finished delay. Elapsed time: ${elapsed * 1000} ms`)
+        console.log(`Finished delay. Elapsed time: ${elapsed * 1000} ms`);
     }
+
     delay(1000).then(print);
     delay(500).then(print);
     delay(200).then(print);
     delay(600).then(print);
     delay(30).then(print);
+
+    let i = 0;
+    function counter() {
+        console.log(`Iteration number ${i} for JS interval`);
+        i += 1;
+    }
+
+    timeout(counter, 100);
 
     for(let i = 0; i <= 100000; i++) {
         // Emulate a long-running evaluation of a script.

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -200,7 +200,7 @@ fn add_runtime(context: &mut Context) {
     // Finally, bind the defined async job to the ECMAScript function "interval".
     context
         .register_global_builtin_callable(
-            js_string!("timeout"),
+            js_string!("interval"),
             1,
             NativeFunction::from_fn_ptr(interval),
         )
@@ -225,7 +225,7 @@ const SCRIPT: &str = r"
         i += 1;
     }
 
-    timeout(counter, 100);
+    interval(counter, 100);
 
     for(let i = 0; i <= 100000; i++) {
         // Emulate a long-running evaluation of a script.

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -289,7 +289,9 @@ impl Test {
 
                     let promise = module.load_link_evaluate(context);
 
-                    context.run_jobs();
+                    if let Err(err) = context.run_jobs() {
+                        return (false, format!("Uncaught {err}"));
+                    };
 
                     match promise.state() {
                         PromiseState::Pending => {
@@ -322,7 +324,9 @@ impl Test {
                     }
                 };
 
-                context.run_jobs();
+                if let Err(err) = context.run_jobs() {
+                    return (false, format!("Uncaught {err}"));
+                };
 
                 match *async_result.inner.borrow() {
                     UninitResult::Err(ref e) => return (false, format!("Uncaught {e}")),
@@ -388,7 +392,9 @@ impl Test {
 
                 let promise = module.load(context);
 
-                context.run_jobs();
+                if let Err(err) = context.run_jobs() {
+                    return (false, format!("Uncaught {err}"));
+                };
 
                 match promise.state() {
                     PromiseState::Pending => {
@@ -433,7 +439,9 @@ impl Test {
 
                     let promise = module.load(context);
 
-                    context.run_jobs();
+                    if let Err(err) = context.run_jobs() {
+                        return (false, format!("Uncaught {err}"));
+                    };
 
                     match promise.state() {
                         PromiseState::Pending => {
@@ -451,7 +459,9 @@ impl Test {
 
                     let promise = module.evaluate(context);
 
-                    context.run_jobs();
+                    if let Err(err) = context.run_jobs() {
+                        return (false, format!("Uncaught {err}"));
+                    };
 
                     match promise.state() {
                         PromiseState::Pending => {


### PR DESCRIPTION
This changes the API of `JobQueue` to take a non_exhaustive enum `Job`, which should avoid breaking changes in the future. Some other changes:
- Renames `JobQueue` to `JobExecutor`.
- Introduces `JobPromise`, which is a wrapper around `NativeJob` but clearly states that the job will push promises forward.
- Introduces `NativeAsyncJob`, an equivalent to `NativeJob` that is `Future`-compatible.