### PR TITLE
[DRAFT] feat: console.table implementation

### DIFF
--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -346,6 +346,11 @@ impl Console {
             0,
         )
         .function(
+            console_method(Self::table, state.clone(), logger.clone()),
+            js_string!("table"),
+            0
+        )
+        .function(
             console_method_mut(Self::count, state.clone(), logger.clone()),
             js_string!("count"),
             0,
@@ -538,6 +543,17 @@ impl Console {
     /// [spec]: https://console.spec.whatwg.org/#log
     /// [mdn]: https://developer.mozilla.org/en-US/docs/Web/API/console/log
     fn log(
+        _: &JsValue,
+        args: &[JsValue],
+        console: &Self,
+        logger: &impl Logger,
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        logger.log(formatter(args, context)?, &console.state, context)?;
+        Ok(JsValue::undefined())
+    }
+
+    fn table(
         _: &JsValue,
         args: &[JsValue],
         console: &Self,

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -107,6 +107,8 @@ fn console_log_cyclic() {
                 let a = [1];
                 a[1] = a;
                 console.log(a);
+                let obj = {a: 1, b: 2};
+                console.table(obj);
             "#})],
         &mut context,
     );


### PR DESCRIPTION

`console.table` features: -

- [x] Fall back to just logging the argument if it can’t be parsed as tabular.
- [ ] Display array in tabular format
- [ ] Display object in tabular format
- [ ] Restrict the columns shown in the table

This Pull Request fixes/closes #3806 

It changes the following:

- 
-
-
