### PR TITLE
Implement since and until methods for ZonedDateTime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=c61468264e27bed14bd7717f2153a7178e2dfe5f#c61468264e27bed14bd7717f2153a7178e2dfe5f"
+source = "git+https://github.com/boa-dev/temporal.git?rev=cb10eecbd68a5249f5f60f08ba9e09d2a24040a9#cb10eecbd68a5249f5f60f08ba9e09d2a24040a9"
 dependencies = [
  "combine",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "c61468264e27bed14bd7717f2153a7178e2dfe5f", features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "cb10eecbd68a5249f5f60f08ba9e09d2a24040a9", features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/bigint.rs
+++ b/core/engine/src/bigint.rs
@@ -80,6 +80,15 @@ impl JsBigInt {
         self.inner.to_f64().unwrap_or(f64::INFINITY)
     }
 
+    /// Converts the `BigInt` to a i128 type.
+    ///
+    /// Returns `i128::MAX` if the `BigInt` is too big.
+    #[inline]
+    #[must_use]
+    pub fn to_i128(&self) -> i128 {
+        self.inner.to_i128().unwrap_or(i128::MAX)
+    }
+
     /// Converts a string to a `BigInt` with the specified radix.
     #[inline]
     #[must_use]

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -27,7 +27,9 @@ use temporal_rs::{
     options::{
         ArithmeticOverflow, DisplayCalendar, RoundingIncrement, RoundingOptions,
         TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions,
-    }, partial::PartialDateTime, Calendar, PlainDateTime as InnerDateTime, PlainTime
+    },
+    partial::PartialDateTime,
+    Calendar, PlainDateTime as InnerDateTime, PlainTime,
 };
 
 use super::{

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -19,7 +19,9 @@ use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 
 use temporal_rs::{
-    options::{ArithmeticOverflow, DisplayCalendar}, partial::PartialDate, Calendar, PlainMonthDay as InnerMonthDay, TinyAsciiStr
+    options::{ArithmeticOverflow, DisplayCalendar},
+    partial::PartialDate,
+    Calendar, PlainMonthDay as InnerMonthDay, TinyAsciiStr,
 };
 
 use super::{calendar::to_temporal_calendar_slot_value, DateTimeValues};

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -20,7 +20,8 @@ use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 
 use temporal_rs::{
-    options::{ArithmeticOverflow, DisplayCalendar}, Calendar, Duration, PlainYearMonth as InnerYearMonth
+    options::{ArithmeticOverflow, DisplayCalendar},
+    Calendar, Duration, PlainYearMonth as InnerYearMonth,
 };
 
 use super::{calendar::to_temporal_calendar_slot_value, to_temporal_duration, DateTimeValues};
@@ -197,7 +198,6 @@ impl BuiltInConstructor for PlainYearMonth {
             .map(|s| Calendar::from_utf8(s.as_bytes()))
             .transpose()?
             .unwrap_or_default();
-
 
         // 6. Let ref be ? ToIntegerWithTruncation(referenceISODay).
         let ref_day = args

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -1,4 +1,3 @@
-
 use crate::{
     builtins::{
         options::{get_option, get_options_object},
@@ -12,8 +11,8 @@ use crate::{
     realm::Realm,
     string::StaticJsStrings,
     value::{IntoOrUndefined, PreferredType},
-    Context, JsArgs, JsBigInt, JsData, JsNativeError, JsObject, JsResult, JsString,
-    JsSymbol, JsValue, JsVariant,
+    Context, JsArgs, JsBigInt, JsData, JsNativeError, JsObject, JsResult, JsString, JsSymbol,
+    JsValue, JsVariant,
 };
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
@@ -404,7 +403,6 @@ impl BuiltInConstructor for ZonedDateTime {
             .map(|s| Calendar::from_utf8(s.as_bytes()))
             .transpose()?
             .unwrap_or_default();
-
 
         let inner = ZonedDateTimeInner::try_new(epoch_nanos.to_i128(), calendar, timezone)?;
 

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -19,7 +19,6 @@ use crate::{
 use boa_gc::{Finalize, Trace};
 use boa_profiler::Profiler;
 use cow_utils::CowUtils;
-use num_traits::ToPrimitive;
 use temporal_rs::{
     options::{
         ArithmeticOverflow, Disambiguation, DisplayCalendar, DisplayOffset, DisplayTimeZone,
@@ -31,7 +30,8 @@ use temporal_rs::{
 
 use super::{
     calendar::to_temporal_calendar_slot_value, create_temporal_date, create_temporal_datetime,
-    create_temporal_instant, create_temporal_time, to_partial_date_record, to_partial_time_record,
+    create_temporal_duration, create_temporal_instant, create_temporal_time,
+    options::get_difference_settings, to_partial_date_record, to_partial_time_record,
     to_temporal_duration, to_temporal_time,
 };
 
@@ -329,6 +329,8 @@ impl IntrinsicObject for ZonedDateTime {
             .method(Self::with_calendar, js_string!("withCalendar"), 1)
             .method(Self::add, js_string!("add"), 1)
             .method(Self::subtract, js_string!("subtract"), 1)
+            .method(Self::until, js_string!("until"), 1)
+            .method(Self::since, js_string!("since"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
@@ -367,14 +369,8 @@ impl BuiltInConstructor for ZonedDateTime {
                 .into());
         }
         //  2. Set epochNanoseconds to ? ToBigInt(epochNanoseconds).
-        let epoch_nanos = args.get_or_undefined(0).to_bigint(context)?;
         //  3. If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
-        // TODO: Better primitive for handling epochNanoseconds is needed in temporal_rs
-        let Some(nanos) = epoch_nanos.to_f64().to_i128() else {
-            return Err(JsNativeError::range()
-                .with_message("epochNanoseconds exceeded valid range.")
-                .into());
-        };
+        let epoch_nanos = args.get_or_undefined(0).to_bigint(context)?;
 
         //  4. If timeZone is not a String, throw a TypeError exception.
         let Some(timezone_str) = args.get_or_undefined(1).as_string() else {
@@ -413,7 +409,7 @@ impl BuiltInConstructor for ZonedDateTime {
             .transpose()?
             .unwrap_or_default();
 
-        let inner = ZonedDateTimeInner::try_new(nanos, calendar, timezone)?;
+        let inner = ZonedDateTimeInner::try_new(epoch_nanos.to_i128(), calendar, timezone)?;
 
         //  11. Return ? CreateTemporalZonedDateTime(epochNanoseconds, timeZone, calendar, NewTarget).
         create_temporal_zoneddatetime(inner, Some(new_target), context).map(Into::into)
@@ -893,13 +889,10 @@ impl ZonedDateTime {
         let options = get_options_object(args.get_or_undefined(1))?;
         let overflow = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
 
-        create_temporal_zoneddatetime(
-            zdt.inner
-                .add_with_provider(&duration, overflow, context.tz_provider())?,
-            None,
-            context,
-        )
-        .map(Into::into)
+        let result = zdt
+            .inner
+            .add_with_provider(&duration, overflow, context.tz_provider())?;
+        create_temporal_zoneddatetime(result, None, context).map(Into::into)
     }
 
     /// 6.3.36 `Temporal.ZonedDateTime.prototype.subtract ( temporalDurationLike [ , options ] )`
@@ -916,13 +909,48 @@ impl ZonedDateTime {
         let options = get_options_object(args.get_or_undefined(1))?;
         let overflow = get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
 
-        create_temporal_zoneddatetime(
+        let result =
             zdt.inner
-                .subtract_with_provider(&duration, overflow, context.tz_provider())?,
-            None,
-            context,
-        )
-        .map(Into::into)
+                .subtract_with_provider(&duration, overflow, context.tz_provider())?;
+        create_temporal_zoneddatetime(result, None, context).map(Into::into)
+    }
+
+    fn since(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
+
+        let options = get_options_object(args.get_or_undefined(1))?;
+        let settings = get_difference_settings(&options, context)?;
+
+        let result = zdt
+            .inner
+            .since_with_provider(&other, settings, context.tz_provider())?;
+        create_temporal_duration(result, None, context).map(Into::into)
+    }
+
+    fn until(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        let other = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
+
+        let options = get_options_object(args.get_or_undefined(1))?;
+        let settings = get_difference_settings(&options, context)?;
+
+        let result = zdt
+            .inner
+            .until_with_provider(&other, settings, context.tz_provider())?;
+        create_temporal_duration(result, None, context).map(Into::into)
     }
 
     /// 6.3.40 `Temporal.ZonedDateTime.prototype.equals ( other )`


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to ongoing progress for #4075.

It changes the following:

- Implements `since` and `until` methods for `ZonedDateTime`
- Includes a few bug fixes to various parts in `temporal_rs`
- Adds a `to_i128` to `JsBigInt` to skip indirect casting via `to_f64`