### PR TITLE
Fix truncation on max microseconds and nanoseconds

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -1024,7 +1024,7 @@ pub(crate) fn to_temporal_partial_duration(
         .map(|v| {
             let finite = v.to_finitef64(context)?;
             let integral_int = finite
-                .as_integer_if_integral::<i64>()
+                .as_integer_if_integral::<i128>()
                 .map_err(JsError::from)?;
             integral_int.try_into().map_err(JsError::from)
         })
@@ -1076,7 +1076,7 @@ pub(crate) fn to_temporal_partial_duration(
         .map(|v| {
             let finite = v.to_finitef64(context)?;
             let integral_int = finite
-                .as_integer_if_integral::<i64>()
+                .as_integer_if_integral::<i128>()
                 .map_err(JsError::from)?;
             integral_int.try_into().map_err(JsError::from)
         })


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to ongoing work for #1804 and #4070.

It changes the following:

- Changes adjusts the integer type from i64 -> i128 as the max nanosecond value * 2 and the max microsecond value * 2 exceeds the range of i64.

[Relevant test](https://github.com/tc39/test262/blob/main/test/built-ins/Temporal/Instant/prototype/add/minimum-maximum-instant.js)
