### PR TITLE
Bump temporal_rs and fix instant return

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3551,7 +3551,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=40e5dfbb8f04657b9dc17d994b8b934094bc11a1#40e5dfbb8f04657b9dc17d994b8b934094bc11a1"
+source = "git+https://github.com/boa-dev/temporal.git?rev=50003f04706406654e695c68e54d12c471851421#50003f04706406654e695c68e54d12c471851421"
 dependencies = [
  "combine",
  "iana-time-zone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,9 +2315,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91335e575850c5c4c673b9bd467b0e025f164ca59d0564f69d0c2ee0ffad4653"
+checksum = "cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3"
 
 [[package]]
 name = "js-sys"
@@ -3551,7 +3551,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=cb10eecbd68a5249f5f60f08ba9e09d2a24040a9#cb10eecbd68a5249f5f60f08ba9e09d2a24040a9"
+source = "git+https://github.com/boa-dev/temporal.git?rev=40e5dfbb8f04657b9dc17d994b8b934094bc11a1#40e5dfbb8f04657b9dc17d994b8b934094bc11a1"
 dependencies = [
  "combine",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "40e5dfbb8f04657b9dc17d994b8b934094bc11a1", features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "50003f04706406654e695c68e54d12c471851421", features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "cb10eecbd68a5249f5f60f08ba9e09d2a24040a9", features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "40e5dfbb8f04657b9dc17d994b8b934094bc11a1", features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -833,7 +833,7 @@ impl Duration {
         let smallest_unit =
             get_option::<TemporalUnit>(&options, js_string!("smallestUnit"), context)?;
 
-        let result = duration.inner.to_temporal_string(ToStringRoundingOptions {
+        let result = duration.inner.as_temporal_string(ToStringRoundingOptions {
             precision,
             smallest_unit,
             rounding_mode,
@@ -853,7 +853,7 @@ impl Duration {
 
         let result = duration
             .inner
-            .to_temporal_string(ToStringRoundingOptions::default())?;
+            .as_temporal_string(ToStringRoundingOptions::default())?;
 
         Ok(JsString::from(result).into())
     }

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -168,7 +168,7 @@ impl Instant {
         // 4. If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError exception.
         // 5. Return ! CreateTemporalInstant(epochNanoseconds).
         create_temporal_instant(
-            InnerInstant::from_epoch_milliseconds(epoch_millis.to_i128().unwrap_or(i128::MAX))?,
+            InnerInstant::from_epoch_milliseconds(epoch_millis.to_i64().unwrap_or(i64::MAX))?,
             None,
             context,
         )
@@ -509,7 +509,7 @@ impl Instant {
             rounding_mode,
         };
 
-        let ixdtf = instant.inner.as_ixdtf_string_with_provider(
+        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
             timezone.as_ref(),
             options,
             context.tz_provider(),
@@ -527,7 +527,7 @@ impl Instant {
                     .with_message("the this object must be a Temporal.Instant object.")
             })?;
 
-        let ixdtf = instant.inner.as_ixdtf_string_with_provider(
+        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
             None,
             ToStringRoundingOptions::default(),
             context.tz_provider(),

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -225,9 +225,9 @@ impl Instant {
                 JsNativeError::typ().with_message("the this object must be an instant object.")
             })?;
         // 3. Let ns be instant.[[Nanoseconds]].
-        // 4. Let ms be floor(ℝ(ns) / 106).
+        // 4. Let ms be floor(ℝ(ns) / 10^6).
         // 5. Return 𝔽(ms).
-        Ok(JsBigInt::from(instant.inner.epoch_milliseconds()).into())
+        Ok(instant.inner.epoch_milliseconds().into())
     }
 
     /// 8.3.6 get Temporal.Instant.prototype.epochNanoseconds
@@ -509,7 +509,7 @@ impl Instant {
             rounding_mode,
         };
 
-        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
+        let ixdtf = instant.inner.as_ixdtf_string_with_provider(
             timezone.as_ref(),
             options,
             context.tz_provider(),
@@ -527,7 +527,7 @@ impl Instant {
                     .with_message("the this object must be a Temporal.Instant object.")
             })?;
 
-        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
+        let ixdtf = instant.inner.as_ixdtf_string_with_provider(
             None,
             ToStringRoundingOptions::default(),
             context.tz_provider(),

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -510,7 +510,7 @@ impl PlainDate {
         let one = to_temporal_date(args.get_or_undefined(0), None, context)?;
         let two = to_temporal_date(args.get_or_undefined(1), None, context)?;
 
-        Ok((one.cmp(&two) as i8).into())
+        Ok((one.compare_iso(&two) as i8).into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -708,7 +708,7 @@ impl PlainDateTime {
         // one.[[ISOMicrosecond]], one.[[ISONanosecond]], two.[[ISOYear]], two.[[ISOMonth]],
         // two.[[ISODay]], two.[[ISOHour]], two.[[ISOMinute]], two.[[ISOSecond]],
         // two.[[ISOMillisecond]], two.[[ISOMicrosecond]], two.[[ISONanosecond]])).
-        Ok((one.cmp(&two) as i8).into())
+        Ok((one.compare_iso(&two) as i8).into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -554,7 +554,7 @@ impl PlainTime {
             smallest_unit,
         };
 
-        let ixdtf = time.inner.to_ixdtf_string(options)?;
+        let ixdtf = time.inner.as_ixdtf_string(options)?;
 
         Ok(JsString::from(ixdtf).into())
     }
@@ -570,7 +570,7 @@ impl PlainTime {
 
         let ixdtf = time
             .inner
-            .to_ixdtf_string(ToStringRoundingOptions::default())?;
+            .as_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())
     }
 

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -554,7 +554,7 @@ impl PlainTime {
             smallest_unit,
         };
 
-        let ixdtf = time.inner.as_ixdtf_string(options)?;
+        let ixdtf = time.inner.to_ixdtf_string(options)?;
 
         Ok(JsString::from(ixdtf).into())
     }
@@ -570,7 +570,7 @@ impl PlainTime {
 
         let ixdtf = time
             .inner
-            .as_ixdtf_string(ToStringRoundingOptions::default())?;
+            .to_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())
     }
 

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -350,7 +350,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.get_days_in_year()?.into())
+        Ok(inner.days_in_year()?.into())
     }
 
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
@@ -361,7 +361,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.get_days_in_month()?.into())
+        Ok(inner.days_in_month()?.into())
     }
 
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
@@ -372,7 +372,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.get_months_in_year()?.into())
+        Ok(inner.months_in_year()?.into())
     }
 
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -158,6 +158,14 @@ impl IntrinsicObject for ZonedDateTime {
             .name(js_string!("get inLeapYear"))
             .build();
 
+        let get_offset_nanos = BuiltInBuilder::callable(realm, Self::get_offset_nanoseconds)
+            .name(js_string!("get offsetNanoseconds"))
+            .build();
+
+        let get_offset = BuiltInBuilder::callable(realm, Self::get_offset)
+            .name(js_string!("get offset"))
+            .build();
+
         BuiltInBuilder::from_standard_constructor::<Self>(realm)
             .property(
                 JsSymbol::to_string_tag(),
@@ -317,6 +325,18 @@ impl IntrinsicObject for ZonedDateTime {
             .accessor(
                 js_string!("inLeapYear"),
                 Some(get_in_leap_year),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("offsetNanoseconds"),
+                Some(get_offset_nanos),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("offset"),
+                Some(get_offset),
                 None,
                 Attribute::CONFIGURABLE,
             )
@@ -789,6 +809,37 @@ impl ZonedDateTime {
             .inner
             .in_leap_year_with_provider(context.tz_provider())?
             .into())
+    }
+
+    /// 6.3.29 get Temporal.ZonedDateTime.prototype.offsetNanoseconds
+    fn get_offset_nanoseconds(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        Ok(zdt
+            .inner
+            .offset_nanoseconds_with_provider(context.tz_provider())?
+            .into())
+    }
+
+    /// 6.3.30 get Temporal.ZonedDateTime.prototype.offset
+    fn get_offset(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        Ok(JsString::from(zdt.inner.offset_with_provider(context.tz_provider())?).into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -809,7 +809,7 @@ impl ZonedDateTime {
         // 1. Return ? ToTemporalZonedDateTime(item, options).
         let one = to_temporal_zoneddatetime(args.get_or_undefined(0), None, context)?;
         let two = to_temporal_zoneddatetime(args.get_or_undefined(1), None, context)?;
-        Ok((one.cmp(&two) as i8).into())
+        Ok((one.compare_instant(&two) as i8).into())
     }
 
     /// 6.3.32 `Temporal.ZonedDateTime.prototype.withPlainTime ( [ plainTimeLike ] )`


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to ongoing work for #1804.

It changes the following:

- Fixes the returned value of `Instant::get_epoch_milliseconds`
- Bumps `temporal_rs` with some bug fixes
- Adjusts some method names due to `temporal_rs` changes
