### PR TITLE
Simplify date parser

### DIFF
--- a/core/engine/src/builtins/date/tests.rs
+++ b/core/engine/src/builtins/date/tests.rs
@@ -94,7 +94,7 @@ fn parse_ascii_digits() {
     assert_eq!(12, parse_4_ascii_digits(b"12xx", 2));
     assert_eq!(3, parse_4_ascii_digits(b"003x", 3));
     assert_eq!(23, parse_4_ascii_digits(b"023x", 3));
-    assert_eq!(0, parse_4_ascii_digits(b"0000", 8));
+    assert_eq!(0, parse_4_ascii_digits(b"0000", 4));
 }
 
 #[test]

--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -825,7 +825,6 @@ impl<'a> DateParser<'a> {
             .and_then(|c| if *c == expect { Some(()) } else { None })
     }
 
-    #[allow(unused)]
     fn next_digit(&mut self) -> Option<u8> {
         self.input.next().and_then(|c| {
             if c.is_ascii_digit() {
@@ -837,17 +836,9 @@ impl<'a> DateParser<'a> {
     }
 
     fn next_n_digits<const N: usize>(&mut self) -> Option<[u8; N]> {
-        if self.input.len() < N {
-            return None;
-        }
         let mut digits = [0; N];
         for digit in &mut digits {
-            // SAFETY: Bound check has been done above.
-            let c = unsafe { *self.input.next().unwrap_unchecked() };
-            if !c.is_ascii_digit() {
-                return None;
-            }
-            *digit = c - b'0';
+            *digit = self.next_digit()?;
         }
         Some(digits)
     }

--- a/core/engine/src/builtins/date/utils.rs
+++ b/core/engine/src/builtins/date/utils.rs
@@ -756,9 +756,13 @@ pub(super) fn parse_date(date: &JsString, hooks: &dyn HostHooks) -> Option<i64> 
     let owned_js_str = date.as_str();
     let owned_string: String;
     let date = match owned_js_str.variant() {
-        JsStrVariant::Latin1(s) =>
-        // SAFETY: Since all characters are ASCII we can safely convert this into str.
-        unsafe { str::from_utf8_unchecked(s) },
+        JsStrVariant::Latin1(s) => {
+            if !s.is_ascii() {
+                return None;
+            }
+            // SAFETY: Since all characters are ASCII we can safely convert this into str.
+            unsafe { str::from_utf8_unchecked(s) }
+        }
         JsStrVariant::Utf16(s) => {
             owned_string = String::from_utf16(s).ok()?;
             if !owned_string.is_ascii() {


### PR DESCRIPTION
- Avoid allocation if string is ascii
- Return early if string from utf16 encoded `JsString` is not ascii
- Replace `Char<'_>` with `slice::Iter<'_, u8>`
- Add `next_n_digits` helper method to save calls of `next_digit`
- Merge duplicate codes in matches
