### PR TITLE
Fix issues with `to_temporal_time` and `ZonedDateTime.prototype.withPlainTime`

### DIFF
--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -674,19 +674,9 @@ pub(crate) fn to_temporal_time(
 
             let options = get_options_object(options)?;
             let overflow =
-                get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?
-                    .unwrap_or(ArithmeticOverflow::Constrain);
+                get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
 
-            PlainTimeInner::new_with_overflow(
-                partial.hour.unwrap_or(0),
-                partial.minute.unwrap_or(0),
-                partial.second.unwrap_or(0),
-                partial.millisecond.unwrap_or(0),
-                partial.microsecond.unwrap_or(0),
-                partial.nanosecond.unwrap_or(0),
-                overflow,
-            )
-            .map_err(Into::into)
+            PlainTimeInner::from_partial(partial, overflow).map_err(Into::into)
         }
         // 3. Else,
         JsVariant::String(str) => {
@@ -718,20 +708,11 @@ pub(crate) fn to_partial_time_record(
         .transpose()?
         .map(Into::into);
 
-    let minute = partial_object
-        .get(js_string!("minute"), context)?
+    let microsecond = partial_object
+        .get(js_string!("microsecond"), context)?
         .map(|v| {
             let finite = v.to_finitef64(context)?;
-            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
-        })
-        .transpose()?
-        .map(Into::into);
-
-    let second = partial_object
-        .get(js_string!("second"), context)?
-        .map(|v| {
-            let finite = v.to_finitef64(context)?;
-            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+            Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
         })
         .transpose()?
         .map(Into::into);
@@ -745,11 +726,11 @@ pub(crate) fn to_partial_time_record(
         .transpose()?
         .map(Into::into);
 
-    let microsecond = partial_object
-        .get(js_string!("microsecond"), context)?
+    let minute = partial_object
+        .get(js_string!("minute"), context)?
         .map(|v| {
             let finite = v.to_finitef64(context)?;
-            Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
+            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
         })
         .transpose()?
         .map(Into::into);
@@ -759,6 +740,15 @@ pub(crate) fn to_partial_time_record(
         .map(|v| {
             let finite = v.to_finitef64(context)?;
             Ok::<u16, JsError>(finite.as_integer_with_truncation::<u16>())
+        })
+        .transpose()?
+        .map(Into::into);
+
+    let second = partial_object
+        .get(js_string!("second"), context)?
+        .map(|v| {
+            let finite = v.to_finitef64(context)?;
+            Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
         })
         .transpose()?
         .map(Into::into);

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -826,7 +826,7 @@ impl ZonedDateTime {
             })?;
 
         let time = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_time(v, None, context))
             .transpose()?;
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the ongoing work for temporal

It fixes a couple bugs

- Order of ops for accessing a time-like property bag 
- Uses the correct `from_partial` method from `temporal_rs`
- Properly handles an `undefined` arg provided to `withPlainTime`
