### PR TITLE
Add trace function to Logger trait

### DIFF
--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -521,9 +521,21 @@ impl Context {
     }
 
     /// Retrieves the current stack trace of the context.
+    ///
+    /// When constructing the stack trace the current frame is taken from [`Vm::frame`],
+    /// and the rest of the frames are taken from [`Vm::frames`].
+    /// The first frame is always a dummy frame (see [`Vm::frame`]).
+    ///
+    /// The stack trace is returned ordered with the most recent frames first.
     #[inline]
     pub fn stack_trace(&self) -> impl Iterator<Item = &CallFrame> {
-        self.vm.frames.iter().rev()
+        let frames: Vec<_> = self
+            .vm
+            .frames
+            .iter()
+            .chain(std::iter::once(&self.vm.frame))
+            .collect();
+        frames.into_iter().skip(1).rev()
     }
 
     /// Replaces the currently active realm with `realm`, and returns the old realm.

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -522,19 +522,19 @@ impl Context {
 
     /// Retrieves the current stack trace of the context.
     ///
-    /// When constructing the stack trace the current frame is taken from [`Vm::frame`],
-    /// and the rest of the frames are taken from [`Vm::frames`].
-    /// The first frame is always a dummy frame (see [`Vm::frame`]).
-    ///
     /// The stack trace is returned ordered with the most recent frames first.
     #[inline]
     pub fn stack_trace(&self) -> impl Iterator<Item = &CallFrame> {
+        // Create a list containing the previous frames plus the current frame.
         let frames: Vec<_> = self
             .vm
             .frames
             .iter()
             .chain(std::iter::once(&self.vm.frame))
             .collect();
+
+        // The first frame is always a dummy frame (see `Vm` implementation for more details),
+        // so skip the dummy frame and return the reversed list so that the most recent frames are first.
         frames.into_iter().skip(1).rev()
     }
 

--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -28,6 +28,30 @@ use std::{cell::RefCell, collections::hash_map::Entry, io::Write, rc::Rc, time::
 
 /// A trait that can be used to forward console logs to an implementation.
 pub trait Logger: Trace + Sized {
+    /// Log a trace message (`console.trace`). By default, passes the message and the
+    /// code block names of each stack trace frame to `log`.
+    ///
+    /// # Errors
+    /// Returning an error will throw an exception in JavaScript.
+    fn trace(&self, msg: String, state: &ConsoleState, context: &mut Context) -> JsResult<()> {
+        self.log(msg, state, context)?;
+
+        let stack_trace_dump = context
+            .stack_trace()
+            .map(|frame| frame.code_block().name())
+            .filter(|name| !name.is_empty()) // The last frame has an empty name.
+            .collect::<Vec<_>>()
+            .into_iter()
+            .map(JsString::to_std_string_escaped)
+            .collect::<Vec<_>>();
+
+        for frame in stack_trace_dump {
+            self.log(frame, state, context)?;
+        }
+
+        Ok(())
+    }
+
     /// Log a debug message (`console.debug`). By default, passes the message to `log`.
     ///
     /// # Errors
@@ -565,20 +589,7 @@ impl Console {
         logger: &impl Logger,
         context: &mut Context,
     ) -> JsResult<JsValue> {
-        if !args.is_empty() {
-            logger.log(formatter(args, context)?, &console.state, context)?;
-        }
-
-        let stack_trace_dump = context
-            .stack_trace()
-            .map(|frame| frame.code_block().name())
-            .collect::<Vec<_>>()
-            .into_iter()
-            .map(JsString::to_std_string_escaped)
-            .collect::<Vec<_>>()
-            .join("\n");
-        logger.log(stack_trace_dump, &console.state, context)?;
-
+        Logger::trace(logger, formatter(args, context)?, &console.state, context)?;
         Ok(JsValue::undefined())
     }
 

--- a/core/runtime/src/console/mod.rs
+++ b/core/runtime/src/console/mod.rs
@@ -39,9 +39,6 @@ pub trait Logger: Trace + Sized {
         let stack_trace_dump = context
             .stack_trace()
             .map(|frame| frame.code_block().name())
-            .filter(|name| !name.is_empty()) // The last frame has an empty name.
-            .collect::<Vec<_>>()
-            .into_iter()
             .map(JsString::to_std_string_escaped)
             .collect::<Vec<_>>();
 

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -367,7 +367,9 @@ fn trace_with_stack_trace() {
         logs,
         indoc! { r#"
             one
+            <main>
             two
+            b
             a
             <main>
         "# }

--- a/core/runtime/src/console/tests.rs
+++ b/core/runtime/src/console/tests.rs
@@ -337,3 +337,39 @@ fn console_namespace_object_class_string() {
         &mut context,
     );
 }
+
+#[test]
+fn trace_with_stack_trace() {
+    let mut context = Context::default();
+    let logger = RecordingLogger::default();
+    Console::register_with_logger(&mut context, logger.clone()).unwrap();
+
+    run_test_actions_with(
+        [
+            TestAction::run(TEST_HARNESS),
+            TestAction::run(indoc! {r#"
+            console.trace("one");
+            a();
+
+            function a() {
+                b();
+            }
+            function b() {
+                console.trace("two");
+            }
+        "#}),
+        ],
+        &mut context,
+    );
+
+    let logs = logger.log.borrow().clone();
+    assert_eq!(
+        logs,
+        indoc! { r#"
+            one
+            two
+            a
+            <main>
+        "# }
+    );
+}


### PR DESCRIPTION
This Pull Request implements the discussion in Matrix about trace logging.

It changes the following:

- Adds a `trace` function to the `Logger` trait.
- Calls that `trace` function  from `Console.trace`.

For such a small PR, I encountered a few niggles:

## 1. Conflicting `trace` method
The `Logger` trait derives from the `Trace` trait, which already has a `trace` function, but is unrelated to trace logging. This meant I had to call the new trace function by doing:
```rust
Logger::trace(logger, formatter(args, context)?, &console.state, context)?;
```
rather than the following which is ambiguous to the compiler:
```rust
logger.trace(formatter(args, context)?, &console.state, context)?;
```

This is unsatisfactory, but I also felt that renaming the new `Logger.trace` function would make it inconsistent with the surrounding code.

## 2. Passing the stack trace
In matrix we discussed passing the stack trace into the `Logger.trace` function.
- I could pass in the `Vec<string>` of stack frame code block names, but this feels quite prescriptive with the Console deciding in how the stack trace is formatted.
- I could pass in a `Vec<&CallFrame>`, but the borrow checker points out that this means I'd be passing in both a mutable reference to `Context` and immutable references to the `CallFrame` instances inside `Context`.
- Therefore it seemed to make sense to just allow the `Logger.trace` implementation to extract the call stack from `Context` itself, and format the call frames as it sees fit, and it also keeps the `trace` signature consistent with the other logging functions.

## 3. Code block names
There were a couple of unexpected things here. If I comment out the `.filter(|name| !name.is_empty())` line which I added and run on the following test javascript:
```js
function run() {
  console.trace("Trace from 'run' function.");
  a();
}

function a() {
  b();
}

function b() {
  c();
}

function c() {
  console.trace("Trace from 'c' function.");
}

run();
```

I get the following output:
```
Trace from 'run' function.
<main>

Trace from 'c' function.
b
a
run
<main>

```
Unexpected things:
1. The blank lines under <main> are caused by a code block with an empty name, which isn't very useful to log.
2. The function that is calling `console.trace` isn't included in the stack trace.

I resolved the first by filtering out empty stack frame names, although I didn't love this solution.

I wasn't sure how to resolve the second point.
