### PR TITLE
Implement toLocaleString and some general cleanup

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -194,6 +194,7 @@ impl IntrinsicObject for Duration {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::total, js_string!("total"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -858,6 +859,29 @@ impl Duration {
         Ok(JsString::from(result).into())
     }
 
+    // TODO: Potentially update docs if localeString is inverted.
+    /// 7.3.24 `Temporal.Duration.prototype.toLocaleString ( )`
+    pub(crate) fn to_locale_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let duration = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a Duration object.")
+            })?;
+
+        let result = duration
+            .inner
+            .as_temporal_string(ToStringRoundingOptions::default())?;
+
+        Ok(JsString::from(result).into())
+    }
+
+    /// 7.3.25 `Temporal.Duration.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -92,8 +92,8 @@ impl IntrinsicObject for Instant {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
-            .method(Self::to_zoned_date_time, js_string!("toZonedDateTime"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .method(
@@ -457,30 +457,7 @@ impl Instant {
         Ok(true.into())
     }
 
-    /// 8.3.17 `Temporal.Instant.prototype.toZonedDateTime ( item )`
-    pub(crate) fn to_zoned_date_time(
-        _: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
-    ) -> JsResult<JsValue> {
-        // TODO: Complete
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
-    }
-
-    /// 8.3.18 `Temporal.Instant.prototype.toZonedDateTimeISO ( timeZone )`
-    pub(crate) fn to_zoned_date_time_iso(
-        _: &JsValue,
-        _: &[JsValue],
-        _: &mut Context,
-    ) -> JsResult<JsValue> {
-        // TODO Complete
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
-    }
-
+    /// 8.3.11 `Temporal.Instant.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let instant = this
             .as_object()
@@ -518,6 +495,26 @@ impl Instant {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 8.3.12 `Temporal.Instant.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let instant = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ()
+                    .with_message("the this object must be a Temporal.Instant object.")
+            })?;
+
+        let ixdtf = instant.inner.to_ixdtf_string_with_provider(
+            None,
+            ToStringRoundingOptions::default(),
+            context.tz_provider(),
+        )?;
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 8.3.13 `Temporal.Instant.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let instant = this
             .as_object()
@@ -535,9 +532,22 @@ impl Instant {
         Ok(JsString::from(ixdtf).into())
     }
 
-    pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+    /// 8.3.14 `Temporal.Instant.prototype.valueOf ( )`
+    fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
+            .into())
+    }
+
+    /// 8.3.15 `Temporal.Instant.prototype.toZonedDateTimeISO ( timeZone )`
+    pub(crate) fn to_zoned_date_time_iso(
+        _: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO Complete
+        Err(JsNativeError::error()
+            .with_message("not yet implemented.")
             .into())
     }
 }

--- a/core/engine/src/builtins/temporal/mod.rs
+++ b/core/engine/src/builtins/temporal/mod.rs
@@ -37,24 +37,13 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    Context, JsBigInt, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
 };
 use boa_profiler::Profiler;
 use temporal_rs::options::RelativeTo;
 use temporal_rs::{
     primitive::FiniteF64, PlainDate as TemporalDate, ZonedDateTime as TemporalZonedDateTime,
-    NS_PER_DAY,
 };
-
-// TODO: Remove in favor of `temporal_rs`
-pub(crate) fn ns_max_instant() -> JsBigInt {
-    JsBigInt::from(i128::from(NS_PER_DAY) * 100_000_000_i128)
-}
-
-// TODO: Remove in favor of `temporal_rs`
-pub(crate) fn ns_min_instant() -> JsBigInt {
-    JsBigInt::from(i128::from(NS_PER_DAY) * -100_000_000_i128)
-}
 
 // An enum representing common fields across `Temporal` objects.
 pub(crate) enum DateTimeValues {

--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -7,16 +7,14 @@ use crate::{
     property::Attribute,
     realm::Realm,
     string::StaticJsStrings,
-    sys::time::SystemTime,
-    Context, JsBigInt, JsNativeError, JsObject, JsResult, JsString, JsSymbol, JsValue,
+    Context, JsArgs, JsObject, JsResult, JsString, JsSymbol, JsValue,
 };
 use boa_profiler::Profiler;
-use temporal_rs::{Now as NowInner, TimeZone};
+use temporal_rs::Now as NowInner;
 
 use super::{
     create_temporal_date, create_temporal_datetime, create_temporal_instant, create_temporal_time,
-    create_temporal_zoneddatetime, ns_max_instant, ns_min_instant, time_zone::default_time_zone,
-    to_temporal_timezone_identifier,
+    create_temporal_zoneddatetime, to_temporal_timezone_identifier,
 };
 
 /// JavaScript `Temporal.Now` object.
@@ -65,12 +63,9 @@ impl Now {
     ///
     /// [spec]: https://tc39.es/proposal-temporal/#sec-temporal.now.timezone
     #[allow(clippy::unnecessary_wraps)]
-    fn time_zone_id(_: &JsValue, _args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+    fn time_zone_id(_: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Return ! SystemTimeZone().
-        system_time_zone(context)?
-            .identifier()
-            .map(|s| JsValue::from(js_string!(s.as_str())))
-            .map_err(Into::into)
+        Ok(JsString::from(NowInner::time_zone_id()?).into())
     }
 
     /// `Temporal.Now.instant()`
@@ -81,7 +76,7 @@ impl Now {
     /// `Temporal.Now.plainDateTime()`
     fn plain_datetime(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         create_temporal_datetime(
@@ -95,7 +90,7 @@ impl Now {
     /// `Temporal.Now.zonedDateTime`
     fn zoneddatetime(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let timezone = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let zdt = NowInner::zoneddatetime_iso(timezone)?;
@@ -105,7 +100,7 @@ impl Now {
     /// `Temporal.Now.plainDateISO`
     fn plain_date(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let pd = NowInner::plain_date_iso_with_provider(tz, context.tz_provider())?;
@@ -114,76 +109,10 @@ impl Now {
 
     fn plain_time(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let tz = args
-            .first()
+            .get_or_undefined(0)
             .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
         let pt = NowInner::plain_time_iso_with_provider(tz, context.tz_provider())?;
         create_temporal_time(pt, None, context).map(Into::into)
     }
-}
-
-// -- Temporal.Now abstract operations --
-
-/// 2.3.1 `HostSystemUTCEpochNanoseconds ( global )`
-fn host_system_utc_epoch_nanoseconds() -> JsResult<JsBigInt> {
-    // TODO: Implement `SystemTime::now()` calls for `no_std`
-    let epoch_nanos = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .map_err(|e| JsNativeError::range().with_message(e.to_string()))?
-        .as_nanos();
-    Ok(clamp_epoc_nanos(JsBigInt::from(epoch_nanos)))
-}
-
-fn clamp_epoc_nanos(ns: JsBigInt) -> JsBigInt {
-    let max = ns_max_instant();
-    let min = ns_min_instant();
-    ns.clamp(min, max)
-}
-
-/// 2.3.2 `SystemUTCEpochMilliseconds`
-#[allow(unused)]
-fn system_utc_epoch_millis() -> JsResult<f64> {
-    let now = host_system_utc_epoch_nanoseconds()?;
-    Ok(now.to_f64().div_euclid(1_000_000_f64).floor())
-}
-
-/// 2.3.3 `SystemUTCEpochNanoseconds`
-#[allow(unused)]
-fn system_utc_epoch_nanos() -> JsResult<JsBigInt> {
-    host_system_utc_epoch_nanoseconds()
-}
-
-/// `SystemInstant`
-#[allow(unused)]
-fn system_instant() {
-    todo!()
-}
-
-/// `SystemDateTime`
-#[allow(unused)]
-fn system_date_time() {
-    todo!()
-}
-
-/// `SystemZonedDateTime`
-#[allow(unused)]
-fn system_zoned_date_time() {
-    todo!()
-}
-
-/// Abstract operation `SystemTimeZone ( )`
-///
-/// More information:
-///  - [ECMAScript specififcation][spec]
-///
-/// [spec]: https://tc39.es/proposal-temporal/#sec-temporal-systemtimezone
-#[allow(unused)]
-fn system_time_zone(context: &mut Context) -> JsResult<TimeZone> {
-    // 1. Let identifier be ! DefaultTimeZone().
-    let identifier = default_time_zone(context);
-    // 2. Return ! CreateTemporalTimeZone(identifier).
-
-    Err(JsNativeError::error()
-        .with_message("not yet implemented.")
-        .into())
 }

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -342,7 +342,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.year()?.into())
+        Ok(date.inner.era_year()?.into_or_undefined())
     }
 
     /// 3.3.6 get `Temporal.PlainDate.prototype.year`

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -61,6 +61,14 @@ impl IntrinsicObject for PlainDate {
             .name(js_string!("get calendarId"))
             .build();
 
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+            .name(js_string!("get era"))
+            .build();
+
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+            .name(js_string!("get eraYear"))
+            .build();
+
         let get_year = BuiltInBuilder::callable(realm, Self::get_year)
             .name(js_string!("get year"))
             .build();
@@ -122,6 +130,18 @@ impl IntrinsicObject for PlainDate {
             .accessor(
                 js_string!("calendarId"),
                 Some(get_calendar_id),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("era"),
+                Some(get_era),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("eraYear"),
+                Some(get_era_year),
                 None,
                 Attribute::CONFIGURABLE,
             )
@@ -207,7 +227,6 @@ impl IntrinsicObject for PlainDate {
             .static_method(Self::compare, js_string!("compare"), 2)
             .method(Self::to_plain_year_month, js_string!("toPlainYearMonth"), 0)
             .method(Self::to_plain_month_day, js_string!("toPlainMonthDay"), 0)
-            .method(Self::get_iso_fields, js_string!("getISOFields"), 0)
             .method(Self::add, js_string!("add"), 1)
             .method(Self::subtract, js_string!("subtract"), 1)
             .method(Self::with, js_string!("with"), 1)
@@ -217,6 +236,7 @@ impl IntrinsicObject for PlainDate {
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_plain_datetime, js_string!("toPlainDateTime"), 0)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -291,7 +311,41 @@ impl PlainDate {
         Ok(JsString::from(date.inner.calendar().identifier()).into())
     }
 
-    /// 3.3.4 get `Temporal.PlainDate.prototype.year`
+    /// 3.3.4 get `Temporal.PlainDate.prototype.era`
+    fn get_era(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        let obj = this
+            .as_object()
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
+
+        let Some(date) = obj.downcast_ref::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDate object.")
+                .into());
+        };
+
+        Ok(date
+            .inner
+            .era()?
+            .map(|s| JsString::from(s.as_str()))
+            .into_or_undefined())
+    }
+
+    /// 3.3.5 get `Temporal.PlainDate.prototype.eraYear`
+    fn get_era_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        let obj = this
+            .as_object()
+            .ok_or_else(|| JsNativeError::typ().with_message("this must be an object."))?;
+
+        let Some(date) = obj.downcast_ref::<Self>() else {
+            return Err(JsNativeError::typ()
+                .with_message("the this object must be a PlainDate object.")
+                .into());
+        };
+
+        Ok(date.inner.year()?.into())
+    }
+
+    /// 3.3.6 get `Temporal.PlainDate.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -306,7 +360,7 @@ impl PlainDate {
         Ok(date.inner.year()?.into())
     }
 
-    /// 3.3.5 get `Temporal.PlainDate.prototype.month`
+    /// 3.3.7 get `Temporal.PlainDate.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -321,7 +375,7 @@ impl PlainDate {
         Ok(date.inner.month()?.into())
     }
 
-    /// 3.3.6 get Temporal.PlainDate.prototype.monthCode
+    /// 3.3.8 get Temporal.PlainDate.prototype.monthCode
     fn get_month_code(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -336,7 +390,7 @@ impl PlainDate {
         Ok(JsString::from(date.inner.month_code()?.as_str()).into())
     }
 
-    /// 3.3.7 get `Temporal.PlainDate.prototype.day`
+    /// 3.3.9 get `Temporal.PlainDate.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -351,7 +405,7 @@ impl PlainDate {
         Ok(date.inner.day()?.into())
     }
 
-    /// 3.3.8 get `Temporal.PlainDate.prototype.dayOfWeek`
+    /// 3.3.10 get `Temporal.PlainDate.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -366,7 +420,7 @@ impl PlainDate {
         Ok(date.inner.day_of_week()?.into())
     }
 
-    /// 3.3.9 get `Temporal.PlainDate.prototype.dayOfYear`
+    /// 3.3.11 get `Temporal.PlainDate.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -381,7 +435,7 @@ impl PlainDate {
         Ok(date.inner.day_of_year()?.into())
     }
 
-    /// 3.3.10 get `Temporal.PlainDate.prototype.weekOfYear`
+    /// 3.3.12 get `Temporal.PlainDate.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -396,7 +450,7 @@ impl PlainDate {
         Ok(date.inner.week_of_year()?.into_or_undefined())
     }
 
-    /// 3.3.11 get `Temporal.PlainDate.prototype.yearOfWeek`
+    /// 3.3.13 get `Temporal.PlainDate.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -411,7 +465,7 @@ impl PlainDate {
         Ok(date.inner.year_of_week()?.into_or_undefined())
     }
 
-    /// 3.3.12 get `Temporal.PlainDate.prototype.daysInWeek`
+    /// 3.3.14 get `Temporal.PlainDate.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -426,7 +480,7 @@ impl PlainDate {
         Ok(date.inner.days_in_week()?.into())
     }
 
-    /// 3.3.13 get `Temporal.PlainDate.prototype.daysInMonth`
+    /// 3.3.15 get `Temporal.PlainDate.prototype.daysInMonth`
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -441,7 +495,7 @@ impl PlainDate {
         Ok(date.inner.days_in_month()?.into())
     }
 
-    /// 3.3.14 get `Temporal.PlainDate.prototype.daysInYear`
+    /// 3.3.16 get `Temporal.PlainDate.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -456,7 +510,7 @@ impl PlainDate {
         Ok(date.inner.days_in_year()?.into())
     }
 
-    /// 3.3.15 get `Temporal.PlainDate.prototype.monthsInYear`
+    /// 3.3.17 get `Temporal.PlainDate.prototype.monthsInYear`
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -471,7 +525,7 @@ impl PlainDate {
         Ok(date.inner.months_in_year()?.into())
     }
 
-    /// 3.3.16 get `Temporal.PlainDate.prototype.inLeapYear`
+    /// 3.3.18 get `Temporal.PlainDate.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let obj = this
             .as_object()
@@ -527,47 +581,6 @@ impl PlainDate {
         Err(JsNativeError::error()
             .with_message("not yet implemented.")
             .into())
-    }
-
-    fn get_iso_fields(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
-        // 1. Let temporalDate be the this value.
-        // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
-        let date = this
-            .as_object()
-            .and_then(JsObject::downcast_ref::<Self>)
-            .ok_or_else(|| {
-                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
-            })?;
-
-        // 3. Let fields be OrdinaryObjectCreate(%Object.prototype%).
-        let fields = JsObject::with_object_proto(context.intrinsics());
-
-        // 4. Perform ! CreateDataPropertyOrThrow(fields, "calendar", temporalDate.[[Calendar]]).
-        fields.create_data_property_or_throw(
-            js_string!("calendar"),
-            JsString::from(date.inner.calendar().identifier()),
-            context,
-        )?;
-        // 5. Perform ! CreateDataPropertyOrThrow(fields, "isoDay", 𝔽(temporalDate.[[ISODay]])).
-        fields.create_data_property_or_throw(
-            js_string!("isoDay"),
-            date.inner.iso_day(),
-            context,
-        )?;
-        // 6. Perform ! CreateDataPropertyOrThrow(fields, "isoMonth", 𝔽(temporalDate.[[ISOMonth]])).
-        fields.create_data_property_or_throw(
-            js_string!("isoMonth"),
-            date.inner.iso_month(),
-            context,
-        )?;
-        // 7. Perform ! CreateDataPropertyOrThrow(fields, "isoYear", 𝔽(temporalDate.[[ISOYear]])).
-        fields.create_data_property_or_throw(
-            js_string!("isoYear"),
-            date.inner.iso_year(),
-            context,
-        )?;
-        // 8. Return fields.
-        Ok(fields.into())
     }
 
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
@@ -707,6 +720,7 @@ impl PlainDate {
         create_temporal_duration(date.inner.since(&other, settings)?, None, context).map(Into::into)
     }
 
+    /// 3.3.27 `Temporal.PlainDate.prototype.equals ( other )`
     fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let date = this
             .as_object()
@@ -760,7 +774,20 @@ impl PlainDate {
         Ok(JsString::from(date.inner.to_ixdtf_string(display_calendar)).into())
     }
 
-    // 3.3.32 `Temporal.PlainDate.prototype.toJSON ( )`
+    /// 3.3.31 `Temporal.PlainDate.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let date = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
+            })?;
+
+        Ok(JsString::from(date.inner.to_string()).into())
+    }
+
+    /// 3.3.32 `Temporal.PlainDate.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let date = this
             .as_object()

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -69,6 +69,14 @@ impl IntrinsicObject for PlainDateTime {
             .name(js_string!("get calendarId"))
             .build();
 
+        let get_era = BuiltInBuilder::callable(realm, Self::get_era)
+            .name(js_string!("get era"))
+            .build();
+
+        let get_era_year = BuiltInBuilder::callable(realm, Self::get_era_year)
+            .name(js_string!("get eraYear"))
+            .build();
+
         let get_year = BuiltInBuilder::callable(realm, Self::get_year)
             .name(js_string!("get year"))
             .build();
@@ -154,6 +162,18 @@ impl IntrinsicObject for PlainDateTime {
             .accessor(
                 js_string!("calendarId"),
                 Some(get_calendar_id),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("era"),
+                Some(get_era),
+                None,
+                Attribute::CONFIGURABLE,
+            )
+            .accessor(
+                js_string!("eraYear"),
+                Some(get_era_year),
                 None,
                 Attribute::CONFIGURABLE,
             )
@@ -283,6 +303,7 @@ impl IntrinsicObject for PlainDateTime {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -416,6 +437,34 @@ impl PlainDateTime {
     }
 
     /// 5.3.4 get `Temporal.PlainDatedt.prototype.year`
+    fn get_era(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        Ok(dt
+            .inner
+            .era()?
+            .map(|s| JsString::from(s.as_str()))
+            .into_or_undefined())
+    }
+
+    /// 5.3.5 get `Temporal.PlainDatedt.prototype.eraYear`
+    fn get_era_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        Ok(dt.inner.era_year()?.into_or_undefined())
+    }
+
+    /// 5.3.6 get `Temporal.PlainDatedt.prototype.year`
     fn get_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -427,7 +476,7 @@ impl PlainDateTime {
         Ok(dt.inner.year()?.into())
     }
 
-    /// 5.3.5 get `Temporal.PlainDatedt.prototype.month`
+    /// 5.3.7 get `Temporal.PlainDatedt.prototype.month`
     fn get_month(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -439,7 +488,7 @@ impl PlainDateTime {
         Ok(dt.inner.month()?.into())
     }
 
-    /// 5.3.6 get Temporal.PlainDatedt.prototype.monthCode
+    /// 5.3.8 get Temporal.PlainDatedt.prototype.monthCode
     fn get_month_code(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -451,7 +500,7 @@ impl PlainDateTime {
         Ok(JsString::from(dt.inner.month_code()?.as_str()).into())
     }
 
-    /// 5.3.7 get `Temporal.PlainDatedt.prototype.day`
+    /// 5.3.9 get `Temporal.PlainDatedt.prototype.day`
     fn get_day(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -463,7 +512,7 @@ impl PlainDateTime {
         Ok(dt.inner.day()?.into())
     }
 
-    /// 5.3.8 get `Temporal.PlainDatedt.prototype.hour`
+    /// 5.3.10 get `Temporal.PlainDatedt.prototype.hour`
     fn get_hour(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -478,7 +527,7 @@ impl PlainDateTime {
         Ok(dt.inner.hour().into())
     }
 
-    /// 5.3.9 get `Temporal.PlainDatedt.prototype.minute`
+    /// 5.3.11 get `Temporal.PlainDatedt.prototype.minute`
     fn get_minute(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -493,7 +542,7 @@ impl PlainDateTime {
         Ok(dt.inner.minute().into())
     }
 
-    /// 5.3.10 get `Temporal.PlainDatedt.prototype.second`
+    /// 5.3.12 get `Temporal.PlainDatedt.prototype.second`
     fn get_second(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -508,7 +557,7 @@ impl PlainDateTime {
         Ok(dt.inner.second().into())
     }
 
-    /// 5.3.11 get `Temporal.PlainDatedt.prototype.millisecond`
+    /// 5.3.13 get `Temporal.PlainDatedt.prototype.millisecond`
     fn get_millisecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -523,7 +572,7 @@ impl PlainDateTime {
         Ok(dt.inner.millisecond().into())
     }
 
-    /// 5.3.12 get `Temporal.PlainDatedt.prototype.microsecond`
+    /// 5.3.14 get `Temporal.PlainDatedt.prototype.microsecond`
     fn get_microsecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -538,7 +587,7 @@ impl PlainDateTime {
         Ok(dt.inner.microsecond().into())
     }
 
-    /// 5.3.13 get `Temporal.PlainDatedt.prototype.nanosecond`
+    /// 5.3.15 get `Temporal.PlainDatedt.prototype.nanosecond`
     fn get_nanosecond(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         // 1. Let dateTime be the this value.
         // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
@@ -553,7 +602,7 @@ impl PlainDateTime {
         Ok(dt.inner.nanosecond().into())
     }
 
-    /// 5.3.14 get `Temporal.PlainDatedt.prototype.dayOfWeek`
+    /// 5.3.16 get `Temporal.PlainDatedt.prototype.dayOfWeek`
     fn get_day_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -565,7 +614,7 @@ impl PlainDateTime {
         Ok(dt.inner.day_of_week()?.into())
     }
 
-    /// 5.3.15 get `Temporal.PlainDatedt.prototype.dayOfYear`
+    /// 5.3.17 get `Temporal.PlainDatedt.prototype.dayOfYear`
     fn get_day_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -577,7 +626,7 @@ impl PlainDateTime {
         Ok(dt.inner.day_of_year()?.into())
     }
 
-    /// 5.3.16 get `Temporal.PlainDatedt.prototype.weekOfYear`
+    /// 5.3.18 get `Temporal.PlainDatedt.prototype.weekOfYear`
     fn get_week_of_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -589,7 +638,7 @@ impl PlainDateTime {
         Ok(dt.inner.week_of_year()?.into_or_undefined())
     }
 
-    /// 5.3.17 get `Temporal.PlainDatedt.prototype.yearOfWeek`
+    /// 5.3.19 get `Temporal.PlainDatedt.prototype.yearOfWeek`
     fn get_year_of_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -601,7 +650,7 @@ impl PlainDateTime {
         Ok(dt.inner.year_of_week()?.into_or_undefined())
     }
 
-    /// 5.3.18 get `Temporal.PlainDatedt.prototype.daysInWeek`
+    /// 5.3.20 get `Temporal.PlainDatedt.prototype.daysInWeek`
     fn get_days_in_week(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -613,7 +662,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_week()?.into())
     }
 
-    /// 5.3.19 get `Temporal.PlainDatedt.prototype.daysInMonth`
+    /// 5.3.21 get `Temporal.PlainDatedt.prototype.daysInMonth`
     fn get_days_in_month(
         this: &JsValue,
         _: &[JsValue],
@@ -629,7 +678,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_month()?.into())
     }
 
-    /// 5.3.20 get `Temporal.PlainDatedt.prototype.daysInYear`
+    /// 5.3.22 get `Temporal.PlainDatedt.prototype.daysInYear`
     fn get_days_in_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -641,7 +690,7 @@ impl PlainDateTime {
         Ok(dt.inner.days_in_year()?.into())
     }
 
-    /// 5.3.21 get `Temporal.PlainDatedt.prototype.monthsInYear`
+    /// 5.3.23 get `Temporal.PlainDatedt.prototype.monthsInYear`
     fn get_months_in_year(
         this: &JsValue,
         _: &[JsValue],
@@ -657,7 +706,7 @@ impl PlainDateTime {
         Ok(dt.inner.months_in_year()?.into())
     }
 
-    /// 5.3.22 get `Temporal.PlainDatedt.prototype.inLeapYear`
+    /// 5.3.24 get `Temporal.PlainDatedt.prototype.inLeapYear`
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -978,6 +1027,27 @@ impl PlainDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 5.3.35 `Temporal.PlainDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        let ixdtf = dt
+            .inner
+            .to_ixdtf_string(ToStringRoundingOptions::default(), DisplayCalendar::Auto)?;
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 5.3.36 `Temporal.PlainDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
             .as_object()
@@ -992,6 +1062,7 @@ impl PlainDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 5.3.37 `Temporal.PlainDateTime.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -84,6 +84,7 @@ impl IntrinsicObject for PlainMonthDay {
             )
             .static_method(Self::from, js_string!("from"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -231,7 +232,24 @@ impl PlainMonthDay {
         Ok(JsString::from(ixdtf).into())
     }
 
-    /// 10.3.10 Temporal.PlainMonthDay.prototype.toJSON ( )
+    /// 10.3.9 `Temporal.PlainMonthDay.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    pub(crate) fn to_locale_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let month_day = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a PlainMonthDay object.")
+            })?;
+
+        Ok(JsString::from(month_day.inner.to_string()).into())
+    }
+
+    /// 10.3.10 `Temporal.PlainMonthDay.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let month_day = this
             .as_object()
@@ -243,7 +261,7 @@ impl PlainMonthDay {
         Ok(JsString::from(month_day.inner.to_string()).into())
     }
 
-    /// 9.3.11 Temporal.PlainMonthDay.prototype.valueOf ( )
+    /// 9.3.11 `Temporal.PlainMonthDay.prototype.valueOf ( )`
     pub(crate) fn value_of(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")

--- a/core/engine/src/builtins/temporal/plain_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_time/mod.rs
@@ -119,6 +119,7 @@ impl IntrinsicObject for PlainTime {
             .method(Self::round, js_string!("round"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -556,6 +557,22 @@ impl PlainTime {
 
         let ixdtf = time.inner.to_ixdtf_string(options)?;
 
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 4.3.17 `Temporal.PlainTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let time = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainTime object.")
+            })?;
+
+        let ixdtf = time
+            .inner
+            .to_ixdtf_string(ToStringRoundingOptions::default())?;
         Ok(JsString::from(ixdtf).into())
     }
 

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -24,7 +24,9 @@ use temporal_rs::{
     Calendar, Duration, PlainYearMonth as InnerYearMonth,
 };
 
-use super::{calendar::to_temporal_calendar_slot_value, to_temporal_duration, DateTimeValues};
+use super::{
+    calendar::get_temporal_calendar_slot_value_with_default, to_temporal_duration, DateTimeValues,
+};
 
 /// The `Temporal.PlainYearMonth` object.
 #[derive(Debug, Clone, Trace, Finalize, JsData)]
@@ -133,7 +135,8 @@ impl IntrinsicObject for PlainYearMonth {
                 None,
                 Attribute::CONFIGURABLE,
             )
-            .static_method(Self::from, js_string!("from"), 2)
+            .static_method(Self::from, js_string!("from"), 1)
+            .static_method(Self::compare, js_string!("compare"), 2)
             .method(Self::with, js_string!("with"), 1)
             .method(Self::add, js_string!("add"), 1)
             .method(Self::subtract, js_string!("subtract"), 1)
@@ -141,6 +144,7 @@ impl IntrinsicObject for PlainYearMonth {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .build();
@@ -226,71 +230,18 @@ impl BuiltInConstructor for PlainYearMonth {
 impl PlainYearMonth {
     // 9.2.2 `Temporal.PlainYearMonth.from ( item [ , options ] )`
     fn from(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // 1. Return ? ToTemporalYearMonth(item, options).
         let item = args.get_or_undefined(0);
-        // 1. If Type(item) is Object or Type(item) is String and item is not null, then
-
-        let inner = if item.is_object() {
-            // 9.2.2.2
-            if let Some(data) = item
-                .as_object()
-                .and_then(JsObject::downcast_ref::<PlainYearMonth>)
-            {
-                // Perform ? [GetTemporalOverflowOption](https://tc39.es/proposal-temporal/#sec-temporal-gettemporaloverflowoption)(options).
-                let options = get_options_object(args.get_or_undefined(1))?;
-                let _ =
-                    get_option::<ArithmeticOverflow>(&options, js_string!("overflow"), context)?;
-                data.inner.clone()
-            } else {
-                let options = get_options_object(args.get_or_undefined(1))?;
-                let overflow = get_option(&options, js_string!("overflow"), context)?
-                    .unwrap_or(ArithmeticOverflow::Constrain);
-
-                let year = item
-                    .get_v(js_string!("year"), context)?
-                    .map(|v| {
-                        let finite = v.to_finitef64(context)?;
-                        Ok::<i32, JsError>(finite.as_integer_with_truncation::<i32>())
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-
-                let month = item
-                    .get_v(js_string!("month"), context)?
-                    .map(|v| {
-                        let finite = v.to_finitef64(context)?;
-                        Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-
-                let ref_day = item
-                    .get_v(js_string!("day"), context)?
-                    .map(|v| {
-                        let finite = v.to_finitef64(context)?;
-                        Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
-                    })
-                    .transpose()?;
-
-                // a. Let calendar be ? ToTemporalCalendar(item).
-                let calendar = to_temporal_calendar_slot_value(args.get_or_undefined(1))?;
-                InnerYearMonth::new_with_overflow(
-                    year,
-                    month,
-                    ref_day.map(Into::into),
-                    calendar,
-                    overflow,
-                )?
-            }
-        } else if let Some(item_as_string) = item.as_string() {
-            InnerYearMonth::from_str(item_as_string.to_std_string_escaped().as_str())?
-        } else {
-            return Err(JsNativeError::typ()
-                .with_message("item must be an object, string, or null.")
-                .into());
-        };
-
-        // b. Return ? ToTemporalYearMonth(item, calendar).
+        let options = args.get_or_undefined(1);
+        let inner = to_temporal_year_month(item, Some(options.clone()), context)?;
         create_temporal_year_month(inner, None, context)
+    }
+
+    /// 9.2.3 Temporal.PlainYearMonth.compare ( one, two )
+    fn compare(_: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let one = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
+        let two = to_temporal_year_month(args.get_or_undefined(1), None, context)?;
+        Ok((one.compare_iso(&two) as i8).into())
     }
 }
 
@@ -410,25 +361,35 @@ impl PlainYearMonth {
         add_or_subtract_duration(false, this, duration_like, &options, context)
     }
 
+    /// 9.3.16 `Temporal.PlainYearMonth.prototype.until ( other [ , options ] )`
     fn until(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::typ()
+        Err(JsNativeError::error()
             .with_message("not yet implemented.")
             .into())
     }
 
+    /// 9.3.17 `Temporal.PlainYearMonth.prototype.since ( other [ , options ] )`
     fn since(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::typ()
+        Err(JsNativeError::error()
             .with_message("not yet implemented.")
             .into())
     }
 
-    fn equals(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::typ()
-            .with_message("not yet implemented.")
-            .into())
+    /// 9.3.18 `Temporal.PlainYearMonth.prototype.equals ( other )`
+    fn equals(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let year_month = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
+            })?;
+
+        let other = to_temporal_year_month(args.get_or_undefined(0), None, context)?;
+
+        Ok((year_month.inner == other).into())
     }
 
-    /// `9.3.19 Temporal.PlainYearMonth.prototype.toString ( [ options ] )`
+    /// 9.3.19 `Temporal.PlainYearMonth.prototype.toString ( [ options ] )`
     fn to_string(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         // 1. Let YearMonth be the this value.
         // 2. Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
@@ -451,7 +412,24 @@ impl PlainYearMonth {
         Ok(JsString::from(ixdtf).into())
     }
 
-    /// `9.3.21 Temporal.PlainYearMonth.prototype.toJSON ( )`
+    /// 9.3.20 `Temporal.PlainYearMonth.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    pub(crate) fn to_locale_string(
+        this: &JsValue,
+        _: &[JsValue],
+        _: &mut Context,
+    ) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let year_month = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
+            })?;
+
+        Ok(JsString::from(year_month.inner.to_string()).into())
+    }
+
+    /// 9.3.21 `Temporal.PlainYearMonth.prototype.toJSON ( )`
     pub(crate) fn to_json(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
         let year_month = this
             .as_object()
@@ -475,6 +453,106 @@ impl PlainYearMonth {
 
 // 9.5.2 `RegulateISOYearMonth ( year, month, overflow )`
 // Implemented on `TemporalFields`.
+
+fn to_temporal_year_month(
+    value: &JsValue,
+    options: Option<JsValue>,
+    context: &mut Context,
+) -> JsResult<InnerYearMonth> {
+    // If options is not present, set options to undefined.
+    let options = options.unwrap_or_default();
+    // 2. If item is an Object, then
+    if let Some(obj) = value.as_object() {
+        // a. If item has an [[InitializedTemporalYearMonth]] internal slot, then
+        if let Some(ym) = obj.downcast_ref::<PlainYearMonth>() {
+            // i. Let resolvedOptions be ? GetOptionsObject(options).
+            let resolved_options = get_options_object(&options)?;
+            // ii. Perform ? GetTemporalOverflowOption(resolvedOptions).
+            let _overflow = get_option::<ArithmeticOverflow>(
+                &resolved_options,
+                js_string!("overflow"),
+                context,
+            )?
+            .unwrap_or(ArithmeticOverflow::Constrain);
+            // iii. Return ! CreateTemporalYearMonth(item.[[ISODate]], item.[[Calendar]]).
+            return Ok(ym.inner.clone());
+        }
+        // b. Let calendar be ? GetTemporalCalendarIdentifierWithISODefault(item).
+        // c. Let fields be ? PrepareCalendarFields(calendar, item, « year, month, month-code », «», «»).
+        // d. Let resolvedOptions be ? GetOptionsObject(options).
+        let resolved_options = get_options_object(&options)?;
+        // e. Let overflow be ? GetTemporalOverflowOption(resolvedOptions).
+        let overflow =
+            get_option::<ArithmeticOverflow>(&resolved_options, js_string!("overflow"), context)?
+                .unwrap_or(ArithmeticOverflow::Constrain);
+
+        // f. Let isoDate be ? CalendarYearMonthFromFields(calendar, fields, overflow).
+        // g. Return ! CreateTemporalYearMonth(isoDate, calendar).
+        let year = obj
+            .get(js_string!("year"), context)?
+            .map(|v| {
+                let finite = v.to_finitef64(context)?;
+                Ok::<i32, JsError>(finite.as_integer_with_truncation::<i32>())
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let month = obj
+            .get(js_string!("month"), context)?
+            .map(|v| {
+                let finite = v.to_finitef64(context)?;
+                Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+            })
+            .transpose()?
+            .unwrap_or_default();
+
+        let ref_day = obj
+            .get(js_string!("day"), context)?
+            .map(|v| {
+                let finite = v.to_finitef64(context)?;
+                Ok::<u8, JsError>(finite.as_integer_with_truncation::<u8>())
+            })
+            .transpose()?;
+
+        // a. Let calendar be ? ToTemporalCalendar(item).
+        let calendar = get_temporal_calendar_slot_value_with_default(obj, context)?;
+        // TODO: implement from_partial on `temporal_rs::PlainYearMonth`
+        return Ok(InnerYearMonth::new_with_overflow(
+            year,
+            month,
+            ref_day.map(Into::into),
+            calendar,
+            overflow,
+        )?);
+    }
+
+    // 3. If item is not a String, throw a TypeError exception.
+    let Some(ym_string) = value.as_string() else {
+        return Err(JsNativeError::typ()
+            .with_message("toTemporalYearMonth target must be an object or string")
+            .into());
+    };
+
+    // 4. Let result be ? ParseISODateTime(item, « TemporalYearMonthString »).
+    let result = InnerYearMonth::from_str(&ym_string.to_std_string_escaped())?;
+    // 5. Let calendar be result.[[Calendar]].
+    // 6. If calendar is empty, set calendar to "iso8601".
+    // 7. Set calendar to ? CanonicalizeCalendar(calendar).
+    // 8. Let resolvedOptions be ? GetOptionsObject(options).
+    let resolved_options = get_options_object(&options)?;
+    // 9. Perform ? GetTemporalOverflowOption(resolvedOptions).
+    let _overflow =
+        get_option::<ArithmeticOverflow>(&resolved_options, js_string!("overflow"), context)?
+            .unwrap_or(ArithmeticOverflow::Constrain);
+
+    // 10. Let isoDate be CreateISODateRecord(result.[[Year]], result.[[Month]], result.[[Day]]).
+    // 11. If ISOYearMonthWithinLimits(isoDate) is false, throw a RangeError exception.
+    // 12. Set result to ISODateToFields(calendar, isoDate, year-month).
+    // 13. NOTE: The following operation is called with constrain regardless of the value of overflow, in order for the calendar to store a canonical value in the [[Day]] field of the [[ISODate]] internal slot of the result.
+    // 14. Set isoDate to ? CalendarYearMonthFromFields(calendar, result, constrain).
+    // 15. Return ! CreateTemporalYearMonth(isoDate, calendar).
+    Ok(result)
+}
 
 // 9.5.6 `CreateTemporalYearMonth ( isoYear, isoMonth, calendar, referenceISODay [ , newTarget ] )`
 pub(crate) fn create_temporal_year_month(

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -351,6 +351,7 @@ impl IntrinsicObject for ZonedDateTime {
             .method(Self::since, js_string!("since"), 1)
             .method(Self::equals, js_string!("equals"), 1)
             .method(Self::to_string, js_string!("toString"), 0)
+            .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
             .method(Self::start_of_day, js_string!("startOfDay"), 0)
@@ -1053,6 +1054,28 @@ impl ZonedDateTime {
         Ok(JsString::from(ixdtf).into())
     }
 
+    /// 6.3.42 `Temporal.ZonedDateTime.prototype.toLocaleString ( [ locales [ , options ] ] )`
+    fn to_locale_string(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        // TODO: Update for ECMA-402 compliance
+        let zdt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a ZonedDateTime object.")
+            })?;
+
+        let ixdtf = zdt.inner.to_ixdtf_string_with_provider(
+            DisplayOffset::Auto,
+            DisplayTimeZone::Auto,
+            DisplayCalendar::Auto,
+            ToStringRoundingOptions::default(),
+            context.tz_provider(),
+        )?;
+
+        Ok(JsString::from(ixdtf).into())
+    }
+
+    /// 6.3.43 `Temporal.ZonedDateTime.prototype.toJSON ( )`
     fn to_json(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let zdt = this
             .as_object()


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the ongoing work for #1804 .

It changes the following:

- Implements the baseline `toLocaleString` stub for all types (the non ECMA-402 implementation)
- Add the intl methods `era` and `eraYear` to `PlainDate` and `PlainDateTime`
- Adds some general cleanup to `PlainYearMonth` to better align it with other Temporal builtins
- Removes some dead code from `now.rs` and `mod.rs`
