### PR TITLE
Bump temporal_rs to Feb. 15 version + adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,6 +371,7 @@ dependencies = [
  "float-cmp",
  "futures-lite 2.6.0",
  "hashbrown 0.15.2",
+ "iana-time-zone",
  "icu_calendar 1.5.2",
  "icu_casemap",
  "icu_collator",
@@ -3567,7 +3568,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=50003f04706406654e695c68e54d12c471851421#50003f04706406654e695c68e54d12c471851421"
+source = "git+https://github.com/boa-dev/temporal.git?rev=6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8#6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8"
 dependencies = [
  "combine",
  "iana-time-zone",
@@ -3577,7 +3578,6 @@ dependencies = [
  "num-traits",
  "tinystr 0.8.0",
  "tzif",
- "web-time",
  "writeable 0.6.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "50003f04706406654e695c68e54d12c471851421", features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8", default-features = false, features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -59,7 +59,7 @@ trace = ["js"]
 annex-b = ["boa_ast/annex-b", "boa_parser/annex-b"]
 
 # Enable Boa's Temporal proposal implementation
-temporal = ["dep:icu_calendar", "dep:temporal_rs"]
+temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:iana-time-zone"]
 
 # Enable experimental features, like Stage 3 proposals.
 experimental = ["temporal"]
@@ -130,6 +130,7 @@ tinystr = { workspace = true, optional = true }
 
 # temporal deps
 temporal_rs = { workspace = true, optional = true }
+iana-time-zone = { version = "0.1.61", optional = true }
 
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 web-time = { workspace = true, optional = true }


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to the ongoing work for #1804

This most recent version includes some bug fixes along with some API changes to `Now` in `temporal_rs`. Changes were made to accommodate the `Now` changes.