### PR TITLE
Add `PlainDateTime.prototype.round` implementation from `temporal_rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3568,7 +3568,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8#6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8"
+source = "git+https://github.com/boa-dev/temporal.git?rev=1e4a438e58f67b2c4ec44689c5a5c2f1fe718ba3#1e4a438e58f67b2c4ec44689c5a5c2f1fe718ba3"
 dependencies = [
  "combine",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "6a3c74fbf20a870bacccdcd6b11d8c0d4dd459d8", default-features = false, features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "1e4a438e58f67b2c4ec44689c5a5c2f1fe718ba3", default-features = false, features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -477,7 +477,7 @@ impl Instant {
         // NOTE: There may be an order-of-operations here due to a check on Unit groups and smallest_unit value.
         let timezone = options
             .get(js_string!("timeZone"), context)?
-            .map(to_temporal_timezone_identifier)
+            .map(|v| to_temporal_timezone_identifier(v, context))
             .transpose()?;
 
         let options = ToStringRoundingOptions {

--- a/core/engine/src/builtins/temporal/instant/mod.rs
+++ b/core/engine/src/builtins/temporal/instant/mod.rs
@@ -477,7 +477,7 @@ impl Instant {
         // NOTE: There may be an order-of-operations here due to a check on Unit groups and smallest_unit value.
         let timezone = options
             .get(js_string!("timeZone"), context)?
-            .map(|v| to_temporal_timezone_identifier(v, context))
+            .map(to_temporal_timezone_identifier)
             .transpose()?;
 
         let options = ToStringRoundingOptions {

--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -114,13 +114,9 @@ fn resolve_system_values(
     timezone: &JsValue,
     context: &mut Context,
 ) -> JsResult<(EpochNanoseconds, TimeZone)> {
-    let user_timezone = timezone
-        .map(|v| to_temporal_timezone_identifier(v, context))
-        .transpose()?;
-    let timezone = user_timezone.unwrap_or(TimeZone::try_from_str_with_provider(
-        &system_time_zone()?,
-        context.tz_provider(),
-    )?);
+    let user_timezone = timezone.map(to_temporal_timezone_identifier).transpose()?;
+    let timezone =
+        user_timezone.unwrap_or(TimeZone::try_from_identifier_str(&system_time_zone()?)?);
     let epoch_nanos = EpochNanoseconds::try_from(context.clock().now().nanos_since_epoch())?;
     Ok((epoch_nanos, timezone))
 }

--- a/core/engine/src/builtins/temporal/now.rs
+++ b/core/engine/src/builtins/temporal/now.rs
@@ -114,7 +114,9 @@ fn resolve_system_values(
     timezone: &JsValue,
     context: &mut Context,
 ) -> JsResult<(EpochNanoseconds, TimeZone)> {
-    let user_timezone = timezone.map(to_temporal_timezone_identifier).transpose()?;
+    let user_timezone = timezone
+        .map(|v| to_temporal_timezone_identifier(v, context))
+        .transpose()?;
     let timezone =
         user_timezone.unwrap_or(TimeZone::try_from_identifier_str(&system_time_zone()?)?);
     let epoch_nanos = EpochNanoseconds::try_from(context.clock().now().nanos_since_epoch())?;

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -961,7 +961,7 @@ impl PlainDateTime {
             &round_to,
             js_string!("smallestUnit"),
             TemporalUnitGroup::Time,
-            None,
+            Some(vec![TemporalUnit::Day]),
             context,
         )?;
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -907,7 +907,6 @@ impl PlainDateTime {
         create_temporal_duration(dt.inner.since(&other, settings)?, None, context).map(Into::into)
     }
 
-    // TODO(nekevss): finish after temporal_rs impl
     /// 5.3.32 Temporal.PlainDateTime.prototype.round ( roundTo )
     fn round(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
         let dt = this
@@ -966,10 +965,7 @@ impl PlainDateTime {
             context,
         )?;
 
-        // TODO: implement in temporal_rs
-        Err(JsNativeError::range()
-            .with_message("not yet implemented.")
-            .into())
+        create_temporal_datetime(dt.inner().round(options)?, None, context).map(Into::into)
     }
 
     /// 5.3.33 Temporal.PlainDateTime.prototype.equals ( other )

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -1344,15 +1344,15 @@ pub(crate) fn to_temporal_timezone_identifier(
     // 8. If timeZoneIdentifierRecord is empty, throw a RangeError exception.
     // 9. Return timeZoneIdentifierRecord.[[Identifier]].
     let timezone = TimeZone::try_from_str(&tz_string.to_std_string_escaped())?;
-    if !context
-        .tz_provider()
-        .check_identifier(&timezone.identifier()?)
+    if matches!(timezone, TimeZone::IanaIdentifier(_))
+        && !context
+            .tz_provider()
+            .check_identifier(&timezone.identifier()?)
     {
         return Err(JsNativeError::range()
             .with_message("TimeZone string is not a supported by IANA identifier.")
             .into());
     }
-
     Ok(timezone)
 }
 

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -407,6 +407,15 @@ impl BuiltInConstructor for ZonedDateTime {
         //  7. Else,
         // a. Set timeZone to FormatOffsetTimeZoneIdentifier(timeZoneParse.[[OffsetMinutes]]).
         let timezone = TimeZone::try_from_identifier_str(&timezone_str.to_std_string_escaped())?;
+        if matches!(timezone, TimeZone::IanaIdentifier(_))
+            && !context
+                .tz_provider()
+                .check_identifier(&timezone.identifier()?)
+        {
+            return Err(JsNativeError::range()
+                .with_message("TimeZone string is not a supported by IANA identifier.")
+                .into());
+        }
 
         //  8. If calendar is undefined, set calendar to "iso8601".
         //  9. If calendar is not a String, throw a TypeError exception.

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -1350,7 +1350,7 @@ pub(crate) fn to_temporal_timezone_identifier(
             .check_identifier(&timezone.identifier()?)
     {
         return Err(JsNativeError::range()
-            .with_message("TimeZone string is not a supported by IANA identifier.")
+            .with_message("TimeZone string is not a supported IANA identifier.")
             .into());
     }
     Ok(timezone)

--- a/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
+++ b/core/engine/src/builtins/temporal/zoneddatetime/mod.rs
@@ -1339,9 +1339,7 @@ pub(crate) fn to_temporal_timezone_identifier(value: &JsValue) -> JsResult<TimeZ
     // 7. Let timeZoneIdentifierRecord be GetAvailableNamedTimeZoneIdentifier(name).
     // 8. If timeZoneIdentifierRecord is empty, throw a RangeError exception.
     // 9. Return timeZoneIdentifierRecord.[[Identifier]].
-    Ok(TimeZone::try_from_identifier_str(
-        &tz_string.to_std_string_escaped(),
-    )?)
+    Ok(TimeZone::try_from_str(&tz_string.to_std_string_escaped())?)
 }
 
 fn to_offset_string(value: &JsValue, context: &mut Context) -> JsResult<String> {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #1804 and #4072.

It changes the following:

- Adds the `PlainDateTime::round` implementation from `temporal_rs`
- Bumps `temporal_rs` and related adjustments for time zone parsing
