### PR TITLE
Build out remaining method stubs for temporal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,7 +3579,7 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 [[package]]
 name = "temporal_rs"
 version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=1566796fcf3536cce7406ccfafb969883810c5d4#1566796fcf3536cce7406ccfafb969883810c5d4"
+source = "git+https://github.com/boa-dev/temporal.git?rev=7484b2584efc7430f5ca34cf3a91e858286a3a29#7484b2584efc7430f5ca34cf3a91e858286a3a29"
 dependencies = [
  "combine",
  "iana-time-zone",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.13.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "1566796fcf3536cce7406ccfafb969883810c5d4", default-features = false, features = ["tzdb"] }
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "7484b2584efc7430f5ca34cf3a91e858286a3a29", default-features = false, features = ["tzdb"] }
 web-time = "1.1.0"
 criterion = "0.5.1"
 float-cmp = "0.10.0"

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -754,7 +754,7 @@ impl Duration {
     ) -> JsResult<JsValue> {
         // 1. Let duration be the this value.
         // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
-        let _duration = this
+        let duration = this
             .as_object()
             .and_then(JsObject::downcast_ref::<Self>)
             .ok_or_else(|| {
@@ -794,11 +794,10 @@ impl Duration {
         // 7. Let relativeToRecord be ? ToRelativeTemporalObject(totalOf).
         // 8. Let zonedRelativeTo be relativeToRecord.[[ZonedRelativeTo]].
         // 9. Let plainRelativeTo be relativeToRecord.[[PlainRelativeTo]].
-        let (_plain_relative_to, _zoned_relative_to) =
-            super::to_relative_temporal_object(&total_of, context)?;
+        let relative_to = get_relative_to_option(&total_of, context)?;
 
         // 10. Let unit be ? GetTemporalUnit(totalOf, "unit", datetime, required).
-        let _unit = get_temporal_unit(
+        let unit = get_temporal_unit(
             &total_of,
             js_string!("unit"),
             TemporalUnitGroup::DateTime,
@@ -807,10 +806,9 @@ impl Duration {
         )?
         .ok_or_else(|| JsNativeError::range().with_message("unit cannot be undefined."))?;
 
-        // TODO: Implement the rest of the new `Temporal.Duration.prototype.total`
-
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
+        Ok(duration
+            .inner
+            .total_with_provider(unit, relative_to, context.tz_provider())?
             .into())
     }
 

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -25,18 +25,22 @@ mod tests;
 
 use temporal_rs::{
     options::{
-        ArithmeticOverflow, DisplayCalendar, RoundingIncrement, RoundingOptions,
+        ArithmeticOverflow, Disambiguation, DisplayCalendar, RoundingIncrement, RoundingOptions,
         TemporalRoundingMode, TemporalUnit, ToStringRoundingOptions,
     },
     partial::{PartialDate, PartialDateTime, PartialTime},
     Calendar, PlainDateTime as InnerDateTime, TinyAsciiStr,
 };
 
+// TODO: Remove once implementations are complete.
+#[allow(unused_imports)]
 use super::{
     calendar::{get_temporal_calendar_slot_value_with_default, to_temporal_calendar_slot_value},
-    create_temporal_duration,
+    create_temporal_date, create_temporal_duration, create_temporal_time,
+    create_temporal_zoneddatetime,
     options::{get_difference_settings, get_digits_option, get_temporal_unit, TemporalUnitGroup},
-    to_temporal_duration_record, to_temporal_time, PlainDate, ZonedDateTime,
+    to_temporal_duration_record, to_temporal_time, to_temporal_timezone_identifier, PlainDate,
+    ZonedDateTime,
 };
 use crate::value::JsVariant;
 
@@ -306,6 +310,9 @@ impl IntrinsicObject for PlainDateTime {
             .method(Self::to_locale_string, js_string!("toLocaleString"), 0)
             .method(Self::to_json, js_string!("toJSON"), 0)
             .method(Self::value_of, js_string!("valueOf"), 0)
+            .method(Self::to_zoned_date_time, js_string!("toZonedDateTime"), 1)
+            .method(Self::to_plain_date, js_string!("toPlainDate"), 0)
+            .method(Self::to_plain_time, js_string!("toPlainTime"), 0)
             .build();
     }
 
@@ -1063,6 +1070,64 @@ impl PlainDateTime {
         Err(JsNativeError::typ()
             .with_message("`valueOf` not supported by Temporal built-ins. See 'compare', 'equals', or `toString`")
             .into())
+    }
+
+    fn to_zoned_date_time(
+        this: &JsValue,
+        args: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let dateTime be the this value.
+        // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+        let _dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+        // 3. Let timeZone be ? ToTemporalTimeZoneIdentifier(temporalTimeZoneLike).
+        let _timezone = to_temporal_timezone_identifier(args.get_or_undefined(0), context)?;
+        // 4. Let resolvedOptions be ? GetOptionsObject(options).
+        let options = get_options_object(args.get_or_undefined(1))?;
+        // 5. Let disambiguation be ? GetTemporalDisambiguationOption(resolvedOptions).
+        let _disambiguation =
+            get_option::<Disambiguation>(&options, js_string!("disambiguation"), context)?
+                .unwrap_or_default();
+        // 6. Let epochNs be ? GetEpochNanosecondsFor(timeZone, dateTime.[[ISODateTime]], disambiguation).
+        // 7. Return ! CreateTemporalZonedDateTime(epochNs, timeZone, dateTime.[[Calendar]]).
+
+        // let result = dt.inner.to_zoned_date_time_with_provider(timezone, disambiguation, context.tz_provider())?;
+        // create_temporal_zoneddatetime(result, None, context)
+        Err(JsNativeError::error()
+            .with_message("Not yet implemented")
+            .into())
+    }
+
+    fn to_plain_date(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        // let result = dt.inner.to_plain_date();
+        // create_temporal_date(result, None, context)
+        Err(JsNativeError::error()
+            .with_message("Not yet implemented")
+            .into())
+    }
+
+    fn to_plain_time(this: &JsValue, _: &[JsValue], context: &mut Context) -> JsResult<JsValue> {
+        let dt = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
+            })?;
+
+        let result = dt.inner.to_plain_time()?;
+        create_temporal_time(result, None, context).map(Into::into)
     }
 }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request is related to ongoing work for #1804

It changes the following:

- Bumps `temporal_rs` version
- Adds stubs for all remaining methods except for `Duration.prototype.compare`, `PlainDate.prototype.toZonedDateTime` (these methods are)

The main goal here was to complete some of the remaining leg work for Temporal in Boa (outside of any remaining debugging).
