### PR TITLE
Fix JsValue::to_json with cyclic values

### DIFF
--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -161,7 +161,7 @@ impl JsValue {
                     }
                     // Passing the object rather than its clone that was inserted to the set should be fine
                     // as they hash to the same value and therefore HashSet can still remove the clone
-                    seen_objects.remove(&obj);
+                    seen_objects.remove(obj);
                     Ok(Value::Array(arr))
                 } else {
                     let mut map = Map::new();
@@ -185,7 +185,7 @@ impl JsValue {
                         let value = value_by_prop_key(property_key, context)?;
                         map.insert(key, value);
                     }
-                    seen_objects.remove(&obj);
+                    seen_objects.remove(obj);
                     Ok(Value::Object(map))
                 }
             }

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -7,8 +7,9 @@ use crate::{
     js_string,
     object::JsObject,
     property::{PropertyDescriptor, PropertyKey},
-    Context, JsResult, JsVariant, NativeObject,
+    Context, JsResult, JsVariant,
 };
+use indexmap::IndexSet;
 use serde_json::{Map, Value};
 
 impl JsValue {
@@ -113,14 +114,14 @@ impl JsValue {
     ///
     /// Panics if the `JsValue` is `Undefined`.
     pub fn to_json(&self, context: &mut Context) -> JsResult<Value> {
-        let mut stack = vec![];
+        let mut stack = IndexSet::new();
         self.to_json_inner(context, &mut stack)
     }
 
     fn to_json_inner(
         &self,
         context: &mut Context,
-        stack: &mut Vec<JsObject<dyn NativeObject>>,
+        stack: &mut IndexSet<JsObject>,
     ) -> JsResult<Value> {
         match self.variant() {
             JsVariant::Null => Ok(Value::Null),
@@ -138,7 +139,7 @@ impl JsValue {
                         .with_message("cyclic object value")
                         .into());
                 }
-                stack.push(obj.clone());
+                stack.insert(obj.clone());
                 let mut value_by_prop_key = |property_key, context: &mut Context| {
                     obj.borrow()
                         .properties()


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #4175.

It changes the following:

- The actual content of `to_json` is moved to a new internal method `to_json_inner`. This internal method takes one more argument `stack` that keeps track of objects seen so far. If the current object is in the stack, it means that there's a cycle and we return a TypeError.
- `to_json` calls the internal method and returns results as usual.
- A test case is added.
