### PR TITLE
Stack alloc reduce

### DIFF
--- a/core/ast/src/expression/access.rs
+++ b/core/ast/src/expression/access.rs
@@ -163,7 +163,7 @@ impl SimplePropertyAccess {
         F: Into<PropertyAccessField>,
     {
         Self {
-            target: target,
+            target,
             field: field.into(),
         }
     }

--- a/core/ast/src/expression/access.rs
+++ b/core/ast/src/expression/access.rs
@@ -151,12 +151,12 @@ impl SimplePropertyAccess {
     }
 
     /// Creates a `PropertyAccess` AST Expression.
-    pub fn new<F>(target: Expression, field: F) -> Self
+    pub fn new<F>(target: Box<Expression>, field: F) -> Self
     where
         F: Into<PropertyAccessField>,
     {
         Self {
-            target: target.into(),
+            target: target,
             field: field.into(),
         }
     }
@@ -222,9 +222,9 @@ impl PrivatePropertyAccess {
     /// Creates a `GetPrivateField` AST Expression.
     #[inline]
     #[must_use]
-    pub fn new(value: Expression, field: PrivateName) -> Self {
+    pub fn new(value: Box<Expression>, field: PrivateName) -> Self {
         Self {
-            target: value.into(),
+            target: value,
             field,
         }
     }

--- a/core/ast/src/expression/access.rs
+++ b/core/ast/src/expression/access.rs
@@ -47,6 +47,13 @@ impl From<Expression> for PropertyAccessField {
     }
 }
 
+impl From<Box<Expression>> for PropertyAccessField {
+    #[inline]
+    fn from(expr: Box<Expression>) -> Self {
+        Self::Expr(expr)
+    }
+}
+
 impl VisitWith for PropertyAccessField {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where

--- a/core/ast/src/expression/call.rs
+++ b/core/ast/src/expression/call.rs
@@ -200,6 +200,7 @@ pub struct ImportCall {
 
 impl ImportCall {
     /// Creates a new `ImportCall` AST node.
+    #[must_use]
     pub fn new(arg: Box<Expression>) -> Self {
         Self { arg }
     }

--- a/core/ast/src/expression/call.rs
+++ b/core/ast/src/expression/call.rs
@@ -38,6 +38,13 @@ impl Call {
         }
     }
 
+    /// Creates a new `Call` AST Expression from boxed function.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(function: Box<Expression>, args: Box<[Expression]>) -> Self {
+        Self { function, args }
+    }
+
     /// Gets the target function of this call expression.
     #[inline]
     #[must_use]
@@ -68,6 +75,12 @@ impl From<Call> for Expression {
     #[inline]
     fn from(call: Call) -> Self {
         Self::Call(call)
+    }
+}
+
+impl From<Call> for Box<Expression> {
+    fn from(call: Call) -> Self {
+        Box::new(Expression::Call(call))
     }
 }
 
@@ -140,6 +153,12 @@ impl From<SuperCall> for Expression {
     }
 }
 
+impl From<SuperCall> for Box<Expression> {
+    fn from(call: SuperCall) -> Self {
+        Box::new(Expression::SuperCall(call))
+    }
+}
+
 impl VisitWith for SuperCall {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
@@ -181,13 +200,8 @@ pub struct ImportCall {
 
 impl ImportCall {
     /// Creates a new `ImportCall` AST node.
-    pub fn new<A>(arg: A) -> Self
-    where
-        A: Into<Expression>,
-    {
-        Self {
-            arg: Box::new(arg.into()),
-        }
+    pub fn new(arg: Box<Expression>) -> Self {
+        Self { arg }
     }
 
     /// Retrieves the single argument of the import call.
@@ -208,6 +222,12 @@ impl From<ImportCall> for Expression {
     #[inline]
     fn from(call: ImportCall) -> Self {
         Self::ImportCall(call)
+    }
+}
+
+impl From<ImportCall> for Box<Expression> {
+    fn from(call: ImportCall) -> Self {
+        Box::new(Expression::ImportCall(call))
     }
 }
 

--- a/core/ast/src/expression/identifier.rs
+++ b/core/ast/src/expression/identifier.rs
@@ -105,6 +105,12 @@ impl From<Identifier> for Expression {
     }
 }
 
+impl From<Identifier> for Box<Expression> {
+    fn from(local: Identifier) -> Self {
+        Box::new(Expression::Identifier(local))
+    }
+}
+
 impl VisitWith for Identifier {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where

--- a/core/ast/src/expression/mod.rs
+++ b/core/ast/src/expression/mod.rs
@@ -92,22 +92,22 @@ pub enum Expression {
     Spread(Spread),
 
     /// See [`FunctionExpression`].
-    FunctionExpression(FunctionExpression),
+    FunctionExpression(Box<FunctionExpression>),
 
     /// See [`ArrowFunction`].
-    ArrowFunction(ArrowFunction),
+    ArrowFunction(Box<ArrowFunction>),
 
     /// See [`AsyncArrowFunction`].
-    AsyncArrowFunction(AsyncArrowFunction),
+    AsyncArrowFunction(Box<AsyncArrowFunction>),
 
     /// See [`GeneratorExpression`].
-    GeneratorExpression(GeneratorExpression),
+    GeneratorExpression(Box<GeneratorExpression>),
 
     /// See [`AsyncFunctionExpression`].
-    AsyncFunctionExpression(AsyncFunctionExpression),
+    AsyncFunctionExpression(Box<AsyncFunctionExpression>),
 
     /// See [`AsyncGeneratorExpression`].
-    AsyncGeneratorExpression(AsyncGeneratorExpression),
+    AsyncGeneratorExpression(Box<AsyncGeneratorExpression>),
 
     /// See [`ClassExpression`].
     ClassExpression(Box<ClassExpression>),

--- a/core/ast/src/expression/mod.rs
+++ b/core/ast/src/expression/mod.rs
@@ -277,6 +277,12 @@ impl Expression {
         }
         expression
     }
+
+    /// Create boxed expression.
+    #[must_use]
+    pub fn boxed(f: impl FnOnce() -> Self) -> Box<Self> {
+        Box::new(f())
+    }
 }
 
 impl From<Expression> for Statement {

--- a/core/ast/src/expression/new.rs
+++ b/core/ast/src/expression/new.rs
@@ -70,6 +70,12 @@ impl From<New> for Expression {
     }
 }
 
+impl From<New> for Box<Expression> {
+    fn from(new: New) -> Self {
+        Box::new(Expression::New(new))
+    }
+}
+
 impl VisitWith for New {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where

--- a/core/ast/src/expression/operator/assign/mod.rs
+++ b/core/ast/src/expression/operator/assign/mod.rs
@@ -49,6 +49,13 @@ impl Assign {
         }
     }
 
+    /// Creates an `Assign` AST Expression with boxed values.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(op: AssignOp, lhs: Box<AssignTarget>, rhs: Box<Expression>) -> Self {
+        Self { op, lhs, rhs }
+    }
+
     /// Gets the operator of the assignment operation.
     #[inline]
     #[must_use]

--- a/core/ast/src/expression/operator/binary/mod.rs
+++ b/core/ast/src/expression/operator/binary/mod.rs
@@ -176,10 +176,7 @@ impl BinaryInPrivate {
     #[inline]
     #[must_use]
     pub fn new_boxed(lhs: PrivateName, rhs: Box<Expression>) -> Self {
-        Self {
-            lhs,
-            rhs,
-        }
+        Self { lhs, rhs }
     }
 
     /// Gets the left hand side of the binary operation.

--- a/core/ast/src/expression/operator/binary/mod.rs
+++ b/core/ast/src/expression/operator/binary/mod.rs
@@ -50,6 +50,13 @@ impl Binary {
         }
     }
 
+    /// Creates a `BinOp` AST Expression with boxed values.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(op: BinaryOp, lhs: Box<Expression>, rhs: Box<Expression>) -> Self {
+        Self { op, lhs, rhs }
+    }
+
     /// Gets the binary operation of the Expression.
     #[inline]
     #[must_use]

--- a/core/ast/src/expression/operator/binary/mod.rs
+++ b/core/ast/src/expression/operator/binary/mod.rs
@@ -57,6 +57,17 @@ impl Binary {
         Self { op, lhs, rhs }
     }
 
+    /// Creates an `Box<Expression::Binary>` from boxed values.
+    // Non-inline to reduce stack alloc size: most likely, it will be inlined in release anyway.
+    #[must_use]
+    pub fn new_boxed_expr(
+        op: BinaryOp,
+        lhs: Box<Expression>,
+        rhs: Box<Expression>,
+    ) -> Box<Expression> {
+        Box::new(Self::new_boxed(op, lhs, rhs).into())
+    }
+
     /// Gets the binary operation of the Expression.
     #[inline]
     #[must_use]

--- a/core/ast/src/expression/operator/binary/mod.rs
+++ b/core/ast/src/expression/operator/binary/mod.rs
@@ -123,6 +123,13 @@ impl From<Binary> for Expression {
     }
 }
 
+impl From<Binary> for Box<Expression> {
+    #[inline]
+    fn from(op: Binary) -> Self {
+        Box::new(Expression::Binary(op))
+    }
+}
+
 impl VisitWith for Binary {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where
@@ -165,6 +172,16 @@ impl BinaryInPrivate {
         }
     }
 
+    /// Creates a `BinaryInPrivate` AST Expression.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(lhs: PrivateName, rhs: Box<Expression>) -> Self {
+        Self {
+            lhs,
+            rhs,
+        }
+    }
+
     /// Gets the left hand side of the binary operation.
     #[inline]
     #[must_use]
@@ -195,6 +212,12 @@ impl From<BinaryInPrivate> for Expression {
     #[inline]
     fn from(op: BinaryInPrivate) -> Self {
         Self::BinaryInPrivate(op)
+    }
+}
+
+impl From<BinaryInPrivate> for Box<Expression> {
+    fn from(op: BinaryInPrivate) -> Self {
+        Box::new(Expression::BinaryInPrivate(op))
     }
 }
 

--- a/core/ast/src/expression/operator/conditional.rs
+++ b/core/ast/src/expression/operator/conditional.rs
@@ -53,11 +53,15 @@ impl Conditional {
     /// Creates a `Conditional` AST Expression.
     #[inline]
     #[must_use]
-    pub fn new(condition: Expression, if_true: Expression, if_false: Expression) -> Self {
+    pub fn new(
+        condition: Box<Expression>,
+        if_true: Box<Expression>,
+        if_false: Box<Expression>,
+    ) -> Self {
         Self {
-            condition: Box::new(condition),
-            if_true: Box::new(if_true),
-            if_false: Box::new(if_false),
+            condition,
+            if_true,
+            if_false,
         }
     }
 }
@@ -78,6 +82,13 @@ impl From<Conditional> for Expression {
     #[inline]
     fn from(cond_op: Conditional) -> Self {
         Self::Conditional(cond_op)
+    }
+}
+
+impl From<Conditional> for Box<Expression> {
+    #[inline]
+    fn from(cond_op: Conditional) -> Self {
+        Box::new(Expression::Conditional(cond_op))
     }
 }
 

--- a/core/ast/src/expression/operator/unary/mod.rs
+++ b/core/ast/src/expression/operator/unary/mod.rs
@@ -47,6 +47,13 @@ impl Unary {
         }
     }
 
+    /// Creates a new `UnaryOp` AST Expression with boxed expression.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(op: UnaryOp, target: Box<Expression>) -> Self {
+        Self { op, target }
+    }
+
     /// Gets the unary operation of the Expression.
     #[inline]
     #[must_use]
@@ -80,6 +87,12 @@ impl From<Unary> for Expression {
     #[inline]
     fn from(op: Unary) -> Self {
         Self::Unary(op)
+    }
+}
+
+impl From<Unary> for Box<Expression> {
+    fn from(op: Unary) -> Self {
+        Box::new(Expression::Unary(op))
     }
 }
 

--- a/core/ast/src/expression/operator/update/op.rs
+++ b/core/ast/src/expression/operator/update/op.rs
@@ -77,6 +77,7 @@ impl UpdateOp {
     }
 
     /// Return true if self is Inc op
+    #[must_use]
     pub const fn is_inc(self) -> bool {
         match self {
             Self::IncrementPost | Self::IncrementPre => true,

--- a/core/ast/src/expression/operator/update/op.rs
+++ b/core/ast/src/expression/operator/update/op.rs
@@ -75,6 +75,14 @@ impl UpdateOp {
             Self::DecrementPost | Self::DecrementPre => "--",
         }
     }
+
+    /// Return true if self is Inc op
+    pub const fn is_inc(self) -> bool {
+        match self {
+            Self::IncrementPost | Self::IncrementPre => true,
+            Self::DecrementPost | Self::DecrementPre => false,
+        }
+    }
 }
 
 impl std::fmt::Display for UpdateOp {

--- a/core/ast/src/expression/optional.rs
+++ b/core/ast/src/expression/optional.rs
@@ -208,11 +208,8 @@ impl Optional {
     /// Creates a new `Optional` expression.
     #[inline]
     #[must_use]
-    pub fn new(target: Expression, chain: Box<[OptionalOperation]>) -> Self {
-        Self {
-            target: Box::new(target),
-            chain,
-        }
+    pub fn new(target: Box<Expression>, chain: Box<[OptionalOperation]>) -> Self {
+        Self { target, chain }
     }
 
     /// Gets the target of this `Optional` expression.
@@ -233,6 +230,12 @@ impl Optional {
 impl From<Optional> for Expression {
     fn from(opt: Optional) -> Self {
         Self::Optional(opt)
+    }
+}
+
+impl From<Optional> for Box<Expression> {
+    fn from(opt: Optional) -> Self {
+        Box::new(Expression::Optional(opt))
     }
 }
 

--- a/core/ast/src/expression/tagged_template.rs
+++ b/core/ast/src/expression/tagged_template.rs
@@ -105,6 +105,12 @@ impl From<TaggedTemplate> for Expression {
     }
 }
 
+impl From<Box<TaggedTemplate>> for Box<Expression> {
+    fn from(boxed_template: Box<TaggedTemplate>) -> Self {
+        Box::new(Expression::TaggedTemplate(*boxed_template))
+    }
+}
+
 impl VisitWith for TaggedTemplate {
     fn visit_with<'a, V>(&'a self, visitor: &mut V) -> ControlFlow<V::BreakTy>
     where

--- a/core/ast/src/expression/tagged_template.rs
+++ b/core/ast/src/expression/tagged_template.rs
@@ -29,14 +29,14 @@ impl TaggedTemplate {
     #[inline]
     #[must_use]
     pub fn new(
-        tag: Expression,
+        tag: Box<Expression>,
         raws: Box<[Sym]>,
         cookeds: Box<[Option<Sym>]>,
         exprs: Box<[Expression]>,
         identifier: u64,
     ) -> Self {
         Self {
-            tag: tag.into(),
+            tag,
             raws,
             cookeds,
             exprs,

--- a/core/ast/src/expression/yield.rs
+++ b/core/ast/src/expression/yield.rs
@@ -44,6 +44,16 @@ impl Yield {
             delegate,
         }
     }
+
+    /// Creates a `Yield` AST Expression from boxed expression.
+    #[inline]
+    #[must_use]
+    pub fn new_boxed(expr: Option<Box<Expression>>, delegate: bool) -> Self {
+        Self {
+            target: expr,
+            delegate,
+        }
+    }
 }
 
 impl From<Yield> for Expression {

--- a/core/ast/src/function/arrow_function.rs
+++ b/core/ast/src/function/arrow_function.rs
@@ -55,6 +55,16 @@ impl ArrowFunction {
             linear_span: linear_span.into(),
         }
     }
+    /// Creates a new `ArrowFunctionDecl` AST Expression.
+    #[must_use]
+    pub fn new_boxed(
+        name: Option<Identifier>,
+        parameters: FormalParameterList,
+        body: FunctionBody,
+        linear_span: LinearSpan,
+    ) -> Box<Self> {
+        Box::new(Self::new(name, parameters, body, linear_span))
+    }
 
     /// Gets the name of the arrow function.
     #[inline]
@@ -121,8 +131,8 @@ impl ToIndentedString for ArrowFunction {
     }
 }
 
-impl From<ArrowFunction> for Expression {
-    fn from(decl: ArrowFunction) -> Self {
+impl From<Box<ArrowFunction>> for Expression {
+    fn from(decl: Box<ArrowFunction>) -> Self {
         Self::ArrowFunction(decl)
     }
 }

--- a/core/ast/src/function/async_arrow_function.rs
+++ b/core/ast/src/function/async_arrow_function.rs
@@ -36,24 +36,23 @@ pub struct AsyncArrowFunction {
 
 impl AsyncArrowFunction {
     /// Creates a new `AsyncArrowFunction` AST Expression.
-    #[inline]
     #[must_use]
-    pub fn new(
+    pub fn new_boxed(
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: FunctionBody,
         linear_span: LinearSpan,
-    ) -> Self {
+    ) -> Box<Self> {
         let contains_direct_eval = contains(&parameters, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
-        Self {
+        Box::new(Self {
             name,
             parameters,
             body,
             contains_direct_eval,
             scopes: FunctionScopes::default(),
             linear_span: linear_span.into(),
-        }
+        })
     }
 
     /// Gets the name of the async arrow function.
@@ -121,8 +120,8 @@ impl ToIndentedString for AsyncArrowFunction {
     }
 }
 
-impl From<AsyncArrowFunction> for Expression {
-    fn from(decl: AsyncArrowFunction) -> Self {
+impl From<Box<AsyncArrowFunction>> for Expression {
+    fn from(decl: Box<AsyncArrowFunction>) -> Self {
         Self::AsyncArrowFunction(decl)
     }
 }

--- a/core/ast/src/function/async_function.rs
+++ b/core/ast/src/function/async_function.rs
@@ -166,18 +166,17 @@ pub struct AsyncFunctionExpression {
 
 impl AsyncFunctionExpression {
     /// Creates a new async function expression.
-    #[inline]
     #[must_use]
-    pub fn new(
+    pub fn new_boxed(
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: FunctionBody,
         linear_span: LinearSpan,
         has_binding_identifier: bool,
-    ) -> Self {
+    ) -> Box<Self> {
         let contains_direct_eval = contains(&parameters, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
-        Self {
+        Box::new(Self {
             name,
             parameters,
             body,
@@ -186,7 +185,7 @@ impl AsyncFunctionExpression {
             contains_direct_eval,
             scopes: FunctionScopes::default(),
             linear_span: linear_span.into(),
-        }
+        })
     }
 
     /// Gets the name of the async function expression.
@@ -271,9 +270,9 @@ impl ToIndentedString for AsyncFunctionExpression {
     }
 }
 
-impl From<AsyncFunctionExpression> for Expression {
+impl From<Box<AsyncFunctionExpression>> for Expression {
     #[inline]
-    fn from(expr: AsyncFunctionExpression) -> Self {
+    fn from(expr: Box<AsyncFunctionExpression>) -> Self {
         Self::AsyncFunctionExpression(expr)
     }
 }

--- a/core/ast/src/function/async_generator.rs
+++ b/core/ast/src/function/async_generator.rs
@@ -166,18 +166,17 @@ pub struct AsyncGeneratorExpression {
 
 impl AsyncGeneratorExpression {
     /// Creates a new async generator expression.
-    #[inline]
     #[must_use]
-    pub fn new(
+    pub fn new_boxed(
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: FunctionBody,
         linear_span: LinearSpan,
         has_binding_identifier: bool,
-    ) -> Self {
+    ) -> Box<Self> {
         let contains_direct_eval = contains(&parameters, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
-        Self {
+        Box::new(Self {
             name,
             parameters,
             body,
@@ -186,7 +185,7 @@ impl AsyncGeneratorExpression {
             contains_direct_eval,
             scopes: FunctionScopes::default(),
             linear_span: linear_span.into(),
-        }
+        })
     }
 
     /// Gets the name of the async generator expression.
@@ -264,9 +263,9 @@ impl ToIndentedString for AsyncGeneratorExpression {
     }
 }
 
-impl From<AsyncGeneratorExpression> for Expression {
+impl From<Box<AsyncGeneratorExpression>> for Expression {
     #[inline]
-    fn from(expr: AsyncGeneratorExpression) -> Self {
+    fn from(expr: Box<AsyncGeneratorExpression>) -> Self {
         Self::AsyncGeneratorExpression(expr)
     }
 }

--- a/core/ast/src/function/generator.rs
+++ b/core/ast/src/function/generator.rs
@@ -163,19 +163,18 @@ pub struct GeneratorExpression {
 }
 
 impl GeneratorExpression {
-    /// Creates a new generator expression.
-    #[inline]
+    /// Creates a new boxed generator expression.
     #[must_use]
-    pub fn new(
+    pub fn new_boxed(
         name: Option<Identifier>,
         parameters: FormalParameterList,
         body: FunctionBody,
         linear_span: LinearSpan,
         has_binding_identifier: bool,
-    ) -> Self {
+    ) -> Box<Self> {
         let contains_direct_eval = contains(&parameters, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
-        Self {
+        Box::new(Self {
             name,
             parameters,
             body,
@@ -184,7 +183,7 @@ impl GeneratorExpression {
             contains_direct_eval,
             scopes: FunctionScopes::default(),
             linear_span: linear_span.into(),
-        }
+        })
     }
 
     /// Gets the name of the generator expression.
@@ -262,9 +261,9 @@ impl ToIndentedString for GeneratorExpression {
     }
 }
 
-impl From<GeneratorExpression> for Expression {
+impl From<Box<GeneratorExpression>> for Expression {
     #[inline]
-    fn from(expr: GeneratorExpression) -> Self {
+    fn from(expr: Box<GeneratorExpression>) -> Self {
         Self::GeneratorExpression(expr)
     }
 }

--- a/core/ast/src/function/ordinary_function.rs
+++ b/core/ast/src/function/ordinary_function.rs
@@ -202,6 +202,24 @@ impl FunctionExpression {
         }
     }
 
+    /// Creates a new boxed function expression.
+    #[must_use]
+    pub fn new_boxed(
+        name: Option<Identifier>,
+        parameters: FormalParameterList,
+        body: FunctionBody,
+        linear_span: Option<LinearSpan>,
+        has_binding_identifier: bool,
+    ) -> Box<Self> {
+        Box::new(Self::new(
+            name,
+            parameters,
+            body,
+            linear_span,
+            has_binding_identifier,
+        ))
+    }
+
     /// Gets the name of the function expression.
     #[inline]
     #[must_use]
@@ -285,9 +303,9 @@ impl ToIndentedString for FunctionExpression {
     }
 }
 
-impl From<FunctionExpression> for Expression {
+impl From<Box<FunctionExpression>> for Expression {
     #[inline]
-    fn from(expr: FunctionExpression) -> Self {
+    fn from(expr: Box<FunctionExpression>) -> Self {
         Self::FunctionExpression(expr)
     }
 }

--- a/core/ast/src/statement/iteration/for_in_loop.rs
+++ b/core/ast/src/statement/iteration/for_in_loop.rs
@@ -20,7 +20,7 @@ use core::ops::ControlFlow;
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForInLoop {
     pub(crate) initializer: IterableLoopInitializer,
-    pub(crate) target: Expression,
+    pub(crate) target: Box<Expression>,
     pub(crate) body: Box<Statement>,
     pub(crate) target_contains_direct_eval: bool,
     pub(crate) contains_direct_eval: bool,
@@ -36,8 +36,12 @@ impl ForInLoop {
     /// Creates a new `ForInLoop`.
     #[inline]
     #[must_use]
-    pub fn new(initializer: IterableLoopInitializer, target: Expression, body: Statement) -> Self {
-        let target_contains_direct_eval = contains(&target, ContainsSymbol::DirectEval);
+    pub fn new(
+        initializer: IterableLoopInitializer,
+        target: Box<Expression>,
+        body: Statement,
+    ) -> Self {
+        let target_contains_direct_eval = contains(target.as_ref(), ContainsSymbol::DirectEval);
         let contains_direct_eval = contains(&initializer, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
         Self {

--- a/core/ast/src/statement/iteration/for_of_loop.rs
+++ b/core/ast/src/statement/iteration/for_of_loop.rs
@@ -25,7 +25,7 @@ use core::ops::ControlFlow;
 #[derive(Clone, Debug, PartialEq)]
 pub struct ForOfLoop {
     pub(crate) init: IterableLoopInitializer,
-    pub(crate) iterable: Expression,
+    pub(crate) iterable: Box<Expression>,
     pub(crate) body: Box<Statement>,
     r#await: bool,
     pub(crate) iterable_contains_direct_eval: bool,
@@ -44,11 +44,11 @@ impl ForOfLoop {
     #[must_use]
     pub fn new(
         init: IterableLoopInitializer,
-        iterable: Expression,
+        iterable: Box<Expression>,
         body: Statement,
         r#await: bool,
     ) -> Self {
-        let iterable_contains_direct_eval = contains(&iterable, ContainsSymbol::DirectEval);
+        let iterable_contains_direct_eval = contains(iterable.as_ref(), ContainsSymbol::DirectEval);
         let contains_direct_eval = contains(&init, ContainsSymbol::DirectEval)
             || contains(&body, ContainsSymbol::DirectEval);
         Self {

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -129,22 +129,22 @@ impl ByteCompiler<'_> {
             Expression::This => self.access_get(Access::This, dst),
             Expression::Spread(spread) => self.compile_expr(spread.target(), dst),
             Expression::FunctionExpression(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::ArrowFunction(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::AsyncArrowFunction(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::GeneratorExpression(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::AsyncFunctionExpression(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::AsyncGeneratorExpression(function) => {
-                self.function_with_binding(function.into(), NodeKind::Expression, dst);
+                self.function_with_binding(function.as_ref().into(), NodeKind::Expression, dst);
             }
             Expression::Call(call) => self.call(Callable::Call(call), dst),
             Expression::New(new) => self.call(Callable::New(new), dst),

--- a/core/parser/src/error/tests.rs
+++ b/core/parser/src/error/tests.rs
@@ -16,12 +16,12 @@ fn context() {
     assert_eq!(result.context(), Some("after"));
 
     let error = result.unwrap_err();
-    if let Error::Expected {
+    if let ErrorInner::Expected {
         expected,
         found,
         span,
         context,
-    } = error
+    } = error.into()
     {
         assert_eq!(expected.as_ref(), &["testing".to_owned()]);
         assert_eq!(found, "nottesting".into());
@@ -31,7 +31,7 @@ fn context() {
         unreachable!();
     }
 
-    let err = Error::AbruptEnd;
+    let err = Error::abrupt_end();
     assert!(err.context().is_none());
     let err = err.set_context("ignored");
     assert!(err.context().is_none());
@@ -40,20 +40,20 @@ fn context() {
 #[test]
 fn from_lex_error() {
     let lex_err = LexError::syntax("testing", Position::new(1, 1));
-    let parse_err: Error = lex_err.into();
+    let parse_err: ErrorInner = lex_err.into();
 
-    assert!(matches!(parse_err, Error::Lex { .. }));
+    assert!(matches!(parse_err, ErrorInner::Lex { .. }));
 
     let lex_err = LexError::syntax("testing", Position::new(1, 1));
-    let parse_err = Error::lex(lex_err);
+    let parse_err = ErrorInner::lex(lex_err);
 
-    assert!(matches!(parse_err, Error::Lex { .. }));
+    assert!(matches!(parse_err, ErrorInner::Lex { .. }));
 }
 
 #[test]
 fn misplaced_function_declaration() {
     let err = Error::misplaced_function_declaration(Position::new(1, 1), false);
-    if let Error::General { message, position } = err {
+    if let ErrorInner::General { message, position } = err.into() {
         assert_eq!(
             message.as_ref(),
             "functions can only be declared at the top level or inside a block."
@@ -64,7 +64,7 @@ fn misplaced_function_declaration() {
     }
 
     let err = Error::misplaced_function_declaration(Position::new(1, 1), true);
-    if let Error::General { message, position } = err {
+    if let ErrorInner::General { message, position } = err.into() {
         assert_eq!(
             message.as_ref(),
             "in strict mode code, functions can only be declared at the top level or inside a block."
@@ -78,7 +78,7 @@ fn misplaced_function_declaration() {
 #[test]
 fn wrong_labelled_function_declaration() {
     let err = Error::wrong_labelled_function_declaration(Position::new(1, 1));
-    if let Error::General { message, position } = err {
+    if let ErrorInner::General { message, position } = err.into() {
         assert_eq!(
             message.as_ref(),
             "labelled functions can only be declared at the top level or inside a block"
@@ -156,7 +156,7 @@ fn display() {
         "this is a general error message at line 1, col 1"
     );
 
-    let err = Error::AbruptEnd;
+    let err = Error::abrupt_end();
     assert_eq!(err.to_string(), "abrupt end");
 
     let lex_err = LexError::syntax("testing", Position::new(1, 1));

--- a/core/parser/src/parser/expression/assignment/async_arrow_function.rs
+++ b/core/parser/src/parser/expression/assignment/async_arrow_function.rs
@@ -67,6 +67,14 @@ where
     type Output = ast::function::AsyncArrowFunction;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
+    }
+
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<Self::Output>> {
         let _timer = Profiler::global().start_event("AsyncArrowFunction", "Parsing");
 
         let async_token =
@@ -149,7 +157,7 @@ where
         let linear_pos_end = body.linear_pos_end();
         let span = start_linear_span.union(linear_pos_end);
 
-        Ok(ast::function::AsyncArrowFunction::new(
+        Ok(ast::function::AsyncArrowFunction::new_boxed(
             None, params, body, span,
         ))
     }

--- a/core/parser/src/parser/expression/assignment/exponentiation.rs
+++ b/core/parser/src/parser/expression/assignment/exponentiation.rs
@@ -88,13 +88,10 @@ where
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Exp) {
                 cursor.advance(interner);
-                return Ok(Box::new(
-                    Binary::new_boxed(
-                        ArithmeticOp::Exp.into(),
-                        lhs,
-                        self.parse_boxed(cursor, interner)?,
-                    )
-                    .into(),
+                return Ok(Binary::new_boxed_expr(
+                    ArithmeticOp::Exp.into(),
+                    lhs,
+                    self.parse_boxed(cursor, interner)?,
                 ));
             }
         }

--- a/core/parser/src/parser/expression/assignment/exponentiation.rs
+++ b/core/parser/src/parser/expression/assignment/exponentiation.rs
@@ -85,6 +85,22 @@ where
 
         let lhs = UpdateExpression::new(self.allow_yield, self.allow_await)
             .parse_boxed(cursor, interner)?;
+
+        self.parse_boxed_tail(cursor, interner, lhs)
+    }
+}
+
+impl ExponentiationExpression {
+    /// This function was added to optimize the stack size.
+    /// It has an stack size optimization impact only for `profile.#.opt-level = 0`.
+    /// It allow to reduce stack size allocation in `parse_boxed`,
+    /// and an often called function in recursion stays outside of this function.
+    fn parse_boxed_tail<R: ReadChar>(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+        lhs: Box<Expression>,
+    ) -> ParseResult<Box<Expression>> {
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Exp) {
                 cursor.advance(interner);

--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -123,7 +123,7 @@ where
                             self.allow_await,
                         )
                         .parse_boxed(cursor, interner)
-                        .map(|arrow| Box::new(Expression::ArrowFunction(*arrow)));
+                        .map(|arrow| Box::new(Expression::ArrowFunction(arrow)));
                     }
                 }
             }
@@ -154,7 +154,7 @@ where
                 {
                     return AsyncArrowFunction::new(self.allow_in, self.allow_yield)
                         .parse_boxed(cursor, interner)
-                        .map(|arrow| Box::new(Expression::AsyncArrowFunction(*arrow)));
+                        .map(|arrow| Box::new(Expression::AsyncArrowFunction(arrow)));
                 }
             }
             _ => {}
@@ -230,7 +230,7 @@ where
             let span = start_linear_span.union(linear_pos_end);
 
             return Ok(Expression::boxed(|| {
-                boa_ast::function::ArrowFunction::new(None, parameters, body, span).into()
+                boa_ast::function::ArrowFunction::new_boxed(None, parameters, body, span).into()
             }));
         }
 

--- a/core/parser/src/parser/expression/assignment/mod.rs
+++ b/core/parser/src/parser/expression/assignment/mod.rs
@@ -141,7 +141,7 @@ impl AssignmentExpression {
             TokenKind::Keyword((Keyword::Yield, _)) if self.allow_yield.0 => {
                 return YieldExpression::new(self.allow_in, self.allow_await)
                     .parse_boxed(cursor, interner)
-                    .map(|x| Some(x))
+                    .map(Some)
             }
             // ArrowFunction[?In, ?Yield, ?Await] -> ArrowParameters[?Yield, ?Await] -> BindingIdentifier[?Yield, ?Await]
             TokenKind::IdentifierName(_)
@@ -277,9 +277,9 @@ impl AssignmentExpression {
         let linear_pos_end = body.linear_pos_end();
         let span = start_linear_span.union(linear_pos_end);
 
-        return Ok(Expression::boxed(|| {
+        Ok(Expression::boxed(|| {
             boa_ast::function::ArrowFunction::new_boxed(None, parameters, body, span).into()
-        }));
+        }))
     }
 
     /// This function was added to optimize the stack size.

--- a/core/parser/src/parser/expression/assignment/yield.rs
+++ b/core/parser/src/parser/expression/assignment/yield.rs
@@ -72,8 +72,8 @@ where
             TokenKind::Punctuator(Punctuator::Mul) => {
                 cursor.advance(interner);
                 let expr = AssignmentExpression::new(self.allow_in, true, self.allow_await)
-                    .parse(cursor, interner)?;
-                Ok(Yield::new(Some(expr), true).into())
+                    .parse_boxed(cursor, interner)?;
+                Ok(Yield::new_boxed(Some(expr), true).into())
             }
             TokenKind::IdentifierName(_)
             | TokenKind::Punctuator(
@@ -111,10 +111,10 @@ where
             | TokenKind::RegularExpressionLiteral(_, _)
             | TokenKind::TemplateMiddle(_) => {
                 let expr = AssignmentExpression::new(self.allow_in, true, self.allow_await)
-                    .parse(cursor, interner)?;
-                Ok(Yield::new(Some(expr), false).into())
+                    .parse_boxed(cursor, interner)?;
+                Ok(Yield::new_boxed(Some(expr), false).into())
             }
-            _ => Ok(Yield::new(None, false).into()),
+            _ => Ok(Yield::new_boxed(None, false).into()),
         }
     }
 }

--- a/core/parser/src/parser/expression/left_hand_side/mod.rs
+++ b/core/parser/src/parser/expression/left_hand_side/mod.rs
@@ -87,19 +87,18 @@ where
 
         cursor.set_goal(InputElement::TemplateTail);
 
-        let lhs = match self.parse_boxed_special_kws(cursor, interner)? {
-            Some(lhs) => lhs,
-            None => {
-                let mut member = MemberExpression::new(self.allow_yield, self.allow_await)
-                    .parse_boxed(cursor, interner)?;
-                if let Some(tok) = cursor.peek(0, interner)? {
-                    if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
-                        member = CallExpression::new(self.allow_yield, self.allow_await, member)
-                            .parse_boxed(cursor, interner)?;
-                    }
+        let lhs = if let Some(lhs) = self.parse_boxed_special_kws(cursor, interner)? {
+            lhs
+        } else {
+            let mut member = MemberExpression::new(self.allow_yield, self.allow_await)
+                .parse_boxed(cursor, interner)?;
+            if let Some(tok) = cursor.peek(0, interner)? {
+                if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
+                    member = CallExpression::new(self.allow_yield, self.allow_await, member)
+                        .parse_boxed(cursor, interner)?;
                 }
-                member
             }
+            member
         };
 
         self.parse_boxed_tail(cursor, interner, lhs)

--- a/core/parser/src/parser/expression/left_hand_side/mod.rs
+++ b/core/parser/src/parser/expression/left_hand_side/mod.rs
@@ -83,85 +83,124 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> ParseResult<Box<Self::Output>> {
-        /// Checks if we need to parse a keyword call expression `keyword()`.
-        ///
-        /// It first checks if the next token is `keyword`, and if it is, it checks if the second next
-        /// token is the open parenthesis (`(`) punctuator.
-        ///
-        /// This is needed because the `if let` chain is very complex, and putting it inline in the
-        /// initialization of `lhs` would make it very hard to return an expression over all
-        /// possible branches of the `if let`s. Instead, we extract the check into its own function,
-        /// then use it inside the condition of a simple `if ... else` expression.
-        fn is_keyword_call<R: ReadChar>(
-            keyword: Keyword,
-            cursor: &mut Cursor<R>,
-            interner: &mut Interner,
-        ) -> ParseResult<bool> {
-            if let Some(next) = cursor.peek(0, interner)? {
-                if let TokenKind::Keyword((kw, escaped)) = next.kind() {
-                    if kw == &keyword {
-                        if *escaped {
-                            return Err(Error::general(
-                                format!(
-                                    "keyword `{}` cannot contain escaped characters",
-                                    kw.as_str().0
-                                ),
-                                next.span().start(),
-                            ));
-                        }
-                        if let Some(next) = cursor.peek(1, interner)? {
-                            if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
-                                return Ok(true);
-                            }
-                        }
-                    }
-                }
-            }
-            Ok(false)
-        }
-
         let _timer = Profiler::global().start_event("LeftHandSideExpression", "Parsing");
 
         cursor.set_goal(InputElement::TemplateTail);
 
-        let mut lhs = if is_keyword_call(Keyword::Super, cursor, interner)? {
-            cursor.advance(interner);
-            let args =
-                Arguments::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
-            SuperCall::new(args).into()
-        } else if is_keyword_call(Keyword::Import, cursor, interner)? {
-            // `import`
-            cursor.advance(interner);
-            // `(`
-            cursor.advance(interner);
-
-            let arg = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                .parse_boxed(cursor, interner)?;
-
-            cursor.expect(
-                TokenKind::Punctuator(Punctuator::CloseParen),
-                "import call",
-                interner,
-            )?;
-
-            CallExpressionTail::new(
-                self.allow_yield,
-                self.allow_await,
-                ImportCall::new(arg).into(),
-            )
-            .parse_boxed(cursor, interner)?
-        } else {
-            let mut member = MemberExpression::new(self.allow_yield, self.allow_await)
-                .parse_boxed(cursor, interner)?;
-            if let Some(tok) = cursor.peek(0, interner)? {
-                if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
-                    member = CallExpression::new(self.allow_yield, self.allow_await, member)
-                        .parse_boxed(cursor, interner)?;
+        let lhs = match self.parse_boxed_special_kws(cursor, interner)? {
+            Some(lhs) => lhs,
+            None => {
+                let mut member = MemberExpression::new(self.allow_yield, self.allow_await)
+                    .parse_boxed(cursor, interner)?;
+                if let Some(tok) = cursor.peek(0, interner)? {
+                    if tok.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
+                        member = CallExpression::new(self.allow_yield, self.allow_await, member)
+                            .parse_boxed(cursor, interner)?;
+                    }
                 }
+                member
             }
-            member
         };
 
+        self.parse_boxed_tail(cursor, interner, lhs)
+    }
+}
+
+impl LeftHandSideExpression {
+    /// Checks if we need to parse a keyword call expression `keyword()`.
+    ///
+    /// It first checks if the next token is `keyword`, and if it is, it checks if the second next
+    /// token is the open parenthesis (`(`) punctuator.
+    ///
+    /// This is needed because the `if let` chain is very complex, and putting it inline in the
+    /// initialization of `lhs` would make it very hard to return an expression over all
+    /// possible branches of the `if let`s. Instead, we extract the check into its own function,
+    /// then use it inside the condition of a simple `if ... else` expression.
+    fn is_keyword_call<R: ReadChar>(
+        keyword: Keyword,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<bool> {
+        if let Some(next) = cursor.peek(0, interner)? {
+            if let TokenKind::Keyword((kw, escaped)) = next.kind() {
+                if kw == &keyword {
+                    if *escaped {
+                        return Err(Error::general(
+                            format!(
+                                "keyword `{}` cannot contain escaped characters",
+                                kw.as_str().0
+                            ),
+                            next.span().start(),
+                        ));
+                    }
+                    if let Some(next) = cursor.peek(1, interner)? {
+                        if next.kind() == &TokenKind::Punctuator(Punctuator::OpenParen) {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// This function was added to optimize the stack size.
+    /// It has an stack size optimization impact only for `profile.#.opt-level = 0`.
+    /// It allow to reduce stack size allocation in `parse_boxed`,
+    /// and an often called function in recursion stays outside of this function.
+    ///
+    /// # Return
+    /// * `Err(_)` if error occurs;
+    /// * `Ok(None)` if next expression is not `Keyword((Super, _)) || Keyword((Import, _))`;
+    /// * `Ok(Some(Box<Expr>))` otherwise;
+    fn parse_boxed_special_kws<R: ReadChar>(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Option<Box<Expression>>> {
+        Ok(Some(
+            if Self::is_keyword_call(Keyword::Super, cursor, interner)? {
+                cursor.advance(interner);
+                let args =
+                    Arguments::new(self.allow_yield, self.allow_await).parse(cursor, interner)?;
+                SuperCall::new(args).into()
+            } else if Self::is_keyword_call(Keyword::Import, cursor, interner)? {
+                // `import`
+                cursor.advance(interner);
+                // `(`
+                cursor.advance(interner);
+
+                let arg = AssignmentExpression::new(true, self.allow_yield, self.allow_await)
+                    .parse_boxed(cursor, interner)?;
+
+                cursor.expect(
+                    TokenKind::Punctuator(Punctuator::CloseParen),
+                    "import call",
+                    interner,
+                )?;
+
+                CallExpressionTail::new(
+                    self.allow_yield,
+                    self.allow_await,
+                    ImportCall::new(arg).into(),
+                )
+                .parse_boxed(cursor, interner)?
+            } else {
+                return Ok(None);
+            },
+        ))
+    }
+
+    /// This function was added to optimize the stack size.
+    /// It has an stack size optimization impact only for `profile.#.opt-level = 0`.
+    /// It allow to reduce stack size allocation in `parse_boxed`,
+    /// and an often called function in recursion stays outside of this function.
+    fn parse_boxed_tail<R: ReadChar>(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+        mut lhs: Box<Expression>,
+    ) -> ParseResult<Box<Expression>> {
         if let Some(tok) = cursor.peek(0, interner)? {
             if tok.kind() == &TokenKind::Punctuator(Punctuator::Optional) {
                 lhs = OptionalExpression::new(self.allow_yield, self.allow_await, lhs)

--- a/core/parser/src/parser/expression/left_hand_side/optional/mod.rs
+++ b/core/parser/src/parser/expression/left_hand_side/optional/mod.rs
@@ -31,7 +31,7 @@ use boa_profiler::Profiler;
 pub(in crate::parser) struct OptionalExpression {
     allow_yield: AllowYield,
     allow_await: AllowAwait,
-    target: ast::Expression,
+    target: Box<ast::Expression>,
 }
 
 impl OptionalExpression {
@@ -39,7 +39,7 @@ impl OptionalExpression {
     pub(in crate::parser) fn new<Y, A>(
         allow_yield: Y,
         allow_await: A,
-        target: ast::Expression,
+        target: Box<ast::Expression>,
     ) -> Self
     where
         Y: Into<AllowYield>,

--- a/core/parser/src/parser/expression/left_hand_side/optional/tests.rs
+++ b/core/parser/src/parser/expression/left_hand_side/optional/tests.rs
@@ -18,7 +18,7 @@ fn simple() {
         r#"5?.name"#,
         vec![Statement::Expression(
             Optional::new(
-                Literal::Int(5).into(),
+                Box::new(Literal::Int(5).into()),
                 vec![OptionalOperation::new(
                     OptionalOperationKind::SimplePropertyAccess {
                         field: PropertyAccessField::Const(

--- a/core/parser/src/parser/expression/left_hand_side/template.rs
+++ b/core/parser/src/parser/expression/left_hand_side/template.rs
@@ -22,7 +22,7 @@ pub(super) struct TaggedTemplateLiteral {
     allow_yield: AllowYield,
     allow_await: AllowAwait,
     start: PositionGroup,
-    tag: ast::Expression,
+    tag: Box<ast::Expression>,
 }
 
 impl TaggedTemplateLiteral {
@@ -31,7 +31,7 @@ impl TaggedTemplateLiteral {
         allow_yield: Y,
         allow_await: A,
         start: PositionGroup,
-        tag: ast::Expression,
+        tag: Box<ast::Expression>,
     ) -> Self
     where
         Y: Into<AllowYield>,

--- a/core/parser/src/parser/expression/mod.rs
+++ b/core/parser/src/parser/expression/mod.rs
@@ -403,17 +403,25 @@ impl BitwiseORExpression {
     }
 }
 
-
 impl<R> TokenParser<R> for BitwiseORExpression
-where R: ReadChar
+where
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
-    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner)-> ParseResult<ast::Expression> {
-        self.parse_boxed(cursor, interner).map(|ok|*ok)
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<ast::Expression> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
     }
 
-    fn parse_boxed(self, cursor: &mut Cursor<R>, interner: &mut Interner)-> ParseResult<Box<ast::Expression>> {
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<ast::Expression>> {
         // TODO: recursive `expression!`
         //
         // unwrapping of
@@ -438,9 +446,7 @@ where R: ReadChar
                 lhs = {
                     expression!([PREFIX][cursor] EqualityExpression);
                     let lower = expression!([LOWER_CTOR][self] RelationalExpression, [allow_in, allow_yield, allow_await]);
-                    lhs = {
-                        lower.parse_boxed(cursor, interner)?
-                    };
+                    lhs = { lower.parse_boxed(cursor, interner)? };
                     expression!(
                         [POSTFIX]
                         [self; cursor; interner; lhs]
@@ -613,11 +619,19 @@ where
 {
     type Output = ast::Expression;
 
-    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner)-> ParseResult<ast::Expression> {
-        self.parse_boxed(cursor, interner).map(|ok|*ok)
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<ast::Expression> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
     }
 
-    fn parse_boxed(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Box<Self::Output>> {
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<Self::Output>> {
         let _timer = Profiler::global().start_event("Relation Expression", "Parsing");
 
         if self.allow_in.0 {
@@ -639,15 +653,17 @@ where
                         let rhs = ShiftExpression::new(self.allow_yield, self.allow_await)
                             .parse_boxed(cursor, interner)?;
 
-                        return Ok(BinaryInPrivate::new_boxed(PrivateName::new(identifier), rhs).into());
+                        return Ok(
+                            BinaryInPrivate::new_boxed(PrivateName::new(identifier), rhs).into(),
+                        );
                     }
                     _ => {}
                 }
             }
         }
 
-        let mut lhs =
-            ShiftExpression::new(self.allow_yield, self.allow_await).parse_boxed(cursor, interner)?;
+        let mut lhs = ShiftExpression::new(self.allow_yield, self.allow_await)
+            .parse_boxed(cursor, interner)?;
 
         while let Some(tok) = cursor.peek(0, interner)? {
             match *tok.kind() {
@@ -722,15 +738,24 @@ impl ShiftExpression {
 }
 
 impl<R> TokenParser<R> for ShiftExpression
-where R: ReadChar
+where
+    R: ReadChar,
 {
     type Output = ast::Expression;
 
-    fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner)-> ParseResult<ast::Expression> {
-        self.parse_boxed(cursor, interner).map(|ok|*ok)
+    fn parse(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<ast::Expression> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
     }
 
-    fn parse_boxed(self, cursor: &mut Cursor<R>, interner: &mut Interner)-> ParseResult<Box<ast::Expression>> {
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<ast::Expression>> {
         // TODO: recursive `expression!`
         //
         // unwrapping of
@@ -756,9 +781,7 @@ where R: ReadChar
             lhs = {
                 expression!([PREFIX][cursor] MultiplicativeExpression, InputElement::Div);
                 let lower = expression!([LOWER_CTOR][self] ExponentiationExpression, [allow_yield, allow_await]);
-                lhs = {
-                    lower.parse_boxed(cursor, interner)?
-                };
+                lhs = { lower.parse_boxed(cursor, interner)? };
                 expression!([POSTFIX][self; cursor; interner; lhs] lower, [Punctuator::Mul, Punctuator::Div, Punctuator::Mod])
             };
             expression!([POSTFIX][self; cursor; interner; lhs] lower, [Punctuator::Add, Punctuator::Sub])

--- a/core/parser/src/parser/expression/mod.rs
+++ b/core/parser/src/parser/expression/mod.rs
@@ -285,9 +285,10 @@ where
                         BitwiseORExpression::new(self.allow_in, self.allow_yield, self.allow_await)
                             .parse_boxed(cursor, interner)?;
 
-                    current_node = Box::new(
-                        Binary::new_boxed(BinaryOp::Logical(LogicalOp::And), current_node, rhs)
-                            .into(),
+                    current_node = Binary::new_boxed_expr(
+                        BinaryOp::Logical(LogicalOp::And),
+                        current_node,
+                        rhs,
                     );
                 }
                 TokenKind::Punctuator(Punctuator::BoolOr) => {
@@ -307,10 +308,8 @@ where
                         PreviousExpr::Logical,
                     )
                     .parse_boxed(cursor, interner)?;
-                    current_node = Box::new(
-                        Binary::new_boxed(BinaryOp::Logical(LogicalOp::Or), current_node, rhs)
-                            .into(),
-                    );
+                    current_node =
+                        Binary::new_boxed_expr(BinaryOp::Logical(LogicalOp::Or), current_node, rhs);
                 }
                 TokenKind::Punctuator(Punctuator::Coalesce) => {
                     if previous == PreviousExpr::Logical {
@@ -326,13 +325,10 @@ where
                     let rhs =
                         BitwiseORExpression::new(self.allow_in, self.allow_yield, self.allow_await)
                             .parse_boxed(cursor, interner)?;
-                    current_node = Box::new(
-                        Binary::new_boxed(
-                            BinaryOp::Logical(LogicalOp::Coalesce),
-                            current_node,
-                            rhs,
-                        )
-                        .into(),
+                    current_node = Binary::new_boxed_expr(
+                        BinaryOp::Logical(LogicalOp::Coalesce),
+                        current_node,
+                        rhs,
                     );
                 }
                 _ => break,

--- a/core/parser/src/parser/expression/primary/async_function_expression/tests.rs
+++ b/core/parser/src/parser/expression/primary/async_function_expression/tests.rs
@@ -27,7 +27,7 @@ fn check_async_expression() {
             vec![Variable::from_identifier(
                 add.into(),
                 Some(
-                    AsyncFunctionExpression::new(
+                    AsyncFunctionExpression::new_boxed(
                         Some(add.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -67,7 +67,7 @@ fn check_nested_async_expression() {
             vec![Variable::from_identifier(
                 a.into(),
                 Some(
-                    AsyncFunctionExpression::new(
+                    AsyncFunctionExpression::new_boxed(
                         Some(a.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -75,7 +75,7 @@ fn check_nested_async_expression() {
                                 vec![Variable::from_identifier(
                                     b.into(),
                                     Some(
-                                        AsyncFunctionExpression::new(
+                                        AsyncFunctionExpression::new_boxed(
                                             Some(b.into()),
                                             FormalParameterList::default(),
                                             FunctionBody::new(

--- a/core/parser/src/parser/expression/primary/async_generator_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/async_generator_expression/mod.rs
@@ -52,6 +52,14 @@ where
     type Output = AsyncGeneratorExpressionNode;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
+    }
+
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<Self::Output>> {
         let _timer = Profiler::global().start_event("AsyncGeneratorExpression", "Parsing");
         let token = cursor.expect(
             (Keyword::Async, false),
@@ -184,9 +192,10 @@ where
 
         let span = start_linear_span.union(body.linear_pos_end());
 
-        let function = AsyncGeneratorExpressionNode::new(name, params, body, span, name.is_some());
+        let function =
+            AsyncGeneratorExpressionNode::new_boxed(name, params, body, span, name.is_some());
 
-        if contains(&function, ContainsSymbol::Super) {
+        if contains(function.as_ref(), ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(
                 "invalid super usage".into(),
                 params_start_position,

--- a/core/parser/src/parser/expression/primary/async_generator_expression/tests.rs
+++ b/core/parser/src/parser/expression/primary/async_generator_expression/tests.rs
@@ -28,7 +28,7 @@ fn check_async_generator_expr() {
             vec![Variable::from_identifier(
                 add.into(),
                 Some(
-                    AsyncGeneratorExpression::new(
+                    AsyncGeneratorExpression::new_boxed(
                         Some(add.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -68,7 +68,7 @@ fn check_nested_async_generator_expr() {
             vec![Variable::from_identifier(
                 a.into(),
                 Some(
-                    AsyncGeneratorExpression::new(
+                    AsyncGeneratorExpression::new_boxed(
                         Some(a.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -76,7 +76,7 @@ fn check_nested_async_generator_expr() {
                                 vec![Variable::from_identifier(
                                     b.into(),
                                     Some(
-                                        AsyncGeneratorExpression::new(
+                                        AsyncGeneratorExpression::new_boxed(
                                             Some(b.into()),
                                             FormalParameterList::default(),
                                             FunctionBody::new(

--- a/core/parser/src/parser/expression/primary/function_expression/tests.rs
+++ b/core/parser/src/parser/expression/primary/function_expression/tests.rs
@@ -25,7 +25,7 @@ fn check_function_expression() {
             vec![Variable::from_identifier(
                 add.into(),
                 Some(
-                    FunctionExpression::new(
+                    FunctionExpression::new_boxed(
                         Some(add.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -65,7 +65,7 @@ fn check_nested_function_expression() {
             vec![Variable::from_identifier(
                 a.into(),
                 Some(
-                    FunctionExpression::new(
+                    FunctionExpression::new_boxed(
                         Some(a.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -73,7 +73,7 @@ fn check_nested_function_expression() {
                                 vec![Variable::from_identifier(
                                     b.into(),
                                     Some(
-                                        FunctionExpression::new(
+                                        FunctionExpression::new_boxed(
                                             Some(b.into()),
                                             FormalParameterList::default(),
                                             FunctionBody::new(
@@ -118,7 +118,7 @@ fn check_function_non_reserved_keyword() {
                 vec![Variable::from_identifier(
                     $interner.get_or_intern_static("add", utf16!("add")).into(),
                     Some(
-                        FunctionExpression::new(
+                        FunctionExpression::new_boxed(
                             Some($interner.get_or_intern_static($keyword, utf16!($keyword)).into()),
                             FormalParameterList::default(),
                             FunctionBody::new(

--- a/core/parser/src/parser/expression/primary/generator_expression/mod.rs
+++ b/core/parser/src/parser/expression/primary/generator_expression/mod.rs
@@ -53,6 +53,14 @@ where
     type Output = GeneratorExpressionNode;
 
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
+        self.parse_boxed(cursor, interner).map(|ok| *ok)
+    }
+
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<Self::Output>> {
         let _timer = Profiler::global().start_event("GeneratorExpression", "Parsing");
 
         let token = cursor.expect((Keyword::Function, false), "generator expression", interner)?;
@@ -156,9 +164,9 @@ where
 
         let span = start_linear_span.union(body.linear_pos_end());
 
-        let function = GeneratorExpressionNode::new(name, params, body, span, name.is_some());
+        let function = GeneratorExpressionNode::new_boxed(name, params, body, span, name.is_some());
 
-        if contains(&function, ContainsSymbol::Super) {
+        if contains(function.as_ref(), ContainsSymbol::Super) {
             return Err(Error::lex(LexError::Syntax(
                 "invalid super usage".into(),
                 params_start_position,

--- a/core/parser/src/parser/expression/primary/generator_expression/tests.rs
+++ b/core/parser/src/parser/expression/primary/generator_expression/tests.rs
@@ -25,7 +25,7 @@ fn check_generator_function_expression() {
             vec![Variable::from_identifier(
                 gen.into(),
                 Some(
-                    GeneratorExpression::new(
+                    GeneratorExpression::new_boxed(
                         Some(gen.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(
@@ -62,7 +62,7 @@ fn check_generator_function_delegate_yield_expression() {
             vec![Variable::from_identifier(
                 gen.into(),
                 Some(
-                    GeneratorExpression::new(
+                    GeneratorExpression::new_boxed(
                         Some(gen.into()),
                         FormalParameterList::default(),
                         FunctionBody::new(

--- a/core/parser/src/parser/expression/primary/mod.rs
+++ b/core/parser/src/parser/expression/primary/mod.rs
@@ -118,11 +118,11 @@ where
                 let next_token = cursor.peek(1, interner).or_abrupt()?;
                 if next_token.kind() == &TokenKind::Punctuator(Punctuator::Mul) {
                     GeneratorExpression::new()
-                        .parse(cursor, interner)
+                        .parse_boxed(cursor, interner)
                         .map(Into::into)
                 } else {
                     FunctionExpression::new()
-                        .parse(cursor, interner)
+                        .parse_boxed(cursor, interner)
                         .map(Into::into)
                 }
             }
@@ -154,11 +154,11 @@ where
                         match cursor.peek(2, interner)?.map(Token::kind) {
                             Some(TokenKind::Punctuator(Punctuator::Mul)) => {
                                 AsyncGeneratorExpression::new()
-                                    .parse(cursor, interner)
+                                    .parse_boxed(cursor, interner)
                                     .map(Into::into)
                             }
                             _ => AsyncFunctionExpression::new()
-                                .parse(cursor, interner)
+                                .parse_boxed(cursor, interner)
                                 .map(Into::into),
                         }
                     }
@@ -515,19 +515,14 @@ fn formal_parameter_list_ctor(
     expressions: Vec<InnerExpression>,
     start_span: Span,
     tailing_comma: Option<Span>,
-    strict: bool
+    strict: bool,
 ) -> ParseResult<ast::Expression> {
     let mut parameters = Vec::new();
 
     for expression in expressions {
         match expression {
             InnerExpression::Expression(node) => {
-                expression_to_formal_parameters(
-                    &node,
-                    &mut parameters,
-                    strict,
-                    start_span,
-                )?;
+                expression_to_formal_parameters(&node, &mut parameters, strict, start_span)?;
             }
             InnerExpression::SpreadObject(bindings) => {
                 let declaration = Variable::from_pattern(bindings.into(), None);

--- a/core/parser/src/parser/expression/primary/mod.rs
+++ b/core/parser/src/parser/expression/primary/mod.rs
@@ -321,6 +321,7 @@ enum InnerExpression {
     SpreadBinding(Identifier),
 }
 impl InnerExpression {
+    #[allow(clippy::unnecessary_wraps)]
     fn parenthesized(expression: &ast::Expression) -> ParseResult<ast::Expression> {
         Ok(ast::Expression::Parenthesized(Parenthesized::new(
             expression.clone(),
@@ -345,20 +346,21 @@ where
         let mut expressions = Vec::new();
         let mut tailing_comma = None;
 
-        let span = match self.parse_special_initial_expr(cursor, interner, &mut expressions)? {
-            Some(span) => span,
-            None => {
-                let expression = Expression::new(true, self.allow_yield, self.allow_await)
-                    .parse_boxed(cursor, interner)?;
-                expressions.push(InnerExpression::Expression(expression));
+        let span = if let Some(span) =
+            self.parse_special_initial_expr(cursor, interner, &mut expressions)?
+        {
+            span
+        } else {
+            let expression = Expression::new(true, self.allow_yield, self.allow_await)
+                .parse_boxed(cursor, interner)?;
+            expressions.push(InnerExpression::Expression(expression));
 
-                self.parse_non_special_expr_tail(
-                    cursor,
-                    interner,
-                    &mut expressions,
-                    &mut tailing_comma,
-                )?
-            }
+            self.parse_non_special_expr_tail(
+                cursor,
+                interner,
+                &mut expressions,
+                &mut tailing_comma,
+            )?
         };
 
         let is_arrow = if cursor.peek(0, interner)?.map(Token::kind)

--- a/core/parser/src/parser/expression/tests.rs
+++ b/core/parser/src/parser/expression/tests.rs
@@ -692,7 +692,7 @@ fn parse_async_arrow_function_named_of() {
     check_script_parser(
         "async of => {}",
         vec![
-            Statement::Expression(Expression::from(AsyncArrowFunction::new(
+            Statement::Expression(Expression::from(AsyncArrowFunction::new_boxed(
                 None,
                 FormalParameterList::from_parameters(vec![FormalParameter::new(
                     Variable::from_identifier(

--- a/core/parser/src/parser/expression/update.rs
+++ b/core/parser/src/parser/expression/update.rs
@@ -96,60 +96,24 @@ where
     ) -> ParseResult<Box<Self::Output>> {
         let _timer = Profiler::global().start_event("UpdateExpression", "Parsing");
 
-        fn update_expr_ctor(
-            expr: &Box<Expression>,
-            pos: Position,
-            err_pos: Position,
-            op: UpdateOp,
-            strict: bool,
-        ) -> ParseResult<Box<Expression>> {
-            as_simple(expr, pos, strict)?.map_or_else(
-                || {
-                    Err(Error::lex(LexError::Syntax(
-                        "Invalid left-hand side in assignment".into(),
-                        err_pos,
-                    )))
-                },
-                |target| Ok(Box::new(Update::new(op, target).into())),
-            )
-        }
-
         let tok = cursor.peek(0, interner).or_abrupt()?;
         let position = tok.span().start();
         match tok.kind() {
             TokenKind::Punctuator(Punctuator::Inc) => {
-                cursor
-                    .next(interner)?
-                    .expect("Punctuator::Inc token disappeared");
-
-                let target = UnaryExpression::new(self.allow_yield, self.allow_await)
-                    .parse_boxed(cursor, interner)?;
-
-                // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                return update_expr_ctor(
-                    &target,
-                    position,
+                return self.parse_initial_inc_dec_token(
+                    cursor,
+                    interner,
                     position,
                     UpdateOp::IncrementPre,
-                    cursor.strict(),
-                );
+                )
             }
             TokenKind::Punctuator(Punctuator::Dec) => {
-                cursor
-                    .next(interner)?
-                    .expect("Punctuator::Dec token disappeared");
-
-                let target = UnaryExpression::new(self.allow_yield, self.allow_await)
-                    .parse_boxed(cursor, interner)?;
-
-                // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                return update_expr_ctor(
-                    &target,
-                    position,
+                return self.parse_initial_inc_dec_token(
+                    cursor,
+                    interner,
                     position,
                     UpdateOp::DecrementPre,
-                    cursor.strict(),
-                );
+                )
             }
             _ => {}
         }
@@ -157,6 +121,60 @@ where
         let lhs = LeftHandSideExpression::new(self.allow_yield, self.allow_await)
             .parse_boxed(cursor, interner)?;
 
+        self.parse_tail(cursor, interner, position, lhs)
+    }
+}
+
+impl UpdateExpression {
+    fn update_expr_ctor(
+        expr: &Box<Expression>,
+        pos: Position,
+        err_pos: Position,
+        op: UpdateOp,
+        strict: bool,
+    ) -> ParseResult<Box<Expression>> {
+        as_simple(expr, pos, strict)?.map_or_else(
+            || {
+                Err(Error::lex(LexError::Syntax(
+                    "Invalid left-hand side in assignment".into(),
+                    err_pos,
+                )))
+            },
+            |target| Ok(Box::new(Update::new(op, target).into())),
+        )
+    }
+
+    /// This function was added to optimize the stack size.
+    /// It has an stack size optimization impact only for `profile.#.opt-level = 0`.
+    /// It allow to reduce stack size allocation in `parse_boxed`,
+    /// and an often called function in recursion stays outside of this function.
+    fn parse_initial_inc_dec_token<R: ReadChar>(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+        position: Position,
+        op: UpdateOp,
+    ) -> ParseResult<Box<Expression>> {
+        cursor.next(interner)?.expect(disappeared_err(op.is_inc()));
+
+        let target = UnaryExpression::new(self.allow_yield, self.allow_await)
+            .parse_boxed(cursor, interner)?;
+
+        // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
+        return Self::update_expr_ctor(&target, position, position, op, cursor.strict());
+    }
+
+    /// This function was added to optimize the stack size.
+    /// It has an stack size optimization impact only for `profile.#.opt-level = 0`.
+    /// It allow to reduce stack size allocation in `parse_boxed`,
+    /// and an often called function in recursion stays outside of this function.
+    fn parse_tail<R: ReadChar>(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+        position: Position,
+        lhs: Box<Expression>,
+    ) -> ParseResult<Box<Expression>> {
         if cursor.peek_is_line_terminator(0, interner)?.unwrap_or(true) {
             return Ok(lhs);
         }
@@ -165,12 +183,10 @@ where
             let token_start = tok.span().start();
             match tok.kind() {
                 TokenKind::Punctuator(Punctuator::Inc) => {
-                    cursor
-                        .next(interner)?
-                        .expect("Punctuator::Inc token disappeared");
+                    cursor.next(interner)?.expect(disappeared_err(true));
 
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    return update_expr_ctor(
+                    return Self::update_expr_ctor(
                         &lhs,
                         position,
                         token_start,
@@ -179,12 +195,10 @@ where
                     );
                 }
                 TokenKind::Punctuator(Punctuator::Dec) => {
-                    cursor
-                        .next(interner)?
-                        .expect("Punctuator::Dec token disappeared");
+                    cursor.next(interner)?.expect(disappeared_err(false));
 
                     // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-                    return update_expr_ctor(
+                    return Self::update_expr_ctor(
                         &lhs,
                         position,
                         token_start,
@@ -197,5 +211,13 @@ where
         }
 
         Ok(lhs)
+    }
+}
+
+const fn disappeared_err(is_inc: bool) -> &'static str {
+    if is_inc {
+        "Punctuator::Inc token disappeared"
+    } else {
+        "Punctuator::Dec token disappeared"
     }
 }

--- a/core/parser/src/parser/expression/update.rs
+++ b/core/parser/src/parser/expression/update.rs
@@ -121,13 +121,14 @@ where
         let lhs = LeftHandSideExpression::new(self.allow_yield, self.allow_await)
             .parse_boxed(cursor, interner)?;
 
-        self.parse_tail(cursor, interner, position, lhs)
+        Self::parse_tail(cursor, interner, position, lhs)
     }
 }
 
+#[allow(clippy::expect_fun_call)]
 impl UpdateExpression {
     fn update_expr_ctor(
-        expr: &Box<Expression>,
+        expr: &Expression,
         pos: Position,
         err_pos: Position,
         op: UpdateOp,
@@ -161,7 +162,7 @@ impl UpdateExpression {
             .parse_boxed(cursor, interner)?;
 
         // https://tc39.es/ecma262/#sec-update-expressions-static-semantics-early-errors
-        return Self::update_expr_ctor(&target, position, position, op, cursor.strict());
+        Self::update_expr_ctor(&target, position, position, op, cursor.strict())
     }
 
     /// This function was added to optimize the stack size.
@@ -169,7 +170,6 @@ impl UpdateExpression {
     /// It allow to reduce stack size allocation in `parse_boxed`,
     /// and an often called function in recursion stays outside of this function.
     fn parse_tail<R: ReadChar>(
-        self,
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
         position: Position,

--- a/core/parser/src/parser/function/tests.rs
+++ b/core/parser/src/parser/function/tests.rs
@@ -234,13 +234,15 @@ fn check_arrow_only_rest() {
     assert_eq!(params.length(), 0);
     check_script_parser(
         "(...a) => {}",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::default(),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::default(),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -270,13 +272,15 @@ fn check_arrow_rest() {
     assert_eq!(params.length(), 2);
     check_script_parser(
         "(a, b, ...c) => {}",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::default(),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::default(),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -299,26 +303,30 @@ fn check_arrow() {
     assert_eq!(params.length(), 2);
     check_script_parser(
         "(a, b) => { return a + b; }",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::new(
-                [StatementListItem::Statement(Statement::Return(
-                    Return::new(Some(
-                        Binary::new(
-                            ArithmeticOp::Add.into(),
-                            Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
-                            Identifier::new(interner.get_or_intern_static("b", utf16!("b"))).into(),
-                        )
-                        .into(),
-                    )),
-                ))],
-                PSEUDO_LINEAR_POS,
-                false,
-            ),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::new(
+                    [StatementListItem::Statement(Statement::Return(
+                        Return::new(Some(
+                            Binary::new(
+                                ArithmeticOp::Add.into(),
+                                Identifier::new(interner.get_or_intern_static("a", utf16!("a")))
+                                    .into(),
+                                Identifier::new(interner.get_or_intern_static("b", utf16!("b")))
+                                    .into(),
+                            )
+                            .into(),
+                        )),
+                    ))],
+                    PSEUDO_LINEAR_POS,
+                    false,
+                ),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -339,26 +347,30 @@ fn check_arrow_semicolon_insertion() {
     ]);
     check_script_parser(
         "(a, b) => { return a + b }",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::new(
-                [StatementListItem::Statement(Statement::Return(
-                    Return::new(Some(
-                        Binary::new(
-                            ArithmeticOp::Add.into(),
-                            Identifier::new(interner.get_or_intern_static("a", utf16!("a"))).into(),
-                            Identifier::new(interner.get_or_intern_static("b", utf16!("b"))).into(),
-                        )
-                        .into(),
-                    )),
-                ))],
-                PSEUDO_LINEAR_POS,
-                false,
-            ),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::new(
+                    [StatementListItem::Statement(Statement::Return(
+                        Return::new(Some(
+                            Binary::new(
+                                ArithmeticOp::Add.into(),
+                                Identifier::new(interner.get_or_intern_static("a", utf16!("a")))
+                                    .into(),
+                                Identifier::new(interner.get_or_intern_static("b", utf16!("b")))
+                                    .into(),
+                            )
+                            .into(),
+                        )),
+                    ))],
+                    PSEUDO_LINEAR_POS,
+                    false,
+                ),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -379,19 +391,21 @@ fn check_arrow_epty_return() {
     ]);
     check_script_parser(
         "(a, b) => { return; }",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::new(
-                [StatementListItem::Statement(Statement::Return(
-                    Return::new(None),
-                ))],
-                PSEUDO_LINEAR_POS,
-                false,
-            ),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::new(
+                    [StatementListItem::Statement(Statement::Return(
+                        Return::new(None),
+                    ))],
+                    PSEUDO_LINEAR_POS,
+                    false,
+                ),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -412,19 +426,21 @@ fn check_arrow_empty_return_semicolon_insertion() {
     ]);
     check_script_parser(
         "(a, b) => { return }",
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::new(
-                [StatementListItem::Statement(Statement::Return(
-                    Return::new(None),
-                ))],
-                PSEUDO_LINEAR_POS,
-                false,
-            ),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::new(
+                    [StatementListItem::Statement(Statement::Return(
+                        Return::new(None),
+                    ))],
+                    PSEUDO_LINEAR_POS,
+                    false,
+                ),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }
@@ -444,7 +460,7 @@ fn check_arrow_assignment() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -487,7 +503,7 @@ fn check_arrow_assignment_nobrackets() {
             vec![Variable::from_identifier(
                 interner.get_or_intern_static("foo", utf16!("foo")).into(),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -530,7 +546,7 @@ fn check_arrow_assignment_noparenthesis() {
             vec![Variable::from_identifier(
                 interner.get_or_intern_static("foo", utf16!("foo")).into(),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -573,7 +589,7 @@ fn check_arrow_assignment_noparenthesis_nobrackets() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -622,7 +638,7 @@ fn check_arrow_assignment_2arg() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -671,7 +687,7 @@ fn check_arrow_assignment_2arg_nobrackets() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -724,7 +740,7 @@ fn check_arrow_assignment_3arg() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(
@@ -777,7 +793,7 @@ fn check_arrow_assignment_3arg_nobrackets() {
             vec![Variable::from_identifier(
                 Identifier::new(interner.get_or_intern_static("foo", utf16!("foo"))),
                 Some(
-                    ArrowFunction::new(
+                    ArrowFunction::new_boxed(
                         Some(interner.get_or_intern_static("foo", utf16!("foo")).into()),
                         params,
                         FunctionBody::new(

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -595,7 +595,7 @@ fn name_in_lexically_declared_names(
 
 /// Trait to reduce boilerplate in the parser.
 trait OrAbrupt<T> {
-    /// Will convert an `Ok(None)` to an [`Error::AbruptEnd`] or return the inner type if not.
+    /// Will convert an `Ok(None)` to an [`crate::error::ErrorInner::AbruptEnd`] or return the inner type if not.
     fn or_abrupt(self) -> ParseResult<T>;
 }
 

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -67,7 +67,7 @@ where
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> ParseResult<Box<Self::Output>> {
-        self.parse(cursor, interner).map(|result| Box::new(result))
+        self.parse(cursor, interner).map(Box::new)
     }
 }
 

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -601,6 +601,6 @@ trait OrAbrupt<T> {
 
 impl<T> OrAbrupt<T> for ParseResult<Option<T>> {
     fn or_abrupt(self) -> ParseResult<T> {
-        self?.ok_or(Error::AbruptEnd)
+        self?.ok_or(Error::abrupt_end())
     }
 }

--- a/core/parser/src/parser/mod.rs
+++ b/core/parser/src/parser/mod.rs
@@ -56,6 +56,19 @@ where
     ///
     /// It will fail if the cursor is not placed at the beginning of the expected non-terminal.
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output>;
+
+    /// Parses the token stream into boxed result using the current parser.
+    ///
+    /// # Errors
+    ///
+    /// It will fail if the cursor is not placed at the beginning of the expected non-terminal.
+    fn parse_boxed(
+        self,
+        cursor: &mut Cursor<R>,
+        interner: &mut Interner,
+    ) -> ParseResult<Box<Self::Output>> {
+        self.parse(cursor, interner).map(|result| Box::new(result))
+    }
 }
 
 /// Boolean representing if the parser should allow a `yield` keyword.

--- a/core/parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
+++ b/core/parser/src/parser/statement/declaration/hoistable/class_decl/tests.rs
@@ -104,7 +104,7 @@ fn check_new_target_with_property_access() {
 
     let new_target = Expression::PropertyAccess(
         SimplePropertyAccess::new(
-            Expression::NewTarget,
+            Box::new(Expression::NewTarget),
             interner.get_or_intern_static("name", utf16!("name")),
         )
         .into(),

--- a/core/parser/src/parser/statement/expression/mod.rs
+++ b/core/parser/src/parser/statement/expression/mod.rs
@@ -45,7 +45,7 @@ where
     fn parse(self, cursor: &mut Cursor<R>, interner: &mut Interner) -> ParseResult<Self::Output> {
         let _timer = Profiler::global().start_event("ExpressionStatement", "Parsing");
 
-        self.parse_prefix_keywords(cursor, interner)?;
+        Self::parse_prefix_keywords(cursor, interner)?;
 
         let expr = Expression::new(true, self.allow_yield, self.allow_await)
             .parse_boxed(cursor, interner)?;
@@ -62,7 +62,6 @@ impl ExpressionStatement {
     /// It allow to reduce stack size allocation in `parse`,
     /// and an often called function in recursion stays outside of this function.
     fn parse_prefix_keywords<R: ReadChar>(
-        self,
         cursor: &mut Cursor<R>,
         interner: &mut Interner,
     ) -> ParseResult<()> {

--- a/core/parser/src/parser/statement/iteration/for_statement.rs
+++ b/core/parser/src/parser/statement/iteration/for_statement.rs
@@ -204,10 +204,10 @@ where
                 cursor.advance(interner);
                 let expr = if in_loop {
                     Expression::new(true, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?
+                        .parse_boxed(cursor, interner)?
                 } else {
                     AssignmentExpression::new(true, self.allow_yield, self.allow_await)
-                        .parse(cursor, interner)?
+                        .parse_boxed(cursor, interner)?
                 };
 
                 cursor.expect(Punctuator::CloseParen, "for in/of statement", interner)?;

--- a/core/parser/src/parser/statement/mod.rs
+++ b/core/parser/src/parser/statement/mod.rs
@@ -247,7 +247,7 @@ impl Statement {
 
             _ => return Ok(None),
         }
-        .map(|x| Some(x))
+        .map(Some)
     }
 }
 

--- a/core/parser/src/parser/tests/mod.rs
+++ b/core/parser/src/parser/tests/mod.rs
@@ -531,17 +531,19 @@ fn spread_in_arrow_function() {
     assert_eq!(params.length(), 0);
     check_script_parser(
         s,
-        vec![Statement::Expression(Expression::from(ArrowFunction::new(
-            None,
-            params,
-            FunctionBody::new(
-                [Statement::Expression(Expression::from(Identifier::from(b))).into()],
-                PSEUDO_LINEAR_POS,
-                false,
-            ),
-            EMPTY_LINEAR_SPAN,
-        )))
-        .into()],
+        vec![
+            Statement::Expression(Expression::from(ArrowFunction::new_boxed(
+                None,
+                params,
+                FunctionBody::new(
+                    [Statement::Expression(Expression::from(Identifier::from(b))).into()],
+                    PSEUDO_LINEAR_POS,
+                    false,
+                ),
+                EMPTY_LINEAR_SPAN,
+            )))
+            .into(),
+        ],
         interner,
     );
 }

--- a/tests/tester/src/exec/mod.rs
+++ b/tests/tester/src/exec/mod.rs
@@ -522,14 +522,7 @@ impl Test {
         optimizer_options: OptimizerOptions,
         console: bool,
     ) -> Result<(Box<Context>, AsyncResult, WorkerHandles), String> {
-        let async_result = AsyncResult::default();
-        let handles = WorkerHandles::new();
-        let loader = Rc::new(
-            SimpleModuleLoader::new(self.path.parent().expect("test should have a parent dir"))
-                .expect("test path should be canonicalizable"),
-        );
-
-        fn create_boxed_ctx(test: &Test, loader: Rc<SimpleModuleLoader>) -> Box<Context> {
+        fn create_boxed_ctx(test: &Test, loader: &Rc<SimpleModuleLoader>) -> Box<Context> {
             Box::new(
                 Context::builder()
                     .module_loader(loader.clone())
@@ -539,7 +532,14 @@ impl Test {
             )
         }
 
-        let mut context = create_boxed_ctx(self, loader);
+        let async_result = AsyncResult::default();
+        let handles = WorkerHandles::new();
+        let loader = Rc::new(
+            SimpleModuleLoader::new(self.path.parent().expect("test should have a parent dir"))
+                .expect("test path should be canonicalizable"),
+        );
+
+        let mut context = create_boxed_ctx(self, &loader);
 
         context.set_optimizer_options(optimizer_options);
 

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -779,6 +779,7 @@ struct SuiteResult {
 }
 
 impl SuiteResult {
+    #[allow(clippy::large_types_passed_by_value)]
     fn new_boxed(
         name: Box<str>,
         stats: Statistics,

--- a/tests/tester/src/main.rs
+++ b/tests/tester/src/main.rs
@@ -467,64 +467,7 @@ fn run_test_suite(
             console,
         );
 
-        if versioned {
-            let mut table = comfy_table::Table::new();
-            table.load_preset(comfy_table::presets::UTF8_HORIZONTAL_ONLY);
-            table.set_header(vec![
-                "Edition", "Total", "Passed", "Ignored", "Failed", "Panics", "%",
-            ]);
-            for column in table.column_iter_mut().skip(1) {
-                column.set_cell_alignment(comfy_table::CellAlignment::Right);
-            }
-            for (v, stats) in SpecEdition::all_editions()
-                .filter(|v| *v <= edition)
-                .map(|v| {
-                    let stats = results.versioned_stats.get(v).unwrap_or(results.stats);
-                    (v, stats)
-                })
-            {
-                let Statistics {
-                    total,
-                    passed,
-                    ignored,
-                    panic,
-                } = stats;
-                let failed = total - passed - ignored;
-                let conformance = (passed as f64 / total as f64) * 100.0;
-                let conformance = format!("{conformance:.2}");
-                table.add_row(vec![
-                    v.to_string(),
-                    total.to_string(),
-                    passed.to_string(),
-                    ignored.to_string(),
-                    failed.to_string(),
-                    panic.to_string(),
-                    conformance,
-                ]);
-            }
-            println!("\n\nResults\n");
-            println!("{table}");
-        } else {
-            let Statistics {
-                total,
-                passed,
-                ignored,
-                panic,
-            } = results.stats;
-            println!("\n\nResults ({edition}):");
-            println!("Total tests: {total}");
-            println!("Passed tests: {}", passed.to_string().green());
-            println!("Ignored tests: {}", ignored.to_string().yellow());
-            println!(
-                "Failed tests: {} ({})",
-                (total - passed - ignored).to_string().red(),
-                format!("{panic} panics").red()
-            );
-            println!(
-                "Conformance: {:.2}%",
-                (passed as f64 / total as f64) * 100.0
-            );
-        }
+        print_statistic(&results, versioned, edition);
 
         if let Some(output) = output {
             write_json(results, output, verbose, test262_path)
@@ -533,6 +476,67 @@ fn run_test_suite(
     }
 
     Ok(())
+}
+
+fn print_statistic(results: &SuiteResult, versioned: bool, edition: SpecEdition) {
+    if versioned {
+        let mut table = comfy_table::Table::new();
+        table.load_preset(comfy_table::presets::UTF8_HORIZONTAL_ONLY);
+        table.set_header(vec![
+            "Edition", "Total", "Passed", "Ignored", "Failed", "Panics", "%",
+        ]);
+        for column in table.column_iter_mut().skip(1) {
+            column.set_cell_alignment(comfy_table::CellAlignment::Right);
+        }
+        for (v, stats) in SpecEdition::all_editions()
+            .filter(|v| *v <= edition)
+            .map(|v| {
+                let stats = results.versioned_stats.get(v).unwrap_or(results.stats);
+                (v, stats)
+            })
+        {
+            let Statistics {
+                total,
+                passed,
+                ignored,
+                panic,
+            } = stats;
+            let failed = total - passed - ignored;
+            let conformance = (passed as f64 / total as f64) * 100.0;
+            let conformance = format!("{conformance:.2}");
+            table.add_row(vec![
+                v.to_string(),
+                total.to_string(),
+                passed.to_string(),
+                ignored.to_string(),
+                failed.to_string(),
+                panic.to_string(),
+                conformance,
+            ]);
+        }
+        println!("\n\nResults\n");
+        println!("{table}");
+    } else {
+        let Statistics {
+            total,
+            passed,
+            ignored,
+            panic,
+        } = results.stats;
+        println!("\n\nResults ({edition}):");
+        println!("Total tests: {total}");
+        println!("Passed tests: {}", passed.to_string().green());
+        println!("Ignored tests: {}", ignored.to_string().yellow());
+        println!(
+            "Failed tests: {} ({})",
+            (total - passed - ignored).to_string().red(),
+            format!("{panic} panics").red()
+        );
+        println!(
+            "Conformance: {:.2}%",
+            (passed as f64 / total as f64) * 100.0
+        );
+    }
 }
 
 /// All the harness include files.
@@ -774,6 +778,26 @@ struct SuiteResult {
     features: FxHashSet<String>,
 }
 
+impl SuiteResult {
+    fn new_boxed(
+        name: Box<str>,
+        stats: Statistics,
+        versioned_stats: VersionedStats,
+        suites: Vec<SuiteResult>,
+        tests: Vec<TestResult>,
+        features: FxHashSet<String>,
+    ) -> Box<Self> {
+        Box::new(Self {
+            name,
+            stats,
+            versioned_stats,
+            suites,
+            tests,
+            features,
+        })
+    }
+}
+
 /// Outcome of a test.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(dead_code)]
@@ -820,7 +844,7 @@ struct Test {
 
 impl Test {
     /// Creates a new test.
-    fn new<N, C>(name: N, path: C, metadata: MetaData) -> Result<Self>
+    fn new<N, C>(name: N, path: C, metadata: MetaData) -> Result<Box<Self>>
     where
         N: Into<Box<str>>,
         C: Into<Box<Path>>,
@@ -828,7 +852,7 @@ impl Test {
         let edition = SpecEdition::from_test_metadata(&metadata)
             .map_err(|feats| eyre!("test metadata contained unknown features: {feats:?}"))?;
 
-        Ok(Self {
+        Ok(Box::new(Self {
             edition,
             name: name.into(),
             description: metadata.description,
@@ -841,7 +865,7 @@ impl Test {
             locale: metadata.locale,
             path: path.into(),
             ignored: false,
-        })
+        }))
     }
 
     /// Sets the test as ignored.

--- a/tests/tester/src/read.rs
+++ b/tests/tester/src/read.rs
@@ -93,7 +93,7 @@ pub(super) enum TestFlag {
 }
 
 /// Reads the Test262 defined bindings.
-pub(super) fn read_harness(test262_path: &Path) -> Result<Harness> {
+pub(super) fn read_harness(test262_path: &Path) -> Result<Box<Harness>> {
     let mut includes: HashMap<Box<str>, HarnessFile, FxBuildHasher> = FxHashMap::default();
 
     let harness_path = &test262_path.join("harness");
@@ -110,12 +110,12 @@ pub(super) fn read_harness(test262_path: &Path) -> Result<Harness> {
         .remove("doneprintHandle.js")
         .ok_or_eyre("failed to load harness file `donePrintHandle.js`")?;
 
-    Ok(Harness {
+    Ok(Box::new(Harness {
         assert,
         sta,
         doneprint_handle,
         includes,
-    })
+    }))
 }
 
 fn read_harness_dir(
@@ -215,7 +215,7 @@ pub(super) fn read_suite(
         {
             test.set_ignored();
         }
-        tests.push(test);
+        tests.push(*test);
     }
 
     Ok(TestSuite {
@@ -227,7 +227,7 @@ pub(super) fn read_suite(
 }
 
 /// Reads information about a given test case.
-pub(super) fn read_test(path: &Path) -> Result<Test> {
+pub(super) fn read_test(path: &Path) -> Result<Box<Test>> {
     let name = path
         .file_stem()
         .and_then(OsStr::to_str)

--- a/tests/tester/src/results.rs
+++ b/tests/tester/src/results.rs
@@ -82,7 +82,7 @@ const FEATURES_FILE_NAME: &str = "features.json";
 ///
 /// It will append the results to the ones already present, in an array.
 pub(crate) fn write_json(
-    results: SuiteResult,
+    results: Box<SuiteResult>,
     output_dir: &Path,
     verbose: u8,
     test262_path: &Path,
@@ -111,7 +111,7 @@ pub(crate) fn write_json(
     let new_results = ResultInfo {
         commit: env::var("GITHUB_SHA").unwrap_or_default().into_boxed_str(),
         test262_commit: get_test262_commit(test262_path)?,
-        results,
+        results: *results,
     };
 
     let latest = BufWriter::new(fs::File::create(latest)?);


### PR DESCRIPTION
This Pull Request closes #4089

Reduce the stack size. Mostly affected expression with nested parenthesizes.
<details>
<summary> Some examples & comparison charts</summary>

```rust
fn parenthesized_fn_test() {
    let n = ...;
    let js = "(function(){ ".repeat(n) + &" })()".repeat(n);

    let interner = &mut Interner::default();
    crate::Parser::new(crate::Source::from_bytes(&js))
        .parse_script(&boa_ast::scope::Scope::new_global(), interner)
        .expect("failed to parse");
}
```
| profile | prev max `n` <br/> without stack overflow | new max `n` <br/> without stack overflow | x |
|--|--|--|--|
| dev (`opt-level = 0`) | 11 | 79 | ~6 |
| test (`opt-level = 1`) | 50 | 160 | ~3 |
| release | 50 | 217 | ~4 |

---
```rust
fn parenthesized_sum_test() {
    let n = ...;
    let js = "(1+".repeat(n) + "41" + &")".repeat(n);

    let interner = &mut Interner::default();
    crate::Parser::new(crate::Source::from_bytes(&js))
        .parse_script(&boa_ast::scope::Scope::new_global(), interner)
        .expect("failed to parse");
}
```
| profile | prev max `n` <br/> without stack overflow | new max `n` <br/> without stack overflow | x |
|--|--|--|--|
| dev (`opt-level = 0`) | 30 | 200 | ~6.5 |
| test (`opt-level = 1`) | 105 | 390 | ~3.5 |
| release | 105 | 510 | ~4.5 |

</details>

Now there no stack overflow when running the `boa_tester` in debug(`cargo run -p boa_tester -- run -v -o test262 `). The problem was here `test262\test\language\statements\function\S13.2.1_A1_T1.js`, so you can run `cargo run -p boa_tester -- run -s test/language/statements/function/` to test the fix. For more details see the issue.

---

The reduction performed by 3 operations:
1. boxing of large objects. It's affected all `profile`s and allow to reduce the stack size by ~ 3 times;
1. In [one place](https://github.com/Nikita-str/boa/blob/df4c22fdd3db488ff23649846b86b751389ec5b9/core/parser/src/parser/expression/mod.rs#L416-L458) nested `parse` calls was unwrapped. Also affected all `profile`s;
1. [Splitting](https://github.com/Nikita-str/boa/blob/86bbd0f460210630f8b8f7bb80b745d90fffde1e/core/parser/src/parser/expression/assignment/conditional.rs#L76-L107) `parse` function. Affected only `profile.dev` (`opt-level = 0`) where the problem arose. Allow to reduce the stack size by ~ 2 times (and with boxing it becomes ~ 6 times).

---

There are some ugly changes that need to be discussed & maybe rewritten to a less ugly:
* The [unwrapping](https://github.com/Nikita-str/boa/blob/df4c22fdd3db488ff23649846b86b751389ec5b9/core/parser/src/parser/expression/mod.rs#L416-L458);
* Splitting like [this](https://github.com/Nikita-str/boa/blob/86bbd0f460210630f8b8f7bb80b745d90fffde1e/core/parser/src/parser/expression/assignment/mod.rs#L100-L102) --> [this](https://github.com/Nikita-str/boa/blob/86bbd0f460210630f8b8f7bb80b745d90fffde1e/core/parser/src/parser/expression/assignment/mod.rs#L132) --> [this](https://github.com/Nikita-str/boa/blob/86bbd0f460210630f8b8f7bb80b745d90fffde1e/core/parser/src/parser/expression/assignment/mod.rs#L113-L121) --> [this](https://github.com/Nikita-str/boa/blob/86bbd0f460210630f8b8f7bb80b745d90fffde1e/core/parser/src/parser/expression/assignment/mod.rs#L214).

All of the changes reduce the stack size, so even if they are ugly, they are still not meaningless :/
