### PR TITLE
Update duration.total due to signature change in temporal.rs

### DIFF
--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -823,6 +823,7 @@ impl Duration {
         Ok(duration
             .inner
             .total_with_provider(unit, relative_to, context.tz_provider())?
+            .as_inner()
             .into())
     }
 


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

- After implementing Duration.Total in temporal.rs it now returns a FiniteF64 rather than an i164
- Changes in duration/mod.rs to reflect this change
-
