### PR TITLE
Temporal bump and implementation of toPlainYearMonth and toPlainMonthDay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1639,7 +1639,7 @@ dependencies = [
  "icu_locale_core",
  "icu_provider 2.0.0-beta2",
  "tinystr 0.8.1",
- "writeable 0.6.0",
+ "writeable 0.6.1",
  "zerovec 0.11.1",
 ]
 
@@ -1892,7 +1892,7 @@ dependencies = [
  "displaydoc",
  "litemap",
  "tinystr 0.8.1",
- "writeable 0.6.0",
+ "writeable 0.6.1",
  "zerovec 0.11.1",
 ]
 
@@ -2052,7 +2052,7 @@ dependencies = [
  "icu_locale_core",
  "stable_deref_trait",
  "tinystr 0.8.1",
- "writeable 0.6.0",
+ "writeable 0.6.1",
  "yoke 0.8.0",
  "zerofrom",
  "zerovec 0.11.1",
@@ -2079,7 +2079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2794f00ee1999495f4f1a1e35aee8f54fe7cfcbcf909ec05b60522377200aecb"
 dependencies = [
  "icu_provider 2.0.0-beta2",
- "writeable 0.6.0",
+ "writeable 0.6.1",
  "zerotrie 0.2.0",
  "zerovec 0.11.1",
 ]
@@ -2310,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-tzdb"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2cec2f5d266af45a071ece48b1fb89f3b00b2421ac3a5fe10285a6caaa60d3"
+checksum = "962e1dfe9b2d75a84536cf5bf5eaaa4319aa7906c7160134a22883ac316d5f31"
 
 [[package]]
 name = "js-sys"
@@ -3574,8 +3574,8 @@ checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
 
 [[package]]
 name = "temporal_rs"
-version = "0.0.4"
-source = "git+https://github.com/boa-dev/temporal.git?rev=f27e2ffa3324e4cfb2bdf0b654b0d5bb2f15ed61#f27e2ffa3324e4cfb2bdf0b654b0d5bb2f15ed61"
+version = "0.0.5"
+source = "git+https://github.com/boa-dev/temporal.git?rev=5e864d826a264ef6205b61784e56dc7a3ba43ade#5e864d826a264ef6205b61784e56dc7a3ba43ade"
 dependencies = [
  "combine",
  "iana-time-zone",
@@ -3585,7 +3585,7 @@ dependencies = [
  "num-traits",
  "tinystr 0.8.1",
  "tzif",
- "writeable 0.6.0",
+ "writeable 0.6.1",
 ]
 
 [[package]]
@@ -4451,9 +4451,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b3b5b7c6114bf7253093603034e102d479ecc8501deca33b6c1c816418b6d2"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 dependencies = [
  "serde",
 ]
@@ -315,7 +315,7 @@ name = "boa_ast"
 version = "0.20.0"
 dependencies = [
  "arbitrary",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "boa_interner",
  "boa_macros",
  "boa_string",
@@ -351,7 +351,7 @@ name = "boa_engine"
 version = "0.20.0"
 dependencies = [
  "arrayvec",
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "boa_ast",
  "boa_gc",
  "boa_icu_provider",
@@ -517,7 +517,7 @@ dependencies = [
 name = "boa_parser"
 version = "0.20.0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "boa_ast",
  "boa_interner",
  "boa_macros",
@@ -569,7 +569,7 @@ dependencies = [
 name = "boa_tester"
 version = "0.20.0"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "boa_engine",
  "boa_gc",
  "boa_runtime",
@@ -619,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -679,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8769706aad5d996120af43197bf46ef6ad0fda35216b4505f926a365a232d924"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -753,9 +753,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -763,9 +763,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
 dependencies = [
  "anstream",
  "anstyle",
@@ -876,7 +876,7 @@ checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
  "crossterm",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1020,7 +1020,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "crossterm_winapi",
  "parking_lot",
  "rustix",
@@ -1180,9 +1180,9 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elsa"
@@ -2188,9 +2188,9 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instant"
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "ixdtf"
@@ -2524,7 +2524,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2902,9 +2902,9 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
 name = "postcard"
@@ -2954,18 +2954,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "c1f1914ce909e1658d9907913b4b91947430c7d9be598b15a1912935b8c04801"
 dependencies = [
  "proc-macro2",
 ]
@@ -3063,7 +3063,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -3168,7 +3168,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3219,7 +3219,7 @@ version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1e066dc922e513bda599c6ccb5f3bb2b0ea5870a579448f2622993f0a9a2f"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -3229,7 +3229,7 @@ dependencies = [
  "nix",
  "rustyline-derive",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
  "utf8parse",
  "windows-sys 0.59.0",
 ]
@@ -3307,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3348,9 +3348,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -3360,9 +3360,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3527,9 +3527,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3632,13 +3632,13 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -3649,18 +3649,18 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3685,9 +3685,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "dad298b01a40a23aac4580b67e3dbedb7cc8402f3592d7f49469de2ea4aecdd8"
 dependencies = [
  "deranged",
  "itoa",
@@ -3703,15 +3703,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "765c97a5b985b7c11d7bc27fa927dc4fe6af3a6dfb021d28deb60d3bf51e76ef"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "e8093bc3e81c3bc5f7879de09619d06c9a5a5e45ca44dfeeb7225bae38005c5c"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3751,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -3898,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "trybuild"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b812699e0c4f813b872b373a4471717d9eb550da14b311058a4d9cf4173cbca6"
+checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
 dependencies = [
  "glob",
  "serde",
@@ -3948,12 +3948,6 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -4437,7 +4431,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -4552,9 +4546,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,15 +50,15 @@ tag_ptr = { path = "utils/tag_ptr" }
 
 # Shared deps
 arbitrary = "1"
-bitflags = "2.8.0"
-clap = "4.5.29"
+bitflags = "2.9.0"
+clap = "4.5.31"
 colored = "3.0.0"
 cow-utils = "0.1.3"
 fast-float2 = "0.2.3"
 hashbrown = "0.15.2"
 indexmap = { version = "2.7.1", default-features = false }
-indoc = "2.0.5"
-itoa = "1.0.14"
+indoc = "2.0.6"
+itoa = "1.0.15"
 jemallocator = "0.5.4"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
@@ -68,12 +68,12 @@ pollster = "0.4.0"
 regex = "1.11.1"
 regress = { version = "0.10.3", features = ["utf16"] }
 rustc-hash = { version = "2.1.1", default-features = false }
-serde_json = "1.0.139"
-serde = "1.0.218"
+serde_json = "1.0.140"
+serde = "1.0.219"
 static_assertions = "1.1.0"
-textwrap = "0.16.0"
+textwrap = "0.16.2"
 thin-vec = "0.2.13"
-time = { version = "0.3.37", default-features = false, features = [
+time = { version = "0.3.39", default-features = false, features = [
     "local-offset",
     "large-dates",
     "wasm-bindgen",
@@ -83,13 +83,13 @@ time = { version = "0.3.37", default-features = false, features = [
 ] }
 log = "0.4.26"
 simple_logger = "5.0.0"
-cargo_metadata = "0.19.1"
-trybuild = "1.0.103"
+cargo_metadata = "0.19.2"
+trybuild = "1.0.104"
 rayon = "1.10.0"
 toml = "0.8.20"
 color-eyre = "0.6.3"
 comfy-table = "7.1.4"
-serde_repr = "0.1.19"
+serde_repr = "0.1.20"
 bus = "2.4.1"
 wasm-bindgen = { version = "0.2.97", default-features = false }
 getrandom = { version = "0.3.1", default-features = false }
@@ -99,8 +99,8 @@ smol = "2.0.2"
 isahc = "1.7.2"
 rustyline = { version = "15.0.0", default-features = false }
 dhat = "0.3.3"
-quote = "1.0.38"
-syn = { version = "2.0.98", default-features = false }
+quote = "1.0.39"
+syn = { version = "2.0.100", default-features = false }
 proc-macro2 = "1.0"
 synstructure = "0.13"
 measureme = "12.0.1"
@@ -109,16 +109,16 @@ rand = "0.9.0"
 num-integer = "0.1.46"
 ryu-js = "1.0.2"
 tap = "1.0.1"
-thiserror = { version = "2.0.11", default-features = false }
+thiserror = { version = "2.0.12", default-features = false }
 dashmap = "6.1.0"
 num_enum = "0.7.3"
 itertools = { version = "0.14.0", default-features = false }
-portable-atomic = "1.10.0"
-bytemuck = { version = "1.21.0", default-features = false }
+portable-atomic = "1.11.0"
+bytemuck = { version = "1.22.0", default-features = false }
 arrayvec = "0.7.6"
 intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
-either = "1.14.0"
+either = "1.15.0"
 sys-locale = "0.3.2"
 temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "f27e2ffa3324e4cfb2bdf0b654b0d5bb2f15ed61", default-features = false, features = [
     "tzdb",
@@ -129,7 +129,7 @@ float-cmp = "0.10.0"
 futures-lite = "2.6.0"
 test-case = "3.3.1"
 url = "2.5.4"
-tokio = { version = "1.43.0", default-features = false }
+tokio = { version = "1.44.0", default-features = false }
 futures-concurrency = "7.6.3"
 
 
@@ -154,7 +154,7 @@ icu_decimal = { version = "~1.5.0", default-features = false }
 writeable = "~0.5.5"
 tinystr = "~0.8.1"
 yoke = "~0.7.5"
-zerofrom = "~0.1.5"
+zerofrom = "~0.1.6"
 fixed_decimal = "~0.5.6"
 
 [workspace.metadata.workspaces]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ intrusive-collections = "0.9.7"
 cfg-if = "1.0.0"
 either = "1.15.0"
 sys-locale = "0.3.2"
-temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "f27e2ffa3324e4cfb2bdf0b654b0d5bb2f15ed61", default-features = false, features = [
+temporal_rs = { git = "https://github.com/boa-dev/temporal.git", rev = "5e864d826a264ef6205b61784e56dc7a3ba43ade", default-features = false, features = [
     "tzdb",
 ] }
 web-time = "1.1.0"

--- a/core/engine/src/builtins/temporal/duration/mod.rs
+++ b/core/engine/src/builtins/temporal/duration/mod.rs
@@ -823,6 +823,7 @@ impl Duration {
         Ok(duration
             .inner
             .total_with_provider(unit, relative_to, context.tz_provider())?
+            .as_inner()
             .into())
     }
 

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -331,7 +331,7 @@ impl PlainDate {
 
         Ok(date
             .inner
-            .era()?
+            .era()
             .map(|s| JsString::from(s.as_str()))
             .into_or_undefined())
     }
@@ -348,7 +348,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.era_year()?.into_or_undefined())
+        Ok(date.inner.era_year().into_or_undefined())
     }
 
     /// 3.3.6 get `Temporal.PlainDate.prototype.year`
@@ -363,7 +363,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.year()?.into())
+        Ok(date.inner.year().into())
     }
 
     /// 3.3.7 get `Temporal.PlainDate.prototype.month`
@@ -378,7 +378,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.month()?.into())
+        Ok(date.inner.month().into())
     }
 
     /// 3.3.8 get Temporal.PlainDate.prototype.monthCode
@@ -393,7 +393,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(JsString::from(date.inner.month_code()?.as_str()).into())
+        Ok(JsString::from(date.inner.month_code().as_str()).into())
     }
 
     /// 3.3.9 get `Temporal.PlainDate.prototype.day`
@@ -408,7 +408,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.day()?.into())
+        Ok(date.inner.day().into())
     }
 
     /// 3.3.10 get `Temporal.PlainDate.prototype.dayOfWeek`
@@ -423,7 +423,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.day_of_week()?.into())
+        Ok(date.inner.day_of_week().into())
     }
 
     /// 3.3.11 get `Temporal.PlainDate.prototype.dayOfYear`
@@ -438,7 +438,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.day_of_year()?.into())
+        Ok(date.inner.day_of_year().into())
     }
 
     /// 3.3.12 get `Temporal.PlainDate.prototype.weekOfYear`
@@ -498,7 +498,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.days_in_month()?.into())
+        Ok(date.inner.days_in_month().into())
     }
 
     /// 3.3.16 get `Temporal.PlainDate.prototype.daysInYear`
@@ -513,7 +513,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.days_in_year()?.into())
+        Ok(date.inner.days_in_year().into())
     }
 
     /// 3.3.17 get `Temporal.PlainDate.prototype.monthsInYear`
@@ -528,7 +528,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.months_in_year()?.into())
+        Ok(date.inner.months_in_year().into())
     }
 
     /// 3.3.18 get `Temporal.PlainDate.prototype.inLeapYear`
@@ -543,7 +543,7 @@ impl PlainDate {
                 .into());
         };
 
-        Ok(date.inner.in_leap_year()?.into())
+        Ok(date.inner.in_leap_year().into())
     }
 }
 
@@ -761,7 +761,8 @@ impl PlainDate {
             .map(|v| to_temporal_time(v, None, context))
             .transpose()?;
         // 4. Return ? CreateTemporalDateTime(temporalDate.[[ISOYear]], temporalDate.[[ISOMonth]], temporalDate.[[ISODay]], temporalTime.[[ISOHour]], temporalTime.[[ISOMinute]], temporalTime.[[ISOSecond]], temporalTime.[[ISOMillisecond]], temporalTime.[[ISOMicrosecond]], temporalTime.[[ISONanosecond]], temporalDate.[[Calendar]]).
-        create_temporal_datetime(date.inner.to_date_time(time)?, None, context).map(Into::into)
+        create_temporal_datetime(date.inner.to_plain_date_time(time)?, None, context)
+            .map(Into::into)
     }
 
     /// `3.3.29 Temporal.PlainDate.prototype.toZonedDateTime ( item )`

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -593,7 +593,7 @@ impl PlainDate {
             })?;
 
         let year_month = date.inner.to_plain_year_month()?;
-        create_temporal_year_month(year_month, None, context).map(Into::into)
+        create_temporal_year_month(year_month, None, context)
     }
 
     fn to_plain_month_day(
@@ -611,7 +611,7 @@ impl PlainDate {
             })?;
 
         let month_day = date.inner.to_plain_month_day()?;
-        create_temporal_month_day(month_day, None, context).map(Into::into)
+        create_temporal_month_day(month_day, None, context)
     }
 
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/core/engine/src/builtins/temporal/plain_date/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date/mod.rs
@@ -27,6 +27,7 @@ use temporal_rs::{
     Calendar, MonthCode, PlainDate as InnerDate, TinyAsciiStr,
 };
 
+use super::{create_temporal_month_day, create_temporal_year_month};
 // TODO: Remove once `temporal_rs` funcctionality implemented
 #[allow(unused_imports)]
 use super::{
@@ -577,16 +578,40 @@ impl PlainDate {
 // ==== `PlainDate.prototype` method implementation ====
 
 impl PlainDate {
-    fn to_plain_year_month(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
+    fn to_plain_year_month(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let temporalDate be the this value.
+        // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
+        let date = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
+            })?;
+
+        let year_month = date.inner.to_plain_year_month()?;
+        create_temporal_year_month(year_month, None, context).map(Into::into)
     }
 
-    fn to_plain_month_day(_this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
-        Err(JsNativeError::error()
-            .with_message("not yet implemented.")
-            .into())
+    fn to_plain_month_day(
+        this: &JsValue,
+        _: &[JsValue],
+        context: &mut Context,
+    ) -> JsResult<JsValue> {
+        // 1. Let temporalDate be the this value.
+        // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
+        let date = this
+            .as_object()
+            .and_then(JsObject::downcast_ref::<Self>)
+            .ok_or_else(|| {
+                JsNativeError::typ().with_message("the this object must be a PlainDate object.")
+            })?;
+
+        let month_day = date.inner.to_plain_month_day()?;
+        create_temporal_month_day(month_day, None, context).map(Into::into)
     }
 
     fn add(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult<JsValue> {

--- a/core/engine/src/builtins/temporal/plain_date_time/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_date_time/mod.rs
@@ -455,7 +455,7 @@ impl PlainDateTime {
 
         Ok(dt
             .inner
-            .era()?
+            .era()
             .map(|s| JsString::from(s.as_str()))
             .into_or_undefined())
     }
@@ -469,7 +469,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.era_year()?.into_or_undefined())
+        Ok(dt.inner.era_year().into_or_undefined())
     }
 
     /// 5.3.6 get `Temporal.PlainDatedt.prototype.year`
@@ -481,7 +481,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.year()?.into())
+        Ok(dt.inner.year().into())
     }
 
     /// 5.3.7 get `Temporal.PlainDatedt.prototype.month`
@@ -493,7 +493,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.month()?.into())
+        Ok(dt.inner.month().into())
     }
 
     /// 5.3.8 get Temporal.PlainDatedt.prototype.monthCode
@@ -505,7 +505,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(JsString::from(dt.inner.month_code()?.as_str()).into())
+        Ok(JsString::from(dt.inner.month_code().as_str()).into())
     }
 
     /// 5.3.9 get `Temporal.PlainDatedt.prototype.day`
@@ -517,7 +517,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.day()?.into())
+        Ok(dt.inner.day().into())
     }
 
     /// 5.3.10 get `Temporal.PlainDatedt.prototype.hour`
@@ -619,7 +619,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.day_of_week()?.into())
+        Ok(dt.inner.day_of_week().into())
     }
 
     /// 5.3.17 get `Temporal.PlainDatedt.prototype.dayOfYear`
@@ -631,7 +631,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.day_of_year()?.into())
+        Ok(dt.inner.day_of_year().into())
     }
 
     /// 5.3.18 get `Temporal.PlainDatedt.prototype.weekOfYear`
@@ -679,7 +679,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.days_in_month()?.into())
+        Ok(dt.inner.days_in_month().into())
     }
 
     /// 5.3.22 get `Temporal.PlainDatedt.prototype.daysInYear`
@@ -691,7 +691,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.days_in_year()?.into())
+        Ok(dt.inner.days_in_year().into())
     }
 
     /// 5.3.23 get `Temporal.PlainDatedt.prototype.monthsInYear`
@@ -703,7 +703,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.months_in_year()?.into())
+        Ok(dt.inner.months_in_year().into())
     }
 
     /// 5.3.24 get `Temporal.PlainDatedt.prototype.inLeapYear`
@@ -715,7 +715,7 @@ impl PlainDateTime {
                 JsNativeError::typ().with_message("the this object must be a PlainDateTime object.")
             })?;
 
-        Ok(dt.inner.in_leap_year()?.into())
+        Ok(dt.inner.in_leap_year().into())
     }
 }
 

--- a/core/engine/src/builtins/temporal/plain_month_day/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_month_day/mod.rs
@@ -189,7 +189,7 @@ impl PlainMonthDay {
         let inner = &month_day.inner;
         match field {
             DateTimeValues::Day => Ok(inner.iso_day().into()),
-            DateTimeValues::MonthCode => Ok(js_string!(inner.month_code()?.as_str()).into()),
+            DateTimeValues::MonthCode => Ok(js_string!(inner.month_code().as_str()).into()),
             _ => unreachable!(),
         }
     }

--- a/core/engine/src/builtins/temporal/plain_year_month/mod.rs
+++ b/core/engine/src/builtins/temporal/plain_year_month/mod.rs
@@ -259,7 +259,7 @@ impl PlainYearMonth {
             DateTimeValues::Year => Ok(inner.iso_year().into()),
             DateTimeValues::Month => Ok(inner.iso_month().into()),
             DateTimeValues::MonthCode => {
-                Ok(JsString::from(InnerYearMonth::month_code(inner)?.as_str()).into())
+                Ok(JsString::from(InnerYearMonth::month_code(inner).as_str()).into())
             }
             _ => unreachable!(),
         }
@@ -300,7 +300,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.days_in_year()?.into())
+        Ok(inner.days_in_year().into())
     }
 
     fn get_days_in_month(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
@@ -311,7 +311,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.days_in_month()?.into())
+        Ok(inner.days_in_month().into())
     }
 
     fn get_months_in_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {
@@ -322,7 +322,7 @@ impl PlainYearMonth {
                 JsNativeError::typ().with_message("this value must be a PlainYearMonth object.")
             })?;
         let inner = &year_month.inner;
-        Ok(inner.months_in_year()?.into())
+        Ok(inner.months_in_year().into())
     }
 
     fn get_in_leap_year(this: &JsValue, _: &[JsValue], _: &mut Context) -> JsResult<JsValue> {


### PR DESCRIPTION
<!---
Thank you for contributing to Boa! Please fill out the template below, and remove or add any
information as you feel necessary.
--->

This Pull Request fixes/closes #{issue_num}.

It changes the following:

- Bump temporal and adapt the corresponding function calls in the engine:)
- Implement functions ``PlainDate.prototype.toPlainMonthDay`` and ``PlainDate.prototype.toPlainYearMonth``
