### PR TITLE
Update JsValue::to_json to support undefined

### DIFF
--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -85,6 +85,9 @@ impl JsValue {
 
     /// Converts the `JsValue` to a [`serde_json::Value`].
     ///
+    /// If the `JsValue` is `Undefined`, this method will return `None`.
+    /// Otherwise it will return the corresponding `serde_json::Value`.
+    ///
     /// # Example
     ///
     /// ```

--- a/core/engine/src/value/conversions/serde_json.rs
+++ b/core/engine/src/value/conversions/serde_json.rs
@@ -112,10 +112,6 @@ impl JsValue {
     /// #
     /// # assert_eq!(Some(json), back_to_json);
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `JsValue` is `Undefined`.
     pub fn to_json(&self, context: &mut Context) -> JsResult<Option<Value>> {
         let mut seen_objects = HashSet::new();
         self.to_json_inner(context, &mut seen_objects)

--- a/core/engine/tests/module.rs
+++ b/core/engine/tests/module.rs
@@ -59,7 +59,7 @@ fn test_json_module_from_str() {
         .unwrap();
 
     assert_eq!(
-        JsString::from(json.to_json(&mut context).unwrap().to_string()),
+        JsString::from(json.to_json(&mut context).unwrap().unwrap().to_string()),
         json_string
     );
 }


### PR DESCRIPTION
This Pull Request fixes/closes #3842.

Personally I've found `JsValue::to_json` to be fairly useless in its current implementation, as it will panic if the data structure being converted contains undefined, and I often don't have control over this.

The PR changes the following:

The `JsValue::to_json` method no longer panics if the structure contains `undefined`.

If `undefined` is encountered it will:
- Omit the property if it is part of an object.
- Replace with `null` if `undefined` is an element of an array. I don't love this, but couldn't think of a better solution.
- Return None if `to_json` is being called on `JsValue::undefined()`.

Because of the last point there is a breaking change: `JsValue::to_json` now returns `JsResult<Option<Value>>` instead of `JsResult<Value>`.

To avoid a breaking change we could perhaps introduce a new method `try_to_json` instead, and have the original `to_json` call `try_to_json` and panic if `None` is returned.

On the other hand, the new behaviour forces people to think about handling `undefined`, which will probably prevent unexpected panics in the future.