### PR TITLE
Prototype support for async native functions

### DIFF
--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -4,8 +4,12 @@
 //! from native Rust functions and closures.
 
 use std::cell::RefCell;
+use std::future::Future;
+use std::pin::Pin;
+use std::rc::Rc;
 
 use boa_gc::{custom_trace, Finalize, Gc, Trace};
+use futures_lite::FutureExt as _;
 
 use crate::job::NativeAsyncJob;
 use crate::value::JsVariant;
@@ -108,6 +112,133 @@ impl JsData for NativeFunctionObject {
     }
 }
 
+enum AsyncCallResult {
+    Pending,
+    Ready(JsResult<JsValue>),
+}
+
+enum AsyncRunningState {
+    None,
+    Calling,
+    Constructing {
+        new_target: JsValue,
+    }
+}
+trait TraceableAsyncFunction: Trace {
+    fn running(&self) -> AsyncRunningState;
+    fn call_or_construct(&self, this: &JsValue, args: &[JsValue], new_target: &JsValue, context: &mut Context) -> AsyncCallResult;
+    fn poll(&self, context: &mut Context) -> AsyncCallResult {
+        self.call_or_construct(&JsValue::undefined(), &[], &JsValue::undefined(), context)
+    }
+}
+
+#[derive(Finalize)]
+enum AsyncCallState {
+    None,
+    Calling {
+        this: JsValue,
+        args: Vec<JsValue>,
+        f: Pin<Box<dyn Future<Output = JsResult<JsValue>>>>
+    },
+    Constructing {
+        new_target: JsValue,
+        args: Vec<JsValue>,
+        f: Pin<Box<dyn Future<Output = JsResult<JsValue>>>>
+    }
+}
+unsafe impl Trace for AsyncCallState {
+    custom_trace!(this, mark, {
+        match this {
+            AsyncCallState::None => {}
+            AsyncCallState::Calling { this, args, f: _ } => {
+                mark(this);
+                mark(args);
+            }
+            AsyncCallState::Constructing { new_target, args, f: _ } => {
+                mark(new_target);
+                mark(args);
+            }
+        }
+    });
+}
+
+#[derive(Finalize)]
+struct NativeAsyncFunction<T: Trace> {
+    start: Rc<dyn Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<Pin<Box<dyn Future<Output = JsResult<JsValue>>>>>>,
+    captures: T,
+    state: RefCell<AsyncCallState>,
+}
+unsafe impl<T: Trace> Trace for NativeAsyncFunction<T> {
+    custom_trace!(this, mark, {
+       mark(&this.captures);
+       mark(&*this.state.borrow());
+    });
+}
+
+impl<T> TraceableAsyncFunction for NativeAsyncFunction<T>
+where
+    T: Trace,
+{
+    fn running(&self) -> AsyncRunningState {
+        match &*self.state.borrow() {
+            AsyncCallState::None => AsyncRunningState::None,
+            AsyncCallState::Calling { .. } => AsyncRunningState::Calling,
+            AsyncCallState::Constructing { new_target, .. } => {
+                AsyncRunningState::Constructing { new_target: new_target.clone() }
+            }
+        }
+    }
+
+    fn call_or_construct(&self, this: &JsValue, args: &[JsValue], new_target: &JsValue, context: &mut Context) -> AsyncCallResult {
+        let mut state = self.state.borrow_mut();
+        match *state {
+            AsyncCallState::None => {
+                if new_target.is_undefined() {
+                    let f = (*self.start)(this, args, context);
+                    let f = match f {
+                        Ok(f) => f,
+                        Err(e) => return AsyncCallResult::Ready(Err(e)),
+                    };
+                    *state = AsyncCallState::Calling {
+                        this: this.clone(),
+                        args: args.to_vec(),
+                        f
+                    };
+                } else {
+                    let f = (*self.start)(new_target, args, context);
+                    let f = match f {
+                        Ok(f) => f,
+                        Err(e) => return AsyncCallResult::Ready(Err(e)),
+                    };
+                    *state = AsyncCallState::Constructing {
+                        new_target: new_target.clone(),
+                        args: args.to_vec(),
+                        f
+                    };
+                }
+
+                AsyncCallResult::Pending
+            }
+            AsyncCallState::Calling { ref mut f, .. } | AsyncCallState::Constructing { ref mut f, .. }=> {
+                // FIXME: figure out how to work with an async Context / Waker from the application (e.g. from Tokio)
+                let waker = std::task::Waker::noop();
+                let mut context = std::task::Context::from_waker(waker);
+                let result = f.poll(&mut context);
+                match result {
+                    std::task::Poll::Pending => {
+                        //println!("Pending");
+                        AsyncCallResult::Pending
+                    }
+                    std::task::Poll::Ready(result) => {
+                        *state = AsyncCallState::None;
+                        AsyncCallResult::Ready(result)
+                    }
+                }
+            }
+        }
+    }
+}
+
 /// A callable Rust function that can be invoked by the engine.
 ///
 /// `NativeFunction` functions are divided in two:
@@ -129,6 +260,7 @@ pub struct NativeFunction {
 #[derive(Clone)]
 enum Inner {
     PointerFn(NativeFunctionPointer),
+    AsyncFn(Gc<dyn TraceableAsyncFunction>),
     Closure(Gc<dyn TraceableClosure>),
 }
 
@@ -308,6 +440,35 @@ impl NativeFunction {
         })
     }
 
+    /// Creates a `NativeFunction` from a function returning a [`Future`] and a list of traceable
+    /// captures.
+    ///
+    /// When called from JavaScript, the function will appear to be synchronous, but it will be
+    /// able to yield the VM's control to the applications event loop, enabling the native function to
+    /// perform I/O operations or other tasks that may take a long time to complete without blocking.
+    ///
+    /// This also ensures that scripts that make long-running calls to native functions can be
+    /// cooperatively scheduled within a single threaded environment (e.g. a browser) and can be
+    /// stopped if they take too long to complete.
+    pub fn from_async_as_sync_with_captures<F, T>(f: F, captures: T) -> Self
+    where
+        F: Fn(&JsValue, &[JsValue], &mut Context) -> JsResult<Pin<Box<dyn Future<Output = JsResult<JsValue>>>>> + 'static,
+        T: Trace + 'static,
+    {
+        let ptr = Gc::into_raw(Gc::new(NativeAsyncFunction {
+            start: Rc::new(f),
+            captures,
+            state: RefCell::new(AsyncCallState::None),
+        }));
+
+        // SAFETY: The pointer returned by `into_raw` is only used to coerce to a trait object,
+        unsafe {
+            Self {
+                inner: Inner::AsyncFn(Gc::from_raw(ptr)),
+            }
+        }
+    }
+
     /// Creates a `NativeFunction` from a `Copy` closure.
     pub fn from_copy_closure<F>(closure: F) -> Self
     where
@@ -377,16 +538,85 @@ impl NativeFunction {
     }
 
     /// Calls this `NativeFunction`, forwarding the arguments to the corresponding function.
+    ///
+    /// XXX: Does it make sense to allow constructors to be called if the `NativeFunction`
+    /// for a constructor expects a `new_target` argument which will be `undefined`?
+    ///
+    /// The ECMA spec has a more general `BuiltinCallOrConstruct` operation that differentiates
+    /// `this` and `newTarget` and maybe a NativeFunction should implement that?
     #[inline]
-    pub fn call(
+    fn call(
         &self,
-        this: &JsValue,
-        args: &[JsValue],
+        is_constructor: bool,
+        argument_count: usize,
         context: &mut Context,
-    ) -> JsResult<JsValue> {
-        match self.inner {
-            Inner::PointerFn(f) => f(this, args, context),
-            Inner::Closure(ref c) => c.call(this, args, context),
+    ) -> AsyncCallResult {
+        //println!("[NativeFunction] call, arg_count: {}", argument_count);
+        if let Inner::AsyncFn(ref f) = self.inner {
+            match f.running() {
+                AsyncRunningState::None => {
+                    let args = context.vm.pop_n_values(argument_count);
+                    let _func = context.vm.pop();
+                    let _this = context.vm.pop();
+                    let this = if is_constructor { &JsValue::undefined() } else { &_this };
+                    let result = f.call_or_construct(this, &args, &JsValue::undefined(), context);
+                    if matches!(result, AsyncCallResult::Pending) {
+                        context.vm.push(_this);
+                        context.vm.push(_func);
+                        context.vm.push_values(&args);
+                    }
+                    result
+                }
+                AsyncRunningState::Calling => {
+                    f.poll(context)
+                }
+                AsyncRunningState::Constructing { new_target: _ } => {
+                    unreachable!()
+                }
+            }
+        } else {
+            let args = context.vm.pop_n_values(argument_count);
+            let _func = context.vm.pop();
+            let this = context.vm.pop();
+            let this = if is_constructor { JsValue::undefined() } else { this };
+            AsyncCallResult::Ready(match self.inner {
+                Inner::PointerFn(f) => f(&this, &args, context),
+                Inner::Closure(ref c) => c.call(&this, &args, context),
+                Inner::AsyncFn(_) => unreachable!(),
+            })
+        }
+    }
+
+    fn construct(
+        &self,
+        argument_count: usize,
+        context: &mut Context,
+    ) -> (JsValue, AsyncCallResult) {
+        if let Inner::AsyncFn(ref f) = self.inner {
+            match f.running() {
+                AsyncRunningState::None => {
+                    let new_target = context.vm.pop();
+                    let args = context.vm.pop_n_values(argument_count);
+                    let _func = context.vm.pop();
+                    (new_target.clone(), f.call_or_construct(&JsValue::undefined(), &args, &new_target, context))
+                }
+                AsyncRunningState::Constructing { new_target } => {
+                    (new_target.clone(), f.poll(context))
+                }
+                AsyncRunningState::Calling => {
+                    unreachable!()
+                }
+            }
+        } else {
+            let new_target = context.vm.pop();
+            let args = context.vm.pop_n_values(argument_count);
+            let _func = context.vm.pop();
+            let result = AsyncCallResult::Ready(match self.inner {
+                Inner::PointerFn(f) => f(&new_target, &args, context),
+                Inner::Closure(ref c) => c.call(&new_target, &args, context),
+                Inner::AsyncFn(_) => unreachable!(),
+            });
+            (new_target.clone(), result)
         }
     }
 
@@ -410,10 +640,7 @@ pub(crate) fn native_function_call(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
-    let args = context.vm.pop_n_values(argument_count);
-    let _func = context.vm.pop();
-    let this = context.vm.pop();
-
+    //println!("native_function_call");
     // We technically don't need this since native functions don't push any new frames to the
     // vm, but we'll eventually have to combine the native stack with the vm stack.
     context.check_runtime_limits()?;
@@ -433,19 +660,22 @@ pub(crate) fn native_function_call(
     context.swap_realm(&mut realm);
     context.vm.native_active_function = Some(this_function_object);
 
-    let result = if constructor.is_some() {
-        function.call(&JsValue::undefined(), &args, context)
-    } else {
-        function.call(&this, &args, context)
-    }
-    .map_err(|err| err.inject_realm(context.realm().clone()));
+    let result = function.call(constructor.is_some(), argument_count, context);
+
+    let result = match result {
+        AsyncCallResult::Pending => {
+            Ok(CallValue::AsyncPending)
+        },
+        AsyncCallResult::Ready(result) => {
+            context.vm.push(result.map_err(|err| err.inject_realm(context.realm().clone()))?);
+            Ok(CallValue::Complete)
+        }
+    };
 
     context.vm.native_active_function = None;
     context.swap_realm(&mut realm);
 
-    context.vm.push(result?);
-
-    Ok(CallValue::Complete)
+    result
 }
 
 /// Construct an instance of this object with the specified arguments.
@@ -459,6 +689,7 @@ fn native_function_construct(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
+    //println!("native_function_construct");
     // We technically don't need this since native functions don't push any new frames to the
     // vm, but we'll eventually have to combine the native stack with the vm stack.
     context.check_runtime_limits()?;
@@ -478,39 +709,51 @@ fn native_function_construct(
     context.swap_realm(&mut realm);
     context.vm.native_active_function = Some(this_function_object);
 
-    let new_target = context.vm.pop();
-    let args = context.vm.pop_n_values(argument_count);
-    let _func = context.vm.pop();
+    let (new_target, result) = function
+        .construct(argument_count, context);
 
-    let result = function
-        .call(&new_target, &args, context)
-        .map_err(|err| err.inject_realm(context.realm().clone()))
-        .and_then(|v| match v.variant() {
-            JsVariant::Object(o) => Ok(o.clone()),
-            val => {
-                if constructor.expect("must be a constructor").is_base() || val.is_undefined() {
-                    let prototype = get_prototype_from_constructor(
-                        &new_target,
-                        StandardConstructors::object,
-                        context,
-                    )?;
-                    Ok(JsObject::from_proto_and_data_with_shared_shape(
-                        context.root_shape(),
-                        prototype,
-                        OrdinaryObject,
-                    ))
-                } else {
-                    Err(JsNativeError::typ()
-                        .with_message("derived constructor can only return an Object or undefined")
-                        .into())
-                }
+    let result =
+        match result {
+            AsyncCallResult::Pending => None,
+            AsyncCallResult::Ready(result) => {
+                Some(
+                    result
+                        .map_err(|err| err.inject_realm(context.realm().clone()))
+                        .and_then(|v| match v.variant() {
+                            JsVariant::Object(o) => Ok(o.clone()),
+                            val => {
+                                if constructor.expect("must be a constructor").is_base() || val.is_undefined() {
+                                    let prototype = get_prototype_from_constructor(
+                                        &new_target,
+                                        StandardConstructors::object,
+                                        context,
+                                    )?;
+                                    Ok(JsObject::from_proto_and_data_with_shared_shape(
+                                        context.root_shape(),
+                                        prototype,
+                                        OrdinaryObject,
+                                    ))
+                                } else {
+                                    Err(JsNativeError::typ()
+                                        .with_message("derived constructor can only return an Object or undefined")
+                                        .into())
+                                }
+                            }
+                        })
+                    )
             }
-        });
+        };
 
     context.vm.native_active_function = None;
     context.swap_realm(&mut realm);
 
-    context.vm.push(result?);
-
-    Ok(CallValue::Complete)
+    match result {
+        None => {
+            Ok(CallValue::AsyncPending)
+        }
+        Some(result) => {
+            context.vm.push(result?);
+            Ok(CallValue::Complete)
+        }
+    }
 }

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -406,7 +406,20 @@ pub(crate) enum CallValue {
         argument_count: usize,
     },
 
+    /// Further processing is needed.
+    ///
+    /// Unlike for `Pending`, the further processing should not block the VM and
+    /// be completed synchronously, it should integrate with VM cycle budgeting
+    /// and yielding.
+    AsyncPending,
+
     /// The value has been computed and is the first element on the stack.
+    Complete,
+}
+
+pub(crate) enum ResolvedCallValue {
+    Ready { register_count: usize },
+    Pending,
     Complete,
 }
 
@@ -426,6 +439,25 @@ impl CallValue {
             Self::Ready { register_count } => Ok(Some(register_count)),
             Self::Complete => Ok(None),
             Self::Pending { .. } => unreachable!(),
+            Self::AsyncPending { .. } => unreachable!(),
+        }
+    }
+
+    pub(crate) fn async_resolve(mut self, context: &mut Context) -> JsResult<ResolvedCallValue> {
+        while let Self::Pending {
+            func,
+            object,
+            argument_count,
+        } = self
+        {
+            self = func(&object, argument_count, context)?;
+        }
+
+        match self {
+            Self::Ready { register_count } => Ok(ResolvedCallValue::Ready { register_count }),
+            Self::Complete => Ok(ResolvedCallValue::Complete),
+            Self::Pending { .. } => unreachable!(),
+            Self::AsyncPending { .. } => Ok(ResolvedCallValue::Pending),
         }
     }
 }

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -191,6 +191,7 @@ impl Script {
     /// customize this parameter.
     #[allow(clippy::future_not_send)]
     pub async fn evaluate_async(&self, context: &mut Context) -> JsResult<JsValue> {
+        println!("Evaluating async script");
         self.evaluate_async_with_budget(context, 256).await
     }
 

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -138,6 +138,7 @@ impl Vm {
     where
         T: Into<JsValue>,
     {
+        //println!("Pushing value");
         self.stack.push(value.into());
     }
 
@@ -148,6 +149,7 @@ impl Vm {
     /// If there is nothing to pop, then this will panic.
     #[track_caller]
     pub(crate) fn pop(&mut self) -> JsValue {
+        //println!("Popping value");
         self.stack.pop().expect("stack was empty")
     }
 
@@ -254,11 +256,13 @@ impl Vm {
     }
 
     pub(crate) fn pop_n_values(&mut self, n: usize) -> Vec<JsValue> {
+        //println!("Popping {n} values");
         let at = self.stack.len() - n;
         self.stack.split_off(at)
     }
 
     pub(crate) fn push_values(&mut self, values: &[JsValue]) {
+        //println!("Pushing {} values", values.len());
         self.stack.extend_from_slice(values);
     }
 
@@ -270,6 +274,7 @@ impl Vm {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum CompletionType {
     Normal,
+    NormalPending,
     Return,
     Throw,
     Yield,
@@ -405,7 +410,7 @@ impl Context {
     where
         F: FnOnce(Opcode, &mut Registers, &mut Context) -> JsResult<CompletionType>,
     {
-        let opcode: Opcode = {
+        let (opcode, save_pc): (Opcode, _) = {
             let _timer = Profiler::global().start_event("Opcode retrieval", "vm");
 
             let frame = self.vm.frame_mut();
@@ -413,12 +418,28 @@ impl Context {
             let pc = frame.pc;
             let opcode = frame.code_block.bytecode[pc as usize].into();
             frame.pc += 1;
-            opcode
+            (opcode, pc)
         };
 
         let _timer = Profiler::global().start_event(opcode.as_instruction_str(), "vm");
 
-        f(opcode, registers, self)
+        //println!("Executing opcode: {} @ {}", opcode.as_str(), save_pc);
+        let r = f(opcode, registers, self);
+        match r {
+            Err(ref err) if err.is_catchable() => {
+                // If the error is catchable, we need to set the pc to the
+                // instruction that caused the error.
+                self.vm.frame_mut().pc = save_pc;
+            }
+            Ok(CompletionType::NormalPending) => {
+                //println!("Reverting PC for 'Pending' opcode to {}", save_pc);
+                // If the instruction is pending, we need to set the pc to the
+                // instruction that is still pending.
+                self.vm.frame_mut().pc = save_pc;
+            }
+            _ => {}
+        }
+        r
     }
 
     fn execute_one<F>(&mut self, f: F, registers: &mut Registers) -> ControlFlow<CompletionRecord>
@@ -446,7 +467,9 @@ impl Context {
         let result = self.execute_instruction(f, registers);
 
         let result = match result {
-            Ok(result) => result,
+            Ok(result) => {
+                result
+            },
             Err(err) => {
                 // If we hit the execution step limit, bubble up the error to the
                 // (Rust) caller instead of trying to handle as an exception.
@@ -490,6 +513,9 @@ impl Context {
 
         match result {
             CompletionType::Normal => {}
+            CompletionType::NormalPending => {
+
+            }
             CompletionType::Return => {
                 let frame = self.vm.frame();
                 let fp = frame.fp() as usize;
@@ -598,6 +624,7 @@ impl Context {
 
             if runtime_budget == 0 {
                 runtime_budget = budget;
+                //println!("Yielding to executor");
                 yield_now().await;
             }
         }

--- a/core/engine/src/vm/opcode/call/mod.rs
+++ b/core/engine/src/vm/opcode/call/mod.rs
@@ -2,7 +2,7 @@ use crate::{
     builtins::{promise::PromiseCapability, Promise},
     error::JsNativeError,
     module::{ModuleKind, Referrer},
-    object::FunctionObjectBuilder,
+    object::{internal_methods::{CallValue, ResolvedCallValue}, FunctionObjectBuilder},
     vm::{opcode::Operation, CompletionType, Registers},
     Context, JsObject, JsResult, JsValue, NativeFunction,
 };
@@ -224,17 +224,26 @@ impl Call {
         let at = context.vm.stack.len() - argument_count;
         let func = &context.vm.stack[at - 1];
 
+        //println!("Call function: {:?}", func);
         let Some(object) = func.as_object() else {
             return Err(JsNativeError::typ()
                 .with_message("not a callable function")
                 .into());
         };
 
-        if let Some(register_count) = object.__call__(argument_count).resolve(context)? {
-            registers.push_function(register_count);
+        match object.__call__(argument_count).async_resolve(context)? {
+            ResolvedCallValue::Ready { register_count } => {
+                registers.push_function(register_count);
+                Ok(CompletionType::Normal)
+            }
+            ResolvedCallValue::Complete => {
+                Ok(CompletionType::Normal)
+            }
+            ResolvedCallValue::Pending => {
+                //println!("Pending call");
+                Ok(CompletionType::NormalPending)
+            }
         }
-
-        Ok(CompletionType::Normal)
     }
 }
 

--- a/examples/src/bin/tokio_event_loop.rs
+++ b/examples/src/bin/tokio_event_loop.rs
@@ -28,7 +28,7 @@ use tokio::{task, time};
 fn main() -> JsResult<()> {
     // An internally async event loop. This event loop blocks the execution of the thread
     // while executing tasks, but internally uses async to run its tasks.
-    internally_async_event_loop()?;
+    //internally_async_event_loop()?;
 
     // An externally async event loop. This event loop can yield to the runtime to concurrently
     // run tasks with it.
@@ -213,6 +213,20 @@ fn interval(this: &JsValue, args: &[JsValue], context: &mut Context) -> JsResult
     Ok(JsValue::undefined())
 }
 
+async fn host_async_fn(n: usize) -> JsResult<JsValue> {
+    println!("Host async function called");
+
+    // XXX: can't use Tokio currently since the VM doesn't have access to the
+    // Tokio Context + Waker
+
+    for i in 0..n {
+        println!("Host async function iteration {i}");
+        time::sleep(Duration::from_millis(500)).await;
+    }
+    println!("Host async function finished");
+    Ok(JsValue::undefined())
+}
+
 /// Adds the custom runtime to the context.
 fn add_runtime(context: &mut Context) {
     // First add the `console` object, to be able to call `console.log()`.
@@ -238,6 +252,26 @@ fn add_runtime(context: &mut Context) {
             NativeFunction::from_fn_ptr(interval),
         )
         .expect("the delay builtin shouldn't exist");
+
+    context
+        .register_global_builtin_callable(
+            js_string!("host_async"),
+            1,
+            NativeFunction::from_async_as_sync_with_captures(
+                |this, args, context| {
+                    let Some(arg) = args.get(0) else {
+                        return Err(JsNativeError::typ()
+                            .with_message("arg must be a callable")
+                            .into());
+                    };
+                    let arg = arg.to_u32(context)?;
+
+                    Ok(Box::pin(host_async_fn(arg as usize)))
+                },
+                (),
+            ),
+        )
+        .expect("the foo builtin shouldn't exist");
 }
 
 // Script that does multiple calls to multiple async timers.
@@ -245,6 +279,9 @@ const SCRIPT: &str = r"
     function print(elapsed) {
         console.log(`Finished delay. Elapsed time: ${elapsed * 1000} ms`);
     }
+
+    console.log(`======= host_async(5) =======`);
+    host_async(5);
 
     delay(1000).then(print);
     delay(500).then(print);
@@ -259,6 +296,12 @@ const SCRIPT: &str = r"
     }
 
     interval(counter, 100);
+    console.log(`====================`);
+    console.log(`Started interval job`);
+    console.log(`====================`);
+
+    console.log(`======= host_async(2) =======`);
+    host_async(2);
 
     for(let i = 0; i <= 100000; i++) {
         // Emulate a long-running evaluation of a script.
@@ -337,7 +380,9 @@ async fn externally_async_event_loop() -> JsResult<()> {
         script.evaluate_async(context).await.unwrap();
 
         // Run the jobs asynchronously, which avoids blocking the main thread.
+        println!("===============");
         println!("Running jobs...");
+        println!("===============");
         context.run_jobs_async().await
     });
 


### PR DESCRIPTION
Based on some discussion in https://github.com/boa-dev/boa/issues/3442#issuecomment-2859413836; this experiments with enabling support for async NativeFunctions that are only async from the pov of the host, and appear as synchronous from within JavaScript.

Instead of running the async functions as a Promise via `enqueue_job`, this works by allowing Operations to be executed over multiple VM cycles, so an Operation may start some async work in one step and then further steps can poll for completion of that work and finish the Operation.

In particular this works by allowing Call Operations to return a `NormalPending` completion type that indicates that the same Call operation needs to be executed repeatedly, until it returns a `Normal` status.

In the case of a `NormalPending` status, the program counter is reset and anything that was taken off the stack is pushed back so the same Operation can be re-executed.

There is a new `NativeFunction::from_async_as_sync_with_captures()` that lets the host provide a (sync) closure that itself returns / spawns a boxed Future. This is tracked internally as an `Inner::AsyncFn`.

Whenever the function is `__call__`ed then (assuming the operation isn't already in a pending / running state) a new Future is spawned via the application's closure and the Operation enters a "pending" state.

When a NativeFunction is pending then each `__call__` will `poll()` the spawned `Future` to see if the `async` function has a result.

This effectively stalls the VM at the same Opcode while still accounting for any cycle budget and periodically yielding to the application's async runtime while waiting for an async Call Operation to finish.

Limitations / Issues
====================

## Busy Loop Polling

Even though the implementation does yield back to the application's async runtime when waiting for a NativeFunction to complete, the implementation isn't ideal because it uses a noop task Context
+ Waker when polling NativeFunction Futures. The effectively relies on the VM polling the future in a busy loop, wasting CPU time.

A better solution could be to implement a shim Waker that would flag some state on the Boa engine Context, and then adapt the Future that's used to yield the VM to the executor so that it only becomes Ready once the async NativeFunction has signalled the waker. I.e. the Waker would act like a bridge/proxy between a spawned async NativeFunction and the the Future/Task associated with the VM's async `run_async_with_budget`.

This way I think the VM could remain async runtime agnostic but would be able to actually sleep while waiting for async functions instead of entering a busy yield loop.

## Rewinding relies on coop between VM an Operation

Ideally there could be a more elegant way to reliably rewind the side effects of a Pending Operation, or else avoid the need to rewind anything and instead track partial progress for an Operation.

The support for rewiding a Call Operation partly relies on the VM handling resetting of the program counter while the operation itself handles pushing arguments back to the stack.

## Only adapts Call Operation

Currently only the Call Operation handles async NativeFunctions but there are other `Call[XYZ]` Operations that could be adapted too.

## Not compatible with composite Operations that `call()`

The ability to track pending async functions is implemented in terms of repeatedly executing an Opcode in the VM until it signals that it's not Pending.

This relies on being able to reset and re-execute the Operation (such as reverting program counter and stack changes).

There are lots of Operations that make use of `JsObject::call()` internally and they would currently trigger a panic if they called an `async` `NativeFunction` because they wouldn't not be able to "resolve()" the "AsyncPending" status that would be returned by the `call()`.

Ideally all Operations that use `__call__` or `__construct__` should support `CallValue::AsyncPending` and be fully resumable in the same way that the `Call` `Operation` is now.

This would probably be easier to achieve this with Rust Coroutines if they were stable because it would otherwise be necessary to adapt the Operation's execution into a state machine, similar to what the compiler does for an async Future. It probably wouldn't be ideal to be spawning futures directly at the level of `Operation::execute` while that would likely have a disproportionate overhead. Maybe a trade-off would be that Operations that use `call()` could be manually adapted into `match` state machines and the VM would track an integer for progressing resumable Operations - but that would notably complicate the implementation for a lot of (most?) operations.

Addresses: #3442