### PR TITLE
Enable `wasm_js` feature of getrandom in boa_engine crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "fixed_decimal",
  "float-cmp",
  "futures-lite 2.6.0",
+ "getrandom 0.3.3",
  "hashbrown 0.15.3",
  "iana-time-zone",
  "icu_calendar 1.5.2",
@@ -595,7 +596,6 @@ version = "0.20.0"
 dependencies = [
  "boa_engine",
  "console_error_panic_hook",
- "getrandom 0.3.3",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/README.md
+++ b/README.md
@@ -111,21 +111,24 @@ Check [debugging.md](./docs/debugging.md) for more info on debugging.
 
 ### Web Assembly
 
-This interpreter can be exposed to JavaScript!
-You can build the example locally with:
+> [!IMPORTANT]
+>
+> This only applies to `wasm32-unknown-unknown` target,
+> `WASI` and `Emscripten` target variants are handled automatically.
 
-```shell
-npm run build
+- Enable the `js` feature flag.
+- Set `RUSTFLAGS='--cfg getrandom_backend="wasm_js"'`
+
+The `rustflags` can also be set by adding a `.cargo/config.toml` file in the project root directory:
+
+```toml
+[target.wasm32-unknown-unknown]
+rustflags = '--cfg getrandom_backend="wasm_js"'
 ```
 
-In the console you can use `window.evaluate` to pass JavaScript in.
-To develop on the web assembly side you can run:
+For more information see: [`getrandom` WebAssembly Support][getrandom-webassembly-support]
 
-```shell
-npm run serve
-```
-
-then go to `http://localhost:8080`.
+[getrandom-webassembly-support]: https://docs.rs/getrandom/latest/getrandom/index.html#webassembly-support
 
 ## Usage
 

--- a/core/engine/Cargo.toml
+++ b/core/engine/Cargo.toml
@@ -65,7 +65,7 @@ temporal = ["dep:icu_calendar", "dep:temporal_rs", "dep:iana-time-zone"]
 experimental = ["temporal"]
 
 # Enable binding to JS APIs for system related utilities.
-js = ["dep:web-time"]
+js = ["dep:web-time", "dep:getrandom"]
 
 [dependencies]
 tag_ptr.workspace = true
@@ -158,6 +158,8 @@ iana-time-zone = { version = "0.1.63", optional = true }
 
 [target.'cfg(all(target_family = "wasm", not(any(target_os = "emscripten", target_os = "wasi"))))'.dependencies]
 web-time = { workspace = true, optional = true }
+# NOTE: This enables the wasm_js required for rand to work on wasm
+getrandom = { workspace = true, features = ["wasm_js"], optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/core/engine/src/sys/js/mod.rs
+++ b/core/engine/src/sys/js/mod.rs
@@ -1,1 +1,2 @@
+pub(crate) use getrandom as _;
 pub(crate) use web_time as time;

--- a/ffi/wasm/Cargo.toml
+++ b/ffi/wasm/Cargo.toml
@@ -14,14 +14,17 @@ rust-version.workspace = true
 [dependencies]
 boa_engine = { workspace = true, features = ["js"] }
 wasm-bindgen = { workspace = true, default-features = false }
-getrandom = { workspace = true, features = ["wasm_js"] }
 console_error_panic_hook.workspace = true
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test.workspace = true
 
 [features]
-default = ["boa_engine/annex-b", "boa_engine/intl_bundled", "boa_engine/experimental"]
+default = [
+    "boa_engine/annex-b",
+    "boa_engine/intl_bundled",
+    "boa_engine/experimental",
+]
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/ffi/wasm/src/lib.rs
+++ b/ffi/wasm/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(unused_crate_dependencies)]
 
 use boa_engine::{Context, Source};
-use getrandom as _;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(start)]


### PR DESCRIPTION
Related to #4211 

It changes the following:

- Enables the `wasm_js` feature of getrandom for `wasm32-unknown-unknown` target in `boa_engine` crate
- Add some documentation to `README.md`


Rendered doc:

![image](https://github.com/user-attachments/assets/e557a1de-f964-45e7-838d-0e303abbeb1c)
