### PR TITLE
Fix the Set methods to pass the 262 tests

### DIFF
--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -120,7 +120,7 @@ fn get_set_record(obj: &JsValue, context: &mut Context) -> JsResult<SetRecord> {
 
 /// [`CanonicalizeKeyedCollectionKey ( key )`][spec]
 ///
-/// The abstract operation CanonicalizeKeyedCollectionKey takes argument key (an ECMAScript
+/// The abstract operation `CanonicalizeKeyedCollectionKey` takes argument key (an ECMAScript
 /// language value) and returns an ECMAScript language value. It performs the following steps
 /// when called:
 ///
@@ -785,7 +785,7 @@ impl Set {
                     "Method Set.prototype.symmetricDifference called on incompatible receiver",
                 )
                 .into());
-        };
+        }
 
         // 3. Let otherRec be ? GetSetRecord(other).
         let other = args.get_or_undefined(0);
@@ -869,7 +869,7 @@ impl Set {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.union called on incompatible receiver")
                 .into());
-        };
+        }
 
         // 3. Let otherRec be ? GetSetRecord(other).
         let other = args.get_or_undefined(0);

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -633,21 +633,21 @@ impl Set {
                     .as_downcast_ref::<OrderedSet>()
                     .and_then(|o| o.get_index(index).cloned());
 
-                //       ii. Set index to index + 1.
+                // ii. Set index to index + 1.
                 index += 1;
 
-                //       iii. If e is not empty, then
+                // iii. If e is not empty, then
                 if let Some(e) = e {
-                    //            1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+                    // 1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
                     let in_other = other_rec.has.call(other, &[e], context)?.to_boolean();
 
-                    //            2. If inOther is true, return false.
+                    // 2. If inOther is true, return false.
                     if in_other {
                         return Ok(JsValue::from(false));
                     }
 
-                    //            3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
-                    //            4. Set thisSize to the number of elements in O.[[SetData]].
+                    // 3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+                    // 4. Set thisSize to the number of elements in O.[[SetData]].
                     this_size = Self::get_size_full(this)?;
                 }
             }
@@ -660,13 +660,13 @@ impl Set {
             //    c. Repeat, while next is not done,
             //       i. Set next to ? IteratorStepValue(keysIter).
             while let Some(next) = keys_iter.step_value(context)? {
-                //       ii. If next is not done, then
-                //           1. If SetDataHas(O.[[SetData]], next) is true, then
+                //   ii. If next is not done, then
+                //       1. If SetDataHas(O.[[SetData]], next) is true, then
                 if Self::has(this, &[next], context)?.to_boolean() {
-                    //              a. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
+                    //      a. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
                     keys_iter.close(Ok(JsValue::undefined()), context)?;
 
-                    //              b. Return false.
+                    //      b. Return false.
                     return Ok(JsValue::from(false));
                 }
             }
@@ -715,7 +715,7 @@ impl Set {
 
         // 7. Repeat, while index < thisSize,
         while index < this_size {
-            //    a. Let e be O.[[SetData]][index].
+            // a. Let e be O.[[SetData]][index].
             let Some(set) = this
                 .as_object()
                 .and_then(JsObject::downcast_ref::<OrderedSet>)
@@ -727,21 +727,21 @@ impl Set {
             let e = set.get_index(index).cloned();
             drop(set);
 
-            //    b. Set index to index + 1.
+            // b. Set index to index + 1.
             index += 1;
 
-            //    c. If e is not empty, then
+            // c. If e is not empty, then
             if let Some(e) = e {
-                //       i. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+                // i. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
                 let in_other = other_rec.has.call(other, &[e], context)?.to_boolean();
 
-                //       ii. If inOther is false, return false.
+                // ii. If inOther is false, return false.
                 if !in_other {
                     return Ok(JsValue::from(false));
                 }
 
-                //       iii. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
-                //       iv. Set thisSize to the number of elements in O.[[SetData]].
+                // iii. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+                // iv. Set thisSize to the number of elements in O.[[SetData]].
                 this_size = Self::get_size_full(this)?;
             }
         }
@@ -794,9 +794,9 @@ impl Set {
             //  b. If next is not done, then
             //     i. If SetDataHas(O.[[SetData]], next) is false, then
             if !Self::has(this, &[next], context)?.to_boolean() {
-                //    1. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
+                // 1. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
                 keys_iter.close(Ok(JsValue::undefined()), context)?;
-                //    2. Return false.
+                // 2. Return false.
                 return Ok(JsValue::from(false));
             }
         }
@@ -992,32 +992,33 @@ impl Set {
         // 5. If SetDataSize(O.[[SetData]]) ≤ otherRec.[[Size]], then
         let mut this_size = Self::get_size_full(this)?;
         if this_size <= other_rec.size {
-            //    a. Let thisSize be the number of elements in O.[[SetData]].
-            //    b. Let index be 0.
+            // a. Let thisSize be the number of elements in O.[[SetData]].
+            // b. Let index be 0.
             let mut index = 0;
-            //    c. Repeat, while index < thisSize,
+            // c. Repeat, while index < thisSize,
             while index < this_size {
-                //   i. Let e be O.[[SetData]][index].
+                // i. Let e be O.[[SetData]][index].
                 let e = this
                     .as_downcast_ref::<OrderedSet>()
                     .and_then(|o| o.get_index(index).cloned());
-                //   ii. Set index to index + 1.
+                // ii. Set index to index + 1.
                 index += 1;
 
-                //   iii. If e is not empty, then
+                // iii. If e is not empty, then
                 let Some(e) = e else {
                     continue;
                 };
-                //        1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
+
+                //      1. Let inOther be ToBoolean(? Call(otherRec.[[Has]], otherRec.[[SetObject]], « e »)).
                 let in_other = other_rec.has.call(other, &[e.clone()], context)?;
-                //        2. If inOther is true, then
-                //           a. NOTE: It is possible for earlier calls to otherRec.[[Has]] to remove and re-add an element of O.[[SetData]], which can cause the same element to be visited twice during this iteration.
+                //      2. If inOther is true, then
+                //         a. NOTE: It is possible for earlier calls to otherRec.[[Has]] to remove and re-add an element of O.[[SetData]], which can cause the same element to be visited twice during this iteration.
                 if in_other.to_boolean() {
-                    //           b. If SetDataHas(resultSetData, e) is false, then
-                    //              i. Append e to resultSetData.
+                    //     b. If SetDataHas(resultSetData, e) is false, then
+                    //        i. Append e to resultSetData.
                     result_set_data.add(e);
-                    //        3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
-                    //        4. Set thisSize to the number of elements in O.[[SetData]].
+                    //  3. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
+                    //  4. Set thisSize to the number of elements in O.[[SetData]].
                     this_size = Self::get_size_full(this)?;
                 }
             }
@@ -1124,18 +1125,18 @@ impl Set {
         }
         // 6. Else,
         else {
-            //    a. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
+            // a. Let keysIter be ? GetIteratorFromMethod(otherRec.[[SetObject]], otherRec.[[Keys]]).
             let mut keys_iter = other.get_iterator_from_method(&other_rec.keys, context)?;
-            //    b. Let next be not-started.
-            //    c. Repeat, while next is not done,
-            //       i. Set next to ? IteratorStepValue(keysIter).
+            // b. Let next be not-started.
+            // c. Repeat, while next is not done,
+            //     i. Set next to ? IteratorStepValue(keysIter).
             while let Some(next) = keys_iter.step_value(context)? {
-                //   ii. If next is not done, then
-                //       1. Set next to CanonicalizeKeyedCollectionKey(next).
+                // ii. If next is not done, then
+                //     1. Set next to CanonicalizeKeyedCollectionKey(next).
                 let next = canonicalize_keyed_collection_value(next);
-                //       2. Let valueIndex be SetDataIndex(resultSetData, next).
-                //       3. If valueIndex is not not-found, then
-                //          a. Set resultSetData[valueIndex] to empty.
+                //     2. Let valueIndex be SetDataIndex(resultSetData, next).
+                //     3. If valueIndex is not not-found, then
+                //        a. Set resultSetData[valueIndex] to empty.
                 result_set_data.delete(&next);
             }
         }

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -1081,7 +1081,7 @@ impl Set {
             return Err(JsNativeError::typ()
                 .with_message("Method Set.prototype.difference called on incompatible receiver")
                 .into());
-        };
+        }
 
         // 3. Let otherRec be ? GetSetRecord(other).
         let other = args.get_or_undefined(0);

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -691,7 +691,7 @@ impl Set {
         }
 
         // 5. Let thisSize be the number of elements in O.[[SetData]].
-        let this_size = Self::get_size_full(this)?;
+        let mut this_size = Self::get_size_full(this)?;
         // 6. Let index be 0.
         let mut index = 0;
 
@@ -724,6 +724,7 @@ impl Set {
 
                 //       iii. NOTE: The number of elements in O.[[SetData]] may have increased during execution of otherRec.[[Has]].
                 //       iv. Set thisSize to the number of elements in O.[[SetData]].
+                this_size = Self::get_size_full(this)?;
             }
         }
 

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -32,7 +32,6 @@ use crate::{
     Context, JsArgs, JsResult, JsString, JsValue,
 };
 use boa_engine::value::IntegerOrInfinity;
-use boa_engine::vm::CompletionRecord;
 use boa_profiler::Profiler;
 use num_traits::Zero;
 pub(crate) use set_iterator::SetIterator;
@@ -665,10 +664,7 @@ impl Set {
                 //           1. If SetDataHas(O.[[SetData]], next) is true, then
                 if Self::has(this, &[next], context)?.to_boolean() {
                     //              a. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
-                    keys_iter.close(
-                        CompletionRecord::Normal(JsValue::undefined()).consume(),
-                        context,
-                    )?;
+                    keys_iter.close(Ok(JsValue::undefined()), context)?;
 
                     //              b. Return false.
                     return Ok(JsValue::from(false));
@@ -799,10 +795,7 @@ impl Set {
             //     i. If SetDataHas(O.[[SetData]], next) is false, then
             if !Self::has(this, &[next], context)?.to_boolean() {
                 //    1. Perform ? IteratorClose(keysIter, NormalCompletion(unused)).
-                keys_iter.close(
-                    CompletionRecord::Normal(JsValue::undefined()).consume(),
-                    context,
-                )?;
+                keys_iter.close(Ok(JsValue::undefined()), context)?;
                 //    2. Return false.
                 return Ok(JsValue::from(false));
             }

--- a/core/engine/src/builtins/set/mod.rs
+++ b/core/engine/src/builtins/set/mod.rs
@@ -624,12 +624,12 @@ impl Set {
         // 4. If SetDataSize(O.[[SetData]]) ≤ otherRec.[[Size]], then
         let mut this_size = Self::get_size_full(this)?;
         if this_size <= other_rec.size {
-            //    a. Let thisSize be the number of elements in O.[[SetData]].
-            //    b. Let index be 0.
+            // a. Let thisSize be the number of elements in O.[[SetData]].
+            // b. Let index be 0.
             let mut index = 0;
-            //    c. Repeat, while index < thisSize,
+            // c. Repeat, while index < thisSize,
             while index < this_size {
-                //       i. Let e be O.[[SetData]][index].
+                // i. Let e be O.[[SetData]][index].
                 let e = this
                     .as_downcast_ref::<OrderedSet>()
                     .and_then(|o| o.get_index(index).cloned());

--- a/core/engine/src/builtins/set/tests.rs
+++ b/core/engine/src/builtins/set/tests.rs
@@ -356,9 +356,8 @@ fn symmetric_difference_same_set() {
     run_test_actions([
         TestAction::run(indoc! {r#"
             let setA = new Set(["JavaScript", "HTML", "CSS"]);
-            let setACopy = new Set(["JavaScript", "HTML", "CSS"]);
-            "#}),
-        // We use a copy instead of the same object to avoid borrowing conflicts.
+            let setACopy = setA;
+        "#}),
         TestAction::assert_with_op("setA.symmetricDifference(setACopy)", |v, _| {
             v.display().to_string() == "Set(0)"
         }),
@@ -395,6 +394,18 @@ fn union() {
         }),
         TestAction::assert_with_op("setB.union(setA)", |v, _| {
             v.display().to_string() == "Set { 1, 4, 9, 2, 6, 8 }"
+        }),
+    ]);
+}
+
+#[test]
+fn union_same_set() {
+    run_test_actions([
+        TestAction::run(indoc! {r#"
+            let setA = new Set([1, 4, 9]);
+            "#}),
+        TestAction::assert_with_op("setA.union(setA)", |v, _| {
+            v.display().to_string() == "Set { 1, 4, 9 }"
         }),
     ]);
 }

--- a/core/engine/src/builtins/set/tests.rs
+++ b/core/engine/src/builtins/set/tests.rs
@@ -358,14 +358,14 @@ fn symmetric_difference_same_set() {
             let setA = new Set(["JavaScript", "HTML", "CSS"]);
             let setACopy = new Set(["JavaScript", "HTML", "CSS"]);
             "#}),
-        // Используем копию вместо того же объекта, чтобы избежать конфликта заимствований
+        // We use a copy instead of the same object to avoid borrowing conflicts.
         TestAction::assert_with_op("setA.symmetricDifference(setACopy)", |v, _| {
             v.display().to_string() == "Set(0)"
         }),
     ]);
 }
 
-// Альтернативный тест, который создает новый Set с тем же содержимым программно
+// Alternative test that programmatically creates a new Set with the same content.
 #[test]
 fn symmetric_difference_with_identical_content() {
     run_test_actions([
@@ -376,7 +376,7 @@ fn symmetric_difference_with_identical_content() {
                 return new Set(Array.from(setA));
             }
             "#}),
-        // Используем функцию для получения нового объекта Set с тем же содержимым
+        // We use a function to get a new Set object with the same content.
         TestAction::assert_with_op("setA.symmetricDifference(getIdenticalSet())", |v, _| {
             v.display().to_string() == "Set(0)"
         }),

--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     object::JsObject,
     property::{PropertyDescriptor, PropertyKey},
     symbol::JsSymbol,
-    Context, JsBigInt, JsResult, JsString,
+    Context, JsBigInt, JsResult, JsString, NativeObject,
 };
 
 mod conversions;
@@ -158,6 +158,15 @@ impl JsValue {
     #[must_use]
     pub const fn as_object(&self) -> Option<&JsObject> {
         self.0.as_object()
+    }
+
+    /// Returns a downcasted ref object if the type matches. This is a shorthand
+    /// for `value.as_object().and_then(|o| o.downcast_ref<T>())`, which at time
+    /// can be contriving.
+    #[inline]
+    #[must_use]
+    pub fn as_downcast_ref<T: NativeObject>(&self) -> Option<boa_engine::object::Ref<'_, T>> {
+        self.as_object().and_then(|o| o.downcast_ref::<T>())
     }
 
     /// Consumes the value and return the inner object if it was an object.

--- a/test262_config.toml
+++ b/test262_config.toml
@@ -60,10 +60,6 @@ features = [
     # https://github.com/tc39/proposal-iterator-helpers
     "iterator-helpers",
 
-    # Set methods
-    # https://github.com/tc39/proposal-set-methods
-    "set-methods",
-
     # Uint8Array Base64
     # https://github.com/tc39/proposal-arraybuffer-base64
     "uint8array-base64",


### PR DESCRIPTION
There are differences in the steps and the spec, and the 262 tests fail because they are very strict on the order of operations.

There are 3 tests in `test262/test/staging/sm/Set` that are failing (`is-subset-of`, `difference` and `intersection`). The three tests actual check that `delete()` replaces entries with `empty` (according to spec) and behave expectedly. Using the `OrderedSet` (which uses an internal map) it would be impossible without some extra logic in those methods. I did not implement that logic, as it would be outside the scope of this PR IMO.