### PR TITLE
Add support for LZ4 compression in embedded module loader

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -83,11 +83,11 @@ jobs:
         run: cargo test --no-run --profile ci
       # this order is faster according to rust-analyzer
       - name: Build
-        run: cargo build --all-targets --quiet --profile ci --features annex-b,intl_bundled,experimental
+        run: cargo build --all-targets --quiet --profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
       - name: Install latest nextest
         uses: taiki-e/install-action@nextest
       - name: Test with nextest
-        run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl_bundled,experimental
+        run: cargo nextest run --profile ci --cargo-profile ci --features annex-b,intl_bundled,experimental,embedded_lz4
       - name: Test docs
         run: cargo test --doc --profile ci --features annex-b,intl_bundled,experimental
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,7 @@ dependencies = [
  "boa_engine",
  "boa_gc",
  "boa_macros",
+ "lz4_flex",
  "rustc-hash 2.1.1",
 ]
 
@@ -499,7 +500,9 @@ dependencies = [
 name = "boa_macros"
 version = "0.20.0"
 dependencies = [
+ "cfg-if",
  "cow-utils",
+ "lz4_flex",
  "proc-macro2",
  "quote",
  "syn",
@@ -2444,6 +2447,15 @@ dependencies = [
  "scoped-tls",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ indexmap = { version = "2.9.0", default-features = false }
 indoc = "2.0.6"
 itoa = "1.0.15"
 jemallocator = "0.5.4"
+lz4_flex = "0.11.3"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 once_cell = { version = "1.21.3", default-features = false }

--- a/core/interop/Cargo.toml
+++ b/core/interop/Cargo.toml
@@ -15,6 +15,7 @@ publish = false
 boa_engine.workspace = true
 boa_gc.workspace = true
 boa_macros.workspace = true
+lz4_flex = { workspace = true, optional = true }
 rustc-hash = { workspace = true, features = ["std"] }
 
 [lints]
@@ -22,3 +23,6 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[features]
+embedded_lz4 = ["boa_macros/embedded_lz4", "lz4_flex"]

--- a/core/interop/tests/embedded.rs
+++ b/core/interop/tests/embedded.rs
@@ -8,14 +8,9 @@ use boa_engine::builtins::promise::PromiseState;
 use boa_engine::module::ModuleLoader;
 use boa_engine::{js_string, Context, JsString, JsValue, Module, Source};
 use boa_interop::embed_module;
+use boa_interop::loaders::embedded::EmbeddedModuleLoader;
 
-#[test]
-fn simple() {
-    #[cfg(target_family = "unix")]
-    let module_loader = Rc::new(embed_module!("tests/embedded/"));
-    #[cfg(target_family = "windows")]
-    let module_loader = Rc::new(embed_module!("tests\\embedded\\"));
-
+fn load_module_and_test(module_loader: &Rc<EmbeddedModuleLoader>) {
     let mut context = Context::builder()
         .module_loader(module_loader.clone())
         .build()
@@ -66,4 +61,25 @@ fn simple() {
         ),
         PromiseState::Pending => panic!("Promise was not settled"),
     }
+}
+
+#[test]
+fn simple() {
+    #[cfg(target_family = "unix")]
+    let module_loader = Rc::new(embed_module!("tests/embedded/"));
+    #[cfg(target_family = "windows")]
+    let module_loader = Rc::new(embed_module!("tests\\embedded\\"));
+
+    load_module_and_test(&module_loader);
+}
+
+#[cfg(feature = "embedded_lz4")]
+#[test]
+fn compressed_lz4() {
+    #[cfg(target_family = "unix")]
+    let module_loader = Rc::new(embed_module!("tests/embedded/", compress = "lz4"));
+    #[cfg(target_family = "windows")]
+    let module_loader = Rc::new(embed_module!("tests\\embedded\\", compress = "lz4"));
+
+    load_module_and_test(&module_loader);
 }

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -12,7 +12,9 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
+cfg-if.workspace = true
 cow-utils.workspace = true
+lz4_flex = { workspace = true, optional = true }
 quote.workspace = true
 syn = { workspace = true, features = ["full"] }
 proc-macro2.workspace = true
@@ -23,3 +25,6 @@ workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
+
+[features]
+embedded_lz4 = ["lz4_flex"]

--- a/core/macros/src/embedded_module_loader.rs
+++ b/core/macros/src/embedded_module_loader.rs
@@ -2,28 +2,125 @@
 //! files embedded in the binary at build time.
 
 use proc_macro::TokenStream;
+use quote::{quote, ToTokens, TokenStreamExt};
+use std::fs;
 use std::path::PathBuf;
+use syn::parse::ParseStream;
+use syn::punctuated::Punctuated;
+use syn::{parse::Parse, Ident, LitInt, LitStr, Token};
 
-use quote::quote;
-use syn::{parse::Parse, LitInt, LitStr, Token};
+#[derive(Copy, Clone)]
+enum CompressType {
+    None,
+
+    #[cfg(feature = "embedded_lz4")]
+    Lz4,
+}
+
+impl ToTokens for CompressType {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match self {
+            CompressType::None => tokens.append(proc_macro2::Literal::string("none")),
+            #[cfg(feature = "embedded_lz4")]
+            CompressType::Lz4 => tokens.append(proc_macro2::Literal::string("lz4")),
+        }
+    }
+}
+
+impl Parse for CompressType {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let ty = input.parse::<LitStr>()?;
+        match ty.value().as_ref() {
+            "none" => Ok(Self::None),
+
+            #[cfg(feature = "lz4_flex")]
+            "lz4" => Ok(Self::Lz4),
+
+            other => Err(input.error(format!("Invalid compression type: {other}"))),
+        }
+    }
+}
+
+enum Argument {
+    Path(LitStr),
+    MaxSize(u64),
+    Compress(CompressType),
+}
+
+impl Parse for Argument {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let lookahead = input.lookahead1();
+        // If it's a single literal string, use it as path.
+        if lookahead.peek(LitStr) {
+            return Ok(Self::Path(input.parse()?));
+        }
+
+        match input.parse::<Ident>()?.to_string().as_ref() {
+            "path" => {
+                let _sep = input.parse::<Token![,]>()?;
+                Ok(Self::Path(input.parse()?))
+            }
+            "max_size" => {
+                let _sep = input.parse::<Token![,]>()?;
+                let value: LitInt = input.parse()?;
+                Ok(Self::MaxSize(value.base10_parse()?))
+            }
+            "compress" => {
+                let lookahead = input.lookahead1();
+                if lookahead.peek(Token![=]) {
+                    let _sep = input.parse::<Token![=]>()?;
+                    Ok(Self::Compress(input.parse()?))
+                } else {
+                    cfg_if::cfg_if! {
+                        if #[cfg(feature = "embedded_lz4")] {
+                            Ok(Self::Compress(CompressType::Lz4))
+                        } else {
+                            Err(input.error("No compression available by default."))
+                        }
+                    }
+                }
+            }
+            other => Err(input.error(format!("Invalid argument name: {other}"))),
+        }
+    }
+}
 
 struct EmbedModuleMacroInput {
     path: LitStr,
-    max_size: u64,
+    max_size: Option<u64>,
+    compress: CompressType,
 }
 
 impl Parse for EmbedModuleMacroInput {
-    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
-        let path = input.parse()?;
-        let _comma: Token![,] = input.parse()?;
-        let max_size = input.parse::<LitInt>()?.base10_parse()?;
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let tokens = input.fork();
+        let arguments = Punctuated::<Argument, Token![,]>::parse_terminated(input)?;
 
-        Ok(Self { path, max_size })
+        let mut path = None;
+        let mut max_size = None;
+        let mut compress = CompressType::None;
+        for arg in arguments {
+            match arg {
+                Argument::Path(p) => path = Some(p),
+                Argument::MaxSize(sz) => max_size = Some(sz),
+                Argument::Compress(t) => compress = t,
+            }
+        }
+
+        if let Some(path) = path {
+            Ok(Self {
+                path,
+                max_size,
+                compress,
+            })
+        } else {
+            Err(tokens.error("Must specify a path."))
+        }
     }
 }
 
 /// List all the files readable from the given directory, recursively.
-fn find_all_files(dir: &mut std::fs::ReadDir, root: &PathBuf) -> Vec<PathBuf> {
+fn find_all_files(dir: &mut fs::ReadDir, root: &PathBuf) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for entry in dir {
         let Ok(entry) = entry else {
@@ -32,7 +129,7 @@ fn find_all_files(dir: &mut std::fs::ReadDir, root: &PathBuf) -> Vec<PathBuf> {
 
         let path = entry.path();
         if path.is_dir() {
-            let Ok(mut sub_dir) = std::fs::read_dir(&path) else {
+            let Ok(mut sub_dir) = fs::read_dir(&path) else {
                 continue;
             };
             files.append(&mut find_all_files(&mut sub_dir, root));
@@ -52,9 +149,9 @@ pub(crate) fn embed_module_impl(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as EmbedModuleMacroInput);
 
     let root = manifest_dir.join(input.path.value());
-    let max_size = input.max_size;
+    let max_size = input.max_size.unwrap_or(u64::MAX);
 
-    let mut dir = match std::fs::read_dir(root.clone()) {
+    let mut dir = match fs::read_dir(root.clone()) {
         Ok(dir) => dir,
         Err(e) => {
             return syn::Error::new_spanned(
@@ -81,7 +178,7 @@ pub(crate) fn embed_module_impl(input: TokenStream) -> TokenStream {
         let relative_path = format!("{}{}", std::path::MAIN_SEPARATOR, relative_path);
 
         // Check the size.
-        let size = std::fs::metadata(&path)
+        let size = fs::metadata(&path)
             .map_err(|e| {
                 syn::Error::new_spanned(input.path.clone(), format!("Error reading file size: {e}"))
             })?
@@ -91,16 +188,32 @@ pub(crate) fn embed_module_impl(input: TokenStream) -> TokenStream {
         if total > max_size {
             return Err(syn::Error::new_spanned(
                 input.path.clone(),
-                "Total embedded file size exceeds the maximum size",
+                "The total embedded file size exceeds the maximum size",
             ));
         }
+
+        let bytes = fs::read_to_string(&absolute_path).map_err(|e| {
+            syn::Error::new_spanned(
+                input.path.clone(),
+                format!("Could not read {absolute_path}: {e}"),
+            )
+        })?;
+
+        let compress = input.compress;
+        let bytes = match compress {
+            CompressType::None => bytes.as_bytes().to_vec(),
+
+            #[cfg(feature = "embedded_lz4")]
+            CompressType::Lz4 => lz4_flex::compress_prepend_size(bytes.as_bytes()),
+        };
 
         Ok(quote! {
             #acc
 
             (
+                #compress,
                 #relative_path,
-                include_bytes!(#absolute_path).as_ref(),
+                &[#(#bytes),*] as &[u8],
             ),
         })
     }) {


### PR DESCRIPTION
This results in much smaller binaries when embedding javascript. The compression is hidden behind a flag and by default will not compress, so there is no breaking change.
