### PR TITLE
Refactor registers to use the stack

### DIFF
--- a/core/engine/src/builtins/eval/mod.rs
+++ b/core/engine/src/builtins/eval/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     realm::Realm,
     spanned_source_text::SourceText,
     string::StaticJsStrings,
-    vm::{CallFrame, CallFrameFlags, Constant, Registers},
+    vm::{CallFrame, CallFrameFlags, Constant},
     Context, JsArgs, JsResult, JsString, JsValue, SpannedSourceText,
 };
 use boa_ast::{
@@ -333,8 +333,7 @@ impl Eval {
 
         context.realm().resize_global_env();
 
-        let register_count = context.vm.frame().code_block().register_count;
-        let record = context.run(&mut Registers::new(register_count as usize));
+        let record = context.run();
         context.vm.pop_frame();
 
         record.consume()

--- a/core/engine/src/builtins/function/bound.rs
+++ b/core/engine/src/builtins/function/bound.rs
@@ -109,15 +109,19 @@ fn bound_function_exotic_call(
         .downcast_ref::<BoundFunction>()
         .expect("bound function exotic method should only be callable from bound function objects");
 
-    let arguments_start_index = context.vm.stack.len() - argument_count;
-
     // 1. Let target be F.[[BoundTargetFunction]].
     let target = bound_function.target_function();
-    context.vm.stack[arguments_start_index - 1] = target.clone().into();
+    context
+        .vm
+        .stack
+        .calling_convention_set_function(argument_count, target.clone().into());
 
     // 2. Let boundThis be F.[[BoundThis]].
     let bound_this = bound_function.this();
-    context.vm.stack[arguments_start_index - 2] = bound_this.clone();
+    context
+        .vm
+        .stack
+        .calling_convention_set_this(argument_count, bound_this.clone());
 
     // 3. Let boundArgs be F.[[BoundArguments]].
     let bound_args = bound_function.args();
@@ -125,7 +129,8 @@ fn bound_function_exotic_call(
     // 4. Let args be the list-concatenation of boundArgs and argumentsList.
     context
         .vm
-        .insert_values_at(bound_args, arguments_start_index);
+        .stack
+        .calling_convention_insert_arguments(argument_count, bound_args);
 
     // 5. Return ? Call(target, boundThis, args).
     Ok(target.__call__(bound_args.len() + argument_count))
@@ -143,7 +148,7 @@ fn bound_function_exotic_construct(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
-    let new_target = context.vm.pop();
+    let new_target = context.vm.stack.pop();
 
     debug_assert!(new_target.is_object(), "new.target should be an object");
 
@@ -160,10 +165,10 @@ fn bound_function_exotic_construct(
     let bound_args = bound_function.args();
 
     // 4. Let args be the list-concatenation of boundArgs and argumentsList.
-    let arguments_start_index = context.vm.stack.len() - argument_count;
     context
         .vm
-        .insert_values_at(bound_args, arguments_start_index);
+        .stack
+        .calling_convention_insert_arguments(argument_count, bound_args);
 
     // 5. If SameValue(F, newTarget) is true, set newTarget to target.
     let function_object: JsValue = function_object.clone().into();
@@ -174,6 +179,6 @@ fn bound_function_exotic_construct(
     };
 
     // 6. Return ? Construct(target, args, newTarget).
-    context.vm.push(new_target);
+    context.vm.stack.push(new_target);
     Ok(target.__construct__(bound_args.len() + argument_count))
 }

--- a/core/engine/src/builtins/generator/mod.rs
+++ b/core/engine/src/builtins/generator/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     string::StaticJsStrings,
     symbol::JsSymbol,
     value::JsValue,
-    vm::{CallFrame, CallFrameFlags, CompletionRecord, GeneratorResumeKind, Registers},
+    vm::{CallFrame, CallFrameFlags, CompletionRecord, GeneratorResumeKind, Stack},
     Context, JsArgs, JsData, JsError, JsResult, JsString,
 };
 use boa_gc::{custom_trace, Finalize, Trace};
@@ -59,23 +59,17 @@ unsafe impl Trace for GeneratorState {
 /// context/vm before the generator execution starts/resumes and after it has ended/yielded.
 #[derive(Debug, Trace, Finalize)]
 pub(crate) struct GeneratorContext {
-    pub(crate) stack: Vec<JsValue>,
+    pub(crate) stack: Stack,
     pub(crate) call_frame: Option<CallFrame>,
-    registers: Registers,
 }
 
 impl GeneratorContext {
     /// Creates a new `GeneratorContext` from the current `Context` state.
-    pub(crate) fn from_current(
-        context: &mut Context,
-        mut registers: Registers,
-        async_generator: Option<JsObject>,
-    ) -> Self {
+    pub(crate) fn from_current(context: &mut Context, async_generator: Option<JsObject>) -> Self {
         let mut frame = context.vm.frame().clone();
         frame.environments = context.vm.environments.clone();
         frame.realm = context.realm().clone();
-        let fp = frame.fp() as usize;
-        let stack = context.vm.stack.split_off(fp);
+        let mut stack = context.vm.stack.split_off_frame(&frame);
 
         frame.rp = CallFrame::FUNCTION_PROLOGUE + frame.argument_count;
 
@@ -84,16 +78,12 @@ impl GeneratorContext {
         frame.flags |= CallFrameFlags::REGISTERS_ALREADY_PUSHED;
 
         if let Some(async_generator) = async_generator {
-            registers.set(
-                CallFrame::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX,
-                async_generator.into(),
-            );
+            stack.set_async_generator_object(&frame, async_generator);
         }
 
         Self {
             call_frame: Some(frame),
             stack,
-            registers,
         }
     }
 
@@ -114,11 +104,11 @@ impl GeneratorContext {
         frame.set_exit_early(true);
 
         if let Some(value) = value {
-            context.vm.push(value);
+            context.vm.stack.push(value);
         }
-        context.vm.push(resume_kind);
+        context.vm.stack.push(resume_kind);
 
-        let result = context.run(&mut self.registers);
+        let result = context.run();
 
         std::mem::swap(&mut context.vm.stack, &mut self.stack);
         self.call_frame = context.vm.pop_frame();
@@ -128,9 +118,10 @@ impl GeneratorContext {
 
     /// Returns the async generator object, if the function that this [`GeneratorContext`] is from an async generator, [`None`] otherwise.
     pub(crate) fn async_generator_object(&self) -> Option<JsObject> {
-        self.call_frame
-            .as_ref()
-            .and_then(|frame| frame.async_generator_object(&self.registers))
+        if let Some(frame) = &self.call_frame {
+            return self.stack.async_generator_object(frame);
+        }
+        None
     }
 }
 

--- a/core/engine/src/builtins/intl/number_format/mod.rs
+++ b/core/engine/src/builtins/intl/number_format/mod.rs
@@ -410,7 +410,7 @@ impl BuiltInConstructor for NumberFormat {
         // ChainNumberFormat ( numberFormat, newTarget, this )
         // <https://tc39.es/ecma402/#sec-chainnumberformat>
 
-        let this = context.vm.frame().this(&context.vm);
+        let this = context.vm.stack.get_this(context.vm.frame());
         let Some(this_obj) = this.as_object() else {
             return Ok(number_format.into());
         };

--- a/core/engine/src/builtins/json/mod.rs
+++ b/core/engine/src/builtins/json/mod.rs
@@ -31,7 +31,7 @@ use crate::{
     string::{CodePoint, StaticJsStrings},
     symbol::JsSymbol,
     value::IntegerOrInfinity,
-    vm::{CallFrame, CallFrameFlags, Registers},
+    vm::{CallFrame, CallFrameFlags},
     Context, JsArgs, JsBigInt, JsResult, JsString, JsValue, SpannedSourceText,
 };
 use boa_gc::Gc;
@@ -147,8 +147,7 @@ impl Json {
         );
 
         context.realm().resize_global_env();
-        let register_count = context.vm.frame().code_block().register_count;
-        let record = context.run(&mut Registers::new(register_count as usize));
+        let record = context.run();
         context.vm.pop_frame();
 
         let unfiltered = record.consume()?;

--- a/core/engine/src/builtins/proxy/mod.rs
+++ b/core/engine/src/builtins/proxy/mod.rs
@@ -1165,21 +1165,24 @@ fn proxy_exotic_call(
         return Ok(target.__call__(argument_count));
     };
 
-    let args = context.vm.pop_n_values(argument_count);
+    let args = context
+        .vm
+        .stack
+        .calling_convention_pop_arguments(argument_count);
 
     // 7. Let argArray be ! CreateArrayFromList(argumentsList).
     let arg_array = array::Array::create_array_from_list(args, context);
 
     // 8. Return ? Call(trap, handler, « target, thisArgument, argArray »).
-    let _func = context.vm.pop();
-    let this = context.vm.pop();
+    let _func = context.vm.stack.pop();
+    let this = context.vm.stack.pop();
 
-    context.vm.push(handler); // This
-    context.vm.push(trap.clone()); // Function
+    context.vm.stack.push(handler); // This
+    context.vm.stack.push(trap.clone()); // Function
 
-    context.vm.push(target);
-    context.vm.push(this);
-    context.vm.push(arg_array);
+    context.vm.stack.push(target);
+    context.vm.stack.push(this);
+    context.vm.stack.push(arg_array);
     Ok(trap.__call__(3))
 }
 
@@ -1213,9 +1216,13 @@ fn proxy_exotic_construct(
         return Ok(target.__construct__(argument_count));
     };
 
-    let new_target = context.vm.pop();
-    let args = context.vm.pop_n_values(argument_count);
-    let _func = context.vm.pop();
+    let new_target = context.vm.stack.pop();
+    let args = context
+        .vm
+        .stack
+        .calling_convention_pop_arguments(argument_count);
+    let _func = context.vm.stack.pop();
+    let _this = context.vm.stack.pop();
 
     // 8. Let argArray be ! CreateArrayFromList(argumentsList).
     let arg_array = array::Array::create_array_from_list(args, context);
@@ -1233,6 +1240,6 @@ fn proxy_exotic_construct(
     })?;
 
     // 11. Return newObj.
-    context.vm.push(new_obj);
+    context.vm.stack.push(new_obj);
     Ok(CallValue::Complete)
 }

--- a/core/engine/src/bytecompiler/expression/mod.rs
+++ b/core/engine/src/bytecompiler/expression/mod.rs
@@ -351,9 +351,13 @@ impl ByteCompiler<'_> {
                 self.compile_class(class.deref().into(), Some(dst));
             }
             Expression::SuperCall(super_call) => {
+                let this = self.register_allocator.alloc();
                 let value = self.register_allocator.alloc();
                 self.bytecode.emit_super_call_prepare(value.variable());
+                self.bytecode.emit_push_undefined(this.variable());
+                self.push_from_register(&this);
                 self.push_from_register(&value);
+                self.register_allocator.dealloc(this);
                 self.register_allocator.dealloc(value);
 
                 let contains_spread = super_call

--- a/core/engine/src/bytecompiler/mod.rs
+++ b/core/engine/src/bytecompiler/mod.rs
@@ -511,22 +511,22 @@ impl<'ctx> ByteCompiler<'ctx> {
 
             debug_assert_eq!(
                 promise_register.index(),
-                CallFrame::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX
+                CallFrame::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX as u32
             );
             debug_assert_eq!(
                 resolve_register.index(),
-                CallFrame::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX
+                CallFrame::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX as u32
             );
             debug_assert_eq!(
                 reject_register.index(),
-                CallFrame::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX
+                CallFrame::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX as u32
             );
 
             if is_generator {
                 let async_function_object_register = register_allocator.alloc_persistent();
                 debug_assert_eq!(
                     async_function_object_register.index(),
-                    CallFrame::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX
+                    CallFrame::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX as u32
                 );
             }
         }
@@ -1833,7 +1833,6 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.register_allocator.dealloc(this);
                 self.register_allocator.dealloc(dst);
             }
-
             Expression::Optional(opt) if kind == CallKind::Call => {
                 let this = self.register_allocator.alloc();
                 let dst = self.register_allocator.alloc();
@@ -1883,9 +1882,13 @@ impl<'ctx> ByteCompiler<'ctx> {
                 self.register_allocator.dealloc(value);
             }
             expr => {
+                let this = self.register_allocator.alloc();
                 let value = self.register_allocator.alloc();
                 self.compile_expr(expr, &value);
+                self.bytecode.emit_push_undefined(this.variable());
+                self.push_from_register(&this);
                 self.push_from_register(&value);
+                self.register_allocator.dealloc(this);
                 self.register_allocator.dealloc(value);
             }
         }

--- a/core/engine/src/context/mod.rs
+++ b/core/engine/src/context/mod.rs
@@ -880,7 +880,7 @@ impl Context {
             return self.vm.native_active_function.clone();
         }
 
-        self.vm.frame.function(&self.vm)
+        self.vm.stack.get_function(self.vm.frame())
     }
 }
 

--- a/core/engine/src/module/source.rs
+++ b/core/engine/src/module/source.rs
@@ -27,7 +27,7 @@ use crate::{
     realm::Realm,
     vm::{
         create_function_object_fast, ActiveRunnable, CallFrame, CallFrameFlags, CodeBlock,
-        CompletionRecord, Registers,
+        CompletionRecord,
     },
     Context, JsArgs, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue, NativeFunction,
     SpannedSourceText,
@@ -1752,13 +1752,10 @@ impl SourceTextModule {
             .vm
             .push_frame_with_stack(callframe, JsValue::undefined(), JsValue::null());
 
-        let register_count = context.vm.frame().code_block().register_count;
-        let registers = &mut Registers::new(register_count as usize);
-
         context
             .vm
-            .frame
-            .set_promise_capability(registers, capability);
+            .stack
+            .set_promise_capability(&context.vm.frame, capability);
 
         // 9. If module.[[HasTLA]] is false, then
         //    a. Assert: capability is not present.
@@ -1769,7 +1766,7 @@ impl SourceTextModule {
         // 10. Else,
         //    a. Assert: capability is a PromiseCapability Record.
         //    b. Perform AsyncBlockStart(capability, module.[[ECMAScriptCode]], moduleContext).
-        let result = context.run(registers);
+        let result = context.run();
 
         context.vm.pop_frame();
 

--- a/core/engine/src/module/synthetic.rs
+++ b/core/engine/src/module/synthetic.rs
@@ -394,7 +394,7 @@ impl SyntheticModule {
         // 11. Suspend moduleContext and remove it from the execution context stack.
         // 12. Resume the context that is now on the top of the execution context stack as the running execution context.
         let frame = context.vm.pop_frame().expect("there should be a frame");
-        frame.restore_stack(&mut context.vm);
+        context.vm.stack.truncate_to_frame(&frame);
 
         // 13. Let pc be ! NewPromiseCapability(%Promise%).
         let (promise, ResolvingFunctions { resolve, reject }) = JsPromise::new_pending(context);

--- a/core/engine/src/native_function/mod.rs
+++ b/core/engine/src/native_function/mod.rs
@@ -410,9 +410,12 @@ pub(crate) fn native_function_call(
     argument_count: usize,
     context: &mut Context,
 ) -> JsResult<CallValue> {
-    let args = context.vm.pop_n_values(argument_count);
-    let _func = context.vm.pop();
-    let this = context.vm.pop();
+    let args = context
+        .vm
+        .stack
+        .calling_convention_pop_arguments(argument_count);
+    let _func = context.vm.stack.pop();
+    let this = context.vm.stack.pop();
 
     // We technically don't need this since native functions don't push any new frames to the
     // vm, but we'll eventually have to combine the native stack with the vm stack.
@@ -443,7 +446,7 @@ pub(crate) fn native_function_call(
     context.vm.native_active_function = None;
     context.swap_realm(&mut realm);
 
-    context.vm.push(result?);
+    context.vm.stack.push(result?);
 
     Ok(CallValue::Complete)
 }
@@ -478,9 +481,13 @@ fn native_function_construct(
     context.swap_realm(&mut realm);
     context.vm.native_active_function = Some(this_function_object);
 
-    let new_target = context.vm.pop();
-    let args = context.vm.pop_n_values(argument_count);
-    let _func = context.vm.pop();
+    let new_target = context.vm.stack.pop();
+    let args = context
+        .vm
+        .stack
+        .calling_convention_pop_arguments(argument_count);
+    let _func = context.vm.stack.pop();
+    let _this = context.vm.stack.pop();
 
     let result = function
         .call(&new_target, &args, context)
@@ -510,7 +517,7 @@ fn native_function_construct(
     context.vm.native_active_function = None;
     context.swap_realm(&mut realm);
 
-    context.vm.push(result?);
+    context.vm.stack.push(result?);
 
     Ok(CallValue::Complete)
 }

--- a/core/engine/src/object/builtins/jspromise.rs
+++ b/core/engine/src/object/builtins/jspromise.rs
@@ -1165,13 +1165,12 @@ impl JsPromise {
             builtins::{async_generator::AsyncGenerator, generator::GeneratorContext},
             js_string,
             object::FunctionObjectBuilder,
-            vm::Registers,
         };
         use std::cell::Cell;
 
         // Clone the stack since we split it.
         let stack = context.vm.stack.clone();
-        let gen_ctx = GeneratorContext::from_current(context, Registers::new(0), None);
+        let gen_ctx = GeneratorContext::from_current(context, None);
         context.vm.stack = stack;
 
         // 3. Let fulfilledClosure be a new Abstract Closure with parameters (value) that captures asyncContext and performs the following steps when called:
@@ -1225,7 +1224,9 @@ impl JsPromise {
         .length(1)
         .build();
 
-        let gen_ctx = GeneratorContext::from_current(context, Registers::new(0), None);
+        let stack = context.vm.stack.clone();
+        let gen_ctx = GeneratorContext::from_current(context, None);
+        context.vm.stack = stack;
 
         // 5. Let rejectedClosure be a new Abstract Closure with parameters (reason) that captures asyncContext and performs the following steps when called:
         // 6. Let onRejected be CreateBuiltinFunction(rejectedClosure, 1, "", « »).

--- a/core/engine/src/object/internal_methods/mod.rs
+++ b/core/engine/src/object/internal_methods/mod.rs
@@ -397,7 +397,7 @@ pub(crate) enum CallValue {
     /// Calling is ready, the frames have been setup.
     ///
     /// Requires calling [`Context::run()`].
-    Ready { register_count: usize },
+    Ready,
 
     /// Further processing is needed.
     Pending {
@@ -412,7 +412,7 @@ pub(crate) enum CallValue {
 
 impl CallValue {
     /// Resolves the [`CallValue`], and return if the value is complete.
-    pub(crate) fn resolve(mut self, context: &mut Context) -> JsResult<Option<usize>> {
+    pub(crate) fn resolve(mut self, context: &mut Context) -> JsResult<bool> {
         while let Self::Pending {
             func,
             object,
@@ -423,8 +423,8 @@ impl CallValue {
         }
 
         match self {
-            Self::Ready { register_count } => Ok(Some(register_count)),
-            Self::Complete => Ok(None),
+            Self::Ready => Ok(false),
+            Self::Complete => Ok(true),
             Self::Pending { .. } => unreachable!(),
         }
     }

--- a/core/engine/src/object/operations.rs
+++ b/core/engine/src/object/operations.rs
@@ -13,7 +13,6 @@ use crate::{
     realm::Realm,
     string::StaticJsStrings,
     value::Type,
-    vm::Registers,
     Context, JsResult, JsSymbol, JsValue,
 };
 
@@ -399,16 +398,16 @@ impl JsObject {
         // NOTE(HalidOdat): For object's that are not callable we implement a special __call__ internal method
         //                  that throws on call.
 
-        context.vm.push(this.clone()); // this
-        context.vm.push(self.clone()); // func
+        context.vm.stack.push(this.clone()); // this
+        context.vm.stack.push(self.clone()); // func
         let argument_count = args.len();
-        context.vm.push_values(args);
+        context.vm.stack.calling_convention_push_arguments(args);
 
         // 3. Return ? F.[[Call]](V, argumentsList).
         let frame_index = context.vm.frames.len();
-        let Some(register_count) = self.__call__(argument_count).resolve(context)? else {
-            return Ok(context.vm.pop());
-        };
+        if self.__call__(argument_count).resolve(context)? {
+            return Ok(context.vm.stack.pop());
+        }
 
         if frame_index + 1 == context.vm.frames.len() {
             context.vm.frame.set_exit_early(true);
@@ -416,7 +415,7 @@ impl JsObject {
             context.vm.frames[frame_index + 1].set_exit_early(true);
         }
 
-        let result = context.run(&mut Registers::new(register_count)).consume();
+        let result = context.run().consume();
 
         context.vm.pop_frame().expect("frame must exist");
 
@@ -446,22 +445,23 @@ impl JsObject {
         // 1. If newTarget is not present, set newTarget to F.
         let new_target = new_target.unwrap_or(self);
 
-        context.vm.push(self.clone()); // func
+        context.vm.stack.push(JsValue::undefined());
+        context.vm.stack.push(self.clone()); // func
         let argument_count = args.len();
-        context.vm.push_values(args);
-        context.vm.push(new_target.clone());
+        context.vm.stack.calling_convention_push_arguments(args);
+        context.vm.stack.push(new_target.clone());
 
         // 2. If argumentsList is not present, set argumentsList to a new empty List.
         // 3. Return ? F.[[Construct]](argumentsList, newTarget).
         let frame_index = context.vm.frames.len();
 
-        let Some(register_count) = self.__construct__(argument_count).resolve(context)? else {
-            let result = context.vm.pop();
+        if self.__construct__(argument_count).resolve(context)? {
+            let result = context.vm.stack.pop();
             return Ok(result
                 .as_object()
                 .expect("construct value should be an object")
                 .clone());
-        };
+        }
 
         if frame_index + 1 == context.vm.frames.len() {
             context.vm.frame.set_exit_early(true);
@@ -469,7 +469,7 @@ impl JsObject {
             context.vm.frames[frame_index + 1].set_exit_early(true);
         }
 
-        let result = context.run(&mut Registers::new(register_count)).consume();
+        let result = context.run().consume();
 
         context.vm.pop_frame().expect("frame must exist");
 

--- a/core/engine/src/script.rs
+++ b/core/engine/src/script.rs
@@ -21,7 +21,7 @@ use crate::{
     js_string,
     realm::Realm,
     spanned_source_text::SourceText,
-    vm::{ActiveRunnable, CallFrame, CallFrameFlags, CodeBlock, Registers},
+    vm::{ActiveRunnable, CallFrame, CallFrameFlags, CodeBlock},
     Context, HostDefined, JsResult, JsString, JsValue, Module, SpannedSourceText,
 };
 
@@ -174,8 +174,7 @@ impl Script {
         let _timer = Profiler::global().start_event("Execution", "Main");
 
         self.prepare_run(context)?;
-        let register_count = self.codeblock(context)?.register_count;
-        let record = context.run(&mut Registers::new(register_count as usize));
+        let record = context.run();
 
         context.vm.pop_frame();
         context.clear_kept_objects();
@@ -211,10 +210,7 @@ impl Script {
 
         self.prepare_run(context)?;
 
-        let register_count = self.codeblock(context)?.register_count;
-        let record = context
-            .run_async_with_budget(budget, &mut Registers::new(register_count as usize))
-            .await;
+        let record = context.run_async_with_budget(budget).await;
 
         context.vm.pop_frame();
         context.clear_kept_objects();

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -3,21 +3,14 @@
 //! This module will provides everything needed to implement the `CallFrame`
 
 use crate::{
-    builtins::{
-        iterable::IteratorRecord,
-        promise::{PromiseCapability, ResolvingFunctions},
-    },
-    environments::EnvironmentStack,
-    object::{JsFunction, JsObject},
-    realm::Realm,
-    vm::CodeBlock,
-    JsValue,
+    builtins::iterable::IteratorRecord, environments::EnvironmentStack, realm::Realm,
+    vm::CodeBlock, JsValue,
 };
 use boa_ast::scope::BindingLocator;
 use boa_gc::{Finalize, Gc, Trace};
 use thin_vec::ThinVec;
 
-use super::{ActiveRunnable, Registers, Vm};
+use super::ActiveRunnable;
 
 bitflags::bitflags! {
     /// Flags associated with a [`CallFrame`].
@@ -93,59 +86,13 @@ impl CallFrame {
 
 /// ---- `CallFrame` creation methods ----
 impl CallFrame {
-    /// This is the size of the function prologue.
-    ///
-    /// The position of the elements are relative to the [`CallFrame::fp`] (register pointer).
-    ///
-    /// ```text
-    ///                      Setup by the caller
-    ///   ┌─────────────────────────────────────────────────────────┐ ┌───── register pointer
-    ///   ▼                                                         ▼ ▼
-    /// | -(2 + N): this | -(1 + N): func | -N: arg1 | ... | -1: argN | 0: local1 | ... | K: localK |
-    ///   ▲                              ▲   ▲                      ▲   ▲                         ▲
-    ///   └──────────────────────────────┘   └──────────────────────┘   └─────────────────────────┘
-    ///         function prologue                    arguments              Setup by the callee
-    ///   ▲
-    ///   └─ Frame pointer
-    /// ```
-    ///
-    /// ### Example
-    ///
-    /// The following function calls, generate the following stack:
-    ///
-    /// ```JavaScript
-    /// function x(a) {
-    /// }
-    /// function y(b, c) {
-    ///     return x(b + c)
-    /// }
-    ///
-    /// y(1, 2)
-    /// ```
-    ///
-    /// ```text
-    ///     caller prologue    caller arguments   callee prologue   callee arguments
-    ///   ┌─────────────────┐   ┌─────────┐   ┌─────────────────┐  ┌──────┐
-    ///   ▼                 ▼   ▼         ▼   │                 ▼  ▼      ▼
-    /// | 0: undefined | 1: y | 2: 1 | 3: 2 | 4: undefined | 5: x | 6:  3 |
-    /// ▲                                   ▲                             ▲
-    /// │       caller register pointer ────┤                             │
-    /// │                                   │                 callee register pointer
-    /// │                             callee frame pointer
-    /// │
-    /// └─────  caller frame pointer
-    /// ```
-    ///
-    /// Some questions:
-    ///
-    /// - Who is responsible for cleaning up the stack after a call? The rust caller.
     pub(crate) const FUNCTION_PROLOGUE: u32 = 2;
-    pub(crate) const THIS_POSITION: u32 = 2;
-    pub(crate) const FUNCTION_POSITION: u32 = 1;
-    pub(crate) const PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX: u32 = 0;
-    pub(crate) const PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX: u32 = 1;
-    pub(crate) const PROMISE_CAPABILITY_REJECT_REGISTER_INDEX: u32 = 2;
-    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: u32 = 3;
+    const THIS_POSITION: usize = 2;
+    const FUNCTION_POSITION: usize = 1;
+    pub(crate) const PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX: usize = 0;
+    pub(crate) const PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX: usize = 1;
+    pub(crate) const PROMISE_CAPABILITY_REJECT_REGISTER_INDEX: usize = 2;
+    pub(crate) const ASYNC_GENERATOR_OBJECT_REGISTER_INDEX: usize = 3;
 
     /// Creates a new `CallFrame` with the provided `CodeBlock`.
     pub(crate) fn new(
@@ -189,129 +136,67 @@ impl CallFrame {
         self
     }
 
-    pub(crate) fn this(&self, vm: &Vm) -> JsValue {
-        let this_index = self.rp - self.argument_count - Self::THIS_POSITION;
-        vm.stack[this_index as usize].clone()
+    /// Returns the index of `this` in the stack.
+    pub(crate) fn this_index(&self) -> usize {
+        self.rp as usize - self.argument_count as usize - Self::THIS_POSITION
     }
 
-    pub(crate) fn function(&self, vm: &Vm) -> Option<JsObject> {
-        let function_index = self.rp - self.argument_count - Self::FUNCTION_POSITION;
-        if let Some(object) = vm.stack[function_index as usize].as_object() {
-            return Some(object.clone());
-        }
-
-        None
+    /// Returns the index of the function in the stack.
+    pub(crate) fn function_index(&self) -> usize {
+        self.rp as usize - self.argument_count as usize - Self::FUNCTION_POSITION
     }
 
-    pub(crate) fn arguments<'stack>(&self, vm: &'stack Vm) -> &'stack [JsValue] {
-        let rp = self.rp as usize;
-        let argument_count = self.argument_count as usize;
-        let arguments_start = rp - argument_count;
-        &vm.stack[arguments_start..rp]
+    /// Returns the index of the promise capability promise register in the stack.
+    pub(crate) fn promise_capability_promise_register_index(&self) -> usize {
+        self.rp as usize + Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX
     }
 
-    pub(crate) fn argument<'stack>(&self, index: usize, vm: &'stack Vm) -> Option<&'stack JsValue> {
-        self.arguments(vm).get(index)
+    /// Returns the index of the promise capability resolve register in the stack.
+    pub(crate) fn promise_capability_resolve_register_index(&self) -> usize {
+        self.rp as usize + Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX
     }
 
-    pub(crate) fn fp(&self) -> u32 {
-        self.rp - self.argument_count - Self::FUNCTION_PROLOGUE
+    /// Returns the index of the promise capability reject register in the stack.
+    pub(crate) fn promise_capability_reject_register_index(&self) -> usize {
+        self.rp as usize + Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX
     }
 
-    pub(crate) fn restore_stack(&self, vm: &mut Vm) {
-        let fp = self.fp();
-        vm.stack.truncate(fp as usize);
+    /// Returns the index of the async generator object register in the stack.
+    pub(crate) fn async_generator_object_register_index(&self) -> usize {
+        self.rp as usize + Self::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX
     }
 
-    /// Returns the async generator object, if the function that this [`CallFrame`] is from an async generator, [`None`] otherwise.
-    pub(crate) fn async_generator_object(&self, registers: &Registers) -> Option<JsObject> {
-        if !self.code_block().is_async_generator() {
-            return None;
-        }
-
-        registers
-            .get(Self::ASYNC_GENERATOR_OBJECT_REGISTER_INDEX)
-            .as_object()
-            .cloned()
+    /// Returns the range of the arguments in the stack.
+    pub(crate) fn arguments_range(&self) -> std::ops::Range<usize> {
+        (self.rp as usize - self.argument_count as usize)..self.rp as usize
     }
 
-    #[track_caller]
-    pub(crate) fn promise_capability(&self, registers: &Registers) -> Option<PromiseCapability> {
-        if !self.code_block().is_async() {
-            return None;
-        }
-
-        let promise = registers
-            .get(Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX)
-            .as_object()
-            .cloned()?;
-        let resolve = registers
-            .get(Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX)
-            .as_object()
-            .cloned()
-            .and_then(JsFunction::from_object)?;
-        let reject = registers
-            .get(Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX)
-            .as_object()
-            .cloned()
-            .and_then(JsFunction::from_object)?;
-
-        Some(PromiseCapability {
-            promise,
-            functions: ResolvingFunctions { resolve, reject },
-        })
-    }
-
-    pub(crate) fn set_promise_capability(
-        &self,
-        registers: &mut Registers,
-        promise_capability: Option<&PromiseCapability>,
-    ) {
-        debug_assert!(
-            self.code_block().is_async(),
-            "Only async functions have a promise capability"
-        );
-
-        registers.set(
-            Self::PROMISE_CAPABILITY_PROMISE_REGISTER_INDEX,
-            promise_capability
-                .map(PromiseCapability::promise)
-                .cloned()
-                .map_or_else(JsValue::undefined, Into::into),
-        );
-        registers.set(
-            Self::PROMISE_CAPABILITY_RESOLVE_REGISTER_INDEX,
-            promise_capability
-                .map(PromiseCapability::resolve)
-                .cloned()
-                .map_or_else(JsValue::undefined, Into::into),
-        );
-        registers.set(
-            Self::PROMISE_CAPABILITY_REJECT_REGISTER_INDEX,
-            promise_capability
-                .map(PromiseCapability::reject)
-                .cloned()
-                .map_or_else(JsValue::undefined, Into::into),
-        );
+    /// Returns the frame pointer of this `CallFrame`.
+    pub(crate) fn frame_pointer(&self) -> usize {
+        (self.rp - self.argument_count - Self::FUNCTION_PROLOGUE) as usize
     }
 
     /// Does this have the [`CallFrameFlags::EXIT_EARLY`] flag.
     pub(crate) fn exit_early(&self) -> bool {
         self.flags.contains(CallFrameFlags::EXIT_EARLY)
     }
+
     /// Set the [`CallFrameFlags::EXIT_EARLY`] flag.
     pub(crate) fn set_exit_early(&mut self, early_exit: bool) {
         self.flags.set(CallFrameFlags::EXIT_EARLY, early_exit);
     }
+
     /// Does this have the [`CallFrameFlags::CONSTRUCT`] flag.
     pub(crate) fn construct(&self) -> bool {
         self.flags.contains(CallFrameFlags::CONSTRUCT)
     }
+
     /// Does this [`CallFrame`] need to push registers on [`Vm::push_frame()`].
     pub(crate) fn registers_already_pushed(&self) -> bool {
         self.flags
             .contains(CallFrameFlags::REGISTERS_ALREADY_PUSHED)
     }
+
     /// Does this [`CallFrame`] have a cached `this` value.
     ///
     /// The cached value is placed in the [`CallFrame::THIS_POSITION`] position.

--- a/core/engine/src/vm/call_frame/mod.rs
+++ b/core/engine/src/vm/call_frame/mod.rs
@@ -191,7 +191,7 @@ impl CallFrame {
         self.flags.contains(CallFrameFlags::CONSTRUCT)
     }
 
-    /// Does this [`CallFrame`] need to push registers on [`Vm::push_frame()`].
+    /// Does this [`CallFrame`] need to push registers on [`super::Vm::push_frame()`].
     pub(crate) fn registers_already_pushed(&self) -> bool {
         self.flags
             .contains(CallFrameFlags::REGISTERS_ALREADY_PUSHED)

--- a/core/engine/src/vm/completion_record.rs
+++ b/core/engine/src/vm/completion_record.rs
@@ -2,7 +2,6 @@
 
 #![allow(clippy::inline_always)]
 
-use super::Registers;
 use crate::{Context, JsError, JsResult, JsValue};
 use boa_gc::{custom_trace, Finalize, Trace};
 use std::ops::ControlFlow;
@@ -52,56 +51,36 @@ impl CompletionRecord {
 }
 
 pub(crate) trait IntoCompletionRecord {
-    fn into_completion_record(
-        self,
-        context: &mut Context,
-        registers: &mut Registers,
-    ) -> ControlFlow<CompletionRecord>;
+    fn into_completion_record(self, context: &mut Context) -> ControlFlow<CompletionRecord>;
 }
 
 impl IntoCompletionRecord for () {
     #[inline(always)]
-    fn into_completion_record(
-        self,
-        _: &mut Context,
-        _: &mut Registers,
-    ) -> ControlFlow<CompletionRecord> {
+    fn into_completion_record(self, _: &mut Context) -> ControlFlow<CompletionRecord> {
         ControlFlow::Continue(())
     }
 }
 
 impl IntoCompletionRecord for JsError {
     #[inline(always)]
-    fn into_completion_record(
-        self,
-        context: &mut Context,
-        registers: &mut Registers,
-    ) -> ControlFlow<CompletionRecord> {
-        context.handle_error(registers, self)
+    fn into_completion_record(self, context: &mut Context) -> ControlFlow<CompletionRecord> {
+        context.handle_error(self)
     }
 }
 
 impl IntoCompletionRecord for JsResult<()> {
     #[inline(always)]
-    fn into_completion_record(
-        self,
-        context: &mut Context,
-        registers: &mut Registers,
-    ) -> ControlFlow<CompletionRecord> {
+    fn into_completion_record(self, context: &mut Context) -> ControlFlow<CompletionRecord> {
         match self {
             Ok(()) => ControlFlow::Continue(()),
-            Err(err) => context.handle_error(registers, err),
+            Err(err) => context.handle_error(err),
         }
     }
 }
 
 impl IntoCompletionRecord for ControlFlow<CompletionRecord> {
     #[inline(always)]
-    fn into_completion_record(
-        self,
-        _: &mut Context,
-        _: &mut Registers,
-    ) -> ControlFlow<CompletionRecord> {
+    fn into_completion_record(self, _: &mut Context) -> ControlFlow<CompletionRecord> {
         self
     }
 }

--- a/core/engine/src/vm/mod.rs
+++ b/core/engine/src/vm/mod.rs
@@ -5,8 +5,12 @@
 //! plus an interpreter to execute those instructions
 
 use crate::{
-    environments::EnvironmentStack, realm::Realm, script::Script, Context, JsError, JsNativeError,
-    JsObject, JsResult, JsString, JsValue, Module,
+    builtins::promise::{PromiseCapability, ResolvingFunctions},
+    environments::EnvironmentStack,
+    object::JsFunction,
+    realm::Realm,
+    script::Script,
+    Context, JsError, JsNativeError, JsObject, JsResult, JsString, JsValue, Module,
 };
 use boa_gc::{custom_trace, Finalize, Gc, Trace};
 use boa_profiler::Profiler;
@@ -65,7 +69,7 @@ pub struct Vm {
     /// The stack for call frames.
     pub(crate) frames: Vec<CallFrame>,
 
-    pub(crate) stack: Vec<JsValue>,
+    pub(crate) stack: Stack,
     pub(crate) return_value: JsValue,
 
     /// When an error is thrown, the pending exception is set.
@@ -89,6 +93,303 @@ pub struct Vm {
 
     #[cfg(feature = "trace")]
     pub(crate) trace: bool,
+}
+
+/// The stack holds the [`JsValue`]s that the VM is operationg on.
+///
+/// The stack is persistent across frames.
+/// It's addressing is relative to the frame pointer.
+///
+/// The stack stores the following elements:
+/// - The function prologue
+///   - The `this` value of the function
+///   - The function object itself
+/// - The arguments of the function
+/// - The local function registers
+/// - Some manually pushed values like the return value of a function.
+///
+/// This is the stack layout:
+///
+/// ```text
+///                      Setup by the caller
+///   ┌─────────────────────────────────────────────────────────┐ ┌───── register pointer
+///   ▼                                                         ▼ ▼
+/// | -(2 + N): this | -(1 + N): func | -N: arg1 | ... | -1: argN | 0: reg1 | ... | K: reglK |
+///   ▲                              ▲   ▲                      ▲   ▲                        ▲
+///   └──────────────────────────────┘   └──────────────────────┘   └────────────────────────┘
+///         function prologue                    arguments              Setup by the callee
+///   ▲
+///   └─ Frame pointer
+/// ```
+///
+/// ### Example
+///
+/// The following function calls, generate the following stack:
+///
+/// ```JavaScript
+/// function x(a) {
+/// }
+/// function y(b, c) {
+///     return x(b + c)
+/// }
+///
+/// y(1, 2)
+/// ```
+///
+/// ```text
+///     caller prologue    caller arguments   callee prologue   callee arguments
+///   ┌─────────────────┐   ┌─────────┐   ┌─────────────────┐  ┌──────┐
+///   ▼                 ▼   ▼         ▼   │                 ▼  ▼      ▼
+/// | 0: undefined | 1: y | 2: 1 | 3: 2 | 4: undefined | 5: x | 6:  3 |
+/// ▲                                   ▲                             ▲
+/// │       caller register pointer ────┤                             │
+/// │                                   │                 callee register pointer
+/// │                             callee frame pointer
+/// │
+/// └─────  caller frame pointer
+/// ```
+#[derive(Clone, Debug, Trace, Finalize)]
+pub(crate) struct Stack {
+    stack: Vec<JsValue>,
+}
+
+impl Stack {
+    /// Creates a new stack with the given capacity.
+    fn new(capacity: usize) -> Self {
+        Self {
+            stack: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Truncate the stack to the given frame.
+    pub(crate) fn truncate_to_frame(&mut self, frame: &CallFrame) {
+        self.stack.truncate(frame.frame_pointer());
+    }
+
+    /// Split the stack at the given frame.
+    pub(crate) fn split_off_frame(&mut self, frame: &CallFrame) -> Self {
+        let frame_pointer = frame.frame_pointer();
+        Self {
+            stack: self.stack.split_off(frame_pointer),
+        }
+    }
+
+    /// Get the `this` value of the given frame.
+    pub(crate) fn get_this(&self, frame: &CallFrame) -> JsValue {
+        self.stack[frame.this_index()].clone()
+    }
+
+    /// Set the `this` value of the given frame.
+    pub(crate) fn set_this(&mut self, frame: &CallFrame, this: JsValue) {
+        self.stack[frame.this_index()] = this;
+    }
+
+    /// Get the function object of the given frame.
+    pub(crate) fn get_function(&self, frame: &CallFrame) -> Option<JsObject> {
+        if let Some(object) = self.stack[frame.function_index()].as_object() {
+            return Some(object.clone());
+        }
+        None
+    }
+
+    /// Get the function arguments of the given frame.
+    pub(crate) fn get_arguments(&self, frame: &CallFrame) -> &[JsValue] {
+        &self.stack[frame.arguments_range()]
+    }
+
+    /// Get a single function argument of the given frame by index.
+    pub(crate) fn get_argument(&self, frame: &CallFrame, index: usize) -> Option<&JsValue> {
+        self.get_arguments(frame).get(index)
+    }
+
+    /// Get the rest arguments of the given frame.
+    pub(crate) fn pop_rest_arguments(&mut self, frame: &CallFrame) -> Option<Vec<JsValue>> {
+        let argument_count = frame.argument_count as usize;
+        let param_count = frame.code_block().parameter_length as usize;
+        if argument_count < param_count {
+            return None;
+        }
+        let rp = frame.rp as usize;
+        let rest_count = argument_count - param_count + 1;
+
+        Some(self.stack.drain((rp - rest_count)..rp).collect())
+    }
+
+    /// Set the promise capability for the given frame.
+    #[track_caller]
+    pub(crate) fn set_promise_capability(
+        &mut self,
+        frame: &CallFrame,
+        promise_capability: Option<&PromiseCapability>,
+    ) {
+        debug_assert!(
+            frame.code_block().is_async(),
+            "Only async functions have a promise capability"
+        );
+
+        self.stack[frame.promise_capability_promise_register_index()] = promise_capability
+            .map(PromiseCapability::promise)
+            .cloned()
+            .map_or_else(JsValue::undefined, Into::into);
+        self.stack[frame.promise_capability_resolve_register_index()] = promise_capability
+            .map(PromiseCapability::resolve)
+            .cloned()
+            .map_or_else(JsValue::undefined, Into::into);
+        self.stack[frame.promise_capability_reject_register_index()] = promise_capability
+            .map(PromiseCapability::reject)
+            .cloned()
+            .map_or_else(JsValue::undefined, Into::into);
+    }
+
+    /// Get the promise capability for the given frame.
+    #[track_caller]
+    pub(crate) fn get_promise_capability(&self, frame: &CallFrame) -> Option<PromiseCapability> {
+        if !frame.code_block().is_async() {
+            return None;
+        }
+
+        let promise = self
+            .stack
+            .get(frame.promise_capability_promise_register_index())
+            .expect("stack must have a promise capability")
+            .as_object()
+            .cloned()?;
+        let resolve = self
+            .stack
+            .get(frame.promise_capability_resolve_register_index())
+            .expect("stack must have a resolve function")
+            .as_object()
+            .cloned()
+            .and_then(JsFunction::from_object)?;
+        let reject = self
+            .stack
+            .get(frame.promise_capability_reject_register_index())
+            .expect("stack must have a reject function")
+            .as_object()
+            .cloned()
+            .and_then(JsFunction::from_object)?;
+
+        Some(PromiseCapability {
+            promise,
+            functions: ResolvingFunctions { resolve, reject },
+        })
+    }
+
+    /// Set the async generator object for the given frame.
+    #[track_caller]
+    pub(crate) fn set_async_generator_object(&mut self, frame: &CallFrame, object: JsObject) {
+        self.stack[frame.async_generator_object_register_index()] = object.into();
+    }
+
+    /// Get the async generator object for the given frame.
+    #[track_caller]
+    pub(crate) fn async_generator_object(&self, frame: &CallFrame) -> Option<JsObject> {
+        if !frame.code_block().is_async_generator() {
+            return None;
+        }
+
+        self.stack
+            .get(frame.async_generator_object_register_index())
+            .expect("stack must have an async generator object")
+            .as_object()
+            .cloned()
+    }
+
+    /// Push a value on the stack.
+    pub(crate) fn push<T>(&mut self, value: T)
+    where
+        T: Into<JsValue>,
+    {
+        self.stack.push(value.into());
+    }
+
+    /// Pop a value off the stack.
+    ///
+    /// # Panics
+    ///
+    /// If there is nothing to pop, then this will panic.
+    #[track_caller]
+    pub(crate) fn pop(&mut self) -> JsValue {
+        self.stack.pop().expect("stack was empty")
+    }
+
+    /// Pop the function arguments according to the calling convention.
+    /// This will pop the last `argument_count` values from the stack.
+    pub(crate) fn calling_convention_pop_arguments(
+        &mut self,
+        argument_count: usize,
+    ) -> Vec<JsValue> {
+        let index = self.stack.len() - argument_count;
+        self.stack.split_off(index)
+    }
+
+    /// Push the function arguments according to the calling convention.
+    /// This will push the given values onto the stack.
+    pub(crate) fn calling_convention_push_arguments(&mut self, values: &[JsValue]) {
+        self.stack.extend_from_slice(values);
+    }
+
+    /// Get the function object at the top of the stack according to the calling convention.
+    #[track_caller]
+    pub(crate) fn calling_convention_get_function(&self, argument_count: usize) -> &JsValue {
+        let index = self.stack.len() - 1 - argument_count;
+        self.stack
+            .get(index)
+            .expect("invalid calling convention function index")
+    }
+
+    /// Set the function object value at the top of the stack according to the calling convention.
+    #[track_caller]
+    pub(crate) fn calling_convention_set_function(
+        &mut self,
+        argument_count: usize,
+        function: JsValue,
+    ) {
+        let index = self.stack.len() - 1 - argument_count;
+        self.stack[index] = function;
+    }
+
+    /// Set the `this` value at the top of the stack according to the calling convention.
+    #[track_caller]
+    pub(crate) fn calling_convention_set_this(&mut self, argument_count: usize, function: JsValue) {
+        let index = self.stack.len() - 2 - argument_count;
+        self.stack[index] = function;
+    }
+
+    /// Insert the function arguments at the top of the stack according to the calling convention.
+    /// This will insert the given values at the position of the function arguments.
+    pub(crate) fn calling_convention_insert_arguments(
+        &mut self,
+        existing_argument_count: usize,
+        arguments: &[JsValue],
+    ) {
+        let index = self.stack.len() - existing_argument_count;
+        self.stack.splice(index..index, arguments.iter().cloned());
+    }
+
+    #[cfg(feature = "trace")]
+    /// Display the stack trace of the current frame.
+    fn display_trace(&self, frame: &CallFrame, frame_count: usize) -> String {
+        let mut string = String::from("[ ");
+        for (i, (j, value)) in self.stack.iter().enumerate().rev().enumerate() {
+            match value {
+                value if value.is_callable() => string.push_str("[function]"),
+                value if value.is_object() => string.push_str("[object]"),
+                value => string.push_str(&value.display().to_string()),
+            }
+
+            if frame.frame_pointer() == j {
+                let _ = write!(string, " |{frame_count}|");
+            } else if i + 1 != self.stack.len() {
+                string.push(',');
+            }
+
+            string.push(' ');
+        }
+
+        string.push(']');
+        string
+    }
 }
 
 /// Active runnable in the current vm context.
@@ -119,7 +420,7 @@ impl Vm {
                 EnvironmentStack::new(realm.environment().clone()),
                 realm.clone(),
             ),
-            stack: Vec::with_capacity(1024),
+            stack: Stack::new(1024),
             return_value: JsValue::undefined(),
             environments: EnvironmentStack::new(realm.environment().clone()),
             pending_exception: None,
@@ -131,22 +432,17 @@ impl Vm {
         }
     }
 
-    /// Push a value on the stack.
-    pub(crate) fn push<T>(&mut self, value: T)
-    where
-        T: Into<JsValue>,
-    {
-        self.stack.push(value.into());
+    #[track_caller]
+    pub(crate) fn set_register(&mut self, index: usize, value: JsValue) {
+        self.stack.stack[self.frame.rp as usize + index] = value;
     }
 
-    /// Pop a value off the stack.
-    ///
-    /// # Panics
-    ///
-    /// If there is nothing to pop, then this will panic.
     #[track_caller]
-    pub(crate) fn pop(&mut self) -> JsValue {
-        self.stack.pop().expect("stack was empty")
+    pub(crate) fn get_register(&self, index: usize) -> &JsValue {
+        self.stack
+            .stack
+            .get(self.frame.rp as usize + index)
+            .expect("registers must be initialized")
     }
 
     /// Retrieves the VM frame.
@@ -162,7 +458,7 @@ impl Vm {
     }
 
     pub(crate) fn push_frame(&mut self, mut frame: CallFrame) {
-        let current_stack_length = self.stack.len();
+        let current_stack_length = self.stack.stack.len();
         frame.set_register_pointer(current_stack_length as u32);
         std::mem::swap(&mut self.environments, &mut frame.environments);
         std::mem::swap(&mut self.realm, &mut frame.realm);
@@ -171,8 +467,10 @@ impl Vm {
         //       since generator-like functions push the same call
         //       frame with pre-built stack.
         if !frame.registers_already_pushed() {
-            self.stack
-                .resize_with(current_stack_length, JsValue::undefined);
+            self.stack.stack.resize_with(
+                current_stack_length + frame.code_block.register_count as usize,
+                JsValue::undefined,
+            );
         }
 
         // Keep carrying the last active runnable in case the current callframe
@@ -193,8 +491,8 @@ impl Vm {
         this: JsValue,
         function: JsValue,
     ) {
-        self.push(this);
-        self.push(function);
+        self.stack.push(this);
+        self.stack.push(function);
 
         self.push_frame(frame);
     }
@@ -242,19 +540,6 @@ impl Vm {
     pub(crate) fn take_return_value(&mut self) -> JsValue {
         std::mem::take(&mut self.return_value)
     }
-
-    pub(crate) fn pop_n_values(&mut self, n: usize) -> Vec<JsValue> {
-        let at = self.stack.len() - n;
-        self.stack.split_off(at)
-    }
-
-    pub(crate) fn push_values(&mut self, values: &[JsValue]) {
-        self.stack.extend_from_slice(values);
-    }
-
-    pub(crate) fn insert_values_at(&mut self, values: &[JsValue], at: usize) {
-        self.stack.splice(at..at, values.iter().cloned());
-    }
 }
 
 #[allow(clippy::print_stdout)]
@@ -296,11 +581,10 @@ impl Context {
     fn trace_execute_instruction<F>(
         &mut self,
         f: F,
-        registers: &mut Registers,
         opcode: Opcode,
     ) -> ControlFlow<CompletionRecord>
     where
-        F: FnOnce(&mut Context, &mut Registers, Opcode) -> ControlFlow<CompletionRecord>,
+        F: FnOnce(&mut Context, Opcode) -> ControlFlow<CompletionRecord>,
     {
         let frame = self.vm.frame();
         let (instruction, _) = frame
@@ -330,37 +614,13 @@ impl Context {
         }
 
         let instant = Instant::now();
-        let result = self.execute_instruction(f, registers, opcode);
+        let result = self.execute_instruction(f, opcode);
         let duration = instant.elapsed();
 
-        let fp = if self.vm.frames.is_empty() {
-            None
-        } else {
-            Some(self.vm.frame.fp() as usize)
-        };
-
-        let stack = {
-            let mut stack = String::from("[ ");
-            for (i, (j, value)) in self.vm.stack.iter().enumerate().rev().enumerate() {
-                match value {
-                    value if value.is_callable() => stack.push_str("[function]"),
-                    value if value.is_object() => stack.push_str("[object]"),
-                    value => stack.push_str(&value.display().to_string()),
-                }
-
-                if fp == Some(j) {
-                    let frame_index = self.vm.frames.len() - 1;
-                    let _ = write!(stack, " |{frame_index}|");
-                } else if i + 1 != self.vm.stack.len() {
-                    stack.push(',');
-                }
-
-                stack.push(' ');
-            }
-
-            stack.push(']');
-            stack
-        };
+        let stack = self
+            .vm
+            .stack
+            .display_trace(self.vm.frame(), self.vm.frames.len() - 1);
 
         println!(
             "{:<TIME_COLUMN_WIDTH$} {:<OPCODE_COLUMN_WIDTH$} {operands:<OPERAND_COLUMN_WIDTH$} {stack}",
@@ -376,26 +636,16 @@ impl Context {
 }
 
 impl Context {
-    fn execute_instruction<F>(
-        &mut self,
-        f: F,
-        registers: &mut Registers,
-        opcode: Opcode,
-    ) -> ControlFlow<CompletionRecord>
+    fn execute_instruction<F>(&mut self, f: F, opcode: Opcode) -> ControlFlow<CompletionRecord>
     where
-        F: FnOnce(&mut Context, &mut Registers, Opcode) -> ControlFlow<CompletionRecord>,
+        F: FnOnce(&mut Context, Opcode) -> ControlFlow<CompletionRecord>,
     {
-        f(self, registers, opcode)
+        f(self, opcode)
     }
 
-    fn execute_one<F>(
-        &mut self,
-        f: F,
-        registers: &mut Registers,
-        opcode: Opcode,
-    ) -> ControlFlow<CompletionRecord>
+    fn execute_one<F>(&mut self, f: F, opcode: Opcode) -> ControlFlow<CompletionRecord>
     where
-        F: FnOnce(&mut Context, &mut Registers, Opcode) -> ControlFlow<CompletionRecord>,
+        F: FnOnce(&mut Context, Opcode) -> ControlFlow<CompletionRecord>,
     {
         #[cfg(feature = "fuzz")]
         {
@@ -409,41 +659,37 @@ impl Context {
 
         #[cfg(feature = "trace")]
         if self.vm.trace || self.vm.frame().code_block.traceable() {
-            self.trace_execute_instruction(f, registers, opcode)
+            self.trace_execute_instruction(f, opcode)
         } else {
-            self.execute_instruction(f, registers, opcode)
+            self.execute_instruction(f, opcode)
         }
 
         #[cfg(not(feature = "trace"))]
-        self.execute_instruction(f, registers, opcode)
+        self.execute_instruction(f, opcode)
     }
 
-    fn handle_error(
-        &mut self,
-        registers: &mut Registers,
-        err: JsError,
-    ) -> ControlFlow<CompletionRecord> {
+    fn handle_error(&mut self, err: JsError) -> ControlFlow<CompletionRecord> {
         // If we hit the execution step limit, bubble up the error to the
         // (Rust) caller instead of trying to handle as an exception.
         if !err.is_catchable() {
-            let mut fp = self.vm.stack.len();
+            let mut frame = None;
             let mut env_fp = self.vm.environments.len();
             loop {
                 if self.vm.frame.exit_early() {
                     break;
                 }
 
-                fp = self.vm.frame.fp() as usize;
                 env_fp = self.vm.frame.env_fp as usize;
 
-                if self.vm.pop_frame().is_some() {
-                    registers.pop_function(self.vm.frame().code_block().register_count as usize);
-                } else {
+                let Some(f) = self.vm.pop_frame() else {
                     break;
-                }
+                };
+                frame = Some(f);
             }
             self.vm.environments.truncate(env_fp);
-            self.vm.stack.truncate(fp);
+            if let Some(frame) = frame {
+                self.vm.stack.truncate_to_frame(&frame);
+            }
             return ControlFlow::Break(CompletionRecord::Throw(err));
         }
 
@@ -458,45 +704,39 @@ impl Context {
         let err = err.inject_realm(self.realm().clone());
 
         self.vm.pending_exception = Some(err);
-        self.handle_thow(registers)
+        self.handle_thow()
     }
 
-    fn handle_return(&mut self, registers: &mut Registers) -> ControlFlow<CompletionRecord> {
-        let frame = self.vm.frame();
-        let fp = frame.fp() as usize;
-        let exit_early = frame.exit_early();
-        self.vm.stack.truncate(fp);
+    fn handle_return(&mut self) -> ControlFlow<CompletionRecord> {
+        let exit_early = self.vm.frame().exit_early();
+        self.vm.stack.truncate_to_frame(&self.vm.frame);
 
         let result = self.vm.take_return_value();
         if exit_early {
             return ControlFlow::Break(CompletionRecord::Normal(result));
         }
 
-        self.vm.push(result);
+        self.vm.stack.push(result);
         self.vm.pop_frame().expect("frame must exist");
-        registers.pop_function(self.vm.frame().code_block().register_count as usize);
         ControlFlow::Continue(())
     }
 
-    fn handle_yield(&mut self, registers: &mut Registers) -> ControlFlow<CompletionRecord> {
+    fn handle_yield(&mut self) -> ControlFlow<CompletionRecord> {
         let result = self.vm.take_return_value();
         if self.vm.frame().exit_early() {
             return ControlFlow::Break(CompletionRecord::Return(result));
         }
 
-        self.vm.push(result);
+        self.vm.stack.push(result);
         self.vm.pop_frame().expect("frame must exist");
-        registers.pop_function(self.vm.frame().code_block().register_count as usize);
         ControlFlow::Continue(())
     }
 
-    fn handle_thow(&mut self, registers: &mut Registers) -> ControlFlow<CompletionRecord> {
-        let frame = self.vm.frame();
-        let mut fp = frame.fp();
-        let mut env_fp = frame.env_fp;
-        if frame.exit_early() {
+    fn handle_thow(&mut self) -> ControlFlow<CompletionRecord> {
+        let mut env_fp = self.vm.frame().env_fp;
+        if self.vm.frame().exit_early() {
             self.vm.environments.truncate(env_fp as usize);
-            self.vm.stack.truncate(fp as usize);
+            self.vm.stack.truncate_to_frame(&self.vm.frame);
             return ControlFlow::Break(CompletionRecord::Throw(
                 self.vm
                     .pending_exception
@@ -505,11 +745,9 @@ impl Context {
             ));
         }
 
-        self.vm.pop_frame().expect("frame must exist");
-        registers.pop_function(self.vm.frame().code_block().register_count as usize);
+        let mut frame = self.vm.pop_frame().expect("frame must exist");
 
         loop {
-            fp = self.vm.frame.fp();
             env_fp = self.vm.frame.env_fp;
             let pc = self.vm.frame.pc;
             let exit_early = self.vm.frame.exit_early();
@@ -527,25 +765,20 @@ impl Context {
                 ));
             }
 
-            if self.vm.pop_frame().is_some() {
-                registers.pop_function(self.vm.frame().code_block().register_count as usize);
-            } else {
+            let Some(f) = self.vm.pop_frame() else {
                 break;
-            }
+            };
+            frame = f;
         }
         self.vm.environments.truncate(env_fp as usize);
-        self.vm.stack.truncate(fp as usize);
+        self.vm.stack.truncate_to_frame(&frame);
         ControlFlow::Continue(())
     }
 
     /// Runs the current frame to completion, yielding to the caller each time `budget`
     /// "clock cycles" have passed.
     #[allow(clippy::future_not_send)]
-    pub(crate) async fn run_async_with_budget(
-        &mut self,
-        budget: u32,
-        registers: &mut Registers,
-    ) -> CompletionRecord {
+    pub(crate) async fn run_async_with_budget(&mut self, budget: u32) -> CompletionRecord {
         let _timer = Profiler::global().start_event("run_async_with_budget", "vm");
 
         #[cfg(feature = "trace")]
@@ -566,14 +799,9 @@ impl Context {
             let opcode = Opcode::decode(*byte);
 
             match self.execute_one(
-                |context, registers, opcode| {
-                    context.execute_bytecode_instruction_with_budget(
-                        registers,
-                        &mut runtime_budget,
-                        opcode,
-                    )
+                |context, opcode| {
+                    context.execute_bytecode_instruction_with_budget(&mut runtime_budget, opcode)
                 },
-                registers,
                 opcode,
             ) {
                 ControlFlow::Continue(()) => {}
@@ -589,7 +817,7 @@ impl Context {
         CompletionRecord::Throw(JsError::from_native(JsNativeError::error()))
     }
 
-    pub(crate) fn run(&mut self, registers: &mut Registers) -> CompletionRecord {
+    pub(crate) fn run(&mut self) -> CompletionRecord {
         let _timer = Profiler::global().start_event("run", "vm");
 
         #[cfg(feature = "trace")]
@@ -607,7 +835,7 @@ impl Context {
         {
             let opcode = Opcode::decode(*byte);
 
-            match self.execute_one(Self::execute_bytecode_instruction, registers, opcode) {
+            match self.execute_one(Self::execute_bytecode_instruction, opcode) {
                 ControlFlow::Continue(()) => {}
                 ControlFlow::Break(value) => return value,
             }
@@ -625,7 +853,7 @@ impl Context {
                 .into());
         }
         // Must throw if the stack size exceeds the defined maximum length.
-        if self.vm.runtime_limits.stack_size_limit() <= self.vm.stack.len() {
+        if self.vm.runtime_limits.stack_size_limit() <= self.vm.stack.stack.len() {
             return Err(JsNativeError::runtime_limit()
                 .with_message("exceeded maximum call stack length")
                 .into());
@@ -654,50 +882,4 @@ fn yield_now() -> impl Future<Output = ()> {
     }
 
     YieldNow(false)
-}
-
-#[derive(Debug, Default, Trace, Finalize)]
-pub(crate) struct Registers {
-    rp: usize,
-    registers: Vec<JsValue>,
-}
-
-impl Registers {
-    pub(crate) fn new(register_count: usize) -> Self {
-        let mut registers = Vec::with_capacity(register_count);
-        registers.resize(register_count, JsValue::undefined());
-
-        Self { rp: 0, registers }
-    }
-
-    pub(crate) fn push_function(&mut self, register_count: usize) {
-        self.rp = self.registers.len();
-        self.registers
-            .resize(self.rp + register_count, JsValue::undefined());
-    }
-
-    #[track_caller]
-    pub(crate) fn pop_function(&mut self, register_count: usize) {
-        self.registers.truncate(self.rp);
-        self.rp -= register_count;
-    }
-
-    #[track_caller]
-    pub(crate) fn set(&mut self, index: u32, value: JsValue) {
-        self.registers[self.rp + index as usize] = value;
-    }
-
-    #[track_caller]
-    pub(crate) fn get(&self, index: u32) -> &JsValue {
-        self.registers
-            .get(self.rp + index as usize)
-            .expect("registers must be initialized")
-    }
-
-    pub(crate) fn clone_current_frame(&self) -> Self {
-        Self {
-            rp: 0,
-            registers: self.registers[self.rp..].to_vec(),
-        }
-    }
 }

--- a/core/engine/src/vm/opcode/binary_ops/logical.rs
+++ b/core/engine/src/vm/opcode/binary_ops/logical.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -15,12 +12,8 @@ pub(crate) struct LogicalAnd;
 
 impl LogicalAnd {
     #[inline(always)]
-    pub(crate) fn operation(
-        (exit, lhs): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let lhs = registers.get(lhs.into());
+    pub(crate) fn operation((exit, lhs): (u32, VaryingOperand), context: &mut Context) {
+        let lhs = context.vm.get_register(lhs.into());
         if !lhs.to_boolean() {
             context.vm.frame_mut().pc = exit;
         }
@@ -42,12 +35,8 @@ pub(crate) struct LogicalOr;
 
 impl LogicalOr {
     #[inline(always)]
-    pub(crate) fn operation(
-        (exit, lhs): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let lhs = registers.get(lhs.into());
+    pub(crate) fn operation((exit, lhs): (u32, VaryingOperand), context: &mut Context) {
+        let lhs = context.vm.get_register(lhs.into());
         if lhs.to_boolean() {
             context.vm.frame_mut().pc = exit;
         }
@@ -69,12 +58,8 @@ pub(crate) struct Coalesce;
 
 impl Coalesce {
     #[inline(always)]
-    pub(crate) fn operation(
-        (exit, lhs): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let lhs = registers.get(lhs.into());
+    pub(crate) fn operation((exit, lhs): (u32, VaryingOperand), context: &mut Context) {
+        let lhs = context.vm.get_register(lhs.into());
         if !lhs.is_null_or_undefined() {
             context.vm.frame_mut().pc = exit;
         }

--- a/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
+++ b/core/engine/src/vm/opcode/binary_ops/macro_defined.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -19,13 +16,12 @@ macro_rules! implement_bin_ops {
             #[inline(always)]
             pub(crate) fn operation(
                 (dst, lhs, rhs): (VaryingOperand, VaryingOperand, VaryingOperand),
-                registers: &mut Registers,
                 context: &mut Context,
             ) -> JsResult<()> {
-                let lhs = registers.get(lhs.into());
-                let rhs = registers.get(rhs.into());
+                let lhs = context.vm.get_register(lhs.into()).clone();
+                let rhs = context.vm.get_register(rhs.into()).clone();
                 let value = lhs.$op(&rhs, context)?;
-                registers.set(dst.into(), value.into());
+                context.vm.set_register(dst.into(), value.into());
                 Ok(())
             }
         }

--- a/core/engine/src/vm/opcode/concat/mod.rs
+++ b/core/engine/src/vm/opcode/concat/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsResult, JsString,
-};
+use crate::{vm::opcode::Operation, Context, JsResult, JsString};
 use thin_vec::ThinVec;
 
 /// `ConcatToString` implements the Opcode Operation for `Opcode::ConcatToString`
@@ -16,16 +13,16 @@ impl ConcatToString {
     #[inline(always)]
     pub(super) fn operation(
         (string, values): (VaryingOperand, ThinVec<VaryingOperand>),
-        registers: &mut Registers,
+
         context: &mut Context,
     ) -> JsResult<()> {
         let mut strings = Vec::with_capacity(values.len());
         for value in values {
-            let val = registers.get(value.into());
+            let val = context.vm.get_register(value.into()).clone();
             strings.push(val.to_string(context)?);
         }
         let s = JsString::concat_array(&strings.iter().map(JsString::as_str).collect::<Vec<_>>());
-        registers.set(string.into(), s.into());
+        context.vm.set_register(string.into(), s.into());
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/control_flow/jump.rs
+++ b/core/engine/src/vm/opcode/control_flow/jump.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 use thin_vec::ThinVec;
@@ -16,7 +13,7 @@ pub(crate) struct Jump;
 
 impl Jump {
     #[inline(always)]
-    pub(crate) fn operation(address: u32, _: &mut Registers, context: &mut Context) {
+    pub(crate) fn operation(address: u32, context: &mut Context) {
         context.vm.frame_mut().pc = address;
     }
 }
@@ -36,12 +33,8 @@ pub(crate) struct JumpIfTrue;
 
 impl JumpIfTrue {
     #[inline(always)]
-    pub(crate) fn operation(
-        (address, value): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let value = registers.get(value.into());
+    pub(crate) fn operation((address, value): (u32, VaryingOperand), context: &mut Context) {
+        let value = context.vm.get_register(value.into());
         if value.to_boolean() {
             context.vm.frame_mut().pc = address;
         }
@@ -63,12 +56,8 @@ pub(crate) struct JumpIfFalse;
 
 impl JumpIfFalse {
     #[inline(always)]
-    pub(crate) fn operation(
-        (address, value): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let value = registers.get(value.into());
+    pub(crate) fn operation((address, value): (u32, VaryingOperand), context: &mut Context) {
+        let value = context.vm.get_register(value.into());
         if !value.to_boolean() {
             context.vm.frame_mut().pc = address;
         }
@@ -90,12 +79,8 @@ pub(crate) struct JumpIfNotUndefined;
 
 impl JumpIfNotUndefined {
     #[inline(always)]
-    pub(crate) fn operation(
-        (address, value): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let value = registers.get(value.into());
+    pub(crate) fn operation((address, value): (u32, VaryingOperand), context: &mut Context) {
+        let value = context.vm.get_register(value.into());
         if !value.is_undefined() {
             context.vm.frame_mut().pc = address;
         }
@@ -117,12 +102,8 @@ pub(crate) struct JumpIfNullOrUndefined;
 
 impl JumpIfNullOrUndefined {
     #[inline(always)]
-    pub(crate) fn operation(
-        (address, value): (u32, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
-        let value = registers.get(value.into());
+    pub(crate) fn operation((address, value): (u32, VaryingOperand), context: &mut Context) {
+        let value = context.vm.get_register(value.into());
         if value.is_null_or_undefined() {
             context.vm.frame_mut().pc = address;
         }
@@ -144,12 +125,8 @@ pub(crate) struct JumpTable;
 
 impl JumpTable {
     #[inline(always)]
-    pub(crate) fn operation(
-        (default, addresses): (u32, ThinVec<u32>),
-        _: &mut Registers,
-        context: &mut Context,
-    ) {
-        let value = context.vm.pop();
+    pub(crate) fn operation((default, addresses): (u32, ThinVec<u32>), context: &mut Context) {
+        let value = context.vm.stack.pop();
         if let Some(value) = value.as_i32() {
             let value = value as usize;
             let mut target = None;

--- a/core/engine/src/vm/opcode/copy/mod.rs
+++ b/core/engine/src/vm/opcode/copy/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsResult,
-};
+use crate::{vm::opcode::Operation, Context, JsResult};
 use thin_vec::ThinVec;
 
 /// `CopyDataProperties` implements the Opcode Operation for `Opcode::CopyDataProperties`
@@ -16,21 +13,20 @@ impl CopyDataProperties {
     #[inline(always)]
     pub(super) fn operation(
         (object, source, keys): (VaryingOperand, VaryingOperand, ThinVec<VaryingOperand>),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let object = registers.get(object.into());
-        let source = registers.get(source.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let source = context.vm.get_register(source.into()).clone();
         let mut excluded_keys = Vec::with_capacity(keys.len());
         for key in keys {
-            let key = registers.get(key.into());
+            let key = context.vm.get_register(key.into()).clone();
             excluded_keys.push(
                 key.to_property_key(context)
                     .expect("key must be property key"),
             );
         }
         let object = object.as_object().expect("not an object");
-        object.copy_data_properties(source, excluded_keys, context)?;
+        object.copy_data_properties(&source, excluded_keys, context)?;
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/define/class/getter.rs
+++ b/core/engine/src/vm/opcode/define/class/getter.rs
@@ -4,10 +4,7 @@ use crate::{
     builtins::function::{set_function_name, OrdinaryFunction},
     object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -22,11 +19,10 @@ impl DefineClassStaticGetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = context
             .vm
@@ -80,11 +76,10 @@ impl DefineClassGetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class_proto, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = context
             .vm
@@ -138,12 +133,11 @@ impl DefineClassStaticGetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -195,12 +189,11 @@ impl DefineClassGetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class_proto): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/core/engine/src/vm/opcode/define/class/method.rs
+++ b/core/engine/src/vm/opcode/define/class/method.rs
@@ -2,10 +2,7 @@ use crate::{
     builtins::function::{set_function_name, OrdinaryFunction},
     object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -20,11 +17,10 @@ impl DefineClassStaticMethodByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = context
             .vm
@@ -74,11 +70,10 @@ impl DefineClassMethodByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class_proto, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = context
             .vm
@@ -128,12 +123,11 @@ impl DefineClassStaticMethodByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -180,12 +174,11 @@ impl DefineClassMethodByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class_proto): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/core/engine/src/vm/opcode/define/class/setter.rs
+++ b/core/engine/src/vm/opcode/define/class/setter.rs
@@ -4,10 +4,7 @@ use crate::{
     builtins::function::{set_function_name, OrdinaryFunction},
     object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -22,11 +19,10 @@ impl DefineClassStaticSetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = context
             .vm
@@ -81,11 +77,10 @@ impl DefineClassSetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, class_proto, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = context
             .vm
@@ -141,12 +136,11 @@ impl DefineClassStaticSetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class = registers.get(class.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class = context.vm.get_register(class.into()).clone();
         let class = class.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)
@@ -199,12 +193,11 @@ impl DefineClassSetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (function, key, class_proto): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let function = registers.get(function.into());
-        let key = registers.get(key.into());
-        let class_proto = registers.get(class_proto.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let class_proto = context.vm.get_register(class_proto.into()).clone();
         let class_proto = class_proto.as_object().expect("class must be object");
         let key = key
             .to_property_key(context)

--- a/core/engine/src/vm/opcode/define/mod.rs
+++ b/core/engine/src/vm/opcode/define/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsResult, JsValue,
-};
+use crate::{vm::opcode::Operation, Context, JsResult, JsValue};
 
 pub(crate) mod class;
 pub(crate) mod own_property;
@@ -19,7 +16,7 @@ pub(crate) struct DefVar;
 
 impl DefVar {
     #[inline(always)]
-    pub(super) fn operation(index: VaryingOperand, _: &mut Registers, context: &mut Context) {
+    pub(super) fn operation(index: VaryingOperand, context: &mut Context) {
         // TODO: spec specifies to return `empty` on empty vars, but we're trying to initialize.
         let binding_locator = context.vm.frame().code_block.bindings[usize::from(index)].clone();
 
@@ -48,10 +45,9 @@ impl DefInitVar {
     #[inline(always)]
     pub(super) fn operation(
         (value, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
+        let value = context.vm.get_register(value.into()).clone();
         let frame = context.vm.frame();
         let strict = frame.code_block.strict();
         let mut binding_locator = frame.code_block.bindings[usize::from(index)].clone();
@@ -79,10 +75,9 @@ impl PutLexicalValue {
     #[inline(always)]
     pub(super) fn operation(
         (value, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let value = registers.get(value.into());
+        let value = context.vm.get_register(value.into());
         let binding_locator = context.vm.frame().code_block.bindings[usize::from(index)].clone();
         context.vm.environments.put_lexical_value(
             binding_locator.scope(),

--- a/core/engine/src/vm/opcode/define/own_property.rs
+++ b/core/engine/src/vm/opcode/define/own_property.rs
@@ -1,10 +1,7 @@
 use crate::{
     object::internal_methods::InternalMethodContext,
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsNativeError, JsResult,
 };
 
@@ -19,11 +16,10 @@ impl DefineOwnPropertyByName {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -61,12 +57,11 @@ impl DefineOwnPropertyByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (value, key, object): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
-        let key = registers.get(key.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
         let object = object.to_object(context)?;
         let key = key.to_property_key(context)?;
         let success = object.__define_own_property__(

--- a/core/engine/src/vm/opcode/generator/yield_stm.rs
+++ b/core/engine/src/vm/opcode/generator/yield_stm.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::async_generator::{AsyncGenerator, AsyncGeneratorState},
     vm::{
         opcode::{Operation, VaryingOperand},
-        CompletionRecord, GeneratorResumeKind, Registers,
+        CompletionRecord, GeneratorResumeKind,
     },
     Context, JsValue,
 };
@@ -20,12 +20,11 @@ impl GeneratorYield {
     #[inline(always)]
     pub(crate) fn operation(
         value: VaryingOperand,
-        registers: &mut Registers,
         context: &mut Context,
     ) -> ControlFlow<CompletionRecord> {
-        let value = registers.get(value.into());
+        let value = context.vm.get_register(value.into());
         context.vm.set_return_value(value.clone());
-        context.handle_yield(registers)
+        context.handle_yield()
     }
 }
 
@@ -46,7 +45,6 @@ impl AsyncGeneratorYield {
     #[inline(always)]
     pub(crate) fn operation(
         value: VaryingOperand,
-        registers: &mut Registers,
         context: &mut Context,
     ) -> ControlFlow<CompletionRecord> {
         // AsyncGeneratorYield ( value )
@@ -58,15 +56,15 @@ impl AsyncGeneratorYield {
         // 4. Assert: GetGeneratorKind() is async.
         let async_generator_object = context
             .vm
-            .frame()
-            .async_generator_object(registers)
+            .stack
+            .async_generator_object(&context.vm.frame)
             .expect("`AsyncGeneratorYield` must only be called inside async generators");
         let async_generator_object = async_generator_object
             .downcast::<AsyncGenerator>()
             .expect("must be async generator object");
 
         // 5. Let completion be NormalCompletion(value).
-        let value = registers.get(value.into());
+        let value = context.vm.get_register(value.into());
         let completion = Ok(value.clone());
 
         // TODO: 6. Assert: The execution context stack has at least two elements.
@@ -85,21 +83,21 @@ impl AsyncGeneratorYield {
             // c. Let resumptionValue be Completion(toYield.[[Completion]]).
             let resume_kind = match next.completion.clone() {
                 CompletionRecord::Normal(val) => {
-                    context.vm.push(val);
+                    context.vm.stack.push(val);
                     GeneratorResumeKind::Normal
                 }
                 CompletionRecord::Return(val) => {
-                    context.vm.push(val);
+                    context.vm.stack.push(val);
                     GeneratorResumeKind::Return
                 }
                 CompletionRecord::Throw(err) => {
                     let err = err.to_opaque(context);
-                    context.vm.push(err);
+                    context.vm.stack.push(err);
                     GeneratorResumeKind::Throw
                 }
             };
 
-            context.vm.push(resume_kind);
+            context.vm.stack.push(resume_kind);
 
             // d. Return ? AsyncGeneratorUnwrapYieldResumption(resumptionValue).
             return ControlFlow::Continue(());
@@ -116,7 +114,7 @@ impl AsyncGeneratorYield {
         //     e. Assert: If control reaches here, then genContext is the running execution context again.
         //     f. Return ? AsyncGeneratorUnwrapYieldResumption(resumptionValue).
         context.vm.set_return_value(JsValue::undefined());
-        context.handle_yield(registers)
+        context.handle_yield()
     }
 }
 

--- a/core/engine/src/vm/opcode/get/argument.rs
+++ b/core/engine/src/vm/opcode/get/argument.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -15,18 +12,14 @@ pub(crate) struct GetArgument;
 
 impl GetArgument {
     #[inline(always)]
-    pub(crate) fn operation(
-        (index, dst): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
+    pub(crate) fn operation((index, dst): (VaryingOperand, VaryingOperand), context: &mut Context) {
         let value = context
             .vm
-            .frame()
-            .argument(index.into(), &context.vm)
+            .stack
+            .get_argument(context.vm.frame(), index.into())
             .cloned()
             .unwrap_or_default();
-        registers.set(dst.into(), value);
+        context.vm.set_register(dst.into(), value);
     }
 }
 

--- a/core/engine/src/vm/opcode/get/function.rs
+++ b/core/engine/src/vm/opcode/get/function.rs
@@ -2,7 +2,6 @@ use crate::{
     vm::{
         code_block::create_function_object_fast,
         opcode::{Operation, VaryingOperand},
-        Registers,
     },
     Context,
 };
@@ -16,18 +15,14 @@ pub(crate) struct GetFunction;
 
 impl GetFunction {
     #[inline(always)]
-    pub(crate) fn operation(
-        (dst, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
+    pub(crate) fn operation((dst, index): (VaryingOperand, VaryingOperand), context: &mut Context) {
         let code = context
             .vm
             .frame()
             .code_block()
             .constant_function(index.into());
         let function = create_function_object_fast(code, context);
-        registers.set(dst.into(), function.into());
+        context.vm.set_register(dst.into(), function.into());
     }
 }
 

--- a/core/engine/src/vm/opcode/get/name.rs
+++ b/core/engine/src/vm/opcode/get/name.rs
@@ -2,10 +2,7 @@ use crate::{
     error::JsNativeError,
     object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
     property::PropertyKey,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult, JsValue,
 };
 
@@ -20,7 +17,6 @@ impl GetName {
     #[inline(always)]
     pub(crate) fn operation(
         (value, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let mut binding_locator =
@@ -30,7 +26,7 @@ impl GetName {
             let name = binding_locator.name().to_std_string_escaped();
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
-        registers.set(value.into(), result);
+        context.vm.set_register(value.into(), result);
         Ok(())
     }
 }
@@ -52,7 +48,6 @@ impl GetNameGlobal {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, index, ic_index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let mut binding_locator =
@@ -82,7 +77,7 @@ impl GetNameGlobal {
                         context,
                     )?;
                 }
-                registers.set(dst.into(), result);
+                context.vm.set_register(dst.into(), result);
                 return Ok(());
             }
 
@@ -107,7 +102,7 @@ impl GetNameGlobal {
                 ic.set(shape, slot);
             }
 
-            registers.set(dst.into(), result);
+            context.vm.set_register(dst.into(), result);
             return Ok(());
         }
 
@@ -116,7 +111,7 @@ impl GetNameGlobal {
             JsNativeError::reference().with_message(format!("{name} is not defined"))
         })?;
 
-        registers.set(dst.into(), result);
+        context.vm.set_register(dst.into(), result);
         Ok(())
     }
 }
@@ -136,11 +131,7 @@ pub(crate) struct GetLocator;
 
 impl GetLocator {
     #[inline(always)]
-    pub(crate) fn operation(
-        index: VaryingOperand,
-        _: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
+    pub(crate) fn operation(index: VaryingOperand, context: &mut Context) -> JsResult<()> {
         let mut binding_locator =
             context.vm.frame().code_block.bindings[usize::from(index)].clone();
         context.find_runtime_binding(&mut binding_locator)?;
@@ -169,7 +160,6 @@ impl GetNameAndLocator {
     #[inline(always)]
     pub(crate) fn operation(
         (value, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let mut binding_locator =
@@ -181,7 +171,7 @@ impl GetNameAndLocator {
         })?;
 
         context.vm.frame_mut().binding_stack.push(binding_locator);
-        registers.set(value.into(), result);
+        context.vm.set_register(value.into(), result);
         Ok(())
     }
 }
@@ -203,7 +193,6 @@ impl GetNameOrUndefined {
     #[inline(always)]
     pub(crate) fn operation(
         (value, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let mut binding_locator =
@@ -224,7 +213,7 @@ impl GetNameOrUndefined {
                 .into());
         };
 
-        registers.set(value.into(), result);
+        context.vm.set_register(value.into(), result);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/get/private.rs
+++ b/core/engine/src/vm/opcode/get/private.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -17,7 +14,6 @@ impl GetPrivateField {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, object, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let name = context
@@ -25,7 +21,7 @@ impl GetPrivateField {
             .frame()
             .code_block()
             .constant_string(index.into());
-        let object = registers.get(object.into());
+        let object = context.vm.get_register(object.into()).clone();
         let object = object.to_object(context)?;
         let name = context
             .vm
@@ -34,7 +30,7 @@ impl GetPrivateField {
             .expect("private name must be in environment");
 
         let result = object.private_get(&name, context)?;
-        registers.set(dst.into(), result);
+        context.vm.set_register(dst.into(), result);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/global.rs
+++ b/core/engine/src/vm/opcode/global.rs
@@ -1,4 +1,4 @@
-use super::{Operation, Registers, VaryingOperand};
+use super::{Operation, VaryingOperand};
 use crate::{Context, JsResult};
 
 /// `HasRestrictedGlobalProperty` implements the Opcode Operation for `Opcode::HasRestrictedGlobalProperty`
@@ -14,7 +14,6 @@ impl HasRestrictedGlobalProperty {
     #[inline(always)]
     pub(super) fn operation(
         (dst, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let name = &context
@@ -23,7 +22,7 @@ impl HasRestrictedGlobalProperty {
             .code_block()
             .constant_string(index.into());
         let value = context.has_restricted_global_property(name)?;
-        registers.set(dst.into(), value.into());
+        context.vm.set_register(dst.into(), value.into());
         Ok(())
     }
 }
@@ -47,7 +46,6 @@ impl CanDeclareGlobalFunction {
     #[inline(always)]
     pub(super) fn operation(
         (dst, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let name = &context
@@ -56,7 +54,7 @@ impl CanDeclareGlobalFunction {
             .code_block()
             .constant_string(index.into());
         let value = context.can_declare_global_function(name)?;
-        registers.set(dst.into(), value.into());
+        context.vm.set_register(dst.into(), value.into());
         Ok(())
     }
 }
@@ -80,7 +78,6 @@ impl CanDeclareGlobalVar {
     #[inline(always)]
     pub(super) fn operation(
         (dst, index): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let name = &context
@@ -89,7 +86,7 @@ impl CanDeclareGlobalVar {
             .code_block()
             .constant_string(index.into());
         let value = context.can_declare_global_var(name)?;
-        registers.set(dst.into(), value.into());
+        context.vm.set_register(dst.into(), value.into());
         Ok(())
     }
 }
@@ -113,11 +110,10 @@ impl CreateGlobalFunctionBinding {
     #[inline(always)]
     pub(super) fn operation(
         (function, configurable, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let configurable = u32::from(configurable) != 0;
-        let value = registers.get(function.into());
+        let value = context.vm.get_register(function.into());
         let name = context
             .vm
             .frame()
@@ -153,7 +149,6 @@ impl CreateGlobalVarBinding {
     #[inline(always)]
     pub(super) fn operation(
         (configurable, index): (VaryingOperand, VaryingOperand),
-        _: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let configurable = u32::from(configurable) != 0;

--- a/core/engine/src/vm/opcode/iteration/for_in.rs
+++ b/core/engine/src/vm/opcode/iteration/for_in.rs
@@ -1,10 +1,7 @@
 use crate::{
     builtins::{iterable::IteratorRecord, object::for_in_iterator::ForInIterator},
     js_string,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult, JsValue,
 };
 
@@ -17,12 +14,8 @@ pub(crate) struct CreateForInIterator;
 
 impl CreateForInIterator {
     #[inline(always)]
-    pub(crate) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        let object = registers.get(value.into());
+    pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        let object = context.vm.get_register(value.into()).clone();
         let object = object.to_object(context)?;
         let iterator = ForInIterator::create_for_in_iterator(JsValue::new(object), context);
         let next_method = iterator

--- a/core/engine/src/vm/opcode/iteration/get.rs
+++ b/core/engine/src/vm/opcode/iteration/get.rs
@@ -1,9 +1,6 @@
 use crate::{
     builtins::iterable::IteratorHint,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -16,12 +13,8 @@ pub(crate) struct GetIterator;
 
 impl GetIterator {
     #[inline(always)]
-    pub(crate) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        let value = registers.get(value.into());
+    pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        let value = context.vm.get_register(value.into()).clone();
         let iterator = value.get_iterator(IteratorHint::Sync, context)?;
         context.vm.frame_mut().iterators.push(iterator);
         Ok(())
@@ -43,12 +36,8 @@ pub(crate) struct GetAsyncIterator;
 
 impl GetAsyncIterator {
     #[inline(always)]
-    pub(crate) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        let value = registers.get(value.into());
+    pub(crate) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        let value = context.vm.get_register(value.into()).clone();
         let iterator = value.get_iterator(IteratorHint::Async, context)?;
         context.vm.frame_mut().iterators.push(iterator);
         Ok(())

--- a/core/engine/src/vm/opcode/iteration/loop_ops.rs
+++ b/core/engine/src/vm/opcode/iteration/loop_ops.rs
@@ -1,8 +1,5 @@
 use crate::JsNativeError;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsResult,
-};
+use crate::{vm::opcode::Operation, Context, JsResult};
 
 /// `IncrementLoopIteration` implements the Opcode Operation for `Opcode::IncrementLoopIteration`.
 ///
@@ -13,7 +10,7 @@ pub(crate) struct IncrementLoopIteration;
 
 impl IncrementLoopIteration {
     #[inline(always)]
-    pub(crate) fn operation((): (), _: &mut Registers, context: &mut Context) -> JsResult<()> {
+    pub(crate) fn operation((): (), context: &mut Context) -> JsResult<()> {
         let max = context.vm.runtime_limits.loop_iteration_limit();
         let frame = context.vm.frame_mut();
         let previous_iteration_count = frame.loop_iteration_count;

--- a/core/engine/src/vm/opcode/locals/mod.rs
+++ b/core/engine/src/vm/opcode/locals/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsNativeError, JsResult,
-};
+use crate::{vm::opcode::Operation, Context, JsNativeError, JsResult};
 
 /// `PopIntoLocal` implements the Opcode Operation for `Opcode::PopIntoLocal`
 ///
@@ -13,13 +10,11 @@ pub(crate) struct PopIntoLocal;
 
 impl PopIntoLocal {
     #[inline(always)]
-    pub(super) fn operation(
-        (src, dst): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
-        context: &mut Context,
-    ) {
+    pub(super) fn operation((src, dst): (VaryingOperand, VaryingOperand), context: &mut Context) {
         context.vm.frame_mut().local_bindings_initialized[usize::from(dst)] = true;
-        registers.set(dst.into(), registers.get(src.into()).clone());
+        context
+            .vm
+            .set_register(dst.into(), context.vm.get_register(src.into()).clone());
     }
 }
 
@@ -40,7 +35,6 @@ impl PushFromLocal {
     #[inline(always)]
     pub(super) fn operation(
         (src, dst): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         if !context.vm.frame().local_bindings_initialized[usize::from(src)] {
@@ -48,7 +42,9 @@ impl PushFromLocal {
                 .with_message("access to uninitialized binding")
                 .into());
         }
-        registers.set(dst.into(), registers.get(src.into()).clone());
+        context
+            .vm
+            .set_register(dst.into(), context.vm.get_register(src.into()).clone());
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/meta/mod.rs
+++ b/core/engine/src/vm/opcode/meta/mod.rs
@@ -1,7 +1,7 @@
 use super::VaryingOperand;
 use crate::{
     module::ModuleKind,
-    vm::{opcode::Operation, ActiveRunnable, Registers},
+    vm::{opcode::Operation, ActiveRunnable},
     Context, JsObject, JsValue,
 };
 use std::unreachable;
@@ -15,7 +15,7 @@ pub(crate) struct NewTarget;
 
 impl NewTarget {
     #[inline(always)]
-    pub(super) fn operation(dst: VaryingOperand, registers: &mut Registers, context: &mut Context) {
+    pub(super) fn operation(dst: VaryingOperand, context: &mut Context) {
         let new_target = if let Some(new_target) = context
             .vm
             .environments
@@ -27,7 +27,7 @@ impl NewTarget {
         } else {
             JsValue::undefined()
         };
-        registers.set(dst.into(), new_target);
+        context.vm.set_register(dst.into(), new_target);
     }
 }
 
@@ -46,7 +46,7 @@ pub(crate) struct ImportMeta;
 
 impl ImportMeta {
     #[inline(always)]
-    pub(super) fn operation(dst: VaryingOperand, registers: &mut Registers, context: &mut Context) {
+    pub(super) fn operation(dst: VaryingOperand, context: &mut Context) {
         // Meta Properties
         //
         // ImportMeta : import . meta
@@ -89,7 +89,7 @@ impl ImportMeta {
 
         //     b. Return importMeta.
         //     f. Return importMeta.
-        registers.set(dst.into(), import_meta.into());
+        context.vm.set_register(dst.into(), import_meta.into());
     }
 }
 

--- a/core/engine/src/vm/opcode/nop/mod.rs
+++ b/core/engine/src/vm/opcode/nop/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context,
-};
+use crate::{vm::opcode::Operation, Context};
 
 /// `Reserved` implements the Opcode Operation for `Opcode::Reserved`
 ///
@@ -12,7 +9,7 @@ pub(crate) struct Reserved;
 
 impl Reserved {
     #[inline(always)]
-    pub(crate) fn operation((): (), _: &mut Registers, _: &mut Context) {
+    pub(crate) fn operation((): (), _: &mut Context) {
         unreachable!("Reserved opcodes are unreachable!")
     }
 }

--- a/core/engine/src/vm/opcode/pop/mod.rs
+++ b/core/engine/src/vm/opcode/pop/mod.rs
@@ -1,7 +1,4 @@
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context,
-};
+use crate::{vm::opcode::Operation, Context};
 
 /// `Pop` implements the Opcode Operation for `Opcode::Pop`
 ///
@@ -12,8 +9,8 @@ pub(crate) struct Pop;
 
 impl Pop {
     #[inline(always)]
-    pub(super) fn operation((): (), _: &mut Registers, context: &mut Context) {
-        let _val = context.vm.pop();
+    pub(super) fn operation((): (), context: &mut Context) {
+        let _val = context.vm.stack.pop();
     }
 }
 
@@ -32,7 +29,7 @@ pub(crate) struct PopEnvironment;
 
 impl PopEnvironment {
     #[inline(always)]
-    pub(super) fn operation((): (), _: &mut Registers, context: &mut Context) {
+    pub(super) fn operation((): (), context: &mut Context) {
         context.vm.environments.pop();
     }
 }

--- a/core/engine/src/vm/opcode/push/class/field.rs
+++ b/core/engine/src/vm/opcode/push/class/field.rs
@@ -1,10 +1,7 @@
 use crate::{
     builtins::function::OrdinaryFunction,
     object::JsFunction,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -24,12 +21,11 @@ impl PushClassField {
             VaryingOperand,
             VaryingOperand,
         ),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let class = registers.get(class.into());
-        let name = registers.get(name.into());
-        let function = registers.get(function.into());
+        let class = context.vm.get_register(class.into()).clone();
+        let name = context.vm.get_register(name.into()).clone();
+        let function = context.vm.get_register(function.into()).clone();
         let is_anonyms_function = u32::from(is_anonyms_function) != 0;
 
         let name = name.to_property_key(context)?;
@@ -76,11 +72,10 @@ impl PushClassFieldPrivate {
     #[inline(always)]
     pub(crate) fn operation(
         (class, function, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let class = registers.get(class.into());
-        let function = registers.get(function.into());
+        let class = context.vm.get_register(class.into());
+        let function = context.vm.get_register(function.into());
         let name = context
             .vm
             .frame()

--- a/core/engine/src/vm/opcode/push/class/mod.rs
+++ b/core/engine/src/vm/opcode/push/class/mod.rs
@@ -1,10 +1,7 @@
 use crate::{
     error::JsNativeError,
     object::PROTOTYPE,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult, JsValue,
 };
 
@@ -25,11 +22,10 @@ impl PushClassPrototype {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, class, superclass): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let class = registers.get(class.into());
-        let superclass = registers.get(superclass.into());
+        let class = context.vm.get_register(class.into()).clone();
+        let superclass = context.vm.get_register(superclass.into()).clone();
 
         // // Taken from `15.7.14 Runtime Semantics: ClassDefinitionEvaluation`:
         // <https://tc39.es/ecma262/#sec-runtime-semantics-classdefinitionevaluation>
@@ -72,7 +68,7 @@ impl PushClassPrototype {
             class_object.set_prototype(Some(constructor_parent));
         }
 
-        registers.set(dst.into(), proto_parent);
+        context.vm.set_register(dst.into(), proto_parent);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/push/class/private.rs
+++ b/core/engine/src/vm/opcode/push/class/private.rs
@@ -3,10 +3,7 @@ use crate::{
     js_str, js_string,
     object::{internal_methods::InternalMethodContext, PrivateElement},
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -26,12 +23,11 @@ impl PushClassPrivateMethod {
             VaryingOperand,
             VaryingOperand,
         ),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let prototype = registers.get(prototype.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let prototype = context.vm.get_register(prototype.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -90,11 +86,10 @@ impl PushClassPrivateGetter {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into());
+        let value = context.vm.get_register(value.into());
         let name = context
             .vm
             .frame()
@@ -134,11 +129,10 @@ impl PushClassPrivateSetter {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into());
+        let value = context.vm.get_register(value.into());
         let name = context
             .vm
             .frame()

--- a/core/engine/src/vm/opcode/push/mod.rs
+++ b/core/engine/src/vm/opcode/push/mod.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsValue,
 };
 
@@ -31,8 +28,8 @@ macro_rules! implement_push_generics {
 
         impl $name {
             #[inline(always)]
-            pub(super) fn operation(dst: VaryingOperand, registers: &mut Registers, _: &mut Context) {
-                registers.set(dst.value, $push_value.into());
+            pub(super) fn operation(dst: VaryingOperand,  context: &mut Context) {
+                context.vm.set_register(dst.into(), $push_value.into());
             }
         }
 

--- a/core/engine/src/vm/opcode/push/numbers.rs
+++ b/core/engine/src/vm/opcode/push/numbers.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -17,8 +14,8 @@ macro_rules! implement_push_numbers_with_conversion {
 
         impl $name {
             #[inline(always)]
-            pub(crate) fn operation((dst, value): (VaryingOperand, $num_type), registers: &mut Registers, _: &mut Context) {
-                registers.set(dst.into(), i32::from(value).into());
+            pub(crate) fn operation((dst, value): (VaryingOperand, $num_type),  context: &mut Context) {
+                context.vm.set_register(dst.into(), i32::from(value).into());
             }
         }
 
@@ -41,8 +38,8 @@ macro_rules! implement_push_numbers_no_conversion {
 
         impl $name {
             #[inline(always)]
-            pub(crate) fn operation((dst, value): (VaryingOperand, $num_type), registers: &mut Registers, _: &mut Context) {
-                registers.set(dst.into(), value.into());
+            pub(crate) fn operation((dst, value): (VaryingOperand, $num_type),  context: &mut Context) {
+                context.vm.set_register(dst.into(), value.into());
             }
         }
 

--- a/core/engine/src/vm/opcode/push/object.rs
+++ b/core/engine/src/vm/opcode/push/object.rs
@@ -1,9 +1,6 @@
 use crate::{
     builtins::OrdinaryObject,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -16,13 +13,13 @@ pub(crate) struct PushEmptyObject;
 
 impl PushEmptyObject {
     #[inline(always)]
-    pub(crate) fn operation(dst: VaryingOperand, registers: &mut Registers, context: &mut Context) {
+    pub(crate) fn operation(dst: VaryingOperand, context: &mut Context) {
         let o = context
             .intrinsics()
             .templates()
             .ordinary_object()
             .create(OrdinaryObject, Vec::default());
-        registers.set(dst.into(), o.into());
+        context.vm.set_register(dst.into(), o.into());
     }
 }
 

--- a/core/engine/src/vm/opcode/set/class_prototype.rs
+++ b/core/engine/src/vm/opcode/set/class_prototype.rs
@@ -4,7 +4,7 @@ use crate::{
     builtins::{function::OrdinaryFunction, OrdinaryObject},
     object::{internal_methods::InternalMethodContext, JsObject, CONSTRUCTOR, PROTOTYPE},
     property::PropertyDescriptorBuilder,
-    vm::{opcode::Operation, Registers},
+    vm::opcode::Operation,
     Context,
 };
 
@@ -19,10 +19,9 @@ impl SetClassPrototype {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, prototype, class): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let prototype = registers.get(prototype.into());
+        let prototype = context.vm.get_register(prototype.into());
         let prototype = match prototype.variant() {
             JsVariant::Object(proto) => Some(proto.clone()),
             JsVariant::Null => None,
@@ -36,7 +35,7 @@ impl SetClassPrototype {
             prototype,
             OrdinaryObject,
         );
-        let class = registers.get(class.into());
+        let class = context.vm.get_register(class.into()).clone();
 
         {
             let class_object = class.as_object().expect("class must be object");
@@ -70,7 +69,7 @@ impl SetClassPrototype {
             )
             .expect("cannot fail per spec");
 
-        registers.set(dst.into(), proto.into());
+        context.vm.set_register(dst.into(), proto.into());
     }
 }
 

--- a/core/engine/src/vm/opcode/set/home_object.rs
+++ b/core/engine/src/vm/opcode/set/home_object.rs
@@ -1,9 +1,6 @@
 use crate::{
     builtins::function::OrdinaryFunction,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -18,11 +15,10 @@ impl SetHomeObject {
     #[inline(always)]
     pub(crate) fn operation(
         (function, home): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
-        _: &mut Context,
+        context: &mut Context,
     ) {
-        let function = registers.get(function.into());
-        let home = registers.get(home.into());
+        let function = context.vm.get_register(function.into());
+        let home = context.vm.get_register(home.into());
 
         function
             .as_object()

--- a/core/engine/src/vm/opcode/set/private.rs
+++ b/core/engine/src/vm/opcode/set/private.rs
@@ -2,10 +2,7 @@ use crate::{
     js_str, js_string,
     object::PrivateElement,
     property::PropertyDescriptor,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsResult,
 };
 
@@ -20,7 +17,6 @@ impl SetPrivateField {
     #[inline(always)]
     pub(crate) fn operation(
         (value, object, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
         let name = context
@@ -28,8 +24,8 @@ impl SetPrivateField {
             .frame()
             .code_block()
             .constant_string(index.into());
-        let value = registers.get(value.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
         let base_obj = object.to_object(context)?;
         let name = context
             .vm
@@ -59,11 +55,10 @@ impl DefinePrivateField {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into());
+        let value = context.vm.get_register(value.into());
         let name = context
             .vm
             .frame()
@@ -98,11 +93,10 @@ impl SetPrivateMethod {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -149,11 +143,10 @@ impl SetPrivateSetter {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into());
+        let value = context.vm.get_register(value.into());
         let name = context
             .vm
             .frame()
@@ -192,11 +185,10 @@ impl SetPrivateGetter {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into());
+        let value = context.vm.get_register(value.into());
         let name = context
             .vm
             .frame()

--- a/core/engine/src/vm/opcode/set/property.rs
+++ b/core/engine/src/vm/opcode/set/property.rs
@@ -6,7 +6,7 @@ use crate::{
     builtins::function::set_function_name,
     object::{internal_methods::InternalMethodContext, shape::slot::SlotAttributes},
     property::{PropertyDescriptor, PropertyKey},
-    vm::{opcode::Operation, Registers},
+    vm::opcode::Operation,
     Context, JsNativeError, JsResult,
 };
 
@@ -26,12 +26,11 @@ impl SetPropertyByName {
             VaryingOperand,
             VaryingOperand,
         ),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
-        let receiver = registers.get(receiver.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let receiver = context.vm.get_register(receiver.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
         let object = object.to_object(context)?;
 
         let ic = &context.vm.frame().code_block().ic[usize::from(index)];
@@ -53,7 +52,7 @@ impl SetPropertyByName {
                 drop(object_borrowed);
                 if slot.attributes.has_set() && result.is_object() {
                     result.as_object().expect("should contain getter").call(
-                        receiver,
+                        &receiver,
                         &[value.clone()],
                         context,
                     )?;
@@ -117,13 +116,12 @@ impl SetPropertyByValue {
             VaryingOperand,
             VaryingOperand,
         ),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
-        let key = registers.get(key.into());
-        let receiver = registers.get(receiver.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let receiver = context.vm.get_register(receiver.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
         let object = object.to_object(context)?;
 
         let key = key.to_property_key(context)?;
@@ -141,7 +139,7 @@ impl SetPropertyByValue {
 
                     if object_borrowed
                         .properties_mut()
-                        .set_dense_property(index.get(), value)
+                        .set_dense_property(index.get(), &value)
                     {
                         return Ok(());
                     }
@@ -183,11 +181,10 @@ impl SetPropertyGetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -232,12 +229,11 @@ impl SetPropertyGetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (value, key, object): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
-        let key = registers.get(key.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
         let object = object.to_object(context)?;
         let name = key.to_property_key(context)?;
 
@@ -277,11 +273,10 @@ impl SetPropertySetterByName {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value, index): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into()).clone();
         let name = context
             .vm
             .frame()
@@ -327,12 +322,11 @@ impl SetPropertySetterByValue {
     #[inline(always)]
     pub(crate) fn operation(
         (value, key, object): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
-        let key = registers.get(key.into());
-        let object = registers.get(object.into());
+        let value = context.vm.get_register(value.into()).clone();
+        let key = context.vm.get_register(key.into()).clone();
+        let object = context.vm.get_register(object.into()).clone();
 
         let object = object.to_object(context)?;
         let name = key.to_property_key(context)?;
@@ -373,11 +367,10 @@ impl SetFunctionName {
     #[inline(always)]
     pub(crate) fn operation(
         (function, name, prefix): (VaryingOperand, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let function = registers.get(function.into());
-        let name = registers.get(name.into());
+        let function = context.vm.get_register(function.into()).clone();
+        let name = context.vm.get_register(name.into()).clone();
         let name = match name.variant() {
             JsVariant::String(name) => PropertyKey::from(name.clone()),
             JsVariant::Symbol(name) => PropertyKey::from(name.clone()),

--- a/core/engine/src/vm/opcode/set/prototype.rs
+++ b/core/engine/src/vm/opcode/set/prototype.rs
@@ -1,9 +1,6 @@
 use crate::{
     object::internal_methods::InternalMethodContext,
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -18,11 +15,10 @@ impl SetPrototype {
     #[inline(always)]
     pub(crate) fn operation(
         (object, value): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let object = registers.get(object.into());
-        let value = registers.get(value.into());
+        let object = context.vm.get_register(object.into()).clone();
+        let value = context.vm.get_register(value.into());
 
         let prototype = if let Some(prototype) = value.as_object() {
             Some(prototype.clone())

--- a/core/engine/src/vm/opcode/switch/mod.rs
+++ b/core/engine/src/vm/opcode/switch/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context,
-};
+use crate::{vm::opcode::Operation, Context};
 
 /// `Case` implements the Opcode Operation for `Opcode::Case`
 ///
@@ -16,11 +13,10 @@ impl Case {
     #[inline(always)]
     pub(super) fn operation(
         (address, value, condition): (u32, VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) {
-        let value = registers.get(value.into());
-        let condition = registers.get(condition.into());
+        let value = context.vm.get_register(value.into());
+        let condition = context.vm.get_register(condition.into());
         if value.strict_equals(condition) {
             context.vm.frame_mut().pc = address;
         }

--- a/core/engine/src/vm/opcode/to/mod.rs
+++ b/core/engine/src/vm/opcode/to/mod.rs
@@ -1,8 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    vm::{opcode::Operation, Registers},
-    Context, JsResult,
-};
+use crate::{vm::opcode::Operation, Context, JsResult};
 
 /// `ToPropertyKey` implements the Opcode Operation for `Opcode::ToPropertyKey`
 ///
@@ -15,12 +12,11 @@ impl ToPropertyKey {
     #[inline(always)]
     pub(super) fn operation(
         (value, dst): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(value.into());
+        let value = context.vm.get_register(value.into()).clone();
         let key = value.to_property_key(context)?;
-        registers.set(dst.into(), key.into());
+        context.vm.set_register(dst.into(), key.into());
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/unary_ops/decrement.rs
+++ b/core/engine/src/vm/opcode/unary_ops/decrement.rs
@@ -1,9 +1,6 @@
 use crate::{
     value::{JsValue, JsVariant, Numeric},
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsBigInt, JsResult,
 };
 
@@ -18,10 +15,9 @@ impl Dec {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, src): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(src.into());
+        let value = context.vm.get_register(src.into()).clone();
 
         let (numeric, value) = match value.variant() {
             JsVariant::Integer32(number) if number > i32::MIN => {
@@ -35,8 +31,8 @@ impl Dec {
                 ),
             },
         };
-        registers.set(src.into(), numeric);
-        registers.set(dst.into(), value);
+        context.vm.set_register(src.into(), numeric);
+        context.vm.set_register(dst.into(), value);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/unary_ops/increment.rs
+++ b/core/engine/src/vm/opcode/unary_ops/increment.rs
@@ -1,9 +1,6 @@
 use crate::{
     value::{JsValue, JsVariant, Numeric},
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context, JsBigInt, JsResult,
 };
 
@@ -18,10 +15,9 @@ impl Inc {
     #[inline(always)]
     pub(crate) fn operation(
         (dst, src): (VaryingOperand, VaryingOperand),
-        registers: &mut Registers,
         context: &mut Context,
     ) -> JsResult<()> {
-        let value = registers.get(src.into());
+        let value = context.vm.get_register(src.into()).clone();
 
         let (numeric, value) = match value.variant() {
             JsVariant::Integer32(number) if number < i32::MAX => {
@@ -35,8 +31,8 @@ impl Inc {
                 ),
             },
         };
-        registers.set(src.into(), numeric);
-        registers.set(dst.into(), value);
+        context.vm.set_register(src.into(), numeric);
+        context.vm.set_register(dst.into(), value);
         Ok(())
     }
 }

--- a/core/engine/src/vm/opcode/unary_ops/logical.rs
+++ b/core/engine/src/vm/opcode/unary_ops/logical.rs
@@ -1,8 +1,5 @@
 use crate::{
-    vm::{
-        opcode::{Operation, VaryingOperand},
-        Registers,
-    },
+    vm::opcode::{Operation, VaryingOperand},
     Context,
 };
 
@@ -15,10 +12,10 @@ pub(crate) struct LogicalNot;
 
 impl LogicalNot {
     #[inline(always)]
-    pub(crate) fn operation(value: VaryingOperand, registers: &mut Registers, _: &mut Context) {
-        registers.set(
+    pub(crate) fn operation(value: VaryingOperand, context: &mut Context) {
+        context.vm.set_register(
             value.into(),
-            (!registers.get(value.into()).to_boolean()).into(),
+            (!context.vm.get_register(value.into()).to_boolean()).into(),
         );
     }
 }

--- a/core/engine/src/vm/opcode/unary_ops/mod.rs
+++ b/core/engine/src/vm/opcode/unary_ops/mod.rs
@@ -1,10 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    builtins::Number,
-    value::Numeric,
-    vm::{opcode::Operation, Registers},
-    Context, JsBigInt, JsResult,
-};
+use crate::{builtins::Number, value::Numeric, vm::opcode::Operation, Context, JsBigInt, JsResult};
 use std::ops::Neg as StdNeg;
 
 pub(crate) mod decrement;
@@ -24,10 +19,10 @@ pub(crate) struct TypeOf;
 
 impl TypeOf {
     #[inline(always)]
-    pub(super) fn operation(value: VaryingOperand, registers: &mut Registers, _: &mut Context) {
-        registers.set(
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) {
+        context.vm.set_register(
             value.into(),
-            registers.get(value.into()).js_type_of().into(),
+            context.vm.get_register(value.into()).js_type_of().into(),
         );
     }
 }
@@ -47,15 +42,14 @@ pub(crate) struct Pos;
 
 impl Pos {
     #[inline(always)]
-    pub(super) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        registers.set(
-            value.into(),
-            registers.get(value.into()).to_number(context)?.into(),
-        );
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        let v = context
+            .vm
+            .get_register(value.into())
+            .clone()
+            .to_number(context)?
+            .into();
+        context.vm.set_register(value.into(), v);
         Ok(())
     }
 }
@@ -75,14 +69,17 @@ pub(crate) struct Neg;
 
 impl Neg {
     #[inline(always)]
-    pub(super) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        match registers.get(value.into()).to_numeric(context)? {
-            Numeric::Number(number) => registers.set(value.into(), number.neg().into()),
-            Numeric::BigInt(bigint) => registers.set(value.into(), JsBigInt::neg(&bigint).into()),
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        match context
+            .vm
+            .get_register(value.into())
+            .clone()
+            .to_numeric(context)?
+        {
+            Numeric::Number(number) => context.vm.set_register(value.into(), number.neg().into()),
+            Numeric::BigInt(bigint) => context
+                .vm
+                .set_register(value.into(), JsBigInt::neg(&bigint).into()),
         }
         Ok(())
     }
@@ -103,14 +100,19 @@ pub(crate) struct BitNot;
 
 impl BitNot {
     #[inline(always)]
-    pub(super) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        context: &mut Context,
-    ) -> JsResult<()> {
-        match registers.get(value.into()).to_numeric(context)? {
-            Numeric::Number(number) => registers.set(value.into(), Number::not(number).into()),
-            Numeric::BigInt(bigint) => registers.set(value.into(), JsBigInt::not(&bigint).into()),
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        match context
+            .vm
+            .get_register(value.into())
+            .clone()
+            .to_numeric(context)?
+        {
+            Numeric::Number(number) => context
+                .vm
+                .set_register(value.into(), Number::not(number).into()),
+            Numeric::BigInt(bigint) => context
+                .vm
+                .set_register(value.into(), JsBigInt::not(&bigint).into()),
         }
         Ok(())
     }

--- a/core/engine/src/vm/opcode/value/mod.rs
+++ b/core/engine/src/vm/opcode/value/mod.rs
@@ -1,9 +1,5 @@
 use super::VaryingOperand;
-use crate::{
-    error::JsNativeError,
-    vm::{opcode::Operation, Registers},
-    Context, JsResult,
-};
+use crate::{error::JsNativeError, vm::opcode::Operation, Context, JsResult};
 
 /// `ValueNotNullOrUndefined` implements the Opcode Operation for `Opcode::ValueNotNullOrUndefined`
 ///
@@ -14,12 +10,8 @@ pub(crate) struct ValueNotNullOrUndefined;
 
 impl ValueNotNullOrUndefined {
     #[inline(always)]
-    pub(super) fn operation(
-        value: VaryingOperand,
-        registers: &mut Registers,
-        _: &mut Context,
-    ) -> JsResult<()> {
-        let value = registers.get(value.into());
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) -> JsResult<()> {
+        let value = context.vm.get_register(value.into());
         if value.is_null() {
             return Err(JsNativeError::typ()
                 .with_message("Cannot destructure 'null' value")
@@ -49,9 +41,9 @@ pub(crate) struct IsObject;
 
 impl IsObject {
     #[inline(always)]
-    pub(super) fn operation(value: VaryingOperand, registers: &mut Registers, _: &mut Context) {
-        let is_object = registers.get(value.into()).is_object();
-        registers.set(value.into(), is_object.into());
+    pub(super) fn operation(value: VaryingOperand, context: &mut Context) {
+        let is_object = context.vm.get_register(value.into()).is_object();
+        context.vm.set_register(value.into(), is_object.into());
     }
 }
 


### PR DESCRIPTION
This Pull Request changes the following:

- Refactor the vm stack into a dedicated struct and implement stack access in functions that are more readable.
- Remove the `Registers` data structure and store registers on the stack.
