### PR TITLE
Add a #[boa_class] proc macro attribute

### DIFF
--- a/core/engine/src/value/mod.rs
+++ b/core/engine/src/value/mod.rs
@@ -29,7 +29,7 @@ pub use self::{
     variant::JsVariant,
 };
 use crate::builtins::RegExp;
-use crate::object::{JsFunction, JsPromise, JsRegExp};
+use crate::object::{ErasedObject, JsFunction, JsPromise, JsRegExp};
 use crate::{
     builtins::{
         number::{f64_to_int32, f64_to_uint32},
@@ -167,6 +167,17 @@ impl JsValue {
     #[must_use]
     pub fn as_downcast_ref<T: NativeObject>(&self) -> Option<boa_engine::object::Ref<'_, T>> {
         self.as_object().and_then(|o| o.downcast_ref::<T>())
+    }
+
+    /// Returns a downcasted mut ref object if the type matches. This is a shorthand
+    /// for `value.as_object().and_then(|o| o.downcast_ref<T>())`, which at time
+    /// can be contriving.
+    #[inline]
+    #[must_use]
+    pub fn as_downcast_mut<T: NativeObject>(
+        &self,
+    ) -> Option<boa_engine::object::RefMut<'_, ErasedObject, T>> {
+        self.as_object().and_then(|o| o.downcast_mut::<T>())
     }
 
     /// Consumes the value and return the inner object if it was an object.

--- a/core/interop/tests/class.rs
+++ b/core/interop/tests/class.rs
@@ -1,0 +1,78 @@
+//! Test for the class proc-macro.
+#![allow(unused_crate_dependencies)]
+
+use boa_engine::{js_str, js_string, Context, JsString, Source};
+use boa_macros::{boa_class, Finalize, JsData, Trace};
+
+#[derive(Clone, Trace, Finalize, JsData)]
+enum AnimalType {
+    Cat,
+    Dog,
+    Other,
+}
+
+#[derive(Clone, Trace, Finalize, JsData)]
+struct Animal {
+    ty: AnimalType,
+    age: i32,
+}
+
+#[boa_class]
+#[boa(debug)]
+impl Animal {
+    #[boa(constructor)]
+    fn new(name: String, age: i32) -> Self {
+        let ty = match name.as_str() {
+            "cat" => AnimalType::Cat,
+            "dog" => AnimalType::Dog,
+            _ => AnimalType::Other,
+        };
+
+        Self { ty, age }
+    }
+
+    #[boa(getter)]
+    fn age(&self) -> i32 {
+        self.age
+    }
+
+    #[boa(setter)]
+    #[boa(name = "age")]
+    fn set_age(&mut self, age: i32) {
+        self.age = age;
+    }
+
+    fn speak(#[boa(error = "`this` was not an animal")] &self) -> JsString {
+        match self.ty {
+            AnimalType::Cat => js_string!("meow"),
+            AnimalType::Dog => js_string!("woof"),
+            AnimalType::Other => js_string!(r"¯\_(ツ)_/¯"),
+        }
+    }
+}
+
+#[test]
+fn boa_class() {
+    let mut context = Context::default();
+
+    context.register_global_class::<Animal>().unwrap();
+
+    let result = context
+        .eval(Source::from_bytes(
+            r#"
+         let pet = new Animal("dog", 3);
+         if (pet.age !== 3) {
+            throw "age should be 3";
+         }
+         pet.age = 4;
+
+        `My pet is ${pet.age} years old. Right, buddy? - ${pet.speak()}!`
+     "#,
+        ))
+        .expect("Could not evaluate script");
+
+    assert_eq!(
+        result.as_string().unwrap(),
+        &js_str!("My pet is 4 years old. Right, buddy? - woof!")
+    );
+}

--- a/core/macros/Cargo.toml
+++ b/core/macros/Cargo.toml
@@ -16,7 +16,7 @@ cfg-if.workspace = true
 cow-utils.workspace = true
 lz4_flex = { workspace = true, optional = true }
 quote.workspace = true
-syn = { workspace = true, features = ["full"] }
+syn = { workspace = true, features = ["full", "visit-mut"] }
 proc-macro2.workspace = true
 synstructure.workspace = true
 

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -1,0 +1,624 @@
+use proc_macro::TokenStream;
+use proc_macro2::{Span as Span2, Span, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::visit_mut::VisitMut;
+use syn::{
+    Attribute, Expr, ExprLit, FnArg, Ident, ImplItemFn, ItemImpl, Lit, Meta, MetaNameValue,
+    PatType, Path, Receiver, ReturnType, Token, Type,
+};
+
+type SpannedResult<T> = Result<T, (Span2, String)>;
+
+/// A function to make it easier to return error messages.
+fn error<T>(span: &impl Spanned, message: impl Display) -> SpannedResult<T> {
+    Err((span.span(), message.to_string()))
+}
+
+/// Look (and remove from AST) a `path` version of the attribute `boa`, e.g. `#[boa(something)]`.
+fn take_path_attr(attrs: &mut Vec<Attribute>, name: &str) -> bool {
+    if let Some((i, _)) = attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| a.meta.path().is_ident("boa"))
+        .filter_map(|(i, a)| a.meta.require_list().ok().map(|nv| (i, nv)))
+        .filter_map(|(i, m)| m.parse_args::<Path>().ok().map(|p| (i, p)))
+        .find(|(_, path)| path.is_ident(name))
+    {
+        attrs.remove(i);
+        true
+    } else {
+        false
+    }
+}
+
+/// Look (and remove from AST) for a `#[boa(name = ...)]` attribute, where `...`
+/// is a literal. The validation of the literal's type should be done separately.
+fn take_name_value_attr(attrs: &mut Vec<Attribute>, name: &str) -> Option<Lit> {
+    if let Some((i, lit)) = attrs
+        .iter()
+        .enumerate()
+        .filter(|(_, a)| a.meta.path().is_ident("boa"))
+        .filter_map(|(i, a)| a.meta.require_list().ok().map(|nv| (i, nv)))
+        .filter_map(|(i, a)| {
+            syn::parse2::<MetaNameValue>(a.tokens.to_token_stream())
+                .ok()
+                .map(|nv| (i, nv))
+        })
+        .filter(|(_, nv)| nv.path.is_ident(name))
+        .find_map(|(i, nv)| match &nv.value {
+            Expr::Lit(ExprLit { lit, .. }) => Some((i, lit.clone())),
+            _ => None,
+        })
+    {
+        attrs.remove(i);
+        Some(lit)
+    } else {
+        None
+    }
+}
+
+/// Take the length name-value from the list of attributes.
+fn take_length_from_attrs(attrs: &mut Vec<Attribute>) -> SpannedResult<Option<usize>> {
+    match take_name_value_attr(attrs, "length") {
+        None => Ok(None),
+        Some(lit) => match lit {
+            Lit::Int(int) if int.base10_parse::<usize>().is_ok() => int
+                .base10_parse::<usize>()
+                .map(Some)
+                .map_err(|e| (int.span(), format!("Invalid literal: {e}"))),
+            l => error(&l, "Invalid literal type. Was expecting a number")?,
+        },
+    }
+}
+
+/// Take the last `#[boa(error = "...")]` statement if found, remove it from the list
+/// of attributes, and return the literal string.
+fn take_error_from_attrs(attrs: &mut Vec<Attribute>) -> SpannedResult<Option<String>> {
+    match take_name_value_attr(attrs, "error") {
+        None => Ok(None),
+        Some(lit) => match lit {
+            Lit::Str(s) => Ok(Some(s.value())),
+            l => Err((
+                l.span(),
+                "Invalid literal type. Was expecting a number".to_string(),
+            )),
+        },
+    }
+}
+
+/// A function representation. Takes a function from the AST and remember its name, length and
+/// how its body should be in the output AST.
+/// There are three types of functions: Constructors, Methods and Accessors (setter/getter).
+///
+/// This is not an enum for simplicity. The body is dependent on how this was created.
+struct Function {
+    /// The name of the function. Can be overridden with `#[boa(name = "...")]`.
+    name: String,
+    /// The length of the function in JavaScript. Can be overridden with `#[boa(length = ...)]`.
+    length: usize,
+    /// The body of the function serialized. This depends highly on the type of function.
+    body: TokenStream2,
+}
+
+impl std::fmt::Debug for Function {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Function")
+            .field("name", &self.name)
+            .field("length", &self.length)
+            .field("body", &self.body.to_string())
+            .finish()
+    }
+}
+
+impl Function {
+    /// Serializes the `self` argument declaration and call.
+    fn arg_self_from_receiver(
+        receiver: &mut Receiver,
+        class_ty: &Type,
+    ) -> SpannedResult<(TokenStream2, TokenStream2)> {
+        let err = take_error_from_attrs(&mut receiver.attrs)?
+            .unwrap_or("Invalid class for type".to_string());
+
+        // `&mut self`
+        let downcast = if receiver.mutability.is_some() {
+            quote! {
+                let self_ = &mut *this.as_downcast_mut::< #class_ty >()
+                    .ok_or( boa_engine::js_error!( #err ))?;
+            }
+        } else {
+            quote! {
+                let self_ = &*this.as_downcast_ref::< #class_ty >()
+                    .ok_or( boa_engine::js_error!( #err ))?;
+            }
+        };
+
+        Ok((downcast, quote! { self_ }))
+    }
+
+    /// Serializes an argument of form `pat: Type` into its declaration and call.
+    #[allow(clippy::unnecessary_wraps)]
+    fn arg_from_pat_type(pat_type: &mut PatType) -> SpannedResult<(TokenStream2, TokenStream2)> {
+        let path = pat_type.pat.as_ref();
+        let ty = pat_type.ty.as_ref();
+        let ident = Ident::new(
+            &format!("boa_{}", path.to_token_stream()),
+            Span::call_site(),
+        );
+
+        Ok((
+            quote! {
+                let (#ident, rest): (#ty, &[boa_engine::JsValue]) =
+                    boa_engine::interop::TryFromJsArgument::try_from_js_argument( this, rest, context )?;
+            },
+            quote!( #ident ),
+        ))
+    }
+
+    /// Create a `Function` from its name,
+    fn method(name: String, fn_: &mut ImplItemFn, class_ty: &Type) -> SpannedResult<Self> {
+        if fn_.sig.asyncness.is_some() {
+            error(&fn_.sig.asyncness, "Async methods are not supported.")?;
+        }
+
+        if !fn_.sig.generics.params.is_empty() {
+            error(&fn_.sig.generics, "Generic methods are not supported.")?;
+        }
+
+        let mut has_receiver = 0;
+        let (args_decl, args_call): (Vec<TokenStream2>, Vec<TokenStream2>) = fn_
+            .sig
+            .inputs
+            .iter_mut()
+            .map(|a| match a {
+                FnArg::Receiver(receiver) => {
+                    has_receiver += 1;
+                    Self::arg_self_from_receiver(receiver, class_ty)
+                }
+                FnArg::Typed(ty) => Self::arg_from_pat_type(ty),
+            })
+            .collect::<SpannedResult<_>>()?;
+
+        let length =
+            take_length_from_attrs(&mut fn_.attrs)?.unwrap_or(args_decl.len() - has_receiver);
+        let fn_name = &fn_.sig.ident;
+
+        Ok(Self {
+            length,
+            name,
+            body: quote! {
+                |   this: &boa_engine::JsValue,
+                    args: &[boa_engine::JsValue],
+                    context: &mut boa_engine::Context
+                | -> boa_engine::JsResult<boa_engine::JsValue> {
+                    let rest = args;
+                    #(#args_decl)*
+
+                    let result = Self:: #fn_name ( #(#args_call),* );
+                    boa_engine::TryIntoJsResult::try_into_js_result(result, context)
+                }
+            },
+        })
+    }
+
+    fn getter(name: String, fn_: &mut ImplItemFn, class_ty: &Type) -> SpannedResult<Self> {
+        Self::method(name, fn_, class_ty)
+    }
+
+    fn setter(name: String, fn_: &mut ImplItemFn, class_ty: &Type) -> SpannedResult<Self> {
+        Self::method(name, fn_, class_ty)
+    }
+
+    fn constructor(name: String, fn_: &mut ImplItemFn, _class_ty: &Type) -> SpannedResult<Self> {
+        if fn_.sig.asyncness.is_some() {
+            error(&fn_.sig.asyncness, "Async methods are not supported.")?;
+        }
+
+        if !fn_.sig.generics.params.is_empty() {
+            error(&fn_.sig.generics, "Generic methods are not supported.")?;
+        }
+
+        let (args_decl, args_call): (Vec<TokenStream2>, Vec<TokenStream2>) = fn_
+            .sig
+            .inputs
+            .iter_mut()
+            .map(|a| match a {
+                FnArg::Receiver(receiver) => error(receiver, "Constructors cannot use 'self'"),
+                FnArg::Typed(ty) => Self::arg_from_pat_type(ty),
+            })
+            .collect::<SpannedResult<_>>()?;
+
+        let length = take_length_from_attrs(&mut fn_.attrs)?.unwrap_or(args_decl.len());
+        let fn_name = &fn_.sig.ident;
+
+        // Does the function return Result<_> or JsResult<_>? If so, Into JsResult (to
+        // transform the error. If not, return Ok(_).
+        let return_statement = match &fn_.sig.output {
+            ReturnType::Default => quote! { Default::default() },
+            ReturnType::Type(_, ty) => {
+                if let Type::Path(path) = ty.as_ref() {
+                    let Some(t) = path.path.segments.last() else {
+                        return error(&fn_.sig.output, "Cannot infer return type.");
+                    };
+                    if t.ident == "Self" {
+                        quote! { Ok(result) }
+                    } else if t.ident == "JsResult" {
+                        quote! { result.into() }
+                    } else {
+                        return error(&fn_.sig.output, "Invalid return type.");
+                    }
+                } else {
+                    quote! { Ok(result) }
+                }
+            }
+        };
+
+        Ok(Self {
+            length,
+            name,
+            body: quote! {
+                let rest = args;
+                #(#args_decl)*
+
+                let result = Self:: #fn_name ( #(#args_call),* );
+                #return_statement
+            },
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct Accessor {
+    getter: Option<Function>,
+    setter: Option<Function>,
+}
+
+impl Accessor {
+    fn set_getter(
+        &mut self,
+        name: String,
+        fn_: &mut ImplItemFn,
+        class_ty: &Type,
+    ) -> SpannedResult<()> {
+        let getter = Function::getter(name, fn_, class_ty)?;
+        if self.getter.is_some() {
+            error(fn_, "Getter for this property already declared.")
+        } else {
+            self.getter = Some(getter);
+            Ok(())
+        }
+    }
+
+    fn set_setter(
+        &mut self,
+        name: String,
+        fn_: &mut ImplItemFn,
+        class_ty: &Type,
+    ) -> SpannedResult<()> {
+        let setter = Function::setter(name, fn_, class_ty)?;
+        if self.setter.is_some() {
+            error(fn_, "Setter for this property already declared.")
+        } else {
+            self.setter = Some(setter);
+            Ok(())
+        }
+    }
+
+    fn body(&self) -> TokenStream2 {
+        let Some(name) = self
+            .getter
+            .as_ref()
+            .map_or_else(|| self.setter.as_ref().map(|s| &s.name), |g| Some(&g.name))
+        else {
+            return quote! {};
+        };
+        let getter = if let Some(getter) = self.getter.as_ref() {
+            let body = getter.body.clone();
+            quote! {
+                Some(
+                    boa_engine::NativeFunction::from_copy_closure( #body )
+                        .to_js_function(builder.context().realm())
+                )
+            }
+        } else {
+            quote! { None }
+        };
+        let setter = if let Some(setter) = self.setter.as_ref() {
+            let body = setter.body.clone();
+            quote! {
+                Some(
+                    boa_engine::NativeFunction::from_copy_closure( #body )
+                        .to_js_function(builder.context().realm())
+                )
+            }
+        } else {
+            quote! { None }
+        };
+
+        quote! {
+            {
+                let g = #getter;
+                let s = #setter;
+                builder.accessor(
+                    boa_engine::js_string!( #name ),
+                    g,
+                    s,
+                    boa_engine::property::Attribute::CONFIGURABLE
+                        | boa_engine::property::Attribute::NON_ENUMERABLE,
+                );
+            }
+        }
+    }
+}
+
+/// A visitor for the `impl X { ... }` block. This will record all top-level functions
+/// and create endpoints for the JavaScript class.
+#[derive(Debug)]
+struct ClassVisitor {
+    // The type name for this class.
+    type_: Type,
+
+    // Whether we detected a constructor while visiting.
+    constructor: Option<Function>,
+
+    // All methods recorded.
+    methods: Vec<Function>,
+
+    // All accessors (getters and/or setters) with their names.
+    accessors: BTreeMap<String, Accessor>,
+
+    // All errors we found along the way.
+    errors: Option<syn::Error>,
+}
+
+impl ClassVisitor {
+    fn new(type_: Type) -> Self {
+        Self {
+            type_,
+            constructor: None,
+            methods: Vec::new(),
+            accessors: BTreeMap::default(),
+            errors: None,
+        }
+    }
+
+    fn method(&mut self, _span: &impl Spanned, fn_: &mut ImplItemFn) {
+        let name = fn_.sig.ident.to_string();
+        match Function::method(name, fn_, &self.type_) {
+            Ok(f) => self.methods.push(f),
+            Err((span, err)) => self.error(span, err),
+        }
+    }
+
+    fn getter(&mut self, fn_: &mut ImplItemFn) {
+        let name = fn_.sig.ident.to_string();
+        if let Err((span, msg)) =
+            self.accessors
+                .entry(name.clone())
+                .or_default()
+                .set_getter(name, fn_, &self.type_)
+        {
+            self.error(span, msg);
+        }
+    }
+
+    fn setter(&mut self, fn_: &mut ImplItemFn) {
+        let name = take_name_value_attr(&mut fn_.attrs, "name").map_or_else(
+            || Ok(fn_.sig.ident.to_string()),
+            |nv| match &nv {
+                Lit::Str(s) => Ok(s.value()),
+                _ => Err(""),
+            },
+        );
+        let name = match name {
+            Ok(name) => name,
+            Err(err) => {
+                self.error(fn_, err);
+                return;
+            }
+        };
+
+        if let Err((span, msg)) =
+            self.accessors
+                .entry(name.clone())
+                .or_default()
+                .set_setter(name, fn_, &self.type_)
+        {
+            self.error(span, msg);
+        }
+    }
+
+    fn constructor(&mut self, fn_: &mut ImplItemFn) {
+        let name = fn_.sig.ident.to_string();
+        match Function::constructor(name, fn_, &self.type_) {
+            Ok(f) => self.constructor = Some(f),
+            Err((span, err)) => self.error(span, err),
+        }
+    }
+
+    /// Add an error to list of errors we are recording along the way. Errors are handled
+    /// at the end of the process, so this combines all errors.
+    #[allow(clippy::needless_pass_by_value)]
+    fn error(&mut self, node: impl Spanned, message: impl Display) {
+        let error = syn::Error::new(node.span(), message);
+
+        match &mut self.errors {
+            None => {
+                self.errors = Some(error);
+            }
+            Some(e) => {
+                e.combine(error);
+            }
+        }
+    }
+
+    /// Serialize the `boa_engine::Class` implementation into a token stream.
+    fn serialize_class_impl(&self, class_ty: &Type, class_name: &str) -> TokenStream2 {
+        let arg_count = self.constructor.as_ref().map_or(0, |c| c.length);
+
+        let accessors = self.accessors.values().map(Accessor::body);
+
+        let builder_methods = self.methods.iter().map(|m| {
+            let name_str = m.name.as_str();
+            let length = m.length;
+            let body = &m.body;
+
+            quote! {
+                builder.method(
+                    boa_engine::js_string!( #name_str ),
+                    #length,
+                    boa_engine::NativeFunction::from_copy_closure(
+                        #body
+                    )
+                );
+            }
+        });
+
+        let constructor_body = self.constructor.as_ref().map_or_else(
+            || {
+                quote! {
+                    Ok(Default::default())
+                }
+            },
+            |c| c.body.clone(),
+        );
+
+        quote! {
+            impl boa_engine::class::Class for #class_ty {
+                const NAME: &'static str = #class_name;
+                const LENGTH: usize = #arg_count;
+
+                fn data_constructor(
+                    this: &boa_engine::JsValue,
+                    args: &[boa_engine::JsValue],
+                    context: &mut boa_engine::Context
+                ) -> boa_engine::JsResult<Self> {
+                    #constructor_body
+                }
+
+                fn init(builder: &mut boa_engine::class::ClassBuilder) -> boa_engine::JsResult<()> {
+                    // Add all accessors.
+                    #(#accessors)*
+
+                    // Add all methods to the class.
+                    #(#builder_methods)*
+
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
+impl VisitMut for ClassVisitor {
+    fn visit_impl_item_fn_mut(&mut self, item: &mut ImplItemFn) {
+        // If there's a `boa` argument, parse it.
+        let has_ctor_attr = take_path_attr(&mut item.attrs, "constructor");
+        let has_getter_attr = take_path_attr(&mut item.attrs, "getter");
+        let has_setter_attr = take_path_attr(&mut item.attrs, "setter");
+        let has_method_attr = take_path_attr(&mut item.attrs, "method");
+
+        if has_getter_attr {
+            self.getter(item);
+        }
+
+        if has_setter_attr {
+            self.setter(item);
+        }
+
+        if has_ctor_attr {
+            self.constructor(item);
+        }
+
+        // A function is a method if it has a `#[boa(method)]` attribute or has no
+        // method-type related attributes.
+        if has_method_attr || !(has_getter_attr || has_ctor_attr || has_setter_attr) {
+            self.method(&item.sig.span(), item);
+        }
+
+        syn::visit_mut::visit_impl_item_fn_mut(self, item);
+    }
+}
+
+#[derive(Debug)]
+struct ClassArguments {
+    name: Option<String>,
+}
+
+impl Parse for ClassArguments {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        let args: Punctuated<Meta, Token![,]> = Punctuated::parse_terminated(input)?;
+        let mut name = None;
+
+        for arg in &args {
+            match arg {
+                Meta::NameValue(MetaNameValue {
+                    path,
+                    value: Expr::Lit(lit),
+                    ..
+                }) if path.is_ident("name") => {
+                    name = Some(match &lit.lit {
+                        Lit::Str(s) => Ok(s.value()),
+                        _ => Err(syn::Error::new(lit.span(), "Expected a string literal")),
+                    }?);
+                }
+                _ => return Err(syn::Error::new(arg.span(), "Unrecognize argument.")),
+            }
+        }
+
+        Ok(Self { name })
+    }
+}
+
+pub(crate) fn class_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
+    // Parse the attribute arguments.
+    let args = syn::parse_macro_input!(attr as ClassArguments);
+
+    // Parse the input.
+    let mut impl_ = syn::parse_macro_input!(input as ItemImpl);
+
+    // Get all methods from the input.
+    let mut visitor = ClassVisitor::new(impl_.self_ty.as_ref().clone());
+    syn::visit_mut::visit_item_impl_mut(&mut visitor, &mut impl_);
+
+    if let Some(err) = visitor.errors {
+        return err.to_compile_error().into();
+    }
+
+    let Type::Path(pa) = impl_.self_ty.as_ref() else {
+        return syn::Error::new(impl_.span(), "Impossible to find the name of the class.")
+            .to_compile_error()
+            .into();
+    };
+    let Some(name) = args
+        .name
+        .or_else(|| pa.path.get_ident().map(ToString::to_string))
+    else {
+        return syn::Error::new(pa.span(), "Impossible to find the name of the class.")
+            .to_compile_error()
+            .into();
+    };
+
+    let class_impl = visitor.serialize_class_impl(&impl_.self_ty, &name.to_string());
+
+    let debug = take_path_attr(&mut impl_.attrs, "debug");
+
+    let tokens = quote! {
+        // Keep the original implementation as is.
+        #impl_
+
+        // The boa_engine::Class implementation.
+        #class_impl
+    };
+
+    #[allow(clippy::print_stderr)]
+    if debug {
+        eprintln!("---------\n{}\n---------\n", tokens);
+    }
+
+    tokens.into()
+}

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -20,6 +20,8 @@ use synstructure::{decl_derive, AddBounds, Structure};
 
 mod embedded_module_loader;
 
+mod class;
+
 /// Implementation of the inner iterator of the `embed_module!` macro. All
 /// arguments are required.
 ///
@@ -29,6 +31,17 @@ mod embedded_module_loader;
 #[proc_macro]
 pub fn embed_module_inner(input: TokenStream) -> TokenStream {
     embedded_module_loader::embed_module_impl(input)
+}
+
+/// Implementation of the inner iterator of the `embed_module!` macro. All
+/// arguments are required.
+///
+/// # Warning
+/// This should not be used directly as is, and instead should be used through
+/// the `embed_module!` macro in `boa_interop` for convenience.
+#[proc_macro_attribute]
+pub fn boa_class(attr: TokenStream, item: TokenStream) -> TokenStream {
+    class::class_impl(attr, item)
 }
 
 struct Static {


### PR DESCRIPTION
This transforms an `impl XYZ` block into a class. It might not be fully fool proof, and it doesn't implement everything that can be done in the Class implementation, but it is sufficient to get started.

This should reduce the code and complexity of class declaration. It supports accessors, constructors and methods, and uses the same logic for transforming arguments from `JsValue` that is used by `IntoJsFunctionCopied`. This makes it very convenient.

It also copy the `impl` block verbatim so methods inside the block can be used in Rust as regular methods.

There is an additional new functionality that isn't supported by `js_class!`: you can use `&self` or `&mut self` in your method to get a borrowed struct instance. That makes it very convenient to declare regular Rust methods. Unfortunately, it also allows for double borrows if the method calls anything into JavaScript again. I failed to find a proper way to communicate this, outside of documentation.
