### PR TITLE
Add a #[boa(rename = ...)] attribute to TryFromJs and TryIntoJs derive macros

### DIFF
--- a/core/interop/tests/class.rs
+++ b/core/interop/tests/class.rs
@@ -57,7 +57,7 @@ impl Animal {
 
     #[boa(setter)]
     #[boa(method)]
-    #[boa(name = "age")]
+    #[boa(rename = "age")]
     fn set_age(&mut self, age: i32) {
         self.age = age;
     }

--- a/core/interop/tests/module.rs
+++ b/core/interop/tests/module.rs
@@ -58,7 +58,7 @@ mod hello {
 
     const SOME_LITERAL_NUMBER: i32 = 1234;
 
-    #[boa(name = "this_is_different")]
+    #[boa(rename = "this_is_different")]
     const SOME_OTHER_LITERAL: i32 = 5678;
 }
 

--- a/core/macros/src/class.rs
+++ b/core/macros/src/class.rs
@@ -22,7 +22,7 @@ use syn::{
 ///
 /// This is not an enum for simplicity. The body is dependent on how this was created.
 pub(crate) struct Function {
-    /// The name of the function. Can be overridden with `#[boa(name = "...")]`.
+    /// The name of the function. Can be overridden with `#[boa(rename = "...")]`.
     name: String,
 
     /// The length of the function in JavaScript. Can be overridden with `#[boa(length = ...)]`.
@@ -409,7 +409,7 @@ impl ClassVisitor {
     }
 
     fn name_of(&self, fn_: &mut ImplItemFn) -> SpannedResult<String> {
-        take_name_value_attr(&mut fn_.attrs, "name").map_or_else(
+        take_name_value_attr(&mut fn_.attrs, "rename").map_or_else(
             || Ok(self.renaming.rename(fn_.sig.ident.to_string())),
             |nv| match &nv {
                 Lit::Str(s) => Ok(s.value()),
@@ -619,7 +619,7 @@ impl Parse for ClassArguments {
                     path,
                     value: Expr::Lit(lit),
                     ..
-                }) if path.is_ident("name") => {
+                }) if path.is_ident("rename") => {
                     name = Some(match &lit.lit {
                         Lit::Str(s) => Ok(s.value()),
                         _ => Err(syn::Error::new(lit.span(), "Expected a string literal")),
@@ -640,7 +640,7 @@ pub(crate) fn class_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
     // Parse the input.
     let mut impl_ = syn::parse_macro_input!(input as ItemImpl);
 
-    let renaming = match RenameScheme::from_named_attrs(&mut impl_.attrs, "rename") {
+    let renaming = match RenameScheme::from_named_attrs(&mut impl_.attrs, "rename_all") {
         Ok(Some(r)) => r,
         Ok(None) => RenameScheme::CamelCase,
         Err((span, msg)) => {

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -57,7 +57,7 @@ pub fn embed_module_inner(input: TokenStream) -> TokenStream {
 ///
 /// To change this behaviour, you can use the following attributes on the function
 /// declarations:
-/// 1. `#[boa(name = "...")]` renames the function in JavaScript with the string.
+/// 1. `#[boa(rename = "...")]` renames the function in JavaScript with the string.
 /// 2. `#[boa(getter)]` will declare a getter accessor.
 /// 2. `#[boa(setter)]` will declare a setter accessor.
 /// 3. `#[boa(static)]` will declare a static method.
@@ -69,8 +69,8 @@ pub fn embed_module_inner(input: TokenStream) -> TokenStream {
 /// Multiple of those attributes can be added to a single method.
 ///
 /// The top level `boa_class` supports the following:
-/// 1. `#[boa_class(name = "...")]` sets the name of the class in JavaScript.
-/// 2. `#[boa(rename = "camelCase")]` will change the naming scheme of verbatim
+/// 1. `#[boa_class(rename = "...")]` sets the name of the class in JavaScript.
+/// 2. `#[boa(rename_all = "camelCase")]` will change the naming scheme of verbatim
 ///    to using "camelCase" or "none".
 ///
 /// # Warning
@@ -451,7 +451,7 @@ pub fn derive_try_from_js(input: TokenStream) -> TokenStream {
         panic!("you can only derive TryFromJs for named-field structs")
     };
 
-    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename") {
+    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename_all") {
         Ok(renaming) => renaming.unwrap_or(RenameScheme::None),
         Err((span, msg)) => return syn::Error::new(span, msg).to_compile_error().into(),
     };
@@ -581,7 +581,7 @@ pub fn derive_try_into_js(input: TokenStream) -> TokenStream {
         panic!("you can only derive TryFromJs for named-field structs")
     };
 
-    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename") {
+    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename_all") {
         Ok(renaming) => renaming.unwrap_or(RenameScheme::None),
         Err((span, msg)) => return syn::Error::new(span, msg).to_compile_error().into(),
     };

--- a/core/macros/src/lib.rs
+++ b/core/macros/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 
+use crate::utils::RenameScheme;
 use cow_utils::CowUtils;
 use proc_macro::TokenStream;
 use proc_macro2::Literal;
@@ -450,7 +451,12 @@ pub fn derive_try_from_js(input: TokenStream) -> TokenStream {
         panic!("you can only derive TryFromJs for named-field structs")
     };
 
-    let conv = generate_conversion(fields).unwrap_or_else(to_compile_errors);
+    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename") {
+        Ok(renaming) => renaming.unwrap_or(RenameScheme::None),
+        Err((span, msg)) => return syn::Error::new(span, msg).to_compile_error().into(),
+    };
+
+    let conv = generate_conversion(fields, renaming).unwrap_or_else(to_compile_errors);
 
     let type_name = input.ident;
 
@@ -473,7 +479,10 @@ pub fn derive_try_from_js(input: TokenStream) -> TokenStream {
 }
 
 /// Generates the conversion field by field.
-fn generate_conversion(fields: FieldsNamed) -> Result<proc_macro2::TokenStream, Vec<syn::Error>> {
+fn generate_conversion(
+    fields: FieldsNamed,
+    rename: RenameScheme,
+) -> Result<proc_macro2::TokenStream, Vec<syn::Error>> {
     use syn::spanned::Spanned;
 
     let mut field_list = Vec::with_capacity(fields.named.len());
@@ -491,7 +500,7 @@ fn generate_conversion(fields: FieldsNamed) -> Result<proc_macro2::TokenStream, 
         field_list.push(name.clone());
 
         let mut from_js_with = None;
-        let mut field_name = format!("{name}");
+        let mut field_name = rename.rename(format!("{name}"));
         if let Some(attr) = field
             .attrs
             .into_iter()
@@ -572,7 +581,12 @@ pub fn derive_try_into_js(input: TokenStream) -> TokenStream {
         panic!("you can only derive TryFromJs for named-field structs")
     };
 
-    let props = generate_obj_properties(fields)
+    let renaming = match RenameScheme::from_named_attrs(&mut input.attrs.clone(), "rename") {
+        Ok(renaming) => renaming.unwrap_or(RenameScheme::None),
+        Err((span, msg)) => return syn::Error::new(span, msg).to_compile_error().into(),
+    };
+
+    let props = generate_obj_properties(fields, renaming)
         .map_err(|err| vec![err])
         .unwrap_or_else(to_compile_errors);
 
@@ -594,7 +608,10 @@ pub fn derive_try_into_js(input: TokenStream) -> TokenStream {
 }
 
 /// Generates property creation for object.
-fn generate_obj_properties(fields: FieldsNamed) -> Result<proc_macro2::TokenStream, syn::Error> {
+fn generate_obj_properties(
+    fields: FieldsNamed,
+    renaming: RenameScheme,
+) -> Result<proc_macro2::TokenStream, syn::Error> {
     use syn::spanned::Spanned;
 
     let mut prop_ctors = Vec::with_capacity(fields.named.len());
@@ -609,7 +626,7 @@ fn generate_obj_properties(fields: FieldsNamed) -> Result<proc_macro2::TokenStre
         })?;
 
         let mut into_js_with = None;
-        let mut prop_key = format!("{name}");
+        let mut prop_key = renaming.rename(format!("{name}"));
         let mut skip = false;
 
         for attr in field

--- a/core/macros/src/module.rs
+++ b/core/macros/src/module.rs
@@ -97,9 +97,9 @@ pub(crate) fn module_impl(attr: TokenStream, input: TokenStream) -> TokenStream 
 }
 
 fn module_impl_impl(_args: ModuleArguments, mut mod_: ItemMod) -> SpannedResult<TokenStream2> {
-    let renaming = RenameScheme::from_named_attrs(&mut mod_.attrs, "rename")?
+    let renaming = RenameScheme::from_named_attrs(&mut mod_.attrs, "rename_all")?
         .unwrap_or(RenameScheme::CamelCase);
-    let class_renaming = RenameScheme::from_named_attrs(&mut mod_.attrs, "rename_class")?
+    let class_renaming = RenameScheme::from_named_attrs(&mut mod_.attrs, "rename_all_class")?
         .unwrap_or(RenameScheme::PascalCase);
 
     // Iterate through all top-level content. If the module is empty, still

--- a/core/macros/src/module.rs
+++ b/core/macros/src/module.rs
@@ -21,7 +21,7 @@ impl Parse for ModuleArguments {
 
 fn const_item(c: &mut ItemConst, renaming: RenameScheme) -> SpannedResult<(String, TokenStream2)> {
     let ident = &c.ident;
-    let name = take_name_value_string(&mut c.attrs, "name")?
+    let name = take_name_value_string(&mut c.attrs, "rename")?
         .unwrap_or_else(|| renaming.rename(ident.to_string()));
 
     Ok((
@@ -34,7 +34,7 @@ fn const_item(c: &mut ItemConst, renaming: RenameScheme) -> SpannedResult<(Strin
 
 fn fn_item(fn_: &mut ItemFn, renaming: RenameScheme) -> SpannedResult<(String, TokenStream2)> {
     let ident = &fn_.sig.ident;
-    let name = take_name_value_string(&mut fn_.attrs, "name")?
+    let name = take_name_value_string(&mut fn_.attrs, "rename")?
         .unwrap_or_else(|| renaming.rename(ident.to_string()));
 
     if fn_.sig.asyncness.is_some() {
@@ -71,7 +71,7 @@ fn fn_item(fn_: &mut ItemFn, renaming: RenameScheme) -> SpannedResult<(String, T
 
 fn type_item(ty: &mut ItemType, renaming: RenameScheme) -> SpannedResult<(String, TokenStream2)> {
     let ident = &ty.ident;
-    let name = take_name_value_string(&mut ty.attrs, "name")?
+    let name = take_name_value_string(&mut ty.attrs, "rename")?
         .unwrap_or_else(|| renaming.rename(ident.to_string()));
     let path = ty.ty.as_ref();
 

--- a/core/macros/src/utils.rs
+++ b/core/macros/src/utils.rs
@@ -30,7 +30,7 @@ pub(crate) fn take_path_attr(attrs: &mut Vec<Attribute>, name: &str) -> bool {
     }
 }
 
-/// Look (and remove from AST) for a `#[boa(name = ...)]` attribute, where `...`
+/// Look (and remove from AST) for a `#[boa(rename = ...)]` attribute, where `...`
 /// is a literal. The validation of the literal's type should be done separately.
 pub(crate) fn take_name_value_attr(attrs: &mut Vec<Attribute>, name: &str) -> Option<Lit> {
     if let Some((i, lit)) = attrs

--- a/examples/src/bin/try_into_js_derive.rs
+++ b/examples/src/bin/try_into_js_derive.rs
@@ -4,6 +4,12 @@ use boa_engine::{
     Context, JsResult, JsValue, Source,
 };
 
+#[derive(TryFromJs, TryIntoJs, Debug, PartialEq, Eq)]
+#[boa(rename = "camelCase")]
+struct InnerTest {
+    hello_world_how_are_you: u8,
+}
+
 #[derive(TryIntoJs)]
 struct Test {
     x: i32,
@@ -15,6 +21,8 @@ struct Test {
     #[boa(rename = "isReadable")]
     #[boa(into_js_with = "readable_into_js")]
     is_readable: i8,
+
+    inner: InnerTest,
 }
 
 #[derive(TryFromJs, Debug, PartialEq, Eq)]
@@ -23,16 +31,24 @@ struct ResultVerifier {
     y: i32,
     #[boa(rename = "isReadable")]
     is_readable: bool,
+
+    inner: InnerTest,
 }
 
 fn main() -> JsResult<()> {
     let js_code = r#"
     function pointShift(pointA, pointB) {
-        if (pointA.isReadable === true && pointB.isReadable === true) {
+        if (pointA.isReadable === true
+            && pointB.isReadable === true
+            && pointA.inner.helloWorldHowAreYou !== undefined)
+        {
             return {
                 x: pointA.x + pointB.x,
                 y: pointA.y + pointB.y,
                 isReadable: true,
+                inner: {
+                    helloWorldHowAreYou: pointA.inner.helloWorldHowAreYou + pointB.inner.helloWorldHowAreYou
+                }
             }
         }
         return undefined
@@ -54,18 +70,27 @@ fn main() -> JsResult<()> {
         y_point: 20,
         tuple: (30, 40, "no matter".into()),
         is_readable: 1,
+        inner: InnerTest {
+            hello_world_how_are_you: 1,
+        },
     };
     let b = Test {
         x: 2,
         y_point: 1,
         tuple: (30, 40, "no matter".into()),
         is_readable: 2,
+        inner: InnerTest {
+            hello_world_how_are_you: 2,
+        },
     };
     let c = Test {
         x: 2,
         y_point: 1,
         tuple: (30, 40, "no matter".into()),
         is_readable: 0,
+        inner: InnerTest {
+            hello_world_how_are_you: 3,
+        },
     };
 
     let result = point_shift.call(
@@ -78,6 +103,9 @@ fn main() -> JsResult<()> {
         x: 10 + 2,
         y: 20 + 1,
         is_readable: true,
+        inner: InnerTest {
+            hello_world_how_are_you: 3,
+        },
     };
     assert_eq!(verifier, expect);
 

--- a/examples/src/bin/try_into_js_derive.rs
+++ b/examples/src/bin/try_into_js_derive.rs
@@ -5,7 +5,7 @@ use boa_engine::{
 };
 
 #[derive(TryFromJs, TryIntoJs, Debug, PartialEq, Eq)]
-#[boa(rename = "camelCase")]
+#[boa(rename_all = "camelCase")]
 struct InnerTest {
     hello_world_how_are_you: u8,
 }


### PR DESCRIPTION
This should reduce the amount of rename on each fields.
